### PR TITLE
Fix mesh reference in VTKIO write

### DIFF
--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -266,7 +266,7 @@ void VTKIO::write_nodal_data (const std::string & fname,
     libmesh_error_msg("Empty soln vector in VTKIO::write_nodal_data().");
 
   // Get a reference to the mesh
-  MeshBase & mesh = MeshInput<MeshBase>::mesh();
+  const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
 
   // we only use Unstructured grids
   _vtk_grid = vtkSmartPointer<vtkUnstructuredGrid>::New();


### PR DESCRIPTION
If the "writing" constructor is used, MeshInput has an empty pointer to mesh. Calling write_nodal_data then causes dereferencing null pointer. Should be fine to use the const mesh reference from MeshOutput.