### PR TITLE
Avoid raw new, use libmesh_make_unique instead

### DIFF
--- a/configure
+++ b/configure
@@ -10106,6 +10106,7 @@ main ()
         std::shared_ptr<int> p2 (new int);
         std::shared_ptr<int> p3 (p2);
         p3.reset(new int);
+        p3 = std::make_shared<int>(5);
 
   ;
   return 0;

--- a/examples/adjoints/adjoints_ex3/adjoints_ex3.C
+++ b/examples/adjoints/adjoints_ex3/adjoints_ex3.C
@@ -538,7 +538,7 @@ void set_system_parameters(FEMSystem & system,
         system.time_solver.reset(innersolver);
     }
   else
-    system.time_solver.reset(new SteadySolver(system));
+    system.time_solver = libmesh_make_unique<SteadySolver>(system);
 
   system.time_solver->reduce_deltat_on_diffsolver_failure =
     param.deltat_reductions;

--- a/examples/fem_system/fem_system_ex1/fem_system_ex1.C
+++ b/examples/fem_system/fem_system_ex1/fem_system_ex1.C
@@ -257,13 +257,11 @@ int main (int argc, char ** argv)
               // size at once
               libmesh_assert_equal_to (nelem_target, 0);
 
-              UniformRefinementEstimator * u = new UniformRefinementEstimator;
+              error_estimator = libmesh_make_unique<UniformRefinementEstimator>();
 
               // The lid-driven cavity problem isn't in H1, so
               // lets estimate L2 error
-              u->error_norm = L2;
-
-              error_estimator.reset(u);
+              error_estimator->error_norm = L2;
             }
           else
             {
@@ -275,7 +273,7 @@ int main (int argc, char ** argv)
               // not in H1 - if we were doing more than a few
               // timesteps we'd need to turn off or limit the
               // maximum level of our adaptivity eventually
-              error_estimator.reset(new KellyErrorEstimator);
+              error_estimator = libmesh_make_unique<KellyErrorEstimator>();
             }
 
           // Calculate error based on u and v (and w?) but not p

--- a/examples/fem_system/fem_system_ex1/fem_system_ex1.C
+++ b/examples/fem_system/fem_system_ex1/fem_system_ex1.C
@@ -120,9 +120,9 @@ int main (int argc, char ** argv)
   std::shared_ptr<UnstructuredMesh> mesh;
 
   if (mesh_type == "distributed")
-    mesh.reset(new DistributedMesh(init.comm()));
+    mesh = std::make_shared<DistributedMesh>(init.comm());
   else if (mesh_type == "replicated")
-    mesh.reset(new ReplicatedMesh(init.comm()));
+    mesh = std::make_shared<ReplicatedMesh>(init.comm());
   else
     libmesh_error_msg("Error: specified mesh_type not understood");
 

--- a/examples/fem_system/fem_system_ex3/fem_system_ex3.C
+++ b/examples/fem_system/fem_system_ex3/fem_system_ex3.C
@@ -39,6 +39,7 @@
 #include "libmesh/mesh_generation.h"
 #include "libmesh/enum_solver_package.h"
 #include "libmesh/enum_solver_type.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // The systems and solvers we may use
 #include "elasticity_system.h"
@@ -195,26 +196,26 @@ int main (int argc, char ** argv)
       a_system->add_variable("w_accel", FIRST, LAGRANGE);
     }
 
-  if( time_solver == std::string("newmark"))
-    system.time_solver.reset(new NewmarkSolver(system));
+  if (time_solver == std::string("newmark"))
+    system.time_solver = libmesh_make_unique<NewmarkSolver>(system);
 
   else if( time_solver == std::string("euler") )
     {
-      system.time_solver.reset(new EulerSolver(system));
+      system.time_solver = libmesh_make_unique<EulerSolver>(system);
       EulerSolver & euler_solver = cast_ref<EulerSolver &>(*(system.time_solver.get()));
       euler_solver.theta = infile("theta", 1.0);
     }
 
   else if( time_solver == std::string("euler2") )
     {
-      system.time_solver.reset(new Euler2Solver(system));
+      system.time_solver = libmesh_make_unique<Euler2Solver>(system);
       Euler2Solver & euler_solver = cast_ref<Euler2Solver &>(*(system.time_solver.get()));
       euler_solver.theta = infile("theta", 1.0);
     }
 
   else if( time_solver == std::string("steady"))
     {
-      system.time_solver.reset(new SteadySolver(system));
+      system.time_solver = libmesh_make_unique<SteadySolver>(system);
       libmesh_assert_equal_to (n_timesteps, 1);
     }
   else

--- a/examples/fem_system/fem_system_ex4/fem_system_ex4.C
+++ b/examples/fem_system/fem_system_ex4/fem_system_ex4.C
@@ -233,7 +233,7 @@ int main (int argc, char ** argv)
           // not in H1 - if we were doing more than a few
           // timesteps we'd need to turn off or limit the
           // maximum level of our adaptivity eventually
-          error_estimator.reset(new KellyErrorEstimator);
+          error_estimator = libmesh_make_unique<KellyErrorEstimator>();
         }
 
       error_estimator->estimate_error(system, error);

