### PR TITLE
Add Elem::local_edge_node()

### DIFF
--- a/include/geom/cell_hex.h
+++ b/include/geom/cell_hex.h
@@ -133,7 +133,7 @@ public:
   /**
    * \returns \p Hex8::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/cell_hex.h
+++ b/include/geom/cell_hex.h
@@ -137,6 +137,12 @@ public:
                                        unsigned int side_node) const override;
 
   /**
+   * \returns \p Hex8::edge_nodes_map[edge][edge_node] after doing some range checking.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
+  /**
    * \returns A primitive (4-noded) quad for face i.
    */
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override final;

--- a/include/geom/cell_hex20.h
+++ b/include/geom/cell_hex20.h
@@ -143,7 +143,7 @@ public:
   /**
    * \returns \p Hex20::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/cell_hex20.h
+++ b/include/geom/cell_hex20.h
@@ -147,6 +147,12 @@ public:
                                        unsigned int side_node) const override;
 
   /**
+   * \returns \p Hex20::edge_nodes_map[edge][edge_node] after doing some range checking.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
+  /**
    * Builds a \p QUAD8 built coincident with face i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -159,7 +159,7 @@ public:
   /**
    * \returns \p Hex27::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -163,6 +163,12 @@ public:
                                        unsigned int side_node) const override;
 
   /**
+   * \returns \p Hex27::edge_nodes_map[edge][edge_node] after doing some range checking.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
+  /**
    * Builds a \p QUAD9 built coincident with face i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_inf_hex.h
+++ b/include/geom/cell_inf_hex.h
@@ -145,6 +145,12 @@ public:
                                        unsigned int side_node) const override;
 
   /**
+   * \returns \p InfHex8::edge_nodes_map[edge][edge_node] after doing some range checking.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
+  /**
    * \returns A primitive (4-noded) quad or infquad for face i.
    */
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override final;

--- a/include/geom/cell_inf_hex.h
+++ b/include/geom/cell_inf_hex.h
@@ -141,7 +141,7 @@ public:
   /**
    * \returns \p InfHex8::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/cell_inf_hex16.h
+++ b/include/geom/cell_inf_hex16.h
@@ -139,7 +139,7 @@ public:
   /**
    * \returns \p InfHex16::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/cell_inf_hex16.h
+++ b/include/geom/cell_inf_hex16.h
@@ -143,6 +143,12 @@ public:
                                        unsigned int side_node) const override;
 
   /**
+   * \returns \p InfHex16::edge_nodes_map[edge][edge_node] after doing some range checking.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
+  /**
    * \returns A \p QUAD8 built coincident with face 0, or an \p
    * INFQUAD6 built coincident with faces 1 to 4.
    *

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -182,6 +182,12 @@ public:
   virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
+  /**
+   * \returns \p InfHex18::edge_nodes_map[edge][edge_node] after doing some range checking.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -179,7 +179,7 @@ public:
   /**
    * \returns \p InfHex18::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   virtual void connectivity(const unsigned int sc,

--- a/include/geom/cell_inf_prism.h
+++ b/include/geom/cell_inf_prism.h
@@ -136,7 +136,7 @@ public:
   /**
    * \returns InfPrism6::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/cell_inf_prism.h
+++ b/include/geom/cell_inf_prism.h
@@ -140,6 +140,12 @@ public:
                                        unsigned int side_node) const override;
 
   /**
+   * \returns InfPrism6::edge_nodes_map[edge][edge_node] after doing some range checking.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
+  /**
    * \returns A primitive (3-noded) tri or (4-noded) infquad for
    * face i.
    */

--- a/include/geom/cell_inf_prism12.h
+++ b/include/geom/cell_inf_prism12.h
@@ -130,7 +130,7 @@ public:
   /**
    * \returns \p InfPrism12::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/cell_inf_prism12.h
+++ b/include/geom/cell_inf_prism12.h
@@ -134,6 +134,12 @@ public:
                                        unsigned int side_node) const override;
 
   /**
+   * \returns \p InfPrism12::edge_nodes_map[edge][edge_node] after doing some range checking.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
+  /**
    * \returns A \p TRI6 built coincident with face 0, or an \p
    * INFQUAD6 built coincident with faces 1 to 3.
    *

--- a/include/geom/cell_prism.h
+++ b/include/geom/cell_prism.h
@@ -125,7 +125,7 @@ public:
   /**
    * \returns \p Prism6::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/cell_prism.h
+++ b/include/geom/cell_prism.h
@@ -129,6 +129,12 @@ public:
                                        unsigned int side_node) const override;
 
   /**
+   * \returns \p Prism6::edge_nodes_map[edge][edge_node] after doing some range checking.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
+  /**
    * \returns A primitive triangle or quad for face i.
    */
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override final;

--- a/include/geom/cell_prism15.h
+++ b/include/geom/cell_prism15.h
@@ -144,7 +144,7 @@ public:
   /**
    * \returns \p Prism15::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/cell_prism15.h
+++ b/include/geom/cell_prism15.h
@@ -148,6 +148,12 @@ public:
                                        unsigned int side_node) const override;
 
   /**
+   * \returns \p Prism15::edge_nodes_map[edge][edge_node] after doing some range checking.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
+  /**
    * Builds a \p QUAD8 or \p TRI6 built coincident with face i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -160,7 +160,7 @@ public:
   /**
    * \returns \p Prism18::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -164,6 +164,12 @@ public:
                                        unsigned int side_node) const override;
 
   /**
+   * \returns \p Prism18::edge_nodes_map[edge][edge_node] after doing some range checking.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
+  /**
    * Builds a \p QUAD9 or \p TRI6 built coincident with face i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_pyramid.h
+++ b/include/geom/cell_pyramid.h
@@ -134,6 +134,12 @@ public:
                                        unsigned int side_node) const override;
 
   /**
+   * \returns \p Pyramid5::edge_nodes_map[edge][edge_node] after doing some range checking.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
+  /**
    * \returns A primitive triangle or quad for face i.
    */
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;

