### PR TITLE
Call enforce_constraints_on_residual using local solution

### DIFF
--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -182,10 +182,19 @@ extern "C"
     else
       libmesh_error_msg("Error! Unable to compute residual and/or Jacobian!");
 
-    PetscVector<Number> X(x, rc.sys.comm());
+
+    // Synchronize PETSc x to local solution since the local solution may be changed due to the constraints
+    PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(rc.sys.solution.get());
+    PetscVector<Number> X_global(x, rc.sys.comm());
+
+    X_global.swap(X_sys);
+    rc.sys.update();
+    X_global.swap(X_sys);
 
     R.close();
-    rc.sys.get_dof_map().enforce_constraints_on_residual(rc.sys, &R, &X);
+
+    rc.sys.get_dof_map().enforce_constraints_on_residual(rc.sys, &R, rc.sys.current_local_solution.get());
+
     R.close();
 
     return rc.ierr;
@@ -222,9 +231,17 @@ extern "C"
     else
       libmesh_error_msg("Error! Unable to compute residual for forming finite difference Jacobian!");
 
+    // Synchronize PETSc x to local solution since the local solution may be changed due to the constraints
+    PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(rc.sys.solution.get());
+    PetscVector<Number> X_global(x, rc.sys.comm());
+
+    X_global.swap(X_sys);
+    rc.sys.update();
+    X_global.swap(X_sys);
+
     R.close();
-    PetscVector<Number> X(x, rc.sys.comm());
-    rc.sys.get_dof_map().enforce_constraints_on_residual(rc.sys, &R, &X);
+
+    rc.sys.get_dof_map().enforce_constraints_on_residual(rc.sys, &R, rc.sys.current_local_solution.get());
 
     R.close();
 
@@ -264,9 +281,17 @@ extern "C"
       libmesh_error_msg("Error! Unable to compute residual for forming finite differenced"
                         "Jacobian-vector products!");
 
+    // Synchronize PETSc x to local solution since the local solution may be changed due to the constraints
+    PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(rc.sys.solution.get());
+    PetscVector<Number> X_global(x, rc.sys.comm());
+
+    X_global.swap(X_sys);
+    rc.sys.update();
+    X_global.swap(X_sys);
+
     R.close();
-    PetscVector<Number> X(x, rc.sys.comm());
-    rc.sys.get_dof_map().enforce_constraints_on_residual(rc.sys, &R, &X);
+
+    rc.sys.get_dof_map().enforce_constraints_on_residual(rc.sys, &R, rc.sys.current_local_solution.get());
 
     R.close();
 


### PR DESCRIPTION
Do not use parallel global solution that will automatically localize the whole solution. This causes scaling issue and memory issue.

This simply makes the simulation non-scalable.

Here is a test using 1536 cores for a problem with 10,100,279 DoFs.

Original performance:

```
SNESSolve              3 1.0 2.7287e+02 1.0 2.42e+09 2.8 9.1e+07 3.7e+04 7.8e+02 93100 93100 86  93100 93100 87  9061
SNESSetUp              3 1.0 1.7834e-04 8.4 0.00e+00 0.0 0.0e+00 0.0e+00 0.0e+00  0  0  0  0  0   0  0  0  0  0     0
SNESFunctionEval      13 1.0 2.3555e+02 1.0 1.87e+06 1.7 8.1e+07 4.0e+04 7.8e+01 80  0 83 95  9  80  0 83 95  9    10
SNESJacobianEval      10 1.0 2.8432e+01 1.0 3.57e+07 2.3 1.1e+06 1.1e+05 1.5e+02 10  2  1  3 17  10  2  1  3 17  1362
SNESLineSearch        10 1.0 1.6866e+02 1.0 3.87e+07 2.6 6.3e+07 4.0e+04 1.0e+02 57  2 64 73 11  57  2 64 73 11   237
```

With this PR:

```
SNESSolve              3 1.0 3.7522e+01 1.0 2.42e+09 2.8 1.5e+07 1.1e+04 7.2e+02 63100 68 91 85  63100 68 91 86 65895
SNESSetUp              3 1.0 2.3532e-0411.5 0.00e+00 0.0 0.0e+00 0.0e+00 0.0e+00  0  0  0  0  0   0  0  0  0  0     0
SNESFunctionEval      13 1.0 1.6213e+00 1.0 1.87e+06 1.7 4.6e+06 3.2e+03 2.6e+01  3  0 22  8  3   3  0 22  8  3  1444
SNESJacobianEval      10 1.0 2.7916e+01 1.0 3.57e+07 2.3 1.1e+06 1.1e+05 1.5e+02 47  2  5 67 18  47  2  5 67 18  1387
SNESLineSearch        10 1.0 1.4380e+00 1.1 3.87e+07 2.6 3.8e+06 3.2e+03 6.0e+01  2  2 18  7  7   2  2 18  7  7 27849
```


The simulation is almost ten times faster with this PR



