### PR TITLE
Simplify+inline 1D Lagrange shape function calls

### DIFF
--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -667,6 +667,7 @@ include_HEADERS = \
         fe/fe_base.h \
         fe/fe_compute_data.h \
         fe/fe_interface.h \
+        fe/fe_lagrange_shape_1D.h \
         fe/fe_macro.h \
         fe/fe_map.h \
         fe/fe_transformation_base.h \

--- a/include/fe/fe_lagrange_shape_1D.h
+++ b/include/fe/fe_lagrange_shape_1D.h
@@ -125,85 +125,104 @@ Real fe_lagrange_1D_shape(const Order order,
 
 
 inline
-Real fe_lagrange_1D_shape_deriv(const ElemType,
-                                const Order order,
-                                const unsigned int i,
-                                const unsigned int libmesh_dbg_var(j),
-                                const Point & p)
+Real fe_lagrange_1D_linear_shape_deriv(const unsigned int i,
+                                       const unsigned int libmesh_dbg_var(j),
+                                       const Real)
 {
   // only d()/dxi in 1D!
-
   libmesh_assert_equal_to (j, 0);
 
-  const Real xi = p(0);
+  libmesh_assert_less (i, 2);
 
+  switch (i)
+    {
+    case 0:
+      return -.5;
+
+    case 1:
+      return .5;
+
+    default:
+      libmesh_error_msg("Invalid shape function index i = " << i);
+    }
+}
+
+
+inline
+Real fe_lagrange_1D_quadratic_shape_deriv(const unsigned int i,
+                                          const unsigned int libmesh_dbg_var(j),
+                                          const Real xi)
+{
+  // only d()/dxi in 1D!
+  libmesh_assert_equal_to (j, 0);
+
+  libmesh_assert_less (i, 3);
+
+  switch (i)
+    {
+    case 0:
+      return xi-.5;
+
+    case 1:
+      return xi+.5;
+
+    case 2:
+      return -2.*xi;
+
+    default:
+      libmesh_error_msg("Invalid shape function index i = " << i);
+    }
+}
+
+
+inline
+Real fe_lagrange_1D_cubic_shape_deriv(const unsigned int i,
+                                      const unsigned int libmesh_dbg_var(j),
+                                      const Real xi)
+{
+  // only d()/dxi in 1D!
+  libmesh_assert_equal_to (j, 0);
+
+  libmesh_assert_less (i, 4);
+
+  switch (i)
+    {
+    case 0:
+      return -9./16.*(3.*xi*xi-2.*xi-1./9.);
+
+    case 1:
+      return -9./16.*(-3.*xi*xi-2.*xi+1./9.);
+
+    case 2:
+      return 27./16.*(3.*xi*xi-2./3.*xi-1.);
+
+    case 3:
+      return 27./16.*(-3.*xi*xi-2./3.*xi+1.);
+
+    default:
+      libmesh_error_msg("Invalid shape function index i = " << i);
+    }
+}
+
+
+
+inline
+Real fe_lagrange_1D_shape_deriv(const Order order,
+                                const unsigned int i,
+                                const unsigned int j,
+                                const Real xi)
+{
   switch (order)
     {
       // Lagrange linear shape function derivatives
     case FIRST:
-      {
-        libmesh_assert_less (i, 2);
+      return fe_lagrange_1D_linear_shape_deriv(i, j, xi);
 
-        switch (i)
-          {
-          case 0:
-            return -.5;
-
-          case 1:
-            return .5;
-
-          default:
-            libmesh_error_msg("Invalid shape function index i = " << i);
-          }
-      }
-
-
-      // Lagrange quadratic shape function derivatives
     case SECOND:
-      {
-        libmesh_assert_less (i, 3);
+      return fe_lagrange_1D_quadratic_shape_deriv(i, j, xi);
 
-        switch (i)
-          {
-          case 0:
-            return xi-.5;
-
-          case 1:
-            return xi+.5;
-
-          case 2:
-            return -2.*xi;
-
-          default:
-            libmesh_error_msg("Invalid shape function index i = " << i);
-          }
-      }
-
-
-      // Lagrange cubic shape function derivatives
     case THIRD:
-      {
-        libmesh_assert_less (i, 4);
-
-        switch (i)
-          {
-          case 0:
-            return -9./16.*(3.*xi*xi-2.*xi-1./9.);
-
-          case 1:
-            return -9./16.*(-3.*xi*xi-2.*xi+1./9.);
-
-          case 2:
-            return 27./16.*(3.*xi*xi-2./3.*xi-1.);
-
-          case 3:
-            return 27./16.*(-3.*xi*xi-2./3.*xi+1.);
-
-          default:
-            libmesh_error_msg("Invalid shape function index i = " << i);
-          }
-      }
-
+      return fe_lagrange_1D_cubic_shape_deriv(i, j, xi);
 
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order = " << order);

--- a/include/fe/fe_lagrange_shape_1D.h
+++ b/include/fe/fe_lagrange_shape_1D.h
@@ -1,0 +1,286 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2019 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+// Local includes
+#include "libmesh/enum_elem_type.h"
+#include "libmesh/enum_order.h"
+#include "libmesh/point.h"
+
+// Inline functions useful to inline on tensor elements.
+
+namespace libMesh
+{
+
+inline
+Real fe_lagrange_1D_linear_shape(const unsigned int i,
+                                 const Real xi)
+{
+  libmesh_assert_less (i, 2);
+
+  switch (i)
+    {
+    case 0:
+      return .5*(1. - xi);
+
+    case 1:
+      return .5*(1. + xi);
+
+    default:
+      libmesh_error_msg("Invalid shape function index i = " << i);
+    }
+}
+
+
+
+inline
+Real fe_lagrange_1D_quadratic_shape(const unsigned int i,
+                                    const Real xi)
+{
+  libmesh_assert_less (i, 3);
+
+  switch (i)
+    {
+    case 0:
+      return .5*xi*(xi - 1.);
+
+    case 1:
+      return .5*xi*(xi + 1);
+
+    case 2:
+      return (1. - xi*xi);
+
+    default:
+      libmesh_error_msg("Invalid shape function index i = " << i);
+    }
+}
+
+
+
+inline
+Real fe_lagrange_1D_cubic_shape(const unsigned int i,
+                                const Real xi)
+{
+  libmesh_assert_less (i, 4);
+
+  switch (i)
+    {
+    case 0:
+      return 9./16.*(1./9.-xi*xi)*(xi-1.);
+
+    case 1:
+      return -9./16.*(1./9.-xi*xi)*(xi+1.);
+
+    case 2:
+      return 27./16.*(1.-xi*xi)*(1./3.-xi);
+
+    case 3:
+      return 27./16.*(1.-xi*xi)*(1./3.+xi);
+
+    default:
+      libmesh_error_msg("Invalid shape function index i = " << i);
+    }
+}
+
+
+
+inline
+Real fe_lagrange_1D_shape(const Order order,
+                          const unsigned int i,
+                          const Real xi)
+{
+  switch (order)
+    {
+      // Lagrange linears
+    case FIRST:
+      return fe_lagrange_1D_linear_shape(i, xi);
+
+      // Lagrange quadratics
+    case SECOND:
+      return fe_lagrange_1D_quadratic_shape(i, xi);
+
+      // Lagrange cubics
+    case THIRD:
+      return fe_lagrange_1D_cubic_shape(i, xi);
+
+    default:
+      libmesh_error_msg("ERROR: Unsupported polynomial order = " << order);
+    }
+}
+
+
+
+inline
+Real fe_lagrange_1D_shape_deriv(const ElemType,
+                                const Order order,
+                                const unsigned int i,
+                                const unsigned int libmesh_dbg_var(j),
+                                const Point & p)
+{
+  // only d()/dxi in 1D!
+
+  libmesh_assert_equal_to (j, 0);
+
+  const Real xi = p(0);
+
+  switch (order)
+    {
+      // Lagrange linear shape function derivatives
+    case FIRST:
+      {
+        libmesh_assert_less (i, 2);
+
+        switch (i)
+          {
+          case 0:
+            return -.5;
+
+          case 1:
+            return .5;
+
+          default:
+            libmesh_error_msg("Invalid shape function index i = " << i);
+          }
+      }
+
+
+      // Lagrange quadratic shape function derivatives
+    case SECOND:
+      {
+        libmesh_assert_less (i, 3);
+
+        switch (i)
+          {
+          case 0:
+            return xi-.5;
+
+          case 1:
+            return xi+.5;
+
+          case 2:
+            return -2.*xi;
+
+          default:
+            libmesh_error_msg("Invalid shape function index i = " << i);
+          }
+      }
+
+
+      // Lagrange cubic shape function derivatives
+    case THIRD:
+      {
+        libmesh_assert_less (i, 4);
+
+        switch (i)
+          {
+          case 0:
+            return -9./16.*(3.*xi*xi-2.*xi-1./9.);
+
+          case 1:
+            return -9./16.*(-3.*xi*xi-2.*xi+1./9.);
+
+          case 2:
+            return 27./16.*(3.*xi*xi-2./3.*xi-1.);
+
+          case 3:
+            return 27./16.*(-3.*xi*xi-2./3.*xi+1.);
+
+          default:
+            libmesh_error_msg("Invalid shape function index i = " << i);
+          }
+      }
+
+
+    default:
+      libmesh_error_msg("ERROR: Unsupported polynomial order = " << order);
+    }
+}
+
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
+inline
+Real fe_lagrange_1D_shape_second_deriv(const ElemType,
+                                       const Order order,
+                                       const unsigned int i,
+                                       const unsigned int libmesh_dbg_var(j),
+                                       const Point & p)
+{
+  // Don't need to switch on j.  1D shape functions
+  // depend on xi only!
+
+  const Real xi = p(0);
+  libmesh_assert_equal_to (j, 0);
+
+  switch (order)
+    {
+      // linear Lagrange shape functions
+    case FIRST:
+      {
+        // All second derivatives of linears are zero....
+        return 0.;
+      }
+
+      // quadratic Lagrange shape functions
+    case SECOND:
+      {
+        switch (i)
+          {
+          case 0:
+            return 1.;
+
+          case 1:
+            return 1.;
+
+          case 2:
+            return -2.;
+
+          default:
+            libmesh_error_msg("Invalid shape function index i = " << i);
+          }
+      } // end case SECOND
+
+    case THIRD:
+      {
+        switch (i)
+          {
+          case 0:
+            return -9./16.*(6.*xi-2);
+
+          case 1:
+            return -9./16.*(-6*xi-2.);
+
+          case 2:
+            return 27./16.*(6*xi-2./3.);
+
+          case 3:
+            return 27./16.*(-6*xi-2./3.);
+
+          default:
+            libmesh_error_msg("Invalid shape function index i = " << i);
+          }
+      } // end case THIRD
+
+
+    default:
+      libmesh_error_msg("ERROR: Unsupported polynomial order = " << order);
+    } // end switch (order)
+}
+
+#endif // LIBMESH_ENABLE_SECOND_DERIVATIVES
+
+}

--- a/include/fe/fe_lagrange_shape_1D.h
+++ b/include/fe/fe_lagrange_shape_1D.h
@@ -214,7 +214,6 @@ Real fe_lagrange_1D_shape_deriv(const Order order,
 {
   switch (order)
     {
-      // Lagrange linear shape function derivatives
     case FIRST:
       return fe_lagrange_1D_linear_shape_deriv(i, j, xi);
 
@@ -232,68 +231,82 @@ Real fe_lagrange_1D_shape_deriv(const Order order,
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
+// fe_lagrange_1D_linear_shape_second_deriv is 0
+
+
 inline
-Real fe_lagrange_1D_shape_second_deriv(const ElemType,
-                                       const Order order,
-                                       const unsigned int i,
-                                       const unsigned int libmesh_dbg_var(j),
-                                       const Point & p)
+Real fe_lagrange_1D_quadratic_shape_second_deriv(const unsigned int i,
+                                                 const unsigned int libmesh_dbg_var(j),
+                                                 const Real)
 {
   // Don't need to switch on j.  1D shape functions
   // depend on xi only!
-
-  const Real xi = p(0);
   libmesh_assert_equal_to (j, 0);
 
+  switch (i)
+    {
+    case 0:
+      return 1.;
+
+    case 1:
+      return 1.;
+
+    case 2:
+      return -2.;
+
+    default:
+      libmesh_error_msg("Invalid shape function index i = " << i);
+    }
+}
+
+
+inline
+Real fe_lagrange_1D_cubic_shape_second_deriv(const unsigned int i,
+                                             const unsigned int libmesh_dbg_var(j),
+                                             const Real xi)
+{
+  // Don't need to switch on j.  1D shape functions
+  // depend on xi only!
+  libmesh_assert_equal_to (j, 0);
+
+  switch (i)
+    {
+    case 0:
+      return -9./16.*(6.*xi-2);
+
+    case 1:
+      return -9./16.*(-6*xi-2.);
+
+    case 2:
+      return 27./16.*(6*xi-2./3.);
+
+    case 3:
+      return 27./16.*(-6*xi-2./3.);
+
+    default:
+      libmesh_error_msg("Invalid shape function index i = " << i);
+    }
+}
+
+
+
+inline
+Real fe_lagrange_1D_shape_second_deriv(const Order order,
+                                       const unsigned int i,
+                                       const unsigned int j,
+                                       const Real xi)
+{
   switch (order)
     {
-      // linear Lagrange shape functions
+    // All second derivatives of linears are zero....
     case FIRST:
-      {
-        // All second derivatives of linears are zero....
-        return 0.;
-      }
+      return 0.;
 
-      // quadratic Lagrange shape functions
     case SECOND:
-      {
-        switch (i)
-          {
-          case 0:
-            return 1.;
-
-          case 1:
-            return 1.;
-
-          case 2:
-            return -2.;
-
-          default:
-            libmesh_error_msg("Invalid shape function index i = " << i);
-          }
-      } // end case SECOND
+      return fe_lagrange_1D_quadratic_shape_second_deriv(i, j, xi);
 
     case THIRD:
-      {
-        switch (i)
-          {
-          case 0:
-            return -9./16.*(6.*xi-2);
-
-          case 1:
-            return -9./16.*(-6*xi-2.);
-
-          case 2:
-            return 27./16.*(6*xi-2./3.);
-
-          case 3:
-            return 27./16.*(-6*xi-2./3.);
-
-          default:
-            libmesh_error_msg("Invalid shape function index i = " << i);
-          }
-      } // end case THIRD
-
+      return fe_lagrange_1D_cubic_shape_second_deriv(i, j, xi);
 
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order = " << order);

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -88,6 +88,7 @@ include_HEADERS =  \
         fe/fe_base.h \
         fe/fe_compute_data.h \
         fe/fe_interface.h \
+        fe/fe_lagrange_shape_1D.h \
         fe/fe_macro.h \
         fe/fe_map.h \
         fe/fe_transformation_base.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -78,6 +78,7 @@ BUILT_SOURCES = \
         fe_base.h \
         fe_compute_data.h \
         fe_interface.h \
+        fe_lagrange_shape_1D.h \
         fe_macro.h \
         fe_map.h \
         fe_transformation_base.h \
@@ -760,6 +761,9 @@ fe_compute_data.h: $(top_srcdir)/include/fe/fe_compute_data.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 fe_interface.h: $(top_srcdir)/include/fe/fe_interface.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+fe_lagrange_shape_1D.h: $(top_srcdir)/include/fe/fe_lagrange_shape_1D.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 fe_macro.h: $(top_srcdir)/include/fe/fe_macro.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -519,7 +519,8 @@ BUILT_SOURCES = auto_ptr.h default_coupling.h dirichlet_boundaries.h \
 	patch_recovery_error_estimator.h \
 	uniform_refinement_estimator.h \
 	weighted_patch_recovery_error_estimator.h fe.h fe_abstract.h \
-	fe_base.h fe_compute_data.h fe_interface.h fe_macro.h fe_map.h \
+	fe_base.h fe_compute_data.h fe_interface.h \
+	fe_lagrange_shape_1D.h fe_macro.h fe_map.h \
 	fe_transformation_base.h fe_type.h fe_xyz_map.h \
 	h1_fe_transformation.h hcurl_fe_transformation.h inf_fe.h \
 	inf_fe_instantiate_1D.h inf_fe_instantiate_2D.h \
@@ -1103,6 +1104,9 @@ fe_compute_data.h: $(top_srcdir)/include/fe/fe_compute_data.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 fe_interface.h: $(top_srcdir)/include/fe/fe_interface.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+fe_lagrange_shape_1D.h: $(top_srcdir)/include/fe/fe_lagrange_shape_1D.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 fe_macro.h: $(top_srcdir)/include/fe/fe_macro.h

--- a/src/fe/fe_lagrange_shape_1D.C
+++ b/src/fe/fe_lagrange_shape_1D.C
@@ -19,58 +19,27 @@
 // Local includes
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
-
-// Anonymous namespace for functions shared by LAGRANGE and
-// L2_LAGRANGE implementations. Implementations appear at the bottom
-// of this file.
-namespace
-{
-using namespace libMesh;
-
-Real fe_lagrange_1D_shape(const ElemType,
-                          const Order order,
-                          const unsigned int i,
-                          const Point & p);
-
-Real fe_lagrange_1D_shape_deriv(const ElemType,
-                                const Order order,
-                                const unsigned int i,
-                                const unsigned int libmesh_dbg_var(j),
-                                const Point & p);
-
-#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
-
-Real fe_lagrange_1D_shape_second_deriv(const ElemType,
-                                       const Order order,
-                                       const unsigned int i,
-                                       const unsigned int libmesh_dbg_var(j),
-                                       const Point & p);
-
-#endif // LIBMESH_ENABLE_SECOND_DERIVATIVES
-
-} // anonymous namespace
-
-
+#include "libmesh/fe_lagrange_shape_1D.h"
 
 namespace libMesh
 {
 
 template <>
-Real FE<1,LAGRANGE>::shape(const ElemType elem_type,
+Real FE<1,LAGRANGE>::shape(const ElemType,
                            const Order order,
                            const unsigned int i,
                            const Point & p)
 {
-  return fe_lagrange_1D_shape(elem_type, order, i, p);
+  return fe_lagrange_1D_shape(order, i, p(0));
 }
 
 template <>
-Real FE<1,L2_LAGRANGE>::shape(const ElemType elem_type,
+Real FE<1,L2_LAGRANGE>::shape(const ElemType,
                               const Order order,
                               const unsigned int i,
                               const Point & p)
 {
-  return fe_lagrange_1D_shape(elem_type, order, i, p);
+  return fe_lagrange_1D_shape(order, i, p(0));
 }
 
 
@@ -83,7 +52,7 @@ Real FE<1,LAGRANGE>::shape(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_lagrange_1D_shape(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, p);
+  return fe_lagrange_1D_shape(static_cast<Order>(order + add_p_level * elem->p_level()), i, p(0));
 }
 
 
@@ -97,7 +66,7 @@ Real FE<1,L2_LAGRANGE>::shape(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_lagrange_1D_shape(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, p);
+  return fe_lagrange_1D_shape(static_cast<Order>(order + add_p_level * elem->p_level()), i, p(0));
 }
 
 
@@ -218,251 +187,3 @@ Real FE<1,L2_LAGRANGE>::shape_second_deriv(const Elem * elem,
 
 } // namespace libMesh
 
-
-
-// Anonymous namespace function definitions
-namespace
-{
-using namespace libMesh;
-
-Real fe_lagrange_1D_shape(const ElemType,
-                          const Order order,
-                          const unsigned int i,
-                          const Point & p)
-{
-  const Real xi = p(0);
-
-  switch (order)
-    {
-      // Lagrange linears
-    case FIRST:
-      {
-        libmesh_assert_less (i, 2);
-
-        switch (i)
-          {
-          case 0:
-            return .5*(1. - xi);
-
-          case 1:
-            return .5*(1. + xi);
-
-          default:
-            libmesh_error_msg("Invalid shape function index i = " << i);
-          }
-      }
-
-
-
-      // Lagrange quadratics
-    case SECOND:
-      {
-        libmesh_assert_less (i, 3);
-
-        switch (i)
-          {
-          case 0:
-            return .5*xi*(xi - 1.);
-
-          case 1:
-            return .5*xi*(xi + 1);
-
-          case 2:
-            return (1. - xi*xi);
-
-          default:
-            libmesh_error_msg("Invalid shape function index i = " << i);
-          }
-      }
-
-
-
-      // Lagrange cubics
-    case THIRD:
-      {
-        libmesh_assert_less (i, 4);
-
-        switch (i)
-          {
-          case 0:
-            return 9./16.*(1./9.-xi*xi)*(xi-1.);
-
-          case 1:
-            return -9./16.*(1./9.-xi*xi)*(xi+1.);
-
-          case 2:
-            return 27./16.*(1.-xi*xi)*(1./3.-xi);
-
-          case 3:
-            return 27./16.*(1.-xi*xi)*(1./3.+xi);
-
-          default:
-            libmesh_error_msg("Invalid shape function index i = " << i);
-          }
-      }
-
-    default:
-      libmesh_error_msg("ERROR: Unsupported polynomial order = " << order);
-    }
-}
-
-
-
-Real fe_lagrange_1D_shape_deriv(const ElemType,
-                                const Order order,
-                                const unsigned int i,
-                                const unsigned int libmesh_dbg_var(j),
-                                const Point & p)
-{
-  // only d()/dxi in 1D!
-
-  libmesh_assert_equal_to (j, 0);
-
-  const Real xi = p(0);
-
-  switch (order)
-    {
-      // Lagrange linear shape function derivatives
-    case FIRST:
-      {
-        libmesh_assert_less (i, 2);
-
-        switch (i)
-          {
-          case 0:
-            return -.5;
-
-          case 1:
-            return .5;
-
-          default:
-            libmesh_error_msg("Invalid shape function index i = " << i);
-          }
-      }
-
-
-      // Lagrange quadratic shape function derivatives
-    case SECOND:
-      {
-        libmesh_assert_less (i, 3);
-
-        switch (i)
-          {
-          case 0:
-            return xi-.5;
-
-          case 1:
-            return xi+.5;
-
-          case 2:
-            return -2.*xi;
-
-          default:
-            libmesh_error_msg("Invalid shape function index i = " << i);
-          }
-      }
-
-
-      // Lagrange cubic shape function derivatives
-    case THIRD:
-      {
-        libmesh_assert_less (i, 4);
-
-        switch (i)
-          {
-          case 0:
-            return -9./16.*(3.*xi*xi-2.*xi-1./9.);
-
-          case 1:
-            return -9./16.*(-3.*xi*xi-2.*xi+1./9.);
-
-          case 2:
-            return 27./16.*(3.*xi*xi-2./3.*xi-1.);
-
-          case 3:
-            return 27./16.*(-3.*xi*xi-2./3.*xi+1.);
-
-          default:
-            libmesh_error_msg("Invalid shape function index i = " << i);
-          }
-      }
-
-
-    default:
-      libmesh_error_msg("ERROR: Unsupported polynomial order = " << order);
-    }
-}
-
-
-#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
-
-Real fe_lagrange_1D_shape_second_deriv(const ElemType,
-                                       const Order order,
-                                       const unsigned int i,
-                                       const unsigned int libmesh_dbg_var(j),
-                                       const Point & p)
-{
-  // Don't need to switch on j.  1D shape functions
-  // depend on xi only!
-
-  const Real xi = p(0);
-  libmesh_assert_equal_to (j, 0);
-
-  switch (order)
-    {
-      // linear Lagrange shape functions
-    case FIRST:
-      {
-        // All second derivatives of linears are zero....
-        return 0.;
-      }
-
-      // quadratic Lagrange shape functions
-    case SECOND:
-      {
-        switch (i)
-          {
-          case 0:
-            return 1.;
-
-          case 1:
-            return 1.;
-
-          case 2:
-            return -2.;
-
-          default:
-            libmesh_error_msg("Invalid shape function index i = " << i);
-          }
-      } // end case SECOND
-
-    case THIRD:
-      {
-        switch (i)
-          {
-          case 0:
-            return -9./16.*(6.*xi-2);
-
-          case 1:
-            return -9./16.*(-6*xi-2.);
-
-          case 2:
-            return 27./16.*(6*xi-2./3.);
-
-          case 3:
-            return 27./16.*(-6*xi-2./3.);
-
-          default:
-            libmesh_error_msg("Invalid shape function index i = " << i);
-          }
-      } // end case THIRD
-
-
-    default:
-      libmesh_error_msg("ERROR: Unsupported polynomial order = " << order);
-    } // end switch (order)
-}
-
-#endif // LIBMESH_ENABLE_SECOND_DERIVATIVES
-
-}

--- a/src/fe/fe_lagrange_shape_1D.C
+++ b/src/fe/fe_lagrange_shape_1D.C
@@ -128,25 +128,25 @@ Real FE<1,L2_LAGRANGE>::shape_deriv(const Elem * elem,
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
-Real FE<1,LAGRANGE>::shape_second_deriv(const ElemType elem_type,
+Real FE<1,LAGRANGE>::shape_second_deriv(const ElemType,
                                         const Order order,
                                         const unsigned int i,
                                         const unsigned int j,
                                         const Point & p)
 {
-  return fe_lagrange_1D_shape_second_deriv(elem_type, order, i, j, p);
+  return fe_lagrange_1D_shape_second_deriv(order, i, j, p(0));
 }
 
 
 
 template <>
-Real FE<1,L2_LAGRANGE>::shape_second_deriv(const ElemType elem_type,
+Real FE<1,L2_LAGRANGE>::shape_second_deriv(const ElemType,
                                            const Order order,
                                            const unsigned int i,
                                            const unsigned int j,
                                            const Point & p)
 {
-  return fe_lagrange_1D_shape_second_deriv(elem_type, order, i, j, p);
+  return fe_lagrange_1D_shape_second_deriv(order, i, j, p(0));
 }
 
 
@@ -161,8 +161,7 @@ Real FE<1,LAGRANGE>::shape_second_deriv(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_lagrange_1D_shape_second_deriv(elem->type(),
-                                           static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+  return fe_lagrange_1D_shape_second_deriv(static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p(0));
 }
 
 
@@ -177,8 +176,7 @@ Real FE<1,L2_LAGRANGE>::shape_second_deriv(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_lagrange_1D_shape_second_deriv(elem->type(),
-                                           static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+  return fe_lagrange_1D_shape_second_deriv(static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p(0));
 }
 
 #endif // LIBMESH_ENABLE_SECOND_DERIVATIVES

--- a/src/fe/fe_lagrange_shape_1D.C
+++ b/src/fe/fe_lagrange_shape_1D.C
@@ -72,25 +72,25 @@ Real FE<1,L2_LAGRANGE>::shape(const Elem * elem,
 
 
 template <>
-Real FE<1,LAGRANGE>::shape_deriv(const ElemType elem_type,
+Real FE<1,LAGRANGE>::shape_deriv(const ElemType,
                                  const Order order,
                                  const unsigned int i,
                                  const unsigned int j,
                                  const Point & p)
 {
-  return fe_lagrange_1D_shape_deriv(elem_type, order, i, j, p);
+  return fe_lagrange_1D_shape_deriv(order, i, j, p(0));
 }
 
 
 
 template <>
-Real FE<1,L2_LAGRANGE>::shape_deriv(const ElemType elem_type,
+Real FE<1,L2_LAGRANGE>::shape_deriv(const ElemType,
                                     const Order order,
                                     const unsigned int i,
                                     const unsigned int j,
                                     const Point & p)
 {
-  return fe_lagrange_1D_shape_deriv(elem_type, order, i, j, p);
+  return fe_lagrange_1D_shape_deriv(order, i, j, p(0));
 }
 
 
@@ -105,8 +105,7 @@ Real FE<1,LAGRANGE>::shape_deriv(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_lagrange_1D_shape_deriv(elem->type(),
-                                    static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+  return fe_lagrange_1D_shape_deriv(static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p(0));
 }
 
 
@@ -121,8 +120,7 @@ Real FE<1,L2_LAGRANGE>::shape_deriv(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_lagrange_1D_shape_deriv(elem->type(),
-                                    static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+  return fe_lagrange_1D_shape_deriv(static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p(0));
 }
 
 

--- a/src/fe/fe_lagrange_shape_2D.C
+++ b/src/fe/fe_lagrange_shape_2D.C
@@ -446,13 +446,13 @@ Real fe_lagrange_2D_shape_deriv(const ElemType type,
                 {
                   // d()/dxi
                 case 0:
-                  return (fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i0[i], 0, xi)*
-                          fe_lagrange_1D_linear_shape(i1[i], eta));
+                  return (fe_lagrange_1D_linear_shape_deriv(i0[i], 0, xi)*
+                          fe_lagrange_1D_linear_shape      (i1[i], eta));
 
                   // d()/deta
                 case 1:
-                  return (fe_lagrange_1D_linear_shape(i0[i], xi)*
-                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i1[i], 0, eta));
+                  return (fe_lagrange_1D_linear_shape      (i0[i], xi)*
+                          fe_lagrange_1D_linear_shape_deriv(i1[i], 0, eta));
 
                 default:
                   libmesh_error_msg("ERROR: Invalid derivative index j = " << j);
@@ -630,13 +630,13 @@ Real fe_lagrange_2D_shape_deriv(const ElemType type,
                 {
                   // d()/dxi
                 case 0:
-                  return (fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i0[i], 0, xi)*
-                          fe_lagrange_1D_quadratic_shape(i1[i], eta));
+                  return (fe_lagrange_1D_quadratic_shape_deriv(i0[i], 0, xi)*
+                          fe_lagrange_1D_quadratic_shape      (i1[i], eta));
 
                   // d()/deta
                 case 1:
-                  return (fe_lagrange_1D_quadratic_shape(i0[i], xi)*
-                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i1[i], 0, eta));
+                  return (fe_lagrange_1D_quadratic_shape      (i0[i], xi)*
+                          fe_lagrange_1D_quadratic_shape_deriv(i1[i], 0, eta));
 
                 default:
                   libmesh_error_msg("ERROR: Invalid derivative index j = " << j);
@@ -782,8 +782,8 @@ Real fe_lagrange_2D_shape_second_deriv(const ElemType type,
 
                   // d^2() / dxi deta
                 case 1:
-                  return (fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i0[i], 0, xi)*
-                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i1[i], 0, eta));
+                  return (fe_lagrange_1D_linear_shape_deriv(i0[i], 0, xi)*
+                          fe_lagrange_1D_linear_shape_deriv(i1[i], 0, eta));
 
                   // d^2() / deta^2
                 case 2:
@@ -940,8 +940,8 @@ Real fe_lagrange_2D_shape_second_deriv(const ElemType type,
 
                   // d^2() / dxi deta
                 case 1:
-                  return (fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i0[i], 0, xi)*
-                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i1[i], 0, eta));
+                  return (fe_lagrange_1D_quadratic_shape_deriv(i0[i], 0, xi)*
+                          fe_lagrange_1D_quadratic_shape_deriv(i1[i], 0, eta));
 
                   // d^2() / deta^2
                 case 2:

--- a/src/fe/fe_lagrange_shape_2D.C
+++ b/src/fe/fe_lagrange_shape_2D.C
@@ -19,6 +19,7 @@
 // Local includes
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
+#include "libmesh/fe_lagrange_shape_1D.h"
 
 // Anonymous namespace for functions shared by LAGRANGE and
 // L2_LAGRANGE implementations. Implementations appear at the bottom
@@ -260,8 +261,8 @@ Real fe_lagrange_2D_shape(const ElemType type,
               static const unsigned int i0[] = {0, 1, 1, 0};
               static const unsigned int i1[] = {0, 0, 1, 1};
 
-              return (FE<1,LAGRANGE>::shape(EDGE2, FIRST, i0[i], xi)*
-                      FE<1,LAGRANGE>::shape(EDGE2, FIRST, i1[i], eta));
+              return (fe_lagrange_1D_linear_shape(i0[i], xi)*
+                      fe_lagrange_1D_linear_shape(i1[i], eta));
             }
 
           case TRI3:
@@ -352,8 +353,8 @@ Real fe_lagrange_2D_shape(const ElemType type,
               static const unsigned int i0[] = {0, 1, 1, 0, 2, 1, 2, 0, 2};
               static const unsigned int i1[] = {0, 0, 1, 1, 0, 2, 1, 2, 2};
 
-              return (FE<1,LAGRANGE>::shape(EDGE3, SECOND, i0[i], xi)*
-                      FE<1,LAGRANGE>::shape(EDGE3, SECOND, i1[i], eta));
+              return (fe_lagrange_1D_quadratic_shape(i0[i], xi)*
+                      fe_lagrange_1D_quadratic_shape(i1[i], eta));
             }
 
           case TRI6:
@@ -445,13 +446,13 @@ Real fe_lagrange_2D_shape_deriv(const ElemType type,
                 {
                   // d()/dxi
                 case 0:
-                  return (FE<1,LAGRANGE>::shape_deriv(EDGE2, FIRST, i0[i], 0, xi)*
-                          FE<1,LAGRANGE>::shape      (EDGE2, FIRST, i1[i], eta));
+                  return (fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i0[i], 0, xi)*
+                          fe_lagrange_1D_linear_shape(i1[i], eta));
 
                   // d()/deta
                 case 1:
-                  return (FE<1,LAGRANGE>::shape      (EDGE2, FIRST, i0[i], xi)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE2, FIRST, i1[i], 0, eta));
+                  return (fe_lagrange_1D_linear_shape(i0[i], xi)*
+                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i1[i], 0, eta));
 
                 default:
                   libmesh_error_msg("ERROR: Invalid derivative index j = " << j);
@@ -629,13 +630,13 @@ Real fe_lagrange_2D_shape_deriv(const ElemType type,
                 {
                   // d()/dxi
                 case 0:
-                  return (FE<1,LAGRANGE>::shape_deriv(EDGE3, SECOND, i0[i], 0, xi)*
-                          FE<1,LAGRANGE>::shape      (EDGE3, SECOND, i1[i], eta));
+                  return (fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i0[i], 0, xi)*
+                          fe_lagrange_1D_quadratic_shape(i1[i], eta));
 
                   // d()/deta
                 case 1:
-                  return (FE<1,LAGRANGE>::shape      (EDGE3, SECOND, i0[i], xi)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE3, SECOND, i1[i], 0, eta));
+                  return (fe_lagrange_1D_quadratic_shape(i0[i], xi)*
+                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i1[i], 0, eta));
 
                 default:
                   libmesh_error_msg("ERROR: Invalid derivative index j = " << j);
@@ -781,8 +782,8 @@ Real fe_lagrange_2D_shape_second_deriv(const ElemType type,
 
                   // d^2() / dxi deta
                 case 1:
-                  return (FE<1,LAGRANGE>::shape_deriv(EDGE2, FIRST, i0[i], 0, xi)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE2, FIRST, i1[i], 0, eta));
+                  return (fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i0[i], 0, xi)*
+                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i1[i], 0, eta));
 
                   // d^2() / deta^2
                 case 2:
@@ -934,18 +935,18 @@ Real fe_lagrange_2D_shape_second_deriv(const ElemType type,
                 {
                   // d^2() / dxi^2
                 case 0:
-                  return (FE<1,LAGRANGE>::shape_second_deriv(EDGE3, SECOND, i0[i], 0, xi)*
-                          FE<1,LAGRANGE>::shape             (EDGE3, SECOND, i1[i], eta));
+                  return (fe_lagrange_1D_shape_second_deriv(EDGE3, SECOND, i0[i], 0, xi)*
+                          fe_lagrange_1D_quadratic_shape(i1[i], eta));
 
                   // d^2() / dxi deta
                 case 1:
-                  return (FE<1,LAGRANGE>::shape_deriv(EDGE3, SECOND, i0[i], 0, xi)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE3, SECOND, i1[i], 0, eta));
+                  return (fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i0[i], 0, xi)*
+                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i1[i], 0, eta));
 
                   // d^2() / deta^2
                 case 2:
-                  return (FE<1,LAGRANGE>::shape             (EDGE3, SECOND, i0[i], xi)*
-                          FE<1,LAGRANGE>::shape_second_deriv(EDGE3, SECOND, i1[i], 0, eta));
+                  return (fe_lagrange_1D_quadratic_shape(i0[i], xi)*
+                          fe_lagrange_1D_shape_second_deriv(EDGE3, SECOND, i1[i], 0, eta));
 
                 default:
                   libmesh_error_msg("ERROR: Invalid derivative index j = " << j);

--- a/src/fe/fe_lagrange_shape_2D.C
+++ b/src/fe/fe_lagrange_shape_2D.C
@@ -935,8 +935,8 @@ Real fe_lagrange_2D_shape_second_deriv(const ElemType type,
                 {
                   // d^2() / dxi^2
                 case 0:
-                  return (fe_lagrange_1D_shape_second_deriv(EDGE3, SECOND, i0[i], 0, xi)*
-                          fe_lagrange_1D_quadratic_shape(i1[i], eta));
+                  return (fe_lagrange_1D_quadratic_shape_second_deriv(i0[i], 0, xi)*
+                          fe_lagrange_1D_quadratic_shape             (i1[i], eta));
 
                   // d^2() / dxi deta
                 case 1:
@@ -945,8 +945,8 @@ Real fe_lagrange_2D_shape_second_deriv(const ElemType type,
 
                   // d^2() / deta^2
                 case 2:
-                  return (fe_lagrange_1D_quadratic_shape(i0[i], xi)*
-                          fe_lagrange_1D_shape_second_deriv(EDGE3, SECOND, i1[i], 0, eta));
+                  return (fe_lagrange_1D_quadratic_shape             (i0[i], xi)*
+                          fe_lagrange_1D_quadratic_shape_second_deriv(i1[i], 0, eta));
 
                 default:
                   libmesh_error_msg("ERROR: Invalid derivative index j = " << j);

--- a/src/fe/fe_lagrange_shape_3D.C
+++ b/src/fe/fe_lagrange_shape_3D.C
@@ -2611,9 +2611,9 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
                 {
                   // d^2()/dxi^2
                 case 0:
-                  return (fe_lagrange_1D_shape_second_deriv(EDGE3, SECOND, i0[i], 0, xi)*
-                          fe_lagrange_1D_quadratic_shape(i1[i], eta)*
-                          fe_lagrange_1D_quadratic_shape(i2[i], zeta));
+                  return (fe_lagrange_1D_quadratic_shape_second_deriv(i0[i], 0, xi)*
+                          fe_lagrange_1D_quadratic_shape             (i1[i], eta)*
+                          fe_lagrange_1D_quadratic_shape             (i2[i], zeta));
 
                   // d^2()/dxideta
                 case 1:
@@ -2623,9 +2623,9 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
 
                   // d^2()/deta^2
                 case 2:
-                  return (fe_lagrange_1D_quadratic_shape(i0[i], xi)*
-                          fe_lagrange_1D_shape_second_deriv(EDGE3, SECOND, i1[i], 0, eta)*
-                          fe_lagrange_1D_quadratic_shape(i2[i], zeta));
+                  return (fe_lagrange_1D_quadratic_shape             (i0[i], xi)*
+                          fe_lagrange_1D_quadratic_shape_second_deriv(i1[i], 0, eta)*
+                          fe_lagrange_1D_quadratic_shape             (i2[i], zeta));
 
                   // d^2()/dxidzeta
                 case 3:
@@ -2641,9 +2641,9 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
 
                   // d^2()/dzeta^2
                 case 5:
-                  return (fe_lagrange_1D_quadratic_shape(i0[i], xi)*
-                          fe_lagrange_1D_quadratic_shape(i1[i], eta)*
-                          fe_lagrange_1D_shape_second_deriv(EDGE3, SECOND, i2[i], 0, zeta));
+                  return (fe_lagrange_1D_quadratic_shape             (i0[i], xi)*
+                          fe_lagrange_1D_quadratic_shape             (i1[i], eta)*
+                          fe_lagrange_1D_quadratic_shape_second_deriv(i2[i], 0, zeta));
 
                 default:
                   libmesh_error_msg("Invalid j = " << j);
@@ -2981,7 +2981,7 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
                   // d^2()/dzeta^2
                 case 5:
                   return (FE<2,LAGRANGE>::shape(TRI6,  SECOND, i1[i], p2d)*
-                          fe_lagrange_1D_shape_second_deriv(EDGE3, SECOND, i0[i], 0, p1d));
+                          fe_lagrange_1D_quadratic_shape_second_deriv(i0[i], 0, p1d));
 
                 default:
                   libmesh_error_msg("Invalid shape function derivative j = " << j);

--- a/src/fe/fe_lagrange_shape_3D.C
+++ b/src/fe/fe_lagrange_shape_3D.C
@@ -790,19 +790,19 @@ Real fe_lagrange_3D_shape_deriv(const ElemType type,
               switch(j)
                 {
                 case 0:
-                  return (fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i0[i], 0, xi)*
-                          fe_lagrange_1D_linear_shape(i1[i], eta)*
-                          fe_lagrange_1D_linear_shape(i2[i], zeta));
+                  return (fe_lagrange_1D_linear_shape_deriv(i0[i], 0, xi)*
+                          fe_lagrange_1D_linear_shape      (i1[i], eta)*
+                          fe_lagrange_1D_linear_shape      (i2[i], zeta));
 
                 case 1:
-                  return (fe_lagrange_1D_linear_shape(i0[i], xi)*
-                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i1[i], 0, eta)*
-                          fe_lagrange_1D_linear_shape(i2[i], zeta));
+                  return (fe_lagrange_1D_linear_shape      (i0[i], xi)*
+                          fe_lagrange_1D_linear_shape_deriv(i1[i], 0, eta)*
+                          fe_lagrange_1D_linear_shape      (i2[i], zeta));
 
                 case 2:
-                  return (fe_lagrange_1D_linear_shape(i0[i], xi)*
-                          fe_lagrange_1D_linear_shape(i1[i], eta)*
-                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i2[i], 0, zeta));
+                  return (fe_lagrange_1D_linear_shape      (i0[i], xi)*
+                          fe_lagrange_1D_linear_shape      (i1[i], eta)*
+                          fe_lagrange_1D_linear_shape_deriv(i2[i], 0, zeta));
 
                 default:
                   libmesh_error_msg("Invalid j = " << j);
@@ -936,7 +936,7 @@ Real fe_lagrange_3D_shape_deriv(const ElemType type,
                   // d()/dzeta
                 case 2:
                   return (FE<2,LAGRANGE>::shape(TRI3,  FIRST, i1[i], p2d)*
-                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i0[i], 0, p1d));
+                          fe_lagrange_1D_linear_shape_deriv(i0[i], 0, p1d));
 
                 default:
                   libmesh_error_msg("Invalid shape function derivative j = " << j);
@@ -1326,19 +1326,19 @@ Real fe_lagrange_3D_shape_deriv(const ElemType type,
               switch(j)
                 {
                 case 0:
-                  return (fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i0[i], 0, xi)*
-                          fe_lagrange_1D_quadratic_shape(i1[i], eta)*
-                          fe_lagrange_1D_quadratic_shape(i2[i], zeta));
+                  return (fe_lagrange_1D_quadratic_shape_deriv(i0[i], 0, xi)*
+                          fe_lagrange_1D_quadratic_shape      (i1[i], eta)*
+                          fe_lagrange_1D_quadratic_shape      (i2[i], zeta));
 
                 case 1:
-                  return (fe_lagrange_1D_quadratic_shape(i0[i], xi)*
-                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i1[i], 0, eta)*
-                          fe_lagrange_1D_quadratic_shape(i2[i], zeta));
+                  return (fe_lagrange_1D_quadratic_shape      (i0[i], xi)*
+                          fe_lagrange_1D_quadratic_shape_deriv(i1[i], 0, eta)*
+                          fe_lagrange_1D_quadratic_shape      (i2[i], zeta));
 
                 case 2:
-                  return (fe_lagrange_1D_quadratic_shape(i0[i], xi)*
-                          fe_lagrange_1D_quadratic_shape(i1[i], eta)*
-                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i2[i], 0, zeta));
+                  return (fe_lagrange_1D_quadratic_shape      (i0[i], xi)*
+                          fe_lagrange_1D_quadratic_shape      (i1[i], eta)*
+                          fe_lagrange_1D_quadratic_shape_deriv(i2[i], 0, zeta));
 
                 default:
                   libmesh_error_msg("Invalid j = " << j);
@@ -1669,7 +1669,7 @@ Real fe_lagrange_3D_shape_deriv(const ElemType type,
                   // d()/dzeta
                 case 2:
                   return (FE<2,LAGRANGE>::shape(TRI6,  SECOND, i1[i], p2d)*
-                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i0[i], 0, p1d));
+                          fe_lagrange_1D_quadratic_shape_deriv(i0[i], 0, p1d));
 
                 default:
                   libmesh_error_msg("Invalid shape function derivative j = " << j);
@@ -2154,11 +2154,11 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
 
                 case 3: // d^2()/dxidzeta
                   return (FE<2,LAGRANGE>::shape_deriv(TRI3,  FIRST, i1[i], 0, p2d)*
-                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i0[i], 0, p1d));
+                          fe_lagrange_1D_linear_shape_deriv(i0[i], 0, p1d));
 
                 case 4: // d^2()/detadzeta
                   return (FE<2,LAGRANGE>::shape_deriv(TRI3,  FIRST, i1[i], 1, p2d)*
-                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i0[i], 0, p1d));
+                          fe_lagrange_1D_linear_shape_deriv(i0[i], 0, p1d));
 
                 default:
                   libmesh_error_msg("Invalid j = " << j);
@@ -2289,19 +2289,19 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
                   }
 
                 case 1: // d^2()/dxideta
-                  return (fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i0[i], 0, xi)*
-                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i1[i], 0, eta)*
-                          fe_lagrange_1D_linear_shape(i2[i], zeta));
+                  return (fe_lagrange_1D_linear_shape_deriv(i0[i], 0, xi)*
+                          fe_lagrange_1D_linear_shape_deriv(i1[i], 0, eta)*
+                          fe_lagrange_1D_linear_shape      (i2[i], zeta));
 
                 case 3: // d^2()/dxidzeta
-                  return (fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i0[i], 0, xi)*
-                          fe_lagrange_1D_linear_shape(i1[i], eta)*
-                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i2[i], 0, zeta));
+                  return (fe_lagrange_1D_linear_shape_deriv(i0[i], 0, xi)*
+                          fe_lagrange_1D_linear_shape      (i1[i], eta)*
+                          fe_lagrange_1D_linear_shape_deriv(i2[i], 0, zeta));
 
                 case 4: // d^2()/detadzeta
-                  return (fe_lagrange_1D_linear_shape(i0[i], xi)*
-                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i1[i], 0, eta)*
-                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i2[i], 0, zeta));
+                  return (fe_lagrange_1D_linear_shape      (i0[i], xi)*
+                          fe_lagrange_1D_linear_shape_deriv(i1[i], 0, eta)*
+                          fe_lagrange_1D_linear_shape_deriv(i2[i], 0, zeta));
 
                 default:
                   libmesh_error_msg("Invalid j = " << j);
@@ -2617,9 +2617,9 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
 
                   // d^2()/dxideta
                 case 1:
-                  return (fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i0[i], 0, xi)*
-                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i1[i], 0, eta)*
-                          fe_lagrange_1D_quadratic_shape(i2[i], zeta));
+                  return (fe_lagrange_1D_quadratic_shape_deriv(i0[i], 0, xi)*
+                          fe_lagrange_1D_quadratic_shape_deriv(i1[i], 0, eta)*
+                          fe_lagrange_1D_quadratic_shape      (i2[i], zeta));
 
                   // d^2()/deta^2
                 case 2:
@@ -2629,15 +2629,15 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
 
                   // d^2()/dxidzeta
                 case 3:
-                  return (fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i0[i], 0, xi)*
-                          fe_lagrange_1D_quadratic_shape(i1[i], eta)*
-                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i2[i], 0, zeta));
+                  return (fe_lagrange_1D_quadratic_shape_deriv(i0[i], 0, xi)*
+                          fe_lagrange_1D_quadratic_shape      (i1[i], eta)*
+                          fe_lagrange_1D_quadratic_shape_deriv(i2[i], 0, zeta));
 
                   // d^2()/detadzeta
                 case 4:
