### PR TITLE
Fix error from #2409

### DIFF
--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -2035,6 +2035,11 @@ Point FEMap::map (const unsigned int dim,
 {
   libmesh_assert(elem);
 
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+  if (elem->infinite())
+    return InfFEMap::map(dim, elem, reference_point);
+#endif
+
   Point p;
 
   const FEFamily mapping_family = FEMap::map_fe_type(*elem);

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -523,7 +523,7 @@ namespace libMesh
 
         // Build the PetscSection and attach it to the DM
         this->build_section(system, section);
-#if PETSC_VERSION_LESS_THAN(3,12,0)
+#if PETSC_VERSION_LESS_THAN(3,9,0)
         ierr = DMSetDefaultSection(dm, section);
 #else
         ierr = DMSetSection(dm, section);


### PR DESCRIPTION
in #2409 I removed some code which turned out to be wrong; so here it is back. (Yes, a test for ``FEMap`` is obviously missing :-) )

Also I came across a wrong number in deprecation (see ``include/petscdm.h`` in your PETSc directory).
I found this to be too smal for a separate PR...