### PR TITLE
More range for loops

### DIFF
--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -22,6 +22,7 @@
 
 // Local includes
 #include "libmesh/id_types.h"
+#include "libmesh/int_range.h"
 #include "libmesh/libmesh_config.h"
 #include "libmesh/libmesh_common.h"
 #include "libmesh/libmesh.h" // libMesh::invalid_uint
@@ -688,17 +689,18 @@ DofObject::~DofObject ()
 inline
 void DofObject::invalidate_dofs (const unsigned int sys_num)
 {
+  const unsigned int n_sys = this->n_systems();
   // If the user does not specify the system number...
-  if (sys_num >= this->n_systems())
+  if (sys_num >= n_sys)
     {
-      for (unsigned int s=0; s<this->n_systems(); s++)
-        for (unsigned int vg=0; vg<this->n_var_groups(s); vg++)
+      for (auto s : IntRange<unsigned int>(0, n_sys))
+        for (auto vg : IntRange<unsigned int>(0, this->n_var_groups(s)))
           if (this->n_comp_group(s,vg))
             this->set_vg_dof_base(s,vg,invalid_id);
     }
   // ...otherwise invalidate the dofs for all systems
   else
-    for (unsigned int vg=0; vg<this->n_var_groups(sys_num); vg++)
+    for (auto vg : IntRange<unsigned int>(0, this->n_var_groups(sys_num)))
       if (this->n_comp_group(sys_num,vg))
         this->set_vg_dof_base(sys_num,vg,invalid_id);
 }
