### PR TITLE
Add MeshBase::add_elem(std::unique_ptr<Elem>)

### DIFF
--- a/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.C
@@ -218,7 +218,7 @@ void LinearElasticityWithContact::add_contact_edge_elements()
       Node & master_node = mesh.node_ref(master_node_id);
       Node & slave_node = mesh.node_ref(slave_node_id);
 
-      Elem * connector_elem = mesh.add_elem (new Edge2);
+      Elem * connector_elem = mesh.add_elem(Elem::build(EDGE2));
       connector_elem->set_node(0) = &master_node;
       connector_elem->set_node(1) = &slave_node;
 

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -1602,6 +1602,13 @@ public:
    */
   static std::unique_ptr<Elem> build (const ElemType type,
                                       Elem * p=nullptr);
+  /**
+   * Calls the build() method above with a nullptr parent, and
+   * additionally sets the newly-created Elem's id. This can be useful
+   * when adding pre-numbered Elems to a Mesh via add_elem() calls.
+   */
+  static std::unique_ptr<Elem> build_with_id (const ElemType type,
+                                              dof_id_type id);
 
 #ifdef LIBMESH_ENABLE_AMR
 

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -285,6 +285,7 @@ public:
   virtual void delete_node (Node * n) override;
   virtual void renumber_node (dof_id_type old_id, dof_id_type new_id) override;
   virtual Elem * add_elem (Elem * e) override;
