### PR TITLE
Remove support for PETSc < 3.5.x

### DIFF
--- a/include/numerics/petsc_macro.h
+++ b/include/numerics/petsc_macro.h
@@ -69,47 +69,23 @@
 #endif
 #include <libmesh/restore_warnings.h>
 
-#if PETSC_RELEASE_LESS_THAN(3,1,1)
-typedef PetscTruth PetscBool;
-#endif
-
-#if PETSC_RELEASE_LESS_THAN(3,1,1)
-#  define LibMeshVecDestroy(x)         VecDestroy(*(x))
-#  define LibMeshVecScatterDestroy(x)  VecScatterDestroy(*(x))
-#  define LibMeshMatDestroy(x)         MatDestroy(*(x))
-#  define LibMeshISDestroy(x)          ISDestroy(*(x))
-#  define LibMeshKSPDestroy(x)         KSPDestroy(*(x))
-#  define LibMeshSNESDestroy(x)        SNESDestroy(*(x))
-#  define LibMeshPetscViewerDestroy(x) PetscViewerDestroy(*(x))
-#  define LibMeshPCDestroy(x)          PCDestroy(*(x))
-#else
-#  define LibMeshVecDestroy(x)         VecDestroy(x)
-#  define LibMeshVecScatterDestroy(x)  VecScatterDestroy(x)
-#  define LibMeshMatDestroy(x)         MatDestroy(x)
-#  define LibMeshISDestroy(x)          ISDestroy(x)
-#  define LibMeshKSPDestroy(x)         KSPDestroy(x)
-#  define LibMeshSNESDestroy(x)        SNESDestroy(x)
-#  define LibMeshPetscViewerDestroy(x) PetscViewerDestroy(x)
-#  define LibMeshPCDestroy(x)          PCDestroy(x)
-#endif
+// These macros are still around for backwards compatibility, but we
+// no longer use them within the library.
+#define LibMeshVecDestroy(x)         VecDestroy(x)
+#define LibMeshVecScatterDestroy(x)  VecScatterDestroy(x)
+#define LibMeshMatDestroy(x)         MatDestroy(x)
+#define LibMeshISDestroy(x)          ISDestroy(x)
+#define LibMeshKSPDestroy(x)         KSPDestroy(x)
+#define LibMeshSNESDestroy(x)        SNESDestroy(x)
+#define LibMeshPetscViewerDestroy(x) PetscViewerDestroy(x)
+#define LibMeshPCDestroy(x)          PCDestroy(x)
 
 // PETSc devs temporarily considered adding VecScatterCreateWithData, but
 // it was dropped in PETSc-130e142e39 and never made it into any release.
 // We will keep the ifdef for backwards compatibility in case anyone wrote
 // code directly using it, but that should be pretty unlikely.
 #define LibMeshVecScatterCreate(xin,ix,yin,iy,newctx)  VecScatterCreate(xin,ix,yin,iy,newctx)
-
-#if PETSC_RELEASE_LESS_THAN(3,1,1)
-typedef enum { PETSC_COPY_VALUES, PETSC_OWN_POINTER, PETSC_USE_POINTER} PetscCopyMode;
-#  define ISCreateLibMesh(comm,n,idx,mode,is)           \
-  ((mode) == PETSC_USE_POINTER                          \
-   ? ISCreateGeneralWithArray((comm),(n),(idx),(is))    \
-   : ((mode) == PETSC_OWN_POINTER                       \
-      ? ISCreateGeneralNC((comm),(n),(idx),(is))        \
-      : ISCreateGeneral((comm),(n),(idx),(is))))
-#else
-#  define ISCreateLibMesh(comm,n,idx,mode,is) ISCreateGeneral((comm),(n),(idx),(mode),(is))
-#endif
+#define ISCreateLibMesh(comm,n,idx,mode,is) ISCreateGeneral((comm),(n),(idx),(mode),(is))
 
 // As of release 3.8.0, MatGetSubMatrix was renamed to MatCreateSubMatrix.
 #if PETSC_RELEASE_LESS_THAN(3,8,0)

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -275,7 +275,7 @@ public:
    *
    * \note This is generally not required in user-level code.
    *
-   * \note Don't do anything crazy like calling LibMeshMatDestroy() on
+   * \note Don't do anything crazy like calling MatDestroy() on
    * it, or very bad things will likely happen!
    */
   Mat mat () { libmesh_assert (_mat); return _mat; }

--- a/include/numerics/petsc_preconditioner.h
+++ b/include/numerics/petsc_preconditioner.h
@@ -111,13 +111,7 @@ private:
    * so that it can be called from set_petsc_preconditioner_type().  Not sure
    * why set_petsc_preconditioner_type() needs to be static though...
    */
-#if PETSC_VERSION_LESS_THAN(3,0,0)
-  // In Petsc 2.3.3, PCType was #define'd as const char *
-  static void set_petsc_subpreconditioner_type(PCType type, PC & pc);
-#else
-  // In later versions, PCType is #define'd as char *, so we need the const
   static void set_petsc_subpreconditioner_type(const PCType type, PC & pc);
-#endif
 };
 
 

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -329,7 +329,7 @@ public:
    *
    * \note This is generally not required in user-level code.
    *
-   * \note Don't do anything crazy like calling LibMeshVecDestroy() on
+   * \note Don't do anything crazy like calling VecDestroy() on
    * it, or very bad things will likely happen!
    */
   Vec vec () { libmesh_assert (_vec); return _vec; }
