### PR TITLE
Add RBEIMConstruction::init_context() override

### DIFF
--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -275,6 +275,11 @@ protected:
   virtual Real get_RB_error_bound() override;
 
   /**
+   * Pre-request FE data needed for calculations.
+   */
+  virtual void init_context(FEMContext &) override;
+
+  /**
    * Loop over the training set and compute the parametrized function for each
    * training index.
    */

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -809,6 +809,31 @@ Real RBEIMConstruction::get_RB_error_bound()
   return best_fit_error;
 }
 
+void RBEIMConstruction::init_context(FEMContext & c)
+{
+  // Pre-request FE data for all element dimensions present in the
+  // mesh.  Note: we currently pre-request FE data for all variables
+  // in the current system but in some cases that may be overkill, for
+  // example if only variable 0 is used.
+  const System & sys = c.get_system();
+  const MeshBase & mesh = sys.get_mesh();
+
+  for (unsigned int dim=1; dim<=3; ++dim)
+    if (mesh.elem_dimensions().count(dim))
+      for (unsigned int var=0; var<sys.n_vars(); ++var)
+      {
+        auto fe = c.get_element_fe(var, dim);
+        fe->get_JxW();
+        fe->get_phi();
+        fe->get_xyz();
+
+        auto side_fe = c.get_side_fe(var, dim);
+        side_fe->get_JxW();
+        side_fe->get_phi();
+        side_fe->get_xyz();
+      }
+}
+
 void RBEIMConstruction::update_system()
 {
   libMesh::out << "Updating RB matrices" << std::endl;


### PR DESCRIPTION
Otherwise, we run into issues when libmesh is configured with
--disable-deprecated since the base class init_context() is called
instead.

Also pre-request FE required data in
RBEIMConstruction::init_context(). Currently I'm just guessing about
what data might be required in general for EIM, but this works for the
limited number of cases I tried it on.

Refs #2464 