### PR TITLE
Adjust order in  LIBMESH_ASSERT_FP_EQUAL

### DIFF
--- a/tests/fe/fe_test.h
+++ b/tests/fe/fe_test.h
@@ -340,19 +340,19 @@ public:
 
             if (family == RATIONAL_BERNSTEIN && order > 1)
               LIBMESH_ASSERT_FP_EQUAL
-                (libmesh_real(u),
-                 libmesh_real(rational_test(p, dummy, "", "")),
+                (libmesh_real(rational_test(p, dummy, "", "")),
+                 libmesh_real(u),
                  value_tol);
             else if (order > 1)
               LIBMESH_ASSERT_FP_EQUAL
-                (libmesh_real(u),
-                 libmesh_real(x*x + 0.5*y*y + 0.25*z*z + 0.125*x*y +
+                (libmesh_real(x*x + 0.5*y*y + 0.25*z*z + 0.125*x*y +
                               0.0625*x*z + 0.03125*y*z),
+                 libmesh_real(u),
                  value_tol);
             else
               LIBMESH_ASSERT_FP_EQUAL
-                (libmesh_real(u),
-                 libmesh_real(x + 0.25*y + 0.0625*z),
+                (libmesh_real(x + 0.25*y + 0.0625*z),
+                 libmesh_real(u),
                  value_tol);
           }
 #endif
@@ -420,24 +420,24 @@ public:
                 const Real & y = (LIBMESH_DIM > 1) ? p(1) : 0;
                 const Real & z = (LIBMESH_DIM > 2) ? p(2) : 0;
 
-                LIBMESH_ASSERT_FP_EQUAL(libmesh_real(grad_u(0)), 2*x+0.125*y+0.0625*z,
+                LIBMESH_ASSERT_FP_EQUAL(2*x+0.125*y+0.0625*z, libmesh_real(grad_u(0)),
                                         grad_tol);
                 if (_dim > 1)
-                  LIBMESH_ASSERT_FP_EQUAL(libmesh_real(grad_u(1)), y+0.125*x+0.03125*z,
+                  LIBMESH_ASSERT_FP_EQUAL(y+0.125*x+0.03125*z, libmesh_real(grad_u(1)),
                                           grad_tol);
                 if (_dim > 2)
-                  LIBMESH_ASSERT_FP_EQUAL(libmesh_real(grad_u(2)), 0.5*z+0.0625*x+0.03125*y,
+                  LIBMESH_ASSERT_FP_EQUAL(0.5*z+0.0625*x+0.03125*y, libmesh_real(grad_u(2)),
                                           grad_tol);
               }
             else
               {
-                LIBMESH_ASSERT_FP_EQUAL(libmesh_real(grad_u(0)), 1.0,
+                LIBMESH_ASSERT_FP_EQUAL(1.0, libmesh_real(grad_u(0)),
                                         grad_tol);
                 if (_dim > 1)
-                  LIBMESH_ASSERT_FP_EQUAL(libmesh_real(grad_u(1)), 0.25,
+                  LIBMESH_ASSERT_FP_EQUAL(0.25, libmesh_real(grad_u(1)),
                                           grad_tol);
                 if (_dim > 2)
-                  LIBMESH_ASSERT_FP_EQUAL(libmesh_real(grad_u(2)), 0.0625,
+                  LIBMESH_ASSERT_FP_EQUAL(0.0625, libmesh_real(grad_u(2)),
                                           grad_tol);
               }
           }
@@ -514,24 +514,24 @@ public:
                 const Real & y = (LIBMESH_DIM > 1) ? p(1) : 0;
                 const Real & z = (LIBMESH_DIM > 2) ? p(2) : 0;
 
-                LIBMESH_ASSERT_FP_EQUAL(libmesh_real(grad_u_x), 2*x+0.125*y+0.0625*z,
+                LIBMESH_ASSERT_FP_EQUAL(2*x+0.125*y+0.0625*z, libmesh_real(grad_u_x),
                                         grad_tol);
                 if (_dim > 1)
-                  LIBMESH_ASSERT_FP_EQUAL(libmesh_real(grad_u_y), y+0.125*x+0.03125*z,
+                  LIBMESH_ASSERT_FP_EQUAL(y+0.125*x+0.03125*z, libmesh_real(grad_u_y),
                                           grad_tol);
                 if (_dim > 2)
-                  LIBMESH_ASSERT_FP_EQUAL(libmesh_real(grad_u_z), 0.5*z+0.0625*x+0.03125*y,
+                  LIBMESH_ASSERT_FP_EQUAL(0.5*z+0.0625*x+0.03125*y, libmesh_real(grad_u_z),
                                           grad_tol);
               }
             else
               {
-                LIBMESH_ASSERT_FP_EQUAL(libmesh_real(grad_u_x), 1.0,
+                LIBMESH_ASSERT_FP_EQUAL(1.0, libmesh_real(grad_u_x),
                                         grad_tol);
                 if (_dim > 1)
-                  LIBMESH_ASSERT_FP_EQUAL(libmesh_real(grad_u_y), 0.25,
+                  LIBMESH_ASSERT_FP_EQUAL(0.25, libmesh_real(grad_u_y),
                                           grad_tol);
                 if (_dim > 2)
-                  LIBMESH_ASSERT_FP_EQUAL(libmesh_real(grad_u_z), 0.0625,
+                  LIBMESH_ASSERT_FP_EQUAL(0.0625, libmesh_real(grad_u_z),
                                           grad_tol);
               }
           }
@@ -589,15 +589,15 @@ public:
               }
             else if (order > 1)
               {
-                LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(0,0)), 2,
+                LIBMESH_ASSERT_FP_EQUAL(2, libmesh_real(hess_u(0,0)),
                                         hess_tol);
                 if (_dim > 1)
                   {
                     LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(0,1)), libmesh_real(hess_u(1,0)),
                                             hess_tol);
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(0,1)), 0.125,
+                    LIBMESH_ASSERT_FP_EQUAL(0.125, libmesh_real(hess_u(0,1)),
                                             hess_tol);
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(1,1)), 1,
+                    LIBMESH_ASSERT_FP_EQUAL(1, libmesh_real(hess_u(1,1)),
                                             hess_tol);
                   }
                 if (_dim > 2)
@@ -606,38 +606,38 @@ public:
                                             hess_tol);
                     LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(1,2)), libmesh_real(hess_u(2,1)),
                                             hess_tol);
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(0,2)), 0.0625,
+                    LIBMESH_ASSERT_FP_EQUAL(0.0625, libmesh_real(hess_u(0,2)),
                                             hess_tol);
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(1,2)), 0.03125,
+                    LIBMESH_ASSERT_FP_EQUAL(0.03125, libmesh_real(hess_u(1,2)),
                                             hess_tol);
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(2,2)), 0.5,
+                    LIBMESH_ASSERT_FP_EQUAL(0.5, libmesh_real(hess_u(2,2)),
                                             hess_tol);
                   }
               }
             else
               {
-                LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(0,0)), 0,
+                LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real(hess_u(0,0)),
                                         hess_tol);
                 if (_dim > 1)
                   {
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(0,1)), 0,
+                    LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real(hess_u(0,1)),
                                             hess_tol);
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(1,0)), 0,
+                    LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real(hess_u(1,0)),
                                             hess_tol);
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(1,1)), 0,
+                    LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real(hess_u(1,1)),
                                             hess_tol);
                   }
                 if (_dim > 2)
                   {
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(0,2)), 0,
+                    LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real(hess_u(0,2)),
                                             hess_tol);
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(1,2)), 0,
+                    LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real(hess_u(1,2)),
                                             hess_tol);
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(2,0)), 0,
+                    LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real(hess_u(2,0)),
                                             hess_tol);
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(2,1)), 0,
+                    LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real(hess_u(2,1)),
                                             hess_tol);
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(2,2)), 0,
+                    LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real(hess_u(2,2)),
                                             hess_tol);
                   }
               }