@@ -838,7 +838,7 @@ void PetscVector<T>::clear ()
     {
       PetscErrorCode ierr=0;
 
-      ierr = LibMeshVecDestroy(&_vec);
+      ierr = VecDestroy(&_vec);
       LIBMESH_CHKERR(ierr);
     }
 

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -567,54 +567,35 @@ PetscVector<T>::PetscVector (Vec v,
   LIBMESH_CHKERR(ierr);
 
   // Get the vector type from PETSc.
-  // As of PETSc 3.0.0, the VecType #define lost its const-ness, so we
-  // need to have it in the code
-#if PETSC_VERSION_LESS_THAN(3,0,0) || !PETSC_VERSION_LESS_THAN(3,4,0)
-  // Pre-3.0 and petsc-dev (as of October 2012) use non-const versions
   VecType ptype;
-#else
-  const VecType ptype;
-#endif
   ierr = VecGetType(_vec, &ptype);
   LIBMESH_CHKERR(ierr);
 
   if ((std::strcmp(ptype,VECSHARED) == 0) || (std::strcmp(ptype,VECMPI) == 0))
     {
-#if PETSC_RELEASE_LESS_THAN(3,1,1)
-      ISLocalToGlobalMapping mapping = _vec->mapping;
-#else
       ISLocalToGlobalMapping mapping;
       ierr = VecGetLocalToGlobalMapping(_vec, &mapping);
       LIBMESH_CHKERR(ierr);
-#endif
 
       // If is a sparsely stored vector, set up our new mapping
       if (mapping)
         {
           const numeric_index_type my_local_size = static_cast<numeric_index_type>(petsc_local_size);
           const numeric_index_type ghost_begin = static_cast<numeric_index_type>(petsc_local_size);
-#if PETSC_RELEASE_LESS_THAN(3,4,0)
-          const numeric_index_type ghost_end = static_cast<numeric_index_type>(mapping->n);
-#else
           PetscInt n;
           ierr = ISLocalToGlobalMappingGetSize(mapping, &n);
           LIBMESH_CHKERR(ierr);
+
           const numeric_index_type ghost_end = static_cast<numeric_index_type>(n);
-#endif
-#if PETSC_RELEASE_LESS_THAN(3,1,1)
-          const PetscInt * indices = mapping->indices;
-#else
           const PetscInt * indices;
           ierr = ISLocalToGlobalMappingGetIndices(mapping,&indices);
           LIBMESH_CHKERR(ierr);
-#endif
+
           for (numeric_index_type i=ghost_begin; i<ghost_end; i++)
             _global_to_local_map[indices[i]] = i-my_local_size;
           this->_type = GHOSTED;
-#if !PETSC_RELEASE_LESS_THAN(3,1,1)
           ierr = ISLocalToGlobalMappingRestoreIndices(mapping, &indices);
           LIBMESH_CHKERR(ierr);
-#endif
         }
       else
         this->_type = PARALLEL;

--- a/include/solvers/petsc_linear_solver.h
+++ b/include/solvers/petsc_linear_solver.h
@@ -51,40 +51,30 @@
 // Give them an obscure name to avoid namespace pollution.
 extern "C"
 {
-#if PETSC_RELEASE_LESS_THAN(3,0,1)
   /**
    * This function is called by PETSc to initialize the preconditioner.
    * ctx will hold the Preconditioner.
    */
-  PetscErrorCode libmesh_petsc_preconditioner_setup (void * ctx);
+  PetscErrorCode libmesh_petsc_preconditioner_setup (PC);
 
   /**
    * This function is called by PETSc to actually apply the preconditioner.
    * ctx will hold the Preconditioner.
    */
-  PetscErrorCode libmesh_petsc_preconditioner_apply(void * ctx, Vec x, Vec y);
-#else
-  PetscErrorCode libmesh_petsc_preconditioner_setup (PC);
   PetscErrorCode libmesh_petsc_preconditioner_apply(PC, Vec x, Vec y);
-#endif
 
 #if LIBMESH_ENABLE_DEPRECATED
-#if PETSC_RELEASE_LESS_THAN(3,0,1)
   /**
    * This function is called by PETSc to initialize the preconditioner.
    * ctx will hold the Preconditioner.
    */
-  PetscErrorCode __libmesh_petsc_preconditioner_setup (void * ctx);
+  PetscErrorCode __libmesh_petsc_preconditioner_setup (PC);
 
   /**
    * This function is called by PETSc to actually apply the preconditioner.
    * ctx will hold the Preconditioner.
    */
-  PetscErrorCode __libmesh_petsc_preconditioner_apply(void * ctx, Vec x, Vec y);
-#else
-  PetscErrorCode __libmesh_petsc_preconditioner_setup (PC);
   PetscErrorCode __libmesh_petsc_preconditioner_apply(PC, Vec x, Vec y);
-#endif
 #endif
 } // end extern "C"
 
@@ -358,19 +348,9 @@ PetscLinearSolver<T>::_restrict_solve_to_is_local_size() const
 
 template <typename T>
 void
-PetscLinearSolver<T>::_create_complement_is (const NumericVector<T> &
-#if PETSC_VERSION_LESS_THAN(3,0,0)
-                                             // unnamed to avoid compiler "unused parameter" warning
-#else
-                                             vec_in
-#endif
-                                             )
+PetscLinearSolver<T>::_create_complement_is (const NumericVector<T> & vec_in)
 {
   libmesh_assert(_restrict_solve_to_is);
-#if PETSC_VERSION_LESS_THAN(3,0,0)
-  // No ISComplement in PETSc 2.3.3
-  libmesh_not_implemented();
-#else
   if (_restrict_solve_to_is_complement==nullptr)
     {
       int ierr = ISComplement(_restrict_solve_to_is,
@@ -379,7 +359,6 @@ PetscLinearSolver<T>::_create_complement_is (const NumericVector<T> &
                               &_restrict_solve_to_is_complement);
       LIBMESH_CHKERR(ierr);
     }
-#endif
 }
 
 

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -51,19 +51,8 @@ extern "C"
   PetscErrorCode libmesh_petsc_snes_fd_residual (SNES, Vec x, Vec r, void * ctx);
   PetscErrorCode libmesh_petsc_snes_mffd_residual (SNES snes, Vec x, Vec r, void * ctx);
   PetscErrorCode libmesh_petsc_snes_mffd_interface (void * ctx, Vec x, Vec r);
-#if PETSC_RELEASE_LESS_THAN(3,5,0)
-  PetscErrorCode libmesh_petsc_snes_jacobian (SNES, Vec x, Mat * jac, Mat * pc, MatStructure * msflag, void * ctx);
-#else
   PetscErrorCode libmesh_petsc_snes_jacobian (SNES, Vec x, Mat jac, Mat pc, void * ctx);
-#endif
-
-  PetscErrorCode libmesh_petsc_snes_postcheck(
-#if PETSC_VERSION_LESS_THAN(3,3,0)
-                                                SNES, Vec x, Vec y, Vec w, void * context, PetscBool * changed_y, PetscBool * changed_w
-#else
-                                                SNESLineSearch, Vec x, Vec y, Vec w, PetscBool * changed_y, PetscBool * changed_w, void * context
-#endif
-                                                );
+  PetscErrorCode libmesh_petsc_snes_postcheck(SNESLineSearch, Vec x, Vec y, Vec w, PetscBool * changed_y, PetscBool * changed_w, void * context);
   PetscErrorCode libmesh_petsc_linesearch_shellfunc(SNESLineSearch linesearch, void * ctx);
 
 #ifdef LIBMESH_ENABLE_DEPRECATED
@@ -71,19 +60,8 @@ extern "C"
   PetscErrorCode __libmesh_petsc_snes_residual (SNES, Vec x, Vec r, void * ctx);
   PetscErrorCode __libmesh_petsc_snes_fd_residual (SNES, Vec x, Vec r, void * ctx);
   PetscErrorCode __libmesh_petsc_snes_mffd_interface (void * ctx, Vec x, Vec r);
-#if PETSC_RELEASE_LESS_THAN(3,5,0)
-  PetscErrorCode __libmesh_petsc_snes_jacobian (SNES, Vec x, Mat * jac, Mat * pc, MatStructure * msflag, void * ctx);
-#else
   PetscErrorCode __libmesh_petsc_snes_jacobian (SNES, Vec x, Mat jac, Mat pc, void * ctx);
-#endif
-
-  PetscErrorCode __libmesh_petsc_snes_postcheck(
-#if PETSC_VERSION_LESS_THAN(3,3,0)
-                                                SNES, Vec x, Vec y, Vec w, void * context, PetscBool * changed_y, PetscBool * changed_w
-#else
-                                                SNESLineSearch, Vec x, Vec y, Vec w, PetscBool * changed_y, PetscBool * changed_w, void * context
-#endif
-                                                );
+  PetscErrorCode __libmesh_petsc_snes_postcheck(SNESLineSearch, Vec x, Vec y, Vec w, PetscBool * changed_y, PetscBool * changed_w, void * context);
 #endif
 }
 
@@ -257,21 +235,15 @@ protected:
    */
   bool _snesmf_reuse_base;
 
-#if !PETSC_VERSION_LESS_THAN(3,3,0)
   void build_mat_null_space(NonlinearImplicitSystem::ComputeVectorSubspace * computeSubspaceObject,
                             void (*)(std::vector<NumericVector<Number> *> &, sys_type &),
                             MatNullSpace *);
-#endif
 private:
   friend ResidualContext libmesh_petsc_snes_residual_helper (SNES snes, Vec x, void * ctx);
   friend PetscErrorCode libmesh_petsc_snes_residual (SNES snes, Vec x, Vec r, void * ctx);
   friend PetscErrorCode libmesh_petsc_snes_fd_residual (SNES snes, Vec x, Vec r, void * ctx);
   friend PetscErrorCode libmesh_petsc_snes_mffd_residual (SNES snes, Vec x, Vec r, void * ctx);
-#if PETSC_RELEASE_LESS_THAN(3,5,0)
-  friend PetscErrorCode libmesh_petsc_snes_jacobian (SNES snes, Vec x, Mat * jac, Mat * pc, MatStructure * msflag, void * ctx);
-#else
   friend PetscErrorCode libmesh_petsc_snes_jacobian (SNES snes, Vec x, Mat jac, Mat pc, void * ctx);
-#endif
 };
 
 

--- a/include/solvers/petscdmlibmesh.h
+++ b/include/solvers/petscdmlibmesh.h
@@ -22,8 +22,6 @@
 // developer-facing only?)
 
 #include "libmesh/petsc_macro.h"
-// This only works with petsc-3.3 and above.
-#if !PETSC_VERSION_LESS_THAN(3,3,0)
 
 #ifdef I
 # define LIBMESH_SAW_I
@@ -51,5 +49,4 @@ EXTERN_C_BEGIN
 PETSC_EXTERN PetscErrorCode DMCreate_libMesh(DM);
 EXTERN_C_END
 
-#endif // #if !PETSC_VERSION_LESS_THAN(3,3,0)
 #endif // #ifdef PETSCDMLIBEMSH_H

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -68,9 +68,7 @@
 # include "libmesh/petsc_macro.h"
 # include <petsc.h>
 # include <petscerror.h>
-#if !PETSC_RELEASE_LESS_THAN(3,3,0)
-#include "libmesh/petscdmlibmesh.h"
-#endif
+# include "libmesh/petscdmlibmesh.h"
 # if defined(LIBMESH_HAVE_SLEPC)
 // Ignore unused variable warnings from SLEPc
 #  include "libmesh/ignore_warnings.h"
@@ -533,15 +531,8 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
           CHKERRABORT(libMesh::GLOBAL_COMM_WORLD,ierr);
         }
 # endif
-#if !PETSC_RELEASE_LESS_THAN(3,3,0)
       // Register the reference implementation of DMlibMesh
