### PR TITLE
Fix syntax error in reduced_basis ex7.

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex7/reduced_basis_ex7.C
+++ b/examples/reduced_basis/reduced_basis_ex7/reduced_basis_ex7.C
@@ -98,6 +98,7 @@ int main (int argc, char** argv)
                    << std::endl;
       return 77;
    }
+  input.search("-pc_factor_mat_solver_package");
 #else
   if (input.search("-pc_factor_mat_solver_package"))
     {
@@ -106,11 +107,12 @@ int main (int argc, char** argv)
                    << std::endl;
       return 77;
     }
+  input.search("-pc_factor_mat_solver_type");
 #endif
 
   // check that we have the required solver:
   std::string solver;
-  solver = input.next(solver);
+  solver = input.next("invalid_solver");
   if (solver == "mumps")
   {
 #ifndef LIBMESH_PETSC_HAVE_MUMPS

--- a/examples/reduced_basis/reduced_basis_ex7/run.sh
+++ b/examples/reduced_basis/reduced_basis_ex7/run.sh
@@ -20,7 +20,7 @@ example_dir=examples/reduced_basis/$example_name
 # both options and skip the runs with incompatible arguments.
 
 options="-online_mode 0 -ksp_type preonly -pc_type lu"
-for solver in "-pc_factor_mat_solver_type mumps" "-pc_factor_mat_solver_package mumps" #"-pc_factor_mat_solver_type superlu" "-pc_factor_mat_solver_package superlu"
+for solver in "-pc_factor_mat_solver_type mumps" "-pc_factor_mat_solver_package mumps" "-pc_factor_mat_solver_type superlu" "-pc_factor_mat_solver_package superlu"
 do
    run_example_no_extra_options "$example_name" "$options $solver"
 


### PR DESCRIPTION
I just found this error (I think I introduced it myself)...
I think, it should usually if not always fail to run with ``Error: Solver  is unknown``.

So I used the chance to also try for hypre-solver; I hope, this does not break in case of some other configuration.