### PR TITLE
Add MeshBase::{add,insert}_node(std::unique_ptr)

### DIFF
--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -274,6 +274,7 @@ public:
    * Calls add_node().
    */
   virtual Node * insert_node(Node * n) override;
+  virtual Node * insert_node(std::unique_ptr<Node> n) override;
 
   /**
    * Takes ownership of node \p n on this partition of a distributed

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -268,6 +268,7 @@ public:
                             const dof_id_type id = DofObject::invalid_id,
                             const processor_id_type proc_id = DofObject::invalid_processor_id) override;
   virtual Node * add_node (Node * n) override;
+  virtual Node * add_node (std::unique_ptr<Node> n) override;
 
   /**
    * Calls add_node().

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -653,6 +653,16 @@ public:
   virtual Node * insert_node(Node * n) = 0;
 
   /**
+   * Version of insert_node() taking a std::unique_ptr by value. The version
+   * taking a dumb pointer will eventually be deprecated in favor of this
+   * version. This API is intended to indicate that ownership of the Node
+   * is transferred to the Mesh when this function is called, and it should
+   * play more nicely with the Node::build() API which has always returned
+   * a std::unique_ptr.
+   */
+  virtual Node * insert_node(std::unique_ptr<Node> n) = 0;
+
+  /**
    * Removes the Node n from the mesh.
    */
   virtual void delete_node (Node * n) = 0;

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -634,6 +634,16 @@ public:
   virtual Node * add_node (Node * n) = 0;
 
   /**
+   * Version of add_node() taking a std::unique_ptr by value. The version
+   * taking a dumb pointer will eventually be deprecated in favor of this
+   * version. This API is intended to indicate that ownership of the Node
+   * is transferred to the Mesh when this function is called, and it should
+   * play more nicely with the Node::build() API which has always returned
+   * a std::unique_ptr.
+   */
+  virtual Node * add_node (std::unique_ptr<Node> n) = 0;
+
+  /**
    * Insert \p Node \p n into the Mesh at a location consistent with
    * n->id(), allocating extra storage if necessary.  Will error
    * rather than overwriting an existing Node.  Primarily intended for

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -168,6 +168,7 @@ public:
    * storage.
    */
   virtual Node * insert_node(Node * n) override;
+  virtual Node * insert_node(std::unique_ptr<Node> n) override;
 
   virtual void delete_node (Node * n) override;
   virtual void renumber_node (dof_id_type old_id, dof_id_type new_id) override;

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -154,6 +154,7 @@ public:
                             const dof_id_type id = DofObject::invalid_id,
                             const processor_id_type proc_id = DofObject::invalid_processor_id) override;
   virtual Node * add_node (Node * n) override;
+  virtual Node * add_node (std::unique_ptr<Node> n) override;
 
   /**
    * Insert \p Node \p n into the Mesh at a location consistent with

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -773,6 +773,13 @@ Node * DistributedMesh::add_node (Node * n)
   return n;
 }
 
+Node * DistributedMesh::add_node (std::unique_ptr<Node> n)
+{
+  // The mesh now takes ownership of the Node. Eventually the guts of
+  // add_node() will get moved to a private helper function, and
+  // calling add_node() directly will be deprecated.
+  return add_node(n.release());
+}
 
 
 Node * DistributedMesh::insert_node(Node * n)

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -787,6 +787,11 @@ Node * DistributedMesh::insert_node(Node * n)
   return DistributedMesh::add_node(n);
 }
 
+Node * DistributedMesh::insert_node(std::unique_ptr<Node> n)
+{
+  return DistributedMesh::insert_node(std::move(n));
+}
+
 
 
 void DistributedMesh::delete_node(Node * n)

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -505,6 +505,14 @@ Node * ReplicatedMesh::add_node (Node * n)
   return n;
 }
 
+Node * ReplicatedMesh::add_node (std::unique_ptr<Node> n)
+{
+  // The mesh now takes ownership of the Node. Eventually the guts of
+  // add_node() will get moved to a private helper function, and
+  // calling add_node() directly will be deprecated.
+  return add_node(n.release());
+}
+
 
 
 Node * ReplicatedMesh::insert_node(Node * n)

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -558,6 +558,13 @@ Node * ReplicatedMesh::insert_node(Node * n)
   return n;
 }
 
+Node * ReplicatedMesh::insert_node(std::unique_ptr<Node> n)
+{
+  // The mesh now takes ownership of the Node. Eventually the guts of
+  // insert_node(Node*) will get moved to a private helper function, and
+  // calling insert_node(Node*) directly will be deprecated.
+  return insert_node(n.release());
+}
 
 
 void ReplicatedMesh::delete_node(Node * n)


### PR DESCRIPTION
The dumb pointer versions of these APIs are only used in one place the library, we provide the smart pointer versions for consistency with `MeshBase::{add,insert}_elem(std::unique_ptr)` since the idea is the same.
