### PR TITLE
Create parallel backing vector for DiagonalMatrix

### DIFF
--- a/include/numerics/diagonal_matrix.h
+++ b/include/numerics/diagonal_matrix.h
@@ -80,7 +80,7 @@ public:
             const numeric_index_type noz = 10,
             const numeric_index_type blocksize = 1) override;
 
-  void init() override;
+  void init(ParallelType type = PARALLEL) override;
 
   /**
    * Initialize with a NumericVector \p other, e.g. duplicate the storage

--- a/include/numerics/eigen_sparse_matrix.h
+++ b/include/numerics/eigen_sparse_matrix.h
@@ -91,7 +91,7 @@ public:
                      const numeric_index_type noz=10,
                      const numeric_index_type blocksize=1) override;
 
-  virtual void init () override;
+  virtual void init (ParallelType = PARALLEL) override;
 
   virtual void clear () override;
 

--- a/include/numerics/laspack_matrix.h
+++ b/include/numerics/laspack_matrix.h
@@ -101,7 +101,7 @@ public:
                      const numeric_index_type noz=10,
                      const numeric_index_type blocksize=1) override;
 
-  virtual void init () override;
+  virtual void init (ParallelType = PARALLEL) override;
 
   virtual void clear () override;
 

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -151,7 +151,7 @@ public:
              const std::vector<numeric_index_type> & n_oz,
              const numeric_index_type blocksize=1);
 
-  virtual void init () override;
+  virtual void init (ParallelType = PARALLEL) override;
 
   /**
    * Update the sparsity pattern based on \p dof_map, and set the matrix

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -27,6 +27,7 @@
 #include "libmesh/id_types.h"
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/parallel_object.h"
+#include "libmesh/enum_parallel_type.h"
 
 // C++ includes
 #include <cstddef>
@@ -149,8 +150,9 @@ public:
 
   /**
    * Initialize this matrix using the sparsity structure computed by \p dof_map.
+   * @param type The serial/parallel/ghosted type of the matrix
    */
-  virtual void init () = 0;
+  virtual void init (ParallelType type = PARALLEL) = 0;
 
   /**
    * Restores the \p SparseMatrix<T> to a pristine state.

--- a/include/numerics/trilinos_epetra_matrix.h
+++ b/include/numerics/trilinos_epetra_matrix.h
@@ -118,7 +118,7 @@ public:
                      const numeric_index_type noz=10,
                      const numeric_index_type blocksize=1) override;
 
-  virtual void init () override;
+  virtual void init (ParallelType = PARALLEL) override;
 
   virtual void clear () override;
 

--- a/src/numerics/diagonal_matrix.C
+++ b/src/numerics/diagonal_matrix.C
@@ -64,11 +64,14 @@ DiagonalMatrix<T>::init(const numeric_index_type m,
 
 template <typename T>
 void
-DiagonalMatrix<T>::init()
+DiagonalMatrix<T>::init(const ParallelType type)
 {
   libmesh_assert(this->_dof_map);
 
-  _diagonal->init(this->_dof_map->n_dofs(), this->_dof_map->n_dofs_on_processor(this->processor_id()));
+  _diagonal->init(this->_dof_map->n_dofs(),
+                  this->_dof_map->n_dofs_on_processor(this->processor_id()),
+                  /*fast=*/false,
+                  type);
 }
 
 template <typename T>

--- a/src/numerics/diagonal_matrix.C
+++ b/src/numerics/diagonal_matrix.C
@@ -68,7 +68,7 @@ DiagonalMatrix<T>::init()
 {
   libmesh_assert(this->_dof_map);
 
-  _diagonal->init(this->_dof_map->n_dofs());
+  _diagonal->init(this->_dof_map->n_dofs(), this->_dof_map->n_dofs_on_processor(this->processor_id()));
 }
 
 template <typename T>

--- a/src/numerics/eigen_sparse_matrix.C
+++ b/src/numerics/eigen_sparse_matrix.C
@@ -60,7 +60,7 @@ void EigenSparseMatrix<T>::init (const numeric_index_type m_in,
 
 
 template <typename T>
-void EigenSparseMatrix<T>::init ()
+void EigenSparseMatrix<T>::init (const ParallelType)
 {
   // Ignore calls on initialized objects
   if (this->initialized())

--- a/src/numerics/laspack_matrix.C
+++ b/src/numerics/laspack_matrix.C
@@ -144,7 +144,7 @@ void LaspackMatrix<T>::init (const numeric_index_type libmesh_dbg_var(m_in),
 
 
 template <typename T>
-void LaspackMatrix<T>::init ()
+void LaspackMatrix<T>::init (const ParallelType)
 {
   // Ignore calls on initialized objects
   if (this->initialized())

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -355,7 +355,7 @@ void PetscMatrix<T>::init (const numeric_index_type m_in,
 
 
 template <typename T>
-void PetscMatrix<T>::init ()
+void PetscMatrix<T>::init (const ParallelType)
 {
   libmesh_assert(this->_dof_map);
 

--- a/src/numerics/trilinos_epetra_matrix.C
+++ b/src/numerics/trilinos_epetra_matrix.C
@@ -174,7 +174,7 @@ void EpetraMatrix<T>::init (const numeric_index_type m,
 
 
 template <typename T>
-void EpetraMatrix<T>::init ()
+void EpetraMatrix<T>::init (const ParallelType)
 {
   libmesh_assert(this->_dof_map);
 

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -137,7 +137,7 @@ void ImplicitSystem::init_matrices ()
 
   // Initialize matrices
   for (auto & pr : _matrices)
-    pr.second->init ();
+    pr.second->init (_matrix_types[pr.first]);
 
   // Set the additional matrices to 0.
   for (auto & pr : _matrices)
@@ -199,7 +199,8 @@ void ImplicitSystem::assemble ()
 
 
 
-SparseMatrix<Number> & ImplicitSystem::add_matrix (const std::string & mat_name)
+SparseMatrix<Number> & ImplicitSystem::add_matrix (const std::string & mat_name,
+                                                   const ParallelType type)
 {
   // only add matrices before initializing...
   if (!_can_add_matrices)
@@ -213,6 +214,7 @@ SparseMatrix<Number> & ImplicitSystem::add_matrix (const std::string & mat_name)
   // Otherwise build the matrix and return it.
   SparseMatrix<Number> * buf = SparseMatrix<Number>::build(this->comm()).release();
   _matrices.emplace(mat_name, buf);
+  _matrix_types.emplace(mat_name, type);
 
   return *buf;
 }


### PR DESCRIPTION
Before I was calling the backing NumericVector init method with just a global N argument which lead to creation of a serial vector. Now I pass an additional argument corresponding to the local size (taken from the DofMap) that will automatically create a parallel vector when the global size and the local size are different.

EDIT: The first change was not enough. https://github.com/libMesh/libmesh/pull/2410/commits/1f4a32dd8c58d21dc5bec6cb448f3e3611ed9962 alone is susceptible to a corner case where a proc owns all dofs. In that case that proc would create a `SERIAL` type while all other procs would create a `PARALLEL` type, leading to hangs at the first attempted communication. So https://github.com/libMesh/libmesh/pull/2410/commits/b74f36e47f4f86c5d280ce3c7c2f64d2f821b50b mirrors what is done for System::add_vector. We also keep track of the matrix types in a _matrix_types data member. This also adds ParallelType as a default argument to the formerly zero arg SparseMatrix::init method. For almost all concrete SparseMatrix data types this parameter will be unused, but its useful for DiagonalMatrix and it could be useful for other derived matrix types in the future as it is useful for vectors now.