### PR TITLE
Vectorized shape, shape_deriv

### DIFF
--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -151,6 +151,24 @@ public:
                             const unsigned int i,
                             const Point & p,
                             const bool add_p_level = true);
+
+  /**
+   * Fills \p v with the values of the \f$ i^{th} \f$
+   * shape function, evaluated at all points p.  You must specify
+   * element order directly.  \p v should already be the appropriate
+   * size.
+   *
+   * On a p-refined element, \p o should be the base order of the
+   * element if \p add_p_level is left \p true, or can be the base
+   * order of the element if \p add_p_level is set to \p false.
+   */
+  static void shapes(const Elem * elem,
+                     const Order o,
+                     const unsigned int i,
+                     const std::vector<Point> & p,
+                     std::vector<OutputShape> & v,
+                     const bool add_p_level = true);
+
   /**
    * \returns The \f$ j^{th} \f$ derivative of the \f$ i^{th} \f$
    * shape function at point \p p.  This method allows you to
@@ -546,6 +564,21 @@ protected:
                                          const Elem * e) override;
 
 #endif
+
+  /**
+   * A default implementation for shapes
+   */
+  static void default_shapes (const Elem * elem,
+                              const Order o,
+                              const unsigned int i,
+                              const std::vector<Point> & p,
+                              std::vector<OutputShape> & v,
+                              const bool add_p_level = true)
+    {
+      libmesh_assert_equal_to(p.size(), v.size());
+      for (auto vi : index_range(v))
+        v[vi] = FE<Dim,T>::shape (elem, o, i, p[vi], add_p_level);
+    }
 
   /**
    * A default implementation for shape_derivs
@@ -1173,6 +1206,19 @@ typedef FE<3,MONOMIAL> FEMonomial3D;
 
 #define LIBMESH_DEFAULT_VECTORIZED_FE(MyDim, MyType) \
 template<>                                           \
+void FE<MyDim,MyType>::shapes                        \
+  (const Elem * elem,                                \
+   const Order o,                                    \
+   const unsigned int i,                             \
+   const std::vector<Point> & p,                     \
+   std::vector<OutputShape> & v,                     \
+   const bool add_p_level)                           \
+{                                                    \
+  FE<MyDim,MyType>::default_shapes                   \
+    (elem,o,i,p,v,add_p_level);                      \
+}                                                    \
+                                                     \
+template<>                                           \
 void FE<MyDim,MyType>::shape_derivs                  \
   (const Elem * elem,                                \
    const Order o,                                    \
@@ -1182,7 +1228,8 @@ void FE<MyDim,MyType>::shape_derivs                  \
    std::vector<OutputShape> & v,                     \
    const bool add_p_level)                           \
 {                                                    \
-  FE<MyDim,MyType>::default_shape_derivs(elem,o,i,j,p,v,add_p_level);  \
+  FE<MyDim,MyType>::default_shape_derivs             \
+    (elem,o,i,j,p,v,add_p_level);                    \
 }
 
 

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -293,6 +293,22 @@ public:
                     const Point & p,
                     OutputType & phi);
 
+  /**
+   * Fills \p phi with the values of the \f$ i^{th} \f$ shape function
+   * at point \p p. This method allows you to specify the dimension,
+   * element type, and order directly.
+   *
+   * \note On a p-refined element, \p fe_t.order should be the total
+   * order of the element.
+   */
+  template<typename OutputType>
+  static void shapes(const unsigned int dim,
+                     const FEType & fe_t,
+                     const Elem * elem,
+                     const unsigned int i,
+                     const std::vector<Point> & p,
+                     std::vector<OutputType> & phi);
+
   typedef Real (*shape_ptr) (const FEType fe_t,
                              const Elem * elem,
                              const unsigned int i,

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -494,8 +494,7 @@ void FE<Dim,T>::init_shape_functions(const std::vector<Point> & qp,
         // Compute the value of the approximation shape function i at quadrature point p
         if (this->calculate_dphiref)
           for (unsigned int i=0; i<n_approx_shape_functions; i++)
-            for (unsigned int p=0; p<n_qp; p++)
-              this->dphidxi[i][p]  = FE<Dim,T>::shape_deriv (elem, this->fe_type.order, i, 0, qp[p]);
+            FE<Dim,T>::shape_derivs(elem, this->fe_type.order, i, 0, qp, this->dphidxi[i]);
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
         if (this->calculate_d2phi)
           for (unsigned int i=0; i<n_approx_shape_functions; i++)
@@ -515,11 +514,10 @@ void FE<Dim,T>::init_shape_functions(const std::vector<Point> & qp,
         // Compute the value of the approximation shape function i at quadrature point p
         if (this->calculate_dphiref)
           for (unsigned int i=0; i<n_approx_shape_functions; i++)
-            for (unsigned int p=0; p<n_qp; p++)
-              {
-                this->dphidxi[i][p]  = FE<Dim,T>::shape_deriv (elem, this->fe_type.order, i, 0, qp[p]);
-                this->dphideta[i][p] = FE<Dim,T>::shape_deriv (elem, this->fe_type.order, i, 1, qp[p]);
-              }
+            {
+              FE<Dim,T>::shape_derivs(elem, this->fe_type.order, i, 0, qp, this->dphidxi[i]);
+              FE<Dim,T>::shape_derivs(elem, this->fe_type.order, i, 1, qp, this->dphideta[i]);
+            }
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
         if (this->calculate_d2phi)
           for (unsigned int i=0; i<n_approx_shape_functions; i++)
@@ -544,12 +542,11 @@ void FE<Dim,T>::init_shape_functions(const std::vector<Point> & qp,
         // Compute the value of the approximation shape function i at quadrature point p
         if (this->calculate_dphiref)
           for (unsigned int i=0; i<n_approx_shape_functions; i++)
-            for (unsigned int p=0; p<n_qp; p++)
-              {
-                this->dphidxi[i][p]   = FE<Dim,T>::shape_deriv (elem, this->fe_type.order, i, 0, qp[p]);
-                this->dphideta[i][p]  = FE<Dim,T>::shape_deriv (elem, this->fe_type.order, i, 1, qp[p]);
-                this->dphidzeta[i][p] = FE<Dim,T>::shape_deriv (elem, this->fe_type.order, i, 2, qp[p]);
-              }
+            {
+              FE<Dim,T>::shape_derivs(elem, this->fe_type.order, i, 0, qp, this->dphidxi[i]);
+              FE<Dim,T>::shape_derivs(elem, this->fe_type.order, i, 1, qp, this->dphideta[i]);
+              FE<Dim,T>::shape_derivs(elem, this->fe_type.order, i, 2, qp, this->dphidzeta[i]);
+            }
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
         if (this->calculate_d2phi)
           for (unsigned int i=0; i<n_approx_shape_functions; i++)

--- a/src/fe/fe_bernstein_shape_0D.C
+++ b/src/fe/fe_bernstein_shape_0D.C
@@ -23,9 +23,11 @@
 #include "libmesh/elem.h"
 
 
-
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(0,BERNSTEIN)
 
 
 template <>
@@ -100,7 +102,6 @@ Real FE<0,BERNSTEIN>::shape_deriv(const FEType,
   libmesh_error_msg("No spatial derivatives in 0D!");
   return 0.;
 }
-
 
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES

--- a/src/fe/fe_bernstein_shape_1D.C
+++ b/src/fe/fe_bernstein_shape_1D.C
@@ -34,6 +34,9 @@ namespace libMesh
 {
 
 
+LIBMESH_DEFAULT_VECTORIZED_FE(1,BERNSTEIN)
+
+
 template <>
 Real FE<1,BERNSTEIN>::shape(const ElemType,
                             const Order order,

--- a/src/fe/fe_bernstein_shape_2D.C
+++ b/src/fe/fe_bernstein_shape_2D.C
@@ -29,6 +29,10 @@
 namespace libMesh
 {
 
+
+LIBMESH_DEFAULT_VECTORIZED_FE(2,BERNSTEIN)
+
+
 template <>
 Real FE<2,BERNSTEIN>::shape(const Elem * elem,
                             const Order order,

--- a/src/fe/fe_bernstein_shape_3D.C
+++ b/src/fe/fe_bernstein_shape_3D.C
@@ -31,6 +31,8 @@ namespace libMesh
 {
 
 
+LIBMESH_DEFAULT_VECTORIZED_FE(3,BERNSTEIN)
+
 
 template <>
 Real FE<3,BERNSTEIN>::shape(const Elem * elem,

--- a/src/fe/fe_clough_shape_0D.C
+++ b/src/fe/fe_clough_shape_0D.C
@@ -27,6 +27,8 @@ namespace libMesh
 {
 
 
+LIBMESH_DEFAULT_VECTORIZED_FE(0,CLOUGH)
+
 
 template <>
 Real FE<0,CLOUGH>::shape(const ElemType,

--- a/src/fe/fe_clough_shape_1D.C
+++ b/src/fe/fe_clough_shape_1D.C
@@ -223,6 +223,9 @@ namespace libMesh
 {
 
 
+LIBMESH_DEFAULT_VECTORIZED_FE(1,CLOUGH)
+
+
 template <>
 Real FE<1,CLOUGH>::shape(const Elem * elem,
                          const Order order,

--- a/src/fe/fe_clough_shape_2D.C
+++ b/src/fe/fe_clough_shape_2D.C
@@ -1813,6 +1813,9 @@ namespace libMesh
 {
 
 
+LIBMESH_DEFAULT_VECTORIZED_FE(2,CLOUGH)
+
+
 template <>
 Real FE<2,CLOUGH>::shape(const Elem * elem,
                          const Order order,

--- a/src/fe/fe_clough_shape_3D.C
+++ b/src/fe/fe_clough_shape_3D.C
@@ -29,6 +29,9 @@ namespace libMesh
 {
 
 
+LIBMESH_DEFAULT_VECTORIZED_FE(3,CLOUGH)
+
+
 template <>
 Real FE<3,CLOUGH>::shape(const ElemType,
                          const Order,

--- a/src/fe/fe_hermite_shape_0D.C
+++ b/src/fe/fe_hermite_shape_0D.C
@@ -22,10 +22,12 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 
+
 namespace libMesh
 {
 
 
+LIBMESH_DEFAULT_VECTORIZED_FE(0,HERMITE)
 
 
 template <>

--- a/src/fe/fe_hermite_shape_1D.C
+++ b/src/fe/fe_hermite_shape_1D.C
@@ -24,6 +24,7 @@
 #include "libmesh/fe_interface.h"
 #include "libmesh/utility.h"
 
+
 namespace
 {
 using namespace libMesh;
@@ -74,6 +75,10 @@ void hermite_compute_coefs(const Elem * elem, Real & d1xd1x, Real & d2xd2x)
 
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(1,HERMITE)
+
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 

--- a/src/fe/fe_hermite_shape_2D.C
+++ b/src/fe/fe_hermite_shape_2D.C
@@ -24,6 +24,7 @@
 #include "libmesh/fe_interface.h"
 #include "libmesh/number_lookups.h"
 
+
 namespace
 {
 using namespace libMesh;
@@ -190,6 +191,9 @@ Real hermite_bases_2D (std::vector<unsigned int> & bases1D,
 
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(2,HERMITE)
 
 
 template <>

--- a/src/fe/fe_hermite_shape_3D.C
+++ b/src/fe/fe_hermite_shape_3D.C
@@ -24,6 +24,7 @@
 #include "libmesh/fe_interface.h"
 #include "libmesh/number_lookups.h"
 
+
 namespace
 {
 using namespace libMesh;
@@ -375,6 +376,9 @@ Real hermite_bases_3D (std::vector<unsigned int> & bases1D,
 
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(3,HERMITE)
 
 
 template <>

--- a/src/fe/fe_hierarchic_shape_0D.C
+++ b/src/fe/fe_hierarchic_shape_0D.C
@@ -24,6 +24,11 @@
 namespace libMesh
 {
 
+
+LIBMESH_DEFAULT_VECTORIZED_FE(0,HIERARCHIC)
+LIBMESH_DEFAULT_VECTORIZED_FE(0,L2_HIERARCHIC)
+
+
 template <>
 Real FE<0,L2_HIERARCHIC>::shape(const ElemType,
                                 const Order,

--- a/src/fe/fe_hierarchic_shape_1D.C
+++ b/src/fe/fe_hierarchic_shape_1D.C
@@ -21,6 +21,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/utility.h"
 
+
 // Anonymous namespace for functions shared by HIERARCHIC and
 // L2_HIERARCHIC implementations. Implementations appear at the bottom
 // of this file.
@@ -55,6 +56,11 @@ Real fe_hierarchic_1D_shape_second_deriv(const ElemType,
 
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(1,HIERARCHIC)
+LIBMESH_DEFAULT_VECTORIZED_FE(1,L2_HIERARCHIC)
+
 
 template <>
 Real FE<1,HIERARCHIC>::shape(const ElemType elem_type,

--- a/src/fe/fe_hierarchic_shape_2D.C
+++ b/src/fe/fe_hierarchic_shape_2D.C
@@ -67,6 +67,11 @@ Real fe_hierarchic_2D_shape_second_deriv(const Elem * elem,
 namespace libMesh
 {
 
+
+LIBMESH_DEFAULT_VECTORIZED_FE(2,HIERARCHIC)
+LIBMESH_DEFAULT_VECTORIZED_FE(2,L2_HIERARCHIC)
+
+
 template <>
 Real FE<2,HIERARCHIC>::shape(const ElemType,
                              const Order,

--- a/src/fe/fe_hierarchic_shape_3D.C
+++ b/src/fe/fe_hierarchic_shape_3D.C
@@ -21,6 +21,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/number_lookups.h"
 
+
 // Anonymous namespace for functions shared by HIERARCHIC and
 // L2_HIERARCHIC implementations. Implementations appear at the bottom
 // of this file.
@@ -667,6 +668,11 @@ void cube_indices(const Elem * elem,
 
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(3,HIERARCHIC)
+LIBMESH_DEFAULT_VECTORIZED_FE(3,L2_HIERARCHIC)
+
 
 template <>
 Real FE<3,HIERARCHIC>::shape(const ElemType,

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -807,6 +807,49 @@ void FEInterface::shape<Real>(const unsigned int dim,
   return;
 }
 
+
+template<>
+void FEInterface::shapes<Real>(const unsigned int dim,
+                               const FEType & fe_t,
+                               const Elem * elem,
+                               const unsigned int i,
+                               const std::vector<Point> & p,
+                               std::vector<Real> & phi)
+{
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+  if (elem && is_InfFE_elem(elem->type()))
+    {
+      for (auto qpi : index_range(p))
+        phi[qpi] = ifem_shape(dim, fe_t, elem, i, p[qpi]);
+      return;
+    }
+#endif
+
+  const Order o = fe_t.order;
+
+  switch(dim)
+    {
+    case 0:
+      fe_scalar_vec_error_switch(0, shapes(elem,o,i,p,phi), , ; return;);
+      break;
+    case 1:
+      fe_scalar_vec_error_switch(1, shapes(elem,o,i,p,phi), , ; return;);
+      break;
+    case 2:
+      fe_scalar_vec_error_switch(2, shapes(elem,o,i,p,phi), , ; return;);
+      break;
+    case 3:
+      fe_scalar_vec_error_switch(3, shapes(elem,o,i,p,phi), , ; return;);
+      break;
+    default:
+      libmesh_error_msg("Invalid dimension = " << dim);
+    }
+
+  return;
+}
+
+
 template<>
 void FEInterface::shape<RealGradient>(const unsigned int dim,
                                       const FEType & fe_t,
@@ -844,6 +887,46 @@ void FEInterface::shape<RealGradient>(const unsigned int dim,
 
   return;
 }
+
+
+template<>
+void FEInterface::shapes<RealGradient>(const unsigned int dim,
+                                       const FEType & fe_t,
+                                       const Elem * elem,
+                                       const unsigned int i,
+                                       const std::vector<Point> & p,
+                                       std::vector<RealGradient> & phi)
+{
+
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+  if (elem->infinite())
+    libmesh_not_implemented();
+  // This is actually an issue for infinite elements: They require type 'Gradient'!
+#endif
+
+  const Order o = fe_t.order;
+
+  switch(dim)
+    {
+    case 0:
+      fe_vector_scalar_error_switch(0, shapes(elem,o,i,p,phi), , ; return;);
+      break;
+    case 1:
+      fe_vector_scalar_error_switch(1, shapes(elem,o,i,p,phi), , ; return;);
+      break;
+    case 2:
+      fe_vector_scalar_error_switch(2, shapes(elem,o,i,p,phi), , ; return;);
+      break;
+    case 3:
+      fe_vector_scalar_error_switch(3, shapes(elem,o,i,p,phi), , ; return;);
+      break;
+    default:
+      libmesh_error_msg("Invalid dimension = " << dim);
+    }
+
+  return;
+}
+
 
 FEInterface::shape_ptr
 FEInterface::shape_function(const unsigned int dim,

--- a/src/fe/fe_lagrange_shape_0D.C
+++ b/src/fe/fe_lagrange_shape_0D.C
@@ -20,8 +20,14 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 
+
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(0,LAGRANGE)
+LIBMESH_DEFAULT_VECTORIZED_FE(0,L2_LAGRANGE)
+
 
 template <>
 Real FE<0,L2_LAGRANGE>::shape(const ElemType,

--- a/src/fe/fe_lagrange_shape_1D.C
+++ b/src/fe/fe_lagrange_shape_1D.C
@@ -21,8 +21,14 @@
 #include "libmesh/elem.h"
 #include "libmesh/fe_lagrange_shape_1D.h"
 
+
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(1,LAGRANGE)
+LIBMESH_DEFAULT_VECTORIZED_FE(1,L2_LAGRANGE)
+
 
 template <>
 Real FE<1,LAGRANGE>::shape(const ElemType,

--- a/src/fe/fe_lagrange_shape_2D.C
+++ b/src/fe/fe_lagrange_shape_2D.C
@@ -21,6 +21,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/fe_lagrange_shape_1D.h"
 
+
 // Anonymous namespace for functions shared by LAGRANGE and
 // L2_LAGRANGE implementations. Implementations appear at the bottom
 // of this file.
@@ -55,6 +56,11 @@ Real fe_lagrange_2D_shape_second_deriv(const ElemType type,
 
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(2,LAGRANGE)
+LIBMESH_DEFAULT_VECTORIZED_FE(2,L2_LAGRANGE)
+
 
 template <>
 Real FE<2,LAGRANGE>::shape(const ElemType type,

--- a/src/fe/fe_lagrange_shape_3D.C
+++ b/src/fe/fe_lagrange_shape_3D.C
@@ -21,6 +21,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/fe_lagrange_shape_1D.h"
 
+
 // Anonymous namespace for functions shared by LAGRANGE and
 // L2_LAGRANGE implementations. Implementations appear at the bottom
 // of this file.
@@ -53,6 +54,11 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
 
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(3,LAGRANGE)
+LIBMESH_DEFAULT_VECTORIZED_FE(3,L2_LAGRANGE)
+
 
 template <>
 Real FE<3,LAGRANGE>::shape(const ElemType type,

--- a/src/fe/fe_lagrange_vec.C
+++ b/src/fe/fe_lagrange_vec.C
@@ -24,8 +24,16 @@
 #include "libmesh/elem.h"
 #include "libmesh/tensor_value.h"
 
+
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(0,LAGRANGE_VEC)
+LIBMESH_DEFAULT_VECTORIZED_FE(1,LAGRANGE_VEC)
+LIBMESH_DEFAULT_VECTORIZED_FE(2,LAGRANGE_VEC)
+LIBMESH_DEFAULT_VECTORIZED_FE(3,LAGRANGE_VEC)
+
 
 // ------------------------------------------------------------
 // Lagrange-specific implementations

--- a/src/fe/fe_monomial_shape_0D.C
+++ b/src/fe/fe_monomial_shape_0D.C
@@ -22,10 +22,12 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 
+
 namespace libMesh
 {
 
 
+LIBMESH_DEFAULT_VECTORIZED_FE(0,MONOMIAL)
 
 
 template <>

--- a/src/fe/fe_monomial_shape_1D.C
+++ b/src/fe/fe_monomial_shape_1D.C
@@ -22,10 +22,12 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 
+
 namespace libMesh
 {
 
 
+LIBMESH_DEFAULT_VECTORIZED_FE(1,MONOMIAL)
 
 
 template <>

--- a/src/fe/fe_monomial_shape_2D.C
+++ b/src/fe/fe_monomial_shape_2D.C
@@ -22,10 +22,12 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 
+
 namespace libMesh
 {
 
 
+LIBMESH_DEFAULT_VECTORIZED_FE(2,MONOMIAL)
 
 
 template <>

--- a/src/fe/fe_monomial_shape_3D.C
+++ b/src/fe/fe_monomial_shape_3D.C
@@ -22,10 +22,12 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 
+
 namespace libMesh
 {
 
 
+LIBMESH_DEFAULT_VECTORIZED_FE(3,MONOMIAL)
 
 
 template <>

--- a/src/fe/fe_monomial_vec.C
+++ b/src/fe/fe_monomial_vec.C
@@ -22,8 +22,16 @@
 #include "libmesh/elem.h"
 #include "libmesh/tensor_value.h"
 
+
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(0,MONOMIAL_VEC)
+LIBMESH_DEFAULT_VECTORIZED_FE(1,MONOMIAL_VEC)
+LIBMESH_DEFAULT_VECTORIZED_FE(2,MONOMIAL_VEC)
+LIBMESH_DEFAULT_VECTORIZED_FE(3,MONOMIAL_VEC)
+
 
 // ------------------------------------------------------------
 // Vector monomial specific implementations

--- a/src/fe/fe_nedelec_one.C
+++ b/src/fe/fe_nedelec_one.C
@@ -25,8 +25,16 @@
 #include "libmesh/tensor_value.h"
 #include "libmesh/enum_to_string.h"
 
+
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(0,NEDELEC_ONE)
+LIBMESH_DEFAULT_VECTORIZED_FE(1,NEDELEC_ONE)
+LIBMESH_DEFAULT_VECTORIZED_FE(2,NEDELEC_ONE)
+LIBMESH_DEFAULT_VECTORIZED_FE(3,NEDELEC_ONE)
+
 
 // Anonymous namespace for local helper functions
 namespace {

--- a/src/fe/fe_rational_shape_0D.C
+++ b/src/fe/fe_rational_shape_0D.C
@@ -23,9 +23,11 @@
 #include "libmesh/elem.h"
 
 
-
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(0,RATIONAL_BERNSTEIN)
 
 
 template <>

--- a/src/fe/fe_rational_shape_1D.C
+++ b/src/fe/fe_rational_shape_1D.C
@@ -35,6 +35,10 @@ static const libMesh::FEFamily _underlying_fe_family = libMesh::BERNSTEIN;
 namespace libMesh
 {
 
+
+LIBMESH_DEFAULT_VECTORIZED_FE(1,RATIONAL_BERNSTEIN)
+
+
 template <>
 Real FE<1,RATIONAL_BERNSTEIN>::shape(const Elem * elem,
                                      const Order order,

--- a/src/fe/fe_rational_shape_2D.C
+++ b/src/fe/fe_rational_shape_2D.C
@@ -33,6 +33,10 @@ static const libMesh::FEFamily _underlying_fe_family = libMesh::BERNSTEIN;
 namespace libMesh
 {
 
+
+LIBMESH_DEFAULT_VECTORIZED_FE(2,RATIONAL_BERNSTEIN)
+
+
 template <>
 Real FE<2,RATIONAL_BERNSTEIN>::shape(const Elem * elem,
                                      const Order order,

--- a/src/fe/fe_rational_shape_3D.C
+++ b/src/fe/fe_rational_shape_3D.C
@@ -34,6 +34,9 @@ namespace libMesh
 {
 
 
+LIBMESH_DEFAULT_VECTORIZED_FE(3,RATIONAL_BERNSTEIN)
+
+
 template <>
 Real FE<3,RATIONAL_BERNSTEIN>::shape(const Elem * elem,
                                      const Order order,

--- a/src/fe/fe_scalar_shape_0D.C
+++ b/src/fe/fe_scalar_shape_0D.C
@@ -22,8 +22,13 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 
+
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(0,SCALAR)
+
 
 template <>
 Real FE<0,SCALAR>::shape(const ElemType,

--- a/src/fe/fe_scalar_shape_1D.C
+++ b/src/fe/fe_scalar_shape_1D.C
@@ -22,8 +22,13 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 
+
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(1,SCALAR)
+
 
 template <>
 Real FE<1,SCALAR>::shape(const ElemType,

--- a/src/fe/fe_scalar_shape_2D.C
+++ b/src/fe/fe_scalar_shape_2D.C
@@ -22,8 +22,13 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 
+
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(2,SCALAR)
+
 
 template <>
 Real FE<2,SCALAR>::shape(const ElemType,

--- a/src/fe/fe_scalar_shape_3D.C
+++ b/src/fe/fe_scalar_shape_3D.C
@@ -22,8 +22,13 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 
+
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(3,SCALAR)
+
 
 template <>
 Real FE<3,SCALAR>::shape(const ElemType,

--- a/src/fe/fe_subdivision_2D.C
+++ b/src/fe/fe_subdivision_2D.C
@@ -30,6 +30,10 @@
 namespace libMesh
 {
 
+
+LIBMESH_DEFAULT_VECTORIZED_FE(2,SUBDIVISION)
+
+
 FESubdivision::FESubdivision(const FEType & fet) :
   FE<2,SUBDIVISION>(fet)
 {

--- a/src/fe/fe_szabab_shape_0D.C
+++ b/src/fe/fe_szabab_shape_0D.C
@@ -22,10 +22,12 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 
+
 namespace libMesh
 {
 
 
+LIBMESH_DEFAULT_VECTORIZED_FE(0,SZABAB)
 
 
 template <>

--- a/src/fe/fe_szabab_shape_1D.C
+++ b/src/fe/fe_szabab_shape_1D.C
@@ -27,8 +27,12 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 
+
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(1,SZABAB)
 
 
 template <>

--- a/src/fe/fe_szabab_shape_2D.C
+++ b/src/fe/fe_szabab_shape_2D.C
@@ -50,6 +50,9 @@ namespace libMesh
 {
 
 
+LIBMESH_DEFAULT_VECTORIZED_FE(2,SZABAB)
+
+
 template <>
 Real FE<2,SZABAB>::shape(const Elem * elem,
                          const Order order,

--- a/src/fe/fe_szabab_shape_3D.C
+++ b/src/fe/fe_szabab_shape_3D.C
@@ -24,8 +24,12 @@
 
 #include "libmesh/fe.h"
 
+
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(3,SZABAB)
 
 
 template <>

--- a/src/fe/fe_xyz_shape_0D.C
+++ b/src/fe/fe_xyz_shape_0D.C
@@ -22,10 +22,12 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 
+
 namespace libMesh
 {
 
 
+LIBMESH_DEFAULT_VECTORIZED_FE(0,XYZ)
 
 
 template <>

--- a/src/fe/fe_xyz_shape_1D.C
+++ b/src/fe/fe_xyz_shape_1D.C
@@ -23,9 +23,12 @@
 #include "libmesh/elem.h"
 
 
-
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(1,XYZ)
+
 
 template <>
 Real FE<1,XYZ>::shape(const Elem * elem,

--- a/src/fe/fe_xyz_shape_2D.C
+++ b/src/fe/fe_xyz_shape_2D.C
@@ -23,9 +23,12 @@
 #include "libmesh/elem.h"
 
 
-
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(2,XYZ)
+
 
 template <>
 Real FE<2,XYZ>::shape(const Elem * elem,

--- a/src/fe/fe_xyz_shape_3D.C
+++ b/src/fe/fe_xyz_shape_3D.C
@@ -23,9 +23,11 @@
 #include "libmesh/elem.h"
 
 
-
 namespace libMesh
 {
+
+
+LIBMESH_DEFAULT_VECTORIZED_FE(3,XYZ)
 
 
 template <>

--- a/src/fe/h1_fe_transformation.C
+++ b/src/fe/h1_fe_transformation.C
@@ -55,51 +55,10 @@ void H1FETransformation<OutputShape>::map_phi( const unsigned int dim,
                                                const FEGenericBase<OutputShape> & fe,
                                                std::vector<std::vector<OutputShape>> & phi ) const
 {
-  switch(dim)
+  for (auto i : index_range(phi))
     {
-    case 0:
-      {
-        for (auto i : index_range(phi))
-          {
-            libmesh_assert_equal_to ( qp.size(), phi[i].size() );
-            for (auto p : index_range(phi[i]))
-              FEInterface::shape<OutputShape>(0, fe.get_fe_type(), elem, i, qp[p], phi[i][p]);
-          }
-        break;
-      }
-    case 1:
-      {
-        for (auto i : index_range(phi))
-          {
-            libmesh_assert_equal_to ( qp.size(), phi[i].size() );
-            for (auto p : index_range(phi[i]))
-              FEInterface::shape<OutputShape>(1, fe.get_fe_type(), elem, i, qp[p], phi[i][p]);
-          }
-        break;
-      }
-    case 2:
-      {
-        for (auto i : index_range(phi))
-          {
-            libmesh_assert_equal_to ( qp.size(), phi[i].size() );
-            for (auto p : index_range(phi[i]))
-              FEInterface::shape<OutputShape>(2, fe.get_fe_type(), elem, i, qp[p], phi[i][p]);
-          }
-        break;
-      }
-    case 3:
-      {
-        for (auto i : index_range(phi))
-          {
-            libmesh_assert_equal_to ( qp.size(), phi[i].size() );
-            for (auto p : index_range(phi[i]))
-              FEInterface::shape<OutputShape>(3, fe.get_fe_type(), elem, i, qp[p], phi[i][p]);
-          }
-        break;
-      }
-
-    default:
-      libmesh_error_msg("Invalid dim = " << dim);
+      libmesh_assert_equal_to ( qp.size(), phi[i].size() );
+      FEInterface::shapes<OutputShape>(dim, fe.get_fe_type(), elem, i, qp, phi[i]);
     }
 }
 


### PR DESCRIPTION
I intend to actually start trying to *optimize* the vectorized forms of these functions at some point, but as soon as I used FEInterface::shapes in H1FETransformation I saw a 10% speedup in one benchmark (just by avoiding so many redundant switch statements), so let's get the easy win merged ASAP and continue on the harder stuff afterward.