@@ -711,43 +711,43 @@ public:
               }
             else if (order > 1)
               {
-                LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u_xx), 2,
+                LIBMESH_ASSERT_FP_EQUAL(2, libmesh_real(hess_u_xx),
                                         hess_tol);
                 if (_dim > 1)
                   {
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u_xy), 0.125,
+                    LIBMESH_ASSERT_FP_EQUAL(0.125, libmesh_real(hess_u_xy),
                                             hess_tol);
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u_yy), 1,
+                    LIBMESH_ASSERT_FP_EQUAL(1, libmesh_real(hess_u_yy),
                                             hess_tol);
                   }
                 if (_dim > 2)
                   {
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u_xz), 0.0625,
-                                            hess_tol);
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u_yz), 0.03125,
-                                            hess_tol);
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u_zz), 0.5,
-                                            hess_tol);
+                    LIBMESH_ASSERT_FP_EQUAL( 0.0625, libmesh_real(hess_u_xz),
+                                             hess_tol);
+                    LIBMESH_ASSERT_FP_EQUAL( 0.03125, libmesh_real(hess_u_yz),
+                                             hess_tol);
+                    LIBMESH_ASSERT_FP_EQUAL( 0.5, libmesh_real(hess_u_zz),
+                                             hess_tol);
                   }
               }
             else
               {
-                LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u_xx), 0,
+                LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real(hess_u_xx),
                                         hess_tol);
                 if (_dim > 1)
                   {
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u_xy), 0,
+                    LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real(hess_u_xy),
                                             hess_tol);
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u_yy), 0,
+                    LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real(hess_u_yy),
                                             hess_tol);
                   }
                 if (_dim > 2)
                   {
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u_xz), 0,
+                    LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real(hess_u_xz),
                                             hess_tol);
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u_yz), 0,
+                    LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real(hess_u_yz),
                                             hess_tol);
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u_zz), 0,
+                    LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real(hess_u_zz),
                                             hess_tol);
                   }
               }

--- a/tests/fparser/autodiff.C
+++ b/tests/fparser/autodiff.C
@@ -163,9 +163,9 @@ public:
       for (a = -1.0; a < 1.0; a+=0.2642)
         for (y = -1.0; y < 1.0; y+=0.3156)
           {
-            LIBMESH_ASSERT_FP_EQUAL(R.Eval(p), x*a, 1.e-12);
-            LIBMESH_ASSERT_FP_EQUAL(dR.Eval(p), a+x*y, 1.e-12);
-            LIBMESH_ASSERT_FP_EQUAL(d2R.Eval(p), 2*y, 1.e-12);
+            LIBMESH_ASSERT_FP_EQUAL(x*a, R.Eval(p),  1.e-12);
+            LIBMESH_ASSERT_FP_EQUAL(a+x*y, dR.Eval(p), 1.e-12);
+            LIBMESH_ASSERT_FP_EQUAL(2*y, d2R.Eval(p), 1.e-12);
           }
   }
 
@@ -205,9 +205,9 @@ public:
       for (a = -1.0; a < 1.0; a+=0.2642)
         for (y = -1.0; y < 1.0; y+=0.3156)
           {
-            LIBMESH_ASSERT_FP_EQUAL(R.Eval(p), x*a, 1.e-12);
-            LIBMESH_ASSERT_FP_EQUAL(dR.Eval(p), a+x*a, 1.e-12);
-            LIBMESH_ASSERT_FP_EQUAL(d2R.Eval(p), 2*a+x*a, 1.e-12);
+            LIBMESH_ASSERT_FP_EQUAL(x*a, R.Eval(p), 1.e-12);
+            LIBMESH_ASSERT_FP_EQUAL(a+x*a, dR.Eval(p), 1.e-12);
+            LIBMESH_ASSERT_FP_EQUAL(2*a+x*a, d2R.Eval(p), 1.e-12);
           }
   }
 };

--- a/tests/geom/bbox_test.C
+++ b/tests/geom/bbox_test.C
@@ -219,28 +219,28 @@ public:
     BoundingBox unit(Point(0.,0.,0.), Point(1.,1.,1.));
 
     // Test points inside the box