--- a/examples/miscellaneous/miscellaneous_ex7/biharmonic.C
+++ b/examples/miscellaneous/miscellaneous_ex7/biharmonic.C
@@ -2,6 +2,7 @@
 #include "libmesh/mesh_generation.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/replicated_mesh.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // Example includes
 #include "biharmonic.h"
@@ -155,7 +156,7 @@ Biharmonic::Biharmonic(ReplicatedMesh & mesh) :
         }
     }
   _ofile = _ofile_base + ".e";
-  _exio.reset(new ExodusII_IO(_mesh));
+  _exio = libmesh_make_unique<ExodusII_IO>(_mesh);
   _o_dt = command_line_value("output_dt", 0.0);
 #endif // #ifdef LIBMESH_HAVE_EXODUS_API
 } // constructor

--- a/examples/reduced_basis/reduced_basis_ex7/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex7/rb_classes.h
@@ -24,6 +24,7 @@
 #include "libmesh/rb_construction.h"
 #include "libmesh/fe_base.h"
 #include "libmesh/rb_evaluation.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // local include
 #include "assembly.h"
@@ -108,8 +109,8 @@ public:
 
     Parent::init_data();
 
-    acoustics_rb_assembly_expansion.reset
-      (new AcousticsRBAssemblyExpansion);
+    acoustics_rb_assembly_expansion =
+      libmesh_make_unique<AcousticsRBAssemblyExpansion>();
 
     // Set the rb_assembly_expansion for this Construction object.
     // The theta expansion comes from the RBEvaluation object.

--- a/include/numerics/const_function.h
+++ b/include/numerics/const_function.h
@@ -23,6 +23,7 @@
 #include "libmesh/dense_vector.h"
 #include "libmesh/function_base.h"
 #include "libmesh/point.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // C++ includes
 #include <string>
@@ -73,8 +74,7 @@ public:
 
   virtual std::unique_ptr<FunctionBase<Output>> clone() const override
   {
-    return std::unique_ptr<FunctionBase<Output>>
-      (new ConstFunction<Output>(_c));
+    return libmesh_make_unique<ConstFunction<Output>>(_c);
   }
 
 private:

--- a/include/numerics/parsed_fem_function.h
+++ b/include/numerics/parsed_fem_function.h
@@ -26,6 +26,7 @@
 #include "libmesh/fem_function_base.h"
 #include "libmesh/point.h"
 #include "libmesh/system.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 #ifdef LIBMESH_HAVE_FPARSER
 // FParser includes
@@ -386,8 +387,8 @@ inline
 std::unique_ptr<FEMFunctionBase<Output>>
 ParsedFEMFunction<Output>::clone () const
 {
-  return std::unique_ptr<FEMFunctionBase<Output>>
-    (new ParsedFEMFunction(_sys, _expression, &_additional_vars, &_initial_vals));
+  return libmesh_make_unique<ParsedFEMFunction>
+    (_sys, _expression, &_additional_vars, &_initial_vals);
 }
 
 template <typename Output>

