### PR TITLE
Use an actual tree search for candidate_elements

### DIFF
--- a/include/utils/tree.h
+++ b/include/utils/tree.h
@@ -87,6 +87,17 @@ public:
                                     Real relative_tol = TOLERANCE) const override;
 
   /**
+   * Fills \p candidate_elements with any elements containing the
+   * specified point \p p,
+   * optionally restricted to a set of allowed subdomains,
+   * optionally using a non-zero relative tolerance for searches.
+   */
+  virtual void find_elements(const Point & p,
+                             std::set<const Elem *> & candidate_elements,
+                             const std::set<subdomain_id_type> * allowed_subdomains = nullptr,
+                             Real relative_tol = TOLERANCE) const override;
+
+  /**
    * \returns A pointer to the element containing point p,
    * optionally restricted to a set of allowed subdomains,
    * optionally using a non-zero relative tolerance for searches.

--- a/include/utils/tree_base.h
+++ b/include/utils/tree_base.h
@@ -101,6 +101,18 @@ public:
                                     const std::set<subdomain_id_type> * allowed_subdomains = nullptr,
                                     Real relative_tol = TOLERANCE) const = 0;
 
+  /**
+   * Fills \p candidate_elements with any elements containing the
+   * specified point \p p,
+   * optionally restricted to a set of allowed subdomains,
+   * optionally using a non-default relative tolerance for searches.
+   */
+  virtual void find_elements(const Point & p,
+                             std::set<const Elem *> & candidate_elements,
+                             const std::set<subdomain_id_type> * allowed_subdomains = nullptr,
+                             Real relative_tol = TOLERANCE) const = 0;
+
+
 protected:
 
   /**

--- a/include/utils/tree_node.h
+++ b/include/utils/tree_node.h
@@ -161,6 +161,16 @@ public:
                              const std::set<subdomain_id_type> * allowed_subdomains = nullptr,
                              Real relative_tol = TOLERANCE) const;
 
+  /**
+   * Fills \p candidate_elements with any elements containing the
+   * specified point \p p,
+   * optionally restricted to a set of allowed subdomains,
+   * optionally using a non-default relative tolerance for searches.
+   */
+  void find_elements (const Point & p,
+                      std::set<const Elem *> & candidate_elements,
+                      const std::set<subdomain_id_type> * allowed_subdomains = nullptr,
+                      Real relative_tol = TOLERANCE) const;
 
 private:
   /**
@@ -170,6 +180,15 @@ private:
   const Elem * find_element_in_children (const Point & p,
                                          const std::set<subdomain_id_type> * allowed_subdomains,
                                          Real relative_tol) const;
+
+  /**
+   * Look for points in our children,
+   * optionally restricted to a set of allowed subdomains.
+   */
+  void find_elements_in_children (const Point & p,
+                                  std::set<const Elem *> & candidate_elements,
+                                  const std::set<subdomain_id_type> * allowed_subdomains,
+                                  Real relative_tol) const;
 
   /**
    * Constructs the bounding box for child \p c.

--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -261,8 +261,8 @@ void PointLocatorTree::operator() (const Point & p,
 
   LOG_SCOPE("operator() - Version 2", "PointLocatorTree");
 
-  // forward call to perform_linear_search
-  candidate_elements = this->perform_fuzzy_linear_search(p, allowed_subdomains, _close_to_point_tol);
+  // ask the tree
+  this->_tree->find_elements (p, candidate_elements, allowed_subdomains, _close_to_point_tol);
 }
 
 

--- a/src/utils/tree.C
+++ b/src/utils/tree.C
@@ -146,6 +146,18 @@ Tree<N>::find_element (const Point & p,
 
 
 template <unsigned int N>
+void
+Tree<N>::find_elements (const Point & p,
+                        std::set<const Elem *> & candidate_elements,
+                        const std::set<subdomain_id_type> * allowed_subdomains,
+                        Real relative_tol) const
+{
+  return root.find_elements(p, candidate_elements, allowed_subdomains, relative_tol);
+}
+
+
+
+template <unsigned int N>
 const Elem *
 Tree<N>::operator() (const Point & p,
                      const std::set<subdomain_id_type> * allowed_subdomains,

--- a/src/utils/tree_node.C
+++ b/src/utils/tree_node.C
@@ -545,6 +545,30 @@ TreeNode<N>::find_element (const Point & p,
 
 
 
+template <unsigned int N>
+void
+TreeNode<N>::find_elements (const Point & p,
+                            std::set<const Elem *> & candidate_elements,
+                            const std::set<subdomain_id_type> * allowed_subdomains,
+                            Real relative_tol) const
+{
+  if (this->active())
+    {
+      // Only check our children if the point is in our bounding box
+      // or if the node contains infinite elements
+      if (this->bounds_point(p, relative_tol) || this->contains_ifems)
+        // Search the active elements in the active TreeNode.
+        for (const auto & elem : elements)
+          if (!allowed_subdomains || allowed_subdomains->count(elem->subdomain_id()))
+            if (elem->active() && elem->contains_point(p, relative_tol))
+              candidate_elements.insert(elem);
+    }
+  else
+    this->find_elements_in_children(p, candidate_elements,
+                                    allowed_subdomains, relative_tol);
+}
+
+
 
 template <unsigned int N>
 const Elem * TreeNode<N>::find_element_in_children (const Point & p,
@@ -598,6 +622,24 @@ const Elem * TreeNode<N>::find_element_in_children (const Point & p,
   // success.  So, we should return nullptr since at this point
   // _no_ elements in the tree claim to contain point p.
   return nullptr;
+}
+
+
+
+template <unsigned int N>
+void TreeNode<N>::find_elements_in_children (const Point & p,
+                                             std::set<const Elem *> & candidate_elements,
+                                             const std::set<subdomain_id_type> * allowed_subdomains,
+                                             Real relative_tol) const
+{
+  libmesh_assert (!this->active());
+
+  // First only look in the children whose bounding box
+  // contain the point p.
+  for (std::size_t c=0; c<children.size(); c++)
+    if (children[c]->bounds_point(p, relative_tol))
+      children[c]->find_elements(p, candidate_elements,
+                                 allowed_subdomains, relative_tol);
 }
 
 


### PR DESCRIPTION
Ideally, this will greatly speed up problems with large numbers of
periodic boundaries (or of any other multiple-element point locator use
cases).

Less ideally, this will break someone's application horribly when it
turns out that we aren't handling _close_to_point_tol perfectly.  My own
tests haven't uncovered any such cases; hopefully CI will if they exist.

I think *this* ought to be the real fix for #2369; hopefully @lindsayad can see if it does anything for the slow case there.