-                  return (fe_lagrange_1D_quadratic_shape(i0[i], xi)*
-                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i1[i], 0, eta)*
-                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i2[i], 0, zeta));
+                  return (fe_lagrange_1D_quadratic_shape      (i0[i], xi)*
+                          fe_lagrange_1D_quadratic_shape_deriv(i1[i], 0, eta)*
+                          fe_lagrange_1D_quadratic_shape_deriv(i2[i], 0, zeta));
 
                   // d^2()/dzeta^2
                 case 5:
@@ -2971,12 +2971,12 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
                   // d^2()/dxidzeta
                 case 3:
                   return (FE<2,LAGRANGE>::shape_deriv(TRI6,  SECOND, i1[i], 0, p2d)*
-                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i0[i], 0, p1d));
+                          fe_lagrange_1D_quadratic_shape_deriv(i0[i], 0, p1d));
 
                   // d^2()/detadzeta
                 case 4:
                   return (FE<2,LAGRANGE>::shape_deriv(TRI6,  SECOND, i1[i], 1, p2d)*
-                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i0[i], 0, p1d));
+                          fe_lagrange_1D_quadratic_shape_deriv(i0[i], 0, p1d));
 
                   // d^2()/dzeta^2
                 case 5:

--- a/src/fe/fe_lagrange_shape_3D.C
+++ b/src/fe/fe_lagrange_shape_3D.C
@@ -19,6 +19,7 @@
 // Local includes
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
+#include "libmesh/fe_lagrange_shape_1D.h"
 
 // Anonymous namespace for functions shared by LAGRANGE and
 // L2_LAGRANGE implementations. Implementations appear at the bottom
