### PR TITLE
ExodusII_IO: Respect _output_variables variable 

### DIFF
--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1141,8 +1141,8 @@ void ExodusII_IO::write_nodal_data (const std::string & fname,
     output_names = names;
 
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS
-
-  std::vector<std::string> complex_names = exio_helper->get_complex_names(names);
+  std::vector<std::string> complex_names =
+    exio_helper->get_complex_names(output_names);
 
   // Call helper function for opening/initializing data, giving it the
   // complex variable names


### PR DESCRIPTION
Previously, when `LIBMESH_USE_COMPLEX_NUMBERS==1`, we just plotted all variables as nodal, including doing the averaging of complex-valued elemental variables, regardless of the contents of `_output_variables`.
