### PR TITLE
MeshGeneration unit tests, fix ReplicatedMesh::n_* for holes in numbering

### DIFF
--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -101,10 +101,10 @@ public:
   virtual void renumber_nodes_and_elements () override;
 
   virtual dof_id_type n_nodes () const override
-  { return cast_int<dof_id_type>(_nodes.size()); }
+  { return _n_nodes; }
 
   virtual dof_id_type parallel_n_nodes () const override
-  { return cast_int<dof_id_type>(_nodes.size()); }
+  { return _n_nodes; }
 
   virtual dof_id_type max_node_id () const override
   { return cast_int<dof_id_type>(_nodes.size()); }
@@ -113,10 +113,10 @@ public:
   { _nodes.reserve (nn); }
 
   virtual dof_id_type n_elem () const override
-  { return cast_int<dof_id_type>(_elements.size()); }
+  { return _n_elem; }
 
   virtual dof_id_type parallel_n_elem () const override
-  { return cast_int<dof_id_type>(_elements.size()); }
+  { return _n_elem; }
 
   virtual dof_id_type n_active_elem () const override;
 
@@ -510,10 +510,14 @@ protected:
    */
   std::vector<Node *> _nodes;
 
+  dof_id_type _n_nodes;
+
   /**
    * The elements in the mesh.
    */
   std::vector<Elem *> _elements;