-    LIBMESH_ASSERT_FP_EQUAL(unit.signed_distance(Point(0.5, 0.5, 0.5)), -0.5, TOLERANCE * TOLERANCE);
-    LIBMESH_ASSERT_FP_EQUAL(unit.signed_distance(Point(0.5, 0.6, 0.5)), -0.4, TOLERANCE * TOLERANCE);
-    LIBMESH_ASSERT_FP_EQUAL(unit.signed_distance(Point(0.4, 0.5, 0.5)), -0.4, TOLERANCE * TOLERANCE);
-    LIBMESH_ASSERT_FP_EQUAL(unit.signed_distance(Point(0.1, 0.1, 0.1)), -0.1, TOLERANCE * TOLERANCE);
+    LIBMESH_ASSERT_FP_EQUAL(-0.5, unit.signed_distance(Point(0.5, 0.5, 0.5)), TOLERANCE * TOLERANCE);
+    LIBMESH_ASSERT_FP_EQUAL(-0.4, unit.signed_distance(Point(0.5, 0.6, 0.5)), TOLERANCE * TOLERANCE);
+    LIBMESH_ASSERT_FP_EQUAL(-0.4, unit.signed_distance(Point(0.4, 0.5, 0.5)), TOLERANCE * TOLERANCE);
+    LIBMESH_ASSERT_FP_EQUAL(-0.1, unit.signed_distance(Point(0.1, 0.1, 0.1)), TOLERANCE * TOLERANCE);
 
     // Test points on the box
-    LIBMESH_ASSERT_FP_EQUAL(unit.signed_distance(Point(1.0, 0.5, 0.5)), 0., TOLERANCE * TOLERANCE);
-    LIBMESH_ASSERT_FP_EQUAL(unit.signed_distance(Point(1.0, 0., 0.)), 0., TOLERANCE * TOLERANCE);
+    LIBMESH_ASSERT_FP_EQUAL(0., unit.signed_distance(Point(1.0, 0.5, 0.5)), TOLERANCE * TOLERANCE);
+    LIBMESH_ASSERT_FP_EQUAL(0., unit.signed_distance(Point(1.0, 0., 0.)), TOLERANCE * TOLERANCE);
 
     // Test points outside the box
-    LIBMESH_ASSERT_FP_EQUAL(unit.signed_distance(Point(1.5, 0.5, 0.5)), 0.5, TOLERANCE * TOLERANCE);  // right
-    LIBMESH_ASSERT_FP_EQUAL(unit.signed_distance(Point(-0.5, 0.5, 0.5)), 0.5, TOLERANCE * TOLERANCE); // left
-    LIBMESH_ASSERT_FP_EQUAL(unit.signed_distance(Point(0.5, 0.5, 1.5)), 0.5, TOLERANCE * TOLERANCE);  // above
-    LIBMESH_ASSERT_FP_EQUAL(unit.signed_distance(Point(0.5, 0.5, -0.5)), 0.5, TOLERANCE * TOLERANCE); // below
-    LIBMESH_ASSERT_FP_EQUAL(unit.signed_distance(Point(0.5, -0.5, 0.5)), 0.5, TOLERANCE * TOLERANCE); // front
-    LIBMESH_ASSERT_FP_EQUAL(unit.signed_distance(Point(0.5, 1.5, 0.5)), 0.5, TOLERANCE * TOLERANCE);  // back
+    LIBMESH_ASSERT_FP_EQUAL(0.5, unit.signed_distance(Point(1.5, 0.5, 0.5)), TOLERANCE * TOLERANCE);  // right
+    LIBMESH_ASSERT_FP_EQUAL(0.5, unit.signed_distance(Point(-0.5, 0.5, 0.5)), TOLERANCE * TOLERANCE); // left
+    LIBMESH_ASSERT_FP_EQUAL(0.5, unit.signed_distance(Point(0.5, 0.5, 1.5)), TOLERANCE * TOLERANCE);  // above
+    LIBMESH_ASSERT_FP_EQUAL(0.5, unit.signed_distance(Point(0.5, 0.5, -0.5)), TOLERANCE * TOLERANCE); // below
+    LIBMESH_ASSERT_FP_EQUAL(0.5, unit.signed_distance(Point(0.5, -0.5, 0.5)), TOLERANCE * TOLERANCE); // front
+    LIBMESH_ASSERT_FP_EQUAL(0.5, unit.signed_distance(Point(0.5, 1.5, 0.5)), TOLERANCE * TOLERANCE);  // back
 
     // Outside the box, closest to a corner.
-    LIBMESH_ASSERT_FP_EQUAL(unit.signed_distance(Point(2., 2., 2.)), std::sqrt(Real(3)), TOLERANCE * TOLERANCE);    // Point along line (0,0,0) -> (1,1,1)
-    LIBMESH_ASSERT_FP_EQUAL(unit.signed_distance(Point(-1., -1., -1.)), std::sqrt(Real(3)), TOLERANCE * TOLERANCE); // Point along line (0,0,0) -> (1,1,1)
-    LIBMESH_ASSERT_FP_EQUAL(unit.signed_distance(Point(1.5, 1.5, -0.5)), std::sqrt(Real(3))/2., TOLERANCE * TOLERANCE); // Point along line (0.5,0.5,0.5) -> (1,1,0)
-    LIBMESH_ASSERT_FP_EQUAL(unit.signed_distance(Point(1.5, -0.5, -0.5)), std::sqrt(Real(3))/2., TOLERANCE * TOLERANCE); // Point along line (0.5,0.5,0.5) -> (1,0,0)
+    LIBMESH_ASSERT_FP_EQUAL(std::sqrt(Real(3)), unit.signed_distance(Point(2., 2., 2.)), TOLERANCE * TOLERANCE);    // Point along line (0,0,0) -> (1,1,1)
+    LIBMESH_ASSERT_FP_EQUAL(std::sqrt(Real(3)), unit.signed_distance(Point(-1., -1., -1.)), TOLERANCE * TOLERANCE); // Point along line (0,0,0) -> (1,1,1)
+    LIBMESH_ASSERT_FP_EQUAL(std::sqrt(Real(3))/2., unit.signed_distance(Point(1.5, 1.5, -0.5)), TOLERANCE * TOLERANCE); // Point along line (0.5,0.5,0.5) -> (1,1,0)
+    LIBMESH_ASSERT_FP_EQUAL(std::sqrt(Real(3))/2., unit.signed_distance(Point(1.5, -0.5, -0.5)), TOLERANCE * TOLERANCE); // Point along line (0.5,0.5,0.5) -> (1,0,0)
   }
 };
 

--- a/tests/libmesh_cppunit.h
+++ b/tests/libmesh_cppunit.h
@@ -6,11 +6,11 @@
 
 #if defined(LIBMESH_DEFAULT_QUADRUPLE_PRECISION) || \
     defined(LIBMESH_DEFAULT_TRIPLE_PRECISION)
