### PR TITLE
Use MAT_INPLACE_MATRIX in newer PETSc versions.

### DIFF
--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -968,9 +968,14 @@ void PetscMatrix<T>::get_transpose (SparseMatrix<T> & dest) const
     ierr = MatTranspose(_mat,&petsc_dest._mat);
   LIBMESH_CHKERR(ierr);
 #else
-  // FIXME - we can probably use MAT_REUSE_MATRIX in more situations
   if (&petsc_dest == this)
+    // The MAT_REUSE_MATRIX flag was replaced by MAT_INPLACE_MATRIX
+    // in PETSc 3.7.0
+#if PETSC_VERSION_LESS_THAN(3,7,0)
     ierr = MatTranspose(_mat,MAT_REUSE_MATRIX,&petsc_dest._mat);
+#else
+    ierr = MatTranspose(_mat, MAT_INPLACE_MATRIX, &petsc_dest._mat);
+#endif
   else
     ierr = MatTranspose(_mat,MAT_INITIAL_MATRIX,&petsc_dest._mat);
   LIBMESH_CHKERR(ierr);


### PR DESCRIPTION
The MAT_INPLACE_MATRIX flag was added in petsc/petsc@511c6705a which
first appeared in PETSc 3.7.0.  According to the MatTranspose docs
[0], the MAT_REUSE_MATRIX flag is only for use with transposes that
were already created using the MAT_INITIAL_MATRIX flag.

[0]: https://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/Mat/MatTranspose.html