--- a/include/geom/cell_pyramid.h
+++ b/include/geom/cell_pyramid.h
@@ -130,7 +130,7 @@ public:
   /**
    * \returns \p Pyramid5::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/cell_pyramid13.h
+++ b/include/geom/cell_pyramid13.h
@@ -144,7 +144,7 @@ public:
   /**
    * \returns \p Pyramid13::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/cell_pyramid13.h
+++ b/include/geom/cell_pyramid13.h
@@ -148,6 +148,12 @@ public:
                                        unsigned int side_node) const override;
 
   /**
+   * \returns \p Pyramid13::edge_nodes_map[edge][edge_node] after doing some range checking.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
+  /**
    * Builds a \p QUAD8 or \p TRI6 coincident with face i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -163,7 +163,7 @@ public:
   /**
    * \returns \p Pyramid14::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -167,6 +167,12 @@ public:
                                        unsigned int side_node) const override;
 
   /**
+   * \returns \p Pyramid14::edge_nodes_map[edge][edge_node] after doing some range checking.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
+  /**
    * Builds a \p QUAD9 or \p TRI6 coincident with face i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_tet.h
+++ b/include/geom/cell_tet.h
@@ -118,6 +118,12 @@ public:
                                        unsigned int side_node) const override;
 
   /**
+   * \returns \p Tet4::edge_nodes_map[edge][edge_node] after doing some range checking.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
+  /**
    * \returns A primitive (3-noded) triangle for face i.
    */
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override final;

--- a/include/geom/cell_tet.h
+++ b/include/geom/cell_tet.h
@@ -114,7 +114,7 @@ public:
   /**
    * \returns \p Tet4::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/cell_tet10.h
+++ b/include/geom/cell_tet10.h
@@ -142,7 +142,7 @@ public:
   /**
    * \returns \p Tet10::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/cell_tet10.h
+++ b/include/geom/cell_tet10.h
@@ -146,6 +146,12 @@ public:
                                        unsigned int side_node) const override;
 
   /**
+   * \returns \p Tet10::edge_nodes_map[edge][edge_node] after doing some range checking.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
+  /**
    * Builds a \p TRI6 built coincident with face i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -136,7 +136,7 @@ public:
   /**
    * \returns \p side after doing some range checking. \p side_node is ignored.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int /*side_node*/) const override final;
 
   /**

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -140,6 +140,13 @@ public:
                                        unsigned int /*side_node*/) const override final;
 
   /**
+   * Throws an error. Edge elems have n_edges() == 0, so it does not
+   * make sense to call local_edge_node().
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override final;
+
+  /**
    * \returns A pointer to a NodeElem for the specified node.
    */
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override final;

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -408,14 +408,20 @@ public:
    * \returns The local node id for node \p side_node on side \p side of
    * this Elem. Simply relies on the \p side_nodes_map for each of the
    * derived types. For example,
-   * Tri3::which_node_am_i(0, 0) -> 0
-   * Tri3::which_node_am_i(0, 1) -> 1
-   * Tri3::which_node_am_i(1, 0) -> 1
-   * Tri3::which_node_am_i(1, 1) -> 2
+   * Tri3::local_side_node(0, 0) -> 0
+   * Tri3::local_side_node(0, 1) -> 1
+   * Tri3::local_side_node(1, 0) -> 1
+   * Tri3::local_side_node(1, 1) -> 2
    * etc...
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const = 0;
+
+  /**
+   * This function is deprecated, call local_side_node(side, side_node) instead.
+   */
+  unsigned int which_node_am_i(unsigned int side,
+                               unsigned int side_node) const;
 
   /**
    * \returns \p true if a vertex of \p e is contained

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -418,6 +418,16 @@ public:
                                        unsigned int side_node) const = 0;
 
   /**
+   * Similar to Elem::local_side_node(), but instead of a side id, takes
+   * an edge id and a node id on that edge and returns a local node number
+   * for the Elem. The implementation relies on the "edge_nodes_map" tables
+   * for 3D elements. For 2D elements, calls local_side_node(). Throws an
+   * error if called on 1D elements.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const = 0;
+
+  /**
    * This function is deprecated, call local_side_node(side, side_node) instead.
    */
   unsigned int which_node_am_i(unsigned int side,

--- a/include/geom/face_inf_quad.h
+++ b/include/geom/face_inf_quad.h
@@ -154,6 +154,14 @@ public:
                                        unsigned int side_node) const override;
 
   /**
+   * Calls local_side_node(edge, edge_node). For 2D elements, there is an implied
+   * equivalence between edges and sides, e.g. n_edges() == n_sides(), so we treat
+   * these two functions the same.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
+  /**
    * \returns A primitive (2-noded) edge or infedge for edge \p i.
    */
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override final;

--- a/include/geom/face_inf_quad.h
+++ b/include/geom/face_inf_quad.h
@@ -150,7 +150,7 @@ public:
   /**
    * \returns \p InfQuad4::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/face_inf_quad6.h
+++ b/include/geom/face_inf_quad6.h
@@ -137,7 +137,7 @@ public:
   /**
    * \returns \p InfQuad6::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/face_quad.h
+++ b/include/geom/face_quad.h
@@ -152,6 +152,14 @@ public:
                                        unsigned int side_node) const override;
 
   /**
+   * Calls local_side_node(edge, edge_node). For 2D elements, there is an implied
+   * equivalence between edges and sides, e.g. n_edges() == n_sides(), so we treat
+   * these two functions the same.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
+  /**
    * \returns A primitive (2-noded) edge for edge i.
    */
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override final;

--- a/include/geom/face_quad.h
+++ b/include/geom/face_quad.h
@@ -148,7 +148,7 @@ public:
   /**
    * \returns \p Quad4::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/face_quad8.h
+++ b/include/geom/face_quad8.h
@@ -142,7 +142,7 @@ public:
   /**
    * \returns \p Quad8::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,

--- a/include/geom/face_quad9.h
+++ b/include/geom/face_quad9.h
@@ -150,7 +150,7 @@ public:
   /**
    * \returns \p Quad9::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,

--- a/include/geom/face_tri.h
+++ b/include/geom/face_tri.h
@@ -139,6 +139,14 @@ public:
                                        unsigned int side_node) const override;
 
   /**
+   * Calls local_side_node(edge, edge_node). For 2D elements, there is an implied
+   * equivalence between edges and sides, e.g. n_edges() == n_sides(), so we treat
+   * these two functions the same.
+   */
+  virtual unsigned int local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const override;
+
+  /**
    * \returns A primitive (2-noded) edge for edge i.
    */
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override final;