+  virtual Elem * add_elem (std::unique_ptr<Elem> e) override;
   virtual Elem * insert_elem (Elem * e) override;
   virtual void delete_elem (Elem * e) override;
   virtual void renumber_elem (dof_id_type old_id, dof_id_type new_id) override;

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -674,6 +674,16 @@ public:
   virtual Elem * add_elem (Elem * e) = 0;
 
   /**
+   * Version of add_elem() taking a std::unique_ptr by value. The version
+   * taking a dumb pointer will eventually be deprecated in favor of this
+   * version. This API is intended to indicate that ownership of the Elem
+   * is transferred to the Mesh when this function is called, and it should
+   * play more nicely with the Elem::build() API which has always returned
+   * a std::unique_ptr.
+   */
+  virtual Elem * add_elem (std::unique_ptr<Elem> e) = 0;
+
+  /**
    * Insert elem \p e to the element array, preserving its id
    * and replacing/deleting any existing element with the same id.
    *

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -171,6 +171,7 @@ public:
   virtual void delete_node (Node * n) override;
   virtual void renumber_node (dof_id_type old_id, dof_id_type new_id) override;
   virtual Elem * add_elem (Elem * e) override;
+  virtual Elem * add_elem (std::unique_ptr<Elem> e) override;
   virtual Elem * insert_elem (Elem * e) override;
   virtual void delete_elem (Elem * e) override;
   virtual void renumber_elem (dof_id_type old_id, dof_id_type new_id) override;

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -335,6 +335,18 @@ std::unique_ptr<Elem> Elem::build(const ElemType type,
 
 
 
+std::unique_ptr<Elem> Elem::build_with_id (const ElemType type,
+                                           dof_id_type id)
+{
+  // Call the other build() method with nullptr parent, then set the
+  // required id.
+  auto temp = Elem::build(type, nullptr);
+  temp->set_id(id);
+  return temp;
+}
+
+
+
 const Elem * Elem::reference_elem () const
 {
   return &(ReferenceElem::get(this->type()));

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -648,7 +648,7 @@ void AbaqusIO::read_elements(std::string upper, std::string elset_name)
       _in >> abaqus_elem_id >> c;
 
       // Add an element of the appropriate type to the Mesh.
-      Elem * elem = the_mesh.add_elem(Elem::build(elem_type).release());
+      Elem * elem = the_mesh.add_elem(Elem::build(elem_type));
 
       // Associate the ID returned from libmesh with the abaqus element ID
       //_libmesh_to_abaqus_elem_mapping[elem->id()] = abaqus_elem_id;

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -487,7 +487,7 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
 #endif
 
       // Add the side
-      Elem * new_elem = boundary_mesh.add_elem(side.release());
+      Elem * new_elem = boundary_mesh.add_elem(std::move(side));
 
 #ifdef LIBMESH_ENABLE_AMR
       // Set parent links

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -1238,7 +1238,7 @@ void CheckpointIO::read_connectivity (Xdr & io)
       else
         {
           // Create the element
-          Elem * elem = Elem::build(elem_type, parent).release();
+          auto elem = Elem::build(elem_type, parent);
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
           elem->set_unique_id() = unique_id;
@@ -1262,7 +1262,7 @@ void CheckpointIO::read_connectivity (Xdr & io)
             {
               // We must specify a child_num, because we will have
               // skipped adding any preceding remote_elem children
-              parent->add_child(elem, child_num);
+              parent->add_child(elem.get(), child_num);
             }
 #else
           libmesh_ignore(child_num);
@@ -1277,13 +1277,13 @@ void CheckpointIO::read_connectivity (Xdr & io)
             elem->set_node(n) =
               mesh.node_ptr(cast_int<dof_id_type>(conn_data[n]));
 
-          mesh.add_elem(elem);
+          Elem * added_elem = mesh.add_elem(std::move(elem));
 
-          libmesh_assert_equal_to(n_extra_integers, elem->n_extra_integers());
+          libmesh_assert_equal_to(n_extra_integers, added_elem->n_extra_integers());
           for (unsigned int ei=0; ei != n_extra_integers; ++ei)
             {
               const dof_id_type extra_int = cast_int<dof_id_type>(elem_data[6+ei]);
-              elem->set_extra_integer(ei, extra_int);
+              added_elem->set_extra_integer(ei, extra_int);
             }
         }
     }

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -537,6 +537,16 @@ Elem * DistributedMesh::add_elem (Elem * e)
 
 
 
+Elem * DistributedMesh::add_elem (std::unique_ptr<Elem> e)
+{
+  // The mesh now takes ownership of the Elem. Eventually the guts of
+  // add_elem() will get moved to a private helper function, and
+  // calling add_elem() directly will be deprecated.
+  return add_elem(e.release());
+}
+
+
+
 Elem * DistributedMesh::insert_elem (Elem * e)
 {
   if (_elements[e->id()])

--- a/src/mesh/dyna_io.C
+++ b/src/mesh/dyna_io.C
@@ -288,9 +288,8 @@ void DynaIO::read_mesh(std::istream & in)
               // freedom will be tied via constraint equations.
               Node *n = spline_node_ptrs[n_nodes_read] =
                 mesh.add_point(Point(xyzw[0], xyzw[1], xyzw[2]));
-              Elem * elem = Elem::build(NODEELEM).release();
+              Elem * elem = mesh.add_elem(Elem::build(NODEELEM));
               elem->set_node(0) = n;
-              mesh.add_elem(elem);
             }
             ++n_nodes_read;
 
@@ -560,7 +559,7 @@ void DynaIO::read_mesh(std::istream & in)
                " degree " << block_p[block_num] << " not found!");
 
           const ElementDefinition * elem_defn = &(eletypes_it->second);
-          Elem * elem = Elem::build(elem_defn->type).release();
+          auto elem = Elem::build(elem_defn->type);
           libmesh_assert_equal_to(elem->dim(), block_dim[block_num]);
 
           auto & my_constraint_rows = elem_constraint_rows[block_num][elem_num];
@@ -676,7 +675,7 @@ void DynaIO::read_mesh(std::istream & in)
                 }
             }
 
-          mesh.add_elem(elem);
+          mesh.add_elem(std::move(elem));
         }
     }
 }

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -234,9 +234,8 @@ void ExodusII_IO::read (const std::string & fname)
       int jmax = nelem_last_block+exio_helper->num_elem_this_blk;
       for (int j=nelem_last_block; j<jmax; j++)
         {
-          Elem * elem = Elem::build (conv.libmesh_elem_type()).release();
-          libmesh_assert (elem);
-          elem->subdomain_id() = static_cast<subdomain_id_type>(subdomain_id) ;
+          auto uelem = Elem::build(conv.libmesh_elem_type());
+          uelem->subdomain_id() = static_cast<subdomain_id_type>(subdomain_id);
 
           // Use the elem_num_map to obtain the ID of this element in the Exodus file
           int exodus_id = exio_helper->elem_num_map[j];
@@ -246,13 +245,13 @@ void ExodusII_IO::read (const std::string & fname)
           // some day we could use 1-based numbering in libmesh and
           // thus match the Exodus numbering exactly, but at the
           // moment libmesh is zero-based.
-          elem->set_id(exodus_id-1);
+          uelem->set_id(exodus_id-1);
 
-          // Record that we have seen an element of dimension elem->dim()
-          elems_of_dimension[elem->dim()] = true;
+          // Record that we have seen an element of dimension uelem->dim()
+          elems_of_dimension[uelem->dim()] = true;
 
           // Catch the Elem pointer that the Mesh throws back
-          elem = mesh.add_elem (elem);
+          Elem * elem = mesh.add_elem(std::move(uelem));
 
           // If the Mesh assigned an ID different from what is in the
           // Exodus file, we should probably error.

--- a/src/mesh/gmsh_io.C
+++ b/src/mesh/gmsh_io.C
@@ -525,9 +525,8 @@ void GmshIO::read_mesh(std::istream & in)
 
                   // Add the element to the mesh
                   {
-                    Elem * elem = Elem::build(eletype.type).release();
-                    elem->set_id(iel);
-                    elem = mesh.add_elem(elem);
+                    Elem * elem =
+                      mesh.add_elem(Elem::build_with_id(eletype.type, iel));
 
                     // Make sure that the libmesh element we added has nnodes nodes.
                     if (elem->n_nodes() != nnodes)
@@ -617,9 +616,8 @@ void GmshIO::read_mesh(std::istream & in)
                   // Loop over elements with dim > 0
                   for (std::size_t n = 0; n < num_elems_in_block; ++n)
                   {
-                    Elem * elem = Elem::build(eletype.type).release();
-                    elem->set_id(iel++);
-                    elem = mesh.add_elem(elem);
+                    Elem * elem =
+                      mesh.add_elem(Elem::build_with_id(eletype.type, iel++));
 
                     std::size_t gmsh_element_id;
                     in >> gmsh_element_id;

--- a/src/mesh/gmv_io.C
+++ b/src/mesh/gmv_io.C
@@ -2111,7 +2111,7 @@ void GMVIO::_read_one_cell()
       // libmesh element type needs to take that into account.
       ElemType type = this->gmv_elem_to_libmesh_elem(GMVLib::gmv_data.name1);
 
-      Elem * elem = Elem::build(type).release();
+      auto elem = Elem::build(type);
       elem->set_id(_next_elem_id++);
 
       // Get the ElementDefinition object for this element type
@@ -2132,7 +2132,7 @@ void GMVIO::_read_one_cell()
       elems_of_dimension[elem->dim()] = true;
 
       // Add the newly-created element to the mesh
-      mesh.add_elem(elem);
+      mesh.add_elem(std::move(elem));
     }
 
 

--- a/src/mesh/inf_elem_builder.C
+++ b/src/mesh/inf_elem_builder.C
@@ -531,32 +531,32 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
       // use braces to force scope.
       bool is_higher_order_elem = false;
 
-      Elem * el;
+      std::unique_ptr<Elem> el;
       switch(side->type())
         {
           // 3D infinite elements
           // TRIs
         case TRI3:
-          el=new InfPrism6;
+          el = Elem::build(INFPRISM6);
           break;
 
         case TRI6:
-          el=new InfPrism12;
+          el = Elem::build(INFPRISM12);
           is_higher_order_elem = true;
           break;
 
           // QUADs
         case QUAD4:
-          el=new InfHex8;
+          el = Elem::build(INFHEX8);
           break;
 
         case QUAD8:
-          el=new InfHex16;
+          el = Elem::build(INFHEX16);
           is_higher_order_elem = true;
           break;
 
         case QUAD9:
-          el=new InfHex18;
+          el = Elem::build(INFHEX18);
 
           // the method of assigning nodes (which follows below)
           // omits in the case of QUAD9 the bubble node; therefore
@@ -568,11 +568,11 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
 
           // 2D infinite elements
         case EDGE2:
-          el=new InfQuad4;
+          el = Elem::build(INFQUAD4);
           break;
 
         case EDGE3:
-          el=new InfQuad6;
+          el = Elem::build(INFQUAD6);
           el->set_node(4) = side->node_ptr(2);
           break;
 
@@ -662,7 +662,7 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
 
 
       // add infinite element to mesh
-      this->_mesh.add_elem(el);
+      this->_mesh.add_elem(std::move(el));
     } // for
 
 

--- a/src/mesh/matlab_io.C
+++ b/src/mesh/matlab_io.C
@@ -89,9 +89,8 @@ void MatlabIO::read_stream(std::istream & in)
 
     for (unsigned int i=0; i<nElem; i++)
       {
-        Elem * elem = new Tri3; // Always build a triangle
-        elem->set_id(i);
-        the_mesh.add_elem (elem);
+        // Always build a triangle
+        Elem * elem = the_mesh.add_elem(Elem::build_with_id(TRI3, i));
 
         for (unsigned int n=0; n<3; n++)  // Always read three 3 nodes
           {

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -357,7 +357,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
 
         // Build one nodal element for the mesh
         mesh.add_point (Point(0, 0, 0), 0);
-        Elem * elem = mesh.add_elem (new NodeElem);
+        Elem * elem = mesh.add_elem(Elem::build(NODEELEM));
         elem->set_node(0) = mesh.node_ptr(0);
 
         break;
@@ -459,9 +459,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
             {
               for (unsigned int i=0; i<nx; i++)
                 {
-                  Elem * elem = new Edge2;
-                  elem->set_id(i);
-                  elem = mesh.add_elem (elem);
+                  Elem * elem = mesh.add_elem(Elem::build_with_id(EDGE2, i));
                   elem->set_node(0) = mesh.node_ptr(i);
                   elem->set_node(1) = mesh.node_ptr(i+1);
 
@@ -470,6 +468,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
 
                   if (i == (nx-1))
                     boundary_info.add_side(elem, 1, 1);
+
                 }
               break;
             }
@@ -478,9 +477,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
             {
               for (unsigned int i=0; i<nx; i++)
                 {
-                  Elem * elem = new Edge3;
-                  elem->set_id(i);
-                  elem = mesh.add_elem (elem);
+                  Elem * elem = mesh.add_elem(Elem::build_with_id(EDGE3, i));
                   elem->set_node(0) = mesh.node_ptr(2*i);
                   elem->set_node(2) = mesh.node_ptr(2*i+1);
                   elem->set_node(1) = mesh.node_ptr(2*i+2);
@@ -498,9 +495,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
             {
               for (unsigned int i=0; i<nx; i++)
                 {
-                  Elem * elem = new Edge4;
-                  elem->set_id(i);
-                  elem = mesh.add_elem (elem);
+                  Elem * elem = mesh.add_elem(Elem::build_with_id(EDGE4, i));
                   elem->set_node(0) = mesh.node_ptr(3*i);
                   elem->set_node(2) = mesh.node_ptr(3*i+1);
                   elem->set_node(3) = mesh.node_ptr(3*i+2);
@@ -667,10 +662,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
               for (unsigned int j=0; j<ny; j++)
                 for (unsigned int i=0; i<nx; i++)
                   {
-                    Elem * elem = new Quad4;
-                    elem->set_id(elem_id++);
-                    elem = mesh.add_elem (elem);
-
+                    Elem * elem = mesh.add_elem(Elem::build_with_id(QUAD4, elem_id++));
                     elem->set_node(0) = mesh.node_ptr(idx(type,nx,i,j)    );
                     elem->set_node(1) = mesh.node_ptr(idx(type,nx,i+1,j)  );
                     elem->set_node(2) = mesh.node_ptr(idx(type,nx,i+1,j+1));
@@ -698,10 +690,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                 for (unsigned int i=0; i<nx; i++)
                   {
                     // Add first Tri3
-                    Elem * elem = new Tri3;
-                    elem->set_id(elem_id++);
-                    elem = mesh.add_elem (elem);
-
+                    Elem * elem = mesh.add_elem(Elem::build_with_id(TRI3, elem_id++));
                     elem->set_node(0) = mesh.node_ptr(idx(type,nx,i,j)    );
                     elem->set_node(1) = mesh.node_ptr(idx(type,nx,i+1,j)  );
                     elem->set_node(2) = mesh.node_ptr(idx(type,nx,i+1,j+1));
@@ -713,10 +702,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                       boundary_info.add_side(elem, 1, 1);
 
                     // Add second Tri3
-                    elem = new Tri3;
-                    elem->set_id(elem_id++);
-                    elem = mesh.add_elem (elem);
-
+                    elem = mesh.add_elem(Elem::build_with_id(TRI3, elem_id++));
                     elem->set_node(0) = mesh.node_ptr(idx(type,nx,i,j)    );
                     elem->set_node(1) = mesh.node_ptr(idx(type,nx,i+1,j+1));
                     elem->set_node(2) = mesh.node_ptr(idx(type,nx,i,j+1)  );
@@ -738,12 +724,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
               for (unsigned int j=0; j<(2*ny); j += 2)
                 for (unsigned int i=0; i<(2*nx); i += 2)
                   {
-                    Elem * elem = (type == QUAD8) ?
-                      static_cast<Elem *>(new Quad8) :
-                      static_cast<Elem *>(new Quad9);
-                    elem->set_id(elem_id++);
-                    elem = mesh.add_elem (elem);
-
+                    Elem * elem = mesh.add_elem(Elem::build_with_id(type, elem_id++));
                     elem->set_node(0) = mesh.node_ptr(idx(type,nx,i,j)    );
                     elem->set_node(1) = mesh.node_ptr(idx(type,nx,i+2,j)  );
                     elem->set_node(2) = mesh.node_ptr(idx(type,nx,i+2,j+2));
@@ -752,9 +733,9 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                     elem->set_node(5) = mesh.node_ptr(idx(type,nx,i+2,j+1));
                     elem->set_node(6) = mesh.node_ptr(idx(type,nx,i+1,j+2));
                     elem->set_node(7) = mesh.node_ptr(idx(type,nx,i,j+1)  );
+
                     if (type == QUAD9)
                       elem->set_node(8) = mesh.node_ptr(idx(type,nx,i+1,j+1));
-
 
                     if (j == 0)
                       boundary_info.add_side(elem, 0, 0);
@@ -778,10 +759,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                 for (unsigned int i=0; i<(2*nx); i += 2)
                   {
                     // Add first Tri6
-                    Elem * elem = new Tri6;
-                    elem->set_id(elem_id++);
-                    elem = mesh.add_elem (elem);
-
+                    Elem * elem = mesh.add_elem(Elem::build_with_id(TRI6, elem_id++));
                     elem->set_node(0) = mesh.node_ptr(idx(type,nx,i,j)    );
                     elem->set_node(1) = mesh.node_ptr(idx(type,nx,i+2,j)  );
                     elem->set_node(2) = mesh.node_ptr(idx(type,nx,i+2,j+2));
@@ -796,10 +774,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                       boundary_info.add_side(elem, 1, 1);
 
                     // Add second Tri6
-                    elem = new Tri6;
-                    elem->set_id(elem_id++);
-                    elem = mesh.add_elem (elem);
-
+                    elem = mesh.add_elem(Elem::build_with_id(TRI6, elem_id++));
                     elem->set_node(0) = mesh.node_ptr(idx(type,nx,i,j)    );
                     elem->set_node(1) = mesh.node_ptr(idx(type,nx,i+2,j+2));
                     elem->set_node(2) = mesh.node_ptr(idx(type,nx,i,j+2)  );
@@ -812,7 +787,6 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
 
                     if (i == 0)
                       boundary_info.add_side(elem, 2, 3);
-
                   }
               break;
             };
@@ -1005,10 +979,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                 for (unsigned int j=0; j<ny; j++)
                   for (unsigned int i=0; i<nx; i++)
                     {
-                      Elem * elem = new Hex8;
-                      elem->set_id(elem_id++);
-                      elem = mesh.add_elem (elem);
-
+                      Elem * elem = mesh.add_elem(Elem::build_with_id(HEX8, elem_id++));
                       elem->set_node(0) = mesh.node_ptr(idx(type,nx,ny,i,j,k)      );
                       elem->set_node(1) = mesh.node_ptr(idx(type,nx,ny,i+1,j,k)    );
                       elem->set_node(2) = mesh.node_ptr(idx(type,nx,ny,i+1,j+1,k)  );
@@ -1049,10 +1020,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                   for (unsigned int i=0; i<nx; i++)
                     {
                       // First Prism
-                      Elem * elem = new Prism6;
-                      elem->set_id(elem_id++);
-                      elem = mesh.add_elem (elem);
-
+                      Elem * elem = mesh.add_elem(Elem::build_with_id(PRISM6, elem_id++));
                       elem->set_node(0) = mesh.node_ptr(idx(type,nx,ny,i,j,k)      );
                       elem->set_node(1) = mesh.node_ptr(idx(type,nx,ny,i+1,j,k)    );
                       elem->set_node(2) = mesh.node_ptr(idx(type,nx,ny,i,j+1,k)    );
@@ -1074,10 +1042,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                         boundary_info.add_side(elem, 4, 5);
 
                       // Second Prism
-                      elem = new Prism6;
-                      elem->set_id(elem_id++);
-                      elem = mesh.add_elem (elem);
-
+                      elem = mesh.add_elem(Elem::build_with_id(PRISM6, elem_id++));
                       elem->set_node(0) = mesh.node_ptr(idx(type,nx,ny,i+1,j,k)    );
                       elem->set_node(1) = mesh.node_ptr(idx(type,nx,ny,i+1,j+1,k)  );
                       elem->set_node(2) = mesh.node_ptr(idx(type,nx,ny,i,j+1,k)    );
@@ -1118,11 +1083,8 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                 for (unsigned int j=0; j<(2*ny); j += 2)
                   for (unsigned int i=0; i<(2*nx); i += 2)
                     {
-                      Elem * elem = (type == HEX20) ?
-                        static_cast<Elem *>(new Hex20) :
-                        static_cast<Elem *>(new Hex27);
-                      elem->set_id(elem_id++);
-                      elem = mesh.add_elem (elem);
+                      ElemType build_type = (type == HEX20) ? HEX20 : HEX27;
+                      Elem * elem = mesh.add_elem(Elem::build_with_id(build_type, elem_id++));
 
                       elem->set_node(0)  = mesh.node_ptr(idx(type,nx,ny,i,  j,  k)  );
                       elem->set_node(1)  = mesh.node_ptr(idx(type,nx,ny,i+2,j,  k)  );
@@ -1144,6 +1106,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                       elem->set_node(17) = mesh.node_ptr(idx(type,nx,ny,i+2,j+1,k+2));
                       elem->set_node(18) = mesh.node_ptr(idx(type,nx,ny,i+1,j+2,k+2));
                       elem->set_node(19) = mesh.node_ptr(idx(type,nx,ny,i,  j+1,k+2));
+
                       if ((type == HEX27) || (type == TET4) || (type == TET10) ||
                           (type == PYRAMID5) || (type == PYRAMID13) || (type == PYRAMID14))
                         {
@@ -1155,7 +1118,6 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                           elem->set_node(25) = mesh.node_ptr(idx(type,nx,ny,i+1,j+1,k+2));
                           elem->set_node(26) = mesh.node_ptr(idx(type,nx,ny,i+1,j+1,k+1));
                         }
-
 
                       if (k == 0)
                         boundary_info.add_side(elem, 0, 0);
@@ -1189,12 +1151,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                   for (unsigned int i=0; i<(2*nx); i += 2)
                     {
                       // First Prism
-                      Elem * elem = (type == PRISM15) ?
-                        static_cast<Elem *>(new Prism15) :
-                        static_cast<Elem *>(new Prism18);
-                      elem->set_id(elem_id++);
-                      elem = mesh.add_elem (elem);
-
+                      Elem * elem = mesh.add_elem(Elem::build_with_id(type, elem_id++));
                       elem->set_node(0)  = mesh.node_ptr(idx(type,nx,ny,i,  j,  k)  );
                       elem->set_node(1)  = mesh.node_ptr(idx(type,nx,ny,i+2,j,  k)  );
                       elem->set_node(2)  = mesh.node_ptr(idx(type,nx,ny,i,  j+2,k)  );
@@ -1210,6 +1167,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                       elem->set_node(12) = mesh.node_ptr(idx(type,nx,ny,i+1,j,  k+2));
                       elem->set_node(13) = mesh.node_ptr(idx(type,nx,ny,i+1,j+1,k+2));
                       elem->set_node(14) = mesh.node_ptr(idx(type,nx,ny,i,  j+1,k+2));
+
                       if (type == PRISM18)
                         {
                           elem->set_node(15) = mesh.node_ptr(idx(type,nx,ny,i+1,j,  k+1));
@@ -1232,12 +1190,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
 
 
                       // Second Prism
-                      elem = (type == PRISM15) ?
-                        static_cast<Elem *>(new Prism15) :
-                        static_cast<Elem *>(new Prism18);
-                      elem->set_id(elem_id++);
-                      elem = mesh.add_elem (elem);
-
+                      elem = mesh.add_elem(Elem::build_with_id(type, elem_id++));
                       elem->set_node(0)  = mesh.node_ptr(idx(type,nx,ny,i+2,j,k)     );
                       elem->set_node(1)  = mesh.node_ptr(idx(type,nx,ny,i+2,j+2,k)   );
                       elem->set_node(2)  = mesh.node_ptr(idx(type,nx,ny,i,j+2,k)     );
@@ -1253,6 +1206,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                       elem->set_node(12) = mesh.node_ptr(idx(type,nx,ny,i+2,j+1,k+2));
                       elem->set_node(13) = mesh.node_ptr(idx(type,nx,ny,i+1,j+2,k+2));
                       elem->set_node(14) = mesh.node_ptr(idx(type,nx,ny,i+1,j+1,k+2));
+
                       if (type == PRISM18)
                         {
                           elem->set_node(15)  = mesh.node_ptr(idx(type,nx,ny,i+2,j+1,k+1));
@@ -1323,7 +1277,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
             (type == PYRAMID14))
           {
             // Temporary storage for new elements. (24 tets per hex, 6 pyramids)
-            std::vector<Elem *> new_elements;
+            std::vector<std::unique_ptr<Elem>> new_elements;
 
             if ((type == TET4) || (type == TET10))
               new_elements.reserve(24*mesh.n_elem());
@@ -1358,8 +1312,8 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                         // Build 4 sub-tets per side
                         for (unsigned int sub_tet=0; sub_tet<4; ++sub_tet)
                           {
-                            new_elements.push_back( new Tet4 );
-                            Elem * sub_elem = new_elements.back();
+                            new_elements.push_back( Elem::build(TET4) );
+                            auto & sub_elem = new_elements.back();
                             sub_elem->set_node(0) = side->node_ptr(sub_tet);
                             sub_elem->set_node(1) = side->node_ptr(8);                           // centroid of the face
                             sub_elem->set_node(2) = side->node_ptr(sub_tet==3 ? 0 : sub_tet+1 ); // wrap-around
@@ -1369,15 +1323,15 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                             // 0 with the same b_id.  Note: the tets are all aligned so that their
                             // side 0 is on the boundary.
                             if (b_id != BoundaryInfo::invalid_id)
-                              boundary_info.add_side(sub_elem, 0, b_id);
+                              boundary_info.add_side(sub_elem.get(), 0, b_id);
                           }
                       } // end if ((type == TET4) || (type == TET10))
 
                     else // type==PYRAMID5 || type==PYRAMID13 || type==PYRAMID14
                       {
                         // Build 1 sub-pyramid per side.
-                        new_elements.push_back(new Pyramid5);
-                        Elem * sub_elem = new_elements.back();
+                        new_elements.push_back( Elem::build(PYRAMID5) );
+                        auto & sub_elem = new_elements.back();
 
                         // Set the base.  Note that since the apex is *inside* the base_hex,
                         // and the pyramid uses a counter-clockwise base numbering, we need to
@@ -1393,7 +1347,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                         // If the original hex was a boundary hex, add the new sub_pyr's side
                         // 4 (the square base) with the same b_id.
                         if (b_id != BoundaryInfo::invalid_id)
-                          boundary_info.add_side(sub_elem, 4, b_id);
+                          boundary_info.add_side(sub_elem.get(), 4, b_id);
                       } // end else type==PYRAMID5 || type==PYRAMID13 || type==PYRAMID14
                   }
               }
@@ -1407,12 +1361,10 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
               }
 
             // Add the new elements
-            for (dof_id_type i=0,
-                 n_new = cast_int<dof_id_type>(new_elements.size());
-                 i != n_new; ++i)
+            for (auto i : index_range(new_elements))
               {
                 new_elements[i]->set_id(i);
-                mesh.add_elem(new_elements[i]);
+                mesh.add_elem( std::move(new_elements[i]) );
               }
 
           } // end if (type == TET4,TET10,PYRAMID5,PYRAMID13,PYRAMID14
@@ -1651,7 +1603,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
 
             // Element 0
             {
-              Elem * elem0 = mesh.add_elem (new Quad4);
+              Elem * elem0 = mesh.add_elem (Elem::build(QUAD4));
               elem0->set_node(0) = nodes[0];
               elem0->set_node(1) = nodes[1];
               elem0->set_node(2) = nodes[2];
@@ -1660,7 +1612,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
 
             // Element 1
             {
-              Elem * elem1 = mesh.add_elem (new Quad4);
+              Elem * elem1 = mesh.add_elem (Elem::build(QUAD4));
               elem1->set_node(0) = nodes[4];
               elem1->set_node(1) = nodes[0];
               elem1->set_node(2) = nodes[3];
@@ -1669,7 +1621,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
 
             // Element 2
             {
-              Elem * elem2 = mesh.add_elem (new Quad4);
+              Elem * elem2 = mesh.add_elem (Elem::build(QUAD4));
               elem2->set_node(0) = nodes[4];
               elem2->set_node(1) = nodes[5];
               elem2->set_node(2) = nodes[1];
@@ -1678,7 +1630,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
 
             // Element 3
             {
-              Elem * elem3 = mesh.add_elem (new Quad4);
+              Elem * elem3 = mesh.add_elem (Elem::build(QUAD4));
               elem3->set_node(0) = nodes[1];
               elem3->set_node(1) = nodes[5];
               elem3->set_node(2) = nodes[6];
@@ -1687,7 +1639,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
 
             // Element 4
             {
-              Elem * elem4 = mesh.add_elem (new Quad4);
+              Elem * elem4 = mesh.add_elem (Elem::build(QUAD4));
               elem4->set_node(0) = nodes[3];
               elem4->set_node(1) = nodes[2];
               elem4->set_node(2) = nodes[6];
@@ -1725,25 +1677,25 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
             for (unsigned int i = 0; i < 5; ++i)
               {
                 // 5 elems around point 0
-                Elem * new_elem = mesh.add_elem (new Tri3);
+                Elem * new_elem = mesh.add_elem(Elem::build(TRI3));
                 new_elem->set_node(0) = mesh.node_ptr(0);
                 new_elem->set_node(1) = mesh.node_ptr(idx1[i]);
                 new_elem->set_node(2) = mesh.node_ptr(idx1[i+1]);
 
                 // 5 adjacent elems
-                new_elem = mesh.add_elem (new Tri3);
+                new_elem = mesh.add_elem(Elem::build(TRI3));
                 new_elem->set_node(0) = mesh.node_ptr(idx3[i]);
                 new_elem->set_node(1) = mesh.node_ptr(idx3[i+1]);
                 new_elem->set_node(2) = mesh.node_ptr(idx2[i]);
 
                 // 5 elems around point 3
-                new_elem = mesh.add_elem (new Tri3);
+                new_elem = mesh.add_elem(Elem::build(TRI3));
                 new_elem->set_node(0) = mesh.node_ptr(3);
                 new_elem->set_node(1) = mesh.node_ptr(idx2[i]);
                 new_elem->set_node(2) = mesh.node_ptr(idx2[i+1]);
 
                 // 5 adjacent elems
-                new_elem = mesh.add_elem (new Tri3);
+                new_elem = mesh.add_elem(Elem::build(TRI3));
                 new_elem->set_node(0) = mesh.node_ptr(idx2[i+1]);
                 new_elem->set_node(1) = mesh.node_ptr(idx2[i]);
                 new_elem->set_node(2) = mesh.node_ptr(idx3[i+1]);
@@ -1807,7 +1759,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
         // Now create the elements and add them to the mesh
         // Element 0 - center element
         {
-          Elem * elem0 = mesh.add_elem (new Hex8);
+          Elem * elem0 = mesh.add_elem(Elem::build(HEX8));
           elem0->set_node(0) = nodes[0];
           elem0->set_node(1) = nodes[1];
           elem0->set_node(2) = nodes[2];
@@ -1820,7 +1772,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
 
         // Element 1 - "bottom"
         {
-          Elem * elem1 = mesh.add_elem (new Hex8);
+          Elem * elem1 = mesh.add_elem(Elem::build(HEX8));
           elem1->set_node(0) = nodes[8];
           elem1->set_node(1) = nodes[9];
           elem1->set_node(2) = nodes[10];
@@ -1833,7 +1785,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
 
         // Element 2 - "front"
         {
-          Elem * elem2 = mesh.add_elem (new Hex8);
+          Elem * elem2 = mesh.add_elem(Elem::build(HEX8));
           elem2->set_node(0) = nodes[8];
           elem2->set_node(1) = nodes[9];
           elem2->set_node(2) = nodes[1];
@@ -1846,7 +1798,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
 
         // Element 3 - "right"
         {
-          Elem * elem3 = mesh.add_elem (new Hex8);
+          Elem * elem3 = mesh.add_elem(Elem::build(HEX8));
           elem3->set_node(0) = nodes[1];
           elem3->set_node(1) = nodes[9];
           elem3->set_node(2) = nodes[10];
@@ -1859,7 +1811,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
 
         // Element 4 - "back"
         {
-          Elem * elem4 = mesh.add_elem (new Hex8);
+          Elem * elem4 = mesh.add_elem(Elem::build(HEX8));
           elem4->set_node(0) = nodes[3];
           elem4->set_node(1) = nodes[2];
           elem4->set_node(2) = nodes[10];
@@ -1872,7 +1824,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
 
         // Element 5 - "left"
         {
-          Elem * elem5 = mesh.add_elem (new Hex8);
+          Elem * elem5 = mesh.add_elem(Elem::build(HEX8));
           elem5->set_node(0) = nodes[8];
           elem5->set_node(1) = nodes[0];
           elem5->set_node(2) = nodes[3];
@@ -1885,7 +1837,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
 
         // Element 6 - "top"
         {
-          Elem * elem6 = mesh.add_elem (new Hex8);
+          Elem * elem6 = mesh.add_elem(Elem::build(HEX8));
           elem6->set_node(0) = nodes[4];
           elem6->set_node(1) = nodes[5];
           elem6->set_node(2) = nodes[6];
@@ -2079,12 +2031,12 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
 
       for (unsigned int k=0; k != nz; ++k)
         {
-          Elem * new_elem;
+          std::unique_ptr<Elem> new_elem;
           switch (etype)
             {
             case EDGE2:
               {
-                new_elem = new Quad4;
+                new_elem = Elem::build(QUAD4);
                 new_elem->set_node(0) = mesh.node_ptr(elem->node_ptr(0)->id() + (k * orig_nodes));
                 new_elem->set_node(1) = mesh.node_ptr(elem->node_ptr(1)->id() + (k * orig_nodes));
                 new_elem->set_node(2) = mesh.node_ptr(elem->node_ptr(1)->id() + ((k+1) * orig_nodes));
@@ -2099,7 +2051,7 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
               }
             case EDGE3:
               {
-                new_elem = new Quad9;
+                new_elem = Elem::build(QUAD9);
                 new_elem->set_node(0) = mesh.node_ptr(elem->node_ptr(0)->id() + (2*k * orig_nodes));
                 new_elem->set_node(1) = mesh.node_ptr(elem->node_ptr(1)->id() + (2*k * orig_nodes));
                 new_elem->set_node(2) = mesh.node_ptr(elem->node_ptr(1)->id() + ((2*k+2) * orig_nodes));
@@ -2119,7 +2071,7 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
               }
             case TRI3:
               {
-                new_elem = new Prism6;
+                new_elem = Elem::build(PRISM6);
                 new_elem->set_node(0) = mesh.node_ptr(elem->node_ptr(0)->id() + (k * orig_nodes));
                 new_elem->set_node(1) = mesh.node_ptr(elem->node_ptr(1)->id() + (k * orig_nodes));
                 new_elem->set_node(2) = mesh.node_ptr(elem->node_ptr(2)->id() + (k * orig_nodes));
@@ -2138,7 +2090,7 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
               }
             case TRI6:
               {
-                new_elem = new Prism18;
+                new_elem = Elem::build(PRISM18);
                 new_elem->set_node(0) = mesh.node_ptr(elem->node_ptr(0)->id() + (2*k * orig_nodes));
                 new_elem->set_node(1) = mesh.node_ptr(elem->node_ptr(1)->id() + (2*k * orig_nodes));
                 new_elem->set_node(2) = mesh.node_ptr(elem->node_ptr(2)->id() + (2*k * orig_nodes));
@@ -2169,7 +2121,7 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
               }
             case QUAD4:
               {
-                new_elem = new Hex8;
+                new_elem = Elem::build(HEX8);
                 new_elem->set_node(0) = mesh.node_ptr(elem->node_ptr(0)->id() + (k * orig_nodes));
                 new_elem->set_node(1) = mesh.node_ptr(elem->node_ptr(1)->id() + (k * orig_nodes));
                 new_elem->set_node(2) = mesh.node_ptr(elem->node_ptr(2)->id() + (k * orig_nodes));
@@ -2192,7 +2144,7 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
               }
             case QUAD9:
               {
-                new_elem = new Hex27;
+                new_elem = Elem::build(HEX27);
                 new_elem->set_node(0) = mesh.node_ptr(elem->node_ptr(0)->id() + (2*k * orig_nodes));
                 new_elem->set_node(1) = mesh.node_ptr(elem->node_ptr(1)->id() + (2*k * orig_nodes));
                 new_elem->set_node(2) = mesh.node_ptr(elem->node_ptr(2)->id() + (2*k * orig_nodes));
@@ -2260,20 +2212,20 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
             // Allow the user to choose new subdomain_ids
             new_elem->subdomain_id() = elem_subdomain->get_subdomain_for_layer(elem, k);
 
-          new_elem = mesh.add_elem(new_elem);
+          Elem * added_elem = mesh.add_elem(std::move(new_elem));
 
           // Copy any old boundary ids on all sides
           for (auto s : elem->side_index_range())
             {
               cross_section_boundary_info.boundary_ids(elem, s, ids_to_copy);
 
-              if (new_elem->dim() == 3)
+              if (added_elem->dim() == 3)
                 {
                   // For 2D->3D extrusion, we give the boundary IDs
                   // for side s on the old element to side s+1 on the
                   // new element.  This is just a happy coincidence as
                   // far as I can tell...
-                  boundary_info.add_side(new_elem,
+                  boundary_info.add_side(added_elem,
                                          cast_int<unsigned short>(s+1),
                                          ids_to_copy);
                 }
@@ -2285,22 +2237,22 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
                   // 1        -> 1
                   libmesh_assert_less(s, 2);
                   const unsigned short sidemap[2] = {3, 1};
-                  boundary_info.add_side(new_elem, sidemap[s], ids_to_copy);
+                  boundary_info.add_side(added_elem, sidemap[s], ids_to_copy);
                 }
             }
 
           // Give new boundary ids to bottom and top
           if (k == 0)
-            boundary_info.add_side(new_elem, 0, next_side_id);
+            boundary_info.add_side(added_elem, 0, next_side_id);
           if (k == nz-1)
             {
               // For 2D->3D extrusion, the "top" ID is 1+the original
               // element's number of sides.  For 1D->2D extrusion, the
               // "top" ID is side 2.
-              const unsigned short top_id = new_elem->dim() == 3 ?
+              const unsigned short top_id = added_elem->dim() == 3 ?
                 cast_int<unsigned short>(elem->n_sides()+1) : 2;
               boundary_info.add_side
-                (new_elem, top_id,
+                (added_elem, top_id,
                  cast_int<boundary_id_type>(next_side_id+1));
             }
         }

--- a/src/mesh/mesh_tetgen_interface.C
+++ b/src/mesh/mesh_tetgen_interface.C
@@ -94,17 +94,17 @@ void TetGenMeshInterface::triangulate_pointset ()
 
   for (unsigned int i=0; i<num_elements; ++i)
     {
-      Elem * elem = new Tet4;
+      auto elem = Elem::build(TET4);
 
       // Get the nodes associated with this element
       for (auto j : elem->node_index_range())
         node_labels[j] = tetgen_wrapper.get_element_node(i,j);
 
       // Associate the nodes with this element
-      this->assign_nodes_to_elem(node_labels, elem);
+      this->assign_nodes_to_elem(node_labels, elem.get());
 
       // Finally, add this element to the mesh.
-      this->_mesh.add_elem(elem);
+      this->_mesh.add_elem(std::move(elem));
     }
 }
 
@@ -145,16 +145,16 @@ void TetGenMeshInterface::pointset_convexhull ()
 
   for (unsigned int i=0; i<num_elements; ++i)
     {
-      Elem * elem = new Tri3;
+      auto elem = Elem::build(TRI3);
 
       // Get node labels associated with this element
       for (auto j : elem->node_index_range())
         node_labels[j] = tetgen_wrapper.get_triface_node(i,j);
 
-      this->assign_nodes_to_elem(node_labels, elem);
+      this->assign_nodes_to_elem(node_labels, elem.get());
 
       // Finally, add this element to the mesh.
-      this->_mesh.add_elem(elem);
+      this->_mesh.add_elem(std::move(elem));
     }
 }
 
@@ -326,17 +326,17 @@ void TetGenMeshInterface::triangulate_conformingDelaunayMesh_carvehole  (const s
   for (unsigned int i=0; i<num_elements; i++)
     {
       // TetGen only supports Tet4 elements.
-      Elem * elem = new Tet4;
+      auto elem = Elem::build(TET4);
 
       // Fill up the the node_labels vector
       for (auto j : elem->node_index_range())
         node_labels[j] = tetgen_wrapper.get_element_node(i,j);
 
       // Associate nodes with this element
-      this->assign_nodes_to_elem(node_labels, elem);
+      this->assign_nodes_to_elem(node_labels, elem.get());
 
       // Finally, add this element to the mesh
-      this->_mesh.add_elem(elem);
+      this->_mesh.add_elem(std::move(elem));
     }
 
   // Delete original convex hull elements.  Is there ever a case where

--- a/src/mesh/mesh_triangle_wrapper.C
+++ b/src/mesh/mesh_triangle_wrapper.C
@@ -128,7 +128,7 @@ void TriangleWrapper::copy_tri_to_mesh(const triangulateio & triangle_data_input
         {
         case TRI3:
           {
-            Elem * elem = mesh_output.add_elem (new Tri3);
+            Elem * elem = mesh_output.add_elem(Elem::build(TRI3));
 
             for (unsigned int n=0; n<3; ++n)
               elem->set_node(n) = mesh_output.node_ptr(triangle_data_input.trianglelist[i*3 + n]);
@@ -143,7 +143,7 @@ void TriangleWrapper::copy_tri_to_mesh(const triangulateio & triangle_data_input
 
         case TRI6:
           {
-            Elem * elem = mesh_output.add_elem (new Tri6);
+            Elem * elem = mesh_output.add_elem(Elem::build(TRI6));
 
             // Triangle number TRI6 nodes in a different way to libMesh
             elem->set_node(0) = mesh_output.node_ptr(triangle_data_input.trianglelist[i*6 + 0]);

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -838,27 +838,26 @@ void Nemesis_IO::read (const std::string & base_filename)
       // Loop over all the elements in this block
       for (unsigned int j=0; j<to_uint(nemhelper->num_elem_this_blk); j++)
         {
-          Elem * elem = Elem::build (conv.libmesh_elem_type()).release();
-          libmesh_assert (elem);
+          auto uelem = Elem::build (conv.libmesh_elem_type());
 
           // Assign subdomain and processor ID to the newly-created Elem.
           // Assigning the processor ID beforehand ensures that the Elem is
           // not added as an "unpartitioned" element.  Note that the element
           // numbering in Exodus is also 1-based.
-          elem->subdomain_id() = subdomain_id;
-          elem->processor_id() = this->processor_id();
-          elem->set_id()       = my_next_elem++;
+          uelem->subdomain_id() = subdomain_id;
+          uelem->processor_id() = this->processor_id();
+          uelem->set_id()       = my_next_elem++;
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
-          elem->set_unique_id() = elem->id();
+          uelem->set_unique_id() = uelem->id();
 #endif
 
           // Mark that we have seen an element of the current element's
           // dimension.
-          elems_of_dimension[elem->dim()] = true;
+          elems_of_dimension[uelem->dim()] = true;
 
           // Add the created Elem to the Mesh, catch the Elem
           // pointer that the Mesh throws back.
-          elem = mesh.add_elem (elem);
+          Elem * elem = mesh.add_elem(std::move(uelem));
 
           // We are expecting the element "thrown back" by libmesh to have the ID we specified for it...
           // Check to see that really is the case.  Note that my_next_elem was post-incremented, so

--- a/src/mesh/off_io.C
+++ b/src/mesh/off_io.C
@@ -106,15 +106,15 @@ void OFFIO::read_stream(std::istream & in)
             }
         }
 
-      Elem * elem;
+      std::unique_ptr<Elem> elem;
       switch (nv)
         {
         case 2:
-          elem = new Edge2;
+          elem = Elem::build(EDGE2);
           break;
 
         case 3:
-          elem = new Tri3;
+          elem = Elem::build(TRI3);
           break;
 
         default:
@@ -122,13 +122,14 @@ void OFFIO::read_stream(std::istream & in)
         }
 
       elem->set_id(e);
-      the_mesh.add_elem (elem);
 
       for (unsigned int i=0; i<nv; i++)
         {
           in >> nid;
           elem->set_node(i) = the_mesh.node_ptr(nid);
         }
+
+      the_mesh.add_elem(std::move(elem));
     }
 }
 

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -323,6 +323,14 @@ Elem * ReplicatedMesh::add_elem (Elem * e)
   return e;
 }
 
+Elem * ReplicatedMesh::add_elem (std::unique_ptr<Elem> e)
+{
+  // The mesh now takes ownership of the Elem. Eventually the guts of
+  // add_elem() will get moved to a private helper function, and
+  // calling add_elem() directly will be deprecated.
+  return add_elem(e.release());
+}
+
 
 
 Elem * ReplicatedMesh::insert_elem (Elem * e)

--- a/src/mesh/tetgen_io.C
+++ b/src/mesh/tetgen_io.C
@@ -217,20 +217,17 @@ void TetGenIO::element_in (std::istream & ele_stream)
       libmesh_assert (ele_stream.good());
 
       // TetGen only supports Tet4 and Tet10 elements.
-      Elem * elem;
+      Elem * elem = nullptr;
 
       if (n_nodes==4)
-        elem = new Tet4;
+        elem = mesh.add_elem(Elem::build_with_id(TET4, i));
 
       else if (n_nodes==10)
-        elem = new Tet10;
+        elem = mesh.add_elem(Elem::build_with_id(TET10, i));
 
       else
-        libmesh_error_msg("Elements with " << n_nodes << " nodes are not supported in the LibMesh tetgen module.");
-
-      elem->set_id(i);
-
-      mesh.add_elem (elem);
+        libmesh_error_msg("Elements with " << n_nodes <<
+                          " nodes are not supported in the LibMesh tetgen module.");
 
       libmesh_assert(elem);
       libmesh_assert_equal_to (elem->n_nodes(), n_nodes);

--- a/src/mesh/ucd_io.C
+++ b/src/mesh/ucd_io.C
@@ -205,7 +205,7 @@ void UCDIO::read_implementation (std::istream & in)
         ElemType et = libmesh_map_find(_reading_element_map, type);
 
         // Build the required type and release it into our custody.
-        Elem * elem = Elem::build(et).release();
+        auto elem = Elem::build(et);
 
         for (auto n : elem->node_index_range())
           {
@@ -227,7 +227,7 @@ void UCDIO::read_implementation (std::istream & in)
 
         // Add the element to the mesh
         elem->set_id(i);
-        mesh.add_elem (elem);
+        mesh.add_elem (std::move(elem));
       }
 
     // Set the mesh dimension to the largest encountered for an element

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -661,13 +661,13 @@ void UNVIO::elements_in (std::istream & in_file)
         in_file >> node_labels[j];
 
       // element pointer, to be allocated
-      Elem * elem = nullptr;
+      std::unique_ptr<Elem> elem;
 
       switch (fe_descriptor_id)
         {
         case 11: // Rod
           {
-            elem = new Edge2;
+            elem = Elem::build(EDGE2);
 
             assign_elem_nodes[1]=0;
             assign_elem_nodes[2]=1;
@@ -677,7 +677,7 @@ void UNVIO::elements_in (std::istream & in_file)
         case 41: // Plane Stress Linear Triangle
         case 91: // Thin Shell   Linear Triangle
           {
-            elem = new Tri3;  // create new element
+            elem = Elem::build(TRI3);  // create new element
 
             assign_elem_nodes[1]=0;
             assign_elem_nodes[2]=2;
@@ -688,7 +688,7 @@ void UNVIO::elements_in (std::istream & in_file)
         case 42: // Plane Stress Quadratic Triangle
         case 92: // Thin Shell   Quadratic Triangle
           {
-            elem = new Tri6;  // create new element
+            elem = Elem::build(TRI6);  // create new element
 
             assign_elem_nodes[1]=0;
             assign_elem_nodes[2]=5;
@@ -705,7 +705,7 @@ void UNVIO::elements_in (std::istream & in_file)
         case 44: // Plane Stress Linear Quadrilateral
         case 94: // Thin Shell   Linear Quadrilateral
           {
-            elem = new Quad4; // create new element
+            elem = Elem::build(QUAD4); // create new element
 
             assign_elem_nodes[1]=0;
             assign_elem_nodes[2]=3;
@@ -717,7 +717,7 @@ void UNVIO::elements_in (std::istream & in_file)
         case 45: // Plane Stress Quadratic Quadrilateral
         case 95: // Thin Shell   Quadratic Quadrilateral
           {
-            elem = new Quad8; // create new element
+            elem = Elem::build(QUAD8); // create new element
 
             assign_elem_nodes[1]=0;
             assign_elem_nodes[2]=7;
@@ -732,7 +732,7 @@ void UNVIO::elements_in (std::istream & in_file)
 
         case 300: // Thin Shell   Quadratic Quadrilateral (nine nodes)
           {
-            elem = new Quad9; // create new element
+            elem = Elem::build(QUAD9); // create new element
 
             assign_elem_nodes[1]=0;
             assign_elem_nodes[2]=7;
@@ -751,7 +751,7 @@ void UNVIO::elements_in (std::istream & in_file)
 
         case 111: // Solid Linear Tetrahedron
           {
-            elem = new Tet4;  // create new element
+            elem = Elem::build(TET4);  // create new element
 
             assign_elem_nodes[1]=0;
             assign_elem_nodes[2]=1;
@@ -762,7 +762,7 @@ void UNVIO::elements_in (std::istream & in_file)
 
         case 112: // Solid Linear Prism
           {
-            elem = new Prism6;  // create new element
+            elem = Elem::build(PRISM6);  // create new element
 
             assign_elem_nodes[1]=0;
             assign_elem_nodes[2]=1;
@@ -775,7 +775,7 @@ void UNVIO::elements_in (std::istream & in_file)
 
         case 115: // Solid Linear Brick
           {
-            elem = new Hex8;  // create new element
+            elem = Elem::build(HEX8);  // create new element
 
             assign_elem_nodes[1]=0;
             assign_elem_nodes[2]=4;
@@ -790,7 +790,7 @@ void UNVIO::elements_in (std::istream & in_file)
 
         case 116: // Solid Quadratic Brick
           {
-            elem = new Hex20; // create new element
+            elem = Elem::build(HEX20); // create new element
 
             assign_elem_nodes[1]=0;
             assign_elem_nodes[2]=12;
@@ -822,7 +822,7 @@ void UNVIO::elements_in (std::istream & in_file)
 
         case 118: // Solid Quadratic Tetrahedron
           {
-            elem = new Tet10; // create new element
+            elem = Elem::build(TET10); // create new element
 
             assign_elem_nodes[1]=0;
             assign_elem_nodes[2]=4;
@@ -861,7 +861,7 @@ void UNVIO::elements_in (std::istream & in_file)
       _unv_elem_id_to_libmesh_elem_id[element_label] = ctr;
 
       // Add the element to the Mesh
-      mesh.add_elem(elem);
+      mesh.add_elem(std::move(elem));
 
       // Increment the counter for the next iteration
       ctr++;

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -206,7 +206,7 @@ void VTKIO::read (const std::string & name)
 
       // Get the libMesh element type corresponding to this VTK element type.
       ElemType libmesh_elem_type = _element_maps.find(cell->GetCellType());
-      Elem * elem = Elem::build(libmesh_elem_type).release();
+      auto elem = Elem::build(libmesh_elem_type);
 
       // get the straightforward numbering from the VTK cells
       for (auto j : elem->node_index_range())
@@ -228,7 +228,7 @@ void VTKIO::read (const std::string & name)
 
       elems_of_dimension[elem->dim()] = true;
 
-      mesh.add_elem(elem);
+      mesh.add_elem(std::move(elem));
     } // end loop over VTK cells
 
   // Set the mesh dimension to the largest encountered for an element

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -1596,7 +1596,7 @@ void XdrIO::read_serialized_connectivity (Xdr & io, const dof_id_type n_elem, st
           Elem * parent = (parent_id == DofObject::invalid_id) ?
             nullptr : mesh.elem_ptr(parent_id);
 
-          Elem * elem = Elem::build (elem_type, parent).release();
+          auto elem = Elem::build(elem_type, parent);
 
           elem->set_id() = e;
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
@@ -1609,7 +1609,7 @@ void XdrIO::read_serialized_connectivity (Xdr & io, const dof_id_type n_elem, st
 
           if (parent)
             {
-              parent->add_child(elem);
+              parent->add_child(elem.get());
               parent->set_refinement_flag (Elem::INACTIVE);
               elem->set_refinement_flag   (Elem::JUST_REFINED);
             }
@@ -1626,7 +1626,7 @@ void XdrIO::read_serialized_connectivity (Xdr & io, const dof_id_type n_elem, st
             }
 
           elems_of_dimension[elem->dim()] = true;
-          mesh.add_elem(elem);
+          mesh.add_elem(std::move(elem));
         }
     }
 

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -333,7 +333,7 @@ void RBEIMEvaluation::legacy_write_out_interpolation_points_elem(const std::stri
       std::map<dof_id_type,dof_id_type>::iterator id_it = elem_id_map.find(old_elem_id);
       if (id_it == elem_id_map.end())
         {
-          Elem * new_elem = Elem::build(old_elem->type(), /*parent*/ nullptr).release();
+          auto new_elem = Elem::build(old_elem->type(), /*parent*/ nullptr);
           new_elem->subdomain_id() = old_elem->subdomain_id();
 
           // Assign all the nodes
