### PR TITLE
ParMETIS needs METIS

### DIFF
--- a/configure
+++ b/configure
@@ -38712,6 +38712,7 @@ ac_config_files="$ac_config_files contrib/metis/Makefile"
 # -------------------------------------------------------------
 # Parmetis Partitioning -- enabled by default
 # -------------------------------------------------------------
+if test $enablemetis = yes; then :
 
   # Check whether --enable-parmetis was given.
 if test "${enable_parmetis+set}" = set; then :
@@ -38788,6 +38789,9 @@ fi
 
 
 
+else
+  enableparmetis=no
+fi
 if test $enableparmetis = yes; then :
   libmesh_contrib_INCLUDES="$PARMETIS_INCLUDE $libmesh_contrib_INCLUDES"
 fi

--- a/m4/libmesh_optional_packages.m4
+++ b/m4/libmesh_optional_packages.m4
@@ -401,7 +401,9 @@ AC_CONFIG_FILES([contrib/metis/Makefile])
 # -------------------------------------------------------------
 # Parmetis Partitioning -- enabled by default
 # -------------------------------------------------------------
-CONFIGURE_PARMETIS
+AS_IF([test $enablemetis = yes],
+      [CONFIGURE_PARMETIS],
+      [enableparmetis=no])
 AS_IF([test $enableparmetis = yes],
       [libmesh_contrib_INCLUDES="$PARMETIS_INCLUDE $libmesh_contrib_INCLUDES"])
 AM_CONDITIONAL(LIBMESH_ENABLE_PARMETIS, test x$enableparmetis = xyes)


### PR DESCRIPTION
Just configuring with --disable-metis currently fails at build time when the ParMETIS build includes parmetis.h and it can't find metis.h.  Instead, if we're asked to build without METIS we should always build without ParMETIS too.