### PR TITLE
Fixes for PETSc errors, PETSc without mpi

### DIFF
--- a/include/numerics/petsc_solver_exception.h
+++ b/include/numerics/petsc_solver_exception.h
@@ -50,7 +50,9 @@ public:
     // This is one scenario where we don't catch the error code
     // returned by a PETSc function :)
     PetscErrorMessage(error_code, &text, nullptr);
-    what_message = text;
+
+    if (text)
+      what_message = text;
   }
 };
 

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -499,7 +499,12 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
     {
       int ierr=0;
 
+#ifdef LIBMESH_HAVE_MPI
       PETSC_COMM_WORLD = libMesh::GLOBAL_COMM_WORLD;
+#else
+      // PETSc --with-mpi=0 doesn't like our default "communicator" 0
+      this->_comm->get() = PETSC_COMM_SELF;
+#endif
 
       // Check whether the calling program has already initialized
       // PETSc, and avoid duplicate Initialize/Finalize


### PR DESCRIPTION
The errors I was seeing on some routine tests looked a little like errors a user reported several years ago: https://sourceforge.net/p/libmesh/mailman/message/31008444/

But *now* for some reason I was able to (inadvertently) replicate the errors and fix them.