@@ -259,9 +260,9 @@ Real fe_lagrange_3D_shape(const ElemType type,
               static const unsigned int i1[] = {0, 0, 1, 1, 0, 0, 1, 1};
               static const unsigned int i2[] = {0, 0, 0, 0, 1, 1, 1, 1};
 
-              return (FE<1,LAGRANGE>::shape(EDGE2, FIRST, i0[i], xi)*
-                      FE<1,LAGRANGE>::shape(EDGE2, FIRST, i1[i], eta)*
-                      FE<1,LAGRANGE>::shape(EDGE2, FIRST, i2[i], zeta));
+              return (fe_lagrange_1D_linear_shape(i0[i], xi)*
+                      fe_lagrange_1D_linear_shape(i1[i], eta)*
+                      fe_lagrange_1D_linear_shape(i2[i], zeta));
             }
 
             // linear tetrahedral shape functions
@@ -306,14 +307,14 @@ Real fe_lagrange_3D_shape(const ElemType type,
               // of a triangle and an edge
 
               Point p2d(p(0),p(1));
-              Point p1d(p(2));
+              Real p1d = p(2);
 
               //                                0  1  2  3  4  5
               static const unsigned int i0[] = {0, 0, 0, 1, 1, 1};
               static const unsigned int i1[] = {0, 1, 2, 0, 1, 2};
 
               return (FE<2,LAGRANGE>::shape(TRI3,  FIRST, i1[i], p2d)*
-                      FE<1,LAGRANGE>::shape(EDGE2, FIRST, i0[i], p1d));
+                      fe_lagrange_1D_linear_shape(i0[i], p1d));
             }
 
             // linear pyramid shape functions