--- a/include/geom/face_tri.h
+++ b/include/geom/face_tri.h
@@ -135,7 +135,7 @@ public:
   /**
    * \returns \p Tri3::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   /**

--- a/include/geom/face_tri6.h
+++ b/include/geom/face_tri6.h
@@ -147,7 +147,7 @@ public:
   /**
    * \returns \p Tri6::side_nodes_map[side][side_node] after doing some range checking.
    */
-  virtual unsigned int which_node_am_i(unsigned int side,
+  virtual unsigned int local_side_node(unsigned int side,
                                        unsigned int side_node) const override;
 
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -122,6 +122,13 @@ public:
   { libmesh_error_msg("Calling NodeElem::local_side_node() does not make sense."); return 0; }
 
   /**
+   * NodeElems don't have edges, so they can't have nodes on edges.
+   */
+  virtual unsigned int local_edge_node(unsigned int /*edge*/,
+                                       unsigned int /*edge_node*/) const override
+  { libmesh_error_msg("Calling NodeElem::local_edge_node() does not make sense."); return 0; }
+
+  /**
    * The \p Elem::side_ptr() member makes no sense for nodes.
    */
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int) override

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -117,9 +117,9 @@ public:
   /**
    * NodeElems don't have sides, so they can't have nodes on sides.
    */
-  virtual unsigned int which_node_am_i(unsigned int /*side*/,
+  virtual unsigned int local_side_node(unsigned int /*side*/,
                                        unsigned int /*side_node*/) const override
-  { libmesh_error_msg("Calling NodeElem::which_node_am_i() does not make sense."); return 0; }
+  { libmesh_error_msg("Calling NodeElem::local_side_node() does not make sense."); return 0; }
 
   /**
    * The \p Elem::side_ptr() member makes no sense for nodes.

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -98,6 +98,10 @@ public:
                                        unsigned int /*side_node*/) const override
   { libmesh_not_implemented(); return 0; }
 
+  virtual unsigned int local_edge_node(unsigned int /*side*/,
+                                       unsigned int /*side_node*/) const override
+  { libmesh_not_implemented(); return 0; }
+
   virtual bool is_remote () const override
   { return true; }
 

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -94,7 +94,7 @@ public:
   virtual dof_id_type key (const unsigned int) const override
   { libmesh_not_implemented(); return 0; }
 