-# define LIBMESH_ASSERT_FP_EQUAL(first,second,delta) \
-         CPPUNIT_ASSERT_DOUBLES_EQUAL(double(first-second),0,double(delta))
+# define LIBMESH_ASSERT_FP_EQUAL(expected,actual,tolerance) \
+         CPPUNIT_ASSERT_DOUBLES_EQUAL(double(expected-actual),0,double(tolerance))
 #else
-# define LIBMESH_ASSERT_FP_EQUAL(first,second,delta) \
-         CPPUNIT_ASSERT_DOUBLES_EQUAL(first,second,delta)
+# define LIBMESH_ASSERT_FP_EQUAL(expected,actual,tolerance) \
+         CPPUNIT_ASSERT_DOUBLES_EQUAL(expected,actual,tolerance)
 #endif
 
 // THE CPPUNIT_TEST_SUITE_END macro expands to code that involves

--- a/tests/mesh/boundary_mesh.C
+++ b/tests/mesh/boundary_mesh.C
@@ -207,7 +207,7 @@ public:
             CPPUNIT_ASSERT_EQUAL(pip->level(), elem->level());
 
             // We only added right edges
-            LIBMESH_ASSERT_FP_EQUAL(elem->centroid()(0), 0.8,
+            LIBMESH_ASSERT_FP_EQUAL(0.8, elem->centroid()(0),
                                     TOLERANCE*TOLERANCE);
           }
         else
@@ -236,7 +236,7 @@ public:
         CPPUNIT_ASSERT_EQUAL(pip->level(), elem->level());
 
         // We only added left edges
-        LIBMESH_ASSERT_FP_EQUAL(elem->centroid()(0), 0.2,
+        LIBMESH_ASSERT_FP_EQUAL(0.2, elem->centroid()(0),
                                 TOLERANCE*TOLERANCE);
       }
 

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -203,7 +203,7 @@ public:
           {
             Real read_val = sys.point_value(i, elem->centroid());
             LIBMESH_ASSERT_FP_EQUAL
-              (read_val, expected_values[i], TOLERANCE*TOLERANCE);
+              (expected_values[i], read_val, TOLERANCE*TOLERANCE);
           }
     } // end second scope
   } // end testExodusWriteElementDataFromDiscontinuousNodalData

--- a/tests/numerics/composite_function_test.C
+++ b/tests/numerics/composite_function_test.C
@@ -72,11 +72,11 @@ private:
 
       composite_inner(Point(0), 0, test_one);
 
-      LIBMESH_ASSERT_FP_EQUAL(test_one(0), 2, 1.e-12);
-      LIBMESH_ASSERT_FP_EQUAL(test_one(1), 2, 1.e-12);
-      LIBMESH_ASSERT_FP_EQUAL(test_one(2), 2, 1.e-12);
-      LIBMESH_ASSERT_FP_EQUAL(test_one(3), 1, 1.e-12);
-      LIBMESH_ASSERT_FP_EQUAL(test_one(4), 1, 1.e-12);
+      LIBMESH_ASSERT_FP_EQUAL(2, test_one(0), 1.e-12);
+      LIBMESH_ASSERT_FP_EQUAL(2, test_one(1), 1.e-12);
+      LIBMESH_ASSERT_FP_EQUAL(2, test_one(2), 1.e-12);
+      LIBMESH_ASSERT_FP_EQUAL(1, test_one(3), 1.e-12);
+      LIBMESH_ASSERT_FP_EQUAL(1, test_one(4), 1.e-12);
     }
     // Test that ConstFunction copy- and move-assignment works.
     ConstFunction<Real> cf_three(3);
@@ -98,14 +98,14 @@ private:
     DenseVector<Real> test_two(8);
     composite_outer_copy2(Point(0), 0, test_two);
 
-    LIBMESH_ASSERT_FP_EQUAL(test_two(0), 3, 1.e-12);
-    LIBMESH_ASSERT_FP_EQUAL(test_two(2), 3, 1.e-12);
-    LIBMESH_ASSERT_FP_EQUAL(test_two(4), 3, 1.e-12);
-    LIBMESH_ASSERT_FP_EQUAL(test_two(5), 2, 1.e-12);
-    LIBMESH_ASSERT_FP_EQUAL(test_two(1), 2, 1.e-12);
-    LIBMESH_ASSERT_FP_EQUAL(test_two(3), 2, 1.e-12);
-    LIBMESH_ASSERT_FP_EQUAL(test_two(6), 1, 1.e-12);
-    LIBMESH_ASSERT_FP_EQUAL(test_two(7), 1, 1.e-12);
+    LIBMESH_ASSERT_FP_EQUAL(3, test_two(0), 1.e-12);
+    LIBMESH_ASSERT_FP_EQUAL(3, test_two(2), 1.e-12);
+    LIBMESH_ASSERT_FP_EQUAL(3, test_two(4), 1.e-12);
+    LIBMESH_ASSERT_FP_EQUAL(2, test_two(5), 1.e-12);
+    LIBMESH_ASSERT_FP_EQUAL(2, test_two(1), 1.e-12);
+    LIBMESH_ASSERT_FP_EQUAL(2, test_two(3), 1.e-12);
+    LIBMESH_ASSERT_FP_EQUAL(1, test_two(6), 1.e-12);
+    LIBMESH_ASSERT_FP_EQUAL(1, test_two(7), 1.e-12);
   }
 
   void testTimeDependence()

--- a/tests/numerics/diagonal_matrix_test.C
+++ b/tests/numerics/diagonal_matrix_test.C
@@ -82,8 +82,8 @@ public:
     _matrix->set(beginning_index + 1, beginning_index, 1);
 
     // Test that off-diagonal elements are always zero
-    LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(beginning_index, beginning_index + 1)), 0, _tolerance);
-    LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(beginning_index + 1, beginning_index)), 0, _tolerance);
+    LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real((*_matrix)(beginning_index, beginning_index + 1)), _tolerance);
+    LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real((*_matrix)(beginning_index + 1, beginning_index)), _tolerance);
 
     // Test add
     {
@@ -124,9 +124,9 @@ public:
       for (numeric_index_type i = beginning_index; i < end_index; ++i)
       {
         if (i != _global_size - 1)
-          LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, i)), i, _tolerance);
+          LIBMESH_ASSERT_FP_EQUAL(i, libmesh_real((*_matrix)(i, i)), _tolerance);
         else