@@ -463,9 +464,9 @@ Real fe_lagrange_3D_shape(const ElemType type,
               static const unsigned int i1[] = {0, 0, 1, 1, 0, 0, 1, 1, 0, 2, 1, 2, 0, 0, 1, 1, 0, 2, 1, 2, 2, 0, 2, 1, 2, 2, 2};
               static const unsigned int i2[] = {0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 2, 2, 2, 2, 1, 1, 1, 1, 0, 2, 2, 2, 2, 1, 2};
 
-              return (FE<1,LAGRANGE>::shape(EDGE3, SECOND, i0[i], xi)*
-                      FE<1,LAGRANGE>::shape(EDGE3, SECOND, i1[i], eta)*
-                      FE<1,LAGRANGE>::shape(EDGE3, SECOND, i2[i], zeta));
+              return (fe_lagrange_1D_quadratic_shape(i0[i], xi)*
+                      fe_lagrange_1D_quadratic_shape(i1[i], eta)*
+                      fe_lagrange_1D_quadratic_shape(i2[i], zeta));
             }
 
             // quadratic tetrahedral shape functions
@@ -586,14 +587,14 @@ Real fe_lagrange_3D_shape(const ElemType type,
               // of a triangle and an edge
 
               Point p2d(p(0),p(1));
-              Point p1d(p(2));
+              Real p1d = p(2);
 
               //                                0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17
               static const unsigned int i0[] = {0, 0, 0, 1, 1, 1, 0, 0, 0, 2, 2, 2, 1, 1, 1, 2, 2, 2};
               static const unsigned int i1[] = {0, 1, 2, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 3, 4, 5};
 
               return (FE<2,LAGRANGE>::shape(TRI6,  SECOND, i1[i], p2d)*
-                      FE<1,LAGRANGE>::shape(EDGE3, SECOND, i0[i], p1d));
+                      fe_lagrange_1D_quadratic_shape(i0[i], p1d));
             }
 
             // G. Bedrosian, "Shape functions and integration formulas for
