### PR TITLE
Reset ReplicatedMesh::_n_* during clear()

### DIFF
--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -643,6 +643,7 @@ void ReplicatedMesh::clear ()
   for (auto & elem : _elements)
     delete elem;
 
+  _n_elem = 0;
   _elements.clear();
 
   // clear the nodes data structure
@@ -652,6 +653,7 @@ void ReplicatedMesh::clear ()
   for (auto & node : _nodes)
     delete node;
 
+  _n_nodes = 0;
   _nodes.clear();
 }
 


### PR DESCRIPTION
This bug just got introduced by #2482, but somehow doesn't get triggered
by our usual test suite unless we configure with --disable-lgpl-only
(after which point the ElemCutter is using clear() to reuse its internal
Mesh).