-  virtual unsigned int which_node_am_i(unsigned int /*side*/,
+  virtual unsigned int local_side_node(unsigned int /*side*/,
                                        unsigned int /*side_node*/) const override
   { libmesh_not_implemented(); return 0; }
 

--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -85,7 +85,7 @@ dof_id_type Hex::key (const unsigned int s) const
 
 
 
-unsigned int Hex::which_node_am_i(unsigned int side,
+unsigned int Hex::local_side_node(unsigned int side,
                                   unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -89,9 +89,20 @@ unsigned int Hex::local_side_node(unsigned int side,
                                   unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());
-  libmesh_assert_less (side_node, 4);
+  libmesh_assert_less (side_node, Hex8::nodes_per_side);
 
   return Hex8::side_nodes_map[side][side_node];
+}
+
+
+
+unsigned int Hex::local_edge_node(unsigned int edge,
+                                  unsigned int edge_node) const
+{
+  libmesh_assert_less (edge, this->n_edges());
+  libmesh_assert_less (edge_node, Hex8::nodes_per_edge);
+
+  return Hex8::edge_nodes_map[edge][edge_node];
 }
 
 

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -190,7 +190,7 @@ void Hex20::build_side_ptr (std::unique_ptr<Elem> & side,
 
 
 
-unsigned int Hex20::which_node_am_i(unsigned int side,
+unsigned int Hex20::local_side_node(unsigned int side,
                                     unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -201,6 +201,17 @@ unsigned int Hex20::local_side_node(unsigned int side,
 
 
 
+unsigned int Hex20::local_edge_node(unsigned int edge,
+                                    unsigned int edge_node) const
+{
+  libmesh_assert_less (edge, this->n_edges());
+  libmesh_assert_less (edge_node, Hex20::nodes_per_edge);
+
+  return Hex20::edge_nodes_map[edge][edge_node];
+}
+
+
+
 std::unique_ptr<Elem> Hex20::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());

--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -218,7 +218,7 @@ dof_id_type Hex27::key (const unsigned int s) const
 
 
 
-unsigned int Hex27::which_node_am_i(unsigned int side,
+unsigned int Hex27::local_side_node(unsigned int side,
                                     unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -229,6 +229,17 @@ unsigned int Hex27::local_side_node(unsigned int side,
 
 
 
+unsigned int Hex27::local_edge_node(unsigned int edge,
+                                    unsigned int edge_node) const
+{
+  libmesh_assert_less (edge, this->n_edges());
+  libmesh_assert_less (edge_node, Hex27::nodes_per_edge);
+
+  return Hex27::edge_nodes_map[edge][edge_node];
+}
+
+
+
 std::unique_ptr<Elem> Hex27::build_side_ptr (const unsigned int i,
                                              bool proxy)
 {

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -91,9 +91,20 @@ unsigned int InfHex::local_side_node(unsigned int side,
                                      unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());
-  libmesh_assert_less (side_node, 4);
+  libmesh_assert_less (side_node, InfHex8::nodes_per_side);
 
   return InfHex8::side_nodes_map[side][side_node];
+}
+
+
+
+unsigned int InfHex::local_edge_node(unsigned int edge,
+                                     unsigned int edge_node) const
+{
+  libmesh_assert_less (edge, this->n_edges());
+  libmesh_assert_less (edge_node, InfHex8::nodes_per_edge);
+
+  return InfHex8::edge_nodes_map[edge][edge_node];
 }
 
 

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -87,7 +87,7 @@ dof_id_type InfHex::key (const unsigned int s) const
 
 
 
-unsigned int InfHex::which_node_am_i(unsigned int side,
+unsigned int InfHex::local_side_node(unsigned int side,
                                      unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -126,7 +126,7 @@ Order InfHex16::default_order() const
 
 
 
-unsigned int InfHex16::which_node_am_i(unsigned int side,
+unsigned int InfHex16::local_side_node(unsigned int side,
                                        unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -142,6 +142,22 @@ unsigned int InfHex16::local_side_node(unsigned int side,
 
 
 
+unsigned int InfHex16::local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const
+{
+  libmesh_assert_less (edge, this->n_edges());
+
+  // Never more than 3 nodes per edge.
+  libmesh_assert_less (edge_node, InfHex16::nodes_per_edge);
+
+  // Some edges only have 2 nodes.
+  libmesh_assert(edge < 4 || edge_node < 2);
+
+  return InfHex16::edge_nodes_map[edge][edge_node];
+}
+
+
+
 std::unique_ptr<Elem> InfHex16::build_side_ptr (const unsigned int i,
                                                 bool proxy)
 {

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -152,12 +152,28 @@ unsigned int InfHex18::local_side_node(unsigned int side,
   libmesh_assert_less (side, this->n_sides());
 
   // Never more than 9 nodes per side.
-  libmesh_assert_less (side_node, 9);
+  libmesh_assert_less (side_node, InfHex18::nodes_per_side);
 
   // Some sides have 6 nodes.
   libmesh_assert(side == 0 || side_node < 6);
 
   return InfHex18::side_nodes_map[side][side_node];
+}
+
+
+
+unsigned int InfHex18::local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const
+{
+  libmesh_assert_less (edge, this->n_edges());
+
+  // Never more than 3 nodes per edge.
+  libmesh_assert_less (edge_node, InfHex18::nodes_per_edge);
+
+  // Some edges only have 2 nodes.
+  libmesh_assert(edge < 4 || edge_node < 2);
+
+  return InfHex18::edge_nodes_map[edge][edge_node];
 }
 
 

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -146,7 +146,7 @@ dof_id_type InfHex18::key (const unsigned int s) const
 
 
 
-unsigned int InfHex18::which_node_am_i(unsigned int side,
+unsigned int InfHex18::local_side_node(unsigned int side,
                                        unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/cell_inf_prism.C
+++ b/src/geom/cell_inf_prism.C
@@ -90,12 +90,23 @@ unsigned int InfPrism::local_side_node(unsigned int side,
   libmesh_assert_less (side, this->n_sides());
 
   // Never more than 4 nodes per side.
-  libmesh_assert_less(side_node, 4);
+  libmesh_assert_less(side_node, InfPrism6::nodes_per_side);
 
   // Some sides have 3 nodes.
   libmesh_assert(side != 0 || side_node < 3);
 
   return InfPrism6::side_nodes_map[side][side_node];
+}
+
+
+
+unsigned int InfPrism::local_edge_node(unsigned int edge,
+                                       unsigned int edge_node) const
+{
+  libmesh_assert_less(edge, this->n_edges());
+  libmesh_assert_less(edge_node, InfPrism6::nodes_per_edge);
+
+  return InfPrism6::edge_nodes_map[edge][edge_node];
 }
 
 

--- a/src/geom/cell_inf_prism.C
+++ b/src/geom/cell_inf_prism.C
@@ -84,7 +84,7 @@ dof_id_type InfPrism::key (const unsigned int s) const
 
 
 
-unsigned int InfPrism::which_node_am_i(unsigned int side,
+unsigned int InfPrism::local_side_node(unsigned int side,
                                        unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -117,7 +117,7 @@ Order InfPrism12::default_order() const
   return SECOND;
 }
 
-unsigned int InfPrism12::which_node_am_i(unsigned int side,
+unsigned int InfPrism12::local_side_node(unsigned int side,
                                          unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -123,9 +123,25 @@ unsigned int InfPrism12::local_side_node(unsigned int side,
   libmesh_assert_less (side, this->n_sides());
 
   // Never more than 6 nodes per side.
-  libmesh_assert_less(side_node, 6);
+  libmesh_assert_less(side_node, InfPrism12::nodes_per_side);
 
   return InfPrism12::side_nodes_map[side][side_node];
+}
+
+
+
+unsigned int InfPrism12::local_edge_node(unsigned int edge,
+                                         unsigned int edge_node) const
+{
+  libmesh_assert_less (edge, this->n_edges());
+
+  // Never more than 3 nodes per edge.
+  libmesh_assert_less(edge_node, InfPrism12::nodes_per_edge);
+
+  // Some edges only have 2 nodes.
+  libmesh_assert(edge < 3 || edge_node < 2);
+
+  return InfPrism12::edge_nodes_map[edge][edge_node];
 }
 
 

--- a/src/geom/cell_prism.C
+++ b/src/geom/cell_prism.C
@@ -93,12 +93,23 @@ unsigned int Prism::local_side_node(unsigned int side,
   libmesh_assert_less (side, this->n_sides());
 
   // Never more than 4 nodes per side.
-  libmesh_assert_less(side_node, 4);
+  libmesh_assert_less(side_node, Prism6::nodes_per_side);
 
   // Some sides have 3 nodes.
   libmesh_assert(!(side==0 || side==4) || side_node < 3);
 
   return Prism6::side_nodes_map[side][side_node];
+}
+
+
+
+unsigned int Prism::local_edge_node(unsigned int edge,
+                                    unsigned int edge_node) const
+{
+  libmesh_assert_less(edge, this->n_edges());
+  libmesh_assert_less(edge_node, Prism6::nodes_per_edge);
+
+  return Prism6::edge_nodes_map[edge][edge_node];
 }
 
 

--- a/src/geom/cell_prism.C
+++ b/src/geom/cell_prism.C
@@ -87,7 +87,7 @@ dof_id_type Prism::key (const unsigned int s) const
 
 
 
-unsigned int Prism::which_node_am_i(unsigned int side,
+unsigned int Prism::local_side_node(unsigned int side,
                                     unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -149,7 +149,7 @@ Order Prism15::default_order() const
 
 
 
-unsigned int Prism15::which_node_am_i(unsigned int side,
+unsigned int Prism15::local_side_node(unsigned int side,
                                       unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -165,6 +165,17 @@ unsigned int Prism15::local_side_node(unsigned int side,
 
 
 
+unsigned int Prism15::local_edge_node(unsigned int edge,
+                                      unsigned int edge_node) const
+{
+  libmesh_assert_less(edge, this->n_edges());
+  libmesh_assert_less(edge_node, Prism15::nodes_per_edge);
+
+  return Prism15::edge_nodes_map[edge][edge_node];
+}
+
+
+
 std::unique_ptr<Elem> Prism15::build_side_ptr (const unsigned int i,
                                                bool proxy)
 {

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -188,7 +188,7 @@ dof_id_type Prism18::key (const unsigned int s) const
 
 
 
-unsigned int Prism18::which_node_am_i(unsigned int side,
+unsigned int Prism18::local_side_node(unsigned int side,
                                       unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -194,12 +194,23 @@ unsigned int Prism18::local_side_node(unsigned int side,
   libmesh_assert_less (side, this->n_sides());
 
   // Never more than 9 nodes per side.
-  libmesh_assert_less(side_node, 9);
+  libmesh_assert_less(side_node, Prism18::nodes_per_side);
 
   // Some sides have 6 nodes.
   libmesh_assert(!(side==0 || side==4) || side_node < 6);
 
   return Prism18::side_nodes_map[side][side_node];
+}
+
+
+
+unsigned int Prism18::local_edge_node(unsigned int edge,
+                                      unsigned int edge_node) const
+{
+  libmesh_assert_less(edge, this->n_edges());
+  libmesh_assert_less(edge_node, Prism18::nodes_per_edge);
+
+  return Prism18::edge_nodes_map[edge][edge_node];
 }
 
 

--- a/src/geom/cell_pyramid.C
+++ b/src/geom/cell_pyramid.C
@@ -87,12 +87,23 @@ unsigned int Pyramid::local_side_node(unsigned int side,
   libmesh_assert_less (side, this->n_sides());
 
   // Never more than 4 nodes per side.
-  libmesh_assert_less(side_node, 4);
+  libmesh_assert_less(side_node, Pyramid5::nodes_per_side);
 
   // Some sides have 3 nodes.
   libmesh_assert(side == 4 || side_node < 3);
 
   return Pyramid5::side_nodes_map[side][side_node];
+}
+
+
+
+unsigned int Pyramid::local_edge_node(unsigned int edge,
+                                      unsigned int edge_node) const
+{
+  libmesh_assert_less(edge, this->n_edges());
+  libmesh_assert_less(edge_node, Pyramid5::nodes_per_edge);
+
+  return Pyramid5::edge_nodes_map[edge][edge_node];
 }
 
 

--- a/src/geom/cell_pyramid.C
+++ b/src/geom/cell_pyramid.C
@@ -81,7 +81,7 @@ dof_id_type Pyramid::key (const unsigned int s) const
 
 
 
-unsigned int Pyramid::which_node_am_i(unsigned int side,
+unsigned int Pyramid::local_side_node(unsigned int side,
                                       unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -151,6 +151,17 @@ unsigned int Pyramid13::local_side_node(unsigned int side,
 
 
 
+unsigned int Pyramid13::local_edge_node(unsigned int edge,
+                                        unsigned int edge_node) const
+{
+  libmesh_assert_less(edge, this->n_edges());
+  libmesh_assert_less(edge_node, Pyramid13::nodes_per_edge);
+
+  return Pyramid13::edge_nodes_map[edge][edge_node];
+}
+
+
+
 std::unique_ptr<Elem> Pyramid13::build_side_ptr (const unsigned int i, bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -135,7 +135,7 @@ Order Pyramid13::default_order() const
 
 
 
-unsigned int Pyramid13::which_node_am_i(unsigned int side,
+unsigned int Pyramid13::local_side_node(unsigned int side,
                                         unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -167,12 +167,23 @@ unsigned int Pyramid14::local_side_node(unsigned int side,
   libmesh_assert_less (side, this->n_sides());
 
   // Never more than 9 nodes per side.
-  libmesh_assert_less(side_node, 9);
+  libmesh_assert_less(side_node, Pyramid14::nodes_per_side);
 
   // Some sides have 6 nodes.
   libmesh_assert(side == 4 || side_node < 6);
 
   return Pyramid14::side_nodes_map[side][side_node];
+}
+
+
+
+unsigned int Pyramid14::local_edge_node(unsigned int edge,
+                                        unsigned int edge_node) const
+{
+  libmesh_assert_less(edge, this->n_edges());
+  libmesh_assert_less(edge_node, Pyramid14::nodes_per_edge);
+
+  return Pyramid14::edge_nodes_map[edge][edge_node];
 }
 
 

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -161,7 +161,7 @@ dof_id_type Pyramid14::key (const unsigned int s) const
 
 
 
-unsigned int Pyramid14::which_node_am_i(unsigned int side,
+unsigned int Pyramid14::local_side_node(unsigned int side,
                                         unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/cell_tet.C
+++ b/src/geom/cell_tet.C
@@ -66,11 +66,21 @@ unsigned int Tet::local_side_node(unsigned int side,
                                   unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());
-  libmesh_assert_less (side_node, 3);
+  libmesh_assert_less (side_node, Tet4::nodes_per_side);
 
   return Tet4::side_nodes_map[side][side_node];
 }
 
+
+
+unsigned int Tet::local_edge_node(unsigned int edge,
+                                  unsigned int edge_node) const
+{
+  libmesh_assert_less (edge, this->n_edges());
+  libmesh_assert_less (edge_node, Tet4::nodes_per_edge);
+
+  return Tet4::edge_nodes_map[edge][edge_node];
+}
 
 
 std::unique_ptr<Elem> Tet::side_ptr (const unsigned int i)

--- a/src/geom/cell_tet.C
+++ b/src/geom/cell_tet.C
@@ -62,7 +62,7 @@ dof_id_type Tet::key (const unsigned int s) const
 
 
 
-unsigned int Tet::which_node_am_i(unsigned int side,
+unsigned int Tet::local_side_node(unsigned int side,
                                   unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -183,6 +183,17 @@ unsigned int Tet10::local_side_node(unsigned int side,
 
 
 
+unsigned int Tet10::local_edge_node(unsigned int edge,
+                                    unsigned int edge_node) const
+{
+  libmesh_assert_less (edge, this->n_edges());
+  libmesh_assert_less (edge_node, Tet10::nodes_per_edge);
+
+  return Tet10::edge_nodes_map[edge][edge_node];
+}
+
+
+
 std::unique_ptr<Elem> Tet10::build_side_ptr (const unsigned int i,
                                              bool proxy)
 {

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -172,7 +172,7 @@ Order Tet10::default_order() const
 
 
 
-unsigned int Tet10::which_node_am_i(unsigned int side,
+unsigned int Tet10::local_side_node(unsigned int side,
                                     unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/edge.C
+++ b/src/geom/edge.C
@@ -33,6 +33,15 @@ unsigned int Edge::local_side_node(unsigned int side,
 
 
 
+unsigned int Edge::local_edge_node(unsigned int /*edge*/,
+                                   unsigned int /*edge_node*/) const
+{
+  libmesh_error_msg("Calling Edge::local_edge_node() does not make sense.");
+  return 0;
+}
+
+
+
 std::unique_ptr<Elem> Edge::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, 2);

--- a/src/geom/edge.C
+++ b/src/geom/edge.C
@@ -24,7 +24,7 @@
 namespace libMesh
 {
 
-unsigned int Edge::which_node_am_i(unsigned int side,
+unsigned int Edge::local_side_node(unsigned int side,
                                    unsigned int /*side_node*/) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -537,6 +537,15 @@ unsigned int Elem::which_side_am_i (const Elem * e) const
 
 
 
+unsigned int Elem::which_node_am_i(unsigned int side,
+                                   unsigned int side_node) const
+{
+  libmesh_deprecated();
+  return local_side_node(side, side_node);
+}
+
+
+
 bool Elem::contains_vertex_of(const Elem * e) const
 {
   // Our vertices are the first numbered nodes

--- a/src/geom/face_inf_quad.C
+++ b/src/geom/face_inf_quad.C
@@ -72,6 +72,14 @@ unsigned int InfQuad::local_side_node(unsigned int side,
 
 
 
+unsigned int InfQuad::local_edge_node(unsigned int edge,
+                                      unsigned int edge_node) const
+{
+  return local_side_node(edge, edge_node);
+}
+
+
+
 std::unique_ptr<Elem> InfQuad::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());

--- a/src/geom/face_inf_quad.C
+++ b/src/geom/face_inf_quad.C
@@ -61,7 +61,7 @@ dof_id_type InfQuad::key (const unsigned int s) const
 
 
 
-unsigned int InfQuad::which_node_am_i(unsigned int side,
+unsigned int InfQuad::local_side_node(unsigned int side,
                                       unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/face_inf_quad6.C
+++ b/src/geom/face_inf_quad6.C
@@ -150,7 +150,7 @@ dof_id_type InfQuad6::key (const unsigned int s) const
 
 
 
-unsigned int InfQuad6::which_node_am_i(unsigned int side,
+unsigned int InfQuad6::local_side_node(unsigned int side,
                                        unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -62,7 +62,7 @@ dof_id_type Quad::key (const unsigned int s) const
 
 
 
-unsigned int Quad::which_node_am_i(unsigned int side,
+unsigned int Quad::local_side_node(unsigned int side,
                                    unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -66,9 +66,17 @@ unsigned int Quad::local_side_node(unsigned int side,
                                    unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());
-  libmesh_assert_less (side_node, 2);
+  libmesh_assert_less (side_node, Quad4::nodes_per_side);
 
   return Quad4::side_nodes_map[side][side_node];
+}
+
+
+
+unsigned int Quad::local_edge_node(unsigned int edge,
+                                   unsigned int edge_node) const
+{
+  return local_side_node(edge, edge_node);
 }
 
 

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -203,7 +203,7 @@ dof_id_type Quad8::key (const unsigned int s) const
 
 
 
-unsigned int Quad8::which_node_am_i(unsigned int side,
+unsigned int Quad8::local_side_node(unsigned int side,
                                     unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -221,7 +221,7 @@ dof_id_type Quad9::key () const
 
 
 
-unsigned int Quad9::which_node_am_i(unsigned int side,
+unsigned int Quad9::local_side_node(unsigned int side,
                                     unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/face_tri.C
+++ b/src/geom/face_tri.C
@@ -58,7 +58,7 @@ dof_id_type Tri::key (const unsigned int s) const
 
 
 
-unsigned int Tri::which_node_am_i(unsigned int side,
+unsigned int Tri::local_side_node(unsigned int side,
                                   unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/geom/face_tri.C
+++ b/src/geom/face_tri.C
@@ -62,9 +62,17 @@ unsigned int Tri::local_side_node(unsigned int side,
                                   unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());
-  libmesh_assert_less (side_node, 2);
+  libmesh_assert_less (side_node, Tri3::nodes_per_side);
 
   return Tri3::side_nodes_map[side][side_node];
+}
+
+
+
+unsigned int Tri::local_edge_node(unsigned int edge,
+                                  unsigned int edge_node) const
+{
+  return local_side_node(edge, edge_node);
 }
 
 

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -187,7 +187,7 @@ dof_id_type Tri6::key (const unsigned int s) const
 
 
 
-unsigned int Tri6::which_node_am_i(unsigned int side,
+unsigned int Tri6::local_side_node(unsigned int side,
                                    unsigned int side_node) const
 {
   libmesh_assert_less (side, this->n_sides());

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1986,7 +1986,7 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
               //
               // TODO: This should also be given by e.g.:
               // Hex8::edge_nodes_map[edge_id][n]. Note: we have something
-              // like this for sides, Elem::which_node_am_i(), but nothing
+              // like this for sides, Elem::local_side_node(), but nothing
               // equivalent for edges.
               const Elem * parent = mesh.elem_ptr(elem_id);
               for (auto pn : parent->node_index_range())

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1969,38 +1969,25 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
       // objects here.
       for (auto n : edge->node_index_range())
         {
-          dof_id_type libmesh_node_id = edge->node_ptr(n)->id();
-
           // We look up Exodus node numbers differently if we are
           // writing a discontinuous Exodus file.
           int exodus_node_id = -1;
 
           if (!use_discontinuous)
-            exodus_node_id = libmesh_map_find
-              (libmesh_node_num_to_exodus, cast_int<int>(libmesh_node_id));
+            {
+              dof_id_type libmesh_node_id = edge->node_ptr(n)->id();
+              exodus_node_id = libmesh_map_find
+                (libmesh_node_num_to_exodus, cast_int<int>(libmesh_node_id));
+            }
           else
             {
-              // Find the node on the "parent" element containing this edge
-              // which matches libmesh_node_id. Then use that id to look up
+              // Get the node on the element containing this edge
+              // which corresponds to edge node n. Then use that id to look up
               // the exodus_node_id in the discontinuous_node_indices map.
-              //
-              // TODO: This should also be given by e.g.:
-              // Hex8::edge_nodes_map[edge_id][n]. Note: we have something
-              // like this for sides, Elem::local_side_node(), but nothing
-              // equivalent for edges.
-              const Elem * parent = mesh.elem_ptr(elem_id);
-              for (auto pn : parent->node_index_range())
-                if (parent->node_ptr(pn)->id() == libmesh_node_id)
-                  {
-                    exodus_node_id = libmesh_map_find
-                      (discontinuous_node_indices,
-                       std::make_pair(elem_id, pn));
-                    break;
-                  }
+              unsigned int pn = mesh.elem_ptr(elem_id)->local_edge_node(edge_id, n);
+              exodus_node_id = libmesh_map_find
+                (discontinuous_node_indices, std::make_pair(elem_id, pn));
             }
-
-          if (exodus_node_id == -1)
-            libmesh_error_msg("Unable to map edge's libMesh node id to its Exodus node id.");
 
           conn.push_back(exodus_node_id);
         }

--- a/tests/geom/which_node_am_i_test.C
+++ b/tests/geom/which_node_am_i_test.C
@@ -24,9 +24,15 @@ public:
 
   void testPyramids()
   {
-    // The last node on the right side (1) should be node 4 (apex node).
     const Elem & pyr5 = ReferenceElem::get(PYRAMID5);
+    // The last node on the right side (1) should be node 4 (apex node).
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4), pyr5.local_side_node(/*side=*/1, /*node=*/2));
+    // (Edge 0, Node 0) -> Local node 0
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(0), pyr5.local_edge_node(/*edge=*/0, /*node=*/0));
+    // Second node of edges 4-7 is the apex node (4).
+    for (unsigned int edge=4; edge<8; ++edge)
+      CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4),
+                           pyr5.local_edge_node(edge, /*node=*/1));
 
     // Test the libmesh_asserts when they are enabled and exceptions
     // are available. If exceptions aren't available, libmesh_assert
@@ -53,13 +59,21 @@ public:
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(99), n);
 #endif
 
-    // The last node on the right side (1) should be node 10.
     const Elem & pyr13 = ReferenceElem::get(PYRAMID13);
+    // The last node on the right side (1) should be node 10.
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(10), pyr13.local_side_node(/*side=*/1, /*node=*/5));
+    // Second node of edges 4-7 is the apex node (4).
+    for (unsigned int edge=4; edge<8; ++edge)
+      CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4),
+                           pyr13.local_edge_node(edge, /*node=*/1));
 
-    // The central node of the base should be node 13
     const Elem & pyr14 = ReferenceElem::get(PYRAMID14);
+    // The central node of the base should be node 13
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(13), pyr14.local_side_node(/*side=*/4, /*node=*/8));
+    // Second node of edges 4-7 is the apex node (4).
+    for (unsigned int edge=4; edge<8; ++edge)
+      CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4),
+                           pyr14.local_edge_node(edge, /*node=*/1));
   }
 
 
@@ -69,6 +83,14 @@ public:
     // A PRISM6 has four nodes on some sides and three nodes on others
     const Elem & prism6 = ReferenceElem::get(PRISM6);
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4), prism6.local_side_node(/*side=*/4, /*node=*/1));
+    // Edges 3, 4, 5 are the "vertical" Prism edges.
+    for (unsigned int edge=3; edge<6; ++edge)
+      {
+        CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(edge-3),
+                             prism6.local_edge_node(/*edge=*/edge, /*node=*/0));
+        CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(edge),
+                             prism6.local_edge_node(/*edge=*/edge, /*node=*/1));
+      }
 
     // Test the libmesh_asserts when they are enabled and exceptions
     // are available. If exceptions aren't available, libmesh_assert
@@ -101,6 +123,14 @@ public:
     // Test the Prism15.
     const Elem & prism15 = ReferenceElem::get(PRISM15);
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(3), prism15.local_side_node(/*side=*/1, /*node=*/3));
+    // Edges 3, 4, 5 are the "vertical" Prism edges.
+    for (unsigned int edge=3; edge<6; ++edge)
+      {
+        CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(edge-3),
+                             prism15.local_edge_node(/*edge=*/edge, /*node=*/0));
+        CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(edge),
+                             prism15.local_edge_node(/*edge=*/edge, /*node=*/1));
+      }
   }
 
 
@@ -110,9 +140,18 @@ public:
     const Elem & tet4 = ReferenceElem::get(TET4);
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(0), tet4.local_side_node(/*side=*/0, /*node=*/0));
 
-    // Node 4 is a mid-edge node on side 1.
+    // Edges 3, 4, 5 all connect to the "apex" node 3
+    for (unsigned int edge=3; edge<6; ++edge)
+      CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(3),
+                           tet4.local_edge_node(edge, /*node=*/1));
+
     const Elem & tet10 = ReferenceElem::get(TET10);
+    // Node 4 is a mid-edge node on side 1.
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4), tet10.local_side_node(/*side=*/1, /*node=*/3));
+    // Nodes 4, 5, 6 are mid-edge nodes of the first three edges
+    for (unsigned int edge=0; edge<3; ++edge)
+      CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(edge + 4),
+                           tet10.local_edge_node(edge, /*node=*/2));
   }
 
 
@@ -137,6 +176,18 @@ public:
           // Make sure the Hex20 and Hex27 implementations agree.
           CPPUNIT_ASSERT_EQUAL(hex20.local_side_node(side, node),
                                hex27.local_side_node(side, node));
+        }
+
+    for (unsigned int edge=0; edge<hex8.n_edges(); ++edge)
+      for (unsigned int node=0; node<2; ++node)
+        {
+          // Make sure the Hex8 and Hex20 implementations agree.
+          CPPUNIT_ASSERT_EQUAL(hex8.local_edge_node(edge, node),
+                               hex20.local_edge_node(edge, node));
+
+          // Make sure the Hex20 and Hex27 implementations agree.
+          CPPUNIT_ASSERT_EQUAL(hex20.local_edge_node(edge, node),
+                               hex27.local_edge_node(edge, node));
         }
   }
 };

--- a/tests/geom/which_node_am_i_test.C
+++ b/tests/geom/which_node_am_i_test.C
@@ -26,7 +26,7 @@ public:
   {
     // The last node on the right side (1) should be node 4 (apex node).
     const Elem & pyr5 = ReferenceElem::get(PYRAMID5);
-    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4), pyr5.which_node_am_i(/*side=*/1, /*node=*/2));
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4), pyr5.local_side_node(/*side=*/1, /*node=*/2));
 
     // Test the libmesh_asserts when they are enabled and exceptions
     // are available. If exceptions aren't available, libmesh_assert
@@ -38,7 +38,7 @@ public:
         StreamRedirector stream_redirector;
 
         // Asking for the 4th node on a triangular face should throw.
-        unsigned int n = pyr5.which_node_am_i(1, 3);
+        unsigned int n = pyr5.local_side_node(1, 3);
 
         // We shouldn't get here if the line above throws. If we do
         // get here, there's no way this assert will pass.
@@ -49,17 +49,17 @@ public:
 
 #ifdef NDEBUG
     // In optimized mode, we expect to get the "dummy" value 99.
-    unsigned int n = pyr5.which_node_am_i(1, 3);
+    unsigned int n = pyr5.local_side_node(1, 3);
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(99), n);
 #endif
 
     // The last node on the right side (1) should be node 10.
     const Elem & pyr13 = ReferenceElem::get(PYRAMID13);
-    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(10), pyr13.which_node_am_i(/*side=*/1, /*node=*/5));
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(10), pyr13.local_side_node(/*side=*/1, /*node=*/5));
 
     // The central node of the base should be node 13
     const Elem & pyr14 = ReferenceElem::get(PYRAMID14);
-    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(13), pyr14.which_node_am_i(/*side=*/4, /*node=*/8));
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(13), pyr14.local_side_node(/*side=*/4, /*node=*/8));
   }
 
 
@@ -68,7 +68,7 @@ public:
   {
     // A PRISM6 has four nodes on some sides and three nodes on others
     const Elem & prism6 = ReferenceElem::get(PRISM6);
-    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4), prism6.which_node_am_i(/*side=*/4, /*node=*/1));
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4), prism6.local_side_node(/*side=*/4, /*node=*/1));
 
     // Test the libmesh_asserts when they are enabled and exceptions
     // are available. If exceptions aren't available, libmesh_assert
@@ -83,7 +83,7 @@ public:
         // indices 0, 1, and 2. Should throw an exception
         // (libmesh_assert throws an exception) when NDEBUG is not
         // defined.
-        unsigned int n = prism6.which_node_am_i(0, 3);
+        unsigned int n = prism6.local_side_node(0, 3);
 
         // We shouldn't get here if the line above throws. If we do
         // get here, there's no way this assert will pass.
@@ -94,13 +94,13 @@ public:
 
 #ifdef NDEBUG
     // In optimized mode, we expect to get the "dummy" value 99.
-    unsigned int n = prism6.which_node_am_i(0, 3);
+    unsigned int n = prism6.local_side_node(0, 3);
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(99), n);
 #endif
 
     // Test the Prism15.
     const Elem & prism15 = ReferenceElem::get(PRISM15);
-    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(3), prism15.which_node_am_i(/*side=*/1, /*node=*/3));
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(3), prism15.local_side_node(/*side=*/1, /*node=*/3));
   }
 
 
@@ -108,11 +108,11 @@ public:
   void testTets()
   {
     const Elem & tet4 = ReferenceElem::get(TET4);
-    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(0), tet4.which_node_am_i(/*side=*/0, /*node=*/0));
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(0), tet4.local_side_node(/*side=*/0, /*node=*/0));
 
     // Node 4 is a mid-edge node on side 1.
     const Elem & tet10 = ReferenceElem::get(TET10);
-    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4), tet10.which_node_am_i(/*side=*/1, /*node=*/3));
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4), tet10.local_side_node(/*side=*/1, /*node=*/3));
   }
 
 
@@ -121,7 +121,7 @@ public:
   {
     // Top left node on back side.
     const Elem & hex8 = ReferenceElem::get(HEX8);
-    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(7), hex8.which_node_am_i(/*side=*/3, /*node=*/2));
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(7), hex8.local_side_node(/*side=*/3, /*node=*/2));
 
     const Elem & hex20 = ReferenceElem::get(HEX20);
     const Elem & hex27 = ReferenceElem::get(HEX27);
@@ -131,12 +131,12 @@ public:
       for (unsigned int node=0; node<4; ++node)
         {
           // Make sure the Hex8 and Hex20 implementations agree.
-          CPPUNIT_ASSERT_EQUAL(hex8.which_node_am_i(side, node),
-                               hex20.which_node_am_i(side, node));
+          CPPUNIT_ASSERT_EQUAL(hex8.local_side_node(side, node),
+                               hex20.local_side_node(side, node));
 
           // Make sure the Hex20 and Hex27 implementations agree.
-          CPPUNIT_ASSERT_EQUAL(hex20.which_node_am_i(side, node),
-                               hex27.which_node_am_i(side, node));
+          CPPUNIT_ASSERT_EQUAL(hex20.local_side_node(side, node),
+                               hex27.local_side_node(side, node));
         }
   }
 };


### PR DESCRIPTION
Also deprecate `Elem::which_node_am_i()` in favor of `Elem::local_side_node()` for consistency. Finally, use this new function when writing edge blocks in Exodus files.

Refs #2297 