### PR TITLE
Disable FParser JIT on platforms that don't have dlopen

### DIFF
--- a/contrib/fparser/fparser_ad.cc
+++ b/contrib/fparser/fparser_ad.cc
@@ -17,6 +17,7 @@ using namespace FPoptimizer_CodeTree;
 #include <unistd.h>
 
 #if LIBMESH_HAVE_FPARSER_JIT
+#  define FPARSER_CACHING
 #  include <dlfcn.h>
 #endif
 
@@ -477,6 +478,7 @@ int FunctionParserADBase<Value_t>::AutoDiff(const std::string& var_name)
     int result = ad->AutoDiff(var_number, this->mData, autoOptimize);
 
     // save the derivative if cacheing is enabled and derivative was successfully taken
+#ifdef FPARSER_CACHING
     if (cached && result == -1)
     {
       // create cache directory
@@ -510,6 +512,7 @@ int FunctionParserADBase<Value_t>::AutoDiff(const std::string& var_name)
         }
       }
     }
+#endif // FPARSER_CACHING
 
     return result;
   }

--- a/contrib/fparser/fparser_ad.cc
+++ b/contrib/fparser/fparser_ad.cc
@@ -608,13 +608,6 @@ bool FunctionParserADBase<Value_t>::JITCompile()
 }
 
 #if LIBMESH_HAVE_FPARSER_JIT
-// JIT compile for supported types
-template<>
-bool FunctionParserADBase<double>::JITCompile() { return JITCompileHelper("double"); }
-template<>
-bool FunctionParserADBase<float>::JITCompile() { return JITCompileHelper("float"); }
-template<>
-bool FunctionParserADBase<long double>::JITCompile() { return JITCompileHelper("long double"); }
 
 template<typename Value_t>
 Value_t FunctionParserADBase<Value_t>::Eval(const Value_t* Vars)
@@ -624,7 +617,14 @@ Value_t FunctionParserADBase<Value_t>::Eval(const Value_t* Vars)
   else
     return (*compiledFunction)(Vars, pImmed, Epsilon<Value_t>::value);
 }
-#endif // LIBMESH_HAVE_FPARSER_JIT
+
+// JIT compile for supported types
+template<>
+bool FunctionParserADBase<double>::JITCompile() { return JITCompileHelper("double"); }
+template<>
+bool FunctionParserADBase<float>::JITCompile() { return JITCompileHelper("float"); }
+template<>
+bool FunctionParserADBase<long double>::JITCompile() { return JITCompileHelper("long double"); }
 
 template<typename Value_t>
 std::string FunctionParserADBase<Value_t>::JITCodeHash(const std::string & Value_t_name)
@@ -1173,6 +1173,8 @@ void * Compiler::getFunction(const std::string & fname)
   throw std::runtime_error(error);
 }
 }
+
+#endif // LIBMESH_HAVE_FPARSER_JIT
 
 template<typename Value_t>
 void FunctionParserADBase<Value_t>::Serialize(std::ostream & ostr)

--- a/contrib/fparser/fparser_ad.hh
+++ b/contrib/fparser/fparser_ad.hh
@@ -135,6 +135,8 @@ public:
   void RegisterDerivative(const std::string & a, const std::string & b, const std::string & c);
 
 protected:
+
+#if LIBMESH_HAVE_FPARSER_JIT
   /// return a SHA1 hash for the current bytecode and value type name
   std::string JITCodeHash(const std::string & value_type_name);
 
@@ -143,6 +145,7 @@ protected:
 
   /// helper function to perform the JIT compilation (needs the Value_t typename as a string)
   bool JITCompileHelper(const std::string &);
+#endif // LIBMESH_HAVE_FPARSER_JIT
 
   /// JIT function pointer
   Value_t (*compiledFunction)(const Value_t *, const Value_t *, const Value_t);
@@ -185,6 +188,8 @@ protected:
     virtual const char* what() const throw() { return "Unknown serialization file version"; }
   } UnknownSerializationVersionException;
 };
+
+#ifdef LIBMESH_HAVE_FPARSER_JIT
 
 /// Forward declare SHA1 hash object
 class SHA1;
@@ -245,6 +250,8 @@ protected:
   const bool _use_cache;
 };
 } // namespace FParserJIT
+
+#endif // LIBMESH_HAVE_FPARSER_JIT
 
 class FunctionParserAD: public FunctionParserADBase<double> {};
 class FunctionParserAD_f: public FunctionParserADBase<float> {};


### PR DESCRIPTION
This patch gets me past the FParser compilation when building libmesh on msys2 (Windows). The libmesh docs on compiling on msys2 currently state that `--disable-fparser` needs to be supplied. This is not necessary anymore with this change. However there are other new obstacles related to metaphysicl and timpi (both shiny new additions) see #2447 

Closes #2445 