### PR TITLE
DMSetDefaultSection was still DMSetSection in 3.9

### DIFF
--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -523,7 +523,7 @@ namespace libMesh
 
         // Build the PetscSection and attach it to the DM
         this->build_section(system, section);
-#if PETSC_VERSION_LESS_THAN(3,9,0)
+#if PETSC_VERSION_LESS_THAN(3,10,0)
         ierr = DMSetDefaultSection(dm, section);
 #else
         ierr = DMSetSection(dm, section);


### PR DESCRIPTION
See
https://www.mcs.anl.gov/petsc/petsc-3.9/docs/manualpages/DM/index.html
versus
https://www.mcs.anl.gov/petsc/petsc-3.10/docs/manualpages/DM/index.html

This just bit me on an older system.