-          LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, i)), 0, _tolerance);
+          LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real((*_matrix)(i, i)), _tolerance);
       }
     }
 
@@ -152,7 +152,7 @@ public:
       _matrix->close();
 
       for (numeric_index_type i = beginning_index; i < end_index; ++i)
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, i)), i, _tolerance);
+        LIBMESH_ASSERT_FP_EQUAL(i, libmesh_real((*_matrix)(i, i)), _tolerance);
 
       // Build
       auto diagonal = NumericVector<Number>::build(*_comm);
@@ -173,18 +173,18 @@ public:
       _matrix->close();
 
       for (numeric_index_type i = beginning_index; i < end_index; ++i)
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, i)), 2 * i, _tolerance);
+        LIBMESH_ASSERT_FP_EQUAL(2 * i, libmesh_real((*_matrix)(i, i)), _tolerance);
 
       // SparseMatrix add
       _matrix->add(-1, copy);
 
       for (numeric_index_type i = beginning_index; i < end_index; ++i)
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, i)), i, _tolerance);
+        LIBMESH_ASSERT_FP_EQUAL(i, libmesh_real((*_matrix)(i, i)), _tolerance);
 
       _matrix->get_transpose(copy);
 
       for (numeric_index_type i = beginning_index; i < end_index; ++i)
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(copy(i, i)), i, _tolerance);
+        LIBMESH_ASSERT_FP_EQUAL(i, libmesh_real(copy(i, i)), _tolerance);
     }
 
     // Test norms
@@ -200,9 +200,9 @@ public:
         for (numeric_index_type j = beginning_index; j < end_index; ++j)
         {
           if (i == j)
-            LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, j)), 1, _tolerance);
+            LIBMESH_ASSERT_FP_EQUAL(1, libmesh_real((*_matrix)(i, j)), _tolerance);
           else
-            LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, j)), 0, _tolerance);
+            LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real((*_matrix)(i, j)), _tolerance);
         }
     }
   }

--- a/tests/numerics/parsed_fem_function_test.C
+++ b/tests/numerics/parsed_fem_function_test.C
@@ -140,7 +140,7 @@ private:
         ParsedFEMFunction<Number> x2_copy(x2);
 
         LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(x2_copy(*c,Point(0.5,0.5,0.5))), 1.0, TOLERANCE*TOLERANCE);
+          (1.0, libmesh_real(x2_copy(*c,Point(0.5,0.5,0.5))), TOLERANCE*TOLERANCE);
 
         ParsedFEMFunction<Number> xy8(*sys, "x2*y4");
 
@@ -148,7 +148,7 @@ private:
         ParsedFEMFunction<Number> xy8_stolen(std::move(xy8));
 
         LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(xy8_stolen(*c,Point(0.5,0.5,0.5))), 2.0, TOLERANCE*TOLERANCE);
+          (2.0, libmesh_real(xy8_stolen(*c,Point(0.5,0.5,0.5))), TOLERANCE*TOLERANCE);
       }
   }
 
@@ -167,17 +167,17 @@ private:
         // c2_assigned = c2;
 
         LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(c2(*c,Point(0.35,0.45,0.55))), 2.0, TOLERANCE*TOLERANCE);
+          (2.0, libmesh_real(c2(*c,Point(0.35,0.45,0.55))), TOLERANCE*TOLERANCE);
 
         ParsedFEMFunction<Number> xz(*sys, "grad_y_xyz");
 
         LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(xz(*c,Point(0.25,0.35,0.75))), 0.1875, TOLERANCE*TOLERANCE);
+          (0.1875, libmesh_real(xz(*c,Point(0.25,0.35,0.75))), TOLERANCE*TOLERANCE);
 
         ParsedFEMFunction<Number> xyz(*sys, "grad_y_xyz*grad_x_xy");
 
         LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(xyz(*c,Point(0.25,0.5,0.75))), 0.09375, TOLERANCE*TOLERANCE);
+          (0.09375, libmesh_real(xyz(*c,Point(0.25,0.5,0.75))), TOLERANCE*TOLERANCE);
       }
   }
 
@@ -190,17 +190,17 @@ private:
         ParsedFEMFunction<Number> c1(*sys, "hess_xy_xy");
 
         LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(c1(*c,Point(0.35,0.45,0.55))), 1.0, TOLERANCE*TOLERANCE);
+          (1.0, libmesh_real(c1(*c,Point(0.35,0.45,0.55))), TOLERANCE*TOLERANCE);
 
         ParsedFEMFunction<Number> x(*sys, "hess_yz_xyz");
 
         LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(x(*c,Point(0.25,0.35,0.55))), 0.25, TOLERANCE*TOLERANCE);
+          (0.25, libmesh_real(x(*c,Point(0.25,0.35,0.55))), TOLERANCE*TOLERANCE);
 
         ParsedFEMFunction<Number> xz(*sys, "hess_yz_xyz*grad_y_yz");
 
         LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(xz(*c,Point(0.25,0.4,0.75))), 0.1875, TOLERANCE*TOLERANCE);
+          (0.1875, libmesh_real(xz(*c,Point(0.25,0.4,0.75))), TOLERANCE*TOLERANCE);
       }
   }
 
@@ -212,22 +212,22 @@ private:
         ParsedFEMFunction<Number> ax2(*sys, "a:=4.5;a*x2");
 
         LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(ax2(*c,Point(0.25,0.25,0.25))), 2.25, TOLERANCE*TOLERANCE);
+          (2.25, libmesh_real(ax2(*c,Point(0.25,0.25,0.25))), TOLERANCE*TOLERANCE);
 
         LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(ax2.get_inline_value("a")), 4.5, TOLERANCE*TOLERANCE);
+          (4.5, libmesh_real(ax2.get_inline_value("a")), TOLERANCE*TOLERANCE);
 
         ParsedFEMFunction<Number> cxy8
           (*sys, "a := 4 ; b := a/2+1; c:=b-a+3.5; c*x2*y4");
 
         LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(cxy8(*c,Point(0.5,0.5,0.5))), 5.0, TOLERANCE*TOLERANCE);