@@ -789,19 +790,19 @@ Real fe_lagrange_3D_shape_deriv(const ElemType type,
               switch(j)
                 {
                 case 0:
-                  return (FE<1,LAGRANGE>::shape_deriv(EDGE2, FIRST, i0[i], 0, xi)*
-                          FE<1,LAGRANGE>::shape      (EDGE2, FIRST, i1[i], eta)*
-                          FE<1,LAGRANGE>::shape      (EDGE2, FIRST, i2[i], zeta));
+                  return (fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i0[i], 0, xi)*
+                          fe_lagrange_1D_linear_shape(i1[i], eta)*
+                          fe_lagrange_1D_linear_shape(i2[i], zeta));
 
                 case 1:
-                  return (FE<1,LAGRANGE>::shape      (EDGE2, FIRST, i0[i], xi)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE2, FIRST, i1[i], 0, eta)*
-                          FE<1,LAGRANGE>::shape      (EDGE2, FIRST, i2[i], zeta));
+                  return (fe_lagrange_1D_linear_shape(i0[i], xi)*
+                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i1[i], 0, eta)*
+                          fe_lagrange_1D_linear_shape(i2[i], zeta));
 
                 case 2:
-                  return (FE<1,LAGRANGE>::shape      (EDGE2, FIRST, i0[i], xi)*
-                          FE<1,LAGRANGE>::shape      (EDGE2, FIRST, i1[i], eta)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE2, FIRST, i2[i], 0, zeta));
+                  return (fe_lagrange_1D_linear_shape(i0[i], xi)*
+                          fe_lagrange_1D_linear_shape(i1[i], eta)*
+                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i2[i], 0, zeta));
 
                 default:
                   libmesh_error_msg("Invalid j = " << j);