@@ -348,12 +348,12 @@ void RBEIMEvaluation::legacy_write_out_interpolation_points_elem(const std::stri
           new_elem->processor_id() = 0;
 
           // Add the element to the mesh
-          _interpolation_points_mesh.add_elem(new_elem);
+          Elem * added_elem = _interpolation_points_mesh.add_elem(std::move(new_elem));
 
           // Set the id of new_elem appropriately
-          new_elem->set_id(new_elem_id);
-          interpolation_elem_ids[i] = new_elem->id();
-          elem_id_map[old_elem_id] = new_elem->id();
+          added_elem->set_id(new_elem_id);
+          interpolation_elem_ids[i] = added_elem->id();
+          elem_id_map[old_elem_id] = added_elem->id();
 
           new_elem_id++;
         }

--- a/tests/base/overlapping_coupling_test.C
+++ b/tests/base/overlapping_coupling_test.C
@@ -250,8 +250,7 @@ protected:
     _mesh->add_point( Point(0.0,1.0),3 );
 
     {
-      Elem* elem = _mesh->add_elem( new Quad4 );
-      elem->set_id(0);
+      Elem * elem = _mesh->add_elem(Elem::build_with_id(QUAD4, 0));
       elem->subdomain_id() = 1;
 
       for (unsigned int n=0; n<4; n++)
@@ -262,8 +261,7 @@ protected:
     _mesh->add_point( Point(0.0,2.0),5 );
 
     {
-      Elem* elem = _mesh->add_elem( new Quad4 );
-      elem->set_id(1);
+      Elem * elem = _mesh->add_elem(Elem::build_with_id(QUAD4, 1));
       elem->subdomain_id() = 1;
 
       elem->set_node(0) = _mesh->node_ptr(3);
@@ -278,8 +276,7 @@ protected:
     _mesh->add_point( Point(0.0,2.0),9 );
 
     {
-      Elem* elem = _mesh->add_elem( new Quad4 );
-      elem->set_id(2);
+      Elem* elem = _mesh->add_elem(Elem::build_with_id(QUAD4, 2));
       elem->subdomain_id() = 2;
 
       elem->set_node(0) = _mesh->node_ptr(6);

--- a/tests/mesh/boundary_info.C
+++ b/tests/mesh/boundary_info.C
@@ -269,13 +269,13 @@ public:
     mesh.add_point( Point(0.0, 1.0), 3 );
     mesh.add_point( Point(0.0, 0.0), 0 );
 
-    Elem* elem_top = mesh.add_elem( new QuadShell4 );
+    Elem * elem_top = mesh.add_elem(Elem::build(QUADSHELL4));
     elem_top->set_node(0) = mesh.node_ptr(0);
     elem_top->set_node(1) = mesh.node_ptr(1);
     elem_top->set_node(2) = mesh.node_ptr(2);
     elem_top->set_node(3) = mesh.node_ptr(3);
 
-    Elem* elem_bottom = mesh.add_elem( new QuadShell4 );
+    Elem * elem_bottom = mesh.add_elem(Elem::build(QUADSHELL4));
     elem_bottom->set_node(0) = mesh.node_ptr(4);
     elem_bottom->set_node(1) = mesh.node_ptr(5);
     elem_bottom->set_node(2) = mesh.node_ptr(1);

--- a/tests/mesh/boundary_points.C
+++ b/tests/mesh/boundary_points.C
@@ -75,113 +75,89 @@ protected:
     _mesh->add_point( Point(6.0, 1.0), 24 );
 
     {
-      Elem* elem = new Quad4;
+      Elem * elem = _mesh->add_elem(Elem::build_with_id(QUAD4, 0));
       elem->set_node(0) = _mesh->node_ptr(0);
       elem->set_node(1) = _mesh->node_ptr(1);
       elem->set_node(2) = _mesh->node_ptr(2);
       elem->set_node(3) = _mesh->node_ptr(3);
-      elem->set_id() = 0;
-      _mesh->add_elem(elem);
     }
     {
-      Elem* elem = new Quad4;
+      Elem * elem = _mesh->add_elem(Elem::build_with_id(QUAD4, 1));
       elem->set_node(0) = _mesh->node_ptr(4);
       elem->set_node(1) = _mesh->node_ptr(5);
       elem->set_node(2) = _mesh->node_ptr(1);
       elem->set_node(3) = _mesh->node_ptr(0);
-      elem->set_id() = 1;
-      _mesh->add_elem(elem);
     }
     {
-      Elem* elem = new Quad4;
+      Elem * elem = _mesh->add_elem(Elem::build_with_id(QUAD4, 2));
       elem->set_node(0) = _mesh->node_ptr(7);
       elem->set_node(1) = _mesh->node_ptr(2);
       elem->set_node(2) = _mesh->node_ptr(1);
       elem->set_node(3) = _mesh->node_ptr(6);
-      elem->set_id() = 2;
-      _mesh->add_elem(elem);
     }
     {
-      Elem* elem = new Quad4;
+      Elem * elem = _mesh->add_elem(Elem::build_with_id(QUAD4, 3));
       elem->set_node(0) = _mesh->node_ptr(5);
       elem->set_node(1) = _mesh->node_ptr(8);
       elem->set_node(2) = _mesh->node_ptr(6);
       elem->set_node(3) = _mesh->node_ptr(1);
-      elem->set_id() = 3;
-      _mesh->add_elem(elem);
     }
     {
-      Elem* elem = new Quad4;
+      Elem * elem = _mesh->add_elem(Elem::build_with_id(QUAD4, 4));
       elem->set_node(0) = _mesh->node_ptr(9);
       elem->set_node(1) = _mesh->node_ptr(13);
       elem->set_node(2) = _mesh->node_ptr(14);
       elem->set_node(3) = _mesh->node_ptr(10);
-      elem->set_id() = 4;
-      _mesh->add_elem(elem);
     }
     {
-      Elem* elem = new Quad4;
+      Elem * elem = _mesh->add_elem(Elem::build_with_id(QUAD4, 5));
       elem->set_node(0) = _mesh->node_ptr(10);
       elem->set_node(1) = _mesh->node_ptr(14);
       elem->set_node(2) = _mesh->node_ptr(15);
       elem->set_node(3) = _mesh->node_ptr(11);
-      elem->set_id() = 5;
-      _mesh->add_elem(elem);
     }
     {
-      Elem* elem = new Quad4;
+      Elem * elem = _mesh->add_elem(Elem::build_with_id(QUAD4, 6));
       elem->set_node(0) = _mesh->node_ptr(11);
       elem->set_node(1) = _mesh->node_ptr(15);
       elem->set_node(2) = _mesh->node_ptr(16);
       elem->set_node(3) = _mesh->node_ptr(12);
-      elem->set_id() = 6;
-      _mesh->add_elem(elem);
     }
     {
-      Elem* elem = new Quad4;
+      Elem * elem = _mesh->add_elem(Elem::build_with_id(QUAD4, 7));
       elem->set_node(0) = _mesh->node_ptr(13);
       elem->set_node(1) = _mesh->node_ptr(17);
       elem->set_node(2) = _mesh->node_ptr(18);
       elem->set_node(3) = _mesh->node_ptr(14);
-      elem->set_id() = 7;
-      _mesh->add_elem(elem);
     }
     // skip one element here
     {
-      Elem* elem = new Quad4;
+      Elem * elem = _mesh->add_elem(Elem::build_with_id(QUAD4, 8));
       elem->set_node(0) = _mesh->node_ptr(15);
       elem->set_node(1) = _mesh->node_ptr(19);
       elem->set_node(2) = _mesh->node_ptr(20);
       elem->set_node(3) = _mesh->node_ptr(16);
-      elem->set_id() = 8;
-      _mesh->add_elem(elem);
     }
     {
-      Elem* elem = new Quad4;
+      Elem * elem = _mesh->add_elem(Elem::build_with_id(QUAD4, 9));
       elem->set_node(0) = _mesh->node_ptr(17);
       elem->set_node(1) = _mesh->node_ptr(21);
       elem->set_node(2) = _mesh->node_ptr(22);
       elem->set_node(3) = _mesh->node_ptr(18);
-      elem->set_id() = 9;
-      _mesh->add_elem(elem);
     }
     {
-      Elem* elem = new Quad4;
+      Elem * elem = _mesh->add_elem(Elem::build_with_id(QUAD4, 10));
       elem->set_node(0) = _mesh->node_ptr(18);
       elem->set_node(1) = _mesh->node_ptr(22);
       elem->set_node(2) = _mesh->node_ptr(23);
       elem->set_node(3) = _mesh->node_ptr(19);
-      elem->set_id() = 10;
-      _mesh->add_elem(elem);
     }
     {
-      Elem* elem = new Quad4;
+      Elem * elem = _mesh->add_elem(Elem::build_with_id(QUAD4, 11));
       elem->set_node(0) = _mesh->node_ptr(19);
       elem->set_node(1) = _mesh->node_ptr(23);
       elem->set_node(2) = _mesh->node_ptr(24);
       elem->set_node(3) = _mesh->node_ptr(20);
-      elem->set_id() = 11;
-      _mesh->add_elem(elem);
     }
 
     // libMesh shouldn't renumber, or our based-on-initial-id

--- a/tests/mesh/mesh_function_dfem.C
+++ b/tests/mesh/mesh_function_dfem.C
@@ -92,13 +92,13 @@ protected:
     _mesh->add_point( Point(0.0, 0.0), 0 );
 
     {
-      Elem* elem_top = _mesh->add_elem( new Quad4 );
+      Elem * elem_top = _mesh->add_elem(Elem::build(QUAD4));
       elem_top->set_node(0) = _mesh->node_ptr(0);
       elem_top->set_node(1) = _mesh->node_ptr(1);
       elem_top->set_node(2) = _mesh->node_ptr(2);
       elem_top->set_node(3) = _mesh->node_ptr(3);
 
-      Elem* elem_bottom = _mesh->add_elem( new Quad4 );
+      Elem * elem_bottom = _mesh->add_elem(Elem::build(QUAD4));
       elem_bottom->set_node(0) = _mesh->node_ptr(4);
       elem_bottom->set_node(1) = _mesh->node_ptr(5);
       elem_bottom->set_node(2) = _mesh->node_ptr(1);

--- a/tests/mesh/mixed_dim_mesh_test.C
+++ b/tests/mesh/mixed_dim_mesh_test.C
@@ -68,19 +68,19 @@ protected:
     _mesh->add_point( Point(0.0, 0.0), 0 );
 
     {
-      Elem* elem_top = _mesh->add_elem( new Quad4 );
+      Elem * elem_top = _mesh->add_elem(Elem::build(QUAD4));
       elem_top->set_node(0) = _mesh->node_ptr(0);
       elem_top->set_node(1) = _mesh->node_ptr(1);
       elem_top->set_node(2) = _mesh->node_ptr(2);
       elem_top->set_node(3) = _mesh->node_ptr(3);
 
-      Elem* elem_bottom = _mesh->add_elem( new Quad4 );
+      Elem * elem_bottom = _mesh->add_elem(Elem::build(QUAD4));
       elem_bottom->set_node(0) = _mesh->node_ptr(4);
       elem_bottom->set_node(1) = _mesh->node_ptr(5);
       elem_bottom->set_node(2) = _mesh->node_ptr(1);
       elem_bottom->set_node(3) = _mesh->node_ptr(0);
 
-      Elem* edge = _mesh->add_elem( new Edge2 );
+      Elem * edge = _mesh->add_elem(Elem::build(EDGE2));
       edge->set_node(0) = _mesh->node_ptr(0);
       edge->set_node(1) = _mesh->node_ptr(1);
 
@@ -444,31 +444,31 @@ protected:
 
 
     {
-      Elem* quad0 = _mesh->add_elem( new Quad4 );
+      Elem * quad0 = _mesh->add_elem(Elem::build(QUAD4));
       quad0->set_node(0) = _mesh->node_ptr(0);
       quad0->set_node(1) = _mesh->node_ptr(1);
       quad0->set_node(2) = _mesh->node_ptr(2);
       quad0->set_node(3) = _mesh->node_ptr(3);
 
-      Elem* quad1 = _mesh->add_elem( new Quad4 );
+      Elem * quad1 = _mesh->add_elem(Elem::build(QUAD4));
       quad1->set_node(0) = _mesh->node_ptr(3);
       quad1->set_node(1) = _mesh->node_ptr(2);
       quad1->set_node(2) = _mesh->node_ptr(5);
       quad1->set_node(3) = _mesh->node_ptr(4);
 
-      Elem* quad2 = _mesh->add_elem( new Quad4 );
+      Elem * quad2 = _mesh->add_elem(Elem::build(QUAD4));
       quad2->set_node(0) = _mesh->node_ptr(6);
       quad2->set_node(1) = _mesh->node_ptr(7);
       quad2->set_node(2) = _mesh->node_ptr(1);
       quad2->set_node(3) = _mesh->node_ptr(0);
 
-      Elem* quad3 = _mesh->add_elem( new Quad4 );
+      Elem * quad3 = _mesh->add_elem(Elem::build(QUAD4));
       quad3->set_node(0) = _mesh->node_ptr(9);
       quad3->set_node(1) = _mesh->node_ptr(8);
       quad3->set_node(2) = _mesh->node_ptr(7);
       quad3->set_node(3) = _mesh->node_ptr(6);
 
-      Elem* edge = _mesh->add_elem( new Edge2 );
+      Elem * edge = _mesh->add_elem(Elem::build(EDGE2));
       edge->set_node(0) = _mesh->node_ptr(0);
       edge->set_node(1) = _mesh->node_ptr(1);
 
@@ -678,27 +678,27 @@ protected:
     _mesh->add_point( Point(0.0, 0.0), 0 );
 
     {
-      Elem* elem0 = _mesh->add_elem( new Tri3 );
+      Elem * elem0 = _mesh->add_elem(Elem::build(TRI3));
       elem0->set_node(0) = _mesh->node_ptr(0);
       elem0->set_node(1) = _mesh->node_ptr(1);
       elem0->set_node(2) = _mesh->node_ptr(2);
 
-      Elem* elem1 = _mesh->add_elem( new Tri3 );
+      Elem * elem1 = _mesh->add_elem(Elem::build(TRI3));
       elem1->set_node(0) = _mesh->node_ptr(2);
       elem1->set_node(1) = _mesh->node_ptr(3);
       elem1->set_node(2) = _mesh->node_ptr(0);
 
-      Elem* elem2 = _mesh->add_elem( new Tri3 );
+      Elem * elem2 = _mesh->add_elem(Elem::build(TRI3));
       elem2->set_node(0) = _mesh->node_ptr(1);
       elem2->set_node(1) = _mesh->node_ptr(0);
       elem2->set_node(2) = _mesh->node_ptr(4);
 
-      Elem* elem3 = _mesh->add_elem( new Tri3 );
+      Elem * elem3 = _mesh->add_elem(Elem::build(TRI3));
       elem3->set_node(0) = _mesh->node_ptr(4);
       elem3->set_node(1) = _mesh->node_ptr(5);
       elem3->set_node(2) = _mesh->node_ptr(1);
 
-      Elem* edge = _mesh->add_elem( new Edge2 );
+      Elem * edge = _mesh->add_elem(Elem::build(EDGE2));
       edge->set_node(0) = _mesh->node_ptr(0);
       edge->set_node(1) = _mesh->node_ptr(1);
 
@@ -914,7 +914,7 @@ protected:
             {
               for (unsigned int x = 0; x < 3; x++)
                 {
-                  Elem* hex = _mesh->add_elem( new Hex8 );
+                  Elem * hex = _mesh->add_elem(Elem::build(HEX8));
                   hex->set_node(0) = _mesh->node_ptr(x+4*y    +16*z        );
                   hex->set_node(1) = _mesh->node_ptr(x+4*y    +16*z     + 1);
                   hex->set_node(2) = _mesh->node_ptr(x+4*(y+1)+16*z     + 1);
@@ -926,7 +926,7 @@ protected:
                 }
             }
         }
-      Elem* quad = _mesh->add_elem( new Quad4 );
+      Elem * quad = _mesh->add_elem(Elem::build(QUAD4));
       unsigned int x=1,y=1,z=2;
       quad->set_node(0) = _mesh->node_ptr(x+4*y    +16*z    );
       quad->set_node(1) = _mesh->node_ptr(x+4*y    +16*z + 1);

--- a/tests/mesh/slit_mesh_test.C
+++ b/tests/mesh/slit_mesh_test.C
@@ -110,37 +110,29 @@ protected:
     _mesh->add_point( Point(2.0,-1.0), 9 );
 
     {
-      Elem* elem_top_left = new Quad4;
+      Elem * elem_top_left = _mesh->add_elem(Elem::build_with_id(QUAD4, 0));
       elem_top_left->set_node(0) = _mesh->node_ptr(0);
       elem_top_left->set_node(1) = _mesh->node_ptr(1);
       elem_top_left->set_node(2) = _mesh->node_ptr(2);
       elem_top_left->set_node(3) = _mesh->node_ptr(3);
-      elem_top_left->set_id() = 0;
-      _mesh->add_elem(elem_top_left);
 
-      Elem* elem_bottom_left = new Quad4;
+      Elem * elem_bottom_left = _mesh->add_elem(Elem::build_with_id(QUAD4, 1));
       elem_bottom_left->set_node(0) = _mesh->node_ptr(4);
       elem_bottom_left->set_node(1) = _mesh->node_ptr(5);
       elem_bottom_left->set_node(2) = _mesh->node_ptr(6);
       elem_bottom_left->set_node(3) = _mesh->node_ptr(0);
-      elem_bottom_left->set_id() = 1;
-      _mesh->add_elem(elem_bottom_left);
 
-      Elem* elem_top_right = new Quad4;
+      Elem * elem_top_right = _mesh->add_elem(Elem::build_with_id(QUAD4, 2));
       elem_top_right->set_node(0) = _mesh->node_ptr(1);
       elem_top_right->set_node(1) = _mesh->node_ptr(7);
       elem_top_right->set_node(2) = _mesh->node_ptr(8);
       elem_top_right->set_node(3) = _mesh->node_ptr(2);
-      elem_top_right->set_id() = 2;
-      _mesh->add_elem(elem_top_right);
 
-      Elem* elem_bottom_right = new Quad4;
+      Elem * elem_bottom_right = _mesh->add_elem(Elem::build_with_id(QUAD4, 3));
       elem_bottom_right->set_node(0) = _mesh->node_ptr(5);
       elem_bottom_right->set_node(1) = _mesh->node_ptr(9);
       elem_bottom_right->set_node(2) = _mesh->node_ptr(7);
       elem_bottom_right->set_node(3) = _mesh->node_ptr(6);
-      elem_bottom_right->set_id() = 3;
-      _mesh->add_elem(elem_bottom_right);
     }
 
     // libMesh shouldn't renumber, or our based-on-initial-id

--- a/tests/systems/equation_systems_test.C
+++ b/tests/systems/equation_systems_test.C
@@ -119,12 +119,10 @@ public:
     MeshTools::Generation::build_line (mesh, 10, 0., 1., EDGE2);
     es.init();
 
-    Elem* e = Elem::build(EDGE2).release();
-    e->set_id(mesh.max_elem_id());
+    Elem * e = mesh.add_elem(Elem::build_with_id(EDGE2, mesh.max_elem_id()));
     e->processor_id() = 0;
     e->set_node(0) = mesh.node_ptr(2);
     e->set_node(1) = mesh.node_ptr(8);
-    mesh.add_elem(e);
     mesh.prepare_for_use();
 
     es.reinit();
@@ -135,7 +133,7 @@ public:
     ReplicatedMesh mesh(*TestCommWorld);
 
     MeshTools::Generation::build_line (mesh, 10, 0., 1., EDGE2);
-    Elem* node_elem = mesh.add_elem (new NodeElem);
+    auto node_elem = mesh.add_elem(Elem::build(NODEELEM));
     node_elem->set_node(0) = mesh.node_ptr(0);
     mesh.prepare_for_use();
 

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -902,7 +902,7 @@ public:
     Point new_point_b(3.);
     Node* new_node_a = mesh.add_point( new_point_a );
     Node* new_node_b = mesh.add_point( new_point_b );
-    Elem* new_edge_elem = mesh.add_elem (new Edge2);
+    auto new_edge_elem = mesh.add_elem(Elem::build(EDGE2));
     new_edge_elem->set_node(0) = new_node_a;
     new_edge_elem->set_node(1) = new_node_b;
 
@@ -910,9 +910,9 @@ public:
     mesh.elem_ref(1).subdomain_id() = 10;
 
     // Add NodeElems for coupling purposes
-    Elem* node_elem_1 = mesh.add_elem (new NodeElem);
+    auto node_elem_1 = mesh.add_elem(Elem::build(NODEELEM));
     node_elem_1->set_node(0) = mesh.elem_ref(0).node_ptr(1);
-    Elem* node_elem_2 = mesh.add_elem (new NodeElem);
+    auto node_elem_2 = mesh.add_elem(Elem::build(NODEELEM));
     node_elem_2->set_node(0) = new_node_a;
 
     mesh.prepare_for_use();
@@ -1334,9 +1334,7 @@ public:
         mesh.add_point( Point(0,1,0), 2 );
         mesh.add_point( Point(1./3.,1./3.,1), 3 );
 
-        Elem * elem = new Tet4();
-        elem->set_id(0);
-        elem = mesh.add_elem(elem);
+        Elem * elem = mesh.add_elem(Elem::build_with_id(TET4, 0));
         elem->set_node(0) = mesh.node_ptr(0);
         elem->set_node(1) = mesh.node_ptr(1);
         elem->set_node(2) = mesh.node_ptr(2);


### PR DESCRIPTION
This API makes it more clear that we are transferring ownership of the Elem to the Mesh, and works together better with the `Elem::build()` factory functions, allowing us to avoid unnecessary calls to `new` and `release()`. I hope to eventually deprecate the original version of MeshBase::add_elem() taking a dumb pointer, but it may turn out that it's still more convenient in some cases.