+          (5.0, libmesh_real(cxy8(*c,Point(0.5,0.5,0.5))), TOLERANCE*TOLERANCE);
 
         LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(cxy8.get_inline_value("b")), 3.0, TOLERANCE*TOLERANCE);
+          (3.0, libmesh_real(cxy8.get_inline_value("b")), TOLERANCE*TOLERANCE);
 
         LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(cxy8.get_inline_value("c")), 2.5, TOLERANCE*TOLERANCE);
+          (2.5, libmesh_real(cxy8.get_inline_value("c")), TOLERANCE*TOLERANCE);
       }
   }
 
@@ -240,10 +240,10 @@ private:
         ax2.set_inline_value("a", 2.5);
 
         LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(ax2(*c,Point(0.25,0.25,0.25))), 1.25, TOLERANCE*TOLERANCE);
+          (1.25, libmesh_real(ax2(*c,Point(0.25,0.25,0.25))), TOLERANCE*TOLERANCE);
 
         LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(ax2.get_inline_value("a")), 2.5, TOLERANCE*TOLERANCE);
+          (2.5, libmesh_real(ax2.get_inline_value("a")), TOLERANCE*TOLERANCE);
 
         ParsedFEMFunction<Number> cxy8
           (*sys, "a := 4 ; b := a/2+1; c:=b-a+3.5; c*x2*y4");
@@ -251,13 +251,13 @@ private:
         cxy8.set_inline_value("a", 2);
 
         LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(cxy8(*c,Point(0.5,0.5,0.5))), 7.0, TOLERANCE*TOLERANCE);
+          (7.0, libmesh_real(cxy8(*c,Point(0.5,0.5,0.5))), TOLERANCE*TOLERANCE);
 
         LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(cxy8.get_inline_value("b")), 2.0, TOLERANCE*TOLERANCE);
+          (2.0, libmesh_real(cxy8.get_inline_value("b")), TOLERANCE*TOLERANCE);
 
         LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(cxy8.get_inline_value("c")), 3.5, TOLERANCE*TOLERANCE);
+          (3.5, libmesh_real(cxy8.get_inline_value("c")), TOLERANCE*TOLERANCE);
 
       }
   }
@@ -279,11 +279,11 @@ private:
         for (std::size_t qp=0; qp != xyz.size(); ++qp)
           {
             LIBMESH_ASSERT_FP_EQUAL
-              (libmesh_real(nx(*s,xyz[qp])), 0.0, TOLERANCE*TOLERANCE);
+              (0.0, libmesh_real(nx(*s,xyz[qp])), TOLERANCE*TOLERANCE);
             LIBMESH_ASSERT_FP_EQUAL
-              (libmesh_real(ny(*s,xyz[qp])), 1.0, TOLERANCE*TOLERANCE);
+              (1.0, libmesh_real(ny(*s,xyz[qp])), TOLERANCE*TOLERANCE);
             LIBMESH_ASSERT_FP_EQUAL
-              (libmesh_real(nz(*s,xyz[qp])), 0.0, TOLERANCE*TOLERANCE);
+              (0.0, libmesh_real(nz(*s,xyz[qp])), TOLERANCE*TOLERANCE);
           }
       }
   }

--- a/tests/numerics/parsed_function_test.C
+++ b/tests/numerics/parsed_function_test.C
@@ -45,7 +45,7 @@ private:
     ParsedFunction<Number> x2_copy(x2);
 
     LIBMESH_ASSERT_FP_EQUAL
-      (libmesh_real(x2_copy(Point(0.5,1.5,2.5))), 1.0, TOLERANCE*TOLERANCE);
+      (1.0, libmesh_real(x2_copy(Point(0.5,1.5,2.5))), TOLERANCE*TOLERANCE);
 
     ParsedFunction<Number> xy8("x*y*8");
 
@@ -53,7 +53,7 @@ private:
     ParsedFunction<Number> xy8_stolen(std::move(xy8));
 
     LIBMESH_ASSERT_FP_EQUAL
-      (libmesh_real(xy8_stolen(Point(0.5,1.5,2.5))), 6.0, TOLERANCE*TOLERANCE);
+      (6.0, libmesh_real(xy8_stolen(Point(0.5,1.5,2.5))), TOLERANCE*TOLERANCE);
   }
 
   void testInlineGetter()
@@ -65,22 +65,22 @@ private:
     ax2_stolen = std::move(ax2);
 
     LIBMESH_ASSERT_FP_EQUAL
-      (libmesh_real(ax2_stolen(Point(0.25,0.25,0.25))), 2.25, TOLERANCE*TOLERANCE);
+      (2.25, libmesh_real(ax2_stolen(Point(0.25,0.25,0.25))), TOLERANCE*TOLERANCE);
 
     LIBMESH_ASSERT_FP_EQUAL
-      (libmesh_real(ax2_stolen.get_inline_value("a")), 4.5, TOLERANCE*TOLERANCE);
+      (4.5, libmesh_real(ax2_stolen.get_inline_value("a")), TOLERANCE*TOLERANCE);
 
     ParsedFunction<Number> cxy8
       ("a := 4 ; b := a/2+1; c:=b-a+3.5; c*x*2*y*4");
 
     LIBMESH_ASSERT_FP_EQUAL
-      (libmesh_real(cxy8(Point(0.5,0.5,0.5))), 5.0, TOLERANCE*TOLERANCE);
+      (5.0, libmesh_real(cxy8(Point(0.5,0.5,0.5))), TOLERANCE*TOLERANCE);
 
     LIBMESH_ASSERT_FP_EQUAL
-      (libmesh_real(cxy8.get_inline_value("b")), 3.0, TOLERANCE*TOLERANCE);
+      (3.0, libmesh_real(cxy8.get_inline_value("b")), TOLERANCE*TOLERANCE);
 
     LIBMESH_ASSERT_FP_EQUAL
-      (libmesh_real(cxy8.get_inline_value("c")), 2.5, TOLERANCE*TOLERANCE);
+      (2.5, libmesh_real(cxy8.get_inline_value("c")), TOLERANCE*TOLERANCE);
   }
 
   void testInlineSetter()
@@ -89,23 +89,23 @@ private:
     ax2.set_inline_value("a", 2.5);
 
     LIBMESH_ASSERT_FP_EQUAL
