### PR TITLE
Use relative URL for TIMPI submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = ../../roystgnr/MetaPhysicL
 [submodule "contrib/timpi"]
 	path = contrib/timpi
-	url = git@github.com:libMesh/TIMPI
+	url = ../../libMesh/TIMPI


### PR DESCRIPTION
Technically we could use a single ../ but I think this helps make it
more clear that the TIMPI repo is located under the libMesh project.

If you already pulled a version with the previous URL, you may need to
run the command:

git submodule sync contrib/timpi

in order for the URL update to take effect.

Refs #2386.