### PR TITLE
Fix BoundingBox intersection test for QuadTree

### DIFF
--- a/include/utils/tree.h
+++ b/include/utils/tree.h
@@ -49,7 +49,7 @@ public:
    */
   Tree (const MeshBase & m,
         unsigned int target_bin_size,
-        Trees::BuildType bt=Trees::NODES);
+        Trees::BuildType bt = Trees::NODES);
 
   /**
    * Copy-constructor.  Not currently implemented.
@@ -59,7 +59,7 @@ public:
   /**
    * Destructor.
    */
-  ~Tree() {}
+  ~Tree() = default;
 
   /**
    * Prints the nodes.

--- a/include/utils/tree_base.h
+++ b/include/utils/tree_base.h
@@ -22,9 +22,12 @@
 
 // Local includes
 #include "libmesh/reference_counted_object.h"
+#include "libmesh/id_types.h" // subdomain_id_type
+#include "libmesh/libmesh_common.h" // TOLERANCE
 
 // C++ includes
 #include <set>
+#include <ostream>
 
 namespace libMesh
 {
@@ -69,13 +72,13 @@ protected:
    * Constructor.  Protected.
    */
   explicit
-  TreeBase (const MeshBase & m);
+  TreeBase (const MeshBase & m) : mesh(m) {}
 
 public:
   /**
    * Destructor.
    */
-  virtual ~TreeBase() {}
+  virtual ~TreeBase() = default;
 
   /**
    * Prints the nodes.
@@ -112,7 +115,6 @@ public:
                              const std::set<subdomain_id_type> * allowed_subdomains = nullptr,
                              Real relative_tol = TOLERANCE) const = 0;
 
-
 protected:
 
   /**
@@ -121,16 +123,6 @@ protected:
    */
   const MeshBase & mesh;
 };
-
-// ------------------------------------------------------------
-// TreeBase class inline methods
-
-// constructor
-inline
-TreeBase::TreeBase (const MeshBase & m) :
-  mesh(m)
-{
-}
 
 } // namespace libMesh
 

--- a/tests/utils/point_locator_test.C
+++ b/tests/utils/point_locator_test.C
@@ -23,6 +23,7 @@ public:
 #endif
 #if LIBMESH_DIM > 2
   CPPUNIT_TEST( testLocatorOnHex27 );
+  CPPUNIT_TEST( testPlanar );
 #endif
 
   CPPUNIT_TEST_SUITE_END();
@@ -106,7 +107,45 @@ public:
       }
   }
 
+  void testPlanar()
+  {
+    // Here we test locating points in a Mesh which lies slightly above the z-axis
+    Mesh mesh(*TestCommWorld);
 
+    MeshTools::Generation::build_square(mesh,
+                                        /*nx=*/10, /*ny=*/10,
+                                        /*xmin=*/0., /*xmax=*/1.,
+                                        /*ymin=*/0., /*ymax=*/1.,
+                                        TRI3);
+
+    // Move all nodes a small amount in the +z-direction
+    for (auto & node : mesh.node_ptr_range())
+      (*node)(2) += 3.1e-15;
+
+    // Construct a PointLocator object
+    std::unique_ptr<PointLocatorBase> locator = mesh.sub_point_locator();
+
+    // Turn on out-of-mesh-mode to handle parallel testing
+    if (!mesh.is_serial())
+      locator->enable_out_of_mesh_mode();
+
+    // Test locating a Point which is in the z=0 plane, i.e. slightly
+    // below the plane of the Mesh, but which should otherwise be
+    // found within the Mesh.
+    Point p(0.53, 0.7, 0.0);
+    const Elem *elem = (*locator)(p);
+
+    bool found_elem = elem;
+    if (!mesh.is_serial())
+      mesh.comm().max(found_elem);
+
+    CPPUNIT_ASSERT(found_elem);
+
+    // Note: Tri3::contains_point() returns true for points which are
+    // out-of-plane by less than TOLERANCE by default.
+    if (elem)
+      CPPUNIT_ASSERT(elem->contains_point(p));
+  }
 
   void testLocatorOnEdge3() { testLocator(EDGE3); }
   void testLocatorOnQuad9() { testLocator(QUAD9); }


### PR DESCRIPTION
Previously the code used generic BoundingBox::intersects() checks but this isn't robust in the QuadTree (LIBMESH_DIM==2 or is_planar_xy) cases because the BoundingBoxes are infinitesimally thin in the z-direction, and likely to produce spurious intersection failures.