### PR TITLE
Control sorting method used in BoundaryInfo::build_node_list()

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -665,8 +665,8 @@ public:
    * this, but for consistency with the other build_XYZ_list
    * functions, we're using tuples.
    */
-  std::vector<std::tuple<dof_id_type, boundary_id_type>>
-  build_node_list() const;
+  typedef std::tuple<dof_id_type, boundary_id_type> NodeBCTuple;
+  std::vector<NodeBCTuple> build_node_list() const;
 
   /**
    * Adds nodes with boundary ids based on the side's boundary

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -664,9 +664,15 @@ public:
    * advantage of guaranteed RVO. Note: we could use std::pairs for
    * this, but for consistency with the other build_XYZ_list
    * functions, we're using tuples.
+   *
+   * The "sort_by" parameter controls how the resulting list of tuples
+   * is sorted.  It is possible (but not recommended) to choose
+   * UNSORTED, since in that case the resulting vectors will
+   * potentially be in different ordres on different procs.
    */
   typedef std::tuple<dof_id_type, boundary_id_type> NodeBCTuple;
-  std::vector<NodeBCTuple> build_node_list() const;
+  enum NodeBCTupleSortBy : int {NODE_ID, BOUNDARY_ID, UNSORTED};
+  std::vector<NodeBCTuple> build_node_list(NodeBCTupleSortBy sort_by = NODE_ID) const;
 
   /**
    * Adds nodes with boundary ids based on the side's boundary

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1998,10 +1998,10 @@ void BoundaryInfo::build_side_list (std::vector<dof_id_type> & el,
 #endif
 
 
-std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>>
+std::vector<BoundaryInfo::BCTuple>
 BoundaryInfo::build_side_list() const
 {
-  std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>> bc_triples;
+  std::vector<BCTuple> bc_triples;
   bc_triples.reserve(_boundary_side_id.size());
 
   for (const auto & pr : _boundary_side_id)
@@ -2049,10 +2049,10 @@ void BoundaryInfo::build_active_side_list (std::vector<dof_id_type> & el,
 #endif
 
 
-std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>>
+std::vector<BoundaryInfo::BCTuple>
 BoundaryInfo::build_active_side_list () const
 {
-  std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>> bc_triples;
+  std::vector<BCTuple> bc_triples;
   bc_triples.reserve(_boundary_side_id.size());
 
   for (const auto & pr : _boundary_side_id)
@@ -2113,10 +2113,10 @@ void BoundaryInfo::build_edge_list (std::vector<dof_id_type> & el,
 #endif
 
 
-std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>>
+std::vector<BoundaryInfo::BCTuple>
 BoundaryInfo::build_edge_list() const
 {
-  std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>> bc_triples;
+  std::vector<BCTuple> bc_triples;
   bc_triples.reserve(_boundary_edge_id.size());
 
   for (const auto & pr : _boundary_edge_id)
@@ -2161,10 +2161,10 @@ void BoundaryInfo::build_shellface_list (std::vector<dof_id_type> & el,
 #endif
 
 
-std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>>
+std::vector<BoundaryInfo::BCTuple>
 BoundaryInfo::build_shellface_list() const
 {
-  std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>> bc_triples;
+  std::vector<BCTuple> bc_triples;
   bc_triples.reserve(_boundary_shellface_id.size());
 
   for (const auto & pr : _boundary_shellface_id)

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1723,10 +1723,10 @@ void BoundaryInfo::build_node_list (std::vector<dof_id_type> & nl,
 #endif
 
 
-std::vector<std::tuple<dof_id_type, boundary_id_type>>
+std::vector<BoundaryInfo::NodeBCTuple>
 BoundaryInfo::build_node_list() const
 {
-  std::vector<std::tuple<dof_id_type, boundary_id_type>> bc_tuples;
+  std::vector<NodeBCTuple> bc_tuples;
   bc_tuples.reserve(_boundary_node_id.size());
 
   for (const auto & pr : _boundary_node_id)

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1724,7 +1724,7 @@ void BoundaryInfo::build_node_list (std::vector<dof_id_type> & nl,
 
 
 std::vector<BoundaryInfo::NodeBCTuple>
-BoundaryInfo::build_node_list() const
+BoundaryInfo::build_node_list(NodeBCTupleSortBy sort_by) const
 {
   std::vector<NodeBCTuple> bc_tuples;
   bc_tuples.reserve(_boundary_node_id.size());
@@ -1733,8 +1733,13 @@ BoundaryInfo::build_node_list() const
     bc_tuples.emplace_back(pr.first->id(), pr.second);
 
   // This list is currently in memory address (arbitrary) order, so
-  // sort to make it consistent on all procs.
-  std::sort(bc_tuples.begin(), bc_tuples.end());
+  // sort, using the specified ordering, to make it consistent on all procs.
+  if (sort_by == NODE_ID)
+    std::sort(bc_tuples.begin(), bc_tuples.end());
+  else if (sort_by == BOUNDARY_ID)
+    std::sort(bc_tuples.begin(), bc_tuples.end(),
+              [](const NodeBCTuple & left, const NodeBCTuple & right)
+              {return std::get<1>(left) < std::get<1>(right);});
 
   return bc_tuples;
 }


### PR DESCRIPTION
I have a case where it is useful to sort the list of tuples returned by `BoundaryInfo::build_node_list()` by boundary id instead of node id since I later need to search in it by boundary id. This PR adds the ability to control the type of sort, and defaults to the current approach which is by node id.
