### PR TITLE
macrofice second-derivative quantities

### DIFF
--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -2002,7 +2002,9 @@ FEMContext::build_new_fe( const FEGenericBase<OutputShape>* fe,
     case -1:
       fe_new->get_phi();
       fe_new->get_dphi();
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
       fe_new->get_d2phi();
+#endif
       fe_new->get_curl_phi();
       break;
     case 0:
@@ -2012,7 +2014,12 @@ FEMContext::build_new_fe( const FEGenericBase<OutputShape>* fe,
       fe_new->get_dphi();
       break;
     case 2:
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
       fe_new->get_d2phi();
+#else
+      // here a different configuration is required.
+      libmesh_not_implemented();
+#endif
       break;
     case 3:
       fe_new->get_curl_phi();

--- a/tests/numerics/parsed_fem_function_test.C
+++ b/tests/numerics/parsed_fem_function_test.C
@@ -93,7 +93,9 @@ public:
       {
         c->get_element_fe(0)->get_phi();
         c->get_element_fe(0)->get_dphi();
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
         c->get_element_fe(0)->get_d2phi();
+#endif
         c->pre_fe_reinit(*sys, elem);
         c->elem_fe_reinit();
 


### PR DESCRIPTION
Again, some second derivatives sneaked outside the ``ENABLE_SECOND_DERIVATIVE``-macro.

In ``FEMContext::build_new_fe`` I am not sure if one should probably throw a ``libmesh_error()`` instead of just skipping?