### PR TITLE
More direct boundary_info.h inclusions

### DIFF
--- a/src/mesh/mesh_tetgen_interface.C
+++ b/src/mesh/mesh_tetgen_interface.C
@@ -23,10 +23,12 @@
 #include <sstream>
 
 // Local includes
+#include "libmesh/mesh_tetgen_interface.h"
+
+#include "libmesh/boundary_info.h"
 #include "libmesh/cell_tet4.h"
 #include "libmesh/face_tri3.h"
 #include "libmesh/unstructured_mesh.h"
-#include "libmesh/mesh_tetgen_interface.h"
 #include "libmesh/utility.h" // binary_find
 #include "libmesh/mesh_tetgen_wrapper.h"
 

--- a/src/mesh/mesh_triangle_wrapper.C
+++ b/src/mesh/mesh_triangle_wrapper.C
@@ -22,11 +22,13 @@
 
 // Local includes
 #include "libmesh/mesh_triangle_wrapper.h"
-#include "libmesh/unstructured_mesh.h"
-#include "libmesh/point.h"
+
+#include "libmesh/boundary_info.h"
+#include "libmesh/enum_elem_type.h"
 #include "libmesh/face_tri3.h"
 #include "libmesh/face_tri6.h"
-#include "libmesh/enum_elem_type.h"
+#include "libmesh/point.h"
+#include "libmesh/unstructured_mesh.h"
 
 namespace libMesh
 {


### PR DESCRIPTION
This fixes a couple bugs introduced by #2465

Testing must have missed these before because they were disabled by the
default LGPL-compatiblity setting.