### PR TITLE
Add SparseMatrix::clone(), zero_clone()

### DIFF
--- a/include/numerics/diagonal_matrix.h
+++ b/include/numerics/diagonal_matrix.h
@@ -99,6 +99,10 @@ public:
 
   void zero() override;
 
+  virtual std::unique_ptr<SparseMatrix<T>> zero_clone () const override;
+
+  virtual std::unique_ptr<SparseMatrix<T>> clone () const override;
+
   void close() override;
 
   numeric_index_type m() const override;

--- a/include/numerics/eigen_sparse_matrix.h
+++ b/include/numerics/eigen_sparse_matrix.h
@@ -97,6 +97,10 @@ public:
 
   virtual void zero () override;
 
+  virtual std::unique_ptr<SparseMatrix<T>> zero_clone () const override;
+
+  virtual std::unique_ptr<SparseMatrix<T>> clone () const override;
+
   virtual void close () override { this->_closed = true; }
 
   virtual numeric_index_type m () const override;

--- a/include/numerics/laspack_matrix.h
+++ b/include/numerics/laspack_matrix.h
@@ -107,6 +107,10 @@ public:
 
   virtual void zero () override;
 
+  virtual std::unique_ptr<SparseMatrix<T>> zero_clone () const override;
+
+  virtual std::unique_ptr<SparseMatrix<T>> clone () const override;
+
   virtual void close () override;
 
   virtual numeric_index_type m () const override;

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -169,6 +169,10 @@ public:
 
   virtual void zero () override;
 
+  virtual std::unique_ptr<SparseMatrix<T>> zero_clone () const override;
+
+  virtual std::unique_ptr<SparseMatrix<T>> clone () const override;
+
   virtual void zero_rows (std::vector<numeric_index_type> & rows, T diag_value = 0.0) override;
 
   virtual void close () override;

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -165,6 +165,21 @@ public:
   virtual void zero () = 0;
 
   /**
+   * \returns A smart pointer to a copy of this matrix with the same
+   * type, size, and partitioning, but with all zero entries.
+   *
+   * \note This must be overridden in the derived classes.
+   */
+  virtual std::unique_ptr<SparseMatrix<T>> zero_clone () const = 0;
+
+  /**
+   * \returns A smart pointer to a copy of this matrix.
+   *
+   * \note This must be overridden in the derived classes.
+   */
+  virtual std::unique_ptr<SparseMatrix<T>> clone () const = 0;
+
+  /**
    * Sets all row entries to 0 then puts \p diag_value in the diagonal entry.
    */
   virtual void zero_rows (std::vector<numeric_index_type> & rows, T diag_value = 0.0);

--- a/include/numerics/trilinos_epetra_matrix.h
+++ b/include/numerics/trilinos_epetra_matrix.h
@@ -124,6 +124,10 @@ public:
 
   virtual void zero () override;
 
+  virtual std::unique_ptr<SparseMatrix<T>> zero_clone () const override;
+
+  virtual std::unique_ptr<SparseMatrix<T>> clone () const override;
+
   virtual void close () override;
 
   virtual numeric_index_type m () const override;