--- a/include/numerics/parsed_fem_function_parameter.h
+++ b/include/numerics/parsed_fem_function_parameter.h
@@ -24,6 +24,7 @@
 // Local Includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/parameter_accessor.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 namespace libMesh
 {
@@ -87,8 +88,7 @@ public:
    * \returns A new copy of the accessor.
    */
   virtual std::unique_ptr<ParameterAccessor<T>> clone() const {
-    return std::unique_ptr<ParameterAccessor<T>>
-      (new ParsedFEMFunctionParameter<T>(_func, _name));
+    return libmesh_make_unique<ParsedFEMFunctionParameter<T>>(_func, _name);
   }
 
 private:

--- a/include/numerics/parsed_function_parameter.h
+++ b/include/numerics/parsed_function_parameter.h
@@ -25,6 +25,7 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/parameter_accessor.h"
 #include "libmesh/parsed_function.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 namespace libMesh
 {
@@ -85,8 +86,7 @@ public:
    * \returns A new copy of the accessor.
    */
   virtual std::unique_ptr<ParameterAccessor<T>> clone() const {
-    return std::unique_ptr<ParameterAccessor<T>>
-      (new ParsedFunctionParameter<T>(_func, _name));
+    return libmesh_make_unique<ParsedFunctionParameter<T>>(_func, _name);
   }
 
 private:

--- a/include/numerics/trilinos_epetra_vector.h
+++ b/include/numerics/trilinos_epetra_vector.h
@@ -26,6 +26,7 @@
 // Local includes
 #include "libmesh/numeric_vector.h"
 #include "libmesh/parallel.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // Trilinos includes
 #include "libmesh/ignore_warnings.h"
@@ -498,10 +499,11 @@ EpetraVector<T>::EpetraVector(Epetra_Vector & v,
   myFirstID_ = _vec->Map().MinMyGID();
   myNumIDs_ = _vec->Map().NumMyElements();
 
-  _map.reset(new Epetra_Map(_vec->GlobalLength(),
-                            _vec->MyLength(),
-                            0, // IndexBase = 0 for C/C++, 1 for Fortran.
-                            Epetra_MpiComm (this->comm().get())));
+  _map = libmesh_make_unique<Epetra_Map>
+    (_vec->GlobalLength(),
+     _vec->MyLength(),
+     0, // IndexBase = 0 for C/C++, 1 for Fortran.
+     Epetra_MpiComm (this->comm().get()));
 
   //Currently we impose the restriction that NumVectors==1, so we won't
   //need the LDA argument when calling ExtractView. Hence the "dummy" arg.
@@ -590,10 +592,11 @@ void EpetraVector<T>::init (const numeric_index_type n,
   libmesh_assert ((this->_type==SERIAL && n==my_n_local) ||
                   this->_type==PARALLEL);
 
-  _map.reset(new Epetra_Map(static_cast<int>(n),
-                            my_n_local,
-                            0,
-                            Epetra_MpiComm (this->comm().get())));
+  _map = libmesh_make_unique<Epetra_Map>
+    (static_cast<int>(n),
+     my_n_local,
+     0,
+     Epetra_MpiComm (this->comm().get()));
 
   _vec = new Epetra_Vector(*_map);
 

--- a/include/numerics/wrapped_function.h
+++ b/include/numerics/wrapped_function.h
@@ -27,6 +27,7 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/point.h"
 #include "libmesh/system.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // C++ includes
 #include <cstddef>
@@ -135,9 +136,8 @@ inline
 std::unique_ptr<FunctionBase<Output>>
 WrappedFunction<Output>::clone () const
 {
-  return std::unique_ptr<FunctionBase<Output>>
-    (new WrappedFunction<Output>
-     (_sys, _fptr, _parameters, _varnum));
+  return libmesh_make_unique<WrappedFunction<Output>>
+    (_sys, _fptr, _parameters, _varnum);
 }
 
 

--- a/include/numerics/wrapped_functor.h
+++ b/include/numerics/wrapped_functor.h
@@ -24,6 +24,7 @@
 #include "libmesh/fem_function_base.h"
 #include "libmesh/function_base.h"
 #include "libmesh/point.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // C++ includes
 #include <cstddef>
@@ -69,8 +70,7 @@ public:
 
   virtual std::unique_ptr<FEMFunctionBase<Output>> clone () const override
   {
-    return std::unique_ptr<FEMFunctionBase<Output>>
-      (new WrappedFunctor<Output> (*_func));
+    return libmesh_make_unique<WrappedFunctor<Output>>(*_func);
   }
 
   virtual Output operator() (const FEMContext &,

--- a/include/parallel/parallel_algebra.h
+++ b/include/parallel/parallel_algebra.h
@@ -29,6 +29,7 @@
 #include "libmesh/point.h"
 #include "libmesh/tensor_value.h"
 #include "libmesh/vector_value.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // TIMPI includes
 #include "timpi/op_function.h"
@@ -65,7 +66,7 @@ public:
       ex = const_cast<TypeVector<T> *>(example);
     else
       {
-        temp.reset(new TypeVector<T>());
+        temp = libmesh_make_unique<TypeVector<T>>();
         ex = temp.get();
       }
 
@@ -128,7 +129,7 @@ public:
       ex = const_cast<VectorValue<T> *>(example);
     else
       {
-        temp.reset(new VectorValue<T>());
+        temp = libmesh_make_unique<VectorValue<T>>();
         ex = temp.get();
       }
 
@@ -200,7 +201,7 @@ public:
       ex = const_cast<Point *>(example);
     else
       {
-        temp.reset(new Point());
+        temp = libmesh_make_unique<Point>();
         ex = temp.get();
       }
 

--- a/include/partitioning/subdomain_partitioner.h
+++ b/include/partitioning/subdomain_partitioner.h
@@ -105,7 +105,7 @@ public:
    *
    * \code
    * SubdomainPartitioner sp;
-   * sp.internal_partitioner().reset(new SFCPartitioner);
+   * sp.internal_partitioner() = libmesh_make_unique<SFCPartitioner>();
    * \endcode
    */
   std::unique_ptr<Partitioner> & internal_partitioner() { return _internal_partitioner; }

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -36,6 +36,7 @@
 #include "libmesh/quadrature.h"
 #include "libmesh/system.h"
 #include "libmesh/threads.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // TIMPI includes
 #include "timpi/parallel_sync.h"
@@ -1095,7 +1096,7 @@ GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::SubProjector::Su
   SubFunctor(p)
 {
   if (p.master_g)
-    g.reset(new GFunctor(*p.master_g));
+    g = libmesh_make_unique<GFunctor>(*p.master_g);
 
 #ifndef NDEBUG
   // Our C1 elements need gradient information

--- a/m4/cxx11.m4
+++ b/m4/cxx11.m4
@@ -641,6 +641,7 @@ AC_DEFUN([LIBMESH_TEST_CXX11_SHARED_PTR],
         std::shared_ptr<int> p2 (new int);
         std::shared_ptr<int> p3 (p2);
         p3.reset(new int);
+        p3 = std::make_shared<int>(5);
     ]])],[
         have_cxx11_shared_ptr=yes
         AC_MSG_RESULT(yes)

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -42,6 +42,7 @@
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/sparsity_pattern.h"
 #include "libmesh/threads.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // TIMPI includes
 #include "timpi/parallel_implementation.h"
@@ -86,13 +87,13 @@ DofMap::build_sparsity (const MeshBase & mesh) const
   // Even better, if the full sparsity pattern is not needed then
   // the number of nonzeros per row can be estimated from the
   // sparsity patterns created on each thread.
-  std::unique_ptr<SparsityPattern::Build> sp
-    (new SparsityPattern::Build (mesh,
-                                 *this,
-                                 this->_dof_coupling,
-                                 this->_coupling_functors,
-                                 implicit_neighbor_dofs,
-                                 need_full_sparsity_pattern));
+  auto sp = libmesh_make_unique<SparsityPattern::Build>
+    (mesh,
+     *this,
+     this->_dof_coupling,
+     this->_coupling_functors,
+     implicit_neighbor_dofs,
+     need_full_sparsity_pattern);
 
   Threads::parallel_reduce (ConstElemRange (mesh.active_local_elements_begin(),
                                             mesh.active_local_elements_end()), *sp);
@@ -152,8 +153,8 @@ DofMap::DofMap(const unsigned int number,
   _augment_send_list(nullptr),
   _extra_send_list_function(nullptr),
   _extra_send_list_context(nullptr),
-  _default_coupling(new DefaultCoupling()),
-  _default_evaluating(new DefaultCoupling()),
+  _default_coupling(libmesh_make_unique<DefaultCoupling>()),
+  _default_evaluating(libmesh_make_unique<DefaultCoupling>()),
   need_full_sparsity_pattern(false),
   _n_nz(nullptr),
   _n_oz(nullptr),
@@ -175,10 +176,10 @@ DofMap::DofMap(const unsigned int number,
   , _node_constraints()
 #endif
 #ifdef LIBMESH_ENABLE_PERIODIC
-  , _periodic_boundaries(new PeriodicBoundaries)
+  , _periodic_boundaries(libmesh_make_unique<PeriodicBoundaries>())
 #endif
 #ifdef LIBMESH_ENABLE_DIRICHLET
-  , _dirichlet_boundaries(new DirichletBoundaries)
+  , _dirichlet_boundaries(libmesh_make_unique<DirichletBoundaries>())
   , _adjoint_dirichlet_boundaries()
 #endif
   , _implicit_neighbor_dofs_initialized(false),

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -28,6 +28,7 @@
 #include "libmesh/print_trace.h"
 #include "libmesh/enum_solver_package.h"
 #include "libmesh/perf_log.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // TIMPI includes
 #include "timpi/communicator.h"
@@ -341,7 +342,7 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
   libmesh_assert (!libMesh::initialized());
 
   // Build a command-line parser.
-  command_line.reset (new GetPot (argc, argv));
+  command_line = libmesh_make_unique<GetPot>(argc, argv);
 
   // Disable performance logging upon request
   {
@@ -386,7 +387,7 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
     omp_set_num_threads(libMesh::libMeshPrivateData::_n_threads);
 #endif
 
-    task_scheduler.reset (new Threads::task_scheduler_init(libMesh::n_threads()));
+    task_scheduler = libmesh_make_unique<Threads::task_scheduler_init>(libMesh::n_threads());
   }
 
   // Construct singletons who may be at risk of the
@@ -436,7 +437,7 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
               // anyway.
 
               // libMesh::libMeshPrivateData::_n_threads = 1;
-              // task_scheduler.reset (new Threads::task_scheduler_init(libMesh::n_threads()));
+              // task_scheduler = libmesh_make_unique<Threads::task_scheduler_init>(libMesh::n_threads());
             }
           libmesh_initialized_mpi = true;
         }
@@ -554,7 +555,7 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
   // plus we were doing it wrong for many years and not clearing the
   // existing GetPot object before re-parsing the command line, so all
   // the command line arguments appeared twice in the GetPot object...
-  command_line.reset (new GetPot (argc, argv));
+  command_line = libmesh_make_unique<GetPot>(argc, argv);
 
   // The following line is an optimization when simultaneous
   // C and C++ style access to output streams is not required.
@@ -617,7 +618,7 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
 
       std::ostringstream filename;
       filename << basename << ".processor." << libMesh::global_processor_id();
-      _ofstream.reset (new std::ofstream (filename.str().c_str()));
+      _ofstream = libmesh_make_unique<std::ofstream>(filename.str().c_str());
 
       // Redirect, saving the original streambufs!
       out_buf = libMesh::out.rdbuf (_ofstream->rdbuf());

--- a/src/error_estimation/adjoint_residual_error_estimator.C
+++ b/src/error_estimation/adjoint_residual_error_estimator.C
@@ -27,6 +27,7 @@
 #include "libmesh/qoi_set.h"
 #include "libmesh/enum_error_estimator_type.h"
 #include "libmesh/int_range.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // C++ includes
 #include <iostream>
@@ -41,8 +42,8 @@ namespace libMesh
 AdjointResidualErrorEstimator::AdjointResidualErrorEstimator () :
   ErrorEstimator(),
   error_plot_suffix(),
-  _primal_error_estimator(new PatchRecoveryErrorEstimator()),
-  _dual_error_estimator(new PatchRecoveryErrorEstimator()),
+  _primal_error_estimator(libmesh_make_unique<PatchRecoveryErrorEstimator>()),
+  _dual_error_estimator(libmesh_make_unique<PatchRecoveryErrorEstimator>()),
   _qoi_set(QoISet())
 {
 }

--- a/src/error_estimation/exact_error_estimator.C
+++ b/src/error_estimation/exact_error_estimator.C
@@ -39,6 +39,7 @@
 #include "libmesh/tensor_tools.h"
 #include "libmesh/enum_error_estimator_type.h"
 #include "libmesh/enum_norm_type.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 namespace libMesh
 {
@@ -258,11 +259,11 @@ void ExactErrorEstimator::estimate_error (const System & system,
              SERIAL);
           (*fine_soln) = global_soln;
 
-          fine_values = std::unique_ptr<MeshFunction>
-            (new MeshFunction(*_equation_systems_fine,
-                              *fine_soln,
-                              fine_system.get_dof_map(),
-                              fine_system.variable_number(var_name)));
+          fine_values = libmesh_make_unique<MeshFunction>
+            (*_equation_systems_fine,
+             *fine_soln,
+             fine_system.get_dof_map(),
+             fine_system.variable_number(var_name));
           fine_values->init();
         } else {
         // Initialize functors if we're using them

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -33,6 +33,7 @@
 #include "libmesh/tensor_tools.h"
 #include "libmesh/enum_norm_type.h"
 #include "libmesh/utility.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 namespace libMesh
 {
@@ -478,11 +479,11 @@ void ExactSolution::_compute_error(const std::string & sys_name,
       comparison_soln->init(comparison_system.solution->size(), true, SERIAL);
       (*comparison_soln) = global_soln;
 
-      coarse_values = std::unique_ptr<MeshFunction>
-        (new MeshFunction(_equation_systems,
-                          *comparison_soln,
-                          comparison_system.get_dof_map(),
-                          comparison_system.variable_number(unknown_name)));
+      coarse_values = libmesh_make_unique<MeshFunction>
+        (_equation_systems,
+         *comparison_soln,
+         comparison_system.get_dof_map(),
+         comparison_system.variable_number(unknown_name));
       coarse_values->init();
     }
 

--- a/src/error_estimation/jump_error_estimator.C
+++ b/src/error_estimation/jump_error_estimator.C
@@ -21,7 +21,6 @@
 #include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
 #include <cmath>    // for sqrt
 
-
 // Local Includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/jump_error_estimator.h"
@@ -38,6 +37,7 @@
 #include "libmesh/dense_vector.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/int_range.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 namespace libMesh
 {
@@ -139,8 +139,8 @@ void JumpErrorEstimator::estimate_error (const System & system,
       sys.update();
     }
 
-  fine_context.reset(new FEMContext(system));
-  coarse_context.reset(new FEMContext(system));
+  fine_context = libmesh_make_unique<FEMContext>(system);
+  coarse_context = libmesh_make_unique<FEMContext>(system);
 
   // Loop over all the variables we've been requested to find jumps in, to
   // pre-request

--- a/src/error_estimation/uniform_refinement_estimator.C
+++ b/src/error_estimation/uniform_refinement_estimator.C
@@ -21,7 +21,6 @@
 #include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
 #include <cmath>    // for sqrt
 
-
 // Local Includes
 #include "libmesh/dof_map.h"
 #include "libmesh/elem.h"
@@ -41,6 +40,7 @@
 #include "libmesh/enum_error_estimator_type.h"
 #include "libmesh/enum_norm_type.h"
 #include "libmesh/int_range.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 #ifdef LIBMESH_ENABLE_AMR
 
@@ -125,9 +125,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
   // Get a vector of the Systems we're going to work on,
   // and set up a error_norms map if necessary
   std::vector<System *> system_list;
-  std::unique_ptr<std::map<const System *, SystemNorm>> error_norms =
-    std::unique_ptr<std::map<const System *, SystemNorm>>
-    (new std::map<const System *, SystemNorm>);
+  auto error_norms = libmesh_make_unique<std::map<const System *, SystemNorm>>();
 
   if (_es)
     {

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -21,11 +21,13 @@
 #include "libmesh/libmesh_config.h"
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
 #include "libmesh/inf_fe.h"
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/elem.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/int_range.h"
+#include "libmesh/auto_ptr.h"
 
 namespace libMesh
 {
@@ -83,7 +85,7 @@ void InfFE<Dim,T_radial,T_map>::attach_quadrature_rule (QBase * q)
     }
 
   // in radial direction, always use Gauss quadrature
-  radial_qrule.reset(new QGauss(1, radial_int_order));
+  radial_qrule = libmesh_make_unique<QGauss>(1, radial_int_order);
 
   // Maybe helpful to store the QBase *
   // with which we initialized our own quadrature rules.

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -39,6 +39,7 @@
 #include "libmesh/dof_map.h"
 #include "libmesh/parallel.h"
 #include "libmesh/utility.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 namespace libMesh
 {
@@ -58,7 +59,7 @@ ExodusII_IO::ExodusII_IO (MeshBase & mesh,
                         /* serial_only_needed_on_proc_0 = */ true),
   ParallelObject(mesh),
 #ifdef LIBMESH_HAVE_EXODUS_API
-  exio_helper(new ExodusII_IO_Helper(*this, false, true, single_precision)),
+  exio_helper(libmesh_make_unique<ExodusII_IO_Helper>(*this, false, true, single_precision)),
   _timestep(1),
   _verbose(false),
   _append(false),

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -40,7 +40,7 @@
 #include "libmesh/threads.h"
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/enum_point_locator_type.h"
-
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 namespace libMesh
 {
@@ -68,7 +68,7 @@ MeshBase::MeshBase (const Parallel::Communicator & comm_in,
   _skip_renumber_nodes_and_elements(false),
   _allow_remote_element_removal(true),
   _spatial_dimension(d),
-  _default_ghosting(new GhostPointNeighbors(*this)),
+  _default_ghosting(libmesh_make_unique<GhostPointNeighbors>(*this)),
   _point_locator_close_to_point_tol(0.)
 {
   _elem_dims.insert(d);
@@ -99,7 +99,7 @@ MeshBase::MeshBase (const MeshBase & other_mesh) :
   _allow_remote_element_removal(true),
   _elem_dims(other_mesh._elem_dims),
   _spatial_dimension(other_mesh._spatial_dimension),
-  _default_ghosting(new GhostPointNeighbors(*this)),
+  _default_ghosting(libmesh_make_unique<GhostPointNeighbors>(*this)),
   _ghosting_functors(other_mesh._ghosting_functors),
   _point_locator_close_to_point_tol(other_mesh._point_locator_close_to_point_tol)
 {

--- a/src/mesh/mesh_tetgen_wrapper.C
+++ b/src/mesh/mesh_tetgen_wrapper.C
@@ -24,12 +24,13 @@
 // Local includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/mesh_tetgen_wrapper.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 namespace libMesh
 {
 
 TetGenWrapper::TetGenWrapper() :
-  tetgen_output(new tetgenio)
+  tetgen_output(libmesh_make_unique<tetgenio>())
 {
   this->tetgen_data.mesh_dim                = 3;
   this->tetgen_data.numberofpointattributes = 0;

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -35,6 +35,7 @@
 #include "libmesh/equation_systems.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/int_range.h"
+#include "libmesh/auto_ptr.h"
 
 namespace libMesh
 {
@@ -97,7 +98,7 @@ Nemesis_IO::Nemesis_IO (MeshBase & mesh,
   MeshOutput<MeshBase> (mesh, /*is_parallel_format=*/true),
   ParallelObject (mesh),
 #if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
-  nemhelper(new Nemesis_IO_Helper(*this, false, single_precision)),
+  nemhelper(libmesh_make_unique<Nemesis_IO_Helper>(*this, false, single_precision)),
   _timestep(1),
 #endif
   _verbose (false),

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -41,6 +41,7 @@
 #include "libmesh/fem_context.h"
 #include "libmesh/elem.h"
 #include "libmesh/int_range.h"
+#include "libmesh/auto_ptr.h"
 
 // rbOOmit includes
 #include "libmesh/rb_eim_construction.h"
@@ -177,10 +178,11 @@ void RBEIMConstruction::initialize_rb_construction(bool skip_matrix_assembly,
   // solution vector at quadrature points
   std::vector<unsigned int> vars;
   get_explicit_system().get_all_variable_numbers(vars);
-  _mesh_function.reset(new MeshFunction(get_equation_systems(),
-                                        *_ghosted_meshfunction_vector,
-                                        get_explicit_system().get_dof_map(),
-                                        vars));
+  _mesh_function = libmesh_make_unique<MeshFunction>
+    (get_equation_systems(),
+     *_ghosted_meshfunction_vector,
+     get_explicit_system().get_dof_map(),
+     vars);
   _mesh_function->init();
 
   // inner_product_solver performs solves with the same matrix every time

--- a/src/solution_transfer/meshfree_interpolation.C
+++ b/src/solution_transfer/meshfree_interpolation.C
@@ -26,7 +26,7 @@
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/parallel.h"
 #include "libmesh/parallel_algebra.h"
-
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 namespace libMesh
 {
@@ -159,9 +159,10 @@ void InverseDistanceInterpolation<KDDim>::construct_kd_tree ()
 
   // Initialize underlying KD tree
   if (_kd_tree.get() == nullptr)
-    _kd_tree.reset (new kd_tree_t (KDDim,
-                                   _point_list_adaptor,
-                                   nanoflann::KDTreeSingleIndexAdaptorParams(10 /* max leaf */)));
+    _kd_tree = libmesh_make_unique<kd_tree_t>
+      (KDDim,
+       _point_list_adaptor,
+       nanoflann::KDTreeSingleIndexAdaptorParams(10 /* max leaf */));
 
   libmesh_assert (_kd_tree.get() != nullptr);
 

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -38,6 +38,7 @@
 #include "libmesh/enum_preconditioner_type.h"
 #include "libmesh/enum_solver_type.h"
 #include "libmesh/enum_convergence_flags.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 namespace libMesh
 {
@@ -590,7 +591,7 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
 
       if (this->_preconditioner)
         {
-          subprecond_matrix.reset(new PetscMatrix<Number>(subprecond, this->comm()));
+          subprecond_matrix = libmesh_make_unique<PetscMatrix<Number>>(subprecond, this->comm());
           this->_preconditioner->set_matrix(*subprecond_matrix);
           this->_preconditioner->init();
         }
@@ -857,7 +858,7 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
 
       if (this->_preconditioner)
         {
-          subprecond_matrix.reset(new PetscMatrix<Number>(subprecond, this->comm()));
+          subprecond_matrix = libmesh_make_unique<PetscMatrix<Number>>(subprecond, this->comm());
           this->_preconditioner->set_matrix(*subprecond_matrix);
           this->_preconditioner->init();
         }
@@ -1424,7 +1425,7 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
 
       if (this->_preconditioner)
         {
-          subprecond_matrix.reset(new PetscMatrix<Number>(subprecond, this->comm()));
+          subprecond_matrix = libmesh_make_unique<PetscMatrix<Number>>(subprecond, this->comm());
           this->_preconditioner->set_matrix(*subprecond_matrix);
           this->_preconditioner->init();
         }

--- a/src/solvers/time_solver.C
+++ b/src/solvers/time_solver.C
@@ -20,11 +20,10 @@
 #include "libmesh/linear_solver.h"
 #include "libmesh/time_solver.h"
 #include "libmesh/no_solution_history.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 namespace libMesh
 {
-
-
 
 TimeSolver::TimeSolver (sys_type & s)
   : quiet (true),
@@ -32,7 +31,7 @@ TimeSolver::TimeSolver (sys_type & s)
     _diff_solver (),
     _linear_solver (),
     _system (s),
-    solution_history(new NoSolutionHistory()), // Default setting for solution_history
+    solution_history(libmesh_make_unique<NoSolutionHistory>()),
     _is_adjoint (false)
 {
 }

--- a/src/solvers/twostep_time_solver.C
+++ b/src/solvers/twostep_time_solver.C
@@ -20,6 +20,7 @@
 #include "libmesh/diff_system.h"
 #include "libmesh/euler_solver.h"
 #include "libmesh/numeric_vector.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 namespace libMesh
 {
@@ -31,7 +32,7 @@ TwostepTimeSolver::TwostepTimeSolver (sys_type & s)
 
 {
   // We start with a reasonable time solver: implicit Euler
-  core_time_solver.reset(new EulerSolver(s));
+  core_time_solver = libmesh_make_unique<EulerSolver>(s);
 }
 
 

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -39,6 +39,7 @@
 #include "libmesh/fe_type.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/fe_compute_data.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // includes for calculate_norm, point_*
 #include "libmesh/fe_base.h"
@@ -79,7 +80,7 @@ System::System (EquationSystems & es,
   _qoi_evaluate_object              (nullptr),
   _qoi_evaluate_derivative_function (nullptr),
   _qoi_evaluate_derivative_object   (nullptr),
-  _dof_map                          (new DofMap(number_in, es.get_mesh())),
+  _dof_map                          (libmesh_make_unique<DofMap>(number_in, es.get_mesh())),
   _equation_systems                 (es),
   _mesh                             (es.get_mesh()),
   _sys_name                         (name_in),

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -28,12 +28,11 @@
 #include "libmesh/libmesh_version.h"
 #include "libmesh/system.h"
 #include "libmesh/mesh_base.h"
-//#include "libmesh/mesh_tools.h"
 #include "libmesh/elem.h"
 #include "libmesh/xdr_cxx.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/dof_map.h"
-
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 
 // Anonymous namespace for implementation details.
@@ -2072,7 +2071,7 @@ std::size_t System::write_serialized_blocked_dof_objects (const std::vector<cons
 
           // output_vals buffer is now filled for this block.
           // write it to disk
-          async_io.reset(new Threads::Thread(threaded_io));
+          async_io = libmesh_make_unique<Threads::Thread>(threaded_io);
           written_length += output_vals.size();
         }
 

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -33,7 +33,7 @@
 # include "gzstream.h" // For reading/writing compressed streams
 # include "libmesh/restore_warnings.h"
 #endif
-
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // Anonymous namespace for implementation details.
 namespace {
@@ -176,7 +176,7 @@ void Xdr::open (const std::string & name)
         fp = fopen(name.c_str(), (mode == ENCODE) ? "w" : "r");
         if (!fp)
           libmesh_file_error(name.c_str());
-        xdrs.reset(new XDR);
+        xdrs = libmesh_make_unique<XDR>();
         xdrstdio_create (xdrs.get(), fp, (mode == ENCODE) ? XDR_ENCODE : XDR_DECODE);
 #else
 

--- a/tests/base/overlapping_coupling_test.C
+++ b/tests/base/overlapping_coupling_test.C
@@ -12,7 +12,7 @@
 #include <libmesh/mesh_modification.h>
 #include <libmesh/partitioner.h>
 #include <libmesh/sparse_matrix.h>
-
+#include <libmesh/auto_ptr.h> // libmesh_make_unique
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"
@@ -240,7 +240,7 @@ protected:
     // We are making assumptions in various places about the presence
     // of the elements on the current processor so we're restricting to
     // ReplicatedMesh for now.
-    _mesh.reset(new ReplicatedMesh(*TestCommWorld));
+    _mesh = libmesh_make_unique<ReplicatedMesh>(*TestCommWorld);
 
     _mesh->set_mesh_dimension(2);
 
@@ -288,7 +288,7 @@ protected:
       elem->set_node(3) = _mesh->node_ptr(9);
     }
 
-    _mesh->partitioner() = std::unique_ptr<Partitioner>(new OverlappingTestPartitioner);
+    _mesh->partitioner() = libmesh_make_unique<OverlappingTestPartitioner>();
 
     _mesh->prepare_for_use();
 
@@ -303,7 +303,7 @@ protected:
 
   void init(MeshBase & mesh)
   {
-    _es.reset( new EquationSystems(*_mesh) );
+    _es = libmesh_make_unique<EquationSystems>(*_mesh);
     LinearImplicitSystem & sys = _es->add_system<LinearImplicitSystem> ("SimpleSystem");
 
     std::set<subdomain_id_type> sub_one;
@@ -331,8 +331,7 @@ protected:
   {
     System & system = _es->get_system("SimpleSystem");
 
-
-    coupling.reset( new CouplingMatrix(system.n_vars()) );
+    coupling = libmesh_make_unique<CouplingMatrix>(system.n_vars());
 
     const unsigned int u_var = system.variable_number("U");
     const unsigned int l_var = system.variable_number("L");

--- a/tests/mesh/boundary_mesh.C
+++ b/tests/mesh/boundary_mesh.C
@@ -3,6 +3,7 @@
 #include <libmesh/mesh_refinement.h>
 #include <libmesh/remote_elem.h>
 #include <libmesh/replicated_mesh.h>
+#include <libmesh/auto_ptr.h> // libmesh_make_unique
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"
@@ -33,10 +34,10 @@ protected:
 
   void build_mesh()
   {
-    _mesh.reset(new Mesh(*TestCommWorld));
-    _all_boundary_mesh.reset(new Mesh(*TestCommWorld));
-    _left_boundary_mesh.reset(new Mesh(*TestCommWorld));
-    _internal_boundary_mesh.reset(new Mesh(*TestCommWorld));
+    _mesh = libmesh_make_unique<Mesh>(*TestCommWorld);
+    _all_boundary_mesh = libmesh_make_unique<Mesh>(*TestCommWorld);
+    _left_boundary_mesh = libmesh_make_unique<Mesh>(*TestCommWorld);
+    _internal_boundary_mesh = libmesh_make_unique<Mesh>(*TestCommWorld);
 
     MeshTools::Generation::build_square(*_mesh, 3, 5,
                                         0.2, 0.8, 0.2, 0.7, QUAD9);

--- a/tests/numerics/parsed_fem_function_test.C
+++ b/tests/numerics/parsed_fem_function_test.C
@@ -6,6 +6,7 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/parsed_fem_function.h"
 #include "libmesh/system.h"
+#include <libmesh/auto_ptr.h> // libmesh_make_unique
 
 #ifdef LIBMESH_HAVE_FPARSER
 
@@ -24,9 +25,9 @@ class ParsedFEMFunctionTest : public CppUnit::TestCase
 public:
   void setUp() {
 #if LIBMESH_DIM > 2
-    mesh.reset(new Mesh(*TestCommWorld));
+    mesh = libmesh_make_unique<Mesh>(*TestCommWorld);
     MeshTools::Generation::build_cube(*mesh, 1, 1, 1);
-    es.reset(new EquationSystems(*mesh));
+    es = libmesh_make_unique<EquationSystems>(*mesh);
     sys = &(es->add_system<System> ("SimpleSystem"));
     sys->add_variable("x2");
     sys->add_variable("x3");
@@ -86,8 +87,8 @@ public:
     sol.close();
     sys->update();
 
-    c.reset(new FEMContext(*sys));
-    s.reset(new FEMContext(*sys));
+    c = libmesh_make_unique<FEMContext>(*sys);
+    s = libmesh_make_unique<FEMContext>(*sys);
     if (elem && elem->processor_id() == TestCommWorld->rank())
       {
         c->pre_fe_reinit(*sys, elem);

--- a/tests/solvers/time_solver_test_common.h
+++ b/tests/solvers/time_solver_test_common.h
@@ -4,6 +4,7 @@
 #include <libmesh/enum_solver_type.h>
 #include <libmesh/enum_preconditioner_type.h>
 #include <libmesh/parallel.h>
+#include <libmesh/auto_ptr.h> // libmesh_make_unique
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"
@@ -30,7 +31,7 @@ protected:
     EquationSystems es(mesh);
     SystemType & system = es.add_system<SystemType>("ScalarSystem");
 
-    system.time_solver.reset(new TimeSolverType(system));
+    system.time_solver = libmesh_make_unique<TimeSolverType>(system);
 
     es.init();
 


### PR DESCRIPTION
I came across one of these while working on something else, so I fixed as many others as I could find. There are some [technical reasons](https://stackoverflow.com/a/41001856/659433) to prefer `std::make_unique` to calling `new` directly, but mainly I think it's just cleaner, more expressive code. It will also be easy to replace these calls with `std::make_unique` later, once we require C++14.
