### PR TITLE
MeshBase::remove_orphaned_nodes

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -789,6 +789,12 @@ public:
                                const bool reset_current_list    = true) = 0;
 
   /**
+   * Removes any orphaned nodes, nodes not connected to any elements.
+   * Typically done automatically in prepare_for_use
+   */
+  void remove_orphaned_nodes ();
+
+  /**
    * After partitioning a mesh it is useful to renumber the nodes and elements
    * so that they lie in contiguous blocks on the processors.  This method
    * does just that.


### PR DESCRIPTION
Even when we're not renumbering other nodes, we need to remove nodes
that have been orphaned by adaptive coarsening (or by some mesh
generators, e.g. TET4/HEX20/QUAD8 build_*) so algorithms which access
nodes via elements don't get confused when they don't hit everything.

This fixes https://github.com/idaholab/moose/issues/14963 for me.

I'd rather not merge this until I add a couple unit tests to prevent future regression on the bugfix, but I'm putting it up ASAP anyways so that @loganharbour can cherry-pick it if he needs and so I can make sure it doesn't mess with anything else in CI.