### PR TITLE
Add ability to set a tolerance for point containment in the point_locator_tree

### DIFF
--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -176,19 +176,19 @@ public:
    * Set a tolerance to use when checking
    * if a point is within an element in the mesh.
    */
-  virtual void set_find_element_tol(Real find_element_tol);
+  virtual void set_contains_point_tol(Real contains_point_tol);
 
   /**
    * Specify that we do not want to use a user-specified tolerance to
    * determine if a point is inside an element in the mesh.
    */
-  virtual void unset_find_element_tol();
+  virtual void unset_contains_point_tol();
 
   /**
    * Get the tolerance for determining element containment
    * in the point locator.
    */
-  virtual Real get_find_element_tol() const;
+  virtual Real get_contains_point_tol() const;
 
   /**
    * Get a const reference to this PointLocator's mesh.
@@ -233,12 +233,12 @@ protected:
    * \p true if we will use a user-specified tolerance for locating
    * the element.
    */
-  bool _use_find_element_tol;
+  bool _use_contains_point_tol;
 
   /**
    * The tolerance to use when locating an element in the tree.
    */
-  Real _find_element_tol;
+  Real _contains_point_tol;
 };
 
 } // namespace libMesh

--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -173,6 +173,24 @@ public:
   virtual void unset_close_to_point_tol();
 
   /**
+   * Set a tolerance to use when checking
+   * if a point is within an element in the mesh.
+   */
+  virtual void set_find_element_tol(Real find_element_tol);
+
+  /**
+   * Specify that we do not want to use a user-specified tolerance to
+   * determine if a point is inside an element in the mesh.
+   */
+  virtual void unset_find_element_tol();
+
+  /**
+   * Get the tolerance for determining element containment
+   * in the point locator.
+   */
+  virtual Real get_find_element_tol() const;
+
+  /**
    * Get a const reference to this PointLocator's mesh.
    */
   const MeshBase & get_mesh() const;
@@ -202,7 +220,7 @@ protected:
 
   /**
    * \p true if we will use a user-specified tolerance for locating
-   * the element.
+   * the element in an exhaustive search.
    */
   bool _use_close_to_point_tol;
 
@@ -210,6 +228,17 @@ protected:
    * The tolerance to use.
    */
   Real _close_to_point_tol;
+
+  /**
+   * \p true if we will use a user-specified tolerance for locating
+   * the element.
+   */
+  bool _use_find_element_tol;
+
+  /**
+   * The tolerance to use when locating an element in the tree.
+   */
+  Real _find_element_tol;
 };
 
 } // namespace libMesh

--- a/src/utils/point_locator_base.C
+++ b/src/utils/point_locator_base.C
@@ -95,13 +95,27 @@ void PointLocatorBase::set_close_to_point_tol (Real close_to_point_tol)
   _close_to_point_tol = close_to_point_tol;
 }
 
-
 void PointLocatorBase::unset_close_to_point_tol ()
 {
   _use_close_to_point_tol = false;
   _close_to_point_tol = TOLERANCE;
 }
 
