### PR TITLE
More avoiding of serialization

### DIFF
--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -2131,7 +2131,7 @@ void DofMap::enforce_constraints_exactly (const System & system,
       v_built->init (v->size(), v->local_size(),
                      this->get_send_list(), true,
                      GHOSTED);
-      v->localize(*v_built);
+      v->localize(*v_built, this->get_send_list());
       v_built->close();
       v_local = v_built.get();
 
@@ -2210,7 +2210,7 @@ void DofMap::enforce_constraints_on_residual (const NonlinearImplicitSystem & sy
       solution_built = NumericVector<Number>::build(this->comm());
       solution_built->init (solution->size(), solution->local_size(),
                             this->get_send_list(), true, GHOSTED);
-      solution->localize(*solution_built);
+      solution->localize(*solution_built, this->get_send_list());
       solution_built->close();
       solution_local = solution_built.get();
     }
@@ -2307,7 +2307,7 @@ void DofMap::enforce_adjoint_constraints_exactly (NumericVector<Number> & v,
       v_built = NumericVector<Number>::build(this->comm());
       v_built->init (v.size(), v.local_size(),
                      this->get_send_list(), true, GHOSTED);
-      v.localize(*v_built);
+      v.localize(*v_built, this->get_send_list());
       v_built->close();
       v_local = v_built.get();
 


### PR DESCRIPTION
@fdkong caught one incomplete fix in #2446, and while looking for similar failures I found a more extreme example remaining to be fixed in project_vector.  This PR corrects both.

I don't see much difference on small problems on 16 cores, but of course in theory the inefficiency here should have been getting asymptotically worse as problem size and processor count increase.