### PR TITLE
Enable Exodus II IO to load elemental variables into element IDs

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -304,6 +304,13 @@ public:
                      std::vector<std::map<BoundaryInfo::BCTuple, Real>> & bc_vals);
 
   /**
+   * Set the elemental variables in the Exodus file that to be read into extra
+   * element integers. The names of these elemental variables will be used to
+   * name the extra element integers.
+   */
+  void set_reading_extra_integer_vars(const std::vector<std::string> & extra_integer_vars);
+
+  /**
    * Sets the list of variable names to be included in the output.
    * This is _optional_.  If this is never called then all variables
    * will be present. If this is called and an empty vector is supplied
@@ -417,6 +424,13 @@ private:
    */
   bool _append;
 #endif
+
+  /**
+   * An optional list of variables in the EXODUS file that are
+   * to be used to set extra integers when loading the file into a mesh.
+   * The variable names will be used to name the extra integers.
+   */
+  std::vector<std::string> _extra_integer_vars;
 
   /**
    * The names of the variables to be output.

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -304,11 +304,11 @@ public:
                      std::vector<std::map<BoundaryInfo::BCTuple, Real>> & bc_vals);
 
   /**
-   * Set the elemental variables in the Exodus file that to be read into extra
+   * Set the elemental variables in the Exodus file to be read into extra
    * element integers. The names of these elemental variables will be used to
    * name the extra element integers.
    */
-  void set_reading_extra_integer_vars(const std::vector<std::string> & extra_integer_vars);
+  void set_extra_integer_vars(const std::vector<std::string> & extra_integer_vars);
 
   /**
    * Sets the list of variable names to be included in the output.

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -69,7 +69,7 @@ ExodusII_IO::ExodusII_IO (MeshBase & mesh,
 {
 }
 
-void ExodusII_IO::set_reading_extra_integer_vars(const std::vector<std::string> & extra_integer_vars)
+void ExodusII_IO::set_extra_integer_vars(const std::vector<std::string> & extra_integer_vars)
 {
   _extra_integer_vars = extra_integer_vars;
 }

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -69,6 +69,10 @@ ExodusII_IO::ExodusII_IO (MeshBase & mesh,
 {
 }
 
+void ExodusII_IO::set_reading_extra_integer_vars(const std::vector<std::string> & extra_integer_vars)
+{
+  _extra_integer_vars = extra_integer_vars;
+}
 
 void ExodusII_IO::set_output_variables(const std::vector<std::string> & output_variables,
                                        bool allow_empty)
@@ -146,6 +150,11 @@ void ExodusII_IO::read (const std::string & fname)
   // Get a reference to the mesh we are reading
   MeshBase & mesh = MeshInput<MeshBase>::mesh();
 
+  // Add extra integers into the mesh
+  std::vector<unsigned int> extra_ids;
+  for (auto & name : _extra_integer_vars)
+    extra_ids.push_back(mesh.add_elem_integer(name));
+
   // Clear any existing mesh data
   mesh.clear();
 
@@ -212,6 +221,14 @@ void ExodusII_IO::read (const std::string & fname)
   // an elem_num_map, the identity map is returned by this call.
   exio_helper->read_elem_num_map();
 
+  // Read variables for extra integer IDs
+  std::vector<std::map<dof_id_type, Real>> elem_ids(extra_ids.size());
+  // We use the last time step to load the IDs
+  exio_helper->read_num_time_steps();
+  unsigned int last_step = exio_helper->num_time_steps;
+  for (unsigned int i = 0; i < extra_ids.size(); i++)
+    exio_helper->read_elemental_var_values(_extra_integer_vars[i], last_step, elem_ids[i]);
+
   // Read in the element connectivity for each block.
   int nelem_last_block = 0;
 
@@ -262,6 +279,10 @@ void ExodusII_IO::read (const std::string & fname)
                               << " which is different from the (zero-based) Exodus ID " \
                               << exodus_id-1                            \
                               << "!");
+
+          // Assign extra integer IDs
+          for (auto & id : extra_ids)
+            elem->set_extra_integer(id, std::round(elem_ids[id][elem->id()]));
 
           // Set all the nodes for this element
           for (int k=0; k<exio_helper->num_nodes_per_elem; k++)


### PR DESCRIPTION
Close #2470.

Note that I did not have a test in libMesh (will be adding one in MOOSE). If I have to add one, please just let me know.

Another thing is that `NameBasedIO` does not take extra arguments, so when using this capability, users will have to directly construct `ExodusII_IO`. I thought of using naming conventions like any elemental variables in Exodus file with name like `[anything]_id` will be loaded automatically, but thought that may not be a good idea (for example if later a user want to add an extra integer in the same name, there could some implications).