@@ -914,7 +915,7 @@ Real fe_lagrange_3D_shape_deriv(const ElemType type,
               // of a triangle and an edge
 
               Point p2d(p(0),p(1));
-              Point p1d(p(2));
+              Real p1d = p(2);
 
               //                                0  1  2  3  4  5
               static const unsigned int i0[] = {0, 0, 0, 1, 1, 1};
@@ -925,17 +926,17 @@ Real fe_lagrange_3D_shape_deriv(const ElemType type,
                   // d()/dxi
                 case 0:
                   return (FE<2,LAGRANGE>::shape_deriv(TRI3,  FIRST, i1[i], 0, p2d)*
-                          FE<1,LAGRANGE>::shape(EDGE2, FIRST, i0[i], p1d));
+                          fe_lagrange_1D_linear_shape(i0[i], p1d));
 
                   // d()/deta
                 case 1:
                   return (FE<2,LAGRANGE>::shape_deriv(TRI3,  FIRST, i1[i], 1, p2d)*
-                          FE<1,LAGRANGE>::shape(EDGE2, FIRST, i0[i], p1d));
+                          fe_lagrange_1D_linear_shape(i0[i], p1d));
 
                   // d()/dzeta
                 case 2:
                   return (FE<2,LAGRANGE>::shape(TRI3,  FIRST, i1[i], p2d)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE2, FIRST, i0[i], 0, p1d));
