### PR TITLE
ExodusII_IO: Make writing the complex modulus optional

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -87,6 +87,13 @@ public:
   void verbose (bool set_verbosity);
 
   /**
+   * Set the flag indicating whether the complex modulus should be
+   * written when complex numbers are enabled. By default this flag
+   * is set to true.
+   */
+  void write_complex_magnitude (bool val);
+
+  /**
    * \returns An array containing the timesteps in the file.
    */
   const std::vector<Real> & get_time_steps();
@@ -418,12 +425,25 @@ private:
   std::vector<std::string> _output_variables;
 
   /**
-   * If true, _output_variables is allowed to remain empty.
-   * If false, if _output_variables is empty it will be populated with a complete list of all variables
-   * By default, calling set_output_variables() sets this flag to true, but it provides an override.
+   * Flag which controls the behavior of _output_variables:
+   * .) If true, _output_variables is allowed to remain empty.
+   * .) If false, if _output_variables is empty it will be populated
+   *    with a complete list of all variables.
+   * .) By default, calling set_output_variables() sets this flag to
+   *    true, but it provides an override.
    */
   bool _allow_empty_variables;
 
+  /**
+   * By default, when complex numbers are enabled, for each variable
+   * we write out three values: the real part, "r_u" the imaginary
+   * part, "i_u", and the complex modulus, a_u := sqrt(r_u*r_u +
+   * i_u*i_u), which is also the value returned by
+   * std::abs(std::complex).  Since the modulus is not an independent
+   * quantity, we can set this flag to false and save some file space
+   * by not writing out.
+   */
+  bool _write_complex_abs;
 };
 
 

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -439,16 +439,22 @@ public:
 
   /**
    * \returns A vector with three copies of each element in the provided name vector,
-   * starting with r_, i_ and a_ respectively.
+   * starting with r_, i_ and a_ respectively. If the "write_complex_abs" parameter
+   * is true (default), the complex modulus is written, otherwise only the real and
+   * imaginary parts are written.
    */
-  std::vector<std::string> get_complex_names(const std::vector<std::string> & names) const;
+  std::vector<std::string>
+  get_complex_names(const std::vector<std::string> & names,
+                    bool write_complex_abs) const;
 
   /**
    * returns a "tripled" copy of \p vars_active_subdomains, which is necessary in the
    * complex-valued case.
    */
-  std::vector<std::set<subdomain_id_type>> get_complex_vars_active_subdomains(
-    const std::vector<std::set<subdomain_id_type>> & vars_active_subdomains) const;
+  std::vector<std::set<subdomain_id_type>>
+  get_complex_vars_active_subdomains
+  (const std::vector<std::set<subdomain_id_type>> & vars_active_subdomains,
+   bool write_complex_abs) const;
 
   /**
    * Takes a map from subdomain id -> vector of active variable names
@@ -458,8 +464,9 @@ public:
    * function.
    */
   std::map<subdomain_id_type, std::vector<std::string>>
-  get_complex_subdomain_to_var_names(
-    const std::map<subdomain_id_type, std::vector<std::string>> & subdomain_to_var_names) const;
+  get_complex_subdomain_to_var_names
+  (const std::map<subdomain_id_type, std::vector<std::string>> & subdomain_to_var_names,
+   bool write_complex_abs) const;
 
   /**
    * This is the \p ExodusII_IO_Helper Conversion class.  It provides

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -1305,7 +1305,8 @@ void Nemesis_IO::prepare_to_write_nodal_data (const std::string & fname,
   // should not hurt to call this twice because the routine sets a
   // flag the first time it is called.
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS
-  std::vector<std::string> complex_names = nemhelper->get_complex_names(names);
+  std::vector<std::string> complex_names =
+    nemhelper->get_complex_names(names, /*_write_complex_abs=*/true);
   nemhelper->initialize_nodal_variables(complex_names);
 #else
   nemhelper->initialize_nodal_variables(names);
@@ -1514,7 +1515,8 @@ void Nemesis_IO::write_global_data (const std::vector<Number> & soln,
 
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS
 
-  std::vector<std::string> complex_names = nemhelper->get_complex_names(names);
+  std::vector<std::string> complex_names =
+    nemhelper->get_complex_names(names, /*_write_complex_abs=*/true);
 
   nemhelper->initialize_global_variables(complex_names);
 
@@ -1524,24 +1526,28 @@ void Nemesis_IO::write_global_data (const std::vector<Number> & soln,
 
   // This will contain the real and imaginary parts and the magnitude
   // of the values in soln
-  std::vector<Real> complex_soln(3*num_values);
+  int nco = 3; // _write_complex_abs ? 3 : 2;
+  std::vector<Real> complex_soln(nco * num_values);
 
   for (unsigned i=0; i<num_vars; ++i)
     {
       for (unsigned int j=0; j<num_elems; ++j)
         {
           Number value = soln[i*num_vars + j];
-          complex_soln[3*i*num_elems + j] = value.real();
+          complex_soln[nco*i*num_elems + j] = value.real();
         }
       for (unsigned int j=0; j<num_elems; ++j)
         {
           Number value = soln[i*num_vars + j];
-          complex_soln[3*i*num_elems + num_elems +j] = value.imag();
+          complex_soln[nco*i*num_elems + num_elems + j] = value.imag();
         }
-      for (unsigned int j=0; j<num_elems; ++j)
+      if (true/*_write_complex_abs*/)
         {
-          Number value = soln[i*num_vars + j];
-          complex_soln[3*i*num_elems + 2*num_elems + j] = std::abs(value);
+          for (unsigned int j=0; j<num_elems; ++j)
+            {
+              Number value = soln[i*num_vars + j];
+              complex_soln[3*i*num_elems + 2*num_elems + j] = std::abs(value);
+            }
         }
     }
 


### PR DESCRIPTION
* Add ExodusII_IO::write_complex_magnitude(bool val) API for controlling
  whether or not the modulus is written.
* In NemesisIO, the value of this parameter is currently hard-coded to
  true, maintaining the existing functionality.

Refs #2403