--- a/src/numerics/diagonal_matrix.C
+++ b/src/numerics/diagonal_matrix.C
@@ -20,9 +20,11 @@
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/libmesh_common.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 namespace libMesh
 {
+
 template <typename T>
 DiagonalMatrix<T>::DiagonalMatrix(const Parallel::Communicator & comm_in) : SparseMatrix<T>(comm_in)
 {
@@ -100,6 +102,42 @@ void
 DiagonalMatrix<T>::zero()
 {
   _diagonal->zero();
+}
+
+template <typename T>
+std::unique_ptr<SparseMatrix<T>> DiagonalMatrix<T>::zero_clone () const
+{
+  // Make empty copy with matching comm
+  auto mat_copy = libmesh_make_unique<DiagonalMatrix<T>>(this->comm());
+
+  // Make zero copy of our diagonal
+  auto diag_copy = _diagonal->zero_clone();
+
+  // Swap diag_copy with diagonal in mat_copy
+  *mat_copy = std::move(*diag_copy);
+
+  // Work around an issue on older compilers.  We are able to simply
+  // "return mat_copy;" on newer compilers
+  return std::unique_ptr<SparseMatrix<T>>(mat_copy.release());
+}
+
+
+
+template <typename T>
+std::unique_ptr<SparseMatrix<T>> DiagonalMatrix<T>::clone () const
+{
+  // Make empty copy with matching comm
+  auto mat_copy = libmesh_make_unique<DiagonalMatrix<T>>(this->comm());
+
+  // Make copy of our diagonal
+  auto diag_copy = _diagonal->clone();
+
+  // Swap diag_copy with diagonal in mat_copy
+  *mat_copy = std::move(*diag_copy);
+
+  // Work around an issue on older compilers.  We are able to simply
+  // "return mat_copy;" on newer compilers
+  return std::unique_ptr<SparseMatrix<T>>(mat_copy.release());
 }
 
 template <typename T>

--- a/src/numerics/eigen_sparse_matrix.C
+++ b/src/numerics/eigen_sparse_matrix.C
@@ -17,8 +17,6 @@
 
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/libmesh_config.h"
 
@@ -29,6 +27,7 @@
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/sparsity_pattern.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 namespace libMesh
 {
@@ -181,6 +180,29 @@ template <typename T>
 void EigenSparseMatrix<T>::zero ()
 {
   _mat.setZero();
+}
+
+
+
+template <typename T>
+std::unique_ptr<SparseMatrix<T>> EigenSparseMatrix<T>::zero_clone () const
+{
+  // TODO: If there is a more efficient way to make a zeroed-out copy
+  // of an EigenSM, we should call that instead.
+  auto ret = libmesh_make_unique<EigenSparseMatrix<T>>(*this);
+  ret->zero();
+
+  // Work around an issue on older compilers.  We are able to simply
+  // "return ret;" on newer compilers
+  return std::unique_ptr<SparseMatrix<T>>(ret.release());
+}
+
+
+
+template <typename T>
+std::unique_ptr<SparseMatrix<T>> EigenSparseMatrix<T>::clone () const
+{
+  return libmesh_make_unique<EigenSparseMatrix<T>>(*this);
 }
 
 

--- a/src/numerics/laspack_matrix.C
+++ b/src/numerics/laspack_matrix.C
@@ -17,8 +17,6 @@
 
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/libmesh_config.h"
 
@@ -28,6 +26,7 @@
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/sparsity_pattern.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 namespace libMesh
 {
@@ -292,6 +291,38 @@ void LaspackMatrix<T>::zero ()
 }
 
 
+
+template <typename T>
+std::unique_ptr<SparseMatrix<T>> LaspackMatrix<T>::zero_clone () const
+{
+  // This function is marked as "not implemented" since it hasn't been
+  // tested, the code below might serve as a possible implementation.
+  libmesh_not_implemented();
+
+  // Make empty copy with matching comm, initialize, zero, and return.
+  auto mat_copy = libmesh_make_unique<LaspackMatrix<T>>(this->comm());
+  mat_copy->init();
+  mat_copy->zero();
+
+  // Work around an issue on older compilers.  We are able to simply
+  // "return mat_copy;" on newer compilers
+  return std::unique_ptr<SparseMatrix<T>>(mat_copy.release());
+}
+
+
+
+template <typename T>
+std::unique_ptr<SparseMatrix<T>> LaspackMatrix<T>::clone () const
+{
+  // We don't currently have a faster implementation than making a
+  // zero clone and then filling in the values.
+  auto mat_copy = this->zero_clone();
+  mat_copy->add(1., *this);
+
+  // Work around an issue on older compilers.  We are able to simply
+  // "return mat_copy;" on newer compilers
+  return std::unique_ptr<SparseMatrix<T>>(mat_copy.release());
+}
 
 template <typename T>
 numeric_index_type LaspackMatrix<T>::m () const

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -523,6 +523,42 @@ void PetscMatrix<T>::zero_rows (std::vector<numeric_index_type> & rows, T diag_v
 }
 
 template <typename T>
+std::unique_ptr<SparseMatrix<T>> PetscMatrix<T>::zero_clone () const
+{
+  // Copy the nonzero pattern only
+  Mat copy;
+  PetscErrorCode ierr = MatDuplicate(_mat, MAT_DO_NOT_COPY_VALUES, &copy);
+  LIBMESH_CHKERR(ierr);
+
+  // Call wrapping PetscMatrix constructor, have it take over
+  // ownership.
+  auto ret = libmesh_make_unique<PetscMatrix<T>>(copy, this->comm());
+  ret->set_destroy_mat_on_exit(true);
+
+  // Work around an issue on older compilers.  We are able to simply
+  // "return ret;" on newer compilers
+  return std::unique_ptr<SparseMatrix<T>>(ret.release());
+}
+
+template <typename T>
+std::unique_ptr<SparseMatrix<T>> PetscMatrix<T>::clone () const
+{
+  // Copy the nonzero pattern and numerical values
+  Mat copy;
+  PetscErrorCode ierr = MatDuplicate(_mat, MAT_COPY_VALUES, &copy);
+  LIBMESH_CHKERR(ierr);
+
+  // Call wrapping PetscMatrix constructor, have it take over
+  // ownership.
+  auto ret = libmesh_make_unique<PetscMatrix<T>>(copy, this->comm());
+  ret->set_destroy_mat_on_exit(true);
+
+  // Work around an issue on older compilers.  We are able to simply
+  // "return ret;" on newer compilers
+  return std::unique_ptr<SparseMatrix<T>>(ret.release());
+}
+
+template <typename T>
 void PetscMatrix<T>::clear ()
 {
   PetscErrorCode ierr=0;

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -525,6 +525,9 @@ void PetscMatrix<T>::zero_rows (std::vector<numeric_index_type> & rows, T diag_v
 template <typename T>
 std::unique_ptr<SparseMatrix<T>> PetscMatrix<T>::zero_clone () const
 {
+  if (!this->closed())
+    libmesh_error_msg("Matrix must be closed before it can be cloned!");
+
   // Copy the nonzero pattern only
   Mat copy;
   PetscErrorCode ierr = MatDuplicate(_mat, MAT_DO_NOT_COPY_VALUES, &copy);
@@ -540,9 +543,14 @@ std::unique_ptr<SparseMatrix<T>> PetscMatrix<T>::zero_clone () const
   return std::unique_ptr<SparseMatrix<T>>(ret.release());
 }
 
+
+
 template <typename T>
 std::unique_ptr<SparseMatrix<T>> PetscMatrix<T>::clone () const
 {
+  if (!this->closed())
+    libmesh_error_msg("Matrix must be closed before it can be cloned!");
+
   // Copy the nonzero pattern and numerical values
   Mat copy;
   PetscErrorCode ierr = MatDuplicate(_mat, MAT_COPY_VALUES, &copy);

--- a/src/numerics/trilinos_epetra_matrix.C
+++ b/src/numerics/trilinos_epetra_matrix.C
@@ -203,6 +203,40 @@ void EpetraMatrix<T>::zero ()
 
 
 template <typename T>
+std::unique_ptr<SparseMatrix<T>> EpetraMatrix<T>::zero_clone () const
+{
+  // This function is marked as "not implemented" since it hasn't been
+  // tested, the code below might serve as a possible implementation.
+  libmesh_not_implemented();
+
+  // Make empty copy with matching comm, initialize, and return.
+  auto mat_copy = libmesh_make_unique<EpetraMatrix<T>>(this->comm());
+  mat_copy->init();
+  mat_copy->zero();
+
+  // Work around an issue on older compilers.  We are able to simply
+  // "return mat_copy;" on newer compilers
+  return std::unique_ptr<SparseMatrix<T>>(mat_copy.release());
+}
+
+
+
+template <typename T>
+std::unique_ptr<SparseMatrix<T>> EpetraMatrix<T>::clone () const
+{
+  // We don't currently have a faster implementation than making a
+  // zero clone and then filling in the values.
+  auto mat_copy = this->zero_clone();
+  mat_copy->add(1., *this);
+
+  // Work around an issue on older compilers.  We are able to simply
+  // "return mat_copy;" on newer compilers
+  return std::unique_ptr<SparseMatrix<T>>(mat_copy.release());
+}
+
+
+
+template <typename T>
 void EpetraMatrix<T>::clear ()
 {
   //  delete _mat;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -85,6 +85,7 @@ unit_tests_sources = \
   numerics/dense_matrix_test.C \
   numerics/petsc_matrix_test.C \
   numerics/diagonal_matrix_test.C \
+  numerics/eigen_sparse_matrix_test.C \
   parallel/message_tag.C \
   parallel/packed_range_test.C \
   parallel/parallel_sort_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -217,10 +217,10 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
 	numerics/petsc_matrix_test.C numerics/diagonal_matrix_test.C \
-	parallel/message_tag.C parallel/packed_range_test.C \
-	parallel/parallel_sort_test.C parallel/parallel_sync_test.C \
-	parallel/parallel_test.C parallel/parallel_point_test.C \
-	partitioning/partitioner_test.h \
+	numerics/eigen_sparse_matrix_test.C parallel/message_tag.C \
+	parallel/packed_range_test.C parallel/parallel_sort_test.C \
+	parallel/parallel_sync_test.C parallel/parallel_test.C \
+	parallel/parallel_point_test.C partitioning/partitioner_test.h \
 	partitioning/centroid_partitioner_test.C \
 	partitioning/hilbert_sfc_partitioner_test.C \
 	partitioning/linear_partitioner_test.C \
@@ -297,6 +297,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	numerics/unit_tests_dbg-dense_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-petsc_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-diagonal_matrix_test.$(OBJEXT) \
+	numerics/unit_tests_dbg-eigen_sparse_matrix_test.$(OBJEXT) \
 	parallel/unit_tests_dbg-message_tag.$(OBJEXT) \
 	parallel/unit_tests_dbg-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_dbg-parallel_sort_test.$(OBJEXT) \
@@ -362,10 +363,10 @@ am__unit_tests_devel_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
 	numerics/petsc_matrix_test.C numerics/diagonal_matrix_test.C \
-	parallel/message_tag.C parallel/packed_range_test.C \
-	parallel/parallel_sort_test.C parallel/parallel_sync_test.C \
-	parallel/parallel_test.C parallel/parallel_point_test.C \
-	partitioning/partitioner_test.h \
+	numerics/eigen_sparse_matrix_test.C parallel/message_tag.C \
+	parallel/packed_range_test.C parallel/parallel_sort_test.C \
+	parallel/parallel_sync_test.C parallel/parallel_test.C \
+	parallel/parallel_point_test.C partitioning/partitioner_test.h \
 	partitioning/centroid_partitioner_test.C \
 	partitioning/hilbert_sfc_partitioner_test.C \
 	partitioning/linear_partitioner_test.C \
@@ -441,6 +442,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	numerics/unit_tests_devel-dense_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_devel-petsc_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_devel-diagonal_matrix_test.$(OBJEXT) \
+	numerics/unit_tests_devel-eigen_sparse_matrix_test.$(OBJEXT) \
 	parallel/unit_tests_devel-message_tag.$(OBJEXT) \
 	parallel/unit_tests_devel-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_devel-parallel_sort_test.$(OBJEXT) \
@@ -503,10 +505,10 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
 	numerics/petsc_matrix_test.C numerics/diagonal_matrix_test.C \
-	parallel/message_tag.C parallel/packed_range_test.C \
-	parallel/parallel_sort_test.C parallel/parallel_sync_test.C \
-	parallel/parallel_test.C parallel/parallel_point_test.C \
-	partitioning/partitioner_test.h \
+	numerics/eigen_sparse_matrix_test.C parallel/message_tag.C \
+	parallel/packed_range_test.C parallel/parallel_sort_test.C \
+	parallel/parallel_sync_test.C parallel/parallel_test.C \
+	parallel/parallel_point_test.C partitioning/partitioner_test.h \
 	partitioning/centroid_partitioner_test.C \
 	partitioning/hilbert_sfc_partitioner_test.C \
 	partitioning/linear_partitioner_test.C \
@@ -582,6 +584,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	numerics/unit_tests_oprof-dense_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-petsc_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-diagonal_matrix_test.$(OBJEXT) \
+	numerics/unit_tests_oprof-eigen_sparse_matrix_test.$(OBJEXT) \
 	parallel/unit_tests_oprof-message_tag.$(OBJEXT) \
 	parallel/unit_tests_oprof-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_oprof-parallel_sort_test.$(OBJEXT) \
@@ -644,10 +647,10 @@ am__unit_tests_opt_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
 	numerics/petsc_matrix_test.C numerics/diagonal_matrix_test.C \
-	parallel/message_tag.C parallel/packed_range_test.C \
-	parallel/parallel_sort_test.C parallel/parallel_sync_test.C \
-	parallel/parallel_test.C parallel/parallel_point_test.C \
-	partitioning/partitioner_test.h \
+	numerics/eigen_sparse_matrix_test.C parallel/message_tag.C \
+	parallel/packed_range_test.C parallel/parallel_sort_test.C \
+	parallel/parallel_sync_test.C parallel/parallel_test.C \
+	parallel/parallel_point_test.C partitioning/partitioner_test.h \
 	partitioning/centroid_partitioner_test.C \
 	partitioning/hilbert_sfc_partitioner_test.C \
 	partitioning/linear_partitioner_test.C \
@@ -723,6 +726,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	numerics/unit_tests_opt-dense_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_opt-petsc_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_opt-diagonal_matrix_test.$(OBJEXT) \
+	numerics/unit_tests_opt-eigen_sparse_matrix_test.$(OBJEXT) \
 	parallel/unit_tests_opt-message_tag.$(OBJEXT) \
 	parallel/unit_tests_opt-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_opt-parallel_sort_test.$(OBJEXT) \
@@ -784,10 +788,10 @@ am__unit_tests_prof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
 	numerics/petsc_matrix_test.C numerics/diagonal_matrix_test.C \
-	parallel/message_tag.C parallel/packed_range_test.C \
-	parallel/parallel_sort_test.C parallel/parallel_sync_test.C \
-	parallel/parallel_test.C parallel/parallel_point_test.C \
-	partitioning/partitioner_test.h \
+	numerics/eigen_sparse_matrix_test.C parallel/message_tag.C \
+	parallel/packed_range_test.C parallel/parallel_sort_test.C \
+	parallel/parallel_sync_test.C parallel/parallel_test.C \
+	parallel/parallel_point_test.C partitioning/partitioner_test.h \
 	partitioning/centroid_partitioner_test.C \
 	partitioning/hilbert_sfc_partitioner_test.C \
 	partitioning/linear_partitioner_test.C \
@@ -863,6 +867,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	numerics/unit_tests_prof-dense_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_prof-petsc_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_prof-diagonal_matrix_test.$(OBJEXT) \
+	numerics/unit_tests_prof-eigen_sparse_matrix_test.$(OBJEXT) \
 	parallel/unit_tests_prof-message_tag.$(OBJEXT) \
 	parallel/unit_tests_prof-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_prof-parallel_sort_test.$(OBJEXT) \
@@ -1151,6 +1156,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-dense_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-diagonal_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-distributed_vector_test.Po \
+	numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-laspack_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-parsed_fem_function_test.Po \
@@ -1165,6 +1171,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-dense_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-diagonal_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-distributed_vector_test.Po \
+	numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-laspack_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Po \
@@ -1179,6 +1186,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-dense_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-diagonal_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-distributed_vector_test.Po \
+	numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-laspack_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-parsed_fem_function_test.Po \
@@ -1193,6 +1201,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-dense_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-diagonal_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-distributed_vector_test.Po \
+	numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-laspack_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Po \
@@ -1207,6 +1216,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-dense_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-diagonal_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-distributed_vector_test.Po \
+	numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-laspack_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Po \
@@ -1763,10 +1773,10 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
 	numerics/petsc_matrix_test.C numerics/diagonal_matrix_test.C \
-	parallel/message_tag.C parallel/packed_range_test.C \
-	parallel/parallel_sort_test.C parallel/parallel_sync_test.C \
-	parallel/parallel_test.C parallel/parallel_point_test.C \
-	partitioning/partitioner_test.h \
+	numerics/eigen_sparse_matrix_test.C parallel/message_tag.C \
+	parallel/packed_range_test.C parallel/parallel_sort_test.C \
+	parallel/parallel_sync_test.C parallel/parallel_test.C \
+	parallel/parallel_point_test.C partitioning/partitioner_test.h \
 	partitioning/centroid_partitioner_test.C \
 	partitioning/hilbert_sfc_partitioner_test.C \
 	partitioning/linear_partitioner_test.C \
@@ -2011,6 +2021,8 @@ numerics/unit_tests_dbg-petsc_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_dbg-diagonal_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_dbg-eigen_sparse_matrix_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 parallel/$(am__dirstamp):
 	@$(MKDIR_P) parallel
 	@: > parallel/$(am__dirstamp)
@@ -2227,6 +2239,8 @@ numerics/unit_tests_devel-petsc_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-diagonal_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_devel-eigen_sparse_matrix_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_devel-message_tag.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_devel-packed_range_test.$(OBJEXT):  \
@@ -2400,6 +2414,8 @@ numerics/unit_tests_oprof-dense_matrix_test.$(OBJEXT):  \
 numerics/unit_tests_oprof-petsc_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_oprof-diagonal_matrix_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_oprof-eigen_sparse_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_oprof-message_tag.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
@@ -2575,6 +2591,8 @@ numerics/unit_tests_opt-petsc_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-diagonal_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_opt-eigen_sparse_matrix_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_opt-message_tag.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_opt-packed_range_test.$(OBJEXT):  \
@@ -2748,6 +2766,8 @@ numerics/unit_tests_prof-dense_matrix_test.$(OBJEXT):  \
 numerics/unit_tests_prof-petsc_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_prof-diagonal_matrix_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_prof-eigen_sparse_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_prof-message_tag.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
@@ -3067,6 +3087,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-dense_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-diagonal_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-distributed_vector_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-laspack_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-parsed_fem_function_test.Po@am__quote@ # am--include-marker
@@ -3081,6 +3102,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-dense_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-diagonal_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-distributed_vector_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-laspack_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Po@am__quote@ # am--include-marker
@@ -3095,6 +3117,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-dense_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-diagonal_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-distributed_vector_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-laspack_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-parsed_fem_function_test.Po@am__quote@ # am--include-marker
@@ -3109,6 +3132,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-dense_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-diagonal_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-distributed_vector_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-laspack_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Po@am__quote@ # am--include-marker
@@ -3123,6 +3147,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-dense_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-diagonal_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-distributed_vector_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-laspack_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Po@am__quote@ # am--include-marker
@@ -4116,6 +4141,20 @@ numerics/unit_tests_dbg-diagonal_matrix_test.obj: numerics/diagonal_matrix_test.
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/diagonal_matrix_test.C' object='numerics/unit_tests_dbg-diagonal_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-diagonal_matrix_test.obj `if test -f 'numerics/diagonal_matrix_test.C'; then $(CYGPATH_W) 'numerics/diagonal_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/diagonal_matrix_test.C'; fi`
+
+numerics/unit_tests_dbg-eigen_sparse_matrix_test.o: numerics/eigen_sparse_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-eigen_sparse_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_matrix_test.Tpo -c -o numerics/unit_tests_dbg-eigen_sparse_matrix_test.o `test -f 'numerics/eigen_sparse_matrix_test.C' || echo '$(srcdir)/'`numerics/eigen_sparse_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/eigen_sparse_matrix_test.C' object='numerics/unit_tests_dbg-eigen_sparse_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-eigen_sparse_matrix_test.o `test -f 'numerics/eigen_sparse_matrix_test.C' || echo '$(srcdir)/'`numerics/eigen_sparse_matrix_test.C
+
+numerics/unit_tests_dbg-eigen_sparse_matrix_test.obj: numerics/eigen_sparse_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-eigen_sparse_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_matrix_test.Tpo -c -o numerics/unit_tests_dbg-eigen_sparse_matrix_test.obj `if test -f 'numerics/eigen_sparse_matrix_test.C'; then $(CYGPATH_W) 'numerics/eigen_sparse_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/eigen_sparse_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/eigen_sparse_matrix_test.C' object='numerics/unit_tests_dbg-eigen_sparse_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-eigen_sparse_matrix_test.obj `if test -f 'numerics/eigen_sparse_matrix_test.C'; then $(CYGPATH_W) 'numerics/eigen_sparse_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/eigen_sparse_matrix_test.C'; fi`
 
 parallel/unit_tests_dbg-message_tag.o: parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_dbg-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_dbg-message_tag.Tpo -c -o parallel/unit_tests_dbg-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
@@ -5265,6 +5304,20 @@ numerics/unit_tests_devel-diagonal_matrix_test.obj: numerics/diagonal_matrix_tes
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-diagonal_matrix_test.obj `if test -f 'numerics/diagonal_matrix_test.C'; then $(CYGPATH_W) 'numerics/diagonal_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/diagonal_matrix_test.C'; fi`
 
+numerics/unit_tests_devel-eigen_sparse_matrix_test.o: numerics/eigen_sparse_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-eigen_sparse_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_matrix_test.Tpo -c -o numerics/unit_tests_devel-eigen_sparse_matrix_test.o `test -f 'numerics/eigen_sparse_matrix_test.C' || echo '$(srcdir)/'`numerics/eigen_sparse_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/eigen_sparse_matrix_test.C' object='numerics/unit_tests_devel-eigen_sparse_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-eigen_sparse_matrix_test.o `test -f 'numerics/eigen_sparse_matrix_test.C' || echo '$(srcdir)/'`numerics/eigen_sparse_matrix_test.C
+
+numerics/unit_tests_devel-eigen_sparse_matrix_test.obj: numerics/eigen_sparse_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-eigen_sparse_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_matrix_test.Tpo -c -o numerics/unit_tests_devel-eigen_sparse_matrix_test.obj `if test -f 'numerics/eigen_sparse_matrix_test.C'; then $(CYGPATH_W) 'numerics/eigen_sparse_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/eigen_sparse_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/eigen_sparse_matrix_test.C' object='numerics/unit_tests_devel-eigen_sparse_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-eigen_sparse_matrix_test.obj `if test -f 'numerics/eigen_sparse_matrix_test.C'; then $(CYGPATH_W) 'numerics/eigen_sparse_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/eigen_sparse_matrix_test.C'; fi`
+
 parallel/unit_tests_devel-message_tag.o: parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_devel-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_devel-message_tag.Tpo -c -o parallel/unit_tests_devel-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_devel-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_devel-message_tag.Po
@@ -6412,6 +6465,20 @@ numerics/unit_tests_oprof-diagonal_matrix_test.obj: numerics/diagonal_matrix_tes
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/diagonal_matrix_test.C' object='numerics/unit_tests_oprof-diagonal_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-diagonal_matrix_test.obj `if test -f 'numerics/diagonal_matrix_test.C'; then $(CYGPATH_W) 'numerics/diagonal_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/diagonal_matrix_test.C'; fi`
+
+numerics/unit_tests_oprof-eigen_sparse_matrix_test.o: numerics/eigen_sparse_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-eigen_sparse_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_matrix_test.Tpo -c -o numerics/unit_tests_oprof-eigen_sparse_matrix_test.o `test -f 'numerics/eigen_sparse_matrix_test.C' || echo '$(srcdir)/'`numerics/eigen_sparse_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/eigen_sparse_matrix_test.C' object='numerics/unit_tests_oprof-eigen_sparse_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-eigen_sparse_matrix_test.o `test -f 'numerics/eigen_sparse_matrix_test.C' || echo '$(srcdir)/'`numerics/eigen_sparse_matrix_test.C
+
+numerics/unit_tests_oprof-eigen_sparse_matrix_test.obj: numerics/eigen_sparse_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-eigen_sparse_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_matrix_test.Tpo -c -o numerics/unit_tests_oprof-eigen_sparse_matrix_test.obj `if test -f 'numerics/eigen_sparse_matrix_test.C'; then $(CYGPATH_W) 'numerics/eigen_sparse_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/eigen_sparse_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/eigen_sparse_matrix_test.C' object='numerics/unit_tests_oprof-eigen_sparse_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-eigen_sparse_matrix_test.obj `if test -f 'numerics/eigen_sparse_matrix_test.C'; then $(CYGPATH_W) 'numerics/eigen_sparse_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/eigen_sparse_matrix_test.C'; fi`
 
 parallel/unit_tests_oprof-message_tag.o: parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_oprof-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_oprof-message_tag.Tpo -c -o parallel/unit_tests_oprof-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
@@ -7561,6 +7628,20 @@ numerics/unit_tests_opt-diagonal_matrix_test.obj: numerics/diagonal_matrix_test.
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-diagonal_matrix_test.obj `if test -f 'numerics/diagonal_matrix_test.C'; then $(CYGPATH_W) 'numerics/diagonal_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/diagonal_matrix_test.C'; fi`
 
+numerics/unit_tests_opt-eigen_sparse_matrix_test.o: numerics/eigen_sparse_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-eigen_sparse_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_matrix_test.Tpo -c -o numerics/unit_tests_opt-eigen_sparse_matrix_test.o `test -f 'numerics/eigen_sparse_matrix_test.C' || echo '$(srcdir)/'`numerics/eigen_sparse_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/eigen_sparse_matrix_test.C' object='numerics/unit_tests_opt-eigen_sparse_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-eigen_sparse_matrix_test.o `test -f 'numerics/eigen_sparse_matrix_test.C' || echo '$(srcdir)/'`numerics/eigen_sparse_matrix_test.C
+
+numerics/unit_tests_opt-eigen_sparse_matrix_test.obj: numerics/eigen_sparse_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-eigen_sparse_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_matrix_test.Tpo -c -o numerics/unit_tests_opt-eigen_sparse_matrix_test.obj `if test -f 'numerics/eigen_sparse_matrix_test.C'; then $(CYGPATH_W) 'numerics/eigen_sparse_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/eigen_sparse_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/eigen_sparse_matrix_test.C' object='numerics/unit_tests_opt-eigen_sparse_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-eigen_sparse_matrix_test.obj `if test -f 'numerics/eigen_sparse_matrix_test.C'; then $(CYGPATH_W) 'numerics/eigen_sparse_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/eigen_sparse_matrix_test.C'; fi`
+
 parallel/unit_tests_opt-message_tag.o: parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_opt-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_opt-message_tag.Tpo -c -o parallel/unit_tests_opt-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_opt-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_opt-message_tag.Po
@@ -8709,6 +8790,20 @@ numerics/unit_tests_prof-diagonal_matrix_test.obj: numerics/diagonal_matrix_test
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-diagonal_matrix_test.obj `if test -f 'numerics/diagonal_matrix_test.C'; then $(CYGPATH_W) 'numerics/diagonal_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/diagonal_matrix_test.C'; fi`
 
+numerics/unit_tests_prof-eigen_sparse_matrix_test.o: numerics/eigen_sparse_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-eigen_sparse_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_matrix_test.Tpo -c -o numerics/unit_tests_prof-eigen_sparse_matrix_test.o `test -f 'numerics/eigen_sparse_matrix_test.C' || echo '$(srcdir)/'`numerics/eigen_sparse_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/eigen_sparse_matrix_test.C' object='numerics/unit_tests_prof-eigen_sparse_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-eigen_sparse_matrix_test.o `test -f 'numerics/eigen_sparse_matrix_test.C' || echo '$(srcdir)/'`numerics/eigen_sparse_matrix_test.C
+
+numerics/unit_tests_prof-eigen_sparse_matrix_test.obj: numerics/eigen_sparse_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-eigen_sparse_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_matrix_test.Tpo -c -o numerics/unit_tests_prof-eigen_sparse_matrix_test.obj `if test -f 'numerics/eigen_sparse_matrix_test.C'; then $(CYGPATH_W) 'numerics/eigen_sparse_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/eigen_sparse_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/eigen_sparse_matrix_test.C' object='numerics/unit_tests_prof-eigen_sparse_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-eigen_sparse_matrix_test.obj `if test -f 'numerics/eigen_sparse_matrix_test.C'; then $(CYGPATH_W) 'numerics/eigen_sparse_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/eigen_sparse_matrix_test.C'; fi`
+
 parallel/unit_tests_prof-message_tag.o: parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_prof-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_prof-message_tag.Tpo -c -o parallel/unit_tests_prof-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_prof-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_prof-message_tag.Po
@@ -9502,6 +9597,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-dense_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-distributed_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-parsed_fem_function_test.Po
@@ -9516,6 +9612,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-dense_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-distributed_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Po
@@ -9530,6 +9627,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-dense_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-distributed_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-parsed_fem_function_test.Po
@@ -9544,6 +9642,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-dense_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-distributed_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Po
@@ -9558,6 +9657,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-dense_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-distributed_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Po
@@ -9957,6 +10057,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-dense_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-distributed_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-parsed_fem_function_test.Po
@@ -9971,6 +10072,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-dense_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-distributed_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Po
@@ -9985,6 +10087,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-dense_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-distributed_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-parsed_fem_function_test.Po
@@ -9999,6 +10102,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-dense_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-distributed_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Po
@@ -10013,6 +10117,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-dense_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-distributed_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Po

--- a/tests/numerics/diagonal_matrix_test.C
+++ b/tests/numerics/diagonal_matrix_test.C
@@ -33,6 +33,7 @@ public:
 
   CPPUNIT_TEST(testSizes);
   CPPUNIT_TEST(testNumerics);
+  CPPUNIT_TEST(testClone);
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -204,6 +205,39 @@ public:
           else
             LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real((*_matrix)(i, j)), _tolerance);
         }
+    }
+  }
+
+  void testClone()
+  {
+    {
+      // Create copy, test that it can go out of scope
+      auto copy = _matrix->clone();
+
+      // Check that matrices have the same local/global sizes
+      CPPUNIT_ASSERT_EQUAL(copy->m(), _matrix->m());
+      CPPUNIT_ASSERT_EQUAL(copy->n(), _matrix->n());
+      CPPUNIT_ASSERT_EQUAL(copy->local_m(), _matrix->local_m());
+      CPPUNIT_ASSERT_EQUAL(copy->row_start(), _matrix->row_start());
+      CPPUNIT_ASSERT_EQUAL(copy->row_stop(), _matrix->row_stop());
+
+      // Check that copy has same values as original
+      LIBMESH_ASSERT_FP_EQUAL(copy->l1_norm(), _matrix->l1_norm(), _tolerance);
+    }
+
+    {
+      // Create zero copy
+      auto zero_copy = _matrix->zero_clone();
+
+      // Check that matrices have the same local/global sizes
+      CPPUNIT_ASSERT_EQUAL(zero_copy->m(), _matrix->m());
+      CPPUNIT_ASSERT_EQUAL(zero_copy->n(), _matrix->n());
+      CPPUNIT_ASSERT_EQUAL(zero_copy->local_m(), _matrix->local_m());
+      CPPUNIT_ASSERT_EQUAL(zero_copy->row_start(), _matrix->row_start());
+      CPPUNIT_ASSERT_EQUAL(zero_copy->row_stop(), _matrix->row_stop());
+
+      // Check that zero_copy has same values as original
+      LIBMESH_ASSERT_FP_EQUAL(0.0, zero_copy->l1_norm(), _tolerance);
     }
   }
 

--- a/tests/numerics/eigen_sparse_matrix_test.C
+++ b/tests/numerics/eigen_sparse_matrix_test.C
@@ -1,0 +1,108 @@
+#include <libmesh/libmesh_config.h>
+
+#ifdef LIBMESH_HAVE_EIGEN
+
+// Unit test includes
+#include "libmesh_cppunit.h"
+#include "test_comm.h"
+
+// libMesh includes
+#include <libmesh/eigen_sparse_matrix.h>
+#include <libmesh/auto_ptr.h> // libmesh_make_unique
+#include <libmesh/dense_matrix.h>
+
+// C++ includes
+#include <vector>
+
+using namespace libMesh;
+
+class EigenSparseMatrixTest : public CppUnit::TestCase
+{
+public:
+  CPPUNIT_TEST_SUITE(EigenSparseMatrixTest);
+
+  CPPUNIT_TEST(testGetAndSet);
+  CPPUNIT_TEST(testClone);
+
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp()
+  {
+    // EigenSparseMatrix is serial, but its constructor takes a comm
+    // for consistency with other SparseMatrix types.
+    _comm = TestCommWorld;
+    _matrix = libmesh_make_unique<EigenSparseMatrix<Number>>(*_comm);
+
+    // All parameters are ignored except the number of global rows and colums and nnz.
+    _matrix->init(/*m*/10,
+                  /*n*/10,
+                  /*m_l==m*/10,
+                  /*n_l==n*/10,
+                  /*nnz*/3);
+  }
+
+  void tearDown() {}
+
+  void testGetAndSet()
+  {
+    // EigenSparseMatrix is serial, so we simply test inserting the
+    // same values on all procs.
+    std::vector<numeric_index_type> rows = {0, 1, 2};
+    std::vector<numeric_index_type> cols = {0, 1, 2};
+    DenseMatrix<Number> local(3, 3);
+    local.get_values() =
+      {
+        2., -1,  0,
+        -1, 2., -1,
+         0, -1,  2
+      };
+
+    _matrix->add_matrix(local, rows, cols);
+    _matrix->close();
+  }
+
+  void testClone()
+  {
+    {
+      // Create copy, test that it can go out of scope
+      auto copy = _matrix->clone();
+
+      // Check that matrices have the same local/global sizes
+      CPPUNIT_ASSERT_EQUAL(copy->m(), _matrix->m());
+      CPPUNIT_ASSERT_EQUAL(copy->n(), _matrix->n());
+      CPPUNIT_ASSERT_EQUAL(copy->local_m(), _matrix->local_m());
+      CPPUNIT_ASSERT_EQUAL(copy->row_start(), _matrix->row_start());
+      CPPUNIT_ASSERT_EQUAL(copy->row_stop(), _matrix->row_stop());
+
+      // Check that copy has same values as original
+      LIBMESH_ASSERT_FP_EQUAL(copy->l1_norm(), _matrix->l1_norm(), _tolerance);
+    }
+
+    {
+      // Create zero copy
+      auto zero_copy = _matrix->zero_clone();
+
+      // Check that matrices have the same local/global sizes
+      CPPUNIT_ASSERT_EQUAL(zero_copy->m(), _matrix->m());
+      CPPUNIT_ASSERT_EQUAL(zero_copy->n(), _matrix->n());
+      CPPUNIT_ASSERT_EQUAL(zero_copy->local_m(), _matrix->local_m());
+      CPPUNIT_ASSERT_EQUAL(zero_copy->row_start(), _matrix->row_start());
+      CPPUNIT_ASSERT_EQUAL(zero_copy->row_stop(), _matrix->row_stop());
+
+      // Check that zero_copy has same values as original
+      LIBMESH_ASSERT_FP_EQUAL(0.0, zero_copy->l1_norm(), _tolerance);
+    }
+  }
+
+private:
+
+  Parallel::Communicator * _comm;
+  std::unique_ptr<EigenSparseMatrix<Number>> _matrix;
+  const Real _tolerance = TOLERANCE * TOLERANCE;
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(EigenSparseMatrixTest);
+
+#endif

--- a/tests/numerics/petsc_matrix_test.C
+++ b/tests/numerics/petsc_matrix_test.C
@@ -22,6 +22,7 @@ public:
   CPPUNIT_TEST_SUITE(PetscMatrixTest);
 
   CPPUNIT_TEST(testGetAndSet);
+  CPPUNIT_TEST(testClone);
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -104,6 +105,42 @@ public:
 #else
     functor();
 #endif
+  }
+
+  void testClone()
+  {
+    // Matrix must be closed before it can be cloned.
+    _matrix->close();
+
+    {
+      // Create copy, test that it can go out of scope
+      auto copy = _matrix->clone();
+
+      // Check that matrices have the same local/global sizes
+      CPPUNIT_ASSERT_EQUAL(copy->m(), _matrix->m());
+      CPPUNIT_ASSERT_EQUAL(copy->n(), _matrix->n());
+      CPPUNIT_ASSERT_EQUAL(copy->local_m(), _matrix->local_m());
+      CPPUNIT_ASSERT_EQUAL(copy->row_start(), _matrix->row_start());
+      CPPUNIT_ASSERT_EQUAL(copy->row_stop(), _matrix->row_stop());
+
+      // Check that copy has same values as original
+      LIBMESH_ASSERT_FP_EQUAL(copy->l1_norm(), _matrix->l1_norm(), _tolerance);
+    }
+
+    {
+      // Create zero copy
+      auto zero_copy = _matrix->zero_clone();
+
+      // Check that matrices have the same local/global sizes
+      CPPUNIT_ASSERT_EQUAL(zero_copy->m(), _matrix->m());
+      CPPUNIT_ASSERT_EQUAL(zero_copy->n(), _matrix->n());
+      CPPUNIT_ASSERT_EQUAL(zero_copy->local_m(), _matrix->local_m());
+      CPPUNIT_ASSERT_EQUAL(zero_copy->row_start(), _matrix->row_start());
+      CPPUNIT_ASSERT_EQUAL(zero_copy->row_stop(), _matrix->row_stop());
+
+      // Check that zero_copy has same values as original
+      LIBMESH_ASSERT_FP_EQUAL(0.0, zero_copy->l1_norm(), _tolerance);
+    }
   }
 
 private:


### PR DESCRIPTION
The LaspackMatrix and EpetraMatrix implementations are currently
marked as libmesh_not_implemented(), although they include a possible
implementation. In case someone ever needs this capability, they could
use this code as a starting point.

Refs #2431