+                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i0[i], 0, p1d));
 
                 default:
                   libmesh_error_msg("Invalid shape function derivative j = " << j);
@@ -1325,19 +1326,19 @@ Real fe_lagrange_3D_shape_deriv(const ElemType type,
               switch(j)
                 {
                 case 0:
-                  return (FE<1,LAGRANGE>::shape_deriv(EDGE3, SECOND, i0[i], 0, xi)*
-                          FE<1,LAGRANGE>::shape      (EDGE3, SECOND, i1[i], eta)*
-                          FE<1,LAGRANGE>::shape      (EDGE3, SECOND, i2[i], zeta));
+                  return (fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i0[i], 0, xi)*
+                          fe_lagrange_1D_quadratic_shape(i1[i], eta)*
+                          fe_lagrange_1D_quadratic_shape(i2[i], zeta));
 
                 case 1:
-                  return (FE<1,LAGRANGE>::shape      (EDGE3, SECOND, i0[i], xi)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE3, SECOND, i1[i], 0, eta)*
-                          FE<1,LAGRANGE>::shape      (EDGE3, SECOND, i2[i], zeta));
+                  return (fe_lagrange_1D_quadratic_shape(i0[i], xi)*
+                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i1[i], 0, eta)*
+                          fe_lagrange_1D_quadratic_shape(i2[i], zeta));
 
                 case 2:
-                  return (FE<1,LAGRANGE>::shape      (EDGE3, SECOND, i0[i], xi)*
-                          FE<1,LAGRANGE>::shape      (EDGE3, SECOND, i1[i], eta)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE3, SECOND, i2[i], 0, zeta));
+                  return (fe_lagrange_1D_quadratic_shape(i0[i], xi)*
+                          fe_lagrange_1D_quadratic_shape(i1[i], eta)*
+                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i2[i], 0, zeta));
 
                 default:
                   libmesh_error_msg("Invalid j = " << j);
@@ -1647,7 +1648,7 @@ Real fe_lagrange_3D_shape_deriv(const ElemType type,
               // of a triangle and an edge
 
               Point p2d(p(0),p(1));
-              Point p1d(p(2));
+              Real p1d = p(2);
 
               //                                0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17
               static const unsigned int i0[] = {0, 0, 0, 1, 1, 1, 0, 0, 0, 2, 2, 2, 1, 1, 1, 2, 2, 2};
@@ -1658,17 +1659,17 @@ Real fe_lagrange_3D_shape_deriv(const ElemType type,
                   // d()/dxi
                 case 0:
                   return (FE<2,LAGRANGE>::shape_deriv(TRI6,  SECOND, i1[i], 0, p2d)*
-                          FE<1,LAGRANGE>::shape(EDGE3, SECOND, i0[i], p1d));
+                          fe_lagrange_1D_quadratic_shape(i0[i], p1d));
 
                   // d()/deta
                 case 1:
                   return (FE<2,LAGRANGE>::shape_deriv(TRI6,  SECOND, i1[i], 1, p2d)*
-                          FE<1,LAGRANGE>::shape(EDGE3, SECOND, i0[i], p1d));
+                          fe_lagrange_1D_quadratic_shape(i0[i], p1d));
 
                   // d()/dzeta
                 case 2:
                   return (FE<2,LAGRANGE>::shape(TRI6,  SECOND, i1[i], p2d)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE3, SECOND, i0[i], 0, p1d));
+                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i0[i], 0, p1d));
 
                 default:
                   libmesh_error_msg("Invalid shape function derivative j = " << j);
@@ -2134,7 +2135,7 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
               // of a triangle and an edge
 
               Point p2d(p(0),p(1));
-              Point p1d(p(2));
+              Real p1d = p(2);
 
               //                                0  1  2  3  4  5
               static const unsigned int i0[] = {0, 0, 0, 1, 1, 1};
@@ -2153,11 +2154,11 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
 
                 case 3: // d^2()/dxidzeta
                   return (FE<2,LAGRANGE>::shape_deriv(TRI3,  FIRST, i1[i], 0, p2d)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE2, FIRST, i0[i], 0, p1d));
+                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i0[i], 0, p1d));
 
                 case 4: // d^2()/detadzeta
                   return (FE<2,LAGRANGE>::shape_deriv(TRI3,  FIRST, i1[i], 1, p2d)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE2, FIRST, i0[i], 0, p1d));
