### PR TITLE
Add allow_find_neighbors APIs to MeshBase

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1066,6 +1066,13 @@ public:
   bool allow_renumbering() const { return !_skip_renumber_nodes_and_elements; }
 
   /**
+   * If \p false is passed then this mesh will no longer work to find element
+   * neighbors when being prepared for use
+   */
+  void allow_find_neighbors(bool allow) { _skip_find_neighbors = !allow; }
+  bool allow_find_neighbors() const { return !_skip_find_neighbors; }
+
+  /**
    * If false is passed in then this mesh will no longer have remote
    * elements deleted when being prepared for use; i.e. even a
    * DistributedMesh will remain (if it is already) serialized.
@@ -1784,6 +1791,11 @@ protected:
    * This is set when prepare_for_use() is called.
    */
   bool _skip_renumber_nodes_and_elements;
+
+  /**
+   * If this is \p true then we will skip \p find_neighbors in \p prepare_for_use
+   */
+  bool _skip_find_neighbors;
 
   /**
    * If this is false then even on DistributedMesh remote elements

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1016,13 +1016,17 @@ public:
    *  4.) call \p cache_elem_dims()
    *
    * The argument to skip renumbering is now deprecated - to prevent a
-   * mesh from being renumbered, set allow_renumbering(false).
+   * mesh from being renumbered, set allow_renumbering(false). The argument to skip
+   * finding neighbors is also deprecated. To prevent find_neighbors, set
+   * allow_find_neighbors(false)
    *
    * If this is a distributed mesh, local copies of remote elements
    * will be deleted here - to keep those elements replicated during
    * preparation, set allow_remote_element_removal(false).
    */
-  void prepare_for_use (const bool skip_renumber_nodes_and_elements=false, const bool skip_find_neighbors=false);
+  void prepare_for_use (const bool skip_renumber_nodes_and_elements, const bool skip_find_neighbors);
+  void prepare_for_use (const bool skip_renumber_nodes_and_elements);
+  void prepare_for_use ();
 
   /**
    * Call the default partitioner (currently \p metis_partition()).

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -307,7 +307,8 @@ void BoundaryInfo::sync (const std::set<boundary_id_type> & requested_boundary_i
   boundary_mesh.partitioner().reset(nullptr);
 
   // Make boundary_mesh nodes and elements contiguous
-  boundary_mesh.prepare_for_use(/*skip_renumber =*/ false);
+  boundary_mesh.allow_find_neighbors(true);
+  boundary_mesh.prepare_for_use();
 
   // and finally distribute element partitioning to the nodes
   Partitioner::set_node_processor_ids(boundary_mesh);

--- a/src/mesh/gmv_io.C
+++ b/src/mesh/gmv_io.C
@@ -2020,6 +2020,7 @@ void GMVIO::read (const std::string & name)
   // other parts of the simulation which rely on the original
   // ordering.
   mesh.allow_renumbering(false);
+  mesh.allow_find_neighbors(true);
   mesh.prepare_for_use();
 #endif
 }

--- a/src/mesh/inf_elem_builder.C
+++ b/src/mesh/inf_elem_builder.C
@@ -63,7 +63,8 @@ const Point InfElemBuilder::build_inf_elem(bool be_verbose)
   // when finished with building the Ifems,
   // it remains to prepare the mesh for use:
   // find neighbors (again), partition (if needed)...
-  this->_mesh.prepare_for_use (/*skip_renumber =*/ false);
+  this->_mesh.allow_find_neighbors(true);
+  this->_mesh.prepare_for_use ();
 
   return origin;
 }
