### PR TITLE
RB Change: Add support for POD training in RBConstruction

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex1/reduced_basis_ex1.C
+++ b/examples/reduced_basis/reduced_basis_ex1/reduced_basis_ex1.C
@@ -116,6 +116,10 @@ int main (int argc, char ** argv)
   if (command_line.search(1, "-online_mode"))
     online_mode = command_line.next(online_mode);
 
+  int use_POD_training = 0;
+  if (command_line.search(1, "-use_POD_training"))
+    use_POD_training = command_line.next(use_POD_training);
+
   // Build a mesh on the default MPI communicator.
   Mesh mesh (init.comm(), dim);
   MeshTools::Generation::build_square (mesh,

--- a/examples/reduced_basis/reduced_basis_ex1/reduced_basis_ex1.in
+++ b/examples/reduced_basis/reduced_basis_ex1/reduced_basis_ex1.in
@@ -21,3 +21,5 @@ deterministic_training = true        # Are the training points generated randoml
 use_relative_bound_in_greedy = false # Do we use a relative or absolute error bound when training the RB space?
 
 n_training_samples = 100    # The number of parameters in training set (must be square for the 2-parameter deterministic case)
+
+RB_training_type = Greedy # Specify "Greedy" or "POD"


### PR DESCRIPTION
Proper Othogonal Decompositoin (POD) provides an alternative method for training a reduced basis space. Here we add support for POD as an alternative (non-default) approach.

It can be tested with reduced_basis_ex1 by setting `RB_training_type = POD` in reduced_basis_ex1.in.