### PR TITLE
Be more selective about setting use_blas_lapack

### DIFF
--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -771,7 +771,12 @@ typedef DenseMatrix<Complex> ComplexDenseMatrix;
 
 using namespace DenseMatrices;
 
-#ifdef LIBMESH_HAVE_PETSC
+// The PETSc Lapack wrappers are only for PetscScalar, therefore we
+// can't e.g. get a Lapack version of DenseMatrix<Real>::lu_solve()
+// when libmesh/PETSc are compiled with complex numbers.
+#if defined(LIBMESH_HAVE_PETSC) && \
+  defined(LIBMESH_USE_REAL_NUMBERS) && \
+  defined(LIBMESH_DEFAULT_DOUBLE_PRECISION)
 template <>
 struct DenseMatrix<double>::UseBlasLapack
 {


### PR DESCRIPTION
In theory, we should be able to have a complex-valued Lapack version
of `DenseMatrix<Number>::lu_solve()` when libmesh is compiled with
complex number support, but I think this will require some changes to
the ifdef guards in dense_matrix_blas_lapack.C and I did not try to
enable it yet.

One thing we are _not_ able to do is have e.g. a Lapack version of
`DenseMatrix<Real>::lu_solve()` when libmesh/PETSc are compiled with
complex numbers. This is due to the fact that the PETSc wrappers
like `LAPACKgetrf_` are only available for the current `PetscScalar`.

Refs #2426