@@ -259,7 +260,8 @@ const Point InfElemBuilder::build_inf_elem (const InfElemOriginValue & origin_x,
   // when finished with building the Ifems,
   // it remains to prepare the mesh for use:
   // find neighbors again, partition (if needed)...
-  this->_mesh.prepare_for_use (/*skip_renumber =*/ false);
+  this->_mesh.allow_find_neighbors(true);
+  this->_mesh.prepare_for_use ();
 
   return origin;
 }

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -321,7 +321,13 @@ void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, con
 {
   libmesh_deprecated();
 
-  this->allow_renumbering(!skip_renumber_nodes_and_elements);
+  // We only respect the users wish if they tell us to skip renumbering. If they tell us not to
+  // skip renumbering but someone previously called allow_renumbering(false), then the latter takes
+  // precedence
+  if (skip_renumber_nodes_and_elements)
+    this->allow_renumbering(false);
+
+  // We always accept the user's value for skip_find_neighbors, in contrast to skip_renumber
   this->allow_find_neighbors(!skip_find_neighbors);
 
   this->prepare_for_use();
@@ -331,7 +337,11 @@ void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements)
 {
   libmesh_deprecated();
 
-  this->allow_renumbering(!skip_renumber_nodes_and_elements);
+  // We only respect the users wish if they tell us to skip renumbering. If they tell us not to
+  // skip renumbering but someone previously called allow_renumbering(false), then the latter takes
+  // precedence
+  if (skip_renumber_nodes_and_elements)
+    this->allow_renumbering(false);
 
   this->prepare_for_use();
 }

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -319,6 +319,25 @@ bool MeshBase::has_node_integer(const std::string & name) const
 
 void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, const bool skip_find_neighbors)
 {
+  libmesh_deprecated();
+
+  this->allow_renumbering(!skip_renumber_nodes_and_elements);
+  this->allow_find_neighbors(!skip_find_neighbors);
+
+  this->prepare_for_use();
+}
+
+void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements)
+{
+  libmesh_deprecated();
+
+  this->allow_renumbering(!skip_renumber_nodes_and_elements);
+
+  this->prepare_for_use();
+}
+
+void MeshBase::prepare_for_use ()
+{
   LOG_SCOPE("prepare_for_use()", "MeshBase");
 
   parallel_object_only();
@@ -337,26 +356,11 @@ void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, con
   // Renumber the nodes and elements so that they in contiguous
   // blocks.  By default, _skip_renumber_nodes_and_elements is false.
   //
-  // We may currently change that by passing
-  // skip_renumber_nodes_and_elements==true to this function, but we
-  // should use the allow_renumbering() accessor instead.
-  //
   // Instances where you if prepare_for_use() should not renumber the nodes
   // and elements include reading in e.g. an xda/r or gmv file. In
   // this case, the ordering of the nodes may depend on an accompanying
   // solution, and the node ordering cannot be changed.
 
-  if (skip_renumber_nodes_and_elements)
-    {
-      libmesh_deprecated();
-      this->allow_renumbering(false);
-    }
-
-  if (skip_find_neighbors)
-  {
-    libmesh_deprecated();
-    this->allow_find_neighbors(false);
-  }
 
   // Mesh modification operations might not leave us with consistent
   // id counts, but our partitioner might need that consistency.

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1228,8 +1228,9 @@ void MeshCommunication::gather (const processor_id_type root_id, DistributedMesh
   // Inform new elements of their neighbors,
   // while resetting all remote_elem links on
   // the ranks which did the gather.
-  mesh.find_neighbors(root_id == DofObject::invalid_processor_id ||
-                      root_id == mesh.processor_id());
+  if (mesh.allow_find_neighbors())
+    mesh.find_neighbors(root_id == DofObject::invalid_processor_id ||
+                        root_id == mesh.processor_id());
 
   // All done, but let's make sure it's done correctly
 

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -1406,7 +1406,8 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
 
 
   // Done building the mesh.  Now prepare it for use.
-  mesh.prepare_for_use (/*skip_renumber =*/ false);
+  mesh.allow_find_neighbors(true);
+  mesh.prepare_for_use ();
 }
 
 
@@ -1936,7 +1937,8 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
 
 
   // Done building the mesh.  Now prepare it for use.
-  mesh.prepare_for_use(/*skip_renumber =*/ false);
+  mesh.allow_find_neighbors(true);
+  mesh.prepare_for_use();
 }
 
 #endif // #ifndef LIBMESH_ENABLE_AMR
@@ -2261,7 +2263,8 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
   STOP_LOG("build_extrusion()", "MeshTools::Generation");
 
   // Done building the mesh.  Now prepare it for use.
-  mesh.prepare_for_use(/*skip_renumber =*/ false);
+  mesh.allow_find_neighbors(true);
+  mesh.prepare_for_use();
 }
 
 

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1100,7 +1100,8 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
 
 
   // Prepare the newly created mesh for use.
-  mesh.prepare_for_use(/*skip_renumber =*/ false);
+  mesh.allow_find_neighbors(true);
+  mesh.prepare_for_use();
 
   // Let the new_elements and new_bndry_elements vectors go out of scope.
 }
@@ -1368,7 +1369,8 @@ void MeshTools::Modification::flatten(MeshBase & mesh)
                                       saved_bc_ids[e]);
 
   // Trim unused and renumber nodes and elements
-  mesh.prepare_for_use(/*skip_renumber =*/ false);
+  mesh.allow_find_neighbors(true);
+  mesh.prepare_for_use();
 }
 #endif // #ifdef LIBMESH_ENABLE_AMR
 

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -574,7 +574,8 @@ bool MeshRefinement::refine_and_coarsen_elements ()
       _mesh.libmesh_assert_valid_parallel_ids();
 #endif
 
-      _mesh.prepare_for_use (/*skip_renumber =*/false);
+      _mesh.allow_find_neighbors(true);
+      _mesh.prepare_for_use ();
 
       if (_face_level_mismatch_limit)
         libmesh_assert(test_level_one(true));
@@ -673,7 +674,10 @@ bool MeshRefinement::coarsen_elements ()
 
   // Finally, the new mesh may need to be prepared for use
   if (mesh_changed)
-    _mesh.prepare_for_use (/*skip_renumber =*/false);
+  {
+    _mesh.allow_find_neighbors(true);
+    _mesh.prepare_for_use ();
+  }
 
   return mesh_changed;
 }
@@ -746,7 +750,10 @@ bool MeshRefinement::refine_elements ()
 
   // Finally, the new mesh needs to be prepared for use
   if (mesh_changed)
-    _mesh.prepare_for_use (/*skip_renumber =*/false);
+  {
+    _mesh.allow_find_neighbors(true);
+    _mesh.prepare_for_use ();
+  }
 
   return mesh_changed;
 }