+void PointLocatorBase::set_find_element_tol(Real find_element_tol)
+{
+  _use_find_element_tol = true;
+  _find_element_tol = find_element_tol;
+}
+
+void PointLocatorBase::unset_find_element_tol()
+{
+  _use_find_element_tol = false;
+  _find_element_tol = TOLERANCE;
+}
+
+Real PointLocatorBase::get_find_element_tol() const {
+    return _find_element_tol;
+}
 
 const MeshBase & PointLocatorBase::get_mesh () const
 {

--- a/src/utils/point_locator_base.C
+++ b/src/utils/point_locator_base.C
@@ -38,7 +38,9 @@ PointLocatorBase::PointLocatorBase (const MeshBase & mesh,
   _mesh                    (mesh),
   _initialized             (false),
   _use_close_to_point_tol  (false),
-  _close_to_point_tol      (TOLERANCE)
+  _use_contains_point_tol  (false),
+  _close_to_point_tol      (TOLERANCE),
+  _contains_point_tol      (TOLERANCE)
 {
   // If we have a non-nullptr master, inherit its close-to-point tolerances.
   if (_master)

--- a/src/utils/point_locator_base.C
+++ b/src/utils/point_locator_base.C
@@ -101,20 +101,20 @@ void PointLocatorBase::unset_close_to_point_tol ()
   _close_to_point_tol = TOLERANCE;
 }
 
-void PointLocatorBase::set_find_element_tol(Real find_element_tol)
+void PointLocatorBase::set_contains_point_tol(Real contains_point_tol)
 {
-  _use_find_element_tol = true;
-  _find_element_tol = find_element_tol;
+  _use_contains_point_tol = true;
+  _contains_point_tol = contains_point_tol;
 }
 
-void PointLocatorBase::unset_find_element_tol()
+void PointLocatorBase::unset_contains_point_tol()
 {
-  _use_find_element_tol = false;
-  _find_element_tol = TOLERANCE;
+  _use_contains_point_tol = false;
+  _contains_point_tol = TOLERANCE;
 }
 
-Real PointLocatorBase::get_find_element_tol() const {
-    return _find_element_tol;
+Real PointLocatorBase::get_contains_point_tol() const {
+    return _contains_point_tol;
 }
 
 const MeshBase & PointLocatorBase::get_mesh () const

--- a/src/utils/point_locator_base.C
+++ b/src/utils/point_locator_base.C
@@ -38,8 +38,8 @@ PointLocatorBase::PointLocatorBase (const MeshBase & mesh,
   _mesh                    (mesh),
   _initialized             (false),
   _use_close_to_point_tol  (false),
-  _use_contains_point_tol  (false),
   _close_to_point_tol      (TOLERANCE),
+  _use_contains_point_tol  (false),
   _contains_point_tol      (TOLERANCE)
 {
   // If we have a non-nullptr master, inherit its close-to-point tolerances.

--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -207,10 +207,10 @@ const Elem * PointLocatorTree::operator() (const Point & p,
   if (this->_element==nullptr || !(this->_element->contains_point(p)))
     {
       // ask the tree
-      if (_use_find_element_tol) {
-        this->_element = this->_tree->find_element (p, allowed_subdomains, _find_element_tol);
+      if (_use_contains_point_tol) {
+        this->_element = this->_tree->find_element(p, allowed_subdomains, _contains_point_tol);
       } else {
-        this->_element = this->_tree->find_element (p, allowed_subdomains);
+        this->_element = this->_tree->find_element(p, allowed_subdomains);
       }
 
       if (this->_element == nullptr)
@@ -278,10 +278,6 @@ const Elem * PointLocatorTree::perform_linear_search(const Point & p,
 {
   LOG_SCOPE("perform_linear_search", "PointLocatorTree");
 
-  if (use_close_to_point) {
-    return perform_linear_search(p, allowed_subdomains, close_to_point_tolerance);
-  }
-
   // The type of iterator depends on the Trees::BuildType
   // used for this PointLocator.  If it's
   // TREE_LOCAL_ELEMENTS, we only want to double check
@@ -296,7 +292,16 @@ const Elem * PointLocatorTree::perform_linear_search(const Point & p,
       if (!allowed_subdomains ||
           allowed_subdomains->count(elem->subdomain_id()))
         {
-          if (elem->contains_point(p)) { return elem; }
+          if (!use_close_to_point)
+            {
+              if (elem->contains_point(p, _contains_point_tol))
+                return elem;
+            }
+          else
+            {
+              if (elem->close_to_point(p, close_to_point_tolerance))
+                return elem;
+            }
         }
     }
 

--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -229,7 +229,7 @@ const Elem * PointLocatorTree::operator() (const Point & p,
               this->_element =
                 this->perform_linear_search(p,
                                             allowed_subdomains,
-                                            true,
+                                            /*use_close_to_point*/ true,
                                             _close_to_point_tol);
 
               return this->_element;
@@ -294,7 +294,8 @@ const Elem * PointLocatorTree::perform_linear_search(const Point & p,
         {
           if (!use_close_to_point)
             {
-              if (elem->contains_point(p, _contains_point_tol)) { return elem; }
+              if (elem->contains_point(p, _contains_point_tol))
+                return elem;
             }
           else
             {

--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -294,8 +294,7 @@ const Elem * PointLocatorTree::perform_linear_search(const Point & p,
         {
           if (!use_close_to_point)
             {
-              if (elem->contains_point(p, _contains_point_tol))
-                return elem;
+              if (elem->contains_point(p, _contains_point_tol)) { return elem; }
             }
           else
             {

--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -207,7 +207,11 @@ const Elem * PointLocatorTree::operator() (const Point & p,
   if (this->_element==nullptr || !(this->_element->contains_point(p)))
     {
       // ask the tree
-      this->_element = this->_tree->find_element (p,allowed_subdomains);
+      if (_use_find_element_tol) {
+        this->_element = this->_tree->find_element (p, allowed_subdomains, _find_element_tol);
+      } else {
+        this->_element = this->_tree->find_element (p, allowed_subdomains);
+      }
 
       if (this->_element == nullptr)
         {
@@ -225,7 +229,7 @@ const Elem * PointLocatorTree::operator() (const Point & p,
               this->_element =
                 this->perform_linear_search(p,
                                             allowed_subdomains,
-                                            /*use_close_to_point*/ true,
+                                            true,
                                             _close_to_point_tol);
 
               return this->_element;
@@ -274,6 +278,10 @@ const Elem * PointLocatorTree::perform_linear_search(const Point & p,
 {
   LOG_SCOPE("perform_linear_search", "PointLocatorTree");
 
+  if (use_close_to_point) {
+    return perform_linear_search(p, allowed_subdomains, close_to_point_tolerance);
+  }
+
   // The type of iterator depends on the Trees::BuildType
   // used for this PointLocator.  If it's
   // TREE_LOCAL_ELEMENTS, we only want to double check
@@ -288,16 +296,7 @@ const Elem * PointLocatorTree::perform_linear_search(const Point & p,
       if (!allowed_subdomains ||
           allowed_subdomains->count(elem->subdomain_id()))
         {
-          if (!use_close_to_point)
-            {
-              if (elem->contains_point(p))
-                return elem;
-            }
-          else
-            {
-              if (elem->close_to_point(p, close_to_point_tolerance))
-                return elem;
-            }
+          if (elem->contains_point(p)) { return elem; }
         }
     }
 


### PR DESCRIPTION
@friedmud and I were looking at the settings for the point_locator tree and noticed that for the `find_element` call, the tolerance for finding points is always the default `TOLERANCE` value. These changes add the ability to set the tolerance for point containment in the tree search for applications that require a lower tolerance than the default.

First libmesh PR, so let me know if there's anything I'm missing.