+
+  dof_id_type _n_elem;
 
 private:
 

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -181,7 +181,7 @@ const Point & ReplicatedMesh::point (const dof_id_type i) const
 
 const Node * ReplicatedMesh::node_ptr (const dof_id_type i) const
 {
-  libmesh_assert_less (i, this->n_nodes());
+  libmesh_assert_less (i, this->max_node_id());
   libmesh_assert(_nodes[i]);
   libmesh_assert_equal_to (_nodes[i]->id(), i); // This will change soon
 
@@ -193,7 +193,7 @@ const Node * ReplicatedMesh::node_ptr (const dof_id_type i) const
 
 Node * ReplicatedMesh::node_ptr (const dof_id_type i)
 {
-  libmesh_assert_less (i, this->n_nodes());
+  libmesh_assert_less (i, this->max_node_id());
   libmesh_assert(_nodes[i]);
   libmesh_assert_equal_to (_nodes[i]->id(), i); // This will change soon
 
@@ -205,7 +205,7 @@ Node * ReplicatedMesh::node_ptr (const dof_id_type i)
 
 const Node * ReplicatedMesh::query_node_ptr (const dof_id_type i) const
 {
-  if (i >= this->n_nodes())
+  if (i >= this->max_node_id())
     return nullptr;
   libmesh_assert (_nodes[i] == nullptr ||
                   _nodes[i]->id() == i); // This will change soon
@@ -218,7 +218,7 @@ const Node * ReplicatedMesh::query_node_ptr (const dof_id_type i) const
 
 Node * ReplicatedMesh::query_node_ptr (const dof_id_type i)
 {
-  if (i >= this->n_nodes())
+  if (i >= this->max_node_id())
     return nullptr;
   libmesh_assert (_nodes[i] == nullptr ||
                   _nodes[i]->id() == i); // This will change soon
@@ -231,7 +231,7 @@ Node * ReplicatedMesh::query_node_ptr (const dof_id_type i)
 
 const Elem * ReplicatedMesh::elem_ptr (const dof_id_type i) const
 {
-  libmesh_assert_less (i, this->n_elem());
+  libmesh_assert_less (i, this->max_elem_id());
   libmesh_assert(_elements[i]);
   libmesh_assert_equal_to (_elements[i]->id(), i); // This will change soon
 
@@ -243,7 +243,7 @@ const Elem * ReplicatedMesh::elem_ptr (const dof_id_type i) const
 
 Elem * ReplicatedMesh::elem_ptr (const dof_id_type i)
 {
-  libmesh_assert_less (i, this->n_elem());
+  libmesh_assert_less (i, this->max_elem_id());
   libmesh_assert(_elements[i]);
   libmesh_assert_equal_to (_elements[i]->id(), i); // This will change soon
 
@@ -255,7 +255,7 @@ Elem * ReplicatedMesh::elem_ptr (const dof_id_type i)
 
 const Elem * ReplicatedMesh::query_elem_ptr (const dof_id_type i) const
 {
-  if (i >= this->n_elem())
+  if (i >= this->max_elem_id())
     return nullptr;
   libmesh_assert (_elements[i] == nullptr ||
                   _elements[i]->id() == i); // This will change soon
@@ -268,7 +268,7 @@ const Elem * ReplicatedMesh::query_elem_ptr (const dof_id_type i) const
 
 Elem * ReplicatedMesh::query_elem_ptr (const dof_id_type i)
 {
-  if (i >= this->n_elem())
+  if (i >= this->max_elem_id())
     return nullptr;
   libmesh_assert (_elements[i] == nullptr ||
                   _elements[i]->id() == i); // This will change soon

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -84,7 +84,8 @@ public:
 // ReplicatedMesh class member functions
 ReplicatedMesh::ReplicatedMesh (const Parallel::Communicator & comm_in,
                                 unsigned char d) :
-  UnstructuredMesh (comm_in,d)
+  UnstructuredMesh (comm_in,d),
+  _n_nodes(0), _n_elem(0)
 {
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
   // In serial we just need to reset the next unique id to zero
@@ -106,7 +107,8 @@ ReplicatedMesh::~ReplicatedMesh ()
 // make sure the compiler doesn't give us a default (non-deep) copy
 // constructor instead.
 ReplicatedMesh::ReplicatedMesh (const ReplicatedMesh & other_mesh) :
-  UnstructuredMesh (other_mesh)
+  UnstructuredMesh (other_mesh),
+  _n_nodes(0), _n_elem(0) // copy_* will increment this
 {
   this->copy_nodes_and_elements(other_mesh, true);
 
@@ -141,7 +143,8 @@ ReplicatedMesh::ReplicatedMesh (const ReplicatedMesh & other_mesh) :
 
 
 ReplicatedMesh::ReplicatedMesh (const UnstructuredMesh & other_mesh) :
-  UnstructuredMesh (other_mesh)
+  UnstructuredMesh (other_mesh),
+  _n_nodes(0), _n_elem(0) // copy_* will increment this
 {
   this->copy_nodes_and_elements(other_mesh, true);
 
@@ -310,6 +313,7 @@ Elem * ReplicatedMesh::add_elem (Elem * e)
       _elements.resize(id+1, nullptr);
     }
 
+  ++_n_elem;
   _elements[id] = e;
 
   // Make sure any new element is given space for any extra integers
@@ -350,7 +354,8 @@ Elem * ReplicatedMesh::insert_elem (Elem * e)
       this->delete_elem(oldelem);
     }
 
-  _elements[e->id()] = e;
+  ++_n_elem;
+  _elements[eid] = e;
 
   // Make sure any new element is given space for any extra integers
   // we've requested
@@ -407,6 +412,7 @@ void ReplicatedMesh::delete_elem(Elem * e)
   this->get_boundary_info().remove(e);
 
   // delete the element
+  --_n_elem;
   delete e;
 
   // explicitly zero the pointer
@@ -471,6 +477,7 @@ Node * ReplicatedMesh::add_point (const Point & p,
         n->set_unique_id() = _next_unique_id++;
 #endif
 
+      ++_n_nodes;
       if (id == DofObject::invalid_id)
         _nodes.back() = n;
       else
@@ -500,6 +507,7 @@ Node * ReplicatedMesh::add_node (Node * n)
 
   n->add_extra_integers(_node_integer_names.size());
 
+  ++_n_nodes;
   _nodes.push_back(n);
 
   return n;
@@ -551,6 +559,7 @@ Node * ReplicatedMesh::insert_node(Node * n)
 
   // We have enough space and this spot isn't already occupied by
   // another node, so go ahead and add it.
+  ++_n_nodes;
   _nodes[ n->id() ] = n;
 
   // If we made it this far, we just inserted the node the user handed
@@ -598,6 +607,7 @@ void ReplicatedMesh::delete_node(Node * n)
   this->get_boundary_info().remove(n);
 
   // delete the node
+  --_n_nodes;
   delete n;
 
   // explicitly zero the pointer
@@ -777,6 +787,7 @@ void ReplicatedMesh::renumber_nodes_and_elements ()
                 this->get_boundary_info().remove (nd);
 
                 // delete the node
+                --_n_nodes;
                 delete nd;
                 nd = nullptr;
               }
@@ -810,6 +821,7 @@ void ReplicatedMesh::renumber_nodes_and_elements ()
             this->get_boundary_info().remove (node);
 
             // delete the node
+            --_n_nodes;
             delete node;
             node = nullptr;
           }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -55,6 +55,7 @@ unit_tests_sources = \
   mesh/checkpoint.C \
   mesh/contains_point.C \
   mesh/extra_integers.C \
+  mesh/mesh_generation_test.C \
   mesh/mesh_input.C \
   mesh/mesh_function.C \
   mesh/mesh_stitch.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -200,7 +200,8 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	geom/point_test.h geom/side_test.C geom/which_node_am_i_test.C \
 	mesh/all_tri.C mesh/distort.C mesh/boundary_mesh.C \
 	mesh/boundary_info.C mesh/boundary_points.C mesh/checkpoint.C \
-	mesh/contains_point.C mesh/extra_integers.C mesh/mesh_input.C \
+	mesh/contains_point.C mesh/extra_integers.C \
+	mesh/mesh_generation_test.C mesh/mesh_input.C \
 	mesh/mesh_function.C mesh/mesh_stitch.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
@@ -271,6 +272,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	mesh/unit_tests_dbg-checkpoint.$(OBJEXT) \
 	mesh/unit_tests_dbg-contains_point.$(OBJEXT) \
 	mesh/unit_tests_dbg-extra_integers.$(OBJEXT) \
+	mesh/unit_tests_dbg-mesh_generation_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_input.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_function.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_stitch.$(OBJEXT) \
@@ -347,7 +349,8 @@ am__unit_tests_devel_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	geom/point_test.h geom/side_test.C geom/which_node_am_i_test.C \
 	mesh/all_tri.C mesh/distort.C mesh/boundary_mesh.C \
 	mesh/boundary_info.C mesh/boundary_points.C mesh/checkpoint.C \
-	mesh/contains_point.C mesh/extra_integers.C mesh/mesh_input.C \
+	mesh/contains_point.C mesh/extra_integers.C \
+	mesh/mesh_generation_test.C mesh/mesh_input.C \
 	mesh/mesh_function.C mesh/mesh_stitch.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
@@ -417,6 +420,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	mesh/unit_tests_devel-checkpoint.$(OBJEXT) \
 	mesh/unit_tests_devel-contains_point.$(OBJEXT) \
 	mesh/unit_tests_devel-extra_integers.$(OBJEXT) \
+	mesh/unit_tests_devel-mesh_generation_test.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_input.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_function.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_stitch.$(OBJEXT) \
@@ -490,7 +494,8 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	geom/point_test.h geom/side_test.C geom/which_node_am_i_test.C \
 	mesh/all_tri.C mesh/distort.C mesh/boundary_mesh.C \
 	mesh/boundary_info.C mesh/boundary_points.C mesh/checkpoint.C \
-	mesh/contains_point.C mesh/extra_integers.C mesh/mesh_input.C \
+	mesh/contains_point.C mesh/extra_integers.C \
+	mesh/mesh_generation_test.C mesh/mesh_input.C \
 	mesh/mesh_function.C mesh/mesh_stitch.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
@@ -560,6 +565,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	mesh/unit_tests_oprof-checkpoint.$(OBJEXT) \
 	mesh/unit_tests_oprof-contains_point.$(OBJEXT) \
 	mesh/unit_tests_oprof-extra_integers.$(OBJEXT) \
+	mesh/unit_tests_oprof-mesh_generation_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_input.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_function.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_stitch.$(OBJEXT) \
@@ -633,7 +639,8 @@ am__unit_tests_opt_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	geom/point_test.h geom/side_test.C geom/which_node_am_i_test.C \
 	mesh/all_tri.C mesh/distort.C mesh/boundary_mesh.C \
 	mesh/boundary_info.C mesh/boundary_points.C mesh/checkpoint.C \
-	mesh/contains_point.C mesh/extra_integers.C mesh/mesh_input.C \
+	mesh/contains_point.C mesh/extra_integers.C \
+	mesh/mesh_generation_test.C mesh/mesh_input.C \
 	mesh/mesh_function.C mesh/mesh_stitch.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
@@ -703,6 +710,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	mesh/unit_tests_opt-checkpoint.$(OBJEXT) \
 	mesh/unit_tests_opt-contains_point.$(OBJEXT) \
 	mesh/unit_tests_opt-extra_integers.$(OBJEXT) \
+	mesh/unit_tests_opt-mesh_generation_test.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_input.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_function.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_stitch.$(OBJEXT) \
@@ -775,7 +783,8 @@ am__unit_tests_prof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	geom/point_test.h geom/side_test.C geom/which_node_am_i_test.C \
 	mesh/all_tri.C mesh/distort.C mesh/boundary_mesh.C \
 	mesh/boundary_info.C mesh/boundary_points.C mesh/checkpoint.C \
-	mesh/contains_point.C mesh/extra_integers.C mesh/mesh_input.C \
+	mesh/contains_point.C mesh/extra_integers.C \
+	mesh/mesh_generation_test.C mesh/mesh_input.C \
 	mesh/mesh_function.C mesh/mesh_stitch.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
@@ -845,6 +854,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	mesh/unit_tests_prof-checkpoint.$(OBJEXT) \
 	mesh/unit_tests_prof-contains_point.$(OBJEXT) \
 	mesh/unit_tests_prof-extra_integers.$(OBJEXT) \
+	mesh/unit_tests_prof-mesh_generation_test.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_input.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_function.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_stitch.$(OBJEXT) \
@@ -1061,6 +1071,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Po \
+	mesh/$(DEPDIR)/unit_tests_dbg-mesh_generation_test.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_input.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_stitch.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po \
@@ -1083,6 +1094,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Po \
+	mesh/$(DEPDIR)/unit_tests_devel-mesh_generation_test.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_input.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_stitch.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po \
@@ -1105,6 +1117,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Po \
+	mesh/$(DEPDIR)/unit_tests_oprof-mesh_generation_test.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_input.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_stitch.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po \
@@ -1127,6 +1140,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Po \
+	mesh/$(DEPDIR)/unit_tests_opt-mesh_generation_test.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_input.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_stitch.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po \
@@ -1149,6 +1163,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Po \
+	mesh/$(DEPDIR)/unit_tests_prof-mesh_generation_test.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_input.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_stitch.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po \
@@ -1764,7 +1779,8 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 	geom/point_test.h geom/side_test.C geom/which_node_am_i_test.C \
 	mesh/all_tri.C mesh/distort.C mesh/boundary_mesh.C \
 	mesh/boundary_info.C mesh/boundary_points.C mesh/checkpoint.C \
-	mesh/contains_point.C mesh/extra_integers.C mesh/mesh_input.C \
+	mesh/contains_point.C mesh/extra_integers.C \
+	mesh/mesh_generation_test.C mesh/mesh_input.C \
 	mesh/mesh_function.C mesh/mesh_stitch.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
@@ -1969,6 +1985,8 @@ mesh/unit_tests_dbg-contains_point.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-extra_integers.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_dbg-mesh_generation_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-mesh_input.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-mesh_function.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -2195,6 +2213,8 @@ mesh/unit_tests_devel-contains_point.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-extra_integers.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_devel-mesh_generation_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-mesh_input.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-mesh_function.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -2373,6 +2393,8 @@ mesh/unit_tests_oprof-contains_point.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-extra_integers.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_oprof-mesh_generation_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-mesh_input.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-mesh_function.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -2551,6 +2573,8 @@ mesh/unit_tests_opt-contains_point.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-extra_integers.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_opt-mesh_generation_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-mesh_input.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-mesh_function.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -2729,6 +2753,8 @@ mesh/unit_tests_prof-contains_point.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-extra_integers.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_prof-mesh_generation_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-mesh_input.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-mesh_function.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -3005,6 +3031,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_generation_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_input.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_stitch.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po@am__quote@ # am--include-marker
@@ -3027,6 +3054,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_generation_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_input.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_stitch.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po@am__quote@ # am--include-marker
@@ -3049,6 +3077,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_generation_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_input.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_stitch.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po@am__quote@ # am--include-marker
@@ -3071,6 +3100,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_generation_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_input.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_stitch.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po@am__quote@ # am--include-marker
@@ -3093,6 +3123,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_generation_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_input.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_stitch.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po@am__quote@ # am--include-marker
@@ -3774,6 +3805,20 @@ mesh/unit_tests_dbg-extra_integers.obj: mesh/extra_integers.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/extra_integers.C' object='mesh/unit_tests_dbg-extra_integers.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-extra_integers.obj `if test -f 'mesh/extra_integers.C'; then $(CYGPATH_W) 'mesh/extra_integers.C'; else $(CYGPATH_W) '$(srcdir)/mesh/extra_integers.C'; fi`
+
+mesh/unit_tests_dbg-mesh_generation_test.o: mesh/mesh_generation_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mesh_generation_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mesh_generation_test.Tpo -c -o mesh/unit_tests_dbg-mesh_generation_test.o `test -f 'mesh/mesh_generation_test.C' || echo '$(srcdir)/'`mesh/mesh_generation_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-mesh_generation_test.Tpo mesh/$(DEPDIR)/unit_tests_dbg-mesh_generation_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_generation_test.C' object='mesh/unit_tests_dbg-mesh_generation_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mesh_generation_test.o `test -f 'mesh/mesh_generation_test.C' || echo '$(srcdir)/'`mesh/mesh_generation_test.C
+
+mesh/unit_tests_dbg-mesh_generation_test.obj: mesh/mesh_generation_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mesh_generation_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mesh_generation_test.Tpo -c -o mesh/unit_tests_dbg-mesh_generation_test.obj `if test -f 'mesh/mesh_generation_test.C'; then $(CYGPATH_W) 'mesh/mesh_generation_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_generation_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-mesh_generation_test.Tpo mesh/$(DEPDIR)/unit_tests_dbg-mesh_generation_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_generation_test.C' object='mesh/unit_tests_dbg-mesh_generation_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mesh_generation_test.obj `if test -f 'mesh/mesh_generation_test.C'; then $(CYGPATH_W) 'mesh/mesh_generation_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_generation_test.C'; fi`
 
 mesh/unit_tests_dbg-mesh_input.o: mesh/mesh_input.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mesh_input.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mesh_input.Tpo -c -o mesh/unit_tests_dbg-mesh_input.o `test -f 'mesh/mesh_input.C' || echo '$(srcdir)/'`mesh/mesh_input.C
@@ -4951,6 +4996,20 @@ mesh/unit_tests_devel-extra_integers.obj: mesh/extra_integers.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-extra_integers.obj `if test -f 'mesh/extra_integers.C'; then $(CYGPATH_W) 'mesh/extra_integers.C'; else $(CYGPATH_W) '$(srcdir)/mesh/extra_integers.C'; fi`
 
+mesh/unit_tests_devel-mesh_generation_test.o: mesh/mesh_generation_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mesh_generation_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mesh_generation_test.Tpo -c -o mesh/unit_tests_devel-mesh_generation_test.o `test -f 'mesh/mesh_generation_test.C' || echo '$(srcdir)/'`mesh/mesh_generation_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mesh_generation_test.Tpo mesh/$(DEPDIR)/unit_tests_devel-mesh_generation_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_generation_test.C' object='mesh/unit_tests_devel-mesh_generation_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mesh_generation_test.o `test -f 'mesh/mesh_generation_test.C' || echo '$(srcdir)/'`mesh/mesh_generation_test.C
+
+mesh/unit_tests_devel-mesh_generation_test.obj: mesh/mesh_generation_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mesh_generation_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mesh_generation_test.Tpo -c -o mesh/unit_tests_devel-mesh_generation_test.obj `if test -f 'mesh/mesh_generation_test.C'; then $(CYGPATH_W) 'mesh/mesh_generation_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_generation_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mesh_generation_test.Tpo mesh/$(DEPDIR)/unit_tests_devel-mesh_generation_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_generation_test.C' object='mesh/unit_tests_devel-mesh_generation_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mesh_generation_test.obj `if test -f 'mesh/mesh_generation_test.C'; then $(CYGPATH_W) 'mesh/mesh_generation_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_generation_test.C'; fi`
+
 mesh/unit_tests_devel-mesh_input.o: mesh/mesh_input.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mesh_input.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mesh_input.Tpo -c -o mesh/unit_tests_devel-mesh_input.o `test -f 'mesh/mesh_input.C' || echo '$(srcdir)/'`mesh/mesh_input.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mesh_input.Tpo mesh/$(DEPDIR)/unit_tests_devel-mesh_input.Po
@@ -6126,6 +6185,20 @@ mesh/unit_tests_oprof-extra_integers.obj: mesh/extra_integers.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/extra_integers.C' object='mesh/unit_tests_oprof-extra_integers.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-extra_integers.obj `if test -f 'mesh/extra_integers.C'; then $(CYGPATH_W) 'mesh/extra_integers.C'; else $(CYGPATH_W) '$(srcdir)/mesh/extra_integers.C'; fi`
+
+mesh/unit_tests_oprof-mesh_generation_test.o: mesh/mesh_generation_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mesh_generation_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mesh_generation_test.Tpo -c -o mesh/unit_tests_oprof-mesh_generation_test.o `test -f 'mesh/mesh_generation_test.C' || echo '$(srcdir)/'`mesh/mesh_generation_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-mesh_generation_test.Tpo mesh/$(DEPDIR)/unit_tests_oprof-mesh_generation_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_generation_test.C' object='mesh/unit_tests_oprof-mesh_generation_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mesh_generation_test.o `test -f 'mesh/mesh_generation_test.C' || echo '$(srcdir)/'`mesh/mesh_generation_test.C
+
+mesh/unit_tests_oprof-mesh_generation_test.obj: mesh/mesh_generation_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mesh_generation_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mesh_generation_test.Tpo -c -o mesh/unit_tests_oprof-mesh_generation_test.obj `if test -f 'mesh/mesh_generation_test.C'; then $(CYGPATH_W) 'mesh/mesh_generation_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_generation_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-mesh_generation_test.Tpo mesh/$(DEPDIR)/unit_tests_oprof-mesh_generation_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_generation_test.C' object='mesh/unit_tests_oprof-mesh_generation_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mesh_generation_test.obj `if test -f 'mesh/mesh_generation_test.C'; then $(CYGPATH_W) 'mesh/mesh_generation_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_generation_test.C'; fi`
 
 mesh/unit_tests_oprof-mesh_input.o: mesh/mesh_input.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mesh_input.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mesh_input.Tpo -c -o mesh/unit_tests_oprof-mesh_input.o `test -f 'mesh/mesh_input.C' || echo '$(srcdir)/'`mesh/mesh_input.C
@@ -7303,6 +7376,20 @@ mesh/unit_tests_opt-extra_integers.obj: mesh/extra_integers.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-extra_integers.obj `if test -f 'mesh/extra_integers.C'; then $(CYGPATH_W) 'mesh/extra_integers.C'; else $(CYGPATH_W) '$(srcdir)/mesh/extra_integers.C'; fi`
 
+mesh/unit_tests_opt-mesh_generation_test.o: mesh/mesh_generation_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mesh_generation_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mesh_generation_test.Tpo -c -o mesh/unit_tests_opt-mesh_generation_test.o `test -f 'mesh/mesh_generation_test.C' || echo '$(srcdir)/'`mesh/mesh_generation_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mesh_generation_test.Tpo mesh/$(DEPDIR)/unit_tests_opt-mesh_generation_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_generation_test.C' object='mesh/unit_tests_opt-mesh_generation_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mesh_generation_test.o `test -f 'mesh/mesh_generation_test.C' || echo '$(srcdir)/'`mesh/mesh_generation_test.C
+
+mesh/unit_tests_opt-mesh_generation_test.obj: mesh/mesh_generation_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mesh_generation_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mesh_generation_test.Tpo -c -o mesh/unit_tests_opt-mesh_generation_test.obj `if test -f 'mesh/mesh_generation_test.C'; then $(CYGPATH_W) 'mesh/mesh_generation_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_generation_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mesh_generation_test.Tpo mesh/$(DEPDIR)/unit_tests_opt-mesh_generation_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_generation_test.C' object='mesh/unit_tests_opt-mesh_generation_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mesh_generation_test.obj `if test -f 'mesh/mesh_generation_test.C'; then $(CYGPATH_W) 'mesh/mesh_generation_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_generation_test.C'; fi`
+
 mesh/unit_tests_opt-mesh_input.o: mesh/mesh_input.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mesh_input.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mesh_input.Tpo -c -o mesh/unit_tests_opt-mesh_input.o `test -f 'mesh/mesh_input.C' || echo '$(srcdir)/'`mesh/mesh_input.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mesh_input.Tpo mesh/$(DEPDIR)/unit_tests_opt-mesh_input.Po
@@ -8479,6 +8566,20 @@ mesh/unit_tests_prof-extra_integers.obj: mesh/extra_integers.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-extra_integers.obj `if test -f 'mesh/extra_integers.C'; then $(CYGPATH_W) 'mesh/extra_integers.C'; else $(CYGPATH_W) '$(srcdir)/mesh/extra_integers.C'; fi`
 
+mesh/unit_tests_prof-mesh_generation_test.o: mesh/mesh_generation_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mesh_generation_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mesh_generation_test.Tpo -c -o mesh/unit_tests_prof-mesh_generation_test.o `test -f 'mesh/mesh_generation_test.C' || echo '$(srcdir)/'`mesh/mesh_generation_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mesh_generation_test.Tpo mesh/$(DEPDIR)/unit_tests_prof-mesh_generation_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_generation_test.C' object='mesh/unit_tests_prof-mesh_generation_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mesh_generation_test.o `test -f 'mesh/mesh_generation_test.C' || echo '$(srcdir)/'`mesh/mesh_generation_test.C
+
+mesh/unit_tests_prof-mesh_generation_test.obj: mesh/mesh_generation_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mesh_generation_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mesh_generation_test.Tpo -c -o mesh/unit_tests_prof-mesh_generation_test.obj `if test -f 'mesh/mesh_generation_test.C'; then $(CYGPATH_W) 'mesh/mesh_generation_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_generation_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mesh_generation_test.Tpo mesh/$(DEPDIR)/unit_tests_prof-mesh_generation_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_generation_test.C' object='mesh/unit_tests_prof-mesh_generation_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mesh_generation_test.obj `if test -f 'mesh/mesh_generation_test.C'; then $(CYGPATH_W) 'mesh/mesh_generation_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_generation_test.C'; fi`
+
 mesh/unit_tests_prof-mesh_input.o: mesh/mesh_input.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mesh_input.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mesh_input.Tpo -c -o mesh/unit_tests_prof-mesh_input.o `test -f 'mesh/mesh_input.C' || echo '$(srcdir)/'`mesh/mesh_input.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mesh_input.Tpo mesh/$(DEPDIR)/unit_tests_prof-mesh_input.Po
@@ -9590,6 +9691,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_generation_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_input.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po
@@ -9612,6 +9714,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_generation_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_input.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po
@@ -9634,6 +9737,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_generation_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_input.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po
@@ -9656,6 +9760,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_generation_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_input.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po
@@ -9678,6 +9783,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_generation_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_input.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po
@@ -10055,6 +10161,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_generation_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_input.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po
@@ -10077,6 +10184,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_generation_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_input.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po
@@ -10099,6 +10207,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_generation_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_input.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po
@@ -10121,6 +10230,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_generation_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_input.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po
@@ -10143,6 +10253,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_generation_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_input.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po

--- a/tests/mesh/boundary_info.C
+++ b/tests/mesh/boundary_info.C
@@ -285,7 +285,8 @@ public:
     bi.add_shellface(elem_top, 0, 10);
     bi.add_shellface(elem_bottom, 1, 20);
 
-    mesh.prepare_for_use(false /*skip_renumber*/);
+    mesh.allow_renumbering(true);
+    mesh.prepare_for_use();
 
     CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(2), bi.n_shellface_conds());
 

--- a/tests/mesh/mesh_function_dfem.C
+++ b/tests/mesh/mesh_function_dfem.C
@@ -105,10 +105,8 @@ protected:
       elem_bottom->set_node(3) = _mesh->node_ptr(0);
     }
 
-    // libMesh will renumber, but we numbered according to its scheme
-    // anyway. We do this because when we call uniformly_refine subsequently,
-    // it's going use skip_renumber=false.
-    _mesh->prepare_for_use(false /*skip_renumber*/);
+    _mesh->allow_renumbering(true);
+    _mesh->prepare_for_use();
 
     // get a point locator
     _point_locator = _mesh->sub_point_locator();

--- a/tests/mesh/mesh_generation_test.C
+++ b/tests/mesh/mesh_generation_test.C
@@ -47,6 +47,14 @@ public:
 
   CPPUNIT_TEST_SUITE_END();
 
+protected:
+  std::unique_ptr<UnstructuredMesh> new_mesh (bool is_replicated)
+  {
+    if (is_replicated)
+      return libmesh_make_unique<ReplicatedMesh>(*TestCommWorld);
+    return libmesh_make_unique<DistributedMesh>(*TestCommWorld);
+  }
+
 public:
   void setUp() {}
 
@@ -86,7 +94,7 @@ public:
         CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
                              cast_int<dof_id_type>((2*n+1)*(2*n+1)));
         break;
-      default:
+      default: // QUAD8
         CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
                              cast_int<dof_id_type>((2*n+1)*(2*n+1) - n*n));
       }
@@ -177,138 +185,43 @@ public:
     CPPUNIT_ASSERT(bbox.max()(2) >= Real(7.0));
   }
 
-  void buildLineEdge2 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildLine(rep, 6, EDGE2);
-    testBuildLine(dist, 6, EDGE2);
+  typedef void (MeshGenerationTest::*Builder)(UnstructuredMesh&, unsigned int, ElemType);
+
+  void tester(Builder f, unsigned int n, ElemType type)
+  {
+    for (int is_replicated = 0; is_replicated != 2; ++is_replicated)
+      {
+        for (int skip_renumber = 0 ; skip_renumber != 2; ++skip_renumber)
+          {
+            std::unique_ptr<UnstructuredMesh> mesh =
+              new_mesh(is_replicated);
+            mesh->allow_renumbering(!skip_renumber);
+            (this->*f)(*mesh, n, type);
+          }
+      }
   }
 
-  void buildLineEdge3 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildLine(rep, 6, EDGE3);
-    testBuildLine(dist, 6, EDGE3);
-  }
+  void buildLineEdge2 ()     { tester(&MeshGenerationTest::testBuildLine, 5, EDGE2); }
+  void buildLineEdge3 ()     { tester(&MeshGenerationTest::testBuildLine, 5, EDGE3); }
+  void buildLineEdge4 ()     { tester(&MeshGenerationTest::testBuildLine, 5, EDGE4); }
 
-  void buildLineEdge4 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildLine(rep, 6, EDGE3);
-    testBuildLine(dist, 6, EDGE3);
-  }
+  void buildSquareTri3 ()    { tester(&MeshGenerationTest::testBuildSquare, 3, TRI3); }
+  void buildSquareTri6 ()    { tester(&MeshGenerationTest::testBuildSquare, 4, TRI6); }
+  void buildSquareQuad4 ()   { tester(&MeshGenerationTest::testBuildSquare, 4, QUAD4); }
+  void buildSquareQuad8 ()   { tester(&MeshGenerationTest::testBuildSquare, 4, QUAD8); }
+  void buildSquareQuad9 ()   { tester(&MeshGenerationTest::testBuildSquare, 4, QUAD9); }
 
-  void buildSquareTri3 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildSquare(rep, 4, TRI3);
-    testBuildSquare(dist, 4, TRI3);
-  }
-
-  void buildSquareTri6 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildSquare(rep, 4, TRI6);
-    testBuildSquare(dist, 4, TRI6);
-  }
-
-  void buildSquareQuad4 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildSquare(rep, 4, QUAD4);
-    testBuildSquare(dist, 4, QUAD4);
-  }
-
-  void buildSquareQuad8 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildSquare(rep, 4, QUAD8);
-    testBuildSquare(dist, 4, QUAD8);
-  }
-
-  void buildSquareQuad9 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildSquare(rep, 4, QUAD9);
-    testBuildSquare(dist, 4, QUAD9);
-  }
-
-  void buildCubeTet4 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildCube(rep, 2, TET4);
-    testBuildCube(dist, 2, TET4);
-  }
-
-  void buildCubeTet10 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildCube(rep, 2, TET10);
-    testBuildCube(dist, 2, TET10);
-  }
-
-  void buildCubeHex8 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildCube(rep, 2, HEX8);
-    testBuildCube(dist, 2, HEX8);
-  }
-
-  void buildCubeHex20 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildCube(rep, 2, HEX20);
-    testBuildCube(dist, 2, HEX20);
-  }
-
-  void buildCubeHex27 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildCube(rep, 2, HEX27);
-    testBuildCube(dist, 2, HEX27);
-  }
-
-  void buildCubePrism6 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildCube(rep, 2, PRISM6);
-    testBuildCube(dist, 2, PRISM6);
-  }
-
-  void buildCubePrism15 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildCube(rep, 2, PRISM15);
-    testBuildCube(dist, 2, PRISM15);
-  }
-
-  void buildCubePrism18 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildCube(rep, 2, PRISM18);
-    testBuildCube(dist, 2, PRISM18);
-  }
- 
-  void buildCubePyramid5 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildCube(rep, 2, PYRAMID5);
-    testBuildCube(dist, 2, PYRAMID5);
-  }
-   
-  void buildCubePyramid13 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildCube(rep, 2, PYRAMID13);
-    testBuildCube(dist, 2, PYRAMID13);
-  }
- 
-  void buildCubePyramid14 () {
-    ReplicatedMesh rep(*TestCommWorld);
-    DistributedMesh dist(*TestCommWorld);
-    testBuildCube(rep, 2, PYRAMID14);
-    testBuildCube(dist, 2, PYRAMID14);
-  }
+  void buildCubeTet4 ()      { tester(&MeshGenerationTest::testBuildCube, 2, TET4); }
+  void buildCubeTet10 ()     { tester(&MeshGenerationTest::testBuildCube, 2, TET10); }
+  void buildCubeHex8 ()      { tester(&MeshGenerationTest::testBuildCube, 2, HEX8); }
+  void buildCubeHex20 ()     { tester(&MeshGenerationTest::testBuildCube, 2, HEX20); }
+  void buildCubeHex27 ()     { tester(&MeshGenerationTest::testBuildCube, 2, HEX27); }
+  void buildCubePrism6 ()    { tester(&MeshGenerationTest::testBuildCube, 2, PRISM6); }
+  void buildCubePrism15 ()   { tester(&MeshGenerationTest::testBuildCube, 2, PRISM15); }
+  void buildCubePrism18 ()   { tester(&MeshGenerationTest::testBuildCube, 2, PRISM18); }
+  void buildCubePyramid5 ()  { tester(&MeshGenerationTest::testBuildCube, 2, PYRAMID5); }
+  void buildCubePyramid13 () { tester(&MeshGenerationTest::testBuildCube, 2, PYRAMID13); }
+  void buildCubePyramid14 () { tester(&MeshGenerationTest::testBuildCube, 2, PYRAMID14); }
 };
 
 

--- a/tests/mesh/mesh_generation_test.C
+++ b/tests/mesh/mesh_generation_test.C
@@ -63,7 +63,7 @@ public:
   void testBuildLine(UnstructuredMesh & mesh, unsigned int n, ElemType type)
   {
     MeshTools::Generation::build_line (mesh, n, -1.0, 2.0, type);
-    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), n);
+    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), cast_int<dof_id_type>(n));
     CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
                          cast_int<dof_id_type>((Elem::type_to_n_nodes_map[type]-1)*n + 1));
 

--- a/tests/mesh/mesh_generation_test.C
+++ b/tests/mesh/mesh_generation_test.C
@@ -1,0 +1,315 @@
+#include <libmesh/libmesh.h>
+#include <libmesh/distributed_mesh.h>
+#include <libmesh/elem.h>
+#include <libmesh/mesh_generation.h>
+#include <libmesh/mesh_tools.h>
+#include <libmesh/replicated_mesh.h>
+
+#include "test_comm.h"
+#include "libmesh_cppunit.h"
+
+
+using namespace libMesh;
+
+class MeshGenerationTest : public CppUnit::TestCase
+{
+  /**
+   * The goal of this test is to verify proper operation of
+   * MeshGeneration functions, as well as to indirectly verify the
+   * MeshBase functions they rely on.
+   */
+public:
+  CPPUNIT_TEST_SUITE( MeshGenerationTest );
+
+  CPPUNIT_TEST( buildLineEdge2 );
+  CPPUNIT_TEST( buildLineEdge3 );
+  CPPUNIT_TEST( buildLineEdge4 );
+#if LIBMESH_DIM > 1
+  CPPUNIT_TEST( buildSquareTri3 );
+  CPPUNIT_TEST( buildSquareTri6 );
+  CPPUNIT_TEST( buildSquareQuad4 );
+  CPPUNIT_TEST( buildSquareQuad8 );
+  CPPUNIT_TEST( buildSquareQuad9 );
+#endif
+#if LIBMESH_DIM > 2
+  CPPUNIT_TEST( buildCubeTet4 );
+  CPPUNIT_TEST( buildCubeTet10 );
+  CPPUNIT_TEST( buildCubeHex8 );
+  CPPUNIT_TEST( buildCubeHex20 );
+  CPPUNIT_TEST( buildCubeHex27 );
+  CPPUNIT_TEST( buildCubePrism6 );
+  CPPUNIT_TEST( buildCubePrism15 );
+  CPPUNIT_TEST( buildCubePrism18 );
+  CPPUNIT_TEST( buildCubePyramid5 );
+  CPPUNIT_TEST( buildCubePyramid13 );
+  CPPUNIT_TEST( buildCubePyramid14 );
+#endif
+
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp() {}
+
+  void tearDown() {}
+
+  void testBuildLine(UnstructuredMesh & mesh, unsigned int n, ElemType type)
+  {
+    MeshTools::Generation::build_line (mesh, n, -1.0, 2.0, type);
+    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), n);
+    CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                         cast_int<dof_id_type>((Elem::type_to_n_nodes_map[type]-1)*n + 1));
+
+    BoundingBox bbox = MeshTools::create_bounding_box(mesh);
+    CPPUNIT_ASSERT_EQUAL(bbox.min()(0), Real(-1.0));
+    CPPUNIT_ASSERT_EQUAL(bbox.max()(0), Real(2.0));
+  }
+
+  void testBuildSquare(UnstructuredMesh & mesh, unsigned int n, ElemType type)
+  {
+    MeshTools::Generation::build_square (mesh, n, n, -2.0, 3.0, -4.0, 5.0, type);
+    if (Elem::type_to_n_sides_map[type] == 4)
+      CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), cast_int<dof_id_type>(n*n));
+    else
+      CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), cast_int<dof_id_type>(n*n*2));
+
+    const unsigned int n_nodes = Elem::type_to_n_nodes_map[type];
+
+    switch (n_nodes)
+      {
+      case 3: // First-order elements
+      case 4:
+        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                             cast_int<dof_id_type>((n+1)*(n+1)));
+        break;
+      case 6: // Second-order elements
+      case 9:
+        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                             cast_int<dof_id_type>((2*n+1)*(2*n+1)));
+        break;
+      default:
+        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                             cast_int<dof_id_type>((2*n+1)*(2*n+1) - n*n));
+      }
+
+    // Our bounding boxes can be loose on higher order elements, but
+    // we can at least assert that they're not too tight
+    BoundingBox bbox = MeshTools::create_bounding_box(mesh);
+    CPPUNIT_ASSERT(bbox.min()(0) <= Real(-2.0));
+    CPPUNIT_ASSERT(bbox.max()(0) >= Real(3.0));
+    CPPUNIT_ASSERT(bbox.min()(1) <= Real(-4.0));
+    CPPUNIT_ASSERT(bbox.max()(1) >= Real(5.0));
+  }
+
+  void testBuildCube(UnstructuredMesh & mesh, unsigned int n, ElemType type)
+  {
+    MeshTools::Generation::build_cube (mesh, n, n, n, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, type);
+    switch (Elem::type_to_n_sides_map[type])
+      {
+      case 4: // tets
+        CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), cast_int<dof_id_type>(n*n*n*24));
+        break;
+      case 5: // prisms, pyramids
+        if (type == PRISM6 || type == PRISM15 || type == PRISM18)
+          CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), cast_int<dof_id_type>(n*n*n*2));
+        else
+          CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), cast_int<dof_id_type>(n*n*n*6));
+        break;
+      case 6: // hexes
+        CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), cast_int<dof_id_type>(n*n*n));
+        break;
+      default:
+        libmesh_error();
+      }
+
+
+    switch (Elem::type_to_n_nodes_map[type])
+      {
+      case 4: // First-order tets
+        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                             cast_int<dof_id_type>((n+1)*(n+1)*(n+1) + n*n*n + 3*(n+1)*n*n));
+        break;
+      case 6: // First-order prisms and hexes use the same nodes
+      case 8:
+        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                             cast_int<dof_id_type>((n+1)*(n+1)*(n+1)));
+        break;
+      case 10: // Second-order tets
+        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                             cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) + 14*n*n*n + 4*3*(n+1)*n*n));
+        break;
+      case 18: // Second-order prisms and hexes use the same nodes
+      case 27:
+        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                             cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1)));
+        break;
+      case 20:
+        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                             cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) - n*n*n - 3*(n+1)*n*n));
+        break;
+      case 15: // weird partial order prism
+        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                             cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) - n*n*n - 2*(n+1)*n*n));
+        break;
+      case 5: // pyramids
+        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                             cast_int<dof_id_type>((n+1)*(n+1)*(n+1) + n*n*n));
+        break;
+      case 13:
+        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                             cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) + 8*n*n*n - 3*(n+1)*n*n));
+        break;
+      case 14:
+        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                             cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) + 8*n*n*n));
+        break;
+      default:
+        libmesh_error();
+      }
+
+    // Our bounding boxes can be loose on higher order elements, but
+    // we can at least assert that they're not too tight
+    BoundingBox bbox = MeshTools::create_bounding_box(mesh);
+    CPPUNIT_ASSERT(bbox.min()(0) <= Real(-2.0));
+    CPPUNIT_ASSERT(bbox.max()(0) >= Real(3.0));
+    CPPUNIT_ASSERT(bbox.min()(1) <= Real(-4.0));
+    CPPUNIT_ASSERT(bbox.max()(1) >= Real(5.0));
+    CPPUNIT_ASSERT(bbox.min()(2) <= Real(-6.0));
+    CPPUNIT_ASSERT(bbox.max()(2) >= Real(7.0));
+  }
+
+  void buildLineEdge2 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildLine(rep, 6, EDGE2);
+    testBuildLine(dist, 6, EDGE2);
+  }
+
+  void buildLineEdge3 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildLine(rep, 6, EDGE3);
+    testBuildLine(dist, 6, EDGE3);
+  }
+
+  void buildLineEdge4 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildLine(rep, 6, EDGE3);
+    testBuildLine(dist, 6, EDGE3);
+  }
+
+  void buildSquareTri3 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildSquare(rep, 4, TRI3);
+    testBuildSquare(dist, 4, TRI3);
+  }
+
+  void buildSquareTri6 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildSquare(rep, 4, TRI6);
+    testBuildSquare(dist, 4, TRI6);
+  }
+
+  void buildSquareQuad4 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildSquare(rep, 4, QUAD4);
+    testBuildSquare(dist, 4, QUAD4);
+  }
+
+  void buildSquareQuad8 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildSquare(rep, 4, QUAD8);
+    testBuildSquare(dist, 4, QUAD8);
+  }
+
+  void buildSquareQuad9 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildSquare(rep, 4, QUAD9);
+    testBuildSquare(dist, 4, QUAD9);
+  }
+
+  void buildCubeTet4 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildCube(rep, 2, TET4);
+    testBuildCube(dist, 2, TET4);
+  }
+
+  void buildCubeTet10 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildCube(rep, 2, TET10);
+    testBuildCube(dist, 2, TET10);
+  }
+
+  void buildCubeHex8 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildCube(rep, 2, HEX8);
+    testBuildCube(dist, 2, HEX8);
+  }
+
+  void buildCubeHex20 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildCube(rep, 2, HEX20);
+    testBuildCube(dist, 2, HEX20);
+  }
+
+  void buildCubeHex27 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildCube(rep, 2, HEX27);
+    testBuildCube(dist, 2, HEX27);
+  }
+
+  void buildCubePrism6 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildCube(rep, 2, PRISM6);
+    testBuildCube(dist, 2, PRISM6);
+  }
+
+  void buildCubePrism15 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildCube(rep, 2, PRISM15);
+    testBuildCube(dist, 2, PRISM15);
+  }
+
+  void buildCubePrism18 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildCube(rep, 2, PRISM18);
+    testBuildCube(dist, 2, PRISM18);
+  }
+ 
+  void buildCubePyramid5 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildCube(rep, 2, PYRAMID5);
+    testBuildCube(dist, 2, PYRAMID5);
+  }
+   
+  void buildCubePyramid13 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildCube(rep, 2, PYRAMID13);
+    testBuildCube(dist, 2, PYRAMID13);
+  }
+ 
+  void buildCubePyramid14 () {
+    ReplicatedMesh rep(*TestCommWorld);
+    DistributedMesh dist(*TestCommWorld);
+    testBuildCube(rep, 2, PYRAMID14);
+    testBuildCube(dist, 2, PYRAMID14);
+  }
+};
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION( MeshGenerationTest );

--- a/tests/mesh/mixed_dim_mesh_test.C
+++ b/tests/mesh/mixed_dim_mesh_test.C
@@ -88,10 +88,8 @@ protected:
       edge->subdomain_id() = 1;
     }
 
-    // libMesh will renumber, but we numbered according to its scheme
-    // anyway. We do this because when we call uniformly_refine subsequently,
-    // it's going use skip_renumber=false.
-    _mesh->prepare_for_use(false /*skip_renumber*/);
+    _mesh->allow_renumbering(true);
+    _mesh->prepare_for_use();
   }
 
 public:
@@ -476,10 +474,8 @@ protected:
       edge->subdomain_id() = 1;
     }
 
-    // libMesh will renumber, but we numbered according to its scheme
-    // anyway. We do this because when we call uniformly_refine subsequently,
-    // it's going use skip_renumber=false.
-    _mesh->prepare_for_use(false /*skip_renumber*/);
+    _mesh->allow_renumbering(true);
+    _mesh->prepare_for_use();
 
 
 #ifdef LIBMESH_ENABLE_AMR
@@ -707,10 +703,8 @@ protected:
 
     }
 
-    // libMesh will renumber, but we numbered according to its scheme
-    // anyway. We do this because when we call uniformly_refine subsequently,
-    // it's going use skip_renumber=false.
-    _mesh->prepare_for_use(false /*skip_renumber*/);
+    _mesh->allow_renumbering(true);
+    _mesh->prepare_for_use();
 
 #ifdef LIBMESH_ENABLE_AMR
     //Flag the bottom element for refinement
@@ -937,10 +931,8 @@ protected:
       quad->subdomain_id() = 1;
     }
 
-    // libMesh will renumber, but we numbered according to its scheme
-    // anyway. We do this because when we call uniformly_refine subsequently,
-    // it's going use skip_renumber=false.
-    _mesh->prepare_for_use(false /*skip_renumber*/);
+    _mesh->allow_renumbering(true);
+    _mesh->prepare_for_use();
 
 #ifdef LIBMESH_ENABLE_AMR
     //Flag the bottom element for refinement


### PR DESCRIPTION
Aside from adding a little more test coverage for basic code that should really never ever break, this exposes the bugs fixed by #2480 - the broken cases now fail if I don't have that patch included.