### PR TITLE
libmesh_vector_at

### DIFF
--- a/include/utils/utility.h
+++ b/include/utils/utility.h
@@ -35,14 +35,14 @@ namespace libMesh
  * idiom, which is similar to calling map.at(), but gives a more
  * useful error message with a line number.
  */
-#define libmesh_map_find(map, key) Utility::map_find((map), (key), __FILE__, __LINE__)
+#define libmesh_map_find(map, key) libMesh::Utility::map_find((map), (key), __FILE__, __LINE__)
 
 /**
  * Encapsulates the common "get value from vector, otherwise error"
  * idiom, which is similar to calling vec.at(), but gives a more
  * useful error message with a line number.
  */
-#define libmesh_vector_at(vec, idx) Utility::vector_at((vec), (idx), __FILE__, __LINE__)
+#define libmesh_vector_at(vec, idx) libMesh::Utility::vector_at((vec), (idx), __FILE__, __LINE__)
 
 // ------------------------------------------------------------
 // The Utility namespace is for functions

--- a/include/utils/utility.h
+++ b/include/utils/utility.h
@@ -37,6 +37,13 @@ namespace libMesh
  */
 #define libmesh_map_find(map, key) Utility::map_find((map), (key), __FILE__, __LINE__)
 
+/**
+ * Encapsulates the common "get value from vector, otherwise error"
+ * idiom, which is similar to calling vec.at(), but gives a more
+ * useful error message with a line number.
+ */
+#define libmesh_vector_at(vec, idx) Utility::vector_at((vec), (idx), __FILE__, __LINE__)
+
 // ------------------------------------------------------------
 // The Utility namespace is for functions
 // which are useful but don't necessarily belong anywhere else.
@@ -146,6 +153,45 @@ map_find(const Map & map,
     libmesh_error_msg("map_find() error: key \"" << key << "\" not found in file " \
                       << filename << " on line " << line_number);
   return it->second;
+}
+
+
+/**
+ * A replacement for std::vector::at(i) which is meant to be used with
+ * a macro, and, unlike at(), gives a proper line number and useful
+ * error message when the index is past the end.
+ */
+template<typename Vector>
+inline
+typename Vector::reference &
+vector_at(Vector & vec,
+          typename Vector::size_type i,
+          const char * filename,
+          int line_number)
+{
+  if (i >= vec.size())
+    libmesh_error_msg("vec_at() error: Index " + std::to_string(i) +
+                      " past end of vector in file " + std::string(filename) +
+                      " on line " + std::to_string(line_number));
+  return vec[i];
+}
+
+/**
+ * Same as above, but for const inputs.
+ */
+template<typename Vector>
+inline
+typename Vector::const_reference &
+vector_at(const Vector & vec,
+          typename Vector::size_type i,
+          const char * filename,
+          int line_number)
+{
+  if (i >= vec.size())
+    libmesh_error_msg("vec_at() error: Index " + std::to_string(i) +
+                      " past end of vector in file " + std::string(filename) +
+                      " on line " + std::to_string(line_number));
+  return vec[i];
 }
 
 /**

--- a/include/utils/utility.h
+++ b/include/utils/utility.h
@@ -170,9 +170,9 @@ vector_at(Vector & vec,
           int line_number)
 {
   if (i >= vec.size())
-    libmesh_error_msg("vec_at() error: Index " + std::to_string(i) +
-                      " past end of vector in file " + std::string(filename) +
-                      " on line " + std::to_string(line_number));
+    libmesh_error_msg("vec_at() error: Index " << i <<
+                      " past end of vector in file " << filename <<
+                      " on line " << line_number);
   return vec[i];
 }
 
@@ -188,9 +188,9 @@ vector_at(const Vector & vec,
           int line_number)
 {
   if (i >= vec.size())
-    libmesh_error_msg("vec_at() error: Index " + std::to_string(i) +
-                      " past end of vector in file " + std::string(filename) +
-                      " on line " + std::to_string(line_number));
+    libmesh_error_msg("vec_at() error: Index " << i <<
+                      " past end of vector in file " << filename <<
+                      " on line " << line_number);
   return vec[i];
 }
 

--- a/src/mesh/dyna_io.C
+++ b/src/mesh/dyna_io.C
@@ -23,6 +23,7 @@
 #include "libmesh/dyna_io.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/int_range.h"
+#include "libmesh/utility.h"
 
 // TIMPI includes
 #include "timpi/parallel_implementation.h"
@@ -630,7 +631,8 @@ void DynaIO::read_mesh(std::istream & in)
                     my_constraint_rows[spline_node_index];
 
                   const Real coef =
-                    dense_constraint_vecs[0].at(elem_coef_vec_index)[elem_node_index];
+                    libmesh_vector_at(dense_constraint_vecs[0],
+                                      elem_coef_vec_index)[elem_node_index];
 
                   // Global nodes are supposed to be in sorted order
                   if (global_node_idx != DofObject::invalid_id)
@@ -663,12 +665,16 @@ void DynaIO::read_mesh(std::istream & in)
                       const dyna_int_type elem_coef_vec_index =
                         my_constraint_rows[spline_node_index];
 
-                      const Node * spline_node = spline_node_ptrs.at(my_node_idx);
+                      const Node * spline_node =
+                          libmesh_vector_at(spline_node_ptrs,
+                                            my_node_idx);
 
                       const Real coef =
-                        dense_constraint_vecs[0].at(elem_coef_vec_index)[elem_node_index];
+                        libmesh_vector_at(dense_constraint_vecs[0],
+                                          elem_coef_vec_index)[elem_node_index];
                       p.add_scaled(*spline_node, coef);
-                      w += coef * spline_weights.at(my_node_idx);
+                      w += coef * libmesh_vector_at(spline_weights,
+                                                    my_node_idx);
 
                       constraint_row.emplace_back(spline_node->id(), coef);
                     }


### PR DESCRIPTION
@jwpeterson pointed out w.r.t. #2437 that std::vector::at() doesn't give a very useful error message, and he's already been using an upgraded replacement, so let's steal that and put it in the library.

This PR uses it in DynaIO in place of the recent at() calls there, but at some point we should go over the other MeshInput subclasses, find places where (except in dbg mode) we're trusting our input files, and fix that.  It'd be nice if someday we got libMesh to pass fuzz testing without segfaults.