### PR TITLE
Delete old DofObject only if it exists

### DIFF
--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -141,8 +141,11 @@ DofObject & DofObject::operator= (const DofObject & dof_obj)
 
 void  DofObject::clear_old_dof_object ()
 {
-  delete this->old_dof_object;
-  this->old_dof_object = nullptr;
+  if (this->old_dof_object)
+  {
+    delete this->old_dof_object;
+    this->old_dof_object = nullptr;
+  }
 }
 
 


### PR DESCRIPTION
Closes #2468

I hit an issue with the `clear_old_dof_object()` call when using a vector of `Node` in an unusual way.