### PR TITLE
Avoid serial vectors

### DIFF
--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -2128,7 +2128,9 @@ void DofMap::enforce_constraints_exactly (const System & system,
   else if (v->type() == PARALLEL)
     {
       v_built = NumericVector<Number>::build(this->comm());
-      v_built->init (v->size(), v->size(), true, SERIAL);
+      v_built->init (v->size(), v->local_size(),
+                     this->get_send_list(), true,
+                     GHOSTED);
       v->localize(*v_built);
       v_built->close();
       v_local = v_built.get();
@@ -2206,7 +2208,8 @@ void DofMap::enforce_constraints_on_residual (const NonlinearImplicitSystem & sy
   else if (solution->type() == PARALLEL)
     {
       solution_built = NumericVector<Number>::build(this->comm());
-      solution_built->init (solution->size(), solution->size(), true, SERIAL);
+      solution_built->init (solution->size(), solution->local_size(),
+                            this->get_send_list(), true, GHOSTED);
       solution->localize(*solution_built);
       solution_built->close();
       solution_local = solution_built.get();
@@ -2302,7 +2305,8 @@ void DofMap::enforce_adjoint_constraints_exactly (NumericVector<Number> & v,
   else if (v.type() == PARALLEL)
     {
       v_built = NumericVector<Number>::build(this->comm());
-      v_built->init (v.size(), v.size(), true, SERIAL);
+      v_built->init (v.size(), v.local_size(),
+                     this->get_send_list(), true, GHOSTED);
       v.localize(*v_built);
       v_built->close();
       v_local = v_built.get();

--- a/src/error_estimation/uniform_refinement_estimator.C
+++ b/src/error_estimation/uniform_refinement_estimator.C
@@ -306,7 +306,10 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
       // Copy the projected coarse grid solutions, which will be
       // overwritten by solve()
       projected_solutions[i] = NumericVector<Number>::build(system.comm());
-      projected_solutions[i]->init(system.solution->size(), true, SERIAL);
+      projected_solutions[i]->init(system.solution->size(),
+                                   system.solution->local_size(),
+                                   system.get_dof_map().get_send_list(),
+                                   true, GHOSTED);
       system.solution->localize(*projected_solutions[i],
                                 system.get_dof_map().get_send_list());
     }

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1422,7 +1422,8 @@ Real System::calculate_norm(const NumericVector<Number> & v,
 
   // Localize the potentially parallel vector
   std::unique_ptr<NumericVector<Number>> local_v = NumericVector<Number>::build(this->comm());
-  local_v->init(v.size(), true, SERIAL);
+  local_v->init(v.size(), v.local_size(), _dof_map->get_send_list(),
+                true, GHOSTED);
   v.localize (*local_v, _dof_map->get_send_list());
 
   // I'm not sure how best to mix Hilbert norms on some variables (for


### PR DESCRIPTION
These are all the "easy" fixes I can find to cases of overserialization, based on the failure case @jwpeterson pointed out to me and on the discussion of the case in #2440