### PR TITLE
 Forward declare BoundaryInfo in mesh_base.h

### DIFF
--- a/examples/fem_system/fem_system_ex3/elasticity_system.C
+++ b/examples/fem_system/fem_system_ex3/elasticity_system.C
@@ -26,6 +26,7 @@
 #include "libmesh/quadrature.h"
 #include "libmesh/unsteady_solver.h"
 #include "libmesh/parallel_implementation.h" // set_union
+#include "libmesh/boundary_info.h"
 
 using namespace libMesh;
 

--- a/examples/miscellaneous/miscellaneous_ex9/augment_sparsity_on_interface.C
+++ b/examples/miscellaneous/miscellaneous_ex9/augment_sparsity_on_interface.C
@@ -3,6 +3,7 @@
 
 // libMesh includes
 #include "libmesh/elem.h"
+#include "libmesh/boundary_info.h"
 
 using namespace libMesh;
 

--- a/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.C
@@ -23,6 +23,7 @@
 #include "libmesh/fe_compute_data.h"
 #include "libmesh/petsc_matrix.h"
 #include "libmesh/edge_edge2.h"
+#include "libmesh/boundary_info.h"
 
 // The nonlinear solver and system we will be using
 #include "libmesh/nonlinear_solver.h"

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -21,7 +21,6 @@
 #define LIBMESH_MESH_BASE_H
 
 // Local Includes
-#include "libmesh/boundary_info.h"
 #include "libmesh/dof_object.h" // for invalid_processor_id
 #include "libmesh/int_range.h"
 #include "libmesh/libmesh_common.h"
@@ -55,6 +54,7 @@ class GhostingFunctor;
 class Node;
 class Point;
 class Partitioner;
+class BoundaryInfo;
 
 template <class MT>
 class MeshInput;

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -22,7 +22,6 @@
 
 // Local Includes
 #include "libmesh/unstructured_mesh.h"
-#include "libmesh/boundary_info.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // C++ Includes

--- a/src/base/periodic_boundaries.C
+++ b/src/base/periodic_boundaries.C
@@ -25,6 +25,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/periodic_boundary.h"
 #include "libmesh/mesh_base.h"
+#include "libmesh/boundary_info.h"
 
 namespace libMesh
 {

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -130,10 +130,7 @@ BoundaryInfo & BoundaryInfo::operator=(const BoundaryInfo & other_boundary_info)
 }
 
 
-BoundaryInfo::~BoundaryInfo()
-{
-  this->clear();
-}
+BoundaryInfo::~BoundaryInfo() = default;
 
 
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -34,6 +34,7 @@
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/int_range.h"
 #include "libmesh/utility.h"
+#include "libmesh/boundary_info.h"
 
 #ifdef DEBUG
 #  include "libmesh/remote_elem.h"

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -33,6 +33,7 @@
 #include "libmesh/cell_tet10.h"
 #include "libmesh/cell_prism6.h"
 #include "libmesh/utility.h"
+#include "libmesh/boundary_info.h"
 
 // C++ includes
 #include <array>

--- a/tests/mesh/all_tri.C
+++ b/tests/mesh/all_tri.C
@@ -3,6 +3,7 @@
 #include <libmesh/elem.h>
 #include <libmesh/mesh_generation.h>
 #include <libmesh/mesh_modification.h>
+#include <libmesh/boundary_info.h>
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"

--- a/tests/mesh/boundary_mesh.C
+++ b/tests/mesh/boundary_mesh.C
@@ -4,6 +4,7 @@
 #include <libmesh/remote_elem.h>
 #include <libmesh/replicated_mesh.h>
 #include <libmesh/auto_ptr.h> // libmesh_make_unique
+#include <libmesh/boundary_info.h>
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -30,6 +30,7 @@
 #include <libmesh/cell_hex20.h>
 #include <libmesh/cell_hex27.h>
 #include <libmesh/cell_tet10.h>
+#include <libmesh/boundary_info.h>
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"


### PR DESCRIPTION
I noticed while working on #2458 that touching boundary_info.h causes dozens of files to recompile, but it doesn't seem like that should be necessary... I'm guessing that this may break some downstream apps, but hopefully that shouldn't be too hard to fix.
