### PR TITLE
Add MeshRefinement::add_elem(unique_ptr)

### DIFF
--- a/include/mesh/mesh_refinement.h
+++ b/include/mesh/mesh_refinement.h
@@ -321,6 +321,15 @@ public:
   Elem * add_elem (Elem * elem);
 
   /**
+   * Same as the function above, but makes it clear that the
+   * MeshRefinement object (actually, its Mesh) takes ownership of the
+   * Elem which is passed in, so the user is not responsible for
+   * deleting it. The version of add_elem() taking a dumb pointer will
+   * eventually be deprecated in favor of this version.
+   */
+  Elem * add_elem (std::unique_ptr<Elem> elem);
+
+  /**
    * \returns A constant reference to the \p MeshBase object associated
    * with this object.
    */

--- a/src/geom/elem_refinement.C
+++ b/src/geom/elem_refinement.C
@@ -100,8 +100,8 @@ void Elem::refine (MeshRefinement & mesh_refinement)
       const unsigned int nei = this->n_extra_integers();
       for (unsigned int c = 0; c != nc; c++)
         {
-          _children[c] = Elem::build(this->type(), this).release();
-          Elem * current_child = this->child_ptr(c);
+          auto current_child = Elem::build(this->type(), this);
+          _children[c] = current_child.get();
 
           current_child->set_refinement_flag(Elem::JUST_REFINED);
           current_child->set_p_level(parent_p_level);
@@ -116,12 +116,12 @@ void Elem::refine (MeshRefinement & mesh_refinement)
               current_child->set_node(cnode) = node;
             }
 
-          mesh_refinement.add_elem (current_child);
-          current_child->set_n_systems(this->n_systems());
-          libmesh_assert_equal_to (current_child->n_extra_integers(),
+          Elem * added_child = mesh_refinement.add_elem (std::move(current_child));
+          added_child->set_n_systems(this->n_systems());
+          libmesh_assert_equal_to (added_child->n_extra_integers(),
                                    this->n_extra_integers());
           for (unsigned int i=0; i != nei; ++i)
-            current_child->set_extra_integer(i, this->get_extra_integer(i));
+            added_child->set_extra_integer(i, this->get_extra_integer(i));
         }
     }
   else

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -211,10 +211,14 @@ Node * MeshRefinement::add_node(Elem & parent,
 Elem * MeshRefinement::add_elem (Elem * elem)
 {
   libmesh_assert(elem);
-  _mesh.add_elem (elem);
-  return elem;
+  return _mesh.add_elem (elem);
 }
 
+Elem * MeshRefinement::add_elem (std::unique_ptr<Elem> elem)
+{
+  libmesh_assert(elem);
+  return _mesh.add_elem(std::move(elem));
+}
 
 
 void MeshRefinement::create_parent_error_vector(const ErrorVector & error_per_cell,


### PR DESCRIPTION
As the API implies, this calls the new MeshBase::add_elem(unique_ptr)
internally, and is intended to make it clear that the MeshRefinement
object (actually the Mesh inside it) takes ownership of the Elem
pointer that gets passed in.

Call new version of MeshRefinement::add_elem() in Elem::refine().

Follow-up to #2420. This should be the last `MeshBase::add_elem(Elem*)` calls in the library which needed updating.