@@ -749,7 +751,7 @@ unsigned int DofObject::n_dofs (const unsigned int s,
 
   // Count all variables
   if (var == libMesh::invalid_uint)
-    for (unsigned int v=0; v<this->n_vars(s); v++)
+    for (auto v : IntRange<unsigned int>(0, this->n_vars(s)))
       num += this->n_comp(s,v);
 
   // Only count specified variable
@@ -1137,7 +1139,7 @@ bool DofObject::has_dofs (const unsigned int sys) const
 {
   if (sys == libMesh::invalid_uint)
     {
-      for (unsigned int s=0; s<this->n_systems(); s++)
+      for (auto s : IntRange<unsigned int>(0, this->n_systems()))
         if (this->n_vars(s))
           return true;
     }
@@ -1237,8 +1239,8 @@ dof_id_type DofObject::vg_dof_base(const unsigned int s,
 
   // #ifdef DEBUG
   //   std::cout << " [ ";
-  //   for (std:size_t i=0; i<_idx_buf.size(); i++)
-  //     std::cout << _idx_buf[i] << " ";
+  //   for (auto i : _idx_buf)
+  //     std::cout << i << " ";
   //   std::cout << "]\n";
   // #endif
 

--- a/include/base/multi_predicates.h
+++ b/include/base/multi_predicates.h
@@ -59,16 +59,16 @@ struct abstract_multi_predicate : multi_predicate
   virtual ~abstract_multi_predicate()
   {
     // Clean-up vector
-    for (std::size_t i=0; i<_predicates.size(); ++i)
-      delete _predicates[i];
+    for (auto p : _predicates)
+      delete p;
   }
 
   // operator= (perform deep copy of entries in _predicates vector
   abstract_multi_predicate & operator=(const abstract_multi_predicate & rhs)
   {
     // First clear out the predicates vector
-    for (std::size_t i=0; i<_predicates.size(); ++i)
-      delete _predicates[i];
+    for (auto p : _predicates)
+      delete p;
 
     // Now copy over the information from the rhs.
     this->deep_copy(rhs);
@@ -79,10 +79,8 @@ struct abstract_multi_predicate : multi_predicate
   // operator() checks all the predicates in the vector.
   virtual bool operator()(const T & it) const
   {
-    for (std::size_t i=0; i<_predicates.size(); ++i)
+    for (const auto pred : _predicates)
       {
-        const predicate<T> * pred = _predicates[i];
-
         libmesh_assert (pred);
 
         if (!(*pred)(it))
@@ -107,8 +105,8 @@ protected:
   // copy constructor for the predicate class.
   void deep_copy(const abstract_multi_predicate & rhs)
   {
-    for (std::size_t i=0; i<rhs._predicates.size(); ++i)
-      _predicates.push_back(rhs._predicates[i]->clone());
+    for (auto p : rhs._predicates)
+      _predicates.push_back(p->clone());
   }
 
   // Predicates to be evaluated.

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -1988,7 +1988,7 @@ dof_id_type Elem::node_id (const unsigned int i) const
 inline
 unsigned int Elem::local_node (const dof_id_type i) const
 {
-  for (unsigned int n=0; n != this->n_nodes(); ++n)
+  for (auto n : IntRange<unsigned int>(0, this->n_nodes()))
     if (this->node_id(n) == i)
       return n;
 
@@ -2046,7 +2046,7 @@ Node & Elem::node_ref (const unsigned int i)
 inline
 unsigned int Elem::get_node_index (const Node * node_ptr) const
 {
-  for (unsigned int n=0; n != this->n_nodes(); ++n)
+  for (auto n : IntRange<unsigned int>(0, this->n_nodes()))
     if (this->_nodes[n] == node_ptr)
       return n;
 
@@ -2332,7 +2332,7 @@ unsigned int Elem::which_neighbor_am_i (const Elem * e) const
       libmesh_assert(eparent);
     }
 
-  for (unsigned int s=0, n_s = this->n_sides(); s != n_s; ++s)
+  for (auto s : IntRange<unsigned int>(0, this->n_sides()))
     if (this->neighbor_ptr(s) == eparent)
       return s;
 

--- a/include/mesh/sync_refinement_flags.h
+++ b/include/mesh/sync_refinement_flags.h
@@ -28,6 +28,7 @@
 
 // libMesh includes
 #include "libmesh/elem.h"
+#include "libmesh/int_range.h"
 #include "libmesh/mesh_base.h"
 
 // C++ includes
@@ -61,7 +62,7 @@ struct SyncRefinementFlags
   {
     flags.resize(ids.size());
 
-    for (std::size_t i=0; i != ids.size(); ++i)
+    for (auto i : index_range(ids))
       {
         // Look for this element in the mesh
         // We'd better find every element we're asked for
@@ -75,7 +76,7 @@ struct SyncRefinementFlags
   void act_on_data (const std::vector<dof_id_type> & ids,
                     const std::vector<datum> & flags)
   {
-    for (std::size_t i=0; i != ids.size(); ++i)
+    for (auto i : index_range(ids))
       {
         Elem & elem = mesh.elem_ref(ids[i]);
 

--- a/include/numerics/composite_fem_function.h
+++ b/include/numerics/composite_fem_function.h
@@ -21,6 +21,7 @@
 // libMesh includes
 #include "libmesh/dense_vector.h"
 #include "libmesh/fem_function_base.h"
+#include "libmesh/int_range.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/point.h"
 
@@ -87,7 +88,7 @@ public:
         (max_index+1, std::make_pair(libMesh::invalid_uint,
                                      libMesh::invalid_uint));
 
-    for (std::size_t j=0; j != index_map.size(); ++j)
+    for (auto j : index_range(index_map))
       {
         libmesh_assert_less(index_map[j], reverse_index_map.size());
         libmesh_assert_equal_to(reverse_index_map[index_map[j]].first,
@@ -119,11 +120,11 @@ public:
     output.zero();
 
     DenseVector<Output> temp;
-    for (std::size_t i=0; i != subfunctions.size(); ++i)
+    for (auto i : index_range(subfunctions))
       {
         temp.resize(cast_int<unsigned int>(index_maps[i].size()));
         (*subfunctions[i])(c, p, time, temp);
-        for (unsigned int j=0; j != temp.size(); ++j)
+        for (auto j : index_range(temp))
           output(index_maps[i][j]) = temp(j);
       }
   }
@@ -148,7 +149,7 @@ public:
   virtual std::unique_ptr<FEMFunctionBase<Output>> clone() const override
   {
     CompositeFEMFunction * returnval = new CompositeFEMFunction();
-    for (std::size_t i=0; i != subfunctions.size(); ++i)
+    for (auto i : index_range(subfunctions))
       returnval->attach_subfunction(*subfunctions[i], index_maps[i]);
     return std::unique_ptr<FEMFunctionBase<Output>> (returnval);
   }

--- a/include/numerics/composite_function.h
+++ b/include/numerics/composite_function.h
@@ -21,6 +21,7 @@
 // libMesh includes
 #include "libmesh/dense_vector.h"
 #include "libmesh/function_base.h"
+#include "libmesh/int_range.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/point.h"
 
@@ -96,7 +97,7 @@ public:
         (max_index+1, std::make_pair(libMesh::invalid_uint,
                                      libMesh::invalid_uint));
 
-    for (std::size_t j=0; j != index_map.size(); ++j)
+    for (auto j : index_range(index_map))
       {
         libmesh_assert_less(index_map[j], reverse_index_map.size());
         libmesh_assert_equal_to(reverse_index_map[index_map[j]].first,
@@ -140,11 +141,11 @@ public:
     output.zero();
 
     DenseVector<Output> temp;
-    for (std::size_t i=0; i != subfunctions.size(); ++i)
+    for (auto i : index_range(subfunctions))
       {
         temp.resize(cast_int<unsigned int>(index_maps[i].size()));
         (*subfunctions[i])(p, time, temp);
-        for (unsigned int j=0; j != temp.size(); ++j)
+        for (auto j : index_range(temp))
           output(index_maps[i][j]) = temp(j);
       }
   }
@@ -168,7 +169,7 @@ public:
   virtual std::unique_ptr<FunctionBase<Output>> clone() const override
   {
     CompositeFunction * returnval = new CompositeFunction();
-    for (std::size_t i=0; i != subfunctions.size(); ++i)
+    for (auto i : index_range(subfunctions))
       returnval->attach_subfunction(*subfunctions[i], index_maps[i]);
     return std::unique_ptr<FunctionBase<Output>> (returnval);
   }

--- a/include/numerics/const_fem_function.h
+++ b/include/numerics/const_fem_function.h
@@ -21,6 +21,7 @@
 // libMesh includes
 #include "libmesh/dense_vector.h"
 #include "libmesh/fem_function_base.h"
+#include "libmesh/int_range.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // C++ includes
@@ -68,7 +69,7 @@ public:
                            const Real,
                            DenseVector<Output> & output)
   {
-    for (unsigned int i = 0; i < output.size(); i++)
+    for (auto i : index_range(output))
       output(i) = _c;
   }
 

--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -23,6 +23,7 @@
 // Local Includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/dense_matrix_base.h"
+#include "libmesh/int_range.h"
 
 // For the definition of PetscBLASInt.
 #if (LIBMESH_HAVE_PETSC)
@@ -911,8 +912,8 @@ template<typename T>
 inline
 void DenseMatrix<T>::scale (const T factor)
 {
-  for (std::size_t i=0; i<_val.size(); i++)
-    _val[i] *= factor;
+  for (auto & v : _val)
+    v *= factor;
 }
 
 
@@ -920,7 +921,7 @@ template<typename T>
 inline
 void DenseMatrix<T>::scale_column (const unsigned int col, const T factor)
 {
-  for (unsigned int i=0; i<this->m(); i++)
+  for (auto i : IntRange<unsigned int>(0, this->m()))
     (*this)(i, col) *= factor;
 }
 
@@ -947,8 +948,8 @@ DenseMatrix<T>::add (const T2 factor,
   libmesh_assert_equal_to (this->m(), mat.m());
   libmesh_assert_equal_to (this->n(), mat.n());
 
-  for (unsigned int i=0; i<this->m(); i++)
-    for (unsigned int j=0; j<this->n(); j++)
+  for (auto i : IntRange<unsigned int>(0, this->m()))
+    for (auto j : IntRange<unsigned int>(0, this->n()))
       (*this)(i,j) += factor * mat(i,j);
 }
 
@@ -958,7 +959,7 @@ template<typename T>
 inline
 bool DenseMatrix<T>::operator == (const DenseMatrix<T> & mat) const
 {
-  for (std::size_t i=0; i<_val.size(); i++)
+  for (auto i : index_range(_val))
     if (_val[i] != mat._val[i])
       return false;
 
@@ -971,7 +972,7 @@ template<typename T>
 inline
 bool DenseMatrix<T>::operator != (const DenseMatrix<T> & mat) const
 {
-  for (std::size_t i=0; i<_val.size(); i++)
+  for (auto i : index_range(_val))
     if (_val[i] != mat._val[i])
       return true;
 
@@ -984,7 +985,7 @@ template<typename T>
 inline
 DenseMatrix<T> & DenseMatrix<T>::operator += (const DenseMatrix<T> & mat)
 {
-  for (std::size_t i=0; i<_val.size(); i++)
+  for (auto i : index_range(_val))
     _val[i] += mat._val[i];
 
   return *this;
@@ -996,7 +997,7 @@ template<typename T>
 inline
 DenseMatrix<T> & DenseMatrix<T>::operator -= (const DenseMatrix<T> & mat)
 {
-  for (std::size_t i=0; i<_val.size(); i++)
+  for (auto i : index_range(_val))
     _val[i] -= mat._val[i];
 
   return *this;
@@ -1126,14 +1127,14 @@ T DenseMatrix<T>::transpose (const unsigned int i,
 
 //   // move the known value into the RHS
 //   // and zero the column
-//   for (unsigned int i=0; i<this->m(); i++)
+//   for (auto i : IntRange<unsigned int>(0, this->m()))
 //     {
 //       rhs(i) -= ((*this)(i,jv))*val;
 //       (*this)(i,jv) = 0.;
 //     }
 
 //   // zero the row
-//   for (unsigned int j=0; j<this->n(); j++)
+//   for (auto j : IntRange<unsigned int>(0, this->n()))
 //     (*this)(iv,j) = 0.;
 
 //   (*this)(iv,jv) = 1.;

--- a/include/numerics/dense_matrix_base.h
+++ b/include/numerics/dense_matrix_base.h
@@ -23,6 +23,7 @@
 // Local Includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/compare_types.h"
+#include "libmesh/int_range.h"
 
 // C++ includes
 
@@ -197,8 +198,8 @@ DenseMatrixBase<T>::add (const T2 factor,
   libmesh_assert_equal_to (this->m(), mat.m());
   libmesh_assert_equal_to (this->n(), mat.n());
 
-  for (unsigned int j=0; j<this->n(); j++)
-    for (unsigned int i=0; i<this->m(); i++)
+  for (auto j : IntRange<unsigned int>(0, this->n()))
+    for (auto i : IntRange<unsigned int>(0, this->m()))
       this->el(i,j) += factor*mat.el(i,j);
 }
 

--- a/include/numerics/dense_matrix_base_impl.h
+++ b/include/numerics/dense_matrix_base_impl.h
@@ -24,6 +24,7 @@
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector_base.h"
 #include "libmesh/dense_vector.h"
+#include "libmesh/int_range.h"
 
 // C++ includes
 #include <iomanip> // for std::setw()
@@ -80,14 +81,14 @@ namespace libMesh
 
     // move the known value into the RHS
     // and zero the column
-    for (unsigned int i=0; i<this->m(); i++)
+    for (auto i : IntRange<unsigned int>(0, this->m()))
       {
         rhs.el(i) -= this->el(i,jv)*val;
         this->el(i,jv) = 0.;
       }
 
     // zero the row
-    for (unsigned int j=0; j<this->n(); j++)
+    for (auto j : IntRange<unsigned int>(0, this->n()))
       this->el(iv,j) = 0.;
 
     this->el(iv,jv) = 1.;
@@ -103,9 +104,9 @@ namespace libMesh
     std::ios_base::fmtflags os_flags = os.flags();
 
     // Print the matrix entries.
-    for (unsigned int i=0; i<this->m(); i++)
+    for (auto i : IntRange<unsigned int>(0, this->m()))
       {
-        for (unsigned int j=0; j<this->n(); j++)
+        for (auto j : IntRange<unsigned int>(0, this->n()))
           os << std::setw(15)
              << std::scientific
              << std::setprecision(precision)
@@ -123,9 +124,9 @@ namespace libMesh
   template<typename T>
   void DenseMatrixBase<T>::print (std::ostream & os) const
   {
-    for (unsigned int i=0; i<this->m(); i++)
+    for (auto i : IntRange<unsigned int>(0, this->m()))
       {
-        for (unsigned int j=0; j<this->n(); j++)
+        for (auto j : IntRange<unsigned int>(0, this->n()))
           os << std::setw(8)
              << this->el(i,j) << " ";
 

--- a/include/numerics/dense_matrix_impl.h
+++ b/include/numerics/dense_matrix_impl.h
@@ -26,6 +26,7 @@
 // Local Includes
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
+#include "libmesh/int_range.h"
 #include "libmesh/libmesh.h"
 
 #ifdef LIBMESH_HAVE_METAPHYSICL
@@ -612,8 +613,8 @@ void DenseMatrix<T>::get_transpose (DenseMatrix<T> & dest) const
 {
   dest.resize(this->n(), this->m());
 
-  for (unsigned int i=0; i<dest.m(); i++)
-    for (unsigned int j=0; j<dest.n(); j++)
+  for (auto i : IntRange<unsigned int>(0, dest.m()))
+    for (auto j : IntRange<unsigned int>(0, dest.n()))
       dest(i,j) = (*this)(j,i);
 }
 
@@ -915,7 +916,7 @@ T DenseMatrix<T>::det ()
   // the power (of 10) of the determinant in a separate variable
   // and maintain an order 1 value for the determinant itself.
   unsigned int n_interchanges = 0;
-  for (unsigned int i=0; i<this->m(); i++)
+  for (auto i : IntRange<unsigned int>(0, this->m()))
     {
       if (this->_decomposition_type==LU)
         if (_pivots[i] != static_cast<pivot_index_t>(i))

--- a/include/numerics/dense_submatrix.h
+++ b/include/numerics/dense_submatrix.h
@@ -24,6 +24,7 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_subvector.h"
+#include "libmesh/int_range.h"
 
 // C++ includes
 
@@ -190,8 +191,8 @@ template<typename T>
 inline
 void DenseSubMatrix<T>::zero()
 {
-  for (unsigned int i=0; i<this->m(); i++)
-    for (unsigned int j=0; j<this->n(); j++)
+  for (auto i : IntRange<unsigned int>(0, this->m()))
+    for (auto j : IntRange<unsigned int>(0, this->n()))
       _parent_matrix(i + this->i_off(),
                      j + this->j_off()) = 0.;
 }

--- a/include/numerics/dense_subvector.h
+++ b/include/numerics/dense_subvector.h
@@ -23,6 +23,7 @@
 // Local Includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/dense_vector.h"
+#include "libmesh/int_range.h"
 
 // C++ includes
 
@@ -186,7 +187,7 @@ template<typename T>
 inline
 void DenseSubVector<T>::zero()
 {
-  for (unsigned int i=0; i<this->size(); i++)
+  for (auto i : index_range(*this))
     _parent_vector (i + this->i_off()) = 0.;
 }
 
@@ -220,7 +221,7 @@ Real DenseSubVector<T>::min () const
   libmesh_assert (this->size());
   Real my_min = libmesh_real(_parent_vector (this->i_off()));
 
-  for (unsigned int i=1; i!=this->size(); i++)
+  for (auto i : IntRange<unsigned int>(1, this->size()))
     {
       Real current = libmesh_real(_parent_vector (i + this->i_off()));
       my_min = (my_min < current? my_min : current);
@@ -237,7 +238,7 @@ Real DenseSubVector<T>::max () const
   libmesh_assert (this->size());
   Real my_max = libmesh_real(_parent_vector (this->i_off()));
 
-  for (unsigned int i=1; i!=this->size(); i++)
+  for (auto i : IntRange<unsigned int>(1, this->size()))
     {
       Real current = libmesh_real(_parent_vector (i + this->i_off()));
       my_max = (my_max > current? my_max : current);
@@ -252,7 +253,7 @@ inline
 Real DenseSubVector<T>::l1_norm () const
 {
   Real my_norm = 0.;
-  for (unsigned int i=0; i!=this->size(); i++)
+  for (auto i : index_range(*this))
     {
       my_norm += std::abs(_parent_vector (i + this->i_off()));
     }
@@ -266,7 +267,7 @@ inline
 Real DenseSubVector<T>::l2_norm () const
 {
   Real my_norm = 0.;
-  for (unsigned int i=0; i!=this->size(); i++)
+  for (auto i : index_range(*this))
     {
       my_norm += TensorTools::norm_sq(_parent_vector (i + this->i_off()));
     }
@@ -283,7 +284,7 @@ Real DenseSubVector<T>::linfty_norm () const
     return 0.;
   Real my_norm = TensorTools::norm_sq(_parent_vector (this->i_off()));
 
-  for (unsigned int i=1; i!=this->size(); i++)
+  for (auto i : IntRange<unsigned int>(1, this->size()))
     {
       Real current = TensorTools::norm_sq(_parent_vector (i + this->i_off()));
       my_norm = (my_norm > current? my_norm : current);

--- a/include/numerics/distributed_vector.h
+++ b/include/numerics/distributed_vector.h
@@ -25,6 +25,7 @@
 #define LIBMESH_DISTRIBUTED_VECTOR_H
 
 // Local includes
+#include "libmesh/int_range.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/parallel.h"
 
@@ -357,7 +358,7 @@ void DistributedVector<T>::init (const numeric_index_type n,
 
   // _first_local_index is the sum of _local_size
   // for all processor ids less than ours
-  for (processor_id_type p=0; p!=this->processor_id(); p++)
+  for (auto p : IntRange<processor_id_type>(0, this->processor_id()))
     _first_local_index += local_sizes[p];
 
 
@@ -366,7 +367,7 @@ void DistributedVector<T>::init (const numeric_index_type n,
   // size, otherwise there is big trouble!
   numeric_index_type dbg_sum=0;
 
-  for (processor_id_type p=0; p!=this->n_processors(); p++)
+  for (auto p : IntRange<processor_id_type>(0, this->n_processors()))
     dbg_sum += local_sizes[p];
 
   libmesh_assert_equal_to (dbg_sum, n);
@@ -602,10 +603,9 @@ Real DistributedVector<T>::min () const
   libmesh_assert_equal_to (_values.size(), _local_size);
   libmesh_assert_equal_to ((_last_local_index - _first_local_index), _local_size);
 
-  Real local_min = _values.size() ?
-    libmesh_real(_values[0]) : std::numeric_limits<Real>::max();
-  for (numeric_index_type i = 1; i < _values.size(); ++i)
-    local_min = std::min(libmesh_real(_values[i]), local_min);
+  Real local_min = std::numeric_limits<Real>::max();
+  for (auto v : _values)
+    local_min = std::min(libmesh_real(v), local_min);
 
   this->comm().min(local_min);
 
@@ -625,10 +625,9 @@ Real DistributedVector<T>::max() const
   libmesh_assert_equal_to (_values.size(), _local_size);
   libmesh_assert_equal_to ((_last_local_index - _first_local_index), _local_size);
 
-  Real local_max = _values.size() ?
-    libmesh_real(_values[0]) : -std::numeric_limits<Real>::max();
-  for (numeric_index_type i = 1; i < _values.size(); ++i)
-    local_max = std::max(libmesh_real(_values[i]), local_max);
+  Real local_max = -std::numeric_limits<Real>::max();
+  for (auto v : _values)
+    local_max = std::max(libmesh_real(v), local_max);
 
   this->comm().max(local_max);
 

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -24,6 +24,7 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/enum_parallel_type.h"
 #include "libmesh/id_types.h"
+#include "libmesh/int_range.h"
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/parallel_object.h"
@@ -917,7 +918,7 @@ void NumericVector<Complex>::print(std::ostream & os) const
 
   // std::complex<>::operator<<() is defined, but use this form
   os << "#\tReal part\t\tImaginary part" << std::endl;
-  for (numeric_index_type i=this->first_local_index(); i<this->last_local_index(); i++)
+  for (auto i : index_range(*this))
     os << i << "\t"
        << (*this)(i).real() << "\t\t"
        << (*this)(i).imag() << std::endl;
@@ -934,7 +935,7 @@ void NumericVector<T>::print(std::ostream & os) const
      << "\t\tlocal =  " << this->local_size() << std::endl;
 
   os << "#\tValue" << std::endl;
-  for (numeric_index_type i=this->first_local_index(); i<this->last_local_index(); i++)
+  for (auto i : index_range(*this))
     os << i << "\t" << (*this)(i) << std::endl;
 }
 
@@ -955,7 +956,7 @@ void NumericVector<Complex>::print_global(std::ostream & os) const
 
   os << "Size\tglobal =  " << this->size() << std::endl;
   os << "#\tReal part\t\tImaginary part" << std::endl;
-  for (numeric_index_type i=0; i!=v.size(); i++)
+  for (auto i : IntRange<numeric_index_type>(0, v.size()))
     os << i << "\t"
        << v[i].real() << "\t\t"
        << v[i].imag() << std::endl;
@@ -977,7 +978,7 @@ void NumericVector<T>::print_global(std::ostream & os) const
 
   os << "Size\tglobal =  " << this->size() << std::endl;
   os << "#\tValue" << std::endl;
-  for (numeric_index_type i=0; i!=v.size(); i++)
+  for (auto i : IntRange<numeric_index_type>(0, v.size()))
     os << i << "\t" << v[i] << std::endl;
 }
 

--- a/include/numerics/parsed_fem_function.h
+++ b/include/numerics/parsed_fem_function.h
@@ -24,6 +24,7 @@
 
 // Local Includes
 #include "libmesh/fem_function_base.h"
+#include "libmesh/int_range.h"
 #include "libmesh/point.h"
 #include "libmesh/system.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
@@ -338,7 +339,7 @@ ParsedFEMFunction<Output>::reparse (const std::string & expression)
   unsigned int offset = LIBMESH_DIM + 1 + _n_requested_vars +
     _n_requested_grad_components + _n_requested_hess_components;
 
-  for (std::size_t i=0; i < _additional_vars.size(); ++i)
+  for (auto i : index_range(_additional_vars))
     {
       variables += "," + _additional_vars[i];
       // Initialize extra variables to the vector passed in or zero
@@ -450,9 +451,8 @@ ParsedFEMFunction<Output>::get_inline_value(const std::string & inline_var_name)
 #endif
   Output old_var_value(0.);
 
-  for (std::size_t s=0; s != _subexpressions.size(); ++s)
+  for (const std::string & subexpression : _subexpressions)
     {
-      const std::string & subexpression = _subexpressions[s];
       const std::size_t varname_i =
         find_name(inline_var_name, subexpression);
       if (varname_i == std::string::npos)
@@ -523,7 +523,7 @@ ParsedFEMFunction<Output>::set_inline_value (const std::string & inline_var_name
 #ifndef NDEBUG
   bool found_var_name = false;
 #endif
-  for (std::size_t s=0; s != _subexpressions.size(); ++s)
+  for (auto s : index_range(_subexpressions))
     {
       const std::string & subexpression = _subexpressions[s];
       const std::size_t varname_i =
@@ -567,10 +567,10 @@ ParsedFEMFunction<Output>::set_inline_value (const std::string & inline_var_name
 
   std::string new_expression;
 
-  for (std::size_t s=0; s != _subexpressions.size(); ++s)
+  for (const auto & subexpression : _subexpressions)
     {
       new_expression += '{';
-      new_expression += _subexpressions[s];
+      new_expression += subexpression;
       new_expression += '}';
     }
 
@@ -770,7 +770,7 @@ ParsedFEMFunction<Output>::eval_args (const FEMContext & c,
 #ifndef NDEBUG
       bool at_quadrature_point = false;
 #endif
-      for (std::size_t qp = 0; qp != normals.size(); ++qp)
+      for (auto qp : index_range(normals))
         {
           if (p == xyz[qp])
             {
@@ -814,8 +814,8 @@ ParsedFEMFunction<Output>::eval (FunctionParserBase<Output> & parser,
                    << " of expression '"
                    << function_name
                    << "' with arguments:\n";
-      for (std::size_t j=0; j<_spacetime.size(); ++j)
-        libMesh::err << '\t' << _spacetime[j] << '\n';
+      for (const auto & st : _spacetime)
+        libMesh::err << '\t' << st << '\n';
       libMesh::err << '\n';
 
       // Currently no API to report error messages, we'll do it manually

--- a/include/numerics/parsed_function.h
+++ b/include/numerics/parsed_function.h
@@ -26,6 +26,7 @@
 
 // Local includes
 #include "libmesh/dense_vector.h"
+#include "libmesh/int_range.h"
 #include "libmesh/vector_value.h"
 #include "libmesh/point.h"
 
@@ -241,7 +242,7 @@ ParsedFunction<Output,OutputGradient>::reparse (const std::string & expression)
   // If additional vars were passed, append them to the string
   // that we send to the function parser. Also add them to the
   // end of our spacetime vector
-  for (std::size_t i=0; i < _additional_vars.size(); ++i)
+  for (auto i : index_range(_additional_vars))
     {
       variables += "," + _additional_vars[i];
       // Initialize extra variables to the vector passed in or zero

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -29,6 +29,7 @@
 // Local includes
 #include "libmesh/numeric_vector.h"
 #include "libmesh/petsc_macro.h"
+#include "libmesh/int_range.h"
 #include "libmesh/libmesh_common.h"
 #include "libmesh/petsc_solver_exception.h"
 #include "libmesh/parallel_only.h"
@@ -753,7 +754,7 @@ void PetscVector<T>::init (const numeric_index_type n,
   this->_type = GHOSTED;
 
   /* Make the global-to-local ghost cell map.  */
-  for (numeric_index_type i=0; i<ghost.size(); i++)
+  for (auto i : index_range(ghost))
     {
       _global_to_local_map[ghost[i]] = i;
     }

--- a/include/parallel/parallel_conversion_utils.h
+++ b/include/parallel/parallel_conversion_utils.h
@@ -22,6 +22,7 @@
 
 // Local includes
 #include "libmesh/libmesh_common.h"
+#include "libmesh/int_range.h"
 
 #ifdef LIBMESH_HAVE_LIBHILBERT
 #include "hilbert.h"
@@ -53,7 +54,7 @@ bool is_sorted (const std::vector<KeyType> & v)
   if (v.empty())
     return true;
 
-  for (std::size_t i=1; i<v.size(); i++)
+  for (auto i : IntRange<std::size_t>(1, v.size()))
     if (v[i] < v[i-1])
       return false;
 

--- a/include/parallel/parallel_ghost_sync.h
+++ b/include/parallel/parallel_ghost_sync.h
@@ -22,6 +22,7 @@
 
 // libMesh includes
 #include "libmesh/elem.h"
+#include "libmesh/int_range.h"
 #include "libmesh/location_maps.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/parallel_algebra.h"
@@ -268,7 +269,7 @@ void sync_dofobject_data_by_xyz(const Communicator & comm,
 
   // We know how many objects live on each processor, so reserve()
   // space for each.
-  for (processor_id_type p=0; p != comm.size(); ++p)
+  for (auto p : IntRange<processor_id_type>(0, comm.size()))
     if (p != comm.rank() && ghost_objects_from_proc[p])
       {
         requested_objs_pt[p].reserve(ghost_objects_from_proc[p]);
@@ -379,7 +380,7 @@ void sync_dofobject_data_by_id(const Communicator & comm,
 
   // We know how many objects live on each processor, so reserve()
   // space for each.
-  for (processor_id_type p=0; p != comm.size(); ++p)
+  for (auto p : IntRange<processor_id_type>(0, comm.size()))
     if (p != comm.rank() && ghost_objects_from_proc[p])
       requested_objs_id[p].reserve(ghost_objects_from_proc[p]);
 
@@ -463,7 +464,7 @@ void sync_element_data_by_parent_id(MeshBase &       mesh,
 
   // We know how many objects live on each processor, so reserve()
   // space for each.
-  for (processor_id_type p=0; p != comm.size(); ++p)
+  for (auto p : IntRange<processor_id_type>(0, comm.size()))
     if (p != comm.rank() && ghost_objects_from_proc[p])
       {
         requested_objs_id[p].reserve(ghost_objects_from_proc[p]);
@@ -608,7 +609,7 @@ bool sync_node_data_by_element_id_once(MeshBase & mesh,
 
   // We know how many objects live on each processor, so reserve()
   // space for each.
-  for (processor_id_type p=0; p != comm.size(); ++p)
+  for (auto p : IntRange<processor_id_type>(0, comm.size()))
     if (p != comm.rank() && ghost_objects_from_proc[p])
       {
         requested_objs_elem_id_node_num[p].reserve(ghost_objects_from_proc[p]);

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -30,6 +30,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/fe_base.h"
 #include "libmesh/fe_interface.h"
+#include "libmesh/int_range.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_tools.h"
 #include "libmesh/numeric_vector.h"
@@ -511,7 +512,7 @@ public:
     c.set_algebraic_type(FEMContext::DOFS_ONLY);
 
     // Loop over variables, to prerequest
-    for (unsigned int var=0; var!=sys.n_vars(); ++var)
+    for (auto var : IntRange<unsigned int>(0, sys.n_vars()))
       {
         FEBase * fe = nullptr;
         const std::set<unsigned char> & elem_dims =

--- a/include/systems/parameter_multiaccessor.h
+++ b/include/systems/parameter_multiaccessor.h
@@ -107,8 +107,8 @@ public:
 #ifndef NDEBUG
     // If you're already using inconsistent parameters we can't help
     // you.
-    for (std::size_t i=1; i < _accessors.size(); ++i)
-      libmesh_assert_equal_to(_accessors[i]->get(), val);
+    for (const auto & accessor : _accessors)
+      libmesh_assert_equal_to(accessor->get(), val);
 #endif
     return val;
   }

--- a/include/systems/parameter_multipointer.h
+++ b/include/systems/parameter_multipointer.h
@@ -79,12 +79,12 @@ public:
     // Compare other values to the last one we'll change
     const T & val = *_ptrs.back();
 #endif
-    for (std::size_t i=0; i != _ptrs.size(); ++i)
+    for (auto & ptr : _ptrs)
       {
         // If you're already using inconsistent parameters we can't
         // help you.
-        libmesh_assert_equal_to(*_ptrs[i], val);
-        *_ptrs[i] = new_value;
+        libmesh_assert_equal_to(*ptr, val);
+        *ptr = new_value;
       }
   }
 
@@ -98,8 +98,8 @@ public:
 #ifndef NDEBUG
     // If you're already using inconsistent parameters we can't help
     // you.
-    for (std::size_t i=1; i < _ptrs.size(); ++i)
-      libmesh_assert_equal_to(*_ptrs[i], val);
+    for (auto ptr : _ptrs)
+      libmesh_assert_equal_to(*ptr, val);
 #endif
     return val;
   }

--- a/include/utils/int_range.h
+++ b/include/utils/int_range.h
@@ -22,14 +22,16 @@
 
 #include "libmesh/libmesh_common.h" // cast_int
 
-// libMesh includes
-#include "numeric_vector.h"
-
 // C++ includes
 #include <vector>
 
 namespace libMesh
 {
+
+// Forward declarations
+template <typename T> class DenseSubVector;
+template <typename T> class DenseVector;
+template <typename T> class NumericVector;
 
 /**
  * The \p IntRange templated class is intended to make it easy to
@@ -104,6 +106,26 @@ template <typename T>
 IntRange<std::size_t> index_range(const std::vector<T> & vec)
 {
   return IntRange<std::size_t>(0, vec.size());
+}
+
+
+/**
+ * Same thing but for DenseVector
+ */
+template <typename T>
+IntRange<unsigned int> index_range(const DenseVector<T> & vec)
+{
+  return {0, vec.size()};
+}
+
+
+/**
+ * Same thing but for DenseSubVector
+ */
+template <typename T>
+IntRange<unsigned int> index_range(const DenseSubVector<T> & vec)
+{
+  return {0, vec.size()};
 }
 
 

--- a/include/utils/parameters.h
+++ b/include/utils/parameters.h
@@ -20,11 +20,6 @@
 #ifndef LIBMESH_PARAMETERS_H
 #define LIBMESH_PARAMETERS_H
 
-// C++ includes
-#include <typeinfo>
-#include <string>
-#include <map>
-
 // Local includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/reference_counted_object.h"
@@ -33,9 +28,10 @@
 // C++ includes
 #include <cstddef>
 #include <map>
+#include <sstream>
 #include <string>
 #include <typeinfo>
-#include <sstream>
+#include <vector>
 
 namespace libMesh
 {

--- a/include/utils/parameters.h
+++ b/include/utils/parameters.h
@@ -556,17 +556,17 @@ void print_helper(std::ostream & os, const unsigned char * param)
 template<typename P>
 void print_helper(std::ostream & os, const std::vector<P> * param)
 {
-  for (std::size_t i=0; i<param->size(); ++i)
-    os << (*param)[i] << " ";
+  for (const auto & p : param)
+    os << p << " ";
 }
 
 //non-member vector<vector> print function
 template<typename P>
 void print_helper(std::ostream & os, const std::vector<std::vector<P>> * param)
 {
-  for (std::size_t i=0; i<param->size(); ++i)
-    for (std::size_t j=0; j<(*param)[i].size(); ++j)
-      os << (*param)[i][j] << " ";
+  for (const auto & pv : *param)
+    for (const auto & p : pv)
+      os << p << " ";
 }
 
 } // namespace libMesh

--- a/include/utils/parameters.h
+++ b/include/utils/parameters.h
@@ -552,7 +552,7 @@ void print_helper(std::ostream & os, const unsigned char * param)
 template<typename P>
 void print_helper(std::ostream & os, const std::vector<P> * param)
 {
-  for (const auto & p : param)
+  for (const auto & p : *param)
     os << p << " ";
 }
 

--- a/include/utils/tree_node.h
+++ b/include/utils/tree_node.h
@@ -261,10 +261,10 @@ inline
 TreeNode<N>::~TreeNode ()
 {
   // When we are destructed we must delete all of our
-  // children.  They will this delete their children,
+  // children.  They will thus delete their children,
   // All the way down the line...
-  for (std::size_t c=0; c<children.size(); c++)
-    delete children[c];
+  for (auto c : children)
+    delete c;
 }
 
 

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1452,7 +1452,7 @@ void DofMap::print_dof_constraints(std::ostream & os,
       os << "Processor 0:\n";
       os << local_constraints;
 
-      for (processor_id_type p=1, np=this->n_processors(); p != np; ++p)
+      for (auto p : IntRange<processor_id_type>(1, this->n_processors()))
         {
           this->comm().receive(p, local_constraints);
           os << "Processor " << p << ":\n";
@@ -1601,7 +1601,7 @@ void DofMap::constrain_element_matrix (DenseMatrix<Number> & matrix,
         // If the DOF is constrained
         if (this->is_constrained_dof(elem_dofs[i]))
           {
-            for (unsigned int j=0; j<matrix.n(); j++)
+            for (auto j : IntRange<unsigned int>(0, matrix.n()))
               matrix(i,j) = 0.;
 
             matrix(i,i) = 1.;
@@ -1672,7 +1672,7 @@ void DofMap::constrain_element_matrix_and_vector (DenseMatrix<Number> & matrix,
            i != n_elem_dofs; i++)
         if (this->is_constrained_dof(elem_dofs[i]))
           {
-            for (unsigned int j=0; j<matrix.n(); j++)
+            for (auto j : IntRange<unsigned int>(0, matrix.n()))
               matrix(i,j) = 0.;
 
             // If the DOF is constrained
@@ -1775,7 +1775,7 @@ void DofMap::heterogenously_constrain_element_matrix_and_vector (DenseMatrix<Num
 
           if (this->is_constrained_dof(dof_id))
             {
-              for (unsigned int j=0; j<matrix.n(); j++)
+              for (auto j : IntRange<unsigned int>(0, matrix.n()))
                 matrix(i,j) = 0.;
 
               // If the DOF is constrained
@@ -1955,7 +1955,7 @@ void DofMap::constrain_element_matrix (DenseMatrix<Number> & matrix,
            i != n_row_dofs; i++)
         if (this->is_constrained_dof(row_dofs[i]))
           {
-            for (unsigned int j=0; j<matrix.n(); j++)
+            for (auto j : IntRange<unsigned int>(0, matrix.n()))
               {
                 if (row_dofs[i] != col_dofs[j])
                   matrix(i,j) = 0.;
@@ -2406,7 +2406,7 @@ DofMap::max_constraint_error (const System & system,
       libmesh_assert_equal_to (C.m(), raw_dof_indices.size());
       libmesh_assert_equal_to (C.n(), local_dof_indices.size());
 
-      for (unsigned int i=0; i!=C.m(); ++i)
+      for (auto i : IntRange<unsigned int>(0, C.m()))
         {
           // Recalculate any constrained dof owned by this processor
           dof_id_type global_dof = raw_dof_indices[i];
@@ -2427,7 +2427,7 @@ DofMap::max_constraint_error (const System & system,
               if (rhsit != _primal_constraint_values.end())
                 exact_value = rhsit->second;
 
-              for (unsigned int j=0; j!=C.n(); ++j)
+              for (auto j : IntRange<unsigned int>(0, C.n()))
                 {
                   if (local_dof_indices[j] != global_dof)
                     exact_value += C(i,j) *
@@ -3128,9 +3128,8 @@ void DofMap::allgather_recursive_constraints(MeshBase & mesh)
           node_ids_on_proc[node->processor_id()]++;
         }
 
-      for (processor_id_type p = 0; p != this->n_processors(); ++p)
-        if (node_ids_on_proc.count(p))
-          requested_node_ids[p].reserve(node_ids_on_proc[p]);
+      for (auto pair : node_ids_on_proc)
+        requested_node_ids[pair.first].reserve(pair.second);
 
       // Prepare each processor's request set
       for (const auto & node : node_request_set)

--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -65,19 +65,19 @@ DofObject::DofObject (const DofObject & dof_obj) :
 
   libmesh_assert_equal_to (this->n_systems(), dof_obj.n_systems());
 
-  for (unsigned int s=0; s<this->n_systems(); s++)
+  for (auto s : IntRange<unsigned int>(0, this->n_systems()))
     {
       libmesh_assert_equal_to (this->n_vars(s),       dof_obj.n_vars(s));
       libmesh_assert_equal_to (this->n_var_groups(s), dof_obj.n_var_groups(s));
 
-      for (unsigned int vg=0; vg<this->n_var_groups(s); vg++)
+      for (auto vg : IntRange<unsigned int>(0, this->n_var_groups(s)))
         libmesh_assert_equal_to (this->n_vars(s,vg), dof_obj.n_vars(s,vg));
 
-      for (unsigned int v=0; v<this->n_vars(s); v++)
+      for (auto v : IntRange<unsigned int>(0, this->n_vars(s)))
         {
           libmesh_assert_equal_to (this->n_comp(s,v), dof_obj.n_comp(s,v));
 
-          for (unsigned int c=0; c<this->n_comp(s,v); c++)
+          for (auto c : IntRange<unsigned int>(0, this->n_comp(s,v)))
             libmesh_assert_equal_to (this->dof_number(s,v,c), dof_obj.dof_number(s,v,c));
         }
     }
@@ -111,19 +111,19 @@ DofObject & DofObject::operator= (const DofObject & dof_obj)
 
   libmesh_assert_equal_to (this->n_systems(), dof_obj.n_systems());
 
-  for (unsigned int s=0; s<this->n_systems(); s++)
+  for (auto s : IntRange<unsigned int>(0, this->n_systems()))
     {
       libmesh_assert_equal_to (this->n_vars(s),       dof_obj.n_vars(s));
       libmesh_assert_equal_to (this->n_var_groups(s), dof_obj.n_var_groups(s));
 
-      for (unsigned int vg=0; vg<this->n_var_groups(s); vg++)
+      for (auto vg : IntRange<unsigned int>(0, this->n_var_groups(s)))
         libmesh_assert_equal_to (this->n_vars(s,vg), dof_obj.n_vars(s,vg));
 
-      for (unsigned int v=0; v<this->n_vars(s); v++)
+      for (auto v : IntRange<unsigned int>(0, this->n_vars(s)))
         {
           libmesh_assert_equal_to (this->n_comp(s,v), dof_obj.n_comp(s,v));
 
-          for (unsigned int c=0; c<this->n_comp(s,v); c++)
+          for (auto c : IntRange<unsigned int>(0, this->n_comp(s,v)))
             libmesh_assert_equal_to (this->dof_number(s,v,c), dof_obj.dof_number(s,v,c));
         }
     }
@@ -195,7 +195,7 @@ void DofObject::set_n_systems (const unsigned int ns)
 
   // check that all systems now exist and that they have 0 size
   libmesh_assert_equal_to (ns, this->n_systems());
-  for (unsigned int s=0; s<this->n_systems(); s++)
+  for (auto s : IntRange<unsigned int>(0, this->n_systems()))
     {
       libmesh_assert_equal_to (this->n_vars(s),       0);
       libmesh_assert_equal_to (this->n_var_groups(s), 0);
@@ -328,7 +328,7 @@ void DofObject::set_n_vars_per_group(const unsigned int s,
 
   // Make sure we didn't screw up any of our sizes!
 #ifdef DEBUG
-  for (unsigned int s_ctr=0; s_ctr<this->n_systems(); s_ctr++)
+  for (auto s_ctr : IntRange<unsigned int>(0, this->n_systems()))
     if (s_ctr != s)
       libmesh_assert_equal_to (this->n_var_groups(s_ctr), old_system_sizes[s_ctr]);
 
@@ -371,17 +371,17 @@ void DofObject::set_n_vars_per_group(const unsigned int s,
 
   libmesh_assert_equal_to (this->n_var_groups(s), nvpg.size());
 
-  for (unsigned int vg=0; vg<this->n_var_groups(s); vg++)
+  for (auto vg : IntRange<unsigned int>(0, this->n_var_groups(s)))
     {
       libmesh_assert_equal_to (this->n_vars(s,vg), nvpg[vg]);
       libmesh_assert_equal_to (this->n_comp_group(s,vg), 0);
     }
 
-  for (unsigned int v=0; v<this->n_vars(s); v++)
+  for (auto v : IntRange<unsigned int>(0, this->n_vars(s)))
     libmesh_assert_equal_to (this->n_comp(s,v), 0);
 
   // again, all other system sizes should be unchanged!
-  for (unsigned int s_ctr=0; s_ctr<this->n_systems(); s_ctr++)
+  for (auto s_ctr : IntRange<unsigned int>(0, this->n_systems()))
     if (s_ctr != s)
       libmesh_assert_equal_to (this->n_var_groups(s_ctr), old_system_sizes[s_ctr]);
 
@@ -665,13 +665,13 @@ void DofObject::print_dof_info() const
 {
   libMesh::out << this->id() << " [ ";
 
-  for (unsigned int s=0; s<this->n_systems(); s++)
+  for (auto s : IntRange<unsigned int>(0, this->n_systems()))
     {
       libMesh::out << "s:" << s << " ";
-      for (unsigned int var=0; var<this->n_vars(s); var++)
+      for (auto var : IntRange<unsigned int>(0, this->n_vars(s)))
         {
           libMesh::out << "v:" << var << " ";
-          for (unsigned int comp=0; comp<this->n_comp(s,var); comp++)
+          for (auto comp : IntRange<unsigned int>(0, this->n_comp(s,var)))
             {
               libMesh::out << "c:" << comp << " dof:" << this->dof_number(s,var,comp) << " ";
             }

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -25,6 +25,7 @@
 #include "libmesh/libmesh_singleton.h"
 #include "libmesh/remote_elem.h"
 #include "libmesh/threads.h"
+#include "libmesh/parallel_only.h"
 #include "libmesh/print_trace.h"
 #include "libmesh/enum_solver_package.h"
 #include "libmesh/perf_log.h"

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -251,7 +251,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
   // Copy the projected coarse grid solutions, which will be
   // overwritten by solve()
   std::vector<std::unique_ptr<NumericVector<Number>>> coarse_adjoints;
-  for (unsigned int j=0; j != system.n_qois(); j++)
+  for (auto j : IntRange<unsigned int>(0, system.n_qois()))
     {
       if (_qoi_set.has_index(j))
         {
@@ -304,7 +304,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
   // Loop over all the adjoint solutions and get the QoI error
   // contributions from all of them.  While we're looping anyway we'll
   // pull off the coarse adjoints
-  for (unsigned int j=0; j != system.n_qois(); j++)
+  for (auto j : IntRange<unsigned int>(0, system.n_qois()))
     {
       // Skip this QoI if not in the QoI Set
       if (_qoi_set.has_index(j))
@@ -350,7 +350,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
   // stabilized/non-stabilized formulations, except for the case where we not using a
   // heterogenous adjoint bc and have a stabilized formulation.
   // Then, R(u^h_s, z^h_s)  != 0 (no Galerkin orthogonality w.r.t the non-stabilized residual)
-  for (unsigned int j=0; j != system.n_qois(); j++)
+  for (auto j : IntRange<unsigned int>(0, system.n_qois()))
     {
       // Skip this QoI if not in the QoI Set
       if (_qoi_set.has_index(j))
@@ -399,11 +399,8 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
   // We will be iterating over all the active elements in the fine mesh that live on
   // this processor.
   for (const auto & elem : mesh.active_local_element_ptr_range())
-    for (unsigned int n=0; n != elem->n_nodes(); ++n)
+    for (const Node & node : elem->node_ref_range())
       {
-        // Get a reference to the current node
-        const Node & node = elem->node_ref(n);
-
         // Get the id of this node
         dof_id_type node_id = node.id();
 
@@ -437,7 +434,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
                 std::size_t j = 0;
 
                 // If the set already contains this element break out of the loop
-                for (; j != coarse_grid_neighbors.size(); j++)
+                for (std::size_t cgns = coarse_grid_neighbors.size(); j != cgns; j++)
                   if (coarse_grid_neighbors[j] == coarse_id)
                     break;
 
@@ -476,7 +473,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
 
   // We will loop over each adjoint solution, localize that adjoint
   // solution and then loop over local elements
-  for (unsigned int i=0; i != system.n_qois(); i++)
+  for (auto i : IntRange<unsigned int>(0, system.n_qois()))
     {
       // Skip this QoI if not in the QoI Set
       if (_qoi_set.has_index(i))

--- a/src/error_estimation/error_estimator.C
+++ b/src/error_estimation/error_estimator.C
@@ -53,7 +53,7 @@ void ErrorEstimator::estimate_errors(const EquationSystems & equation_systems,
   SystemNorm old_error_norm = this->error_norm;
 
   // Sum the error values from each system
-  for (unsigned int s = 0; s != equation_systems.n_systems(); ++s)
+  for (auto s : IntRange<unsigned int>(0, equation_systems.n_systems()))
     {
       ErrorVector system_error_per_cell;
       const System & sys = equation_systems.get_system(s);
@@ -98,7 +98,7 @@ void ErrorEstimator::estimate_errors(const EquationSystems & equation_systems,
   SystemNorm old_error_norm = this->error_norm;
 
   // Find the requested error values from each system
-  for (unsigned int s = 0; s != equation_systems.n_systems(); ++s)
+  for (auto s : IntRange<unsigned int>(0, equation_systems.n_systems()))
     {
       const System & sys = equation_systems.get_system(s);
 

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -45,7 +45,7 @@ ExactSolution::ExactSolution(const EquationSystems & es) :
 {
   // Initialize the _errors data structure which holds all
   // the eventual values of the error.
-  for (unsigned int sys=0; sys<_equation_systems.n_systems(); ++sys)
+  for (auto sys : IntRange<unsigned int>(0, _equation_systems.n_systems()))
     {
       // Reference to the system
       const System & system = _equation_systems.get_system(sys);
@@ -56,7 +56,7 @@ ExactSolution::ExactSolution(const EquationSystems & es) :
       // The SystemErrorMap to be inserted
       ExactSolution::SystemErrorMap sem;
 
-      for (unsigned int var=0; var<system.n_vars(); ++var)
+      for (auto var : IntRange<unsigned int>(0, system.n_vars()))
         {
           // The name of this variable
           const std::string & var_name = system.variable_name(var);
@@ -98,7 +98,7 @@ void ExactSolution::attach_exact_value (ValueFunctionPointer fptr)
   // entry for each system.
   _exact_values.clear();
 
-  for (unsigned int sys=0; sys<_equation_systems.n_systems(); ++sys)
+  for (auto sys : IntRange<unsigned int>(0, _equation_systems.n_systems()))
     {
       const System & system = _equation_systems.get_system(sys);
       _exact_values.emplace_back(libmesh_make_unique<WrappedFunction<Number>>(system, fptr, &_equation_systems.parameters));
@@ -139,7 +139,7 @@ void ExactSolution::attach_exact_deriv (GradientFunctionPointer gptr)
   // entry for each system.
   _exact_derivs.clear();
 
-  for (unsigned int sys=0; sys<_equation_systems.n_systems(); ++sys)
+  for (auto sys : IntRange<unsigned int>(0, _equation_systems.n_systems()))
     {
       const System & system = _equation_systems.get_system(sys);
       _exact_derivs.emplace_back(libmesh_make_unique<WrappedFunction<Gradient>>(system, gptr, &_equation_systems.parameters));
@@ -180,7 +180,7 @@ void ExactSolution::attach_exact_hessian (HessianFunctionPointer hptr)
   // entry for each system.
   _exact_hessians.clear();
 
-  for (unsigned int sys=0; sys<_equation_systems.n_systems(); ++sys)
+  for (auto sys : IntRange<unsigned int>(0, _equation_systems.n_systems()))
     {
       const System & system = _equation_systems.get_system(sys);
       _exact_hessians.emplace_back(libmesh_make_unique<WrappedFunction<Tensor>>(system, hptr, &_equation_systems.parameters));

--- a/src/error_estimation/hp_coarsentest.C
+++ b/src/error_estimation/hp_coarsentest.C
@@ -89,7 +89,7 @@ void HPCoarsenTest::add_projection(const System & system,
   libmesh_assert_equal_to (Uc.size(), phi_coarse->size());
 
   // Loop over the quadrature points
-  for (unsigned int qp=0; qp<qrule->n_points(); qp++)
+  for (auto qp : IntRange<unsigned int>(0, qrule->n_points()))
     {
       // The solution value at the quadrature point
       Number val = libMesh::zero;
@@ -108,7 +108,7 @@ void HPCoarsenTest::add_projection(const System & system,
         }
 
       // The projection matrix and vector
-      for (unsigned int i=0; i != Fe.size(); ++i)
+      for (auto i : index_range(Fe))
         {
           Fe(i) += (*JxW)[qp] *
             (*phi_coarse)[i][qp]*val;
@@ -119,7 +119,7 @@ void HPCoarsenTest::add_projection(const System & system,
             Fe(i) += (*JxW)[qp] *
               hess.contract((*d2phi_coarse)[i][qp]);
 
-          for (unsigned int j=0; j != Fe.size(); ++j)
+          for (auto j : index_range(Fe))
             {
               Ke(i,j) += (*JxW)[qp] *
                 (*phi_coarse)[i][qp]*(*phi_coarse)[j][qp];
@@ -318,7 +318,7 @@ void HPCoarsenTest::select_refinement (System & system)
               Fe.zero();
 
               // Loop over the quadrature points
-              for (unsigned int qp=0; qp<qrule->n_points(); qp++)
+              for (auto qp : IntRange<unsigned int>(0, qrule->n_points()))
                 {
                   // The solution value at the quadrature point
                   Number val = libMesh::zero;
@@ -337,7 +337,7 @@ void HPCoarsenTest::select_refinement (System & system)
                     }
 
                   // The projection matrix and vector
-                  for (unsigned int i=0; i != Fe.size(); ++i)
+                  for (auto i : index_range(Fe))
                     {
                       Fe(i) += (*JxW)[qp] *
                         (*phi_coarse)[i][qp]*val;
@@ -348,7 +348,7 @@ void HPCoarsenTest::select_refinement (System & system)
                         Fe(i) += (*JxW)[qp] *
                           hess.contract((*d2phi_coarse)[i][qp]);
 
-                      for (unsigned int j=0; j != Fe.size(); ++j)
+                      for (auto j : index_range(Fe))
                         {
                           Ke(i,j) += (*JxW)[qp] *
                             (*phi_coarse)[i][qp]*(*phi_coarse)[j][qp];
@@ -388,7 +388,7 @@ void HPCoarsenTest::select_refinement (System & system)
                 }
               else
                 {
-                  for (unsigned int i=0; i<Up.size(); i++)
+                  for (auto i : index_range(Up))
                     {
                       value_error -= (*phi_coarse)[i][qp] * Up(i);
                       if (cont == C_ZERO || cont == C_ONE)

--- a/src/error_estimation/patch_recovery_error_estimator.C
+++ b/src/error_estimation/patch_recovery_error_estimator.C
@@ -451,8 +451,9 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                   const unsigned int psi_size = cast_int<unsigned int>(psi.size());
 
                   // Patch matrix contribution
-                  for (unsigned int i=0; i<Kp.m(); i++)
-                    for (unsigned int j=0; j<Kp.n(); j++)
+                  const unsigned int m = Kp.m(), n = Kp.n();
+                  for (unsigned int i=0; i<m; i++)
+                    for (unsigned int j=0; j<n; j++)
                       Kp(i,j) += JxW[qp]*psi[i]*psi[j];
 
                   if (error_estimator.error_norm.type(var) == L2 ||

--- a/src/error_estimation/uniform_refinement_estimator.C
+++ b/src/error_estimation/uniform_refinement_estimator.C
@@ -135,7 +135,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
       libmesh_assert_equal_to (&(_system->get_equation_systems()), _es);
 
       libmesh_assert(_es->n_systems());
-      for (unsigned int i=0; i != _es->n_systems(); ++i)
+      for (auto i : IntRange<unsigned int>(0, _es->n_systems()))
         // We have to break the rules here, because we can't refine a const System
         system_list.push_back(const_cast<System *>(&(_es->get_system(i))));
 
@@ -153,7 +153,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
 
           _error_norms = error_norms.get();
 
-          for (unsigned int i=0; i!= _es->n_systems(); ++i)
+          for (auto i : IntRange<unsigned int>(0, _es->n_systems()))
             {
               const System & sys = _es->get_system(i);
               unsigned int n_vars = sys.n_vars();
@@ -319,7 +319,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
       libmesh_assert (solution_vectors->find(sys) !=
                       solution_vectors->end());
       const NumericVector<Number> * vec = solution_vectors->find(sys)->second;
-      for (unsigned int j=0; j != sys->n_qois(); ++j)
+      for (auto j : IntRange<unsigned int>(0, sys->n_qois()))
         {
           std::ostringstream adjoint_name;
           adjoint_name << "adjoint_solution" << j;
@@ -338,7 +338,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
     {
       // Even if we had a decent preconditioner, valid matrix etc. before
       // refinement, we don't any more.
-      for (unsigned int i=0; i != es.n_systems(); ++i)
+      for (auto i : IntRange<unsigned int>(0, _es->n_systems()))
         es.get_system(i).disable_cache();
 
       // No specified vectors == forward solve
@@ -363,7 +363,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
               if (solve_adjoint)
                 {
                   bool found_vec = false;
-                  for (unsigned int j=0; j != sys->n_qois(); ++j)
+                  for (auto j : IntRange<unsigned int>(0, sys->n_qois()))
                     {
                       std::ostringstream adjoint_name;
                       adjoint_name << "adjoint_solution" << j;
@@ -392,8 +392,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
                   libmesh_assert (solution_vectors->find(sys) !=
                                   solution_vectors->end());
                   const NumericVector<Number> * vec = solution_vectors->find(sys)->second;
-                  for (unsigned int j=0, n_qois = sys->n_qois();
-                       j != n_qois; ++j)
+                  for (auto j : IntRange<unsigned int>(0, sys->n_qois()))
                     {
                       std::ostringstream adjoint_name;
                       adjoint_name << "adjoint_solution" << j;

--- a/src/error_estimation/weighted_patch_recovery_error_estimator.C
+++ b/src/error_estimation/weighted_patch_recovery_error_estimator.C
@@ -353,8 +353,9 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                   const unsigned int psi_size = cast_int<unsigned int>(psi.size());
 
                   // Patch matrix contribution
-                  for (unsigned int i=0; i<Kp.m(); i++)
-                    for (unsigned int j=0; j<Kp.n(); j++)
+                  const unsigned int m = Kp.m(), n = Kp.n();
+                  for (unsigned int i=0; i<m; i++)
+                    for (unsigned int j=0; j<n; j++)
                       Kp(i,j) += JxW[qp]*psi[i]*psi[j];
 
                   if (error_estimator.error_norm.type(var) == L2 ||

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -191,10 +191,8 @@ void FE<Dim,T>::reinit(const Elem * elem,
               if (this->shapes_need_reinit())
                 {
                   cached_nodes.resize(elem->n_nodes());
-                  for (unsigned int n = 0; n != elem->n_nodes(); ++n)
-                    {
-                      cached_nodes[n] = elem->point(n);
-                    }
+                  for (auto n : elem->node_index_range())
+                    cached_nodes[n] = elem->point(n);
                 }
             }
           else
@@ -205,7 +203,7 @@ void FE<Dim,T>::reinit(const Elem * elem,
               if (cached_nodes.size() != elem->n_nodes())
                 cached_nodes_still_fit = false;
               else
-                for (unsigned int n = 1; n < elem->n_nodes(); ++n)
+                for (auto n : IntRange<unsigned int>(1, elem->n_nodes()))
                   {
                     if (!(elem->point(n) - elem->point(0)).relative_fuzzy_equals
                         ((cached_nodes[n] - cached_nodes[0]), 1e-13))
@@ -221,7 +219,7 @@ void FE<Dim,T>::reinit(const Elem * elem,
                     (this->qrule->get_points(), elem);
                   this->init_shape_functions (this->qrule->get_points(), elem);
                   cached_nodes.resize(elem->n_nodes());
-                  for (unsigned int n = 0; n != elem->n_nodes(); ++n)
+                  for (auto n : elem->node_index_range())
                     cached_nodes[n] = elem->point(n);
                 }
             }

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -1383,7 +1383,7 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
       DenseVector<Number> Usub;
 
       coarsened_dof_values(old_vector, dof_map, elem, Usub,
-                           use_old_dof_indices);
+                           v, use_old_dof_indices);
 
       Ue.append (Usub);
     }

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -1986,7 +1986,7 @@ compute_periodic_constraints (DofConstraints & constraints,
                   // Container to catch boundary IDs handed back by BoundaryInfo.
                   std::vector<boundary_id_type> new_bc_ids;
 
-                  for (unsigned int n = 0; n != elem->n_nodes(); ++n)
+                  for (auto n : elem->node_index_range())
                     {
                       if (!elem->is_node_on_side(n,s))
                         continue;
@@ -2100,8 +2100,8 @@ compute_periodic_constraints (DofConstraints & constraints,
                       else if (elem->is_edge(n))
                         {
                           // Find which edge we're on
-                          unsigned int e=0;
-                          for (; e != elem->n_edges(); ++e)
+                          unsigned int e=0, ne = elem->n_edges();
+                          for (; e != ne; ++e)
                             {
                               if (elem->is_node_on_edge(n,e))
                                 break;
@@ -2112,7 +2112,7 @@ compute_periodic_constraints (DofConstraints & constraints,
                           const Node
                             * e1 = nullptr,
                             * e2 = nullptr;
-                          for (unsigned int nn = 0; nn != elem->n_nodes(); ++nn)
+                          for (auto nn : elem->node_index_range())
                             {
                               if (nn == n)
                                 continue;

--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -359,8 +359,8 @@ void FE<Dim,T>::side_map (const Elem * elem,
 
   std::vector<unsigned int> elem_nodes_map;
   elem_nodes_map.resize(side->n_nodes());
-  for (unsigned int j = 0; j < side->n_nodes(); j++)
-    for (unsigned int i = 0; i < elem->n_nodes(); i++)
+  for (auto j : side->node_index_range())
+    for (auto i : elem->node_index_range())
       if (side->node_id(j) == elem->node_id(i))
         elem_nodes_map[j] = i;
   std::vector<Point> refspace_nodes;

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -1472,7 +1472,7 @@ void FEMap::compute_map(const unsigned int dim,
     {
       // All other FE use only the nodes of elem itself
       _elem_nodes.resize(elem->n_nodes(), nullptr);
-      for (unsigned int i=0; i<elem->n_nodes(); i++)
+      for (auto i : elem->node_index_range())
         _elem_nodes[i] = elem->node_ptr(i);
     }
 

--- a/src/fe/fe_xyz_shape_1D.C
+++ b/src/fe/fe_xyz_shape_1D.C
@@ -52,9 +52,9 @@ Real FE<1,XYZ>::shape(const Elem * elem,
 
   Point centroid = elem->centroid();
   Real max_distance = 0.;
-  for (unsigned int p = 0; p < elem->n_nodes(); p++)
+  for (const Point & p : elem->node_ref_range())
     {
-      const Real distance = std::abs(centroid(0) - elem->point(p)(0));
+      const Real distance = std::abs(centroid(0) - p(0));
       max_distance = std::max(distance, max_distance);
     }
 
@@ -120,9 +120,9 @@ Real FE<1,XYZ>::shape_deriv(const Elem * elem,
 
   Point centroid = elem->centroid();
   Real max_distance = 0.;
-  for (unsigned int p = 0; p < elem->n_nodes(); p++)
+  for (const Point & p : elem->node_ref_range())
     {
-      const Real distance = std::abs(centroid(0) - elem->point(p)(0));
+      const Real distance = std::abs(centroid(0) - p(0));
       max_distance = std::max(distance, max_distance);
     }
 
@@ -189,9 +189,9 @@ Real FE<1,XYZ>::shape_second_deriv(const Elem * elem,
 
   Point centroid = elem->centroid();
   Real max_distance = 0.;
-  for (unsigned int p = 0; p < elem->n_nodes(); p++)
+  for (const Point & p : elem->node_ref_range())
     {
-      const Real distance = std::abs(centroid(0) - elem->point(p)(0));
+      const Real distance = std::abs(centroid(0) - p(0));
       max_distance = std::max(distance, max_distance);
     }
 

--- a/src/fe/fe_xyz_shape_2D.C
+++ b/src/fe/fe_xyz_shape_2D.C
@@ -53,10 +53,10 @@ Real FE<2,XYZ>::shape(const Elem * elem,
 
   Point centroid = elem->centroid();
   Point max_distance = Point(0.,0.,0.);
-  for (unsigned int p = 0; p < elem->n_nodes(); p++)
+  for (const Point & p : elem->node_ref_range())
     for (unsigned int d = 0; d < 2; d++)
       {
-        const Real distance = std::abs(centroid(d) - elem->point(p)(d));
+        const Real distance = std::abs(centroid(d) - p(d));
         max_distance(d) = std::max(distance, max_distance(d));
       }
 
@@ -180,10 +180,10 @@ Real FE<2,XYZ>::shape_deriv(const Elem * elem,
 
   Point centroid = elem->centroid();
   Point max_distance = Point(0.,0.,0.);
-  for (unsigned int p = 0; p < elem->n_nodes(); p++)
+  for (const Point & p : elem->node_ref_range())
     for (unsigned int d = 0; d < 2; d++)
       {
-        const Real distance = std::abs(centroid(d) - elem->point(p)(d));
+        const Real distance = std::abs(centroid(d) - p(d));
         max_distance(d) = std::max(distance, max_distance(d));
       }
 

--- a/src/fe/fe_xyz_shape_3D.C
+++ b/src/fe/fe_xyz_shape_3D.C
@@ -725,10 +725,10 @@ Real FE<3,XYZ>::shape_second_deriv(const Elem * elem,
 
   Point centroid = elem->centroid();
   Point max_distance = Point(0.,0.,0.);
-  for (unsigned int p = 0; p < elem->n_nodes(); p++)
+  for (const Point & p : elem->node_ref_range())
     for (unsigned int d = 0; d < 3; d++)
       {
-        const Real distance = std::abs(centroid(d) - elem->point(p)(d));
+        const Real distance = std::abs(centroid(d) - p(d));
         max_distance(d) = std::max(distance, max_distance(d));
       }
 

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -225,7 +225,7 @@ void InfFE<Dim,T_radial,T_map>::reinit(const Elem * inf_elem,
           radial_pts.push_back(Point(radius));
           unsigned int n_radial_pts=1;
           unsigned int n_angular_pts=1;
-          for (std::size_t p=1; p < pts->size(); ++p)
+          for (auto p : IntRange<std::size_t>(1, pts->size()))
             {
               radius = (*pts)[p](Dim-1);
               // check for repetition of radius: The max. allowed distance is somewhat arbitrary
@@ -263,7 +263,7 @@ void InfFE<Dim,T_radial,T_map>::reinit(const Elem * inf_elem,
 
       std::vector<Point> base_pts;
       base_pts.reserve(base_pts_size);
-      for (std::size_t p=0; p != pts->size(); p += radial_pts_size)
+      for (std::size_t p=0, ps=pts->size(); p != ps; p += radial_pts_size)
         {
           Point pt = (*pts)[p];
           pt(Dim-1) = 0;

--- a/src/fe/inf_fe_boundary.C
+++ b/src/fe/inf_fe_boundary.C
@@ -118,9 +118,9 @@ void InfFE<Dim,T_radial,T_base>::reinit(const Elem * inf_elem,
   // somewhere else...
   if (s==0)
     {
-      for (unsigned int p=0; p<qp.size(); p++)
+      for (auto & p : qp)
         {
-          qp[p](Dim-1)=-1.;
+          p(Dim-1)=-1.;
         }
     }
 

--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -102,7 +102,7 @@ std::unique_ptr<Elem> Hex::side_ptr (const unsigned int i)
 
   std::unique_ptr<Elem> face = libmesh_make_unique<Quad4>();
 
-  for (unsigned n=0; n<face->n_nodes(); ++n)
+  for (auto n : face->node_index_range())
     face->set_node(n) = this->node_ptr(Hex8::side_nodes_map[i][n]);
 
   return face;

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -173,7 +173,7 @@ std::unique_ptr<Elem> Hex20::build_side_ptr (const unsigned int i,
       std::unique_ptr<Elem> face = libmesh_make_unique<Quad8>();
       face->subdomain_id() = this->subdomain_id();
 
-      for (unsigned n=0; n<face->n_nodes(); ++n)
+      for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Hex20::side_nodes_map[i][n]);
 
       return face;

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -149,7 +149,7 @@ std::unique_ptr<Elem> Hex8::build_side_ptr (const unsigned int i,
       std::unique_ptr<Elem> face = libmesh_make_unique<Quad4>();
       face->subdomain_id() = this->subdomain_id();
 
-      for (unsigned n=0; n<face->n_nodes(); ++n)
+      for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Hex8::side_nodes_map[i][n]);
 
       return face;

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -140,7 +140,7 @@ std::unique_ptr<Elem> InfHex::side_ptr (const unsigned int i)
     }
 
   // Set the nodes
-  for (unsigned n=0; n<face->n_nodes(); ++n)
+  for (auto n : face->node_index_range())
     face->set_node(n) = this->node_ptr(InfHex8::side_nodes_map[i][n]);
 
   return face;

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -199,7 +199,7 @@ std::unique_ptr<Elem> InfHex16::build_side_ptr (const unsigned int i,
       face->subdomain_id() = this->subdomain_id();
 
       // Set the nodes
-      for (unsigned n=0; n<face->n_nodes(); ++n)
+      for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(InfHex16::side_nodes_map[i][n]);
 
       return face;

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -219,7 +219,7 @@ std::unique_ptr<Elem> InfHex18::build_side_ptr (const unsigned int i,
       face->subdomain_id() = this->subdomain_id();
 
       // Set the nodes
-      for (unsigned n=0; n<face->n_nodes(); ++n)
+      for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(InfHex18::side_nodes_map[i][n]);
 
       return face;

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -177,7 +177,7 @@ std::unique_ptr<Elem> InfHex8::build_side_ptr (const unsigned int i,
       face->subdomain_id() = this->subdomain_id();
 
       // Set the nodes
-      for (unsigned n=0; n<face->n_nodes(); ++n)
+      for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(InfHex8::side_nodes_map[i][n]);
 
       return face;

--- a/src/geom/cell_inf_prism.C
+++ b/src/geom/cell_inf_prism.C
@@ -127,7 +127,7 @@ std::unique_ptr<Elem> InfPrism::side_ptr (const unsigned int i)
     }
 
   // Set the nodes
-  for (unsigned n=0; n<face->n_nodes(); ++n)
+  for (auto n : face->node_index_range())
     face->set_node(n) = this->node_ptr(InfPrism6::side_nodes_map[i][n]);
 
   return face;

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -182,7 +182,7 @@ std::unique_ptr<Elem> InfPrism12::build_side_ptr (const unsigned int i,
       face->subdomain_id() = this->subdomain_id();
 
       // Set the nodes
-      for (unsigned n=0; n<face->n_nodes(); ++n)
+      for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(InfPrism12::side_nodes_map[i][n]);
 
       return face;

--- a/src/geom/cell_inf_prism6.C
+++ b/src/geom/cell_inf_prism6.C
@@ -172,7 +172,7 @@ std::unique_ptr<Elem> InfPrism6::build_side_ptr (const unsigned int i,
       face->subdomain_id() = this->subdomain_id();
 
       // Set the nodes
-      for (unsigned n=0; n<face->n_nodes(); ++n)
+      for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(InfPrism6::side_nodes_map[i][n]);
 
       return face;

--- a/src/geom/cell_prism.C
+++ b/src/geom/cell_prism.C
@@ -130,7 +130,7 @@ std::unique_ptr<Elem> Prism::side_ptr (const unsigned int i)
     }
 
   // Set the nodes
-  for (unsigned n=0; n<face->n_nodes(); ++n)
+  for (auto n : face->node_index_range())
     face->set_node(n) = this->node_ptr(Prism6::side_nodes_map[i][n]);
 
   return face;

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -215,7 +215,7 @@ std::unique_ptr<Elem> Prism15::build_side_ptr (const unsigned int i,
       face->subdomain_id() = this->subdomain_id();
 
       // Set the nodes
-      for (unsigned n=0; n<face->n_nodes(); ++n)
+      for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Prism15::side_nodes_map[i][n]);
 
       return face;

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -186,7 +186,7 @@ std::unique_ptr<Elem> Prism6::build_side_ptr (const unsigned int i,
       face->subdomain_id() = this->subdomain_id();
 
       // Set the nodes
-      for (unsigned n=0; n<face->n_nodes(); ++n)
+      for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Prism6::side_nodes_map[i][n]);
 
       return face;

--- a/src/geom/cell_pyramid.C
+++ b/src/geom/cell_pyramid.C
@@ -125,7 +125,7 @@ std::unique_ptr<Elem> Pyramid::side_ptr (const unsigned int i)
     }
 
   // Set the nodes
-  for (unsigned n=0; n<face->n_nodes(); ++n)
+  for (auto n : face->node_index_range())
     face->set_node(n) = this->node_ptr(Pyramid5::side_nodes_map[i][n]);
 
   return face;

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -200,7 +200,7 @@ std::unique_ptr<Elem> Pyramid13::build_side_ptr (const unsigned int i, bool prox
       face->subdomain_id() = this->subdomain_id();
 
       // Set the nodes
-      for (unsigned n=0; n<face->n_nodes(); ++n)
+      for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Pyramid13::side_nodes_map[i][n]);
 
       return face;

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -226,7 +226,7 @@ std::unique_ptr<Elem> Pyramid14::build_side_ptr (const unsigned int i, bool prox
       face->subdomain_id() = this->subdomain_id();
 
       // Set the nodes
-      for (unsigned n=0; n<face->n_nodes(); ++n)
+      for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Pyramid14::side_nodes_map[i][n]);
 
       return face;

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -175,7 +175,7 @@ std::unique_ptr<Elem> Pyramid5::build_side_ptr (const unsigned int i,
       face->subdomain_id() = this->subdomain_id();
 
       // Set the nodes
-      for (unsigned n=0; n<face->n_nodes(); ++n)
+      for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Pyramid5::side_nodes_map[i][n]);
 
       return face;

--- a/src/geom/cell_tet.C
+++ b/src/geom/cell_tet.C
@@ -79,7 +79,7 @@ std::unique_ptr<Elem> Tet::side_ptr (const unsigned int i)
 
   std::unique_ptr<Elem> face = libmesh_make_unique<Tri3>();
 
-  for (unsigned n=0; n<face->n_nodes(); ++n)
+  for (auto n : face->node_index_range())
     face->set_node(n) = this->node_ptr(Tet4::side_nodes_map[i][n]);
 
   return face;

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -196,7 +196,7 @@ std::unique_ptr<Elem> Tet10::build_side_ptr (const unsigned int i,
       std::unique_ptr<Elem> face = libmesh_make_unique<Tri6>();
       face->subdomain_id() = this->subdomain_id();
 
-      for (unsigned n=0; n<face->n_nodes(); ++n)
+      for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Tet10::side_nodes_map[i][n]);
 
       return face;

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -157,7 +157,7 @@ std::unique_ptr<Elem> Tet4::build_side_ptr (const unsigned int i,
       std::unique_ptr<Elem> face = libmesh_make_unique<Tri3>();
       face->subdomain_id() = this->subdomain_id();
 
-      for (unsigned n=0; n<face->n_nodes(); ++n)
+      for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Tet4::side_nodes_map[i][n]);
 
       return face;

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -528,7 +528,7 @@ unsigned int Elem::which_side_am_i (const Elem * e) const
 bool Elem::contains_vertex_of(const Elem * e) const
 {
   // Our vertices are the first numbered nodes
-  for (unsigned int n = 0; n != e->n_vertices(); ++n)
+  for (auto n : IntRange<unsigned int>(0, e->n_vertices()))
     if (this->contains_point(e->point(n)))
       return true;
   return false;
@@ -541,7 +541,7 @@ bool Elem::contains_edge_of(const Elem * e) const
   unsigned int num_contained_edges = 0;
 
   // Our vertices are the first numbered nodes
-  for (unsigned int n = 0; n != e->n_vertices(); ++n)
+  for (auto n : IntRange<unsigned int>(0, e->n_vertices()))
     {
       if (this->contains_point(e->point(n)))
         {
@@ -923,7 +923,7 @@ bool Elem::has_topological_neighbor (const Elem * elem,
 void Elem::libmesh_assert_valid_node_pointers() const
 {
   libmesh_assert(this->valid_id());
-  for (unsigned int n=0; n != this->n_nodes(); ++n)
+  for (auto n : this->node_index_range())
     {
       libmesh_assert(this->node_ptr(n));
       libmesh_assert(this->node_ptr(n)->valid_id());
@@ -1294,7 +1294,7 @@ void Elem::write_connectivity (std::ostream & out_stream,
         // This connectivity vector will be used repeatedly instead
         // of being reconstructed inside the loop.
         std::vector<dof_id_type> conn;
-        for (unsigned int sc=0; sc <this->n_sub_elem(); sc++)
+        for (auto sc : IntRange<unsigned int>(0, this->n_sub_elem()))
           {
             this->connectivity(sc, TECPLOT, conn);
 
@@ -2037,7 +2037,7 @@ Elem::bracketing_nodes(unsigned int child,
           // This only doesn't break horribly because we add children
           // and nodes in straightforward + hierarchical orders...
           for (unsigned int c=0; c <= child; ++c)
-            for (unsigned int n=0; n != this->n_nodes_in_child(c); ++n)
+            for (auto n : IntRange<unsigned int>(0, this->n_nodes_in_child(c)))
               {
                 if (c == child && n == child_node)
                   break;
@@ -2256,12 +2256,12 @@ std::string Elem::get_info () const
       << "   dim()="     << this->dim()                            << '\n'
       << "   n_nodes()=" << this->n_nodes()                        << '\n';
 
-  for (unsigned int n=0; n != this->n_nodes(); ++n)
+  for (auto n : this->node_index_range())
     oss << "    " << n << this->node_ref(n);
 
   oss << "   n_sides()=" << this->n_sides()                        << '\n';
 
-  for (unsigned int s=0; s != this->n_sides(); ++s)
+  for (auto s : this->side_index_range())
     {
       oss << "    neighbor(" << s << ")=";
       if (this->neighbor_ptr(s))
@@ -2303,9 +2303,9 @@ std::string Elem::get_info () const
       ;
 
   oss << "   DoFs=";
-  for (unsigned int s=0; s != this->n_systems(); ++s)
-    for (unsigned int v=0; v != this->n_vars(s); ++v)
-      for (unsigned int c=0; c != this->n_comp(s,v); ++c)
+  for (auto s : IntRange<unsigned int>(0, this->n_systems()))
+    for (auto v : IntRange<unsigned int>(0, this->n_vars(s)))
+      for (auto c : IntRange<unsigned int>(0, this->n_comp(s,v)))
         oss << '(' << s << '/' << v << '/' << this->dof_number(s,v,c) << ") ";
 
 
@@ -2637,8 +2637,8 @@ Real Elem::volume () const
   fe->reinit(this);
 
   Real vol=0.;
-  for (unsigned int qp=0; qp<qrule.n_points(); ++qp)
-    vol += JxW[qp];
+  for (auto jxw : JxW)
+    vol += jxw;
 
   return vol;
 

--- a/src/geom/elem_cutter.C
+++ b/src/geom/elem_cutter.C
@@ -156,7 +156,7 @@ void ElemCutter::find_intersection_points(const Elem & elem,
 {
   _intersection_pts.clear();
 
-  for (unsigned int e=0; e<elem.n_edges(); e++)
+  for (auto e : elem.edge_index_range())
     {
       std::unique_ptr<const Elem> edge (elem.build_edge_ptr(e));
 
@@ -235,7 +235,7 @@ void ElemCutter::cut_2D (const Elem & elem,
   _inside_mesh_2D->clear();
   _outside_mesh_2D->clear();
 
-  for (unsigned int v=0; v<elem.n_vertices(); v++)
+  for (auto v : IntRange<unsigned int>(0, elem.n_vertices()))
     {
       if (vertex_distance_func[v] >= 0.)
         _outside_mesh_2D->add_point (elem.point(v));
@@ -315,7 +315,7 @@ void ElemCutter::cut_3D (const Elem & elem,
   _inside_mesh_3D->clear();
   _outside_mesh_3D->clear();
 
-  for (unsigned int v=0; v<elem.n_vertices(); v++)
+  for (auto v : IntRange<unsigned int>(0, elem.n_vertices()))
     {
       if (vertex_distance_func[v] >= 0.)
         _outside_mesh_3D->add_point (elem.point(v));

--- a/src/geom/elem_refinement.C
+++ b/src/geom/elem_refinement.C
@@ -107,7 +107,7 @@ void Elem::refine (MeshRefinement & mesh_refinement)
           current_child->set_p_level(parent_p_level);
           current_child->set_p_refinement_flag(this->p_refinement_flag());
 
-          for (unsigned int cnode=0; cnode != current_child->n_nodes(); ++cnode)
+          for (auto cnode : current_child->node_index_range())
             {
               Node * node =
                 mesh_refinement.add_node(*this, c, cnode,
@@ -171,18 +171,20 @@ void Elem::coarsen()
 
   unsigned int parent_p_level = 0;
 
+  const unsigned int n_n = this->n_nodes();
+
   // re-compute hanging node nodal locations
   for (unsigned int c = 0, nc = this->n_children(); c != nc; ++c)
     {
       Elem * mychild = this->child_ptr(c);
       if (mychild == remote_elem)
         continue;
-      for (unsigned int cnode=0; cnode != mychild->n_nodes(); ++cnode)
+      for (auto cnode : mychild->node_index_range())
         {
           Point new_pos;
           bool calculated_new_pos = false;
 
-          for (unsigned int n=0; n<this->n_nodes(); n++)
+          for (unsigned int n=0; n<n_n; n++)
             {
               // The value from the embedding matrix
               const float em_val = this->embedding_matrix(c,cnode,n);

--- a/src/geom/face_inf_quad.C
+++ b/src/geom/face_inf_quad.C
@@ -99,7 +99,7 @@ std::unique_ptr<Elem> InfQuad::side_ptr (const unsigned int i)
     }
 
   // Set the nodes
-  for (unsigned n=0; n<edge->n_nodes(); ++n)
+  for (auto n : edge->node_index_range())
     edge->set_node(n) = this->node_ptr(InfQuad4::side_nodes_map[i][n]);
 
   return edge;

--- a/src/geom/face_inf_quad4.C
+++ b/src/geom/face_inf_quad4.C
@@ -230,7 +230,7 @@ std::unique_ptr<Elem> InfQuad4::build_side_ptr (const unsigned int i,
       edge->subdomain_id() = this->subdomain_id();
 
       // Set the nodes
-      for (unsigned n=0; n<edge->n_nodes(); ++n)
+      for (auto n : edge->node_index_range())
         edge->set_node(n) = this->node_ptr(InfQuad4::side_nodes_map[i][n]);
 
       return edge;

--- a/src/geom/face_inf_quad6.C
+++ b/src/geom/face_inf_quad6.C
@@ -210,7 +210,7 @@ std::unique_ptr<Elem> InfQuad6::build_side_ptr (const unsigned int i,
       edge->subdomain_id() = this->subdomain_id();
 
       // Set the nodes
-      for (unsigned n=0; n<edge->n_nodes(); ++n)
+      for (auto n : edge->node_index_range())
         edge->set_node(n) = this->node_ptr(InfQuad6::side_nodes_map[i][n]);
 
       return edge;

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -89,7 +89,7 @@ std::unique_ptr<Elem> Quad::side_ptr (const unsigned int i)
 
   std::unique_ptr<Elem> edge = libmesh_make_unique<Edge2>();
 
-  for (unsigned n=0; n<edge->n_nodes(); ++n)
+  for (auto n : edge->node_index_range())
     edge->set_node(n) = this->node_ptr(Quad4::side_nodes_map[i][n]);
 
   return edge;

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -154,7 +154,7 @@ std::unique_ptr<Elem> Quad4::build_side_ptr (const unsigned int i,
       edge->subdomain_id() = this->subdomain_id();
 
       // Set the nodes
-      for (unsigned n=0; n<edge->n_nodes(); ++n)
+      for (auto n : edge->node_index_range())
         edge->set_node(n) = this->node_ptr(Quad4::side_nodes_map[i][n]);
 
       return edge;

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -228,7 +228,7 @@ std::unique_ptr<Elem> Quad8::build_side_ptr (const unsigned int i,
       edge->subdomain_id() = this->subdomain_id();
 
       // Set the nodes
-      for (unsigned n=0; n<edge->n_nodes(); ++n)
+      for (auto n : edge->node_index_range())
         edge->set_node(n) = this->node_ptr(Quad8::side_nodes_map[i][n]);
 
       return edge;

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -246,7 +246,7 @@ std::unique_ptr<Elem> Quad9::build_side_ptr (const unsigned int i,
       edge->subdomain_id() = this->subdomain_id();
 
       // Set the nodes
-      for (unsigned n=0; n<edge->n_nodes(); ++n)
+      for (auto n : edge->node_index_range())
         edge->set_node(n) = this->node_ptr(Quad9::side_nodes_map[i][n]);
 
       return edge;

--- a/src/geom/face_tri.C
+++ b/src/geom/face_tri.C
@@ -84,7 +84,7 @@ std::unique_ptr<Elem> Tri::side_ptr (const unsigned int i)
 
   std::unique_ptr<Elem> edge = libmesh_make_unique<Edge2>();
 
-  for (unsigned n=0; n<edge->n_nodes(); ++n)
+  for (auto n : edge->node_index_range())
     edge->set_node(n) = this->node_ptr(Tri3::side_nodes_map[i][n]);
 
   return edge;

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -136,7 +136,7 @@ std::unique_ptr<Elem> Tri3::build_side_ptr (const unsigned int i,
       edge->subdomain_id() = this->subdomain_id();
 
       // Set the nodes
-      for (unsigned n=0; n<edge->n_nodes(); ++n)
+      for (auto n : edge->node_index_range())
         edge->set_node(n) = this->node_ptr(Tri3::side_nodes_map[i][n]);
 
       return edge;

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -212,7 +212,7 @@ std::unique_ptr<Elem> Tri6::build_side_ptr (const unsigned int i,
       edge->subdomain_id() = this->subdomain_id();
 
       // Set the nodes
-      for (unsigned n=0; n<edge->n_nodes(); ++n)
+      for (auto n : edge->node_index_range())
         edge->set_node(n) = this->node_ptr(Tri6::side_nodes_map[i][n]);
 
       return edge;

--- a/src/geom/node.C
+++ b/src/geom/node.C
@@ -65,9 +65,9 @@ std::string Node::get_info () const
     ", Point=" << *static_cast<const Point *>(this) << '\n';
 
   oss << "    DoFs=";
-  for (unsigned int s=0; s != this->n_systems(); ++s)
-    for (unsigned int v=0; v != this->n_vars(s); ++v)
-      for (unsigned int c=0; c != this->n_comp(s,v); ++c)
+  for (auto s : IntRange<unsigned int>(0, this->n_systems()))
+    for (auto v : IntRange<unsigned int>(0, this->n_vars(s)))
+      for (auto c : IntRange<unsigned int>(0, this->n_comp(s,v)))
         oss << '(' << s << '/' << v << '/' << this->dof_number(s,v,c) << ") ";
 
   return oss.str();

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -928,8 +928,8 @@ void AbaqusIO::assign_subdomain_ids()
     unsigned char max_dim = this->max_elem_dimension_seen();
 
     // The elemset_id counter assigns a logical numbering to the _elemset_ids keys
-    container_t::iterator it = _elemset_ids.begin();
-    for (unsigned elemset_id=0; it != _elemset_ids.end(); ++it, ++elemset_id)
+    container_t::iterator it = _elemset_ids.begin(), end = _elemset_ids.end();
+    for (unsigned elemset_id=0; it != end; ++it, ++elemset_id)
       {
         // Grab a reference to the vector of IDs
         std::vector<dof_id_type> & id_vector = it->second;
@@ -980,8 +980,8 @@ void AbaqusIO::assign_boundary_node_ids()
   MeshBase & the_mesh = MeshInput<MeshBase>::mesh();
 
   // Iterate over the container of nodesets
-  container_t::iterator it = _nodeset_ids.begin();
-  for (unsigned short current_id=0; it != _nodeset_ids.end(); ++it, ++current_id)
+  container_t::iterator it = _nodeset_ids.begin(), end = _nodeset_ids.end();
+  for (unsigned short current_id=0; it != end; ++it, ++current_id)
     {
       // Associate current_id with the name we determined earlier
       the_mesh.get_boundary_info().nodeset_name(current_id) = it->first;
@@ -1020,8 +1020,8 @@ void AbaqusIO::assign_sideset_ids()
 
   // Iterate over the container of sidesets
   {
-    sideset_container_t::iterator it = _sideset_ids.begin();
-    for (unsigned short current_id=0; it != _sideset_ids.end(); ++it, ++current_id)
+    sideset_container_t::iterator it = _sideset_ids.begin(), end = _sideset_ids.end();
+    for (unsigned short current_id=0; it != end; ++it, ++current_id)
       {
         // Associate current_id with the name we determined earlier
         the_mesh.get_boundary_info().sideset_name(current_id) = it->first;
@@ -1084,8 +1084,8 @@ void AbaqusIO::assign_sideset_ids()
     // The elemset_id counter assigns a logical numbering to the
     // _elemset_ids keys.  We are going to use these ids as boundary
     // ids, so elemset_id is of type boundary_id_type.
-    container_t::iterator it = _elemset_ids.begin();
-    for (boundary_id_type elemset_id=0; it != _elemset_ids.end(); ++it, ++elemset_id)
+    container_t::iterator it = _elemset_ids.begin(), end = _elemset_ids.end();
+    for (boundary_id_type elemset_id=0; it != end; ++it, ++elemset_id)
       {
         // Grab a reference to the vector of IDs
         std::vector<dof_id_type> & id_vector = it->second;

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -515,7 +515,7 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
           // then we share that vertex with our parent, with
           // the same local index.
           bool found_child = false;
-          for (unsigned int v=0; v != new_elem->n_vertices(); ++v)
+          for (auto v : IntRange<unsigned int>(0, new_elem->n_vertices()))
             if (new_elem->node_ptr(v) == side_parent->node_ptr(v))
               {
                 side_parent->add_child(new_elem, v);

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -1080,7 +1080,7 @@ DistributedMesh::renumber_dof_objects(mapvector<T *, dof_id_type> & objects)
 
   // We'll renumber objects in blocks by processor id
   std::vector<dof_id_type> first_object_on_proc(this->n_processors());
-  for (processor_id_type i=1; i != this->n_processors(); ++i)
+  for (processor_id_type i=1, np=this->n_processors(); i != np; ++i)
     first_object_on_proc[i] = first_object_on_proc[i-1] +
       objects_on_proc[i-1];
   dof_id_type next_id = first_object_on_proc[this->processor_id()];
@@ -1099,7 +1099,7 @@ DistributedMesh::renumber_dof_objects(mapvector<T *, dof_id_type> & objects)
   // We know how many objects live on each processor, so reserve() space for
   // each.
   auto ghost_end = ghost_objects_from_proc.end();
-  for (processor_id_type p=0; p != this->n_processors(); ++p)
+  for (auto p : IntRange<processor_id_type>(0, this->n_processors()))
     if (p != this->processor_id())
       {
         const auto p_it = ghost_objects_from_proc.find(p);
@@ -1224,7 +1224,7 @@ DistributedMesh::renumber_dof_objects(mapvector<T *, dof_id_type> & objects)
 
   // Next set unpartitioned object ids
   next_id = 0;
-  for (processor_id_type i=0; i != this->n_processors(); ++i)
+  for (auto i : IntRange<processor_id_type>(0, this->n_processors()))
     next_id += objects_on_proc[i];
   for (it = objects.begin(); it != end; ++it)
     {
@@ -1293,8 +1293,8 @@ void DistributedMesh::renumber_nodes_and_elements ()
 
   // flag the nodes we need
   for (auto & elem : this->element_ptr_range())
-    for (unsigned int n=0; n != elem->n_nodes(); ++n)
-      used_nodes.insert(elem->node_id(n));
+    for (const Node & node : elem->node_ref_range())
+      used_nodes.insert(node.id());
 
   // Nodes not connected to any local elements, and nullptr node entries
   // in our container, are deleted

--- a/src/mesh/ensight_io.C
+++ b/src/mesh/ensight_io.C
@@ -203,8 +203,8 @@ void EnsightIO::write_geometry_ascii()
     {
       ensight_parts_map[elem->type()].push_back(elem);
 
-      for (unsigned int i = 0; i < elem->n_nodes(); i++)
-        mesh_nodes_map[elem->node_id(i)] = elem->point(i);
+      for (const Node & node : elem->node_ref_range())
+        mesh_nodes_map[node.id()] = node;
     }
 
   // Write number of local points
@@ -391,7 +391,7 @@ void EnsightIO::write_scalar_ascii(const std::string & sys,
       libmesh_error_msg("Complex-valued Ensight output not yet supported");
 #endif
 
-      for (unsigned int n=0; n<elem->n_nodes(); n++)
+      for (auto n : elem->node_index_range())
         local_soln[elem->node_id(n)] = libmesh_real(nodal_soln[n]);
     }
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -589,7 +589,7 @@ void ExodusII_IO::copy_scalar_solution(System & system,
   {
     const DofMap & dof_map = system.get_dof_map();
 
-    for (std::size_t i = 0; i < system_var_names.size(); i++)
+    for (auto i : index_range(system_var_names))
     {
       const unsigned int var_num = system.variable_scalar_number(system_var_names[i], 0);
 

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -929,7 +929,7 @@ void ExodusII_IO_Helper::read_edge_blocks(MeshBase & mesh)
 
           // Loop over indices in connectivity array, build edge elements,
           // look them up in the edge_map.
-          for (unsigned int i=0; i<connect.size(); i+=num_nodes_per_edge)
+          for (unsigned int i=0, sz=connect.size(); i<sz; i+=num_nodes_per_edge)
             {
               auto edge = Elem::build(conv.libmesh_elem_type());
               for (int n=0; n<num_nodes_per_edge; ++n)
@@ -1783,16 +1783,16 @@ void ExodusII_IO_Helper::write_nodal_coordinates(const MeshBase & mesh, bool use
   else
     {
       for (const auto & elem : mesh.active_element_ptr_range())
-        for (unsigned int n=0; n<elem->n_nodes(); n++)
+        for (const Node & node : elem->node_ref_range())
           {
-            x.push_back(elem->point(n)(0));
+            x.push_back(node(0));
 #if LIBMESH_DIM > 1
-            y.push_back(elem->point(n)(1));
+            y.push_back(node(1));
 #else
             y.push_back(0.);
 #endif
 #if LIBMESH_DIM > 2
-            z.push_back(elem->point(n)(2));
+            z.push_back(node(2));
 #else
             z.push_back(0.);
 #endif
@@ -1908,7 +1908,7 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
   {
     dof_id_type node_counter = 1; // Exodus numbering is 1-based
     for (const auto & elem : mesh.active_element_ptr_range())
-      for (unsigned int n=0; n<elem->n_nodes(); n++)
+      for (auto n : elem->node_index_range())
         {
           std::pair<dof_id_type,unsigned int> id_pair;
           id_pair.first = elem->id();
@@ -2639,7 +2639,7 @@ write_sideset_data(const MeshBase & mesh,
 
       // For each variable in var_names, write the values for the
       // current sideset, if any.
-      for (unsigned int var=0; var<var_names.size(); ++var)
+      for (auto var : index_range(var_names))
         {
           // If this var has no values on this sideset, go to the next one.
           if (!side_ids[var].count(ss_ids[ss]))

--- a/src/mesh/fro_io.C
+++ b/src/mesh/fro_io.C
@@ -64,7 +64,7 @@ void FroIO::write (const std::string & fname)
                  << the_mesh.get_boundary_info().n_boundary_ids()  << " 1\n";
 
       // Write the nodes -- 1-based!
-      for (unsigned int n=0; n<the_mesh.n_nodes(); n++)
+      for (auto n : IntRange<unsigned int>(0, the_mesh.n_nodes()))
         out_stream << n+1 << " \t"
                    << std::scientific
                    << std::setprecision(this->ascii_precision())
@@ -83,8 +83,8 @@ void FroIO::write (const std::string & fname)
 
           out_stream << ++e << " \t";
 
-          for (unsigned int n=0; n<elem->n_nodes(); n++)
-            out_stream << elem->node_id(n)+1 << " \t";
+          for (const Node & node : elem->node_ref_range())
+            out_stream << node.id()+1 << " \t";
 
           //   // LHS -> RHS Mapping, for inverted triangles
           //   out_stream << elem->node_id(0)+1 << " \t";

--- a/src/mesh/gmsh_io.C
+++ b/src/mesh/gmsh_io.C
@@ -882,7 +882,7 @@ void GmshIO::write_mesh (std::ostream & out_stream)
   out_stream << "$Nodes\n";
   out_stream << mesh.n_nodes() << '\n';
 
-  for (unsigned int v=0; v<mesh.n_nodes(); v++)
+  for (auto v : IntRange<unsigned int>(0, mesh.n_nodes()))
     out_stream << mesh.node_ref(v).id()+1 << " "
                << mesh.node_ref(v)(0) << " "
                << mesh.node_ref(v)(1) << " "
@@ -1175,10 +1175,11 @@ void GmshIO::write_post (const std::string & fname,
           // Loop over the elements and write out the data
           for (const auto & elem : mesh.active_element_ptr_range())
             {
+              const unsigned int nv = elem->n_vertices();
               // this is quite crappy, but I did not invent that file format!
               for (unsigned int d=0; d<3; d++)  // loop over the dimensions
                 {
-                  for (unsigned int n=0; n < elem->n_vertices(); n++)   // loop over vertices
+                  for (unsigned int n=0; n < nv; n++)   // loop over vertices
                     {
                       const Point & vertex = elem->point(n);
                       if (this->binary())
@@ -1198,7 +1199,7 @@ void GmshIO::write_post (const std::string & fname,
                 }
 
               // now finally write out the data
-              for (unsigned int i=0; i < elem->n_vertices(); i++)   // loop over vertices
+              for (unsigned int i=0; i < nv; i++)   // loop over vertices
                 if (this->binary())
                   {
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS

--- a/src/mesh/gmv_io.C
+++ b/src/mesh/gmv_io.C
@@ -333,11 +333,11 @@ void GMVIO::write_ascii_new_impl (const std::string & fname,
 
     // write the nodes
     out_stream << "nodes " << mesh.n_nodes() << "\n";
-    for (unsigned int n=0; n<mesh.n_nodes(); n++)
+    for (auto n : IntRange<unsigned int>(0, mesh.n_nodes()))
       out_stream << mesh.point(n)(0) << " ";
     out_stream << "\n";
 
-    for (unsigned int n=0; n<mesh.n_nodes(); n++)
+    for (auto n : IntRange<unsigned int>(0, mesh.n_nodes()))
 #if LIBMESH_DIM > 1
       out_stream << mesh.point(n)(1) << " ";
 #else
@@ -345,7 +345,7 @@ void GMVIO::write_ascii_new_impl (const std::string & fname,
 #endif
     out_stream << "\n";
 
-    for (unsigned int n=0; n<mesh.n_nodes(); n++)
+    for (auto n : IntRange<unsigned int>(0, mesh.n_nodes()))
 #if LIBMESH_DIM > 2
       out_stream << mesh.point(n)(2) << " ";
 #else
@@ -406,7 +406,7 @@ void GMVIO::write_ascii_new_impl (const std::string & fname,
             // it is a non-const function.
                      << " 0\n";
 
-          for (unsigned int proc=0; proc<mesh.n_partitions(); proc++)
+          for (auto proc : IntRange<unsigned int>(0, mesh.n_partitions()))
             out_stream << "proc_" << proc << "\n";
 
           // FIXME - don't we need to use an ElementDefinition here? - RHS
@@ -454,7 +454,7 @@ void GMVIO::write_ascii_new_impl (const std::string & fname,
           // than are present in the current element!
           libmesh_assert_less_equal (ele.node_map.size(), elem->n_nodes());
 
-          for (std::size_t i=0; i < ele.node_map.size(); i++)
+          for (auto i : index_range(ele.node_map))
             out_stream << elem->p_level() << " ";
         }
       out_stream << "\n\n";
@@ -481,7 +481,7 @@ void GMVIO::write_ascii_new_impl (const std::string & fname,
               const Real the_value = the_array->operator[](elem->id());
 
               if (this->subdivide_second_order())
-                for (unsigned int se=0; se < elem->n_sub_elem(); se++)
+                for (unsigned int se=0, nse=elem->n_sub_elem(); se<nse; se++)
                   out_stream << the_value << " ";
               else
                 out_stream << the_value << " ";
@@ -517,7 +517,7 @@ void GMVIO::write_ascii_new_impl (const std::string & fname,
           // this is the real part
           out_stream << "r_" << (*solution_names)[c] << " 1\n";
 
-          for (unsigned int n=0; n<mesh.n_nodes(); n++)
+          for (auto n : IntRange<dof_id_type>(0, mesh.n_nodes()))
             out_stream << (*v)[n*n_vars + c].real() << " ";
 
           out_stream << "\n\n";
@@ -525,14 +525,14 @@ void GMVIO::write_ascii_new_impl (const std::string & fname,
           // this is the imaginary part
           out_stream << "i_" << (*solution_names)[c] << " 1\n";
 
-          for (unsigned int n=0; n<mesh.n_nodes(); n++)
+          for (auto n : IntRange<dof_id_type>(0, mesh.n_nodes()))
             out_stream << (*v)[n*n_vars + c].imag() << " ";
 
           out_stream << "\n\n";
 
           // this is the magnitude
           out_stream << "a_" << (*solution_names)[c] << " 1\n";
-          for (unsigned int n=0; n<mesh.n_nodes(); n++)
+          for (auto n : IntRange<dof_id_type>(0, mesh.n_nodes()))
             out_stream << std::abs((*v)[n*n_vars + c]) << " ";
 
           out_stream << "\n\n";
@@ -541,7 +541,7 @@ void GMVIO::write_ascii_new_impl (const std::string & fname,
 
           out_stream << (*solution_names)[c] << " 1\n";
 
-          for (unsigned int n=0; n<mesh.n_nodes(); n++)
+          for (auto n : IntRange<dof_id_type>(0, mesh.n_nodes()))
             out_stream << (*v)[n*n_vars + c] << " ";
 
           out_stream << "\n\n";
@@ -622,12 +622,12 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
 
     out_stream << "gmvinput ascii\n\n";
     out_stream << "nodes " << mesh.n_nodes() << '\n';
-    for (unsigned int n=0; n<mesh.n_nodes(); n++)
+    for (auto n : IntRange<dof_id_type>(0, mesh.n_nodes()))
       out_stream << mesh.point(n)(0) << " ";
 
     out_stream << '\n';
 
-    for (unsigned int n=0; n<mesh.n_nodes(); n++)
+    for (auto n : IntRange<dof_id_type>(0, mesh.n_nodes()))
 #if LIBMESH_DIM > 1
       out_stream << mesh.point(n)(1) << " ";
 #else
@@ -636,7 +636,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
 
     out_stream << '\n';
 
-    for (unsigned int n=0; n<mesh.n_nodes(); n++)
+    for (auto n : IntRange<dof_id_type>(0, mesh.n_nodes()))
 #if LIBMESH_DIM > 2
       out_stream << mesh.point(n)(2) << " ";
 #else
@@ -671,7 +671,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
           case 1:
             {
               if (this->subdivide_second_order())
-                for (unsigned int se=0; se<elem->n_sub_elem(); se++)
+                for (auto se : IntRange<unsigned int>(0, elem->n_sub_elem()))
                   {
                     out_stream << "line 2\n";
                     elem->connectivity(se, TECPLOT, conn);
@@ -688,7 +688,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                   else
                     {
                       std::unique_ptr<Elem> lo_elem = Elem::build(Elem::first_order_equivalent_type(elem->type()));
-                      for (unsigned int i = 0; i != lo_elem->n_nodes(); ++i)
+                      for (auto i : lo_elem->node_index_range())
                         lo_elem->set_node(i) = elem->node_ptr(i);
                       lo_elem->connectivity(0, TECPLOT, conn);
                     }
@@ -704,7 +704,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
           case 2:
             {
               if (this->subdivide_second_order())
-                for (unsigned int se=0; se<elem->n_sub_elem(); se++)
+                for (auto se : IntRange<unsigned int>(0, elem->n_sub_elem()))
                   {
                     // Quad elements
                     if ((elem->type() == QUAD4) ||
@@ -758,7 +758,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                            )
                     {
                       std::unique_ptr<Elem> lo_elem = Elem::build(Elem::first_order_equivalent_type(elem->type()));
-                      for (unsigned int i = 0; i != lo_elem->n_nodes(); ++i)
+                      for (auto i : lo_elem->node_index_range())
                         lo_elem->set_node(i) = elem->node_ptr(i);
                       lo_elem->connectivity(0, TECPLOT, conn);
                       out_stream << "quad 4\n";
@@ -775,7 +775,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                   else if (elem->type() == TRI6)
                     {
                       std::unique_ptr<Elem> lo_elem = Elem::build(Elem::first_order_equivalent_type(elem->type()));
-                      for (unsigned int i = 0; i != lo_elem->n_nodes(); ++i)
+                      for (auto i : lo_elem->node_index_range())
                         lo_elem->set_node(i) = elem->node_ptr(i);
                       lo_elem->connectivity(0, TECPLOT, conn);
                       out_stream << "tri 3\n";
@@ -792,7 +792,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
           case 3:
             {
               if (this->subdivide_second_order())
-                for (unsigned int se=0; se<elem->n_sub_elem(); se++)
+                for (auto se : IntRange<unsigned int>(0, elem->n_sub_elem()))
                   {
 
 #ifndef  LIBMESH_ENABLE_INFINITE_ELEMENTS
@@ -948,7 +948,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
               else // !this->subdivide_second_order()
                 {
                   std::unique_ptr<Elem> lo_elem = Elem::build(Elem::first_order_equivalent_type(elem->type()));
-                  for (unsigned int i = 0; i != lo_elem->n_nodes(); ++i)
+                  for (auto i : lo_elem->node_index_range())
                     lo_elem->set_node(i) = elem->node_ptr(i);
                   if ((lo_elem->type() == HEX8)
 #ifdef  LIBMESH_ENABLE_INFINITE_ELEMENTS
@@ -1047,7 +1047,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
               unsigned gmv_mat_number = libmesh_map_find(sbdid_map, elem->subdomain_id());
 
               if (this->subdivide_second_order())
-                for (unsigned int se=0; se<elem->n_sub_elem(); se++)
+                for (unsigned int se=0, nse=elem->n_sub_elem(); se<nse; se++)
                   out_stream << gmv_mat_number+1 << '\n';
               else
                 out_stream << gmv_mat_number+1 << "\n";
@@ -1061,12 +1061,12 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                      << mesh.n_partitions()
                      << " 0"<< '\n';
 
-          for (unsigned int proc=0; proc<mesh.n_partitions(); proc++)
+          for (auto proc : IntRange<unsigned int>(0, mesh.n_partitions()))
             out_stream << "proc_" << proc << '\n';
 
           for (const auto & elem : mesh.active_element_ptr_range())
             if (this->subdivide_second_order())
-              for (unsigned int se=0; se<elem->n_sub_elem(); se++)
+              for (unsigned int se=0, nse=elem->n_sub_elem(); se<nse; se++)
                 out_stream << elem->processor_id()+1 << '\n';
             else
               out_stream << elem->processor_id()+1 << '\n';
@@ -1105,7 +1105,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
 
       for (const auto & elem : mesh.active_element_ptr_range())
         if (this->subdivide_second_order())
-          for (unsigned int se=0; se<elem->n_sub_elem(); se++)
+          for (unsigned int se=0, nse=elem->n_sub_elem(); se<nse; se++)
             out_stream << elem->p_level() << " ";
         else
           out_stream << elem->p_level() << " ";
@@ -1135,7 +1135,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
               const Real the_value = (*the_array)[elem->id()];
 
               if (this->subdivide_second_order())
-                for (unsigned int se=0; se < elem->n_sub_elem(); se++)
+                for (unsigned int se=0, nse=elem->n_sub_elem(); se<nse; se++)
                   out_stream << the_value << " ";
               else
                 out_stream << the_value << " ";
@@ -1175,7 +1175,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
           // this is the real part
           out_stream << "r_" << (*solution_names)[c] << " 1\n";
 
-          for (unsigned int n=0; n<mesh.n_nodes(); n++)
+          for (auto n : IntRange<unsigned int>(0, mesh.n_nodes()))
             out_stream << (*v)[n*n_vars + c].real() << " ";
 
           out_stream << '\n' << '\n';
@@ -1184,14 +1184,14 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
           // this is the imaginary part
           out_stream << "i_" << (*solution_names)[c] << " 1\n";
 
-          for (unsigned int n=0; n<mesh.n_nodes(); n++)
+          for (auto n : IntRange<unsigned int>(0, mesh.n_nodes()))
             out_stream << (*v)[n*n_vars + c].imag() << " ";
 
           out_stream << '\n' << '\n';
 
           // this is the magnitude
           out_stream << "a_" << (*solution_names)[c] << " 1\n";
-          for (unsigned int n=0; n<mesh.n_nodes(); n++)
+          for (auto n : IntRange<unsigned int>(0, mesh.n_nodes()))
             out_stream << std::abs((*v)[n*n_vars + c]) << " ";
 
           out_stream << '\n' << '\n';
@@ -1200,7 +1200,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
 
           out_stream << (*solution_names)[c] << " 1\n";
 
-          for (unsigned int n=0; n<mesh.n_nodes(); n++)
+          for (auto n : IntRange<unsigned int>(0, mesh.n_nodes()))
             out_stream << (*v)[n*n_vars + c] << " ";
 
           out_stream << '\n' << '\n';
@@ -1272,12 +1272,12 @@ void GMVIO::write_binary (const std::string & fname,
 
     // write the x coordinate
     std::vector<float> temp(mesh.n_nodes());
-    for (unsigned int v=0; v<mesh.n_nodes(); v++)
+    for (auto v : IntRange<unsigned int>(0, mesh.n_nodes()))
       temp[v] = static_cast<float>(mesh.point(v)(0));
     out_stream.write(reinterpret_cast<char *>(temp.data()), sizeof(float)*mesh.n_nodes());
 
     // write the y coordinate
-    for (unsigned int v=0; v<mesh.n_nodes(); v++)
+    for (auto v : IntRange<unsigned int>(0, mesh.n_nodes()))
       {
 #if LIBMESH_DIM > 1
         temp[v] = static_cast<float>(mesh.point(v)(1));
@@ -1288,7 +1288,7 @@ void GMVIO::write_binary (const std::string & fname,
     out_stream.write(reinterpret_cast<char *>(temp.data()), sizeof(float)*mesh.n_nodes());
 
     // write the z coordinate
-    for (unsigned int v=0; v<mesh.n_nodes(); v++)
+    for (auto v : IntRange<unsigned int>(0, mesh.n_nodes()))
       {
 #if LIBMESH_DIM > 2
         temp[v] = static_cast<float>(mesh.point(v)(2));
@@ -1370,7 +1370,7 @@ void GMVIO::write_binary (const std::string & fname,
           tmpint = 0; // IDs are cell based
           out_stream.write(reinterpret_cast<char *>(&tmpint), sizeof(unsigned int));
 
-          for (unsigned int proc=0; proc<mesh.n_processors(); proc++)
+          for (auto proc : IntRange<unsigned int>(0, mesh.n_processors()))
             {
               // We have to write exactly 8 bytes.  This means that
               // the processor id can be up to 3 characters long, and
@@ -1422,7 +1422,7 @@ void GMVIO::write_binary (const std::string & fname,
   if (this->p_levels() && mesh_max_p_level)
     {
       unsigned int n_floats = n_active_elem;
-      for (unsigned int i=0; i != mesh.mesh_dimension(); ++i)
+      for (unsigned int i=0, d=mesh.mesh_dimension(); i != d; ++i)
         n_floats *= 2;
 
       std::vector<float> temp(n_floats);
@@ -1435,7 +1435,7 @@ void GMVIO::write_binary (const std::string & fname,
 
       unsigned int n=0;
       for (const auto & elem : mesh.active_element_ptr_range())
-        for (unsigned int se=0; se<elem->n_sub_elem(); se++)
+        for (unsigned int se=0, nse=elem->n_sub_elem(); se<nse; se++)
           temp[n++] = static_cast<float>( elem->p_level() );
 
       out_stream.write(reinterpret_cast<char *>(temp.data()),
@@ -1476,7 +1476,7 @@ void GMVIO::write_binary (const std::string & fname,
           unsigned int tempint = 1; // always do nodal data
           out_stream.write(reinterpret_cast<char *>(&tempint), sizeof(unsigned int));
 
-          for (unsigned int n=0; n<mesh.n_nodes(); n++)
+          for (auto n : IntRange<unsigned int>(0, mesh.n_nodes()))
             temp[n] = static_cast<float>( (*vec)[n*n_vars + c].real() );
 
           out_stream.write(reinterpret_cast<char *>(temp.data()), sizeof(float)*mesh.n_nodes());
@@ -1491,7 +1491,7 @@ void GMVIO::write_binary (const std::string & fname,
 
           out_stream.write(reinterpret_cast<char *>(&tempint), sizeof(unsigned int));
 
-          for (unsigned int n=0; n<mesh.n_nodes(); n++)
+          for (auto n : IntRange<unsigned int>(0, mesh.n_nodes()))
             temp[n] = static_cast<float>( (*vec)[n*n_vars + c].imag() );
 
           out_stream.write(reinterpret_cast<char *>(temp.data()), sizeof(float)*mesh.n_nodes());
@@ -1504,7 +1504,7 @@ void GMVIO::write_binary (const std::string & fname,
 
           out_stream.write(reinterpret_cast<char *>(&tempint), sizeof(unsigned int));
 
-          for (unsigned int n=0; n<mesh.n_nodes(); n++)
+          for (auto n : IntRange<unsigned int>(0, mesh.n_nodes()))
             temp[n] = static_cast<float>(std::abs((*vec)[n*n_vars + c]));
 
           out_stream.write(reinterpret_cast<char *>(temp.data()), sizeof(float)*mesh.n_nodes());
@@ -1517,7 +1517,7 @@ void GMVIO::write_binary (const std::string & fname,
           unsigned int tempint = 1; // always do nodal data
           out_stream.write(reinterpret_cast<char *>(&tempint), sizeof(unsigned int));
 
-          for (unsigned int n=0; n<mesh.n_nodes(); n++)
+          for (auto n : IntRange<unsigned int>(0, mesh.n_nodes()))
             temp[n] = static_cast<float>((*vec)[n*n_vars + c]);
 
           out_stream.write(reinterpret_cast<char *>(temp.data()), sizeof(float)*mesh.n_nodes());
@@ -1591,8 +1591,8 @@ void GMVIO::write_discontinuous_gmv (const std::string & name,
     // Write all the x values
     {
       for (const auto & elem : mesh.active_element_ptr_range())
-        for (unsigned int n=0; n<elem->n_nodes(); n++)
-          out_stream << elem->point(n)(0) << " ";
+        for (const Node & node : elem->node_ref_range())
+          out_stream << node(0) << " ";
 
       out_stream << std::endl;
     }
@@ -1601,9 +1601,9 @@ void GMVIO::write_discontinuous_gmv (const std::string & name,
     // Write all the y values
     {
       for (const auto & elem : mesh.active_element_ptr_range())
-        for (unsigned int n=0; n<elem->n_nodes(); n++)
+        for (const Node & node : elem->node_ref_range())
 #if LIBMESH_DIM > 1
-          out_stream << elem->point(n)(1) << " ";
+          out_stream << node(1) << " ";
 #else
       out_stream << 0. << " ";
 #endif
@@ -1615,9 +1615,9 @@ void GMVIO::write_discontinuous_gmv (const std::string & name,
     // Write all the z values
     {
       for (const auto & elem : mesh.active_element_ptr_range())
-        for (unsigned int n=0; n<elem->n_nodes(); n++)
+        for (const Node & node : elem->node_ref_range())
 #if LIBMESH_DIM > 2
-          out_stream << elem->point(n)(2) << " ";
+          out_stream << node(2) << " ";
 #else
       out_stream << 0. << " ";
 #endif
@@ -1640,7 +1640,7 @@ void GMVIO::write_discontinuous_gmv (const std::string & name,
       case 1:
         {
           for (const auto & elem : mesh.active_element_ptr_range())
-            for (unsigned int se=0; se<elem->n_sub_elem(); se++)
+            for (unsigned int se=0, nse=elem->n_sub_elem(); se<nse; se++)
               {
                 if ((elem->type() == EDGE2) ||
                     (elem->type() == EDGE3) ||
@@ -1651,7 +1651,7 @@ void GMVIO::write_discontinuous_gmv (const std::string & name,
                     )
                   {
                     out_stream << "line 2" << std::endl;
-                    for (unsigned int i=0; i<elem->n_nodes(); i++)
+                    for (unsigned int i=0, enn=elem->n_nodes(); i<enn; i++)
                       out_stream << nn++ << " ";
 
                   }
@@ -1667,7 +1667,7 @@ void GMVIO::write_discontinuous_gmv (const std::string & name,
       case 2:
         {
           for (const auto & elem : mesh.active_element_ptr_range())
-            for (unsigned int se=0; se<elem->n_sub_elem(); se++)
+            for (unsigned int se=0, nse=elem->n_sub_elem(); se<nse; se++)
               {
                 if ((elem->type() == QUAD4) ||
                     (elem->type() == QUAD8) || // Note: QUAD8 will be output as one central quad and
@@ -1681,7 +1681,7 @@ void GMVIO::write_discontinuous_gmv (const std::string & name,
                     )
                   {
                     out_stream << "quad 4" << std::endl;
-                    for (unsigned int i=0; i<elem->n_nodes(); i++)
+                    for (unsigned int i=0, enn=elem->n_nodes(); i<enn; i++)
                       out_stream << nn++ << " ";
 
                   }
@@ -1689,7 +1689,7 @@ void GMVIO::write_discontinuous_gmv (const std::string & name,
                          (elem->type() == TRI6))
                   {
                     out_stream << "tri 3" << std::endl;
-                    for (unsigned int i=0; i<elem->n_nodes(); i++)
+                    for (unsigned int i=0, enn=elem->n_nodes(); i<enn; i++)
                       out_stream << nn++ << " ";
 
                   }
@@ -1706,7 +1706,7 @@ void GMVIO::write_discontinuous_gmv (const std::string & name,
       case 3:
         {
           for (const auto & elem : mesh.active_element_ptr_range())
-            for (unsigned int se=0; se<elem->n_sub_elem(); se++)
+            for (unsigned int se=0, nse=elem->n_sub_elem(); se<nse; se++)
               {
                 if ((elem->type() == HEX8) ||
                     (elem->type() == HEX20) ||
@@ -1719,7 +1719,7 @@ void GMVIO::write_discontinuous_gmv (const std::string & name,
                     )
                   {
                     out_stream << "phex8 8" << std::endl;
-                    for (unsigned int i=0; i<elem->n_nodes(); i++)
+                    for (unsigned int i=0, enn=elem->n_nodes(); i<enn; i++)
                       out_stream << nn++ << " ";
                   }
                 else if ((elem->type() == PRISM6) ||
@@ -1732,14 +1732,14 @@ void GMVIO::write_discontinuous_gmv (const std::string & name,
                          )
                   {
                     out_stream << "pprism6 6" << std::endl;
-                    for (unsigned int i=0; i<elem->n_nodes(); i++)
+                    for (unsigned int i=0, enn=elem->n_nodes(); i<enn; i++)
                       out_stream << nn++ << " ";
                   }
                 else if ((elem->type() == TET4) ||
                          (elem->type() == TET10))
                   {
                     out_stream << "tet 4" << std::endl;
-                    for (unsigned int i=0; i<elem->n_nodes(); i++)
+                    for (unsigned int i=0, enn=elem->n_nodes(); i<enn; i++)
                       out_stream << nn++ << " ";
                   }
                 else
@@ -1772,7 +1772,7 @@ void GMVIO::write_discontinuous_gmv (const std::string & name,
                      << mesh.n_processors()
                      << " 0"<< std::endl;
 
-          for (unsigned int proc=0; proc<mesh.n_processors(); proc++)
+          for (auto proc : IntRange<unsigned int>(0, mesh.n_processors()))
             out_stream << "proc_" << proc << std::endl;
 
           for (const auto & elem : mesh.active_element_ptr_range())
@@ -1812,7 +1812,7 @@ void GMVIO::write_discontinuous_gmv (const std::string & name,
         // this is the real part
         out_stream << "r_" << solution_names[c] << " 1" << std::endl;
         for (const auto & elem : mesh.active_element_ptr_range())
-          for (unsigned int n=0; n<elem->n_nodes(); n++)
+          for (auto n : elem->node_index_range())
             out_stream << v[(n++)*n_vars + c].real() << " ";
         out_stream << std::endl << std::endl;
 
@@ -1820,14 +1820,14 @@ void GMVIO::write_discontinuous_gmv (const std::string & name,
         // this is the imaginary part
         out_stream << "i_" << solution_names[c] << " 1" << std::endl;
         for (const auto & elem : mesh.active_element_ptr_range())
-          for (unsigned int n=0; n<elem->n_nodes(); n++)
+          for (auto n : elem->node_index_range())
             out_stream << v[(n++)*n_vars + c].imag() << " ";
         out_stream << std::endl << std::endl;
 
         // this is the magnitude
         out_stream << "a_" << solution_names[c] << " 1" << std::endl;
         for (const auto & elem : mesh.active_element_ptr_range())
-          for (unsigned int n=0; n<elem->n_nodes(); n++)
+          for (auto n : elem->node_index_range())
             out_stream << std::abs(v[(n++)*n_vars + c]) << " ";
         out_stream << std::endl << std::endl;
 
@@ -1838,7 +1838,7 @@ void GMVIO::write_discontinuous_gmv (const std::string & name,
           unsigned int nn=0;
 
           for (const auto & elem : mesh.active_element_ptr_range())
-            for (unsigned int n=0; n<elem->n_nodes(); n++)
+            for (unsigned int i=0, enn=elem->n_nodes(); i<enn; i++)
               out_stream << v[(nn++)*n_vars + c] << " ";
         }
         out_stream << std::endl << std::endl;
@@ -2179,7 +2179,7 @@ void GMVIO::copy_nodal_solution(EquationSystems & es)
 
   // For each entry in the nodal data map, try to find a system
   // that has the same variable key name.
-  for (unsigned int sys=0; sys<es.n_systems(); ++sys)
+  for (auto sys : IntRange<unsigned int>(0, es.n_systems()))
     {
       // Get a generic reference to the current System
       System & system = es.get_system(sys);

--- a/src/mesh/gmv_io.C
+++ b/src/mesh/gmv_io.C
@@ -454,7 +454,7 @@ void GMVIO::write_ascii_new_impl (const std::string & fname,
           // than are present in the current element!
           libmesh_assert_less_equal (ele.node_map.size(), elem->n_nodes());
 
-          for (auto i : index_range(ele.node_map))
+          for (std::size_t i=0, enms=ele.node_map.size(); i < enms; i++)
             out_stream << elem->p_level() << " ";
         }
       out_stream << "\n\n";

--- a/src/mesh/inf_elem_builder.C
+++ b/src/mesh/inf_elem_builder.C
@@ -207,8 +207,8 @@ const Point InfElemBuilder::build_inf_elem (const InfElemOriginValue & origin_x,
           std::unique_ptr<Elem> side(this->_mesh.elem_ref(p.first).build_side_ptr(p.second));
 
           // insert all the node numbers in inner_boundary_node_numbers
-          for (unsigned int n=0; n<side->n_nodes(); n++)
-            inner_boundary_node_numbers.push_back(side->node_id(n));
+          for (const Node & node : side->node_ref_range())
+            inner_boundary_node_numbers.push_back(node.id());
         }
 
 
@@ -342,10 +342,11 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
 
           // Loop over the nodes to check whether they are on the symmetry planes,
           // and therefore sufficient to use a non-full-ordered side element
-          for (unsigned int n=0; n<side->n_nodes(); n++)
+          for (const Node & node : side->node_ref_range())
             {
+              const dof_id_type node_id = node.id();
               const Point dist_from_origin =
-                this->_mesh.point(side->node_id(n)) - origin;
+                this->_mesh.point(node_id) - origin;
 
               if (x_sym)
                 if (std::abs(dist_from_origin(0)) > 1.e-3)
@@ -377,7 +378,7 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
               if (r > max_r)
                 {
                   max_r = r;
-                  max_r_node=side->node_id(n);
+                  max_r_node=node_id;
                 }
 
             }
@@ -420,8 +421,8 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
       std::unique_ptr<Elem> side(this->_mesh.elem_ref(p.first).build_side_ptr(p.second));
 
       bool found=false;
-      for (unsigned int sn=0; sn<side->n_nodes(); sn++)
-        if (onodes.count(side->node_id(sn)))
+      for (const Node & node : side->node_ref_range())
+        if (onodes.count(node.id()))
           {
             found=true;
             break;
@@ -430,8 +431,8 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
       // If a new oface is found, include its nodes in onodes
       if (found)
         {
-          for (unsigned int sn=0; sn<side->n_nodes(); sn++)
-            onodes.insert(side->node_id(sn));
+          for (const Node & node : side->node_ref_range())
+            onodes.insert(node.id());
 
           ofaces.insert(p);
           face_it = faces.erase(face_it); // increment is done here

--- a/src/mesh/medit_io.C
+++ b/src/mesh/medit_io.C
@@ -91,7 +91,7 @@ void MEDITIO::write_ascii (const std::string & fname,
     out_stream << "Vertices\n";
     out_stream << the_mesh.n_nodes() << "\n";
 
-    for (unsigned int v=0; v<the_mesh.n_nodes(); v++)
+    for (auto v : IntRange<unsigned int>(0, the_mesh.n_nodes()))
       out_stream << the_mesh.point(v)(0) << " " << the_mesh.point(v)(1) << " " << the_mesh.point(v)(2) << " 0\n";
   }
 
@@ -189,7 +189,7 @@ void MEDITIO::write_ascii (const std::string & fname,
       // Header: 3: 3D mesh, 1: scalar output, 2: node-indexed
       const std::size_t n_vars = solution_names->size();
       bbout << "3 1 " << the_mesh.n_nodes() << " 2\n";
-      for (dof_id_type n=0; n<the_mesh.n_nodes(); n++)
+      for (auto n : IntRange<dof_id_type>(0, the_mesh.n_nodes()))
         bbout << std::setprecision(this->ascii_precision()) << (*vec)[n*n_vars + scalar_idx] << " ";
       bbout << "\n";
     } // endif

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -824,7 +824,7 @@ void MeshBase::detect_interior_parents()
   for (const auto & elem : this->active_element_ptr_range())
     {
       // Populating the node_to_elem map, same as MeshTools::build_nodes_to_elem_map
-      for (unsigned int n=0; n<elem->n_vertices(); n++)
+      for (auto n : IntRange<unsigned int>(0, elem->n_vertices()))
         {
           libmesh_assert_less (elem->id(), this->max_elem_id());
 
@@ -847,7 +847,7 @@ void MeshBase::detect_interior_parents()
 
       bool found_interior_parents = false;
 
-      for (dof_id_type n=0; n < element->n_vertices(); n++)
+      for (auto n : IntRange<unsigned int>(0, element->n_vertices()))
         {
           std::vector<dof_id_type> & element_ids = node_to_elem[element->node_id(n)];
           for (const auto & eid : element_ids)
@@ -878,7 +878,7 @@ void MeshBase::detect_interior_parents()
           for (const auto & interior_parent_id : neighbors_0)
             {
               found_interior_parents = false;
-              for (dof_id_type n=1; n < element->n_vertices(); n++)
+              for (auto n : IntRange<unsigned int>(1, element->n_vertices()))
                 {
                   if (neighbors[n].find(interior_parent_id)!=neighbors[n].end())
                     {

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -313,7 +313,7 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
     // Be careful here.  The *_upper_bounds will be used to find the processor
     // a given object belongs to.  So, if a processor contains no objects (possible!)
     // then copy the bound from the lower processor id.
-    for (processor_id_type p=0; p<communicator.size(); p++)
+    for (auto p : IntRange<processor_id_type>(0, communicator.size()))
       {
         node_upper_bounds[p] = my_max[2*p+0];
         elem_upper_bounds[p] = my_max[2*p+1];
@@ -367,7 +367,7 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
 
       // The offset of my first global index
       dof_id_type my_offset = 0;
-      for (processor_id_type pid=0; pid<communicator.rank(); pid++)
+      for (auto pid : IntRange<processor_id_type>(0, communicator.rank()))
         my_offset += node_bin_sizes[pid];
 
       auto gather_functor =
@@ -483,7 +483,7 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
 
       // The offset of my first global index
       dof_id_type my_offset = 0;
-      for (processor_id_type pid=0; pid<communicator.rank(); pid++)
+      for (auto pid : IntRange<processor_id_type>(0, communicator.rank()))
         my_offset += elem_bin_sizes[pid];
 
       auto gather_functor =
@@ -538,7 +538,7 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
       {
         std::vector<std::vector<dof_id_type>::const_iterator>
           next_obj_on_proc; next_obj_on_proc.reserve(communicator.size());
-        for (processor_id_type pid=0; pid<communicator.size(); pid++)
+        for (auto pid : IntRange<processor_id_type>(0, communicator.size()))
           next_obj_on_proc.push_back(filled_request[pid].begin());
 
         for (auto & elem : mesh.element_ptr_range())
@@ -770,7 +770,7 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
 
   // The offset of my first global index
   unsigned int my_offset = 0;
-  for (unsigned int pid=0; pid<communicator.rank(); pid++)
+  for (auto pid : IntRange<processor_id_type>(0, communicator.rank()))
     my_offset += bin_sizes[pid];
 
   //-------------------------------------------------------------
@@ -786,7 +786,7 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
   // Be careful here.  The *_upper_bounds will be used to find the processor
   // a given object belongs to.  So, if a processor contains no objects (possible!)
   // then copy the bound from the lower processor id.
-  for (unsigned int p=1; p<communicator.size(); p++)
+  for (auto p : IntRange<processor_id_type>(1, communicator.size()))
     if (!bin_sizes[p]) upper_bounds[p] = upper_bounds[p-1];
 
 
@@ -940,7 +940,7 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
     {
       std::vector<std::vector<dof_id_type>::const_iterator>
         next_obj_on_proc; next_obj_on_proc.reserve(communicator.size());
-      for (processor_id_type pid=0; pid<communicator.size(); pid++)
+      for (auto pid : IntRange<processor_id_type>(0, communicator.size()))
         next_obj_on_proc.push_back(filled_request[pid].begin());
 
       unsigned int cnt=0;

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -477,7 +477,7 @@ void MeshFunction::gradient (const Point & p,
                 FEInterface::compute_data (dim, fe_type, element, data);
                 //grad [x] = data.dshape[i](v) * dv/dx  * dof_index [i]
                 // sum over all indices
-                for (std::size_t i=0; i<dof_indices.size(); i++)
+                for (auto i : index_range(dof_indices))
                   {
                     // local coordinates
                     for (std::size_t v=0; v<dim; v++)

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -527,8 +527,8 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
           }
         else // !gauss_lobatto_grid
           {
-            for (unsigned int p=0; p<mesh.n_nodes(); p++)
-              mesh.node_ref(p)(0) = (mesh.node_ref(p)(0))*(xmax-xmin) + xmin;
+            for (Node * node : mesh.node_ptr_range())
+              (*node)(0) = (*node)(0)*(xmax-xmin) + xmin;
           }
 
         // Add sideset names to boundary info
@@ -834,10 +834,10 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
           }
         else // !gauss_lobatto_grid
           {
-            for (unsigned int p=0; p<mesh.n_nodes(); p++)
+            for (Node * node : mesh.node_ptr_range())
               {
-                mesh.node_ref(p)(0) = (mesh.node_ref(p)(0))*(xmax-xmin) + xmin;
-                mesh.node_ref(p)(1) = (mesh.node_ref(p)(1))*(ymax-ymin) + ymin;
+                (*node)(0) = ((*node)(0))*(xmax-xmin) + xmin;
+                (*node)(1) = ((*node)(1))*(ymax-ymin) + ymin;
               }
           }
 

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -104,7 +104,7 @@ void MeshTools::Modification::distort (MeshBase & mesh,
     // then we should not move it.
     // [Note: Testing for (in)equality might be wrong
     // (different types, namely float and double)]
-    for (unsigned int n=0; n<mesh.max_node_id(); n++)
+    for (auto n : IntRange<unsigned int>(0, mesh.max_node_id()))
       if ((perturb_boundary || !boundary_node_ids.count(n)) && hmin[n] < 1.e20)
         {
           // the direction, random but unit normalized
@@ -1229,7 +1229,7 @@ void MeshTools::Modification::smooth (MeshBase & mesh,
             /*
              * finally reposition the vertex nodes
              */
-            for (unsigned int nid=0; nid<mesh.n_nodes(); ++nid)
+            for (auto nid : IntRange<unsigned int>(0, mesh.n_nodes()))
               if (!boundary_node_ids.count(nid) && weight[nid] > 0.)
                 mesh.node_ref(nid) = new_positions[nid]/weight[nid];
           }

--- a/src/mesh/mesh_refinement_smoothing.C
+++ b/src/mesh/mesh_refinement_smoothing.C
@@ -59,9 +59,9 @@ bool MeshRefinement::limit_level_mismatch_at_node (const unsigned int max_mismat
                                 ((elem->p_refinement_flag() == Elem::REFINE) ? 1 : 0));
 
       // Set the max_level at each node
-      for (unsigned int n=0; n<elem->n_nodes(); n++)
+      for (const Node & node : elem->node_ref_range())
         {
-          const dof_id_type node_number = elem->node_id(n);
+          const dof_id_type node_number = node.id();
 
           libmesh_assert_less (node_number, max_level_at_node.size());
 
@@ -91,9 +91,9 @@ bool MeshRefinement::limit_level_mismatch_at_node (const unsigned int max_mismat
         continue;
 
       // Loop over the nodes, check for possible mismatch
-      for (unsigned int n=0; n<elem->n_nodes(); n++)
+      for (const Node & node : elem->node_ref_range())
         {
-          const dof_id_type node_number = elem->node_id(n);
+          const dof_id_type node_number = node.id();
 
           // Flag the element for refinement if it violates
           // the requested level mismatch
@@ -148,7 +148,7 @@ bool MeshRefinement::limit_level_mismatch_at_edge (const unsigned int max_mismat
                                 ((elem->p_refinement_flag() == Elem::REFINE) ? 1 : 0));
 
       // Set the max_level at each edge
-      for (unsigned int n=0; n<elem->n_edges(); n++)
+      for (auto n : elem->edge_index_range())
         {
           std::unique_ptr<const Elem> edge = elem->build_edge_ptr(n);
           dof_id_type childnode0 = edge->node_id(0);
@@ -212,7 +212,7 @@ bool MeshRefinement::limit_level_mismatch_at_edge (const unsigned int max_mismat
         continue;
 
       // Loop over the nodes, check for possible mismatch
-      for (unsigned int n=0; n<elem->n_edges(); n++)
+      for (auto n : elem->edge_index_range())
         {
           std::unique_ptr<Elem> edge = elem->build_edge_ptr(n);
           dof_id_type node0 = edge->node_id(0);
@@ -326,13 +326,8 @@ bool MeshRefinement::limit_underrefined_boundary(const signed char max_mismatch)
       std::set<const Elem *> neighbor_set;
       elem->find_interior_neighbors(neighbor_set);
 
-      std::set<const Elem *>::iterator n_it = neighbor_set.begin();
-      for (; n_it != neighbor_set.end(); ++n_it)
+      for (const Elem * neighbor : neighbor_set)
         {
-          // FIXME - non-const versions of the Elem set methods
-          // would be nice
-          const Elem * neighbor = *n_it;
-
           const unsigned char neighbor_level =
             cast_int<unsigned char>(neighbor->level() +
                                     ((neighbor->refinement_flag() == Elem::REFINE) ? 1 : 0));

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -334,10 +334,10 @@ int VariationalMeshSmoother::readgr(Array2D<Real> & R,
                 mask[i] = 1;
 
                 // Search through neighbor nodes looking for two that form a straight line with this node
-                for (std::size_t a=0; a<thetas.size()-1; a++)
+                for (auto a : IntRange<std::size_t>(0, thetas.size()-1))
                   {
                     // Only try each pairing once
-                    for (std::size_t b=a+1; b<thetas.size(); b++)
+                    for (auto b : IntRange<std::size_t>(a+1, thetas.size()))
                       {
                         // Find if the two neighbor nodes angles are 180 degrees (pi) off of each other (withing a tolerance)
                         // In order to make this a true movable boundary node... the two that forma  straight line with
@@ -395,7 +395,7 @@ int VariationalMeshSmoother::readgr(Array2D<Real> & R,
               {
                 // Grab nodes that do exist
               case 3:  // Tri
-                for (unsigned int k=0; k<elem->n_vertices(); k++)
+                for (auto k : IntRange<unsigned int>(0, elem->n_vertices()))
                   cells[i][k] = elem->node_id(k);
 
                 num = elem->n_vertices();
@@ -420,7 +420,7 @@ int VariationalMeshSmoother::readgr(Array2D<Real> & R,
               {
                 // Tet 4
               case 4:
-                for (unsigned int k=0; k<elem->n_vertices(); k++)
+                for (auto k : IntRange<unsigned int>(0, elem->n_vertices()))
                   cells[i][k] = elem->node_id(k);
                 num = elem->n_vertices();
                 break;
@@ -445,7 +445,7 @@ int VariationalMeshSmoother::readgr(Array2D<Real> & R,
           }
 
         // Fill in the rest with -1
-        for (int j=num; j<static_cast<int>(cells[i].size()); j++)
+        for (auto j : IntRange<int>(num, cast_int<int>(cells[i].size())))
           cells[i][j] = -1;
 
         // Mask it with 0 to state that this is an active element
@@ -1953,7 +1953,7 @@ Real VariationalMeshSmoother::minJ(Array2D<Real> & R,
           G[i][j] = 0;  // adaptation metric G is held constant throughout minJ run
           if (adp < 0)
             {
-              for (int k=0; k<std::abs(adp); k++)
+              for (auto k : IntRange<int>(0, std::abs(adp)))
                 G[i][j] += afun[i*(-adp)+k];  // cell-based adaptivity is computed here
             }
         }
@@ -2722,7 +2722,7 @@ Real VariationalMeshSmoother::minJ_BC(Array2D<Real> & R,
             {
               G[i][j] = 0;
               if (adp < 0)
-                for (int k=0; k<std::abs(adp); k++)
+                for (auto k : IntRange<int>(0, std::abs(adp)))
                   G[i][j] += afun[i*(-adp) + k];
             }
 

--- a/src/mesh/mesh_tetgen_interface.C
+++ b/src/mesh/mesh_tetgen_interface.C
@@ -97,7 +97,7 @@ void TetGenMeshInterface::triangulate_pointset ()
       Elem * elem = new Tet4;
 
       // Get the nodes associated with this element
-      for (unsigned int j=0; j<elem->n_nodes(); ++j)
+      for (auto j : elem->node_index_range())
         node_labels[j] = tetgen_wrapper.get_element_node(i,j);
 
       // Associate the nodes with this element
@@ -148,7 +148,7 @@ void TetGenMeshInterface::pointset_convexhull ()
       Elem * elem = new Tri3;
 
       // Get node labels associated with this element
-      for (unsigned int j=0; j<elem->n_nodes(); ++j)
+      for (auto j : elem->node_index_range())
         node_labels[j] = tetgen_wrapper.get_triface_node(i,j);
 
       this->assign_nodes_to_elem(node_labels, elem);
@@ -206,7 +206,7 @@ void TetGenMeshInterface::triangulate_conformingDelaunayMesh_carvehole  (const s
         tetgen_wrapper.allocate_facet_polygonlist(insertnum, 1);
         tetgen_wrapper.allocate_polygon_vertexlist(insertnum, 0, 3);
 
-        for (unsigned int j=0; j<elem->n_nodes(); ++j)
+        for (auto j : elem->node_index_range())
           {
             // We need to get the sequential index of elem->node_ptr(j), but
             // it should already be stored in _sequential_to_libmesh_node_map...
@@ -249,13 +249,12 @@ void TetGenMeshInterface::triangulate_conformingDelaunayMesh_carvehole  (const s
   // fill hole list (if there are holes):
   if (holes.size() > 0)
     {
-      std::vector<Point>::const_iterator ihole;
       unsigned hole_index = 0;
-      for (ihole=holes.begin(); ihole!=holes.end(); ++ihole)
+      for (Point ihole : holes)
         tetgen_wrapper.set_hole(hole_index++,
-                                REAL((*ihole)(0)),
-                                REAL((*ihole)(1)),
-                                REAL((*ihole)(2)));
+                                REAL(ihole(0)),
+                                REAL(ihole(1)),
+                                REAL(ihole(2)));
     }
 
 
@@ -328,7 +327,7 @@ void TetGenMeshInterface::triangulate_conformingDelaunayMesh_carvehole  (const s
       Elem * elem = new Tet4;
 
       // Fill up the the node_labels vector
-      for (unsigned int j=0; j<elem->n_nodes(); j++)
+      for (auto j : elem->node_index_range())
         node_labels[j] = tetgen_wrapper.get_element_node(i,j);
 
       // Associate nodes with this element
@@ -377,7 +376,7 @@ void TetGenMeshInterface::fill_pointlist(TetGenWrapper & wrapper)
 
 void TetGenMeshInterface::assign_nodes_to_elem(unsigned * node_labels, Elem * elem)
 {
-  for (unsigned int j=0; j<elem->n_nodes(); ++j)
+  for (auto j : elem->node_index_range())
     {
       // Get the mapped node index to ask the Mesh for
       unsigned mapped_node_id = _sequential_to_libmesh_node_map[ node_labels[j] ];

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1605,9 +1605,8 @@ void libmesh_assert_contiguous_dof_ids(const MeshBase & mesh, unsigned int sysnu
   // Figure out what our local dof id range is
   for (const auto * node : mesh.local_node_ptr_range())
     {
-      for (unsigned int v=0, nvars = node->n_vars(sysnum);
-           v != nvars; ++v)
-        for (unsigned int c=0; c != node->n_comp(sysnum, v); ++c)
+      for (auto v : IntRange<unsigned int>(0, node->n_vars(sysnum)))
+        for (auto c : IntRange<unsigned int>(0, node->n_comp(sysnum, v)))
           {
             dof_id_type id = node->dof_number(sysnum, v, c);
             min_dof_id = std::min (min_dof_id, id);
@@ -1620,9 +1619,8 @@ void libmesh_assert_contiguous_dof_ids(const MeshBase & mesh, unsigned int sysnu
     {
       if (node->processor_id() == mesh.processor_id())
         continue;
-      for (unsigned int v=0, nvars = node->n_vars(sysnum);
-           v != nvars; ++v)
-        for (unsigned int c=0; c != node->n_comp(sysnum, v); ++c)
+      for (auto v : IntRange<unsigned int>(0, node->n_vars(sysnum)))
+        for (auto c : IntRange<unsigned int>(0, node->n_comp(sysnum, v)))
           {
             dof_id_type id = node->dof_number(sysnum, v, c);
             libmesh_assert (id < min_dof_id ||

--- a/src/mesh/mesh_triangle_interface.C
+++ b/src/mesh/mesh_triangle_interface.C
@@ -91,7 +91,7 @@ void TriangleInterface::triangulate()
       // Insert a new point on each PSLG at some random location
       // np=index into new points vector
       // n =index into original points vector
-      for (std::size_t np=0, n=0; np<2*original_points.size(); ++np)
+      for (std::size_t np=0, n=0, tops=2*original_points.size(); np<tops; ++np)
         {
           // the even entries are the original points
           if (np%2==0)
@@ -169,7 +169,7 @@ void TriangleInterface::triangulate()
   if (have_holes)
     for (const auto & hole : *_holes)
       {
-        for (unsigned int ctr=0, h=0, i=0; i<hole->segment_indices().size()-1; ++i)
+        for (unsigned int ctr=0, h=0, i=0, hsism=hole->segment_indices().size()-1; i<hsism; ++i)
           {
             unsigned int begp = hole_offset + hole->segment_indices()[i];
             unsigned int endp = hole->segment_indices()[i+1];
@@ -230,7 +230,7 @@ void TriangleInterface::triangulate()
 
 
   // If the user provided it, use his ordering to define the segments
-  for (std::size_t ctr=0, s=0; s<this->segments.size(); ctr+=2, ++s)
+  for (std::size_t ctr=0, s=0, ss=this->segments.size(); s<ss; ctr+=2, ++s)
     {
       const unsigned int index0 = 2*hole_offset+ctr;
       const unsigned int index1 = 2*hole_offset+ctr+1;
@@ -248,7 +248,7 @@ void TriangleInterface::triangulate()
     {
       initial.numberofholes = _holes->size();
       initial.holelist      = static_cast<REAL*>(std::malloc(initial.numberofholes * 2 * sizeof(REAL)));
-      for (std::size_t i=0, ctr=0; i<_holes->size(); ++i, ctr+=2)
+      for (std::size_t i=0, ctr=0, hs=_holes->size(); i<hs; ++i, ctr+=2)
         {
           Point inside_point = (*_holes)[i]->inside();
           initial.holelist[ctr]   = inside_point(0);
@@ -260,7 +260,7 @@ void TriangleInterface::triangulate()
     {
       initial.numberofregions = _regions->size();
       initial.regionlist      = static_cast<REAL*>(std::malloc(initial.numberofregions * 4 * sizeof(REAL)));
-      for (std::size_t i=0, ctr=0; i<_regions->size(); ++i, ctr+=4)
+      for (std::size_t i=0, ctr=0, rs=_regions->size(); i<rs; ++i, ctr+=4)
         {
           Point inside_point = (*_regions)[i]->inside();
           initial.regionlist[ctr]   = inside_point(0);

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -424,7 +424,7 @@ void Nemesis_IO::read (const std::string & base_filename)
   std::vector<unsigned int>
     all_num_nodes_i_must_number (this->n_processors());
 
-  for (unsigned int pid=0; pid<this->n_processors(); pid++)
+  for (auto pid : IntRange<unsigned int>(0, this->n_processors()))
     all_num_nodes_i_must_number[pid] = all_loadbal_data[8*pid + 7];
 
   // The sum of all the entries in this vector should sum to the number of global nodes
@@ -433,7 +433,7 @@ void Nemesis_IO::read (const std::string & base_filename)
                                   0) == nemhelper->num_nodes_global);
 
   unsigned int my_next_node = 0;
-  for (unsigned int pid=0; pid<this->processor_id(); pid++)
+  for (auto pid : IntRange<unsigned int>(0, this->processor_id()))
     my_next_node += all_num_nodes_i_must_number[pid];
 
   const unsigned int my_node_offset = my_next_node;
@@ -640,7 +640,7 @@ void Nemesis_IO::read (const std::string & base_filename)
           libmesh_assert_less_equal (needed_node_idxs[cmap].size(),
                                      nemhelper->node_cmap_node_ids[cmap].size());
 
-          for (std::size_t i=0, j=0; i<nemhelper->node_cmap_node_ids[cmap].size(); i++)
+          for (std::size_t i=0, j=0, ncnis=nemhelper->node_cmap_node_ids[cmap].size(); i < ncnis; i++)
             {
               const unsigned int
                 local_node_idx  = nemhelper->node_cmap_node_ids[cmap][i]-1,
@@ -768,7 +768,7 @@ void Nemesis_IO::read (const std::string & base_filename)
   // Compute my_elem_offset, the amount by which to offset the local elem numbering
   // on my processor.
   unsigned int my_next_elem = 0;
-  for (unsigned int pid=0; pid<this->processor_id(); ++pid)
+  for (auto pid : IntRange<unsigned int>(0, this->processor_id()))
     my_next_elem += (all_loadbal_data[8*pid + 3]+  // num_internal_elems, proc pid
                      all_loadbal_data[8*pid + 4]); // num_border_elems, proc pid
   const unsigned int my_elem_offset = my_next_elem;

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -1025,7 +1025,7 @@ void Nemesis_IO_Helper::compute_elem_communication_maps()
         std::set<std::pair<unsigned,unsigned>>::iterator elem_set_iter = elem_set.begin();
 
         // Pack the vectors with elem IDs, side IDs, and processor IDs.
-        for (std::size_t j=0; j<this->elem_cmap_elem_ids[cnt].size(); ++j, ++elem_set_iter)
+        for (std::size_t j=0, eceis=this->elem_cmap_elem_ids[cnt].size(); j<eceis; ++j, ++elem_set_iter)
           {
             this->elem_cmap_elem_ids[cnt][j] =
               libmesh_map_find(libmesh_elem_num_to_exodus, elem_set_iter->first);
@@ -1106,7 +1106,7 @@ void Nemesis_IO_Helper::compute_node_communication_maps()
         std::set<unsigned>::iterator node_set_iter = node_set.begin();
 
         // Pack the vectors with node IDs and processor IDs.
-        for (std::size_t j=0; j<this->node_cmap_node_ids[cnt].size(); ++j, ++node_set_iter)
+        for (std::size_t j=0, nceis=this->node_cmap_node_ids[cnt].size(); j<nceis; ++j, ++node_set_iter)
           {
             this->node_cmap_node_ids[cnt][j] =
               libmesh_map_find(libmesh_node_num_to_exodus, *node_set_iter);

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -1047,8 +1047,9 @@ void ReplicatedMesh::stitching_helper (const ReplicatedMesh * other_mesh,
 
           // Create the dataset needed to build the kd tree with nanoflann
           std::vector<std::pair<Point, dof_id_type>> this_mesh_nodes(this_boundary_node_ids.size());
-          std::set<dof_id_type>::iterator current_node = this_boundary_node_ids.begin();
-          for (unsigned int ctr = 0; current_node != this_boundary_node_ids.end(); ++current_node, ++ctr)
+          std::set<dof_id_type>::iterator current_node = this_boundary_node_ids.begin(),
+                                          node_ids_end = this_boundary_node_ids.end();
+          for (unsigned int ctr = 0; current_node != node_ids_end; ++current_node, ++ctr)
           {
             this_mesh_nodes[ctr].first = this->point(*current_node);
             this_mesh_nodes[ctr].second = *current_node;
@@ -1550,7 +1551,7 @@ ReplicatedMesh::get_boundary_points() const
       boundary_elements.erase(side);
 
       // push all nodes on the side except the node on the other end of the side (index 1)
-      for (unsigned int i = 0; i < local_side_nodes.size(); ++i)
+      for (auto i : index_range(local_side_nodes))
         if (i != 1)
           bpoints.push_back(*static_cast<const Point *>(elem->node_ptr(local_side_nodes[i])));
 

--- a/src/mesh/tecplot_io.C
+++ b/src/mesh/tecplot_io.C
@@ -311,7 +311,7 @@ void TecplotIO::write_ascii (const std::string & fname,
 
   } // finished writing header
 
-  for (unsigned int i=0; i<the_mesh.n_nodes(); i++)
+  for (auto i : IntRange<unsigned int>(0, the_mesh.n_nodes()))
     {
       // Print the point without a newline
       the_mesh.point(i).write_unformatted(out_stream, false);
@@ -460,7 +460,7 @@ void TecplotIO::write_binary (const std::string & fname,
   // Copy the nodes and data to the TecplotMacros class. Note that we store
   // everything as a float here since the eye doesn't require a double to
   // understand what is going on
-  for (unsigned int v=0; v<the_mesh.n_nodes(); v++)
+  for (auto v : IntRange<unsigned int>(0, the_mesh.n_nodes()))
     {
       tm.nd(0,v) = static_cast<float>(the_mesh.point(v)(0));
       tm.nd(1,v) = static_cast<float>(the_mesh.point(v)(1));
@@ -521,7 +521,7 @@ void TecplotIO::write_binary (const std::string & fname,
                         the_mesh.active_subdomain_elements_end(sbd_id)))
           {
             std::vector<dof_id_type> conn;
-            for (unsigned int se=0; se<elem->n_sub_elem(); se++)
+            for (auto se : IntRange<unsigned int>(0, elem->n_sub_elem()))
               {
                 elem->connectivity(se, TECPLOT, conn);
 
@@ -712,7 +712,7 @@ void TecplotIO::write_binary (const std::string & fname,
   // Copy the nodes and data to the TecplotMacros class. Note that we store
   // everything as a float here since the eye doesn't require a double to
   // understand what is going on
-  for (unsigned int v=0; v<the_mesh.n_nodes(); v++)
+  for (auto v : IntRange<unsigned int>(0, the_mesh.n_nodes()))
     {
       tm.nd(0,v) = static_cast<float>(the_mesh.point(v)(0));
       tm.nd(1,v) = static_cast<float>(the_mesh.point(v)(1));
@@ -745,7 +745,7 @@ void TecplotIO::write_binary (const std::string & fname,
     for (const auto & elem : the_mesh.active_element_ptr_range())
       {
         std::vector<dof_id_type> conn;
-        for (unsigned int se=0; se<elem->n_sub_elem(); se++)
+        for (auto se : IntRange<unsigned int>(0, elem->n_sub_elem()))
           {
             elem->connectivity(se, TECPLOT, conn);
 

--- a/src/mesh/tetgen_io.C
+++ b/src/mesh/tetgen_io.C
@@ -295,7 +295,7 @@ void TetGenIO::write (const std::string & fname)
                << mesh.n_nodes() << " 3 0 0\n";
 
     // write the nodes:
-    for (dof_id_type v=0; v<mesh.n_nodes(); v++)
+    for (auto v : IntRange<dof_id_type>(0, mesh.n_nodes()))
       out_stream << v << " "
                  << mesh.point(v)(0) << " "
                  << mesh.point(v)(1) << " "

--- a/src/mesh/ucd_io.C
+++ b/src/mesh/ucd_io.C
@@ -207,7 +207,7 @@ void UCDIO::read_implementation (std::istream & in)
         // Build the required type and release it into our custody.
         Elem * elem = Elem::build(et).release();
 
-        for (unsigned int n=0; n<elem->n_nodes(); n++)
+        for (auto n : elem->node_index_range())
           {
             libmesh_assert (in.good());
 
@@ -372,7 +372,7 @@ void UCDIO::write_soln(std::ostream & out_stream,
 
   // First write out how many variables and how many components per variable
   out_stream << names.size();
-  for (std::size_t i = 0; i < names.size(); i++)
+  for (std::size_t i = 0, ns = names.size(); i < ns; i++)
     {
       libmesh_assert (out_stream.good());
       // Each named variable has only 1 component
@@ -391,7 +391,7 @@ void UCDIO::write_soln(std::ostream & out_stream,
   // Now, for each node, write out the solution variables.
   // We use a 1-based node numbering for UCD.
   std::size_t nv = names.size();
-  for (std::size_t n = 1; n <= mesh.n_nodes(); n++)
+  for (auto n : IntRange<std::size_t>(1, mesh.n_nodes()))
     {
       libmesh_assert (out_stream.good());
       out_stream << n;

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -934,7 +934,7 @@ void UnstructuredMesh::all_first_order ()
        * second order element are identically numbered.
        * transfer these.
        */
-      for (unsigned int v=0; v < so_elem->n_vertices(); v++)
+      for (unsigned int v=0, snv=so_elem->n_vertices(); v < snv; v++)
         {
           lo_elem->set_node(v) = so_elem->node_ptr(v);
           node_touched_by_me[lo_elem->node_id(v)] = true;
@@ -1162,7 +1162,7 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
        * second order element are identically numbered.
        * transfer these.
        */
-      for (unsigned int v=0; v < lo_elem->n_vertices(); v++)
+      for (unsigned int v=0, lnv=lo_elem->n_vertices(); v < lnv; v++)
         so_elem->set_node(v) = lo_elem->node_ptr(v);
 
       /*

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -209,7 +209,7 @@ void VTKIO::read (const std::string & name)
       Elem * elem = Elem::build(libmesh_elem_type).release();
 
       // get the straightforward numbering from the VTK cells
-      for (unsigned int j=0; j<elem->n_nodes(); ++j)
+      for (auto j : elem->node_index_range())
         elem->set_node(j) =
           mesh.node_ptr(cast_int<dof_id_type>(cell->GetPointId(j)));
 
@@ -510,7 +510,7 @@ void VTKIO::node_values_to_vtk(const std::string & name,
   data->SetNumberOfValues(_local_node_map.size());
 
   // copy values into vtk
-  for (size_t i=0; i<local_values.size(); ++i) {
+  for (auto i : index_range(local_values)) {
     data->SetValue(i, local_values[i]);
   }
 

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -364,7 +364,7 @@ void XdrIO::write_serialized_connectivity (Xdr & io, const dof_id_type libmesh_d
   this->comm().gather (0, my_size,      xfer_buf_sizes);
 
   processor_offsets[0] = 0;
-  for (unsigned int pid=1; pid<this->n_processors(); pid++)
+  for (auto pid : IntRange<processor_id_type>(1, this->n_processors()))
     processor_offsets[pid] = processor_offsets[pid-1] + n_elem_on_proc[pid-1];
 
   // All processors send their xfer buffers to processor 0.
@@ -387,7 +387,7 @@ void XdrIO::write_serialized_connectivity (Xdr & io, const dof_id_type libmesh_d
         io.data (n_global_elem_at_level[0], comment.c_str());
       }
 
-      for (unsigned int pid=0; pid<this->n_processors(); pid++)
+      for (auto pid : IntRange<processor_id_type>(0, this->n_processors()))
         {
           recv_conn.resize(xfer_buf_sizes[pid]);
           if (pid == 0)
@@ -509,7 +509,7 @@ void XdrIO::write_serialized_connectivity (Xdr & io, const dof_id_type libmesh_d
             io.data (n_global_elem_at_level[level], comment.c_str());
           }
 
-          for (unsigned int pid=0; pid<this->n_processors(); pid++)
+          for (auto pid : IntRange<processor_id_type>(0, this->n_processors()))
             {
               recv_conn.resize(xfer_buf_sizes[pid]);
               if (pid == 0)
@@ -584,7 +584,7 @@ void XdrIO::write_serialized_connectivity (Xdr & io, const dof_id_type libmesh_d
       // update the processor_offsets
       processor_offsets[0] = processor_offsets.back() + n_elem_on_proc.back();
       this->comm().gather (0, my_n_elem_written_at_level, n_elem_on_proc);
-      for (unsigned int pid=1; pid<this->n_processors(); pid++)
+      for (auto pid : IntRange<processor_id_type>(1, this->n_processors()))
         processor_offsets[pid] = processor_offsets[pid-1] + n_elem_on_proc[pid-1];
 
       // Now, at the next level we will again iterate over local parents.  However,
@@ -728,7 +728,7 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id) con
       // Post the receives -- do this on processor 0 only.
       if (this->processor_id() == 0)
         {
-          for (unsigned int pid=0; pid<this->n_processors(); pid++)
+          for (auto pid : IntRange<processor_id_type>(0, this->n_processors()))
             {
               recv_ids[pid].resize(ids_size[pid]);
               recv_coords[pid].resize(ids_size[pid]*LIBMESH_DIM);
@@ -766,7 +766,7 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id) con
           Parallel::wait (id_request_handles);
           Parallel::wait (coord_request_handles);
 
-          for (unsigned int pid=0; pid<this->n_processors(); pid++)
+          for (auto pid : IntRange<processor_id_type>(0, this->n_processors()))
             libmesh_assert_equal_to(recv_coords[pid].size(),
                                     recv_ids[pid].size()*LIBMESH_DIM);
 
@@ -779,7 +779,7 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id) con
           coords.clear();
           coords.resize (3*tot_id_size, std::numeric_limits<Real>::quiet_NaN());
 
-          for (unsigned int pid=0; pid<this->n_processors(); pid++)
+          for (auto pid : IntRange<processor_id_type>(0, this->n_processors()))
             for (auto idx : index_range(recv_ids[pid]))
               {
                 libmesh_assert_less_equal(first_node, recv_ids[pid][idx]);
@@ -872,7 +872,7 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id) con
       // Post the receives -- do this on processor 0 only.
       if (this->processor_id() == 0)
         {
-          for (unsigned int pid=0; pid<this->n_processors(); pid++)
+          for (auto pid : IntRange<processor_id_type>(0, this->n_processors()))
             {
               recv_ids[pid].resize(ids_size[pid]);
               recv_unique_ids[pid].resize(ids_size[pid]);
@@ -911,7 +911,7 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id) con
           Parallel::wait (unique_id_request_handles);
 
           // Write the unique ids in this block.
-          for (unsigned int pid=0; pid<this->n_processors(); pid++)
+          for (auto pid : IntRange<processor_id_type>(0, this->n_processors()))
             {
               libmesh_assert_equal_to
                 (recv_ids[pid].size(), recv_unique_ids[pid].size());
@@ -923,7 +923,7 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id) con
           unique_ids.clear();
           unique_ids.resize(tot_id_size, unique_id_type(-1));
 
-          for (unsigned int pid=0; pid<this->n_processors(); pid++)
+          for (auto pid : IntRange<processor_id_type>(0, this->n_processors()))
             for (auto idx : index_range(recv_ids[pid]))
               {
                 libmesh_assert_less_equal(first_node, recv_ids[pid][idx]);
@@ -1043,7 +1043,7 @@ void XdrIO::write_serialized_bcs_helper (Xdr & io, const new_header_id_type n_bc
   if (this->processor_id() == 0)
     {
       dof_id_type elem_offset = 0;
-      for (unsigned int pid=0; pid<this->n_processors(); pid++)
+      for (auto pid : IntRange<processor_id_type>(0, this->n_processors()))
         {
           recv_bcs.resize(bc_sizes[pid]);
           if (pid == 0)
@@ -1055,7 +1055,7 @@ void XdrIO::write_serialized_bcs_helper (Xdr & io, const new_header_id_type n_bc
             = cast_int<dof_id_type>(recv_bcs.back());
           recv_bcs.pop_back();
 
-          for (std::size_t idx=0; idx<recv_bcs.size(); idx += 3, n_bcs_out++)
+          for (std::size_t idx=0, rbs=recv_bcs.size(); idx<rbs; idx += 3, n_bcs_out++)
             recv_bcs[idx+0] += elem_offset;
 
           io.data_stream (recv_bcs.empty() ? nullptr : recv_bcs.data(),
@@ -1138,7 +1138,7 @@ void XdrIO::write_serialized_nodesets (Xdr & io, const new_header_id_type n_node
   if (this->processor_id() == 0)
     {
       dof_id_type node_offset = 0;
-      for (unsigned int pid=0; pid<this->n_processors(); pid++)
+      for (auto pid : IntRange<processor_id_type>(0, this->n_processors()))
         {
           recv_bcs.resize(bc_sizes[pid]);
           if (pid == 0)
@@ -1150,7 +1150,7 @@ void XdrIO::write_serialized_nodesets (Xdr & io, const new_header_id_type n_node
             cast_int<dof_id_type>(recv_bcs.back());
           recv_bcs.pop_back();
 
-          for (std::size_t idx=0; idx<recv_bcs.size(); idx += 2, n_nodesets_out++)
+          for (std::size_t idx=0, rbs=recv_bcs.size(); idx<rbs; idx += 2, n_nodesets_out++)
             recv_bcs[idx+0] += node_offset;
 
           io.data_stream (recv_bcs.empty() ? nullptr : recv_bcs.data(),
@@ -1845,7 +1845,7 @@ void XdrIO::read_serialized_bcs_helper (Xdr & io, T, const std::string bc_type)
       // IDs matching an element we can query.
       // We cannot rely on nullptr neighbors at this point since the neighbor
       // data structure has not been initialized.
-      for (std::size_t idx=0; idx<input_buffer.size(); idx+=3)
+      for (std::size_t idx=0, ibs=input_buffer.size(); idx<ibs; idx+=3)
         {
           const dof_id_type dof_id =
             cast_int<dof_id_type>(input_buffer[idx+0]);
@@ -1958,7 +1958,7 @@ void XdrIO::read_serialized_nodesets (Xdr & io, T)
       // Look for BCs in this block for all nodes we have (not just
       // local ones).  Do this by checking all entries for
       // IDs matching a node we can query.
-      for (std::size_t idx=0; idx<input_buffer.size(); idx+=2)
+      for (std::size_t idx=0, ibs=input_buffer.size(); idx<ibs; idx+=2)
         {
           const dof_id_type dof_id =
             cast_int<dof_id_type>(input_buffer[idx+0]);

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -766,9 +766,11 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id) con
           Parallel::wait (id_request_handles);
           Parallel::wait (coord_request_handles);
 
+#ifndef NDEBUG
           for (auto pid : IntRange<processor_id_type>(0, this->n_processors()))
             libmesh_assert_equal_to(recv_coords[pid].size(),
                                     recv_ids[pid].size()*LIBMESH_DIM);
+#endif
 
           // Write the coordinates in this block.
           // Some of these coordinates may correspond to ids for which
@@ -910,16 +912,16 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id) con
           Parallel::wait (id_request_handles);
           Parallel::wait (unique_id_request_handles);
 
-          // Write the unique ids in this block.
+#ifndef NDEBUG
           for (auto pid : IntRange<processor_id_type>(0, this->n_processors()))
-            {
-              libmesh_assert_equal_to
-                (recv_ids[pid].size(), recv_unique_ids[pid].size());
-            }
+            libmesh_assert_equal_to
+              (recv_ids[pid].size(), recv_unique_ids[pid].size());
+#endif
 
           libmesh_assert_less_equal
             (tot_id_size, std::min(io_blksize, std::size_t(max_node_id)));
 
+          // Write the unique ids in this block.
           unique_ids.clear();
           unique_ids.resize(tot_id_size, unique_id_type(-1));
 

--- a/src/numerics/distributed_vector.C
+++ b/src/numerics/distributed_vector.C
@@ -384,7 +384,7 @@ DistributedVector<T>::operator = (const std::vector<T> & v)
     _values = v;
 
   else if (v.size() == size())
-    for (std::size_t i=first_local_index(); i<last_local_index(); i++)
+    for (auto i : index_range(*this))
       _values[i-first_local_index()] = v[i];
 
   else

--- a/src/numerics/eigen_sparse_matrix.C
+++ b/src/numerics/eigen_sparse_matrix.C
@@ -298,7 +298,7 @@ Real EigenSparseMatrix<T>::l1_norm () const
 
   // For a row-major Eigen SparseMatrix like we're using, the
   // InnerIterator iterates over the non-zero entries of rows.
-  for (unsigned row=0; row<this->m(); ++row)
+  for (auto row : IntRange<unsigned int>(0, this->m()))
     {
       EigenSM::InnerIterator it(_mat, row);
       for (; it; ++it)
@@ -317,7 +317,7 @@ Real EigenSparseMatrix<T>::linfty_norm () const
 
   // For a row-major Eigen SparseMatrix like we're using, the
   // InnerIterator iterates over the non-zero entries of rows.
-  for (unsigned row=0; row<this->m(); ++row)
+  for (auto row : IntRange<numeric_index_type>(0, this->m()))
     {
       Real current_abs_row_sum = 0.;
       EigenSM::InnerIterator it(_mat, row);

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -67,7 +67,7 @@ void transform_preallocation_arrays (const PetscInt blocksize,
   b_n_nz.clear(); /**/ b_n_nz.reserve(n_nz.size()/blocksize);
   b_n_oz.clear(); /**/ b_n_oz.reserve(n_oz.size()/blocksize);
 
-  for (std::size_t nn=0; nn<n_nz.size(); nn += blocksize)
+  for (std::size_t nn=0, nnzs=n_nz.size(); nn<nnzs; nn += blocksize)
     {
       b_n_nz.push_back (n_nz[nn]/blocksize);
       b_n_oz.push_back (n_oz[nn]/blocksize);
@@ -1301,7 +1301,7 @@ void PetscMatrix<T>::get_row (numeric_index_type i_in,
   indices.resize(static_cast<std::size_t>(ncols));
   values.resize(static_cast<std::size_t>(ncols));
 
-  for (std::size_t i = 0; i < indices.size(); ++i)
+  for (auto i : index_range(indices))
   {
     indices[i] = static_cast<numeric_index_type>(petsc_cols[i]);
     values[i] = static_cast<T>(petsc_row[i]);

--- a/src/numerics/sparse_matrix.C
+++ b/src/numerics/sparse_matrix.C
@@ -103,17 +103,17 @@ void SparseMatrix<Complex>::print(std::ostream & os, const bool sparse) const
     }
 
   os << "Real part:" << std::endl;
-  for (numeric_index_type i=0; i<this->m(); i++)
+  for (auto i : IntRange<numeric_index_type>(0, this->m()))
     {
-      for (numeric_index_type j=0; j<this->n(); j++)
+      for (auto j : IntRange<numeric_index_type>(0, this->n()))
         os << std::setw(8) << (*this)(i,j).real() << " ";
       os << std::endl;
     }
 
   os << std::endl << "Imaginary part:" << std::endl;
-  for (numeric_index_type i=0; i<this->m(); i++)
+  for (auto i : IntRange<numeric_index_type>(0, this->m()))
     {
-      for (numeric_index_type j=0; j<this->n(); j++)
+      for (auto j : IntRange<numeric_index_type>(0, this->n()))
         os << std::setw(8) << (*this)(i,j).imag() << " ";
       os << std::endl;
     }
@@ -216,7 +216,7 @@ void SparseMatrix<T>::print(std::ostream & os, const bool sparse) const
         {
           if (sparse)
             {
-              for (numeric_index_type j=0; j<this->n(); j++)
+              for (auto j : IntRange<numeric_index_type>(0, this->n()))
                 {
                   T c = (*this)(i,j);
                   if (c != static_cast<T>(0.0))
@@ -227,7 +227,7 @@ void SparseMatrix<T>::print(std::ostream & os, const bool sparse) const
             }
           else
             {
-              for (numeric_index_type j=0; j<this->n(); j++)
+              for (auto j : IntRange<numeric_index_type>(0, this->n()))
                 os << (*this)(i,j) << " ";
               os << std::endl;
             }
@@ -236,7 +236,7 @@ void SparseMatrix<T>::print(std::ostream & os, const bool sparse) const
       std::vector<numeric_index_type> ibuf, jbuf;
       std::vector<T> cbuf;
       numeric_index_type currenti = this->_dof_map->end_dof();
-      for (processor_id_type p=1; p < this->n_processors(); ++p)
+      for (auto p : IntRange<processor_id_type>(1, this->n_processors()))
         {
           this->comm().receive(p, ibuf);
           this->comm().receive(p, jbuf);
@@ -267,7 +267,7 @@ void SparseMatrix<T>::print(std::ostream & os, const bool sparse) const
                 }
               else
                 {
-                  for (numeric_index_type j=0; j<this->n(); j++)
+                  for (auto j : IntRange<numeric_index_type>(0, this->n()))
                     {
                       if (currentb < ibuf.size() &&
                           ibuf[currentb] == currenti &&
@@ -303,7 +303,7 @@ void SparseMatrix<T>::print(std::ostream & os, const bool sparse) const
       for (numeric_index_type i=this->_dof_map->first_dof();
            i!=this->_dof_map->end_dof(); ++i)
         {
-          for (numeric_index_type j=0; j<this->n(); j++)
+          for (auto j : IntRange<numeric_index_type>(0, this->n()))
             {
               T c = (*this)(i,j);
               if (c != static_cast<T>(0.0))

--- a/src/numerics/trilinos_epetra_vector.C
+++ b/src/numerics/trilinos_epetra_vector.C
@@ -461,7 +461,7 @@ void EpetraVector<T>::localize (std::vector<T> & v_local,
   // Get a pointer to the list of global elements for the map, and set
   // all the values from indices.
   int * import_map_global_elements = import_map.MyGlobalElements();
-  for (int i=0; i<import_map.NumMyElements(); ++i)
+  for (auto i : index_range(indices))
     import_map_global_elements[i] = indices[i];
 
   // Create a new EpetraVector to import values into.

--- a/src/parallel/parallel_elem.C
+++ b/src/parallel/parallel_elem.C
@@ -264,8 +264,8 @@ Packing<const Elem *>::pack (const Elem * const & elem,
   else
     *data_out++ =(DofObject::invalid_id);
 
-  for (unsigned int n=0; n<elem->n_nodes(); n++)
-    *data_out++ = (elem->node_id(n));
+  for (const Node & node : elem->node_ref_range())
+    *data_out++ = node.id();
 
   // Add the id of and the side for any return link from each neighbor
   for (auto neigh : elem->neighbor_ptr_range())

--- a/src/parallel/parallel_histogram.C
+++ b/src/parallel/parallel_histogram.C
@@ -93,7 +93,7 @@ void Histogram<KeyType,IdxType>::build_histogram ()
   // Build a local histogram
   std::vector<IdxType> local_hist (this->n_bins());
 
-  for (IdxType b=0; b<this->n_bins(); b++)
+  for (auto b : index_range(local_hist))
     local_hist[b] = this->local_bin_size(b);
 
   // Add all the local histograms to get the global histogram

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -370,11 +370,8 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
                 std::set<const Elem *> neighbor_set;
                 elem->find_interior_neighbors(neighbor_set);
 
-                std::set<const Elem *>::iterator n_it = neighbor_set.begin();
-                for (; n_it != neighbor_set.end(); ++n_it)
+                for (const Elem * neighbor : neighbor_set)
                   {
-                    const Elem * neighbor = *n_it;
-
                     // Not all interior neighbors are necessarily in
                     // the same Mesh (hence not in the global_index_map).
                     // This will be the case when partitioning a

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -282,7 +282,7 @@ void ParmetisPartitioner::initialize (const MeshBase & mesh,
                            cast_int<std::size_t>(mesh.n_processors()+1));
   libmesh_assert_equal_to (_pmetis->vtxdist[0], 0);
 
-  for (processor_id_type pid=0; pid<mesh.n_processors(); pid++)
+  for (auto pid : IntRange<processor_id_type>(0, mesh.n_processors()))
     {
       _pmetis->vtxdist[pid+1] = _pmetis->vtxdist[pid] + _n_active_elem_on_proc[pid];
       n_active_elem += _n_active_elem_on_proc[pid];
@@ -340,7 +340,7 @@ void ParmetisPartitioner::initialize (const MeshBase & mesh,
 
     const dof_id_type first_local_elem = _pmetis->vtxdist[mesh.processor_id()];
 
-    for (processor_id_type pid=0; pid<mesh.n_processors(); pid++)
+    for (auto pid : IntRange<processor_id_type>(0, mesh.n_processors()))
       {
         dof_id_type tgt_subdomain_size = 0;
 

--- a/src/physics/diff_physics.C
+++ b/src/physics/diff_physics.C
@@ -65,7 +65,7 @@ bool DifferentiablePhysics::nonlocal_mass_residual(bool request_jacobian,
 {
   FEMContext & context = cast_ref<FEMContext &>(c);
 
-  for (unsigned int var = 0; var != context.n_vars(); ++var)
+  for (auto var : IntRange<unsigned int>(0, context.n_vars()))
     {
       if (!this->is_time_evolving(var))
         continue;

--- a/src/physics/fem_physics.C
+++ b/src/physics/fem_physics.C
@@ -78,7 +78,7 @@ bool FEMPhysics::eulerian_residual (bool request_jacobian,
   const std::vector<std::vector<Real>>     & psi =
     context.element_fe_var[mesh_xyz_var]->get_phi();
 
-  for (unsigned int var = 0; var != context.n_vars(); ++var)
+  for (auto var : IntRange<unsigned int>(0, context.n_vars()))
     {
       // Mesh motion only affects time-evolving variables
       if (this->is_time_evolving(var))
@@ -204,7 +204,7 @@ bool FEMPhysics::mass_residual (bool request_jacobian,
 
   unsigned int n_qpoints = context.get_element_qrule().n_points();
 
-  for (unsigned int var = 0; var != context.n_vars(); ++var)
+  for (auto var : IntRange<unsigned int>(0, context.n_vars()))
     {
       if (!this->is_time_evolving(var))
         continue;

--- a/src/quadrature/quadrature.C
+++ b/src/quadrature/quadrature.C
@@ -41,7 +41,7 @@ void QBase::print_info(std::ostream & os) const
 
   Real summed_weights=0;
   os << "N_Q_Points=" << this->n_points() << std::endl << std::endl;
-  for (unsigned int qpoint=0; qpoint<this->n_points(); qpoint++)
+  for (auto qpoint: index_range(_points))
     {
       os << " Point " << qpoint << ":\n"
          << "  "

--- a/src/quadrature/quadrature_composite.C
+++ b/src/quadrature/quadrature_composite.C
@@ -148,7 +148,7 @@ void QComposite<QSubCell>::add_subelem_values (const std::vector<Elem const *> &
         {
           libMesh::err << "ERROR: found a bad cut cell!\n";
 
-          for (unsigned int n=0; n<elem->n_nodes(); n++)
+          for (auto n : elem->node_index_range())
             libMesh::err << elem->point(n) << std::endl;
 
           libmesh_error_msg("Tetgen may have created a 0-volume cell during Cutcell integration.");

--- a/src/solution_transfer/dtk_adapter.C
+++ b/src/solution_transfer/dtk_adapter.C
@@ -277,8 +277,8 @@ void
 DTKAdapter::get_semi_local_nodes(std::set<unsigned int> & semi_local_nodes)
 {
   for (const auto & elem : as_range(mesh.local_elements_begin(), mesh.local_elements_end()))
-    for (unsigned int j=0; j<elem->n_nodes(); j++)
-      semi_local_nodes.insert(elem->node_id(j));
+    for (const Node & node : elem->node_ref_range())
+      semi_local_nodes.insert(node.id());
 }
 
 } // namespace libMesh

--- a/src/solution_transfer/dtk_evaluator.C
+++ b/src/solution_transfer/dtk_evaluator.C
@@ -71,7 +71,7 @@ DTKEvaluator::evaluate(const Teuchos::ArrayRCP<int> & elements,
 
       Number value = 0;
 
-      for (std::size_t j=0; j<dof_indices.size(); j++)
+      for (auto j : index_range(dof_indices))
         value += current_local_solution(dof_indices[j]) * data.shape[j];
 
       values[i] = value;

--- a/src/solution_transfer/meshfree_interpolation.C
+++ b/src/solution_transfer/meshfree_interpolation.C
@@ -263,14 +263,13 @@ void InverseDistanceInterpolation<KDDim>::interpolate (const Point              
   if (!src_dist_sqr.empty())
     {
       Real min_dist = src_dist_sqr.front();
-      std::vector<Real>::const_iterator it = src_dist_sqr.begin();
 
-      for (++it; it!= src_dist_sqr.end(); ++it)
+      for (auto i : src_dist_sqr)
         {
-          if (*it < min_dist)
-            libmesh_error_msg(*it << " was less than min_dist = " << min_dist);
+          if (i < min_dist)
+            libmesh_error_msg(i << " was less than min_dist = " << min_dist);
 
-          min_dist = *it;
+          min_dist = i;
         }
     }
 #endif

--- a/src/solvers/first_order_unsteady_solver.C
+++ b/src/solvers/first_order_unsteady_solver.C
@@ -35,7 +35,7 @@ bool FirstOrderUnsteadySolver::compute_second_order_eqns(bool compute_jacobian, 
 
   unsigned int n_qpoints = context.get_element_qrule().n_points();
 
-  for (unsigned int var = 0; var != context.n_vars(); ++var)
+  for (auto var : IntRange<unsigned int>(0, context.n_vars()))
     {
       if (!this->_system.is_second_order_var(var))
         continue;

--- a/src/solvers/memory_solution_history.C
+++ b/src/solvers/memory_solution_history.C
@@ -102,7 +102,9 @@ void MemorySolutionHistory::store()
   std::map<std::string, std::unique_ptr<NumericVector<Number>>> & saved_vectors = stored_sols->second;
 
   // Loop over all the system vectors
-  for (System::vectors_iterator vec = _system.vectors_begin(); vec != _system.vectors_end(); ++vec)
+  for (System::vectors_iterator vec     = _system.vectors_begin(),
+                                vec_end = _system.vectors_end();
+       vec != vec_end; ++vec)
     {
       // The name of this vector
       const std::string & vec_name = vec->first;

--- a/src/solvers/petsc_auto_fieldsplit.C
+++ b/src/solvers/petsc_auto_fieldsplit.C
@@ -69,7 +69,7 @@ void petsc_auto_fieldsplit (PC my_pc,
 
   if (libMesh::on_command_line("--solver-variable-names"))
     {
-      for (unsigned int v = 0; v != sys.n_vars(); ++v)
+      for (auto v : IntRange<unsigned int>(0, sys.n_vars()))
         {
           const std::string & var_name = sys.variable_name(v);
 

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -739,7 +739,7 @@ namespace libMesh
     CHKERRABORT(system.comm().get(),ierr);
 
     // Set the actual names of all the field variables
-    for( unsigned int v = 0; v < system.n_vars(); v++ )
+    for (auto v : IntRange<unsigned int>(0, system.n_vars()))
       {
         ierr = PetscSectionSetFieldName( section, v, system.variable_name(v).c_str() );
         CHKERRABORT(system.comm().get(),ierr);
@@ -819,7 +819,7 @@ namespace libMesh
     // http://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/PetscSF/PetscSFNode.html
     std::vector<PetscSFNode> sf_nodes(send_list.size());
 
-    for( unsigned int i = 0; i < send_list.size(); i++ )
+    for (auto i : index_range(send_list))
       {
         dof_id_type incoming_dof = send_list[i];
 
@@ -905,10 +905,9 @@ namespace libMesh
         // that aren't active on this level.
         for (const auto & elem : mesh.active_local_element_ptr_range())
           {
-            for (unsigned int n = 0; n < elem->n_nodes(); n++)
+            for (const Node & node : elem->node_ref_range())
               {
                 // get the global id number of local node n
-                const Node & node = elem->node_ref(n);
 
                 // Only register nodes with the PetscSection if they have dofs that belong to
                 // this processor. Even though we're active local elements, the dofs associated
@@ -954,7 +953,7 @@ namespace libMesh
             // Loop through all the variables and cache the scalar ones. We cache the
             // SCALAR variable index along with the local point to make it easier when
             // we have to register dofs with the PetscSection
-            for( unsigned int v = 0; v < system.n_vars(); v++ )
+            for (auto v : IntRange<unsigned int>(0, system.n_vars()))
               {
                 if( system.variable(v).type().family == SCALAR )
                   {
@@ -1045,7 +1044,7 @@ namespace libMesh
     unsigned int total_n_dofs_at_dofobject = 0;
 
     // We are assuming variables are also numbered 0 to n_vars()-1
-    for( unsigned int v = 0; v < system.n_vars(); v++ )
+    for (auto v : IntRange<unsigned int>(0, system.n_vars()))
       {
         unsigned int n_dofs_at_dofobject = dof_object.n_dofs(system.number(), v);
 

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -416,7 +416,7 @@ PetscLinearSolver<T>::restrict_solve_to (const std::vector<unsigned int> * const
       ierr = PetscMalloc(dofs->size()*sizeof(PetscInt), &petsc_dofs);
       LIBMESH_CHKERR(ierr);
 
-      for (std::size_t i=0; i<dofs->size(); i++)
+      for (auto i : index_range(*dofs))
         petsc_dofs[i] = (*dofs)[i];
 
       ierr = ISCreateLibMesh(this->comm().get(),

--- a/src/systems/condensed_eigen_system.C
+++ b/src/systems/condensed_eigen_system.C
@@ -50,7 +50,8 @@ CondensedEigenSystem::initialize_condensed_dofs(const std::set<dof_id_type> & gl
 
   // First, put all unconstrained local dofs into non_dirichlet_dofs_set
   std::set<dof_id_type> local_non_condensed_dofs_set;
-  for (dof_id_type i=this->get_dof_map().first_dof(); i<this->get_dof_map().end_dof(); i++)
+  for (auto i : IntRange<dof_id_type>(dof_map.first_dof(),
+                                      dof_map.end_dof()))
 #if LIBMESH_ENABLE_CONSTRAINTS
     if (!dof_map.is_constrained_dof(i))
 #endif

--- a/src/systems/dg_fem_context.C
+++ b/src/systems/dg_fem_context.C
@@ -127,7 +127,7 @@ void DGFEMContext::neighbor_side_fe_reinit ()
   // Initialize the per-variable data for elem.
   {
     unsigned int sub_dofs = 0;
-    for (unsigned int i=0; i != get_system().n_vars(); ++i)
+    for (auto i : IntRange<unsigned int>(0, get_system().n_vars()))
       {
         get_system().get_dof_map().dof_indices (&get_neighbor(), _neighbor_dof_indices_var[i], i);
 

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -498,7 +498,7 @@ void EquationSystems::build_variable_names (std::vector<std::string> & var_names
         if (!use_current_system || pos->second->hide_output())
           continue;
 
-        for (unsigned int vn=0; vn<pos->second->n_vars(); vn++)
+        for (auto vn : IntRange<unsigned int>(0, pos->second->n_vars()))
           {
             if (FEInterface::field_type(pos->second->variable_type(vn)) == TYPE_VECTOR)
               n_vector_vars++;
@@ -533,7 +533,7 @@ void EquationSystems::build_variable_names (std::vector<std::string> & var_names
       if (!use_current_system || pos->second->hide_output())
         continue;
 
-      for (unsigned int vn=0; vn<pos->second->n_vars(); vn++)
+      for (auto vn : IntRange<unsigned int>(0, pos->second->n_vars()))
         {
           const std::string & var_name = pos->second->variable_name(vn);
           const FEType & fe_type = pos->second->variable_type(vn);
@@ -626,7 +626,7 @@ EquationSystems::build_parallel_solution_vector(const std::set<std::string> * sy
         if (!use_current_system || pos->second->hide_output())
           continue;
 
-        for (unsigned int vn=0; vn<pos->second->n_vars(); vn++)
+        for (auto vn : IntRange<unsigned int>(0, pos->second->n_vars()))
           {
             if (FEInterface::field_type(pos->second->variable_type(vn)) == TYPE_VECTOR)
               n_vector_vars++;
@@ -697,7 +697,7 @@ EquationSystems::build_parallel_solution_vector(const std::set<std::string> * sy
       //Could this be replaced by a/some convenience methods?[PB]
       unsigned int n_scalar_vars = 0;
       unsigned int n_vector_vars = 0;
-      for (unsigned int vn=0; vn<pos->second->n_vars(); vn++)
+      for (auto vn : IntRange<unsigned int>(0, pos->second->n_vars()))
         {
           if (FEInterface::field_type(pos->second->variable_type(vn)) == TYPE_VECTOR)
             n_vector_vars++;
@@ -746,7 +746,7 @@ EquationSystems::build_parallel_solution_vector(const std::set<std::string> * sy
 
                   elem_soln.resize(dof_indices.size());
 
-                  for (std::size_t i=0; i<dof_indices.size(); i++)
+                  for (auto i : index_range(dof_indices))
                     elem_soln[i] = sys_soln(dof_indices[i]);
 
                   FEInterface::nodal_soln (dim,
@@ -762,7 +762,7 @@ EquationSystems::build_parallel_solution_vector(const std::set<std::string> * sy
                     {
                       libmesh_assert_equal_to (nodal_soln.size(), n_vec_dim*elem->n_nodes());
 
-                      for (unsigned int n=0; n<elem->n_nodes(); n++)
+                      for (auto n : elem->node_index_range())
                         {
                           for (unsigned int d=0; d < n_vec_dim; d++)
                             {
@@ -777,11 +777,11 @@ EquationSystems::build_parallel_solution_vector(const std::set<std::string> * sy
                     }
                 }
               else // If this variable doesn't exist on this subdomain we have to still increment repeat_count so that we won't divide by 0 later:
-                for (unsigned int n=0; n<elem->n_nodes(); n++)
+                for (const Node & node : elem->node_ref_range())
                   // Only do this if this variable has NO DoFs at this node... it might have some from an adjoining element...
-                  if (!elem->node_ptr(n)->n_dofs(sys_num, var))
+                  if (!node.n_dofs(sys_num, var))
                     for (unsigned int d=0; d < n_vec_dim; d++)
-                      repeat_count.add(nv*(elem->node_id(n)) + (var_inc+d + var_num), 1);
+                      repeat_count.add(nv*node.id() + (var_inc+d + var_num), 1);
 
             } // end loop over elements
           var_inc += n_vec_dim;
@@ -851,7 +851,7 @@ void EquationSystems::get_vars_active_subdomains(const std::vector<std::string> 
 
   for (; pos != end; ++pos)
     {
-      for (unsigned int vn=0; vn<pos->second->n_vars(); vn++)
+      for (auto vn : IntRange<unsigned int>(0, pos->second->n_vars()))
         {
           const std::string & var_name = pos->second->variable_name(vn);
 
@@ -1074,7 +1074,7 @@ EquationSystems::build_discontinuous_solution_vector
 
       // Loop over all variables in this System and check whether we
       // are supposed to use each one.
-      for (unsigned int var_id=0; var_id<system->n_vars(); ++var_id)
+      for (auto var_id : IntRange<unsigned int>(0, system->n_vars()))
         {
           bool use_current_var = (var_names == nullptr);
           if (!use_current_var)
@@ -1164,7 +1164,7 @@ EquationSystems::build_discontinuous_solution_vector
 
                       soln_coeffs.resize(dof_indices.size());
 
-                      for (std::size_t i=0; i<dof_indices.size(); i++)
+                      for (auto i : index_range(dof_indices))
                         soln_coeffs[i] = sys_soln[dof_indices[i]];
 
                       // Compute the FE solution at all the nodes, but

--- a/src/systems/explicit_system.C
+++ b/src/systems/explicit_system.C
@@ -57,7 +57,7 @@ void ExplicitSystem::assemble_qoi (const QoISet & qoi_indices)
 {
   // The user quantity of interest assembly gets to expect to
   // accumulate on initially zero values
-  for (unsigned int i=0; i != this->n_qois(); ++i)
+  for (auto i : IntRange<unsigned int>(0, this->n_qois()))
     if (qoi_indices.has_index(i))
       qoi[i] = 0;
 
@@ -72,7 +72,7 @@ void ExplicitSystem::assemble_qoi_derivative (const QoISet & qoi_indices,
 {
   // The user quantity of interest derivative assembly gets to expect
   // to accumulate on initially zero vectors
-  for (unsigned int i=0; i != this->n_qois(); ++i)
+  for (auto i : IntRange<unsigned int>(0, this->n_qois()))
     if (qoi_indices.has_index(i))
       this->add_adjoint_rhs(i).zero();
 

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -344,7 +344,7 @@ void FEMContext::interior_values (unsigned int var,
   const std::vector<std::vector<OutputShape>> & phi = fe->get_phi();
 
   // Loop over all the q_points on this element
-  for (std::size_t qp=0; qp != u_vals.size(); qp++)
+  for (auto qp : index_range(u_vals))
     {
       OutputType & u = u_vals[qp];
 
@@ -408,7 +408,7 @@ void FEMContext::interior_gradients(unsigned int var,
   const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputGradient>> & dphi = fe->get_dphi();
 
   // Loop over all the q_points in this finite element
-  for (std::size_t qp=0; qp != du_vals.size(); qp++)
+  for (auto qp : index_range(du_vals))
     {
       OutputType & du = du_vals[qp];
 
@@ -470,7 +470,7 @@ void FEMContext::interior_hessians(unsigned int var,
   const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputTensor>> & d2phi = fe->get_d2phi();
 
   // Loop over all the q_points in this finite element
-  for (std::size_t qp=0; qp != d2u_vals.size(); qp++)
+  for (auto qp : index_range(d2u_vals))
     {
       OutputType & d2u = d2u_vals[qp];
 
@@ -596,7 +596,7 @@ void FEMContext::side_values(unsigned int var,
   const std::vector<std::vector<OutputShape>> & phi = the_side_fe->get_phi();
 
   // Loop over all the q_points on this element
-  for (std::size_t qp=0; qp != u_vals.size(); qp++)
+  for (auto qp : index_range(u_vals))
     {
       OutputType & u = u_vals[qp];
 
@@ -678,7 +678,7 @@ void FEMContext::side_gradients(unsigned int var,
   const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputGradient>> & dphi = the_side_fe->get_dphi();
 
   // Loop over all the q_points in this finite element
-  for (std::size_t qp=0; qp != du_vals.size(); qp++)
+  for (auto qp : index_range(du_vals))
     {
       OutputType & du = du_vals[qp];
 
@@ -745,7 +745,7 @@ void FEMContext::side_hessians(unsigned int var,
   const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputTensor>> & d2phi = the_side_fe->get_d2phi();
 
   // Loop over all the q_points in this finite element
-  for (std::size_t qp=0; qp != d2u_vals.size(); qp++)
+  for (auto qp : index_range(d2u_vals))
     {
       OutputType & d2u = d2u_vals[qp];
 
@@ -1654,7 +1654,7 @@ void FEMContext::pre_fe_reinit(const System & sys, const Elem * e)
   // Initialize the per-variable data for elem.
   {
     unsigned int sub_dofs = 0;
-    for (unsigned int i=0; i != sys.n_vars(); ++i)
+    for (auto i : IntRange<unsigned int>(0, sys.n_vars()))
       {
         if (algebraic_type() == CURRENT ||
             algebraic_type() == DOFS_ONLY)
@@ -1769,7 +1769,7 @@ void FEMContext::pre_fe_reinit(const System & sys, const Elem * e)
 
           // Initialize the per-variable data for elem.
           unsigned int sub_dofs = 0;
-          for (unsigned int i=0; i != sys.n_vars(); ++i)
+          for (auto i : IntRange<unsigned int>(0, sys.n_vars()))
             {
               const unsigned int n_dofs_var = cast_int<unsigned int>
                 (this->get_dof_indices(i).size());

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -476,7 +476,7 @@ public:
     bool have_some_heterogenous_qoi_bc = false;
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
     std::vector<bool> have_heterogenous_qoi_bc(_sys.n_qois(), false);
-    for (unsigned int q=0; q != _sys.n_qois(); ++q)
+    for (auto q : IntRange<unsigned int>(0, _sys.n_qois()))
       if (_qoi_indices.has_index(q) &&
           _sys.get_dof_map().has_heterogenous_adjoint_constraints(q))
         {
@@ -503,7 +503,7 @@ public:
         std::vector<bool> elem_has_heterogenous_qoi_bc(_sys.n_qois(), false);
         if (have_some_heterogenous_qoi_bc)
           {
-            for (unsigned int q=0; q != _sys.n_qois(); ++q)
+            for (auto q : IntRange<unsigned int>(0, _sys.n_qois()))
               {
                 if (have_heterogenous_qoi_bc[q])
                   {
@@ -535,7 +535,7 @@ public:
           {
             _sys.time_solver->element_residual(false, _femcontext);
 
-            for (unsigned int q=0; q != _sys.n_qois(); ++q)
+            for (auto q : IntRange<unsigned int>(0, _sys.n_qois()))
               {
                 if (elem_has_heterogenous_qoi_bc[q])
                   {
@@ -613,7 +613,7 @@ public:
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
     std::vector<bool> have_heterogenous_qoi_bc(_sys.n_qois(), false);
     if (_include_liftfunc || _apply_constraints)
-      for (unsigned int q=0; q != _sys.n_qois(); ++q)
+      for (auto q : IntRange<unsigned int>(0, _sys.n_qois()))
         if (_qoi_indices.has_index(q) &&
             _sys.get_dof_map().has_heterogenous_adjoint_constraints(q))
           {
@@ -640,7 +640,7 @@ public:
         std::vector<bool> elem_has_heterogenous_qoi_bc(_sys.n_qois(), false);
         if (have_some_heterogenous_qoi_bc)
           {
-            for (unsigned int q=0; q != _sys.n_qois(); ++q)
+            for (auto q : IntRange<unsigned int>(0, _sys.n_qois()))
               {
                 if (have_heterogenous_qoi_bc[q])
                   {
@@ -694,7 +694,7 @@ public:
         // may handle integrating
         if (_include_liftfunc && elem_has_some_heterogenous_qoi_bc)
           {
-            for (unsigned int q=0; q != _sys.n_qois(); ++q)
+            for (auto q : IntRange<unsigned int>(0, _sys.n_qois()))
               {
                 if (elem_has_heterogenous_qoi_bc[q])
                   {
@@ -751,7 +751,7 @@ public:
             _sys.get_dof_map().constrain_nothing(_femcontext.get_dof_indices());
 #endif
 
-          for (unsigned int i=0; i != _sys.n_qois(); ++i)
+          for (auto i : IntRange<unsigned int>(0, _sys.n_qois()))
             if (_qoi_indices.has_index(i))
               {
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
@@ -921,7 +921,7 @@ void FEMSystem::assembly (bool get_residual, bool get_jacobian,
 
   // Check and see if we have SCALAR variables
   bool have_scalar = false;
-  for (unsigned int i=0; i != this->n_variable_groups(); ++i)
+  for (auto i : IntRange<unsigned int>(0, this->n_variable_groups()))
     {
       if (this->variable_group(i).type().family == SCALAR)
         {
@@ -1156,7 +1156,7 @@ void FEMSystem::assemble_qoi_derivative (const QoISet & qoi_indices,
 
   // The quantity of interest derivative assembly accumulates on
   // initially zero vectors
-  for (unsigned int i=0; i != this->n_qois(); ++i)
+  for (auto i : IntRange<unsigned int>(0, this->n_qois()))
     if (qoi_indices.has_index(i))
       this->add_adjoint_rhs(i).zero();
 
@@ -1168,7 +1168,7 @@ void FEMSystem::assemble_qoi_derivative (const QoISet & qoi_indices,
                                                     include_liftfunc,
                                                     apply_constraints));
 
-  for (unsigned int i=0; i != this->n_qois(); ++i)
+  for (auto i : IntRange<unsigned int>(0, this->n_qois()))
     if (qoi_indices.has_index(i))
       this->diff_qoi->finalize_derivative(this->get_adjoint_rhs(i),i);
 }
@@ -1195,7 +1195,7 @@ void FEMSystem::numerical_jacobian (TimeSolverResPtr res,
   const unsigned int n_dofs =
     cast_int<unsigned int>(context.get_dof_indices().size());
 
-  for (unsigned int v = 0; v != context.n_vars(); ++v)
+  for (auto v : IntRange<unsigned int>(0, context.n_vars()))
     {
       const Real my_h = this->numerical_jacobian_h_for_var(v);
 
@@ -1352,7 +1352,7 @@ void FEMSystem::init_context(DiffContext & c)
   FEMContext & context = cast_ref<FEMContext &>(c);
 
   // Make sure we're prepared to do mass integration
-  for (unsigned int var = 0; var != this->n_vars(); ++var)
+  for (auto var : IntRange<unsigned int>(0, this->n_vars()))
     if (this->get_physics()->is_time_evolving(var))
       {
         // Request shape functions based on FEType

--- a/src/systems/frequency_system.C
+++ b/src/systems/frequency_system.C
@@ -308,7 +308,7 @@ void FrequencySystem::set_frequencies (const std::vector<Number> & frequencies,
   es.parameters.set<unsigned int>("n_frequencies") = frequencies.size();
 
   // set frequencies, build solution storage
-  for (std::size_t n=0; n<frequencies.size(); n++)
+  for (auto n : index_range(frequencies))
     {
       // remember frequencies as parameters
       es.parameters.set<Number>(this->form_freq_param_name(n)) = frequencies[n];

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -380,7 +380,7 @@ ImplicitSystem::adjoint_solve (const QoISet & qoi_indices)
     this->get_linear_solve_parameters();
   std::pair<unsigned int, Real> totalrval = std::make_pair(0,0.0);
 
-  for (unsigned int i=0; i != this->n_qois(); ++i)
+  for (auto i : IntRange<unsigned int>(0, this->n_qois()))
     if (qoi_indices.has_index(i))
       {
         const std::pair<unsigned int, Real> rval =
@@ -397,7 +397,7 @@ ImplicitSystem::adjoint_solve (const QoISet & qoi_indices)
 
   // The linear solver may not have fit our constraints exactly
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
-  for (unsigned int i=0; i != this->n_qois(); ++i)
+  for (auto i : IntRange<unsigned int>(0, this->n_qois()))
     if (qoi_indices.has_index(i))
       this->get_dof_map().enforce_adjoint_constraints_exactly
         (this->get_adjoint_solution(i), i);
@@ -431,7 +431,7 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
   // FIXME: The derivation here does not yet take adjoint boundary
   // conditions into account.
 #ifdef LIBMESH_ENABLE_DIRICHLET
-  for (unsigned int i=0; i != this->n_qois(); ++i)
+  for (auto i : IntRange<unsigned int>(0, this->n_qois()))
     if (qoi_indices.has_index(i))
       libmesh_assert(!this->get_dof_map().has_adjoint_dirichlet_boundaries(i));
 #endif
@@ -443,7 +443,7 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
   // any good reasons why users might want to save these:
 
   std::vector<std::unique_ptr<NumericVector<Number>>> temprhs(this->n_qois());
-  for (unsigned int i=0; i != this->n_qois(); ++i)
+  for (auto i : IntRange<unsigned int>(0, this->n_qois()))
     if (qoi_indices.has_index(i))
       temprhs[i] = this->rhs->zero_clone();
 
@@ -474,7 +474,7 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
   this->assemble_qoi_derivative(qoi_indices,
                                 /* include_liftfunc = */ false,
                                 /* apply_constraints = */ true);
-  for (unsigned int i=0; i != this->n_qois(); ++i)
+  for (auto i : IntRange<unsigned int>(0, this->n_qois()))
     if (qoi_indices.has_index(i))
       {
         this->get_adjoint_rhs(i).close();
@@ -494,7 +494,7 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
   this->assemble_qoi_derivative(qoi_indices,
                                 /* include_liftfunc = */ false,
                                 /* apply_constraints = */ true);
-  for (unsigned int i=0; i != this->n_qois(); ++i)
+  for (auto i : IntRange<unsigned int>(0, this->n_qois()))
     if (qoi_indices.has_index(i))
       {
         this->get_adjoint_rhs(i).close();
@@ -527,7 +527,7 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
     this->get_linear_solve_parameters();
   std::pair<unsigned int, Real> totalrval = std::make_pair(0,0.0);
 
-  for (unsigned int i=0; i != this->n_qois(); ++i)
+  for (auto i : IntRange<unsigned int>(0, this->n_qois()))
     if (qoi_indices.has_index(i))
       {
         const std::pair<unsigned int, Real> rval =
@@ -544,7 +544,7 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
 
   // The linear solver may not have fit our constraints exactly
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
-  for (unsigned int i=0; i != this->n_qois(); ++i)
+  for (auto i : IntRange<unsigned int>(0, this->n_qois()))
     if (qoi_indices.has_index(i))
       this->get_dof_map().enforce_constraints_exactly
         (*this, &this->get_weighted_sensitivity_adjoint_solution(i),
@@ -834,7 +834,7 @@ void ImplicitSystem::forward_qoi_parameter_sensitivity (const QoISet & qoi_indic
   // We don't need these to be closed() in this function, but libMesh
   // standard practice is to have them closed() by the time the
   // function exits
-  for (unsigned int i=0; i != this->n_qois(); ++i)
+  for (auto i : IntRange<unsigned int>(0, this->n_qois()))
     if (qoi_indices.has_index(i))
       this->get_adjoint_rhs(i).close();
 

--- a/src/systems/parameter_vector.C
+++ b/src/systems/parameter_vector.C
@@ -29,8 +29,8 @@ ParameterVector::ParameterVector(const std::vector<Number *> &params)
 {
   _params.reserve(params.size());
 
-  for (std::size_t i=0; i != params.size(); ++i)
-    _params.push_back(new ParameterPointer<Number>(params[i]));
+  for (auto p : params)
+    _params.push_back(new ParameterPointer<Number>(p));
 }
 
 

--- a/src/systems/qoi_set.C
+++ b/src/systems/qoi_set.C
@@ -35,7 +35,7 @@ QoISet::QoISet(const System & sys) : _indices(sys.n_qois(), true) {}
 std::size_t QoISet::size (const System & sys) const
 {
   std::size_t qoi_count = 0;
-  for (unsigned int i=0; i != sys.n_qois(); ++i)
+  for (auto i : IntRange<unsigned int>(0, sys.n_qois()))
     if (this->has_index(i))
       qoi_count++;
   return qoi_count;

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -358,7 +358,7 @@ void System::read_legacy_data (Xdr & io,
 
         // First reorder the nodal DOF values
         for (auto & node : this->get_mesh().node_ptr_range())
-          for (unsigned int index=0; index<node->n_comp(sys,var); index++)
+          for (auto index : IntRange<unsigned int>(0, node->n_comp(sys,var)))
             {
               libmesh_assert_not_equal_to (node->dof_number(sys, var, index),
                                            DofObject::invalid_id);
@@ -371,7 +371,7 @@ void System::read_legacy_data (Xdr & io,
 
         // Then reorder the element DOF values
         for (auto & elem : this->get_mesh().active_element_ptr_range())
-          for (unsigned int index=0; index<elem->n_comp(sys,var); index++)
+          for (auto index : IntRange<unsigned int>(0, elem->n_comp(sys,var)))
             {
               libmesh_assert_not_equal_to (elem->dof_number(sys, var, index),
                                            DofObject::invalid_id);
@@ -448,7 +448,7 @@ void System::read_legacy_data (Xdr & io,
                   const unsigned int var = _written_var_indices[data_var];
                   // First reorder the nodal DOF values
                   for (auto & node : this->get_mesh().node_ptr_range())
-                    for (unsigned int index=0; index<node->n_comp(sys,var); index++)
+                    for (auto index : IntRange<unsigned int>(0, node->n_comp(sys,var)))
                       {
                         libmesh_assert_not_equal_to (node->dof_number(sys, var, index),
                                                      DofObject::invalid_id);
@@ -461,7 +461,7 @@ void System::read_legacy_data (Xdr & io,
 
                   // Then reorder the element DOF values
                   for (auto & elem : this->get_mesh().active_element_ptr_range())
-                    for (unsigned int index=0; index<elem->n_comp(sys,var); index++)
+                    for (auto index : IntRange<unsigned int>(0, elem->n_comp(sys,var)))
                       {
                         libmesh_assert_not_equal_to (elem->dof_number(sys, var, index),
                                                      DofObject::invalid_id);
@@ -572,7 +572,7 @@ void System::read_parallel_data (Xdr & io,
         {
           // First read the node DOF values
           for (const auto & node : ordered_nodes)
-            for (unsigned int comp=0; comp<node->n_comp(sys_num, var); comp++)
+            for (auto comp : IntRange<unsigned int>(0, node->n_comp(sys_num,var)))
               {
                 libmesh_assert_not_equal_to (node->dof_number(sys_num, var, comp),
                                              DofObject::invalid_id);
@@ -582,7 +582,7 @@ void System::read_parallel_data (Xdr & io,
 
           // Then read the element DOF values
           for (const auto & elem : ordered_elements)
-            for (unsigned int comp=0; comp<elem->n_comp(sys_num, var); comp++)
+            for (auto comp : IntRange<unsigned int>(0, elem->n_comp(sys_num,var)))
               {
                 libmesh_assert_not_equal_to (elem->dof_number(sys_num, var, comp),
                                              DofObject::invalid_id);
@@ -604,8 +604,8 @@ void System::read_parallel_data (Xdr & io,
               std::vector<dof_id_type> SCALAR_dofs;
               dof_map.SCALAR_dof_indices(SCALAR_dofs, var);
 
-              for (std::size_t i=0; i<SCALAR_dofs.size(); i++)
-                this->solution->set(SCALAR_dofs[i], io_buffer[cnt++]);
+              for (auto dof : SCALAR_dofs)
+                this->solution->set(dof, io_buffer[cnt++]);
             }
         }
     }
@@ -659,7 +659,7 @@ void System::read_parallel_data (Xdr & io,
                     {
                       // First read the node DOF values
                       for (const auto & node : ordered_nodes)
-                        for (unsigned int comp=0; comp<node->n_comp(sys_num, var); comp++)
+                        for (auto comp : IntRange<unsigned int>(0, node->n_comp(sys_num,var)))
                           {
                             libmesh_assert_not_equal_to (node->dof_number(sys_num, var, comp),
                                                          DofObject::invalid_id);
@@ -669,7 +669,7 @@ void System::read_parallel_data (Xdr & io,
 
                       // Then read the element DOF values
                       for (const auto & elem : ordered_elements)
-                        for (unsigned int comp=0; comp<elem->n_comp(sys_num, var); comp++)
+                        for (auto comp : IntRange<unsigned int>(0, elem->n_comp(sys_num,var)))
                           {
                             libmesh_assert_not_equal_to (elem->dof_number(sys_num, var, comp),
                                                          DofObject::invalid_id);
@@ -691,8 +691,8 @@ void System::read_parallel_data (Xdr & io,
                           std::vector<dof_id_type> SCALAR_dofs;
                           dof_map.SCALAR_dof_indices(SCALAR_dofs, var);
 
-                          for (std::size_t sd=0; sd<SCALAR_dofs.size(); sd++)
-                            pos->second->set(SCALAR_dofs[sd], io_buffer[cnt++]);
+                          for (auto dof : SCALAR_dofs)
+                            pos->second->set(dof, io_buffer[cnt++]);
                         }
                     }
                 }
@@ -984,7 +984,7 @@ std::size_t System::read_serialized_blocked_dof_objects (const dof_id_type n_obj
 #endif
 
           // loop over all processors and process their index request
-          for (unsigned int comm_step=0; comm_step<this->n_processors(); comm_step++)
+          for (processor_id_type comm_step=0, tnp=this->n_processors(); comm_step != tnp; ++comm_step)
             {
 #ifdef LIBMESH_HAVE_MPI
               // blocking receive indices for this block, imposing no particular order on processor
@@ -1003,7 +1003,7 @@ std::size_t System::read_serialized_blocked_dof_objects (const dof_id_type n_obj
 
               // note its possible we didn't receive values for objects in
               // this block if they have no components allocated.
-              for (std::size_t idx=0; idx<ids.size(); idx+=2)
+              for (std::size_t idx=0, sz=ids.size(); idx<sz; idx+=2)
                 {
                   const dof_id_type
                     local_idx          = ids[idx+0]-first_object,
@@ -1032,13 +1032,13 @@ std::size_t System::read_serialized_blocked_dof_objects (const dof_id_type n_obj
           // Wait for read completion
           async_io.join();
           // now copy the values back to the main vector for transfer
-          for (std::size_t i_val=0; i_val<input_vals.size(); i_val++)
+          for (auto i_val : index_range(input_vals))
             input_vals[i_val] = input_vals_tmp[i_val];
 
           n_read_values += input_vals.size();
 
           // pack data replies for each processor
-          for (processor_id_type proc=0; proc<this->n_processors(); proc++)
+          for (auto proc : IntRange<processor_id_type>(0, this->n_processors()))
             {
               const std::vector<dof_id_type> & ids (recv_ids[proc]);
               std::vector<Number> & vals (send_vals[proc]);
@@ -1046,7 +1046,7 @@ std::size_t System::read_serialized_blocked_dof_objects (const dof_id_type n_obj
 
               vals.clear(); /**/ vals.reserve(n_vals_proc);
 
-              for (std::size_t idx=0; idx<ids.size(); idx+=2)
+              for (std::size_t idx=0, sz=ids.size(); idx<sz; idx+=2)
                 {
                   const dof_id_type
                     local_idx          = ids[idx+0]-first_object,
@@ -1151,7 +1151,7 @@ unsigned int System::read_SCALAR_dofs (const unsigned int var,
       std::vector<dof_id_type> SCALAR_dofs;
       dof_map.SCALAR_dof_indices(SCALAR_dofs, var);
 
-      for (std::size_t i=0; i<SCALAR_dofs.size(); i++)
+      for (auto i : index_range(SCALAR_dofs))
         {
           if (vec)
             vec->set (SCALAR_dofs[i], input_buffer[i]);
@@ -1357,7 +1357,7 @@ void System::write_header (Xdr & io,
   }
 
 
-  for (unsigned int var=0; var<this->n_vars(); var++)
+  for (auto var : IntRange<unsigned int>(0, this->n_vars()))
     {
       // 6.)
       // Write the name of the var-th variable
@@ -1569,7 +1569,7 @@ void System::write_parallel_data (Xdr & io,
       {
         // First write the node DOF values
         for (const auto & node : ordered_nodes)
-          for (unsigned int comp=0; comp<node->n_comp(sys_num, var); comp++)
+          for (auto comp : IntRange<unsigned int>(0, node->n_comp(sys_num,var)))
             {
               libmesh_assert_not_equal_to (node->dof_number(sys_num, var, comp),
                                            DofObject::invalid_id);
@@ -1579,7 +1579,7 @@ void System::write_parallel_data (Xdr & io,
 
         // Then write the element DOF values
         for (const auto & elem : ordered_elements)
-          for (unsigned int comp=0; comp<elem->n_comp(sys_num, var); comp++)
+          for (auto comp : IntRange<unsigned int>(0, elem->n_comp(sys_num,var)))
             {
               libmesh_assert_not_equal_to (elem->dof_number(sys_num, var, comp),
                                            DofObject::invalid_id);
@@ -1589,7 +1589,7 @@ void System::write_parallel_data (Xdr & io,
       }
 
   // Finally, write the SCALAR data on the last processor
-  for (unsigned int var=0; var<this->n_vars(); var++)
+  for (auto var : IntRange<unsigned int>(0, this->n_vars()))
     if (this->variable(var).type().family == SCALAR)
       {
         if (this->processor_id() == (this->n_processors()-1))
@@ -1598,8 +1598,8 @@ void System::write_parallel_data (Xdr & io,
             std::vector<dof_id_type> SCALAR_dofs;
             dof_map.SCALAR_dof_indices(SCALAR_dofs, var);
 
-            for (std::size_t i=0; i<SCALAR_dofs.size(); i++)
-              io_buffer.push_back((*this->solution)(SCALAR_dofs[i]));
+            for (auto dof : SCALAR_dofs)
+              io_buffer.push_back((*this->solution)(dof));
           }
       }
 
@@ -1633,7 +1633,7 @@ void System::write_parallel_data (Xdr & io,
               {
                 // First write the node DOF values
                 for (const auto & node : ordered_nodes)
-                  for (unsigned int comp=0; comp<node->n_comp(sys_num, var); comp++)
+                  for (auto comp : IntRange<unsigned int>(0, node->n_comp(sys_num,var)))
                     {
                       libmesh_assert_not_equal_to (node->dof_number(sys_num, var, comp),
                                                    DofObject::invalid_id);
@@ -1643,7 +1643,7 @@ void System::write_parallel_data (Xdr & io,
 
                 // Then write the element DOF values
                 for (const auto & elem : ordered_elements)
-                  for (unsigned int comp=0; comp<elem->n_comp(sys_num, var); comp++)
+                  for (auto comp : IntRange<unsigned int>(0, elem->n_comp(sys_num,var)))
                     {
                       libmesh_assert_not_equal_to (elem->dof_number(sys_num, var, comp),
                                                    DofObject::invalid_id);
@@ -1653,7 +1653,7 @@ void System::write_parallel_data (Xdr & io,
               }
 
           // Finally, write the SCALAR data on the last processor
-          for (unsigned int var=0; var<this->n_vars(); var++)
+          for (auto var : IntRange<unsigned int>(0, this->n_vars()))
             if (this->variable(var).type().family == SCALAR)
               {
                 if (this->processor_id() == (this->n_processors()-1))
@@ -1662,8 +1662,8 @@ void System::write_parallel_data (Xdr & io,
                     std::vector<dof_id_type> SCALAR_dofs;
                     dof_map.SCALAR_dof_indices(SCALAR_dofs, var);
 
-                    for (std::size_t i=0; i<SCALAR_dofs.size(); i++)
-                      io_buffer.push_back((*pr.second)(SCALAR_dofs[i]));
+                    for (auto dof : SCALAR_dofs)
+                      io_buffer.push_back((*pr.second)(dof));
                   }
               }
 
@@ -1739,13 +1739,10 @@ void System::write_serialized_data (Xdr & io,
   // Only write additional vectors if wanted
   if (write_additional_data)
     {
-      std::map<std::string, NumericVector<Number> *>::const_iterator
-        pos = _vectors.begin();
-
-      for (; pos != this->_vectors.end(); ++pos)
+      for (auto & pair : this->_vectors)
         {
           // total_written_size +=
-          this->write_serialized_vector(io, *pos->second);
+          this->write_serialized_vector(io, *pair.second);
 
           // set up the comment
           if (this->processor_id() == 0)
@@ -1753,7 +1750,7 @@ void System::write_serialized_data (Xdr & io,
               comment = "# System \"";
               comment += this->name();
               comment += "\" Additional Vector \"";
-              comment += pos->first;
+              comment += pair.first;
               comment += "\"";
               io.comment (comment);
             }
@@ -1841,7 +1838,7 @@ std::size_t System::write_serialized_blocked_dof_objects (const std::vector<cons
   if (var_to_write == libMesh::invalid_uint)
     {
       vars_to_write.clear(); /**/ vars_to_write.reserve(this->n_vars());
-      for (unsigned int var=0; var<this->n_vars(); var++)
+      for (auto var : IntRange<unsigned int>(0, this->n_vars()))
         vars_to_write.push_back(var);
     }
 
@@ -1987,7 +1984,7 @@ std::size_t System::write_serialized_blocked_dof_objects (const std::vector<cons
           std::size_t n_val_recvd_blk=0;
 
           // receive this block of data from all processors.
-          for (unsigned int comm_step=0; comm_step<this->n_processors(); comm_step++)
+          for (processor_id_type comm_step=0, tnp=this->n_processors(); comm_step != tnp; ++comm_step)
             {
 #ifdef LIBMESH_HAVE_MPI
               // blocking receive indices for this block, imposing no particular order on processor
@@ -2001,7 +1998,7 @@ std::size_t System::write_serialized_blocked_dof_objects (const std::vector<cons
 
               // note its possible we didn't receive values for objects in
               // this block if they have no components allocated.
-              for (std::size_t idx=0; idx<ids.size(); idx+=2)
+              for (std::size_t idx=0, sz=ids.size(); idx<sz; idx+=2)
                 {
                   const dof_id_type
                     local_idx          = ids[idx+0]-first_object,
@@ -2042,13 +2039,13 @@ std::size_t System::write_serialized_blocked_dof_objects (const std::vector<cons
           output_vals.resize(n_val_recvd_blk);
 
           // pack data from all processors into output values
-          for (unsigned int proc=0; proc<this->n_processors(); proc++)
+          for (auto proc : IntRange<unsigned int>(0, this->n_processors()))
             {
               const std::vector<dof_id_type> & ids (recv_ids [proc]);
               const std::vector<Number>      & vals(recv_vals[proc]);
               std::vector<Number>::const_iterator proc_vals(vals.begin());
 
-              for (std::size_t idx=0; idx<ids.size(); idx+=2)
+              for (std::size_t idx=0, sz=ids.size(); idx<sz; idx+=2)
                 {
                   const dof_id_type
                     local_idx          = ids[idx+0]-first_object,
@@ -2184,7 +2181,7 @@ dof_id_type System::write_serialized_vector (Xdr & io,
 
   //-------------------------------------------
   // Finally loop over all the SCALAR variables
-  for (unsigned int var=0; var<this->n_vars(); var++)
+  for (auto var : IntRange<unsigned int>(0, this->n_vars()))
     if (this->variable(var).type().family == SCALAR)
       {
         written_length +=
@@ -2270,22 +2267,22 @@ std::size_t System::read_serialized_vectors (Xdr & io,
 
   //-------------------------------------------
   // Finally loop over all the SCALAR variables
-  for (std::size_t vec=0; vec<vectors.size(); vec++)
-    for (unsigned int var=0; var<this->n_vars(); var++)
+  for (NumericVector<Number> * vec : vectors)
+    for (auto var : IntRange<unsigned int>(0, this->n_vars()))
       if (this->variable(var).type().family == SCALAR)
         {
-          libmesh_assert_not_equal_to (vectors[vec], 0);
+          libmesh_assert_not_equal_to (vec, 0);
 
           read_length +=
-            this->read_SCALAR_dofs (var, io, vectors[vec]);
+            this->read_SCALAR_dofs (var, io, vec);
         }
 
   //---------------------------------------
   // last step - must close all the vectors
-  for (std::size_t vec=0; vec<vectors.size(); vec++)
+  for (NumericVector<Number> * vec : vectors)
     {
-      libmesh_assert_not_equal_to (vectors[vec], 0);
-      vectors[vec]->close();
+      libmesh_assert_not_equal_to (vec, 0);
+      vec->close();
     }
 
   return read_length;
@@ -2339,14 +2336,14 @@ std::size_t System::write_serialized_vectors (Xdr & io,
 
   //-------------------------------------------
   // Finally loop over all the SCALAR variables
-  for (std::size_t vec=0; vec<vectors.size(); vec++)
-    for (unsigned int var=0; var<this->n_vars(); var++)
+  for (const NumericVector<Number> * vec : vectors)
+    for (auto var : IntRange<unsigned int>(0, this->n_vars()))
       if (this->variable(var).type().family == SCALAR)
         {
-          libmesh_assert_not_equal_to (vectors[vec], 0);
+          libmesh_assert_not_equal_to (vec, 0);
 
           written_length +=
-            this->write_SCALAR_dofs (*vectors[vec], var, io);
+            this->write_SCALAR_dofs (*vec, var, io);
         }
 
   return written_length;

--- a/src/systems/system_norm.C
+++ b/src/systems/system_norm.C
@@ -19,6 +19,7 @@
 // libMesh includes
 #include "libmesh/system_norm.h"
 #include "libmesh/enum_norm_type.h"
+#include "libmesh/int_range.h"
 
 namespace libMesh
 {
@@ -56,7 +57,7 @@ SystemNorm::SystemNorm(const std::vector<FEMNormType> & norms,
       _weights_sq.push_back(1.0);
     }
   else
-    for (std::size_t i=0; i != _weights.size(); ++i)
+    for (auto i : index_range(_weights))
       _weights_sq[i] = _weights[i] * _weights[i];
 }
 
@@ -79,7 +80,7 @@ SystemNorm::SystemNorm(const std::vector<FEMNormType> & norms,
     {
       // Loop over the entries of the user provided matrix and store its entries in
       // the _off_diagonal_weights or _diagonal_weights
-      for (std::size_t i=0; i!=_off_diagonal_weights.size(); ++i)
+      for (auto i : index_range(_off_diagonal_weights))
         {
           if (_off_diagonal_weights[i].size() > i)
             {
@@ -89,7 +90,7 @@ SystemNorm::SystemNorm(const std::vector<FEMNormType> & norms,
           else
             _weights[i] = 1.0;
         }
-      for (std::size_t i=0; i != _weights.size(); ++i)
+      for (auto i : index_range(_weights))
         _weights_sq[i] = _weights[i] * _weights[i];
     }
 }

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -386,7 +386,7 @@ void System::project_vector (const NumericVector<Number> & old_v,
       if (this->processor_id() == (this->n_processors()-1))
         {
           const DofMap & dof_map = this->get_dof_map();
-          for (unsigned int var=0; var<this->n_vars(); var++)
+          for (auto var : IntRange<unsigned int>(0, this->n_vars()))
             if (this->variable(var).type().family == SCALAR)
               {
                 // We can just map SCALAR dofs directly across
@@ -412,7 +412,7 @@ void System::project_vector (const NumericVector<Number> & old_v,
       dist_v->init(this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
       dist_v->close();
 
-      for (dof_id_type i=0; i!=dist_v->size(); i++)
+      for (auto i : IntRange<dof_id_type>(0, dist_v->size()))
         if (new_vector(i) != 0.0)
           dist_v->set(i, new_vector(i));
 
@@ -428,7 +428,7 @@ void System::project_vector (const NumericVector<Number> & old_v,
       // We may have to set dof values that this processor doesn't
       // own in certain special cases, like LAGRANGE FIRST or
       // HERMITE THIRD elements on second-order meshes
-      for (dof_id_type i=0; i!=new_v.size(); i++)
+      for (auto i : IntRange<dof_id_type>(0, new_v.size()))
         if (new_vector(i) != 0.0)
           new_v.set(i, new_vector(i));
       new_v.close();
@@ -905,7 +905,7 @@ void System::projection_matrix (SparseMatrix<Number> & proj_mat) const
       if (this->processor_id() == (this->n_processors()-1))
         {
           const DofMap & dof_map = this->get_dof_map();
-          for (unsigned int var=0; var<this->n_vars(); var++)
+          for (auto var : IntRange<unsigned int>(0, this->n_vars()))
             if (this->variable(var).type().family == SCALAR)
               {
                 // We can just map SCALAR dofs directly across
@@ -1063,7 +1063,7 @@ void System::project_vector (NumericVector<Number> & new_vector,
       FEMContext context( *this );
 
       const DofMap & dof_map = this->get_dof_map();
-      for (unsigned int var=0; var<this->n_vars(); var++)
+      for (auto var : IntRange<unsigned int>(0, this->n_vars()))
         if (this->variable(var).type().family == SCALAR)
           {
             // FIXME: We reinit with an arbitrary element in case the user
@@ -1303,9 +1303,9 @@ void BuildProjectionList::operator()(const ConstElemRange & range)
       else
         dof_map.old_dof_indices (elem, di);
 
-      for (std::size_t i=0; i != di.size(); ++i)
-        if (di[i] < first_old_dof || di[i] >= end_old_dof)
-          this->send_list.push_back(di[i]);
+      for (auto di_i : di)
+        if (di_i < first_old_dof || di_i >= end_old_dof)
+          this->send_list.push_back(di_i);
     }  // end elem loop
 }
 
@@ -1355,7 +1355,7 @@ void BoundaryProjectSolution::operator()(const ConstElemRange & range) const
 
 
   // Loop over all the variables we've been requested to project
-  for (std::size_t v=0; v!=variables.size(); v++)
+  for (auto v : IntRange<std::size_t>(0, variables.size()))
     {
       const unsigned int var = variables[v];
 

--- a/src/utils/perf_log.C
+++ b/src/utils/perf_log.C
@@ -17,6 +17,10 @@
 
 #include "libmesh/perf_log.h"
 
+// Local includes
+#include "libmesh/int_range.h"
+#include "libmesh/timestamp.h"
+
 // C++ includes
 #include <algorithm>
 #include <iostream>
@@ -35,9 +39,6 @@
 #ifdef LIBMESH_HAVE_PWD_H
 #include <pwd.h>
 #endif
-
-// Local includes
-#include "libmesh/timestamp.h"
 
 namespace libMesh
 {
@@ -271,16 +272,15 @@ std::string PerfLog::get_info_header() const
 
       // Find the longest string in all the streams
       unsigned int max_length = 0;
-      for (std::size_t i=0; i<v.size(); ++i)
-        if (v[i]->str().size() > max_length)
+      for (auto & v_i : v)
+        if (v_i->str().size() > max_length)
           max_length = cast_int<unsigned int>
-            (v[i]->str().size());
+            (v_i->str().size());
 
       // Find the longest string in the parsed_libmesh_configure_info
-      for (std::size_t i=0; i<parsed_libmesh_configure_info.size(); ++i)
-        if (parsed_libmesh_configure_info[i].size() > max_length)
-          max_length = cast_int<unsigned int>
-            (parsed_libmesh_configure_info[i].size());
+      for (auto & plci_i : parsed_libmesh_configure_info)
+        if (plci_i.size() > max_length)
+          max_length = cast_int<unsigned int> (plci_i.size());
 
       // Print dashed line for the header
       oss << ' '
@@ -288,12 +288,12 @@ std::string PerfLog::get_info_header() const
           << '\n';
 
       // Loop over all the strings and add end formatting
-      for (std::size_t i=0; i<v.size(); ++i)
+      for (auto & v_i : v)
         {
-          if (v[i]->str().size())
-            oss << v[i]->str()
+          if (v_i->str().size())
+            oss << v_i->str()
                 << std::setw (cast_int<int>
-                              (max_length + 4 - v[i]->str().size()))
+                              (max_length + 4 - v_i->str().size()))
                 << std::right
                 << "|\n";
         }
@@ -311,7 +311,7 @@ std::string PerfLog::get_info_header() const
 
       // Loop over the parsed_libmesh_configure_info and add end formatting.  The magic
       // number 3 below accounts for the leading 'pipe' character and indentation
-      for (std::size_t i=1; i<parsed_libmesh_configure_info.size(); ++i)
+      for (auto i : IntRange<std::size_t>(1, parsed_libmesh_configure_info.size()))
         {
           oss << "|  "
               << parsed_libmesh_configure_info[i]

--- a/src/utils/statistics.C
+++ b/src/utils/statistics.C
@@ -23,6 +23,7 @@
 
 // Local includes
 #include "libmesh/statistics.h"
+#include "libmesh/int_range.h"
 #include "libmesh/libmesh_logging.h"
 
 namespace libMesh
@@ -194,7 +195,7 @@ void StatisticsVector<T>::histogram(std::vector<dof_id_type> & bin_members,
   LOG_SCOPE ("histogram()", "StatisticsVector");
 
   std::vector<Real> bin_bounds(n_bins+1);
-  for (std::size_t i=0; i<bin_bounds.size(); i++)
+  for (auto i : index_range(bin_bounds))
     bin_bounds[i] = min + Real(i) * bin_size;
 
   // Give the last bin boundary a little wiggle room: we don't want
@@ -206,7 +207,7 @@ void StatisticsVector<T>::histogram(std::vector<dof_id_type> & bin_members,
   bin_members.resize(n_bins);
 
   dof_id_type data_index = 0;
-  for (std::size_t j=0; j<bin_members.size(); j++) // bin vector indexing
+  for (auto j : index_range(bin_members)) // bin vector indexing
     {
       // libMesh::out << "(debug) Filling bin " << j << std::endl;
 
@@ -291,16 +292,16 @@ void StatisticsVector<T>::plot_histogram(const processor_id_type my_procid,
 
       // abscissa values are located at the center of each bin.
       out_stream << "x=[";
-      for (std::size_t i=0; i<bin_members.size(); ++i)
+      for (auto i : index_range(bin_members))
         {
           out_stream << min + (Real(i)+0.5)*bin_size << " ";
         }
       out_stream << "];\n";
 
       out_stream << "y=[";
-      for (std::size_t i=0; i<bin_members.size(); ++i)
+      for (auto bmi : bin_members)
         {
-          out_stream << bin_members[i] << " ";
+          out_stream << bmi << " ";
         }
       out_stream << "];\n";
       out_stream << "bar(x,y);\n";

--- a/src/utils/topology_map.C
+++ b/src/utils/topology_map.C
@@ -57,10 +57,10 @@ void TopologyMap::add_node(const Node & mid_node,
 
   libmesh_assert_not_equal_to(mid_node_id, DofObject::invalid_id);
 
-  for (std::size_t i=0; i != bracketing_nodes.size(); ++i)
+  for (auto pair : bracketing_nodes)
     {
-      const dof_id_type id1 = bracketing_nodes[i].first;
-      const dof_id_type id2 = bracketing_nodes[i].second;
+      const dof_id_type id1 = pair.first;
+      const dof_id_type id2 = pair.second;
       const dof_id_type lower_id = std::min(id1, id2);
       const dof_id_type upper_id = std::max(id1, id2);
 
@@ -84,12 +84,10 @@ dof_id_type TopologyMap::find(const std::vector<std::pair<dof_id_type, dof_id_ty
 {
   dof_id_type new_node_id = DofObject::invalid_id;
 
-  for (std::size_t i = 0; i != bracketing_nodes.size(); ++i)
+  for (auto pair : bracketing_nodes)
     {
-      const dof_id_type lower_id = std::min(bracketing_nodes[i].first,
-                                            bracketing_nodes[i].second);
-      const dof_id_type upper_id = std::max(bracketing_nodes[i].first,
-                                            bracketing_nodes[i].second);
+      const dof_id_type lower_id = std::min(pair.first, pair.second);
+      const dof_id_type upper_id = std::max(pair.first, pair.second);
 
       const dof_id_type possible_new_node_id =
         this->find(lower_id, upper_id);
@@ -153,7 +151,7 @@ void TopologyMap::fill(const MeshBase & mesh)
           if (child == remote_elem)
             continue;
 
-          for (unsigned int n = 0; n != elem->n_nodes_in_child(c); ++n)
+          for (unsigned int n = 0, nnic = elem->n_nodes_in_child(c); n != nnic; ++n)
             {
               const std::vector<std::pair<dof_id_type, dof_id_type>>
                 bracketing_nodes = elem->bracketing_nodes(c,n);

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -679,7 +679,7 @@ void Xdr::do_read(std::string & a)
 
   a = "";
 
-  for (unsigned int c=0; c<std::strlen(comm); c++)
+  for (unsigned int c=0, sl=std::strlen(comm); c!=sl; c++)
     {
       if (comm[c] == '\t')
         break;
@@ -694,11 +694,11 @@ void Xdr::do_read(std::vector<T> & a)
   data(length, "# vector length");
   a.resize(length);
 
-  for (std::size_t i=0; i<a.size(); i++)
+  for (T & a_i : a)
     {
       libmesh_assert(in.get());
       libmesh_assert (in->good());
-      *in >> a[i];
+      *in >> a_i;
     }
   in->getline(comm, comm_len);
 }
@@ -710,13 +710,13 @@ void Xdr::do_read(std::vector<std::complex<T>> & a)
   data(length, "# vector length x 2 (complex)");
   a.resize(length);
 
-  for (std::size_t i=0; i<a.size(); i++)
+  for (std::complex<T> & a_i : a)
     {
       T r, im;
       libmesh_assert(in.get());
       libmesh_assert (in->good());
       *in >> r >> im;
-      a[i] = std::complex<T>(r,im);
+      a_i = std::complex<T>(r,im);
     }
   in->getline(comm, comm_len);
 }
@@ -736,11 +736,11 @@ void Xdr::do_write(std::vector<T> & a)
   std::size_t length = a.size();
   data(length, "# vector length");
 
-  for (std::size_t i=0; i<a.size(); i++)
+  for (T & a_i : a)
     {
       libmesh_assert(out.get());
       libmesh_assert (out->good());
-      this->do_write(a[i]);
+      this->do_write(a_i);
       *out << "\t ";
     }
 }
@@ -751,11 +751,11 @@ void Xdr::do_write(std::vector<std::complex<T>> & a)
   std::size_t length=a.size();
   data(length, "# vector length x 2 (complex)");
 
-  for (std::size_t i=0; i<a.size(); i++)
+  for (std::complex<T> & a_i : a)
     {
       libmesh_assert(out.get());
       libmesh_assert (out->good());
-      this->do_write(a[i]);
+      this->do_write(a_i);
       *out << "\t ";
     }
 }

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -3,6 +3,7 @@
 #include <libmesh/mesh.h>
 #include <libmesh/mesh_communication.h>
 #include <libmesh/mesh_generation.h>
+#include <libmesh/numeric_vector.h>
 #include <libmesh/replicated_mesh.h>
 #include <libmesh/dyna_io.h>
 #include <libmesh/exodusII_io.h>


### PR DESCRIPTION
The PR I promised in #2370, converting as many traditional for loops to range for loops as seemed reasonable, focusing only on those loops where there was a function call in the counter test so that there would be a good chance of getting a little optimization out of it.

I haven't touched the src/reduced_basis loops - after accidentally misconverting one loop (connected_elements.rend() should not be cached in connect_families(), and I even had a comment to that effect...) I decided to avoid loops where I wasn't semi-familiar with the code.  I may get braver once Akselos applications are added to our regular CI runs.