### PR TITLE
Reduce default JumpErrorEstimator quadrature

### DIFF
--- a/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
+++ b/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
@@ -136,6 +136,7 @@ int main(int argc, char ** argv)
           // Error estimation objects, see Adaptivity Example 2 for details
           ErrorVector error;
           KellyErrorEstimator error_estimator;
+          error_estimator.use_unweighted_quadrature_rules = true;
 
           // Compute the error for each active element
           error_estimator.estimate_error(system, error);

--- a/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
+++ b/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
@@ -379,6 +379,13 @@ int main (int argc, char ** argv)
               // and which to coarsen.
               KellyErrorEstimator error_estimator;
 
+              // This is a subclass of JumpErrorEstimator, based on
+              // measuring discontinuities across sides between
+              // elements, and we can tell it to use a cheaper
+              // "unweighted" quadrature rule when numerically
+              // integrating those discontinuities.
+              error_estimator.use_unweighted_quadrature_rules = true;
+
               // Compute the error for each active element using the provided
               // flux_jump indicator.  Note in general you will need to
               // provide an error estimator specifically designed for your

--- a/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
+++ b/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
@@ -387,6 +387,13 @@ int main(int argc, char ** argv)
               ErrorVector error;
               LaplacianErrorEstimator error_estimator;
 
+              // This is another subclass of JumpErrorEstimator, based
+              // on measuring discontinuities across sides between
+              // elements, and we can tell it to use a cheaper
+              // "unweighted" quadrature rule when numerically
+              // integrating those discontinuities.
+              error_estimator.use_unweighted_quadrature_rules = true;
+
               error_estimator.estimate_error(system, error);
               mesh_refinement.flag_elements_by_elem_fraction (error);
 

--- a/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
+++ b/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
@@ -450,6 +450,13 @@ int main (int argc, char ** argv)
               // and which to coarsen.
               KellyErrorEstimator error_estimator;
 
+              // This is a subclass of JumpErrorEstimator, based
+              // on measuring discontinuities across sides between
+              // elements, and we can tell it to use a cheaper
+              // "unweighted" quadrature rule when numerically
+              // integrating those discontinuities.
+              error_estimator.use_unweighted_quadrature_rules = true;
+
               // Compute the error for each active element using the provided
               // flux_jump indicator.  Note in general you will need to
               // provide an error estimator specifically designed for your

--- a/include/error_estimation/jump_error_estimator.h
+++ b/include/error_estimation/jump_error_estimator.h
@@ -55,6 +55,7 @@ public:
   JumpErrorEstimator()
     : ErrorEstimator(),
       scale_by_n_flux_faces(false),
+      use_unweighted_quadrature_rules(false),
       integrate_boundary_sides(false),
       fine_context(),
       coarse_context(),
@@ -96,6 +97,20 @@ public:
    * want to use the feature.
    */
   bool scale_by_n_flux_faces;
+
+  /**
+   * This boolean flag allows you to use "unweighted" quadrature rules
+   * (sized to exactly integrate unweighted shape functions in master
+   * element space) rather than "default" quadrature rules (sized to
+   * exactly integrate polynomials of one higher degree than mass
+   * matrix terms).  The results with the former, lower-order rules
+   * will be somewhat less accurate in many cases but will be much
+   * cheaper to compute.
+   *
+   * The value is initialized to false, simply set it to true if you
+   * want to use the feature.
+   */
+  bool use_unweighted_quadrature_rules;
 
 protected:
   /**

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -306,18 +306,39 @@ public:
    * \returns The default quadrature order for this \p FEType.  The
    * default quadrature order is calculated assuming a polynomial of
    * degree \p order and is based on integrating the mass matrix for
-   * such an element exactly.
+   * such an element exactly on affine elements.
    */
   Order default_quadrature_order () const;
 
   /**
    * \returns A quadrature rule of appropriate type and order for this \p
    * FEType.  The default quadrature rule is based on integrating the mass
-   * matrix for such an element exactly.  Higher or lower degree rules can
-   * be chosen by changing the extraorder parameter.
+   * matrix for such an element exactly, with an additional power on
+   * the basis order to help account for nonlinearities and/or
+   * nonuniform coefficients.  Higher or lower degree rules can be
+   * chosen by changing the extraorder parameter.
    */
   std::unique_ptr<QBase> default_quadrature_rule (const unsigned int dim,
                                                   const int extraorder=0) const;