@@ -1699,7 +1706,10 @@ void MeshRefinement::uniformly_refine (unsigned int n)
 
   // Finally, the new mesh probably needs to be prepared for use
   if (n > 0)
-    _mesh.prepare_for_use (/*skip_renumber =*/false);
+  {
+    _mesh.allow_find_neighbors(true);
+    _mesh.prepare_for_use ();
+  }
 }
 
 
@@ -1787,7 +1797,10 @@ void MeshRefinement::uniformly_coarsen (unsigned int n)
 
   // Finally, the new mesh probably needs to be prepared for use
   if (n > 0)
-    _mesh.prepare_for_use (/*skip_renumber =*/false);
+  {
+    _mesh.allow_find_neighbors(true);
+    _mesh.prepare_for_use ();
+  }
 }
 
 

--- a/src/mesh/mesh_subdivision_support.C
+++ b/src/mesh/mesh_subdivision_support.C
@@ -130,6 +130,7 @@ void MeshTools::Subdivision::all_subdivision(MeshBase & mesh)
 
       mesh.insert_elem(std::move(tri));
     }
+  mesh.allow_find_neighbors(true);
   mesh.prepare_for_use();
 
   if (mesh_has_boundary_data)
@@ -149,12 +150,14 @@ void MeshTools::Subdivision::all_subdivision(MeshBase & mesh)
                                           new_boundary_ids[s]);
     }
 
+  mesh.allow_find_neighbors(true);
   mesh.prepare_for_use();
 }
 
 
 void MeshTools::Subdivision::prepare_subdivision_mesh(MeshBase & mesh, bool ghosted)
 {
+  mesh.allow_find_neighbors(true);
   mesh.prepare_for_use();
 
   // convert all mesh elements to subdivision elements
@@ -171,6 +174,7 @@ void MeshTools::Subdivision::prepare_subdivision_mesh(MeshBase & mesh, bool ghos
       tag_boundary_ghosts(mesh);
     }
 
+  mesh.allow_find_neighbors(true);
   mesh.prepare_for_use();
 
   std::unordered_map<dof_id_type, std::vector<const Elem *>> nodes_to_elem_map;

--- a/src/mesh/mesh_triangle_interface.C
+++ b/src/mesh/mesh_triangle_interface.C
@@ -409,6 +409,7 @@ void TriangleInterface::triangulate()
   // Prepare the mesh for use before returning.  This ensures (among
   // other things) that it is partitioned and therefore users can
   // iterate over local elements, etc.
+  _mesh.allow_find_neighbors(true);
   _mesh.prepare_for_use();
 }
 

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -1428,7 +1428,8 @@ void ReplicatedMesh::stitching_helper (const ReplicatedMesh * other_mesh,
         }
     }
 
-  this->prepare_for_use( /*skip_renumber_nodes_and_elements= */ false, skip_find_neighbors);
+  this->allow_find_neighbors(!skip_find_neighbors);
+  this->prepare_for_use();
 
   // After the stitching, we may want to clear boundary IDs from element
   // faces that are now internal to the mesh

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -234,12 +234,13 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
   //partitioning for now.
   this->allow_renumbering(false);
   this->allow_remote_element_removal(false);
+  this->allow_find_neighbors(!skip_find_neighbors);
 
   // We should generally be able to skip *all* partitioning here
   // because we're only adding one already-consistent mesh to another.
   this->skip_partitioning(true);
 
-  this->prepare_for_use(false, skip_find_neighbors);
+  this->prepare_for_use();
 
   //But in the long term, use the same renumbering and partitioning
   //policies as our source mesh.

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -644,8 +644,8 @@ void UnstructuredMesh::read (const std::string & name,
     }
 
   // Done reading the mesh.  Now prepare it for use.
-  this->prepare_for_use(/*skip_renumber (deprecated)*/ false,
-                        skip_find_neighbors);
+  this->allow_find_neighbors(!skip_find_neighbors);
+  this->prepare_for_use();
 }
 
 
@@ -791,7 +791,8 @@ void UnstructuredMesh::create_submesh (UnstructuredMesh & new_mesh,
     } // end loop over elements
 
   // Prepare the new_mesh for use
-  new_mesh.prepare_for_use(/*skip_renumber =*/false);
+  new_mesh.allow_find_neighbors(true);
+  new_mesh.prepare_for_use();
 }
 
 
@@ -993,6 +994,7 @@ void UnstructuredMesh::all_first_order ()
   Partitioner::set_node_processor_ids(*this);
 
   // delete or renumber nodes if desired
+  this->allow_find_neighbors(true);
   this->prepare_for_use();
 }
 
@@ -1334,7 +1336,8 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
     }
 
   // renumber nodes, elements etc
-  this->prepare_for_use(/*skip_renumber =*/ false);
+  this->allow_find_neighbors(true);
+  this->prepare_for_use();
 }
 
 } // namespace libMesh


### PR DESCRIPTION
This mirrors the APIs for allow_renumbering, which will allow
a more consistent setup before calling `prepare_for_use`.

Closes #2472