### PR TITLE
Parameters support for std::map

### DIFF
--- a/include/utils/parameters.h
+++ b/include/utils/parameters.h
@@ -47,6 +47,9 @@ void print_helper(std::ostream & os, const std::vector<P> * param);
 template<typename P>
 void print_helper(std::ostream & os, const std::vector<std::vector<P>> * param);
 
+template<typename P1, typename P2, typename C, typename A>
+void print_helper(std::ostream & os, const std::map<P1, P2, C, A> * param);
+
 /**
  * This class provides the ability to map between
  * arbitrary, user-defined strings and several data
@@ -564,6 +567,22 @@ void print_helper(std::ostream & os, const std::vector<std::vector<P>> * param)
     for (const auto & p : pv)
       os << p << " ";
 }
+
+//non-member map print function
+template<typename P1, typename P2, typename C, typename A>
+void print_helper(std::ostream & os, const std::map<P1, P2, C, A> * param)
+{
+  os << '{';
+  std::size_t sz = param->size();
+  for (auto KV : *param)
+    {
+      os << '\'' << KV.first << "\' => \'" << KV.second << '\'';
+      if (--sz)
+        os << ", ";
+    }
+  os << '}';
+}
+
 
 } // namespace libMesh
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -106,6 +106,7 @@ unit_tests_sources = \
   solvers/second_order_unsteady_solver_test.C \
   systems/equation_systems_test.C \
   systems/systems_test.C \
+  utils/parameters_test.C \
   utils/point_locator_test.C \
   utils/vectormap_test.C
 

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -232,8 +232,8 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/first_order_unsteady_solver_test.C \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/systems_test.C \
-	utils/point_locator_test.C utils/vectormap_test.C \
-	fparser/autodiff.C
+	utils/parameters_test.C utils/point_locator_test.C \
+	utils/vectormap_test.C fparser/autodiff.C
 am__dirstamp = $(am__leading_dot)dirstamp
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_1 = fparser/unit_tests_dbg-autodiff.$(OBJEXT)
 am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
@@ -316,6 +316,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	solvers/unit_tests_dbg-second_order_unsteady_solver_test.$(OBJEXT) \
 	systems/unit_tests_dbg-equation_systems_test.$(OBJEXT) \
 	systems/unit_tests_dbg-systems_test.$(OBJEXT) \
+	utils/unit_tests_dbg-parameters_test.$(OBJEXT) \
 	utils/unit_tests_dbg-point_locator_test.$(OBJEXT) \
 	utils/unit_tests_dbg-vectormap_test.$(OBJEXT) $(am__objects_1)
 @LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@am_unit_tests_dbg_OBJECTS = $(am__objects_2)
@@ -378,8 +379,8 @@ am__unit_tests_devel_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/first_order_unsteady_solver_test.C \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/systems_test.C \
-	utils/point_locator_test.C utils/vectormap_test.C \
-	fparser/autodiff.C
+	utils/parameters_test.C utils/point_locator_test.C \
+	utils/vectormap_test.C fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_3 = fparser/unit_tests_devel-autodiff.$(OBJEXT)
 am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	base/unit_tests_devel-dof_map_test.$(OBJEXT) \
@@ -461,6 +462,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	solvers/unit_tests_devel-second_order_unsteady_solver_test.$(OBJEXT) \
 	systems/unit_tests_devel-equation_systems_test.$(OBJEXT) \
 	systems/unit_tests_devel-systems_test.$(OBJEXT) \
+	utils/unit_tests_devel-parameters_test.$(OBJEXT) \
 	utils/unit_tests_devel-point_locator_test.$(OBJEXT) \
 	utils/unit_tests_devel-vectormap_test.$(OBJEXT) \
 	$(am__objects_3)
@@ -520,8 +522,8 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/first_order_unsteady_solver_test.C \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/systems_test.C \
-	utils/point_locator_test.C utils/vectormap_test.C \
-	fparser/autodiff.C
+	utils/parameters_test.C utils/point_locator_test.C \
+	utils/vectormap_test.C fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_5 = fparser/unit_tests_oprof-autodiff.$(OBJEXT)
 am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	base/unit_tests_oprof-dof_map_test.$(OBJEXT) \
@@ -603,6 +605,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	solvers/unit_tests_oprof-second_order_unsteady_solver_test.$(OBJEXT) \
 	systems/unit_tests_oprof-equation_systems_test.$(OBJEXT) \
 	systems/unit_tests_oprof-systems_test.$(OBJEXT) \
+	utils/unit_tests_oprof-parameters_test.$(OBJEXT) \
 	utils/unit_tests_oprof-point_locator_test.$(OBJEXT) \
 	utils/unit_tests_oprof-vectormap_test.$(OBJEXT) \
 	$(am__objects_5)
@@ -662,8 +665,8 @@ am__unit_tests_opt_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/first_order_unsteady_solver_test.C \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/systems_test.C \
-	utils/point_locator_test.C utils/vectormap_test.C \
-	fparser/autodiff.C
+	utils/parameters_test.C utils/point_locator_test.C \
+	utils/vectormap_test.C fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_7 = fparser/unit_tests_opt-autodiff.$(OBJEXT)
 am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	base/unit_tests_opt-dof_map_test.$(OBJEXT) \
@@ -745,6 +748,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	solvers/unit_tests_opt-second_order_unsteady_solver_test.$(OBJEXT) \
 	systems/unit_tests_opt-equation_systems_test.$(OBJEXT) \
 	systems/unit_tests_opt-systems_test.$(OBJEXT) \
+	utils/unit_tests_opt-parameters_test.$(OBJEXT) \
 	utils/unit_tests_opt-point_locator_test.$(OBJEXT) \
 	utils/unit_tests_opt-vectormap_test.$(OBJEXT) $(am__objects_7)
 @LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPT_MODE_TRUE@am_unit_tests_opt_OBJECTS = $(am__objects_8)
@@ -803,8 +807,8 @@ am__unit_tests_prof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/first_order_unsteady_solver_test.C \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/systems_test.C \
-	utils/point_locator_test.C utils/vectormap_test.C \
-	fparser/autodiff.C
+	utils/parameters_test.C utils/point_locator_test.C \
+	utils/vectormap_test.C fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_9 = fparser/unit_tests_prof-autodiff.$(OBJEXT)
 am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	base/unit_tests_prof-dof_map_test.$(OBJEXT) \
@@ -886,6 +890,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	solvers/unit_tests_prof-second_order_unsteady_solver_test.$(OBJEXT) \
 	systems/unit_tests_prof-equation_systems_test.$(OBJEXT) \
 	systems/unit_tests_prof-systems_test.$(OBJEXT) \
+	utils/unit_tests_prof-parameters_test.$(OBJEXT) \
 	utils/unit_tests_prof-point_locator_test.$(OBJEXT) \
 	utils/unit_tests_prof-vectormap_test.$(OBJEXT) \
 	$(am__objects_9)
@@ -1316,14 +1321,19 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	systems/$(DEPDIR)/unit_tests_opt-systems_test.Po \
 	systems/$(DEPDIR)/unit_tests_prof-equation_systems_test.Po \
 	systems/$(DEPDIR)/unit_tests_prof-systems_test.Po \
+	utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po \
 	utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Po \
+	utils/$(DEPDIR)/unit_tests_devel-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po \
 	utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po \
+	utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po \
 	utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Po \
+	utils/$(DEPDIR)/unit_tests_opt-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po \
 	utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po \
+	utils/$(DEPDIR)/unit_tests_prof-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po \
 	utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po
 am__mv = mv -f
@@ -1788,8 +1798,8 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 	solvers/first_order_unsteady_solver_test.C \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/systems_test.C \
-	utils/point_locator_test.C utils/vectormap_test.C \
-	$(am__append_1)
+	utils/parameters_test.C utils/point_locator_test.C \
+	utils/vectormap_test.C $(am__append_1)
 @LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@unit_tests_dbg_SOURCES = $(unit_tests_sources)
 @LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@unit_tests_dbg_CPPFLAGS = $(CPPFLAGS_DBG) $(AM_CPPFLAGS)
 @LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@unit_tests_dbg_CXXFLAGS = $(CXXFLAGS_DBG)
@@ -2103,6 +2113,8 @@ utils/$(am__dirstamp):
 utils/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) utils/$(DEPDIR)
 	@: > utils/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_dbg-parameters_test.$(OBJEXT): utils/$(am__dirstamp) \
+	utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_dbg-point_locator_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_dbg-vectormap_test.$(OBJEXT): utils/$(am__dirstamp) \
@@ -2285,6 +2297,8 @@ systems/unit_tests_devel-equation_systems_test.$(OBJEXT):  \
 	systems/$(am__dirstamp) systems/$(DEPDIR)/$(am__dirstamp)
 systems/unit_tests_devel-systems_test.$(OBJEXT):  \
 	systems/$(am__dirstamp) systems/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_devel-parameters_test.$(OBJEXT):  \
+	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_devel-point_locator_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_devel-vectormap_test.$(OBJEXT):  \
@@ -2461,6 +2475,8 @@ systems/unit_tests_oprof-equation_systems_test.$(OBJEXT):  \
 	systems/$(am__dirstamp) systems/$(DEPDIR)/$(am__dirstamp)
 systems/unit_tests_oprof-systems_test.$(OBJEXT):  \
 	systems/$(am__dirstamp) systems/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_oprof-parameters_test.$(OBJEXT):  \
+	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_oprof-point_locator_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_oprof-vectormap_test.$(OBJEXT):  \
@@ -2637,6 +2653,8 @@ systems/unit_tests_opt-equation_systems_test.$(OBJEXT):  \
 	systems/$(am__dirstamp) systems/$(DEPDIR)/$(am__dirstamp)
 systems/unit_tests_opt-systems_test.$(OBJEXT):  \
 	systems/$(am__dirstamp) systems/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_opt-parameters_test.$(OBJEXT): utils/$(am__dirstamp) \
+	utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_opt-point_locator_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_opt-vectormap_test.$(OBJEXT): utils/$(am__dirstamp) \
@@ -2813,6 +2831,8 @@ systems/unit_tests_prof-equation_systems_test.$(OBJEXT):  \
 	systems/$(am__dirstamp) systems/$(DEPDIR)/$(am__dirstamp)
 systems/unit_tests_prof-systems_test.$(OBJEXT):  \
 	systems/$(am__dirstamp) systems/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_prof-parameters_test.$(OBJEXT):  \
+	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_prof-point_locator_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_prof-vectormap_test.$(OBJEXT): utils/$(am__dirstamp) \
@@ -3247,14 +3267,19 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@systems/$(DEPDIR)/unit_tests_opt-systems_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@systems/$(DEPDIR)/unit_tests_prof-equation_systems_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@systems/$(DEPDIR)/unit_tests_prof-systems_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po@am__quote@ # am--include-marker
 
@@ -4407,6 +4432,20 @@ systems/unit_tests_dbg-systems_test.obj: systems/systems_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='systems/systems_test.C' object='systems/unit_tests_dbg-systems_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o systems/unit_tests_dbg-systems_test.obj `if test -f 'systems/systems_test.C'; then $(CYGPATH_W) 'systems/systems_test.C'; else $(CYGPATH_W) '$(srcdir)/systems/systems_test.C'; fi`
+
+utils/unit_tests_dbg-parameters_test.o: utils/parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_dbg-parameters_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Tpo -c -o utils/unit_tests_dbg-parameters_test.o `test -f 'utils/parameters_test.C' || echo '$(srcdir)/'`utils/parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Tpo utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/parameters_test.C' object='utils/unit_tests_dbg-parameters_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_dbg-parameters_test.o `test -f 'utils/parameters_test.C' || echo '$(srcdir)/'`utils/parameters_test.C
+
+utils/unit_tests_dbg-parameters_test.obj: utils/parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_dbg-parameters_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Tpo -c -o utils/unit_tests_dbg-parameters_test.obj `if test -f 'utils/parameters_test.C'; then $(CYGPATH_W) 'utils/parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/parameters_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Tpo utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/parameters_test.C' object='utils/unit_tests_dbg-parameters_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_dbg-parameters_test.obj `if test -f 'utils/parameters_test.C'; then $(CYGPATH_W) 'utils/parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/parameters_test.C'; fi`
 
 utils/unit_tests_dbg-point_locator_test.o: utils/point_locator_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_dbg-point_locator_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Tpo -c -o utils/unit_tests_dbg-point_locator_test.o `test -f 'utils/point_locator_test.C' || echo '$(srcdir)/'`utils/point_locator_test.C
@@ -5570,6 +5609,20 @@ systems/unit_tests_devel-systems_test.obj: systems/systems_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o systems/unit_tests_devel-systems_test.obj `if test -f 'systems/systems_test.C'; then $(CYGPATH_W) 'systems/systems_test.C'; else $(CYGPATH_W) '$(srcdir)/systems/systems_test.C'; fi`
 
+utils/unit_tests_devel-parameters_test.o: utils/parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_devel-parameters_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_devel-parameters_test.Tpo -c -o utils/unit_tests_devel-parameters_test.o `test -f 'utils/parameters_test.C' || echo '$(srcdir)/'`utils/parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_devel-parameters_test.Tpo utils/$(DEPDIR)/unit_tests_devel-parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/parameters_test.C' object='utils/unit_tests_devel-parameters_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_devel-parameters_test.o `test -f 'utils/parameters_test.C' || echo '$(srcdir)/'`utils/parameters_test.C
+
+utils/unit_tests_devel-parameters_test.obj: utils/parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_devel-parameters_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_devel-parameters_test.Tpo -c -o utils/unit_tests_devel-parameters_test.obj `if test -f 'utils/parameters_test.C'; then $(CYGPATH_W) 'utils/parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/parameters_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_devel-parameters_test.Tpo utils/$(DEPDIR)/unit_tests_devel-parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/parameters_test.C' object='utils/unit_tests_devel-parameters_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_devel-parameters_test.obj `if test -f 'utils/parameters_test.C'; then $(CYGPATH_W) 'utils/parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/parameters_test.C'; fi`
+
 utils/unit_tests_devel-point_locator_test.o: utils/point_locator_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_devel-point_locator_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Tpo -c -o utils/unit_tests_devel-point_locator_test.o `test -f 'utils/point_locator_test.C' || echo '$(srcdir)/'`utils/point_locator_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Tpo utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po
@@ -6731,6 +6784,20 @@ systems/unit_tests_oprof-systems_test.obj: systems/systems_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='systems/systems_test.C' object='systems/unit_tests_oprof-systems_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o systems/unit_tests_oprof-systems_test.obj `if test -f 'systems/systems_test.C'; then $(CYGPATH_W) 'systems/systems_test.C'; else $(CYGPATH_W) '$(srcdir)/systems/systems_test.C'; fi`
+
+utils/unit_tests_oprof-parameters_test.o: utils/parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_oprof-parameters_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Tpo -c -o utils/unit_tests_oprof-parameters_test.o `test -f 'utils/parameters_test.C' || echo '$(srcdir)/'`utils/parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Tpo utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/parameters_test.C' object='utils/unit_tests_oprof-parameters_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_oprof-parameters_test.o `test -f 'utils/parameters_test.C' || echo '$(srcdir)/'`utils/parameters_test.C
+
+utils/unit_tests_oprof-parameters_test.obj: utils/parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_oprof-parameters_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Tpo -c -o utils/unit_tests_oprof-parameters_test.obj `if test -f 'utils/parameters_test.C'; then $(CYGPATH_W) 'utils/parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/parameters_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Tpo utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/parameters_test.C' object='utils/unit_tests_oprof-parameters_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_oprof-parameters_test.obj `if test -f 'utils/parameters_test.C'; then $(CYGPATH_W) 'utils/parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/parameters_test.C'; fi`
 
 utils/unit_tests_oprof-point_locator_test.o: utils/point_locator_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_oprof-point_locator_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Tpo -c -o utils/unit_tests_oprof-point_locator_test.o `test -f 'utils/point_locator_test.C' || echo '$(srcdir)/'`utils/point_locator_test.C
@@ -7894,6 +7961,20 @@ systems/unit_tests_opt-systems_test.obj: systems/systems_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o systems/unit_tests_opt-systems_test.obj `if test -f 'systems/systems_test.C'; then $(CYGPATH_W) 'systems/systems_test.C'; else $(CYGPATH_W) '$(srcdir)/systems/systems_test.C'; fi`
 
+utils/unit_tests_opt-parameters_test.o: utils/parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_opt-parameters_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_opt-parameters_test.Tpo -c -o utils/unit_tests_opt-parameters_test.o `test -f 'utils/parameters_test.C' || echo '$(srcdir)/'`utils/parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_opt-parameters_test.Tpo utils/$(DEPDIR)/unit_tests_opt-parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/parameters_test.C' object='utils/unit_tests_opt-parameters_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_opt-parameters_test.o `test -f 'utils/parameters_test.C' || echo '$(srcdir)/'`utils/parameters_test.C
+
+utils/unit_tests_opt-parameters_test.obj: utils/parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_opt-parameters_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_opt-parameters_test.Tpo -c -o utils/unit_tests_opt-parameters_test.obj `if test -f 'utils/parameters_test.C'; then $(CYGPATH_W) 'utils/parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/parameters_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_opt-parameters_test.Tpo utils/$(DEPDIR)/unit_tests_opt-parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/parameters_test.C' object='utils/unit_tests_opt-parameters_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_opt-parameters_test.obj `if test -f 'utils/parameters_test.C'; then $(CYGPATH_W) 'utils/parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/parameters_test.C'; fi`
+
 utils/unit_tests_opt-point_locator_test.o: utils/point_locator_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_opt-point_locator_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Tpo -c -o utils/unit_tests_opt-point_locator_test.o `test -f 'utils/point_locator_test.C' || echo '$(srcdir)/'`utils/point_locator_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Tpo utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po
@@ -9056,6 +9137,20 @@ systems/unit_tests_prof-systems_test.obj: systems/systems_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o systems/unit_tests_prof-systems_test.obj `if test -f 'systems/systems_test.C'; then $(CYGPATH_W) 'systems/systems_test.C'; else $(CYGPATH_W) '$(srcdir)/systems/systems_test.C'; fi`
 
+utils/unit_tests_prof-parameters_test.o: utils/parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_prof-parameters_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_prof-parameters_test.Tpo -c -o utils/unit_tests_prof-parameters_test.o `test -f 'utils/parameters_test.C' || echo '$(srcdir)/'`utils/parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_prof-parameters_test.Tpo utils/$(DEPDIR)/unit_tests_prof-parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/parameters_test.C' object='utils/unit_tests_prof-parameters_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_prof-parameters_test.o `test -f 'utils/parameters_test.C' || echo '$(srcdir)/'`utils/parameters_test.C
+
+utils/unit_tests_prof-parameters_test.obj: utils/parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_prof-parameters_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_prof-parameters_test.Tpo -c -o utils/unit_tests_prof-parameters_test.obj `if test -f 'utils/parameters_test.C'; then $(CYGPATH_W) 'utils/parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/parameters_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_prof-parameters_test.Tpo utils/$(DEPDIR)/unit_tests_prof-parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/parameters_test.C' object='utils/unit_tests_prof-parameters_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_prof-parameters_test.obj `if test -f 'utils/parameters_test.C'; then $(CYGPATH_W) 'utils/parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/parameters_test.C'; fi`
+
 utils/unit_tests_prof-point_locator_test.o: utils/point_locator_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_prof-point_locator_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Tpo -c -o utils/unit_tests_prof-point_locator_test.o `test -f 'utils/point_locator_test.C' || echo '$(srcdir)/'`utils/point_locator_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Tpo utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po
@@ -9757,14 +9852,19 @@ distclean: distclean-am
 	-rm -f systems/$(DEPDIR)/unit_tests_opt-systems_test.Po
 	-rm -f systems/$(DEPDIR)/unit_tests_prof-equation_systems_test.Po
 	-rm -f systems/$(DEPDIR)/unit_tests_prof-systems_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_devel-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_opt-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_prof-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po
 	-rm -f Makefile
@@ -10217,14 +10317,19 @@ maintainer-clean: maintainer-clean-am
 	-rm -f systems/$(DEPDIR)/unit_tests_opt-systems_test.Po
 	-rm -f systems/$(DEPDIR)/unit_tests_prof-equation_systems_test.Po
 	-rm -f systems/$(DEPDIR)/unit_tests_prof-systems_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_devel-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_opt-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_prof-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po
 	-rm -f Makefile

--- a/tests/utils/parameters_test.C
+++ b/tests/utils/parameters_test.C
@@ -1,0 +1,69 @@
+#include <libmesh/parameters.h>
+
+#include "libmesh_cppunit.h"
+
+#include <map>
+#include <string>
+
+using namespace libMesh;
+
+class ParametersTest : public CppUnit::TestCase {
+public:
+  CPPUNIT_TEST_SUITE( ParametersTest );
+
+  CPPUNIT_TEST( testInt );
+  CPPUNIT_TEST( testFloat );
+  CPPUNIT_TEST( testDouble );
+
+  CPPUNIT_TEST( testMap );
+
+  CPPUNIT_TEST_SUITE_END();
+
+private:
+
+public:
+  void setUp()
+  {}
+
+  void tearDown()
+  {}
+
+  template <typename T>
+  void testScalar ()
+  {
+    Parameters param;
+
+    T t = 10, t_orig = 10;
+
+    param.set<T>("first") = t;
+
+    ++t;
+
+    param.set<T>("second") = t;
+
+    CPPUNIT_ASSERT_EQUAL(t_orig, param.get<T>("first"));
+    CPPUNIT_ASSERT_EQUAL(t, param.get<T>("second"));
+  }
+
+  void testMap ()
+  {
+    Parameters param;
+
+    std::map<int, std::string> m;
+    m[2] = "two";
+    m[4] = "four";
+    param.set<std::map<int, std::string>>("mymap") = m;
+    const std::map<int, std::string> & gotten =
+      param.get<std::map<int, std::string>>("mymap");
+
+    CPPUNIT_ASSERT_EQUAL(gotten.size(), std::size_t(2));
+    CPPUNIT_ASSERT_EQUAL(gotten.at(2), std::string("two"));
+    CPPUNIT_ASSERT_EQUAL(gotten.at(4), std::string("four"));
+  }
+
+  void testInt () { testScalar<int>(); }
+  void testFloat () { testScalar<float>(); }
+  void testDouble () { testScalar<double>(); }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( ParametersTest );


### PR DESCRIPTION
This should handle the libMesh side of the support required for https://github.com/idaholab/moose/issues/14894

The print_helper expansion here is in line with what we're already doing, but in the long term we should factor it into a separate class as discussed in the MOOSE issue.