+
+  /**
+   * \returns The default quadrature order for integrating unweighted
+   * basis functions of this \p FEType.
+   * The unweighted quadrature order is calculated assuming a
+   * polynomial of degree \p order and is based on integrating the
+   * shape functions for such an element exactly on affine elements.
+   */
+  Order unweighted_quadrature_order () const;
+
+  /**
+   * \returns A quadrature rule of appropriate type and order for
+   * unweighted integration of this \p FEType.  The default quadrature
+   * rule is based on integrating the shape functions on an affine
+   * element exactly.  Higher or lower degree rules can be chosen by
+   * changing the extraorder parameter.
+   */
+  std::unique_ptr<QBase> unweighted_quadrature_rule (const unsigned int dim,
+                                                     const int extraorder=0) const;
 
 
 private:
@@ -332,6 +353,12 @@ inline
 Order FEType::default_quadrature_order () const
 {
   return static_cast<Order>(2*static_cast<unsigned int>(order.get_order()) + 1);
+}
+
+inline
+Order FEType::unweighted_quadrature_order () const
+{
+  return order;
 }
 
 } // namespace libMesh

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -82,6 +82,18 @@ public:
   virtual ~FEMContext ();
 
   /**
+   * Use quadrature rules designed to over-integrate a mass matrix,
+   * plus \p extra_quadrature_order.
+   */
+  void use_default_quadrature_rules(int extra_quadrature_order=0);
+
+  /**
+   * Use quadrature rules designed to exactly integrate unweighted
+   * undistorted basis functions, plus \p extra_quadrature_order.
+   */
+  void use_unweighted_quadrature_rules(int extra_quadrature_order=0);
+
+  /**
    * Reports if the boundary id is found on the current side
    */
   bool has_side_boundary_id(boundary_id_type id) const;
@@ -1001,6 +1013,16 @@ public:
    * Current edge for edge_* to examine
    */
   unsigned char edge;
+
+  /**
+   * Helper function for creating quadrature rules
+   */
+  FEType find_hardest_fe_type();
+
+  /**
+   * Helper function for attaching quadrature rules
+   */
+  void attach_quadrature_rules();
 
   /**
    * Helper function to reduce some code duplication in the *_point_* methods.

--- a/src/error_estimation/jump_error_estimator.C
+++ b/src/error_estimation/jump_error_estimator.C
@@ -142,6 +142,11 @@ void JumpErrorEstimator::estimate_error (const System & system,
   fine_context = libmesh_make_unique<FEMContext>(system);
   coarse_context = libmesh_make_unique<FEMContext>(system);
 
+  // Don't overintegrate - we're evaluating differences of FE values,
+  // not products of them.
+  if (this->use_unweighted_quadrature_rules)
+    fine_context->use_unweighted_quadrature_rules(system.extra_quadrature_order);
+
   // Loop over all the variables we've been requested to find jumps in, to
   // pre-request
   for (var=0; var<n_vars; var++)

--- a/src/fe/fe_type.C
+++ b/src/fe/fe_type.C
@@ -45,4 +45,23 @@ FEType::default_quadrature_rule (const unsigned int dim,
   return libmesh_make_unique<QGauss>(dim, static_cast<Order>(this->default_quadrature_order() + extraorder));
 }
 
+
+std::unique_ptr<QBase>
+FEType::unweighted_quadrature_rule (const unsigned int dim,
+                                    const int extraorder) const
+{
+  // Clough elements have at least piecewise cubic functions
+  if (family == CLOUGH)
+    {
+      Order o = static_cast<Order>(std::max(static_cast<unsigned int>(this->unweighted_quadrature_order()),
+                                            static_cast<unsigned int>(3 + extraorder)));
+      return libmesh_make_unique<QClough>(dim, o);
+    }
+
+  if (family == SUBDIVISION)
+    return libmesh_make_unique<QGauss>(dim, static_cast<Order>(1 + extraorder));
+
+  return libmesh_make_unique<QGauss>(dim, static_cast<Order>(this->unweighted_quadrature_order() + extraorder));
+}
+
 } // namespace libMesh


### PR DESCRIPTION
I fear this is going to break people's 2D/3D AMR regression tests
whenever slightly-differing error estimator values lead to differing
refinement patterns, but IMHO sorting that out will be worth it; we can
get nearly-as-good results at roughly half (2D) or a quarter (3D) of the
cost by not overintegrating.

This shouldn't be merged until we've run as many apps through it was we can to see how much hassle there will be.