-#if PETSC_RELEASE_LESS_THAN(3,4,0)
-      ierr = DMRegister(DMLIBMESH, PETSC_NULL, "DMCreate_libMesh", DMCreate_libMesh); CHKERRABORT(libMesh::GLOBAL_COMM_WORLD,ierr);
-#else
       ierr = DMRegister(DMLIBMESH, DMCreate_libMesh); CHKERRABORT(libMesh::GLOBAL_COMM_WORLD,ierr);
-#endif
-
-#endif
     }
 #endif
 

--- a/src/numerics/dense_matrix_blas_lapack.C
+++ b/src/numerics/dense_matrix_blas_lapack.C
@@ -526,7 +526,6 @@ void DenseMatrix<T>::_svd_helper (char,
 
 
 #if (LIBMESH_HAVE_PETSC && LIBMESH_USE_REAL_NUMBERS)
-#if !PETSC_VERSION_LESS_THAN(3,1,0)
 
 template<typename T>
 void DenseMatrix<T>::_svd_solve_lapack(const DenseVector<T> & rhs,
@@ -683,17 +682,6 @@ void DenseMatrix<T>::_svd_solve_lapack(const DenseVector<T> & rhs,
 
 #else
 
-template<typename T>
-void DenseMatrix<T>::_svd_solve_lapack(const DenseVector<T> & /*rhs*/,
-                                       DenseVector<T> & /*x*/,
-                                       Real /*rcond*/) const
-{
-  libmesh_error_msg("svd_solve() requires PETSc >= 3.1!");
-}
-
-#endif // !PETSC_VERSION_LESS_THAN(3,1,0)
-
-#else
 template<typename T>
 void DenseMatrix<T>::_svd_solve_lapack(const DenseVector<T>& /*rhs*/,
                                        DenseVector<T> & /*x*/,

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -531,7 +531,7 @@ void PetscMatrix<T>::clear ()
     {
       semiparallel_only();
 
-      ierr = LibMeshMatDestroy (&_mat);
+      ierr = MatDestroy (&_mat);
       LIBMESH_CHKERR(ierr);
 
       this->_is_initialized = false;
@@ -657,7 +657,7 @@ void PetscMatrix<T>::print_matlab (const std::string & name) const
   /**
    * Destroy the viewer.
    */
-  ierr = LibMeshPetscViewerDestroy (&petsc_viewer);
+  ierr = PetscViewerDestroy (&petsc_viewer);
   LIBMESH_CHKERR(ierr);
 }
 
@@ -869,13 +869,13 @@ void PetscMatrix<T>::_get_submatrix(SparseMatrix<T> & submatrix,
   PetscErrorCode ierr=0;
   IS isrow, iscol;
 
-  ierr = ISCreateLibMesh(this->comm().get(),
+  ierr = ISCreateGeneral(this->comm().get(),
                          cast_int<PetscInt>(rows.size()),
                          numeric_petsc_cast(rows.data()),
                          PETSC_USE_POINTER,
                          &isrow); LIBMESH_CHKERR(ierr);
 
-  ierr = ISCreateLibMesh(this->comm().get(),
+  ierr = ISCreateGeneral(this->comm().get(),
                          cast_int<PetscInt>(cols.size()),
                          numeric_petsc_cast(cols.data()),
                          PETSC_USE_POINTER,
@@ -893,8 +893,8 @@ void PetscMatrix<T>::_get_submatrix(SparseMatrix<T> & submatrix,
   petsc_submatrix->close();
 
   // Clean up PETSc data structures
-  ierr = LibMeshISDestroy(&isrow); LIBMESH_CHKERR(ierr);
-  ierr = LibMeshISDestroy(&iscol); LIBMESH_CHKERR(ierr);
+  ierr = ISDestroy(&isrow); LIBMESH_CHKERR(ierr);
+  ierr = ISDestroy(&iscol); LIBMESH_CHKERR(ierr);
 }
 
 

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -32,19 +32,6 @@
 #include "libmesh/parallel.h"
 
 
-// For some reason, the blocked matrix API calls below seem to break with PETSC 3.2 & presumably earlier.
-// For example:
-// [0]PETSC ERROR: --------------------- Error Message ------------------------------------
-// [0]PETSC ERROR: Nonconforming object sizes!
-// [0]PETSC ERROR: Attempt to set block size 3 with BAIJ 1!
-// [0]PETSC ERROR: ------------------------------------------------------------------------
-// so as a cowardly workaround disable the functionality in this translation unit for older PETSc's
-#if PETSC_VERSION_LESS_THAN(3,3,0)
-#  undef LIBMESH_ENABLE_BLOCKED_STORAGE
-#endif
-
-
-
 #ifdef LIBMESH_ENABLE_BLOCKED_STORAGE
 
 namespace
@@ -210,11 +197,7 @@ void PetscMatrix<T>::init (const numeric_index_type m_in,
     }
 
   // Make it an error for PETSc to allocate new nonzero entries during assembly
-#if PETSC_VERSION_LESS_THAN(3,0,0)
-  ierr = MatSetOption(_mat, MAT_NEW_NONZERO_ALLOCATION_ERR);
-#else
   ierr = MatSetOption(_mat, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
-#endif
   LIBMESH_CHKERR(ierr);
 
   // Is prefix information available somewhere? Perhaps pass in the system name?
@@ -336,11 +319,7 @@ void PetscMatrix<T>::init (const numeric_index_type m_in,
     }
 
   // Make it an error for PETSc to allocate new nonzero entries during assembly
-#if PETSC_VERSION_LESS_THAN(3,0,0)
-  ierr = MatSetOption(_mat, MAT_NEW_NONZERO_ALLOCATION_ERR);
-#else
   ierr = MatSetOption(_mat, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
-#endif
   LIBMESH_CHKERR(ierr);
 
   // Is prefix information available somewhere? Perhaps pass in the system name?
@@ -465,11 +444,7 @@ void PetscMatrix<T>::init (const ParallelType)
     }
 
   // Make it an error for PETSc to allocate new nonzero entries during assembly
-#if PETSC_VERSION_LESS_THAN(3,0,0)
-  ierr = MatSetOption(_mat, MAT_NEW_NONZERO_ALLOCATION_ERR);
-#else
   ierr = MatSetOption(_mat, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
-#endif
   LIBMESH_CHKERR(ierr);
 
   // Is prefix information available somewhere? Perhaps pass in the system name?
@@ -533,13 +508,6 @@ void PetscMatrix<T>::zero_rows (std::vector<numeric_index_type> & rows, T diag_v
 
   PetscErrorCode ierr=0;
 
-#if PETSC_RELEASE_LESS_THAN(3,1,1)
-  if (!rows.empty())
-    ierr = MatZeroRows(_mat, rows.size(),
-                       numeric_petsc_cast(rows.data()), diag_value);
-  else
-    ierr = MatZeroRows(_mat, 0, NULL, diag_value);
-#else
   // As of petsc-dev at the time of 3.1.0, MatZeroRows now takes two additional
   // optional arguments.  The optional arguments (x,b) can be used to specify the
   // solutions for the zeroed rows (x) and right hand side (b) to update.
@@ -549,9 +517,7 @@ void PetscMatrix<T>::zero_rows (std::vector<numeric_index_type> & rows, T diag_v
                        numeric_petsc_cast(rows.data()), PS(diag_value),
                        NULL, NULL);
   else
-    ierr = MatZeroRows(_mat, 0, NULL, PS(diag_value), NULL,
-                       NULL);
-#endif
+    ierr = MatZeroRows(_mat, 0, NULL, PS(diag_value), NULL, NULL);
 
   LIBMESH_CHKERR(ierr);
 }
@@ -919,9 +885,6 @@ void PetscMatrix<T>::_get_submatrix(SparseMatrix<T> & submatrix,
   ierr = LibMeshCreateSubMatrix(_mat,
                                 isrow,
                                 iscol,
-#if PETSC_RELEASE_LESS_THAN(3,0,1)
-                                PETSC_DECIDE,
-#endif
                                 (reuse_submatrix ? MAT_REUSE_MATRIX : MAT_INITIAL_MATRIX),
                                 &(petsc_submatrix->_mat));  LIBMESH_CHKERR(ierr);
 
@@ -961,13 +924,6 @@ void PetscMatrix<T>::get_transpose (SparseMatrix<T> & dest) const
     dest.clear();
 
   PetscErrorCode ierr;
-#if PETSC_VERSION_LESS_THAN(3,0,0)
-  if (&petsc_dest == this)
-    ierr = MatTranspose(_mat,NULL);
-  else
-    ierr = MatTranspose(_mat,&petsc_dest._mat);
-  LIBMESH_CHKERR(ierr);
-#else
   if (&petsc_dest == this)
     // The MAT_REUSE_MATRIX flag was replaced by MAT_INPLACE_MATRIX
     // in PETSc 3.7.0
@@ -979,7 +935,6 @@ void PetscMatrix<T>::get_transpose (SparseMatrix<T> & dest) const
   else
     ierr = MatTranspose(_mat,MAT_INITIAL_MATRIX,&petsc_dest._mat);
   LIBMESH_CHKERR(ierr);
-#endif
 
   // Specify that the transposed matrix is initialized and close it.
   petsc_dest._is_initialized = true;

--- a/src/numerics/petsc_preconditioner.C
+++ b/src/numerics/petsc_preconditioner.C
@@ -19,8 +19,6 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 
-// C++ includes
-
 // Local Includes
 #include "libmesh/petsc_preconditioner.h"
 #include "libmesh/petsc_macro.h"
@@ -28,11 +26,6 @@
 #include "libmesh/petsc_vector.h"
 #include "libmesh/libmesh_common.h"
 #include "libmesh/enum_preconditioner_type.h"
-
-// PCBJacobiGetSubKSP was defined in petscksp.h in PETSc 2.3.3, 3.1.0
-#if PETSC_VERSION_LESS_THAN(3,1,0)
-# include "petscksp.h"
-#endif
 
 namespace libMesh
 {
@@ -77,11 +70,7 @@ void PetscPreconditioner<T>::init ()
       _mat = pmatrix->mat();
     }
 
-#if PETSC_RELEASE_LESS_THAN(3,5,0)
-  int ierr = PCSetOperators(_pc,_mat,_mat,SAME_NONZERO_PATTERN);
-#else
   int ierr = PCSetOperators(_pc,_mat,_mat);
-#endif
   LIBMESH_CHKERR(ierr);
 
   // Set the PCType.  Note: this used to be done *before* the call to
@@ -249,14 +238,8 @@ void PetscPreconditioner<T>::set_petsc_preconditioner_type (const Preconditioner
 }
 
 
-#if PETSC_VERSION_LESS_THAN(3,0,0)
-#define PCTYPE_CV_QUALIFIER
-#else
-#define PCTYPE_CV_QUALIFIER const
-#endif
-
 template <typename T>
-void PetscPreconditioner<T>::set_petsc_subpreconditioner_type(PCTYPE_CV_QUALIFIER PCType type, PC & pc)
+void PetscPreconditioner<T>::set_petsc_subpreconditioner_type(const PCType type, PC & pc)
 {
   // For catching PETSc error return codes
   int ierr = 0;

--- a/src/numerics/petsc_preconditioner.C
+++ b/src/numerics/petsc_preconditioner.C
@@ -65,7 +65,7 @@ void PetscPreconditioner<T>::init ()
       // Should probably use PCReset(), but it's not working at the moment so we'll destroy instead
       if (_pc)
         {
-          int ierr = LibMeshPCDestroy(&_pc);
+          int ierr = PCDestroy(&_pc);
           LIBMESH_CHKERR(ierr);
         }
 
@@ -103,7 +103,7 @@ void PetscPreconditioner<T>::clear()
 {
   if (_pc)
     {
-      int ierr = LibMeshPCDestroy(&_pc);
+      int ierr = PCDestroy(&_pc);
       LIBMESH_CHKERR(ierr);
     }
 }

--- a/src/numerics/petsc_shell_matrix.C
+++ b/src/numerics/petsc_shell_matrix.C
@@ -62,7 +62,7 @@ void PetscShellMatrix<T>::clear ()
 
   if ((this->initialized()))
     {
-      ierr = LibMeshMatDestroy (&_mat);
+      ierr = MatDestroy (&_mat);
       LIBMESH_CHKERR(ierr);
 
       this->_is_initialized = false;

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -279,17 +279,6 @@ void PetscVector<T>::add_vector_transpose (const NumericVector<T> & v_in,
 }
 
 
-#if PETSC_VERSION_LESS_THAN(3,1,0)
-template <typename T>
-void PetscVector<T>::add_vector_conjugate_transpose (const NumericVector<T> &,
-                                                     const SparseMatrix<T> &)
-{
-  libmesh_error_msg("MatMultHermitianTranspose was introduced in PETSc 3.1.0," \
-                    << "No one has made it backwards compatible with older " \
-                    << "versions of PETSc so far.");
-}
-
-#else
 
 template <typename T>
 void PetscVector<T>::add_vector_conjugate_transpose (const NumericVector<T> & v_in,
@@ -321,7 +310,7 @@ void PetscVector<T>::add_vector_conjugate_transpose (const NumericVector<T> & v_
   // Add the temporary copy to the matvec result
   this->add(1., *this_clone);
 }
-#endif
+
 
 
 template <typename T>
@@ -1403,13 +1392,6 @@ void PetscVector<T>::_get_array(bool read_only) const
           PetscErrorCode ierr=0;
           if (this->type() != GHOSTED)
             {
-#if PETSC_VERSION_LESS_THAN(3,2,0)
-              // Vec{Get,Restore}ArrayRead were introduced in PETSc 3.2.0.  If you
-              // have an older PETSc than that, we'll do an ugly
-              // const_cast and call VecGetArray() instead.
-              ierr = VecGetArray(_vec, const_cast<PetscScalar **>(&_values));
-              _values_read_only = false;
-#else
               if (read_only)
                 {
                   ierr = VecGetArrayRead(_vec, &_read_only_values);
@@ -1420,7 +1402,6 @@ void PetscVector<T>::_get_array(bool read_only) const
                   ierr = VecGetArray(_vec, &_values);
                   _values_read_only = false;
                 }
-#endif
               LIBMESH_CHKERR(ierr);
               _local_size = this->local_size();
             }
@@ -1429,13 +1410,6 @@ void PetscVector<T>::_get_array(bool read_only) const
               ierr = VecGhostGetLocalForm (_vec,&_local_form);
               LIBMESH_CHKERR(ierr);
 
-#if PETSC_VERSION_LESS_THAN(3,2,0)
-              // Vec{Get,Restore}ArrayRead were introduced in PETSc 3.2.0.  If you
-              // have an older PETSc than that, we'll do an ugly
-              // const_cast and call VecGetArray() instead.
-              ierr = VecGetArray(_local_form, const_cast<PetscScalar **>(&_values));
-              _values_read_only = false;
-#else
               if (read_only)
                 {
                   ierr = VecGetArrayRead(_local_form, &_read_only_values);
@@ -1446,7 +1420,6 @@ void PetscVector<T>::_get_array(bool read_only) const
                   ierr = VecGetArray(_local_form, &_values);
                   _values_read_only = false;
                 }
-#endif
               LIBMESH_CHKERR(ierr);
 
               PetscInt my_local_size = 0;
@@ -1498,34 +1471,21 @@ void PetscVector<T>::_restore_array() const
           PetscErrorCode ierr=0;
           if (this->type() != GHOSTED)
             {
-#if PETSC_VERSION_LESS_THAN(3,2,0)
-              // Vec{Get,Restore}ArrayRead were introduced in PETSc 3.2.0.  If you
-              // have an older PETSc than that, we'll do an ugly
-              // const_cast and call VecRestoreArray() instead.
-              ierr = VecRestoreArray (_vec, const_cast<PetscScalar **>(&_values));
-#else
               if (_values_read_only)
                 ierr = VecRestoreArrayRead (_vec, &_read_only_values);
               else
                 ierr = VecRestoreArray (_vec, &_values);
-#endif
 
               LIBMESH_CHKERR(ierr);
               _values = nullptr;
             }
           else
             {
-#if PETSC_VERSION_LESS_THAN(3,2,0)
-              // Vec{Get,Restore}ArrayRead were introduced in PETSc 3.2.0.  If you
-              // have an older PETSc than that, we'll do an ugly
-              // const_cast and call VecRestoreArray() instead.
-              ierr = VecRestoreArray (_local_form, const_cast<PetscScalar **>(&_values));
-#else
               if (_values_read_only)
                 ierr = VecRestoreArrayRead (_local_form, &_read_only_values);
               else
                 ierr = VecRestoreArray (_local_form, &_values);
-#endif
+
               LIBMESH_CHKERR(ierr);
               _values = nullptr;
               ierr = VecGhostRestoreLocalForm (_vec,&_local_form);

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -687,10 +687,10 @@ void PetscVector<T>::localize (NumericVector<T> & v_local_in) const
   std::iota (idx.begin(), idx.end(), 0);
 
   // Create the index set & scatter object
-  ierr = ISCreateLibMesh(this->comm().get(), n, idx.data(), PETSC_USE_POINTER, &is);
+  ierr = ISCreateGeneral(this->comm().get(), n, idx.data(), PETSC_USE_POINTER, &is);
   LIBMESH_CHKERR(ierr);
 
-  ierr = LibMeshVecScatterCreate(_vec,          is,
+  ierr = VecScatterCreate(_vec,          is,
                           v_local->_vec, is,
                           &scatter);
   LIBMESH_CHKERR(ierr);
@@ -705,10 +705,10 @@ void PetscVector<T>::localize (NumericVector<T> & v_local_in) const
   LIBMESH_CHKERR(ierr);
 
   // Clean up
-  ierr = LibMeshISDestroy (&is);
+  ierr = ISDestroy (&is);
   LIBMESH_CHKERR(ierr);
 
-  ierr = LibMeshVecScatterDestroy(&scatter);
+  ierr = VecScatterDestroy(&scatter);
   LIBMESH_CHKERR(ierr);
 
   // Make sure ghost dofs are up to date
@@ -759,11 +759,11 @@ void PetscVector<T>::localize (NumericVector<T> & v_local_in,
 
   // Create the index set & scatter object
   PetscInt * idxptr = idx.empty() ? nullptr : idx.data();
-  ierr = ISCreateLibMesh(this->comm().get(), n_sl+this->local_size(),
+  ierr = ISCreateGeneral(this->comm().get(), n_sl+this->local_size(),
                          idxptr, PETSC_USE_POINTER, &is);
   LIBMESH_CHKERR(ierr);
 
-  ierr = LibMeshVecScatterCreate(_vec,          is,
+  ierr = VecScatterCreate(_vec,          is,
                           v_local->_vec, is,
                           &scatter);
   LIBMESH_CHKERR(ierr);
@@ -779,10 +779,10 @@ void PetscVector<T>::localize (NumericVector<T> & v_local_in,
   LIBMESH_CHKERR(ierr);
 
   // Clean up
-  ierr = LibMeshISDestroy (&is);
+  ierr = ISDestroy (&is);
   LIBMESH_CHKERR(ierr);
 
-  ierr = LibMeshVecScatterDestroy(&scatter);
+  ierr = VecScatterDestroy(&scatter);
   LIBMESH_CHKERR(ierr);
 
   // Make sure ghost dofs are up to date
@@ -810,13 +810,13 @@ void PetscVector<T>::localize (std::vector<T> & v_local,
   PetscInt * idxptr =
     indices.empty() ? nullptr : numeric_petsc_cast(indices.data());
   IS is;
-  ierr = ISCreateLibMesh(this->comm().get(), cast_int<PetscInt>(indices.size()), idxptr,
+  ierr = ISCreateGeneral(this->comm().get(), cast_int<PetscInt>(indices.size()), idxptr,
                          PETSC_USE_POINTER, &is);
   LIBMESH_CHKERR(ierr);
 
   // Create the VecScatter object. "PETSC_NULL" means "use the identity IS".
   VecScatter scatter;
-  ierr = LibMeshVecScatterCreate(_vec,
+  ierr = VecScatterCreate(_vec,
                           /*src is=*/is,
                           /*dest vec=*/dest,
                           /*dest is=*/PETSC_NULL,
@@ -847,13 +847,13 @@ void PetscVector<T>::localize (std::vector<T> & v_local,
   LIBMESH_CHKERR(ierr);
 
   // Clean up PETSc data structures.
-  ierr = LibMeshVecScatterDestroy(&scatter);
+  ierr = VecScatterDestroy(&scatter);
   LIBMESH_CHKERR(ierr);
 
-  ierr = LibMeshISDestroy (&is);
+  ierr = ISDestroy (&is);
   LIBMESH_CHKERR(ierr);
 
-  ierr = LibMeshVecDestroy(&dest);
+  ierr = VecDestroy(&dest);
   LIBMESH_CHKERR(ierr);
 }
 
@@ -898,11 +898,11 @@ void PetscVector<T>::localize (const numeric_index_type first_local_idx,
     std::iota (idx.begin(), idx.end(), first_local_idx);
 
     // Create the index set & scatter object
-    ierr = ISCreateLibMesh(this->comm().get(), my_local_size,
+    ierr = ISCreateGeneral(this->comm().get(), my_local_size,
                            my_local_size ? idx.data() : nullptr, PETSC_USE_POINTER, &is);
     LIBMESH_CHKERR(ierr);
 
-    ierr = LibMeshVecScatterCreate(_vec,              is,
+    ierr = VecScatterCreate(_vec,              is,
                             parallel_vec._vec, is,
                             &scatter);
     LIBMESH_CHKERR(ierr);
@@ -916,10 +916,10 @@ void PetscVector<T>::localize (const numeric_index_type first_local_idx,
     LIBMESH_CHKERR(ierr);
 
     // Clean up
-    ierr = LibMeshISDestroy (&is);
+    ierr = ISDestroy (&is);
     LIBMESH_CHKERR(ierr);
 
-    ierr = LibMeshVecScatterDestroy(&scatter);
+    ierr = VecScatterDestroy(&scatter);
     LIBMESH_CHKERR(ierr);
   }
 
@@ -1023,9 +1023,9 @@ void PetscVector<Real>::localize_to_one (std::vector<Real> & v_local,
               LIBMESH_CHKERR(ierr);
             }
 
-          ierr = LibMeshVecScatterDestroy(&ctx);
+          ierr = VecScatterDestroy(&ctx);
           LIBMESH_CHKERR(ierr);
-          ierr = LibMeshVecDestroy(&vout);
+          ierr = VecDestroy(&vout);
           LIBMESH_CHKERR(ierr);
 
         }
@@ -1262,7 +1262,7 @@ void PetscVector<T>::print_matlab (const std::string & name) const
   /**
    * Destroy the viewer.
    */
-  ierr = LibMeshPetscViewerDestroy (&petsc_viewer);
+  ierr = PetscViewerDestroy (&petsc_viewer);
   LIBMESH_CHKERR(ierr);
 }
 
@@ -1317,14 +1317,14 @@ void PetscVector<T>::create_subvector(NumericVector<T> & subvector,
   std::iota (idx.begin(), idx.end(), 0);
 
   // Construct index sets
-  ierr = ISCreateLibMesh(this->comm().get(),
+  ierr = ISCreateGeneral(this->comm().get(),
                          cast_int<PetscInt>(rows.size()),
                          numeric_petsc_cast(rows.data()),
                          PETSC_USE_POINTER,
                          &parent_is);
   LIBMESH_CHKERR(ierr);
 
-  ierr = ISCreateLibMesh(this->comm().get(),
+  ierr = ISCreateGeneral(this->comm().get(),
                          cast_int<PetscInt>(rows.size()),
                          idx.data(),
                          PETSC_USE_POINTER,
@@ -1332,7 +1332,7 @@ void PetscVector<T>::create_subvector(NumericVector<T> & subvector,
   LIBMESH_CHKERR(ierr);
 
   // Construct the scatter object
-  ierr = LibMeshVecScatterCreate(this->_vec,
+  ierr = VecScatterCreate(this->_vec,
                           parent_is,
                           petsc_subvector->_vec,
                           subvector_is,
@@ -1352,9 +1352,9 @@ void PetscVector<T>::create_subvector(NumericVector<T> & subvector,
                        SCATTER_FORWARD); LIBMESH_CHKERR(ierr);
 
   // Clean up
-  ierr = LibMeshISDestroy(&parent_is);       LIBMESH_CHKERR(ierr);
-  ierr = LibMeshISDestroy(&subvector_is);    LIBMESH_CHKERR(ierr);
-  ierr = LibMeshVecScatterDestroy(&scatter); LIBMESH_CHKERR(ierr);
+  ierr = ISDestroy(&parent_is);       LIBMESH_CHKERR(ierr);
+  ierr = ISDestroy(&subvector_is);    LIBMESH_CHKERR(ierr);
+  ierr = VecScatterDestroy(&scatter); LIBMESH_CHKERR(ierr);
 }
 
 

--- a/src/solvers/petsc_auto_fieldsplit.C
+++ b/src/solvers/petsc_auto_fieldsplit.C
@@ -42,7 +42,7 @@ void indices_to_fieldsplit (const Parallel::Communicator & comm,
     idx = reinterpret_cast<const PetscInt *>(indices.data());
 
   IS is;
-  int ierr = ISCreateLibMesh(comm.get(), cast_int<PetscInt>(indices.size()),
+  int ierr = ISCreateGeneral(comm.get(), cast_int<PetscInt>(indices.size()),
                              idx, PETSC_COPY_VALUES, &is);
   CHKERRABORT(comm.get(), ierr);
 

--- a/src/solvers/petsc_auto_fieldsplit.C
+++ b/src/solvers/petsc_auto_fieldsplit.C
@@ -25,10 +25,6 @@
 #include "libmesh/dof_map.h"
 #include "libmesh/system.h"
 
-#if !PETSC_VERSION_LESS_THAN(3,2,0)
-
-// C++ includes
-
 namespace {
 using namespace libMesh;
 
@@ -108,24 +104,4 @@ void petsc_auto_fieldsplit (PC my_pc,
 } // namespace libMesh
 
 
-#else  // #PETSC_VERSION < 3.2.0
-
-namespace libMesh
-{
-void petsc_auto_fieldsplit (PC /* my_pc */,
-                            const System & /* sys */)
-{
-  if (libMesh::on_command_line("--solver-variable-names"))
-    {
-      libmesh_do_once(
-                      libMesh::out << "WARNING: libMesh does not support setting field splits" <<
-                      std::endl << "with PETSc "
-                      << LIBMESH_DETECTED_PETSC_VERSION_MAJOR << '.'
-                      << LIBMESH_DETECTED_PETSC_VERSION_MINOR << '.'
-                      << LIBMESH_DETECTED_PETSC_VERSION_SUBMINOR << std::endl;);
-    }
-}
-}
-
-#endif // #PETSC_VERSION > 3.2.0
 #endif // #ifdef LIBMESH_HAVE_PETSC

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -131,14 +131,8 @@ extern "C"
   PetscErrorCode
   __libmesh_petsc_diff_solver_jacobian (SNES,
                                         Vec x,
-#if PETSC_RELEASE_LESS_THAN(3,5,0)
-                                        Mat * libmesh_dbg_var(j),
-                                        Mat * pc,
-                                        MatStructure * msflag,
-#else
                                         Mat libmesh_dbg_var(j),
                                         Mat pc,
-#endif
                                         void * ctx)
   {
     libmesh_assert(x);
@@ -157,11 +151,7 @@ extern "C"
       *cast_ptr<PetscVector<Number> *>(sys.solution.get());
     PetscVector<Number> X_input(x, sys.comm());
 
-#if PETSC_RELEASE_LESS_THAN(3,5,0)
-    PetscMatrix<Number> J_input(*pc, sys.comm());
-#else
     PetscMatrix<Number> J_input(pc, sys.comm());
-#endif
     PetscMatrix<Number> & J_system =
       *cast_ptr<PetscMatrix<Number> *>(sys.matrix);
 
@@ -186,9 +176,6 @@ extern "C"
     X_input.swap(X_system);
     J_input.swap(J_system);
 
-#if PETSC_RELEASE_LESS_THAN(3,5,0)
-    *msflag = SAME_NONZERO_PATTERN;
-#endif
     // No errors, we hope
     return 0;
   }
@@ -260,11 +247,7 @@ DiffSolver::SolveResult convert_solve_result(SNESConvergedReason r)
       return DiffSolver::CONVERGED_ABSOLUTE_RESIDUAL;
     case SNES_CONVERGED_FNORM_RELATIVE:
       return DiffSolver::CONVERGED_RELATIVE_RESIDUAL;
-#if PETSC_VERSION_LESS_THAN(3,2,1)
-    case SNES_CONVERGED_PNORM_RELATIVE:
-#else
     case SNES_CONVERGED_SNORM_RELATIVE:
-#endif
       return DiffSolver::CONVERGED_RELATIVE_STEP;
     case SNES_CONVERGED_ITS:
       // SNES_CONVERGED_TR_DELTA was changed to a diverged condition,
@@ -277,19 +260,13 @@ DiffSolver::SolveResult convert_solve_result(SNESConvergedReason r)
     case SNES_DIVERGED_FUNCTION_DOMAIN:
     case SNES_DIVERGED_FUNCTION_COUNT:
     case SNES_DIVERGED_FNORM_NAN:
-#if !PETSC_VERSION_LESS_THAN(3,3,0)
     case SNES_DIVERGED_INNER:
-#endif
     case SNES_DIVERGED_LINEAR_SOLVE:
     case SNES_DIVERGED_LOCAL_MIN:
       return DiffSolver::DIVERGED_NO_REASON;
     case SNES_DIVERGED_MAX_IT:
       return DiffSolver::DIVERGED_MAX_NONLINEAR_ITERATIONS;
-#if PETSC_VERSION_LESS_THAN(3,2,0)
-    case SNES_DIVERGED_LS_FAILURE:
-#else
     case SNES_DIVERGED_LINE_SEARCH:
-#endif
       return DiffSolver::DIVERGED_BACKTRACKING_FAILURE;
       // In PETSc, SNES_CONVERGED_ITERATING means
       // the solve is still iterating, but by the

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -224,7 +224,7 @@ void PetscDiffSolver::clear()
 {
   LOG_SCOPE("clear()", "PetscDiffSolver");
 
-  int ierr = LibMeshSNESDestroy(&_snes);
+  int ierr = SNESDestroy(&_snes);
   LIBMESH_CHKERR(ierr);
 
 #if !PETSC_VERSION_LESS_THAN(3,7,3)

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -45,32 +45,6 @@ namespace libMesh
 
 extern "C"
 {
-#if PETSC_RELEASE_LESS_THAN(3,0,1)
-  PetscErrorCode libmesh_petsc_preconditioner_setup (void * ctx)
-  {
-    Preconditioner<Number> * preconditioner = static_cast<Preconditioner<Number> *>(ctx);
-
-    if (!preconditioner->initialized())
-      libmesh_error_msg("Preconditioner not initialized!  Make sure you call init() before solve!");
-
-    preconditioner->setup();
-
-    return 0;
-  }
-
-
-  PetscErrorCode libmesh_petsc_preconditioner_apply(void * ctx, Vec x, Vec y)
-  {
-    Preconditioner<Number> * preconditioner = static_cast<Preconditioner<Number> *>(ctx);
-
-    PetscVector<Number> x_vec(x, preconditioner->comm());
-    PetscVector<Number> y_vec(y, preconditioner->comm());
-
-    preconditioner->apply(x_vec,y_vec);
-
-    return 0;
-  }
-#else
   PetscErrorCode libmesh_petsc_preconditioner_setup (PC pc)
   {
     void * ctx;
@@ -98,23 +72,8 @@ extern "C"
 
     return 0;
   }
-#endif
 
 #ifdef LIBMESH_ENABLE_DEPRECATED
-#if PETSC_RELEASE_LESS_THAN(3,0,1)
-  PetscErrorCode __libmesh_petsc_preconditioner_setup (void * ctx)
-  {
-    libmesh_deprecated();
-    return libmesh_petsc_preconditioner_setup(ctx);
-  }
-
-  PetscErrorCode __libmesh_petsc_preconditioner_apply(void * ctx, Vec x, Vec y)
-  {
-    libmesh_deprecated();
-    return libmesh_petsc_preconditioner_apply(ctx, x, y);
-  }
-
-#else
   PetscErrorCode __libmesh_petsc_preconditioner_setup (PC pc)
   {
     libmesh_deprecated();
@@ -126,7 +85,6 @@ extern "C"
     libmesh_deprecated();
     return libmesh_petsc_preconditioner_apply(pc, x, y);
   }
-#endif
 #endif
 } // end extern "C"
 
@@ -241,12 +199,7 @@ void PetscLinearSolver<T>::init (const char * name)
       // Have the Krylov subspace method use our good initial guess
       // rather than 0, unless the user requested a KSPType of
       // preonly, which complains if asked to use initial guesses.
-#if PETSC_VERSION_LESS_THAN(3,0,0) || !PETSC_RELEASE_LESS_THAN(3,4,0)
-      // Pre-3.0 and petsc-dev (as of October 2012) use non-const versions
       KSPType ksp_type;
-#else
-      const KSPType ksp_type;
-#endif
 
       ierr = KSPGetType (_ksp, &ksp_type);
       LIBMESH_CHKERR(ierr);
@@ -311,11 +264,7 @@ void PetscLinearSolver<T>::init (PetscMatrix<T> * matrix,
       LIBMESH_CHKERR(ierr);
 
       // Set operators. The input matrix works as the preconditioning matrix
-#if PETSC_RELEASE_LESS_THAN(3,5,0)
-      ierr = KSPSetOperators(_ksp, matrix->mat(), matrix->mat(),DIFFERENT_NONZERO_PATTERN);
-#else
       ierr = KSPSetOperators(_ksp, matrix->mat(), matrix->mat());
-#endif
       LIBMESH_CHKERR(ierr);
 
       // Set user-specified  solver and preconditioner types
@@ -346,11 +295,7 @@ void PetscLinearSolver<T>::init (PetscMatrix<T> * matrix,
       // Have the Krylov subspace method use our good initial guess
       // rather than 0, unless the user requested a KSPType of
       // preonly, which complains if asked to use initial guesses.
-#if PETSC_VERSION_LESS_THAN(3,0,0) || !PETSC_RELEASE_LESS_THAN(3,4,0)
       KSPType ksp_type;
-#else
-      const KSPType ksp_type;
-#endif
 
       ierr = KSPGetType (_ksp, &ksp_type);
       LIBMESH_CHKERR(ierr);
@@ -509,9 +454,6 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
       ierr = LibMeshCreateSubMatrix(matrix->mat(),
                                     _restrict_solve_to_is,
                                     _restrict_solve_to_is,
-#if PETSC_VERSION_LESS_THAN(3,1,0)
-                                    PETSC_DECIDE,
-#endif
                                     MAT_INITIAL_MATRIX,
                                     &submat);
       LIBMESH_CHKERR(ierr);
@@ -519,9 +461,6 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
       ierr = LibMeshCreateSubMatrix(precond->mat(),
                                     _restrict_solve_to_is,
                                     _restrict_solve_to_is,
-#if PETSC_VERSION_LESS_THAN(3,1,0)
-                                    PETSC_DECIDE,
-#endif
                                     MAT_INITIAL_MATRIX,
                                     &subprecond);
       LIBMESH_CHKERR(ierr);
@@ -561,9 +500,6 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
           ierr = LibMeshCreateSubMatrix(matrix->mat(),
                                         _restrict_solve_to_is,
                                         _restrict_solve_to_is_complement,
-#if PETSC_VERSION_LESS_THAN(3,1,0)
-                                        PETSC_DECIDE,
-#endif
                                         MAT_INITIAL_MATRIX,
                                         &submat1);
           LIBMESH_CHKERR(ierr);
@@ -578,15 +514,10 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
           ierr = MatDestroy(&submat1);
           LIBMESH_CHKERR(ierr);
         }
-#if PETSC_RELEASE_LESS_THAN(3,5,0)
-      ierr = KSPSetOperators(_ksp, submat, subprecond,
-                             this->same_preconditioner ? SAME_PRECONDITIONER : DIFFERENT_NONZERO_PATTERN);
-#else
       ierr = KSPSetOperators(_ksp, submat, subprecond);
 
       PetscBool ksp_reuse_preconditioner = this->same_preconditioner ? PETSC_TRUE : PETSC_FALSE;
       ierr = KSPSetReusePreconditioner(_ksp, ksp_reuse_preconditioner);
-#endif
       LIBMESH_CHKERR(ierr);
 
       if (this->_preconditioner)
@@ -598,15 +529,10 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
     }
   else
     {
-#if PETSC_RELEASE_LESS_THAN(3,5,0)
-      ierr = KSPSetOperators(_ksp, matrix->mat(), precond->mat(),
-                             this->same_preconditioner ? SAME_PRECONDITIONER : DIFFERENT_NONZERO_PATTERN);
-#else
       ierr = KSPSetOperators(_ksp, matrix->mat(), precond->mat());
 
       PetscBool ksp_reuse_preconditioner = this->same_preconditioner ? PETSC_TRUE : PETSC_FALSE;
       ierr = KSPSetReusePreconditioner(_ksp, ksp_reuse_preconditioner);
-#endif
       LIBMESH_CHKERR(ierr);
 
       if (this->_preconditioner)
@@ -776,9 +702,6 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
       ierr = LibMeshCreateSubMatrix(matrix->mat(),
                                     _restrict_solve_to_is,
                                     _restrict_solve_to_is,
-#if PETSC_VERSION_LESS_THAN(3,1,0)
-                                    PETSC_DECIDE,
-#endif
                                     MAT_INITIAL_MATRIX,
                                     &submat);
       LIBMESH_CHKERR(ierr);
@@ -786,9 +709,6 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
       ierr = LibMeshCreateSubMatrix(precond->mat(),
                                     _restrict_solve_to_is,
                                     _restrict_solve_to_is,
-#if PETSC_VERSION_LESS_THAN(3,1,0)
-                                    PETSC_DECIDE,
-#endif
                                     MAT_INITIAL_MATRIX,
                                     &subprecond);
       LIBMESH_CHKERR(ierr);
@@ -828,9 +748,6 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
           ierr = LibMeshCreateSubMatrix(matrix->mat(),
                                         _restrict_solve_to_is,
                                         _restrict_solve_to_is_complement,
-#if PETSC_VERSION_LESS_THAN(3,1,0)
-                                        PETSC_DECIDE,
-#endif
                                         MAT_INITIAL_MATRIX,
                                         &submat1);
           LIBMESH_CHKERR(ierr);
@@ -845,15 +762,10 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
           ierr = MatDestroy(&submat1);
           LIBMESH_CHKERR(ierr);
         }
-#if PETSC_RELEASE_LESS_THAN(3,5,0)
-      ierr = KSPSetOperators(_ksp, submat, subprecond,
-                             this->same_preconditioner ? SAME_PRECONDITIONER : DIFFERENT_NONZERO_PATTERN);
-#else
       ierr = KSPSetOperators(_ksp, submat, subprecond);
 
       PetscBool ksp_reuse_preconditioner = this->same_preconditioner ? PETSC_TRUE : PETSC_FALSE;
       ierr = KSPSetReusePreconditioner(_ksp, ksp_reuse_preconditioner);
-#endif
       LIBMESH_CHKERR(ierr);
 
       if (this->_preconditioner)
@@ -865,15 +777,10 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
     }
   else
     {
-#if PETSC_RELEASE_LESS_THAN(3,5,0)
-      ierr = KSPSetOperators(_ksp, matrix->mat(), precond->mat(),
-                             this->same_preconditioner ? SAME_PRECONDITIONER : DIFFERENT_NONZERO_PATTERN);
-#else
       ierr = KSPSetOperators(_ksp, matrix->mat(), precond->mat());
 
       PetscBool ksp_reuse_preconditioner = this->same_preconditioner ? PETSC_TRUE : PETSC_FALSE;
       ierr = KSPSetReusePreconditioner(_ksp, ksp_reuse_preconditioner);
-#endif
       LIBMESH_CHKERR(ierr);
 
       if (this->_preconditioner)
@@ -973,15 +880,6 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
                              const double tol,
                              const unsigned int m_its)
 {
-
-#if PETSC_VERSION_LESS_THAN(3,1,0)
-  if (_restrict_solve_to_is != nullptr)
-    libmesh_error_msg("The current implementation of subset solves with " \
-                      << "shell matrices requires PETSc version 3.1 or above.  " \
-                      << "Older PETSc version do not support automatic " \
-                      << "submatrix generation of shell matrices.");
-#endif
-
   LOG_SCOPE("solve()", "PetscLinearSolver");
 
   // Make sure the data passed in are really of Petsc types
@@ -1058,14 +956,12 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
       ierr = VecScatterEnd(scatter,solution->vec(),subsolution,INSERT_VALUES,SCATTER_FORWARD);
       LIBMESH_CHKERR(ierr);
 
-#if !PETSC_VERSION_LESS_THAN(3,1,0)
       ierr = LibMeshCreateSubMatrix(mat,
                                     _restrict_solve_to_is,
                                     _restrict_solve_to_is,
                                     MAT_INITIAL_MATRIX,
                                     &submat);
       LIBMESH_CHKERR(ierr);
-#endif
 
       /* Since removing columns of the matrix changes the equation
          system, we will now change the right hand side to compensate
@@ -1099,14 +995,12 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
           ierr = VecScale(subvec1,-1.0);
           LIBMESH_CHKERR(ierr);
 
-#if !PETSC_VERSION_LESS_THAN(3,1,0)
           ierr = LibMeshCreateSubMatrix(mat,
                                         _restrict_solve_to_is,
                                         _restrict_solve_to_is_complement,
                                         MAT_INITIAL_MATRIX,
                                         &submat1);
           LIBMESH_CHKERR(ierr);
-#endif
 
           // The following lines would be correct, but don't work
           // correctly in PETSc up to 3.1.0-p5.  See discussion in
@@ -1136,22 +1030,12 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
           ierr = MatDestroy(&submat1);
           LIBMESH_CHKERR(ierr);
         }
-#if PETSC_RELEASE_LESS_THAN(3,5,0)
-      ierr = KSPSetOperators(_ksp, submat, submat,
-                             DIFFERENT_NONZERO_PATTERN);
-#else
       ierr = KSPSetOperators(_ksp, submat, submat);
-#endif
       LIBMESH_CHKERR(ierr);
     }
   else
     {
-#if PETSC_RELEASE_LESS_THAN(3,5,0)
-      ierr = KSPSetOperators(_ksp, mat, mat,
-                             DIFFERENT_NONZERO_PATTERN);
-#else
       ierr = KSPSetOperators(_ksp, mat, mat);
-#endif
       LIBMESH_CHKERR(ierr);
     }
 
@@ -1241,15 +1125,6 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
                              const double tol,
                              const unsigned int m_its)
 {
-
-#if PETSC_VERSION_LESS_THAN(3,1,0)
-  if (_restrict_solve_to_is != nullptr)
-    libmesh_error_msg("The current implementation of subset solves with " \
-                      << "shell matrices requires PETSc version 3.1 or above.  " \
-                      << "Older PETSc version do not support automatic " \
-                      << "submatrix generation of shell matrices.");
-#endif
-
   LOG_SCOPE("solve()", "PetscLinearSolver");
 
   // Make sure the data passed in are really of Petsc types
@@ -1329,7 +1204,6 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
       ierr = VecScatterEnd(scatter,solution->vec(),subsolution,INSERT_VALUES,SCATTER_FORWARD);
       LIBMESH_CHKERR(ierr);
 
-#if !PETSC_VERSION_LESS_THAN(3,1,0)
       ierr = LibMeshCreateSubMatrix(mat,
                                     _restrict_solve_to_is,
                                     _restrict_solve_to_is,
@@ -1343,7 +1217,6 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
                                     MAT_INITIAL_MATRIX,
                                     &subprecond);
       LIBMESH_CHKERR(ierr);
-#endif
 
       /* Since removing columns of the matrix changes the equation
          system, we will now change the right hand side to compensate
@@ -1376,14 +1249,12 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
           ierr = VecScale(subvec1,-1.0);
           LIBMESH_CHKERR(ierr);
 
-#if !PETSC_VERSION_LESS_THAN(3,1,0)
           ierr = LibMeshCreateSubMatrix(mat,
                                         _restrict_solve_to_is,
                                         _restrict_solve_to_is_complement,
                                         MAT_INITIAL_MATRIX,
                                         &submat1);
           LIBMESH_CHKERR(ierr);
-#endif
 
           // The following lines would be correct, but don't work
           // correctly in PETSc up to 3.1.0-p5.  See discussion in
@@ -1415,12 +1286,7 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
           LIBMESH_CHKERR(ierr);
         }
 
-#if PETSC_RELEASE_LESS_THAN(3,5,0)
-      ierr = KSPSetOperators(_ksp, submat, subprecond,
-                             DIFFERENT_NONZERO_PATTERN);
-#else
       ierr = KSPSetOperators(_ksp, submat, subprecond);
-#endif
       LIBMESH_CHKERR(ierr);
 
       if (this->_preconditioner)
@@ -1432,12 +1298,7 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
     }
   else
     {
-#if PETSC_RELEASE_LESS_THAN(3,5,0)
-      ierr = KSPSetOperators(_ksp, mat, const_cast<PetscMatrix<T> *>(precond)->mat(),
-                             DIFFERENT_NONZERO_PATTERN);
-#else
       ierr = KSPSetOperators(_ksp, mat, const_cast<PetscMatrix<T> *>(precond)->mat());
-#endif
       LIBMESH_CHKERR(ierr);
 
       if (this->_preconditioner)
@@ -1661,16 +1522,9 @@ void PetscLinearSolver<T>::set_petsc_solver_type()
       return;
 
     case CHEBYSHEV:
-#if defined(LIBMESH_HAVE_PETSC) && PETSC_VERSION_LESS_THAN(3,3,0)
-      ierr = KSPSetType (_ksp, const_cast<KSPType>(KSPCHEBYCHEV));
-      LIBMESH_CHKERR(ierr);
-      return;
-#else
       ierr = KSPSetType (_ksp, const_cast<KSPType>(KSPCHEBYSHEV));
       LIBMESH_CHKERR(ierr);
       return;
-#endif
-
 
     default:
       libMesh::err << "ERROR:  Unsupported PETSC Solver: "
@@ -1689,10 +1543,8 @@ LinearConvergenceReason PetscLinearSolver<T>::get_converged_reason() const
 
   switch(reason)
     {
-#if !PETSC_VERSION_LESS_THAN(3,2,0)
     case KSP_CONVERGED_RTOL_NORMAL     : return CONVERGED_RTOL_NORMAL;
     case KSP_CONVERGED_ATOL_NORMAL     : return CONVERGED_ATOL_NORMAL;
-#endif
     case KSP_CONVERGED_RTOL            : return CONVERGED_RTOL;
     case KSP_CONVERGED_ATOL            : return CONVERGED_ATOL;
     case KSP_CONVERGED_ITS             : return CONVERGED_ITS;
@@ -1707,11 +1559,7 @@ LinearConvergenceReason PetscLinearSolver<T>::get_converged_reason() const
     case KSP_DIVERGED_BREAKDOWN_BICG   : return DIVERGED_BREAKDOWN_BICG;
     case KSP_DIVERGED_NONSYMMETRIC     : return DIVERGED_NONSYMMETRIC;
     case KSP_DIVERGED_INDEFINITE_PC    : return DIVERGED_INDEFINITE_PC;
-#if PETSC_VERSION_LESS_THAN(3,4,0)
-    case KSP_DIVERGED_NAN              : return DIVERGED_NAN;
-#else
     case KSP_DIVERGED_NANORINF         : return DIVERGED_NAN;
-#endif
     case KSP_DIVERGED_INDEFINITE_MAT   : return DIVERGED_INDEFINITE_MAT;
     case KSP_CONVERGED_ITERATING       : return CONVERGED_ITERATING;
 #if !PETSC_VERSION_LESS_THAN(3,7,0)

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -572,7 +572,7 @@ void PetscNonlinearSolver<T>::clear ()
 
       PetscErrorCode ierr=0;
 
-      ierr = LibMeshSNESDestroy(&_snes);
+      ierr = SNESDestroy(&_snes);
       LIBMESH_CHKERR(ierr);
 
       // Reset the nonlinear iteration counter.  This information is only relevant

--- a/src/solvers/petscdmlibmesh.C
+++ b/src/solvers/petscdmlibmesh.C
@@ -18,8 +18,8 @@
 
 
 #include "libmesh/petsc_macro.h"
-// This only works with petsc-3.3 and above.
-#if !PETSC_VERSION_LESS_THAN(3,3,0)
+
+#ifdef LIBMESH_HAVE_PETSC
 
 #if !PETSC_RELEASE_LESS_THAN(3,6,0)
 # include <petsc/private/petscimpl.h>
@@ -38,11 +38,7 @@ PetscErrorCode DMlibMeshSetSystem(DM dm, libMesh::NonlinearImplicitSystem & sys)
 
   PetscFunctionBegin;
   PetscValidHeaderSpecific(dm,DM_CLASSID,1);
-#if PETSC_RELEASE_LESS_THAN(3,4,0)
-  ierr = PetscObjectQueryFunction((PetscObject)dm,"DMlibMeshSetSystem_C",(PetscVoidFunction*)&f);CHKERRQ(ierr);
-#else
   ierr = PetscObjectQueryFunction((PetscObject)dm,"DMlibMeshSetSystem_C",&f);CHKERRQ(ierr);
-#endif
   if (!f) SETERRQ(PETSC_COMM_SELF,PETSC_ERR_SUP, "DM has no implementation for DMlibMeshSetSystem");
   ierr = (*f)(dm,sys);CHKERRQ(ierr);
   PetscFunctionReturn(0);
@@ -57,15 +53,10 @@ PetscErrorCode DMlibMeshGetSystem(DM dm, libMesh::NonlinearImplicitSystem *& sys
 
   PetscFunctionBegin;
   PetscValidHeaderSpecific(dm,DM_CLASSID,1);
-#if PETSC_RELEASE_LESS_THAN(3,4,0)
-  ierr = PetscObjectQueryFunction((PetscObject)dm,"DMlibMeshGetSystem_C",(PetscVoidFunction*)&f);CHKERRQ(ierr);
-#else
   ierr = PetscObjectQueryFunction((PetscObject)dm,"DMlibMeshGetSystem_C",&f);CHKERRQ(ierr);
-#endif
   if (!f) SETERRQ(PETSC_COMM_SELF,PETSC_ERR_SUP, "DM has no implementation for DMlibMeshGetSystem");
   ierr = (*f)(dm,sys);CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
-
-#endif // #if !PETSC_VERSION_LESS_THAN(3,3,0)
+#endif // LIBMESH_HAVE_PETSC

--- a/tests/numerics/dense_matrix_test.C
+++ b/tests/numerics/dense_matrix_test.C
@@ -380,9 +380,7 @@ private:
   }
 };
 
-// Only run the test if we expect it can actually work!
+// These tests require PETSc
 #ifdef LIBMESH_HAVE_PETSC
-#if !PETSC_VERSION_LESS_THAN(3,1,0)
 CPPUNIT_TEST_SUITE_REGISTRATION(DenseMatrixTest);
-#endif
 #endif


### PR DESCRIPTION
As discussed with @roystgnr over IM, PETSc 3.4 was tagged in May 2013 so hopefully no one is still using it. The 3.5 series is the first one where they started tagging releases on the maint branch, so it seems like a reasonable one to jump to. There also seem to be fewer API changes following the 3.5 series, so this lets us get rid of quite a bit of backwards compatibility code.