+                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i0[i], 0, p1d));
 
                 default:
                   libmesh_error_msg("Invalid j = " << j);
@@ -2288,19 +2289,19 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
                   }
 
                 case 1: // d^2()/dxideta
-                  return (FE<1,LAGRANGE>::shape_deriv(EDGE2, FIRST, i0[i], 0, xi)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE2, FIRST, i1[i], 0, eta)*
-                          FE<1,LAGRANGE>::shape      (EDGE2, FIRST, i2[i], zeta));
+                  return (fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i0[i], 0, xi)*
+                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i1[i], 0, eta)*
+                          fe_lagrange_1D_linear_shape(i2[i], zeta));
 
                 case 3: // d^2()/dxidzeta
-                  return (FE<1,LAGRANGE>::shape_deriv(EDGE2, FIRST, i0[i], 0, xi)*
-                          FE<1,LAGRANGE>::shape      (EDGE2, FIRST, i1[i], eta)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE2, FIRST, i2[i], 0, zeta));
+                  return (fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i0[i], 0, xi)*
+                          fe_lagrange_1D_linear_shape(i1[i], eta)*
+                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i2[i], 0, zeta));
 
                 case 4: // d^2()/detadzeta
-                  return (FE<1,LAGRANGE>::shape      (EDGE2, FIRST, i0[i], xi)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE2, FIRST, i1[i], 0, eta)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE2, FIRST, i2[i], 0, zeta));
+                  return (fe_lagrange_1D_linear_shape(i0[i], xi)*
+                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i1[i], 0, eta)*
+                          fe_lagrange_1D_shape_deriv(EDGE2, FIRST, i2[i], 0, zeta));
 
                 default:
                   libmesh_error_msg("Invalid j = " << j);
@@ -2610,39 +2611,39 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
                 {
                   // d^2()/dxi^2
                 case 0:
-                  return (FE<1,LAGRANGE>::shape_second_deriv(EDGE3, SECOND, i0[i], 0, xi)*
-                          FE<1,LAGRANGE>::shape      (EDGE3, SECOND, i1[i], eta)*
-                          FE<1,LAGRANGE>::shape      (EDGE3, SECOND, i2[i], zeta));
+                  return (fe_lagrange_1D_shape_second_deriv(EDGE3, SECOND, i0[i], 0, xi)*
+                          fe_lagrange_1D_quadratic_shape(i1[i], eta)*
+                          fe_lagrange_1D_quadratic_shape(i2[i], zeta));
 
                   // d^2()/dxideta
                 case 1:
-                  return (FE<1,LAGRANGE>::shape_deriv(EDGE3, SECOND, i0[i], 0, xi)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE3, SECOND, i1[i], 0, eta)*
-                          FE<1,LAGRANGE>::shape      (EDGE3, SECOND, i2[i], zeta));
+                  return (fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i0[i], 0, xi)*
+                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i1[i], 0, eta)*
+                          fe_lagrange_1D_quadratic_shape(i2[i], zeta));
 
                   // d^2()/deta^2
                 case 2:
-                  return (FE<1,LAGRANGE>::shape      (EDGE3, SECOND, i0[i], xi)*
-                          FE<1,LAGRANGE>::shape_second_deriv(EDGE3, SECOND, i1[i], 0, eta)*
-                          FE<1,LAGRANGE>::shape      (EDGE3, SECOND, i2[i], zeta));
+                  return (fe_lagrange_1D_quadratic_shape(i0[i], xi)*
+                          fe_lagrange_1D_shape_second_deriv(EDGE3, SECOND, i1[i], 0, eta)*
+                          fe_lagrange_1D_quadratic_shape(i2[i], zeta));
 
                   // d^2()/dxidzeta
                 case 3:
-                  return (FE<1,LAGRANGE>::shape_deriv(EDGE3, SECOND, i0[i], 0, xi)*
-                          FE<1,LAGRANGE>::shape      (EDGE3, SECOND, i1[i], eta)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE3, SECOND, i2[i], 0, zeta));
+                  return (fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i0[i], 0, xi)*
+                          fe_lagrange_1D_quadratic_shape(i1[i], eta)*
+                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i2[i], 0, zeta));
 
                   // d^2()/detadzeta
                 case 4:
-                  return (FE<1,LAGRANGE>::shape      (EDGE3, SECOND, i0[i], xi)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE3, SECOND, i1[i], 0, eta)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE3, SECOND, i2[i], 0, zeta));
+                  return (fe_lagrange_1D_quadratic_shape(i0[i], xi)*
+                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i1[i], 0, eta)*
+                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i2[i], 0, zeta));
 
                   // d^2()/dzeta^2
                 case 5:
-                  return (FE<1,LAGRANGE>::shape      (EDGE3, SECOND, i0[i], xi)*
-                          FE<1,LAGRANGE>::shape      (EDGE3, SECOND, i1[i], eta)*
-                          FE<1,LAGRANGE>::shape_second_deriv(EDGE3, SECOND, i2[i], 0, zeta));
+                  return (fe_lagrange_1D_quadratic_shape(i0[i], xi)*
+                          fe_lagrange_1D_quadratic_shape(i1[i], eta)*
+                          fe_lagrange_1D_shape_second_deriv(EDGE3, SECOND, i2[i], 0, zeta));
 
                 default:
                   libmesh_error_msg("Invalid j = " << j);
@@ -2944,7 +2945,7 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
               // of a triangle and an edge
 
               Point p2d(p(0),p(1));
-              Point p1d(p(2));
+              Real p1d = p(2);
 
               //                                0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17
               static const unsigned int i0[] = {0, 0, 0, 1, 1, 1, 0, 0, 0, 2, 2, 2, 1, 1, 1, 2, 2, 2};
@@ -2955,32 +2956,32 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
                   // d^2()/dxi^2
                 case 0:
                   return (FE<2,LAGRANGE>::shape_second_deriv(TRI6, SECOND, i1[i], 0, p2d)*
-                          FE<1,LAGRANGE>::shape(EDGE3, SECOND, i0[i], p1d));
+                          fe_lagrange_1D_quadratic_shape(i0[i], p1d));
 
                   // d^2()/dxideta
                 case 1:
                   return (FE<2,LAGRANGE>::shape_second_deriv(TRI6, SECOND, i1[i], 1, p2d)*
-                          FE<1,LAGRANGE>::shape(EDGE3, SECOND, i0[i], p1d));
+                          fe_lagrange_1D_quadratic_shape(i0[i], p1d));
 
                   // d^2()/deta^2
                 case 2:
                   return (FE<2,LAGRANGE>::shape_second_deriv(TRI6, SECOND, i1[i], 2, p2d)*
-                          FE<1,LAGRANGE>::shape(EDGE3, SECOND, i0[i], p1d));
+                          fe_lagrange_1D_quadratic_shape(i0[i], p1d));
 
                   // d^2()/dxidzeta
                 case 3:
                   return (FE<2,LAGRANGE>::shape_deriv(TRI6,  SECOND, i1[i], 0, p2d)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE3, SECOND, i0[i], 0, p1d));
+                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i0[i], 0, p1d));
 
                   // d^2()/detadzeta
                 case 4:
                   return (FE<2,LAGRANGE>::shape_deriv(TRI6,  SECOND, i1[i], 1, p2d)*
-                          FE<1,LAGRANGE>::shape_deriv(EDGE3, SECOND, i0[i], 0, p1d));
+                          fe_lagrange_1D_shape_deriv(EDGE3, SECOND, i0[i], 0, p1d));
 
                   // d^2()/dzeta^2
                 case 5:
                   return (FE<2,LAGRANGE>::shape(TRI6,  SECOND, i1[i], p2d)*
-                          FE<1,LAGRANGE>::shape_second_deriv(EDGE3, SECOND, i0[i], 0, p1d));
+                          fe_lagrange_1D_shape_second_deriv(EDGE3, SECOND, i0[i], 0, p1d));
 
                 default:
                   libmesh_error_msg("Invalid shape function derivative j = " << j);


### PR DESCRIPTION
This gives me nearly a 40% speedup in 3D, on a problem that was only using Lagrange for *mapping* functions.  Problems without tensor product elements or with meshes where mapping functions are often cached probably won't do so well though.

I'd like to thank @permcody for his "[Makes we wonder how much long hanging optimization fruit there is hanging on the the tree.](https://github.com/libMesh/libmesh/pull/2370#issuecomment-564708754)" comment - the benchmarking leading to this PR was begun by indignant anger and ended in shamed acceptance.

We still need to vectorize this code, but I think that'll be a much bigger refactoring.

We could get an analogous tensor product elements speedup with similar refactoring on other FE families: BERNSTEIN, HIERARCHIC, and SZABAB at first glance.  Going to throw CI at the LAGRANGE refactoring first.