-      (libmesh_real(ax2(Point(0.25,0.25,0.25))), 1.25, TOLERANCE*TOLERANCE);
+      (1.25, libmesh_real(ax2(Point(0.25,0.25,0.25))), TOLERANCE*TOLERANCE);
 
     LIBMESH_ASSERT_FP_EQUAL
-      (libmesh_real(ax2.get_inline_value("a")), 2.5, TOLERANCE*TOLERANCE);
+      (2.5, libmesh_real(ax2.get_inline_value("a")), TOLERANCE*TOLERANCE);
 
     ParsedFunction<Number> cxy8
       ("a := 4 ; b := a/2+1; c:=b-a+3.5; c*x*2*y*4");
     cxy8.set_inline_value("a", 2);
 
     LIBMESH_ASSERT_FP_EQUAL
-      (libmesh_real(cxy8(Point(0.5,0.5,0.5))), 7.0, TOLERANCE*TOLERANCE);
+      (7.0, libmesh_real(cxy8(Point(0.5,0.5,0.5))), TOLERANCE*TOLERANCE);
 
     LIBMESH_ASSERT_FP_EQUAL
-      (libmesh_real(cxy8.get_inline_value("b")), 2.0, TOLERANCE*TOLERANCE);
+      (2.0, libmesh_real(cxy8.get_inline_value("b")), TOLERANCE*TOLERANCE);
 
     LIBMESH_ASSERT_FP_EQUAL
-      (libmesh_real(cxy8.get_inline_value("c")), 3.5, TOLERANCE*TOLERANCE);
+      (3.5, libmesh_real(cxy8.get_inline_value("c")), TOLERANCE*TOLERANCE);
   }
 
   void testTimeDependence()

--- a/tests/numerics/petsc_matrix_test.C
+++ b/tests/numerics/petsc_matrix_test.C
@@ -83,8 +83,8 @@ public:
         _matrix->get_row(local_index, cols_to_get, values);
         for (numeric_index_type j = 0; j < _local_size; ++j)
         {
-          LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(values[j]),
-                                  (local_count + 1) * (j + 1) * (_comm->rank() + 1),
+          LIBMESH_ASSERT_FP_EQUAL((local_count + 1) * (j + 1) * (_comm->rank() + 1),
+                                  libMesh::libmesh_real(values[j]),
                                   _tolerance);
           CPPUNIT_ASSERT_EQUAL(cols_to_get[local_count], local_index);
         }

--- a/tests/numerics/petsc_vector_test.C
+++ b/tests/numerics/petsc_vector_test.C
@@ -49,13 +49,13 @@ public:
 
     // Check the values through the interface
     for (unsigned int i=0; i<local_size; i++)
-      LIBMESH_ASSERT_FP_EQUAL(std::abs(v(my_offset + i)), i, TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_FP_EQUAL(i, std::abs(v(my_offset + i)), TOLERANCE*TOLERANCE);
 
     // Check that we can see the same thing with get_array_read
     const PetscScalar * read_only_values = v.get_array_read();
 
     for (unsigned int i=0; i<local_size; i++)
-      LIBMESH_ASSERT_FP_EQUAL(std::abs(read_only_values[i]), i, TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_FP_EQUAL(i, std::abs(read_only_values[i]), TOLERANCE*TOLERANCE);
 
     v.restore_array();
 

--- a/tests/numerics/type_tensor_test.C
+++ b/tests/numerics/type_tensor_test.C
@@ -56,10 +56,10 @@ private:
     VectorValue<Real> vector(5, 6, 0);
     auto left_mult = vector * tensor;
     auto right_mult = tensor * vector;
-    LIBMESH_ASSERT_FP_EQUAL(left_mult(0), 23, 1e-12);
-    LIBMESH_ASSERT_FP_EQUAL(left_mult(1), 34, 1e-12);
-    LIBMESH_ASSERT_FP_EQUAL(right_mult(0), 17, 1e-12);
-    LIBMESH_ASSERT_FP_EQUAL(right_mult(1), 39, 1e-12);
+    LIBMESH_ASSERT_FP_EQUAL(23, left_mult(0), 1e-12);
+    LIBMESH_ASSERT_FP_EQUAL(34, left_mult(1), 1e-12);
+    LIBMESH_ASSERT_FP_EQUAL(17, right_mult(0), 1e-12);
+    LIBMESH_ASSERT_FP_EQUAL(39, right_mult(1), 1e-12);
   }
 
   void testOuterProduct()
@@ -68,15 +68,15 @@ private:
     VectorValue<Real> a(2, 3, 4);
     VectorValue<Real> b(5, 6, 7);
     auto product = outer_product(a, b);
-    LIBMESH_ASSERT_FP_EQUAL(product(0, 0), 10, tol);
-    LIBMESH_ASSERT_FP_EQUAL(product(0, 1), 12, tol);
-    LIBMESH_ASSERT_FP_EQUAL(product(0, 2), 14, tol);
-    LIBMESH_ASSERT_FP_EQUAL(product(1, 0), 15, tol);
-    LIBMESH_ASSERT_FP_EQUAL(product(1, 1), 18, tol);
-    LIBMESH_ASSERT_FP_EQUAL(product(1, 2), 21, tol);
-    LIBMESH_ASSERT_FP_EQUAL(product(2, 0), 20, tol);
-    LIBMESH_ASSERT_FP_EQUAL(product(2, 1), 24, tol);
-    LIBMESH_ASSERT_FP_EQUAL(product(2, 2), 28, tol);
+    LIBMESH_ASSERT_FP_EQUAL(10, product(0, 0), tol);
+    LIBMESH_ASSERT_FP_EQUAL(12, product(0, 1), tol);
+    LIBMESH_ASSERT_FP_EQUAL(14, product(0, 2), tol);
+    LIBMESH_ASSERT_FP_EQUAL(15, product(1, 0), tol);
+    LIBMESH_ASSERT_FP_EQUAL(18, product(1, 1), tol);
+    LIBMESH_ASSERT_FP_EQUAL(21, product(1, 2), tol);
+    LIBMESH_ASSERT_FP_EQUAL(20, product(2, 0), tol);
+    LIBMESH_ASSERT_FP_EQUAL(24, product(2, 1), tol);
+    LIBMESH_ASSERT_FP_EQUAL(28, product(2, 2), tol);
   }
 
   void testIsZero()

--- a/tests/numerics/type_vector_test.h
+++ b/tests/numerics/type_vector_test.h
@@ -123,12 +123,12 @@ public:
 
   void testNorm()
   {
-    LIBMESH_ASSERT_FP_EQUAL( std::sqrt(Real(LIBMESH_DIM)) , m_1_1_1->norm() , TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_FP_EQUAL(m_1_1_1->norm() ,  std::sqrt(Real(LIBMESH_DIM)) , TOLERANCE*TOLERANCE );
   }
 
   void testNormSq()
   {
-    LIBMESH_ASSERT_FP_EQUAL( Real(LIBMESH_DIM) , m_1_1_1->norm_sq() , TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_FP_EQUAL(m_1_1_1->norm_sq() ,  Real(LIBMESH_DIM) , TOLERANCE*TOLERANCE );
   }
 
   void testEquality()

--- a/tests/solvers/time_solver_test_common.h
+++ b/tests/solvers/time_solver_test_common.h
@@ -75,8 +75,8 @@ protected:
         system.comm().max(rel_error);
 
         // Using relative error for comparison, so "exact" is 0
-        LIBMESH_ASSERT_FP_EQUAL( 0.0,
-                                 rel_error,
+        LIBMESH_ASSERT_FP_EQUAL( rel_error,
+                                 0.0,
                                  std::numeric_limits<Real>::epsilon()*10 );
       }
   }

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -470,38 +470,38 @@ private:
 
     if (u_subdomains.count(sbd_id))
       {
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(0,p)),
-                                libmesh_real(cubic_test(p,param,"","")),
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(cubic_test(p,param,"","")),
+                                libmesh_real(sys.point_value(0,p)),
                                 TOLERANCE*TOLERANCE*10);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(0,p,sys.old_local_solution.get())),
-                                libmesh_real(cubic_test(p,param,"","") + Number(10)),
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(cubic_test(p,param,"","") + Number(10)),
+                                libmesh_real(sys.point_value(0,p,sys.old_local_solution.get())),
                                 TOLERANCE*TOLERANCE*100);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(0,p,sys.older_local_solution.get())),
-                                libmesh_real(cubic_test(p,param,"","") + Number(20)),
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(cubic_test(p,param,"","") + Number(20)),
+                                libmesh_real(sys.point_value(0,p,sys.older_local_solution.get())),
                                 TOLERANCE*TOLERANCE*100);
       }
     if (v_subdomains.count(sbd_id))
       {
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(1,p)),
-                                libmesh_real(new_linear_test(p,param,"","")),
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(new_linear_test(p,param,"","")),
+                                libmesh_real(sys.point_value(1,p)),
                                 TOLERANCE*TOLERANCE*10);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(1,p,sys.old_local_solution.get())),
-                                libmesh_real(new_linear_test(p,param,"","") + Number(10)),
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(new_linear_test(p,param,"","") + Number(10)),
+                                libmesh_real(sys.point_value(1,p,sys.old_local_solution.get())),
                                 TOLERANCE*TOLERANCE*100);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(1,p,sys.older_local_solution.get())),
-                                libmesh_real(new_linear_test(p,param,"","") + Number(20)),
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(new_linear_test(p,param,"","") + Number(20)),
+                                libmesh_real(sys.point_value(1,p,sys.older_local_solution.get())),
                                 TOLERANCE*TOLERANCE*100);
       }
     if (w_subdomains.count(sbd_id))
       {
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(2,p)),
-                                libmesh_real(disc_thirds_test(p,param,"","")),
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(disc_thirds_test(p,param,"","")),
+                                libmesh_real(sys.point_value(2,p)),
                                 TOLERANCE*TOLERANCE*10);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(2,p,sys.old_local_solution.get())),
-                                libmesh_real(disc_thirds_test(p,param,"","") + Number(10)),
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(disc_thirds_test(p,param,"","") + Number(10)),
+                                libmesh_real(sys.point_value(2,p,sys.old_local_solution.get())),
                                 TOLERANCE*TOLERANCE*100);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(2,p,sys.older_local_solution.get())),
-                                libmesh_real(disc_thirds_test(p,param,"","") + Number(20)),
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(disc_thirds_test(p,param,"","") + Number(20)),
+                                libmesh_real(sys.point_value(2,p,sys.older_local_solution.get())),
                                 TOLERANCE*TOLERANCE*100);
       }
   }
@@ -736,8 +736,8 @@ public:
         for (Real z = 0.1; z < 1; z += 0.2)
           {
             Point p(x,y,z);
-            LIBMESH_ASSERT_FP_EQUAL(libmesh_real(proj_sys.point_value(0,p)),
-                                    libmesh_real(cubic_test(p,es.parameters,"","")),
+            LIBMESH_ASSERT_FP_EQUAL(libmesh_real(cubic_test(p,es.parameters,"","")),
+                                    libmesh_real(proj_sys.point_value(0,p)),
                                     TOLERANCE*TOLERANCE);
           }
   }

--- a/tests/utils/point_locator_test.C
+++ b/tests/utils/point_locator_test.C
@@ -92,13 +92,13 @@ public:
 
                 if (node)
                   {
-                    LIBMESH_ASSERT_FP_EQUAL((*node)(0), i*h,
+                    LIBMESH_ASSERT_FP_EQUAL(i*h, (*node)(0),
                                             TOLERANCE*TOLERANCE);
                     if (LIBMESH_DIM > 1)
-                      LIBMESH_ASSERT_FP_EQUAL((*node)(1), j*h,
+                      LIBMESH_ASSERT_FP_EQUAL(j*h, (*node)(1),
                                               TOLERANCE*TOLERANCE);
                     if (LIBMESH_DIM > 2)
-                      LIBMESH_ASSERT_FP_EQUAL((*node)(2), k*h,
+                      LIBMESH_ASSERT_FP_EQUAL(k*h, (*node)(2),
                                               TOLERANCE*TOLERANCE);
                   }
               }


### PR DESCRIPTION
These are the changes in the unit-tests discussed in the context of #2409.
It renames the arguments to ``LIBMESH_ASSERT_FP_EQUAL`` and adjusts the order in those cases, where it could add some confusion...