### PR TITLE
Add Elem::base_type()

### DIFF
--- a/include/enums/enum_elem_type.h
+++ b/include/enums/enum_elem_type.h
@@ -84,6 +84,37 @@ enum ElemMappingType : unsigned char {
   RATIONAL_BERNSTEIN_MAP,
   INVALID_MAP };
 
+/**
+ * Defines an \p enum for geometric element base types.
+ *
+ * The fixed type, i.e. ": int", enumeration syntax used here allows
+ * this enum to be forward declared as
+ * enum BaseElemType : int;
+ * reducing header file dependencies.
+ */
+ enum BaseElemType : int {
+                    // 1D
+                    EDGE = 0,
+                    // 2D
+                    TRI = 1,
+                    QUAD = 2,
+                    // 3D
+                    TET = 3,
+                    HEX = 4,
+                    PRISM = 5,
+                    PYRAMID = 6,
+                    // Infinite Elems
+                    INFEDGE = 7,
+                    INFQUAD = 8,
+                    INFHEX = 9,
+                    INFPRISM = 10,
+                    // 0D
+                    NODE = 11,
+                    // Miscellaneous Elems
+                    REMOTE = 12,
+                    // Invalid
+                    INVALID_BASE_ELEM};   // should always be last
+
 }
 
 #endif

--- a/include/geom/cell_hex.h
+++ b/include/geom/cell_hex.h
@@ -68,6 +68,11 @@ public:
   }
 
   /**
+   * \returns \p HEX.
+   */
+  virtual BaseElemType base_type () const override final { return HEX; }
+
+  /**
    * \returns 6.
    */
   virtual unsigned int n_sides() const override final { return 6; }

--- a/include/geom/cell_inf_hex.h
+++ b/include/geom/cell_inf_hex.h
@@ -78,6 +78,11 @@ public:
   }
 
   /**
+   * \returns \p INFHEX.
+   */
+  virtual BaseElemType base_type () const override final { return INFHEX; }
+
+  /**
    * \returns 5.  Infinite elements have one side less
    * than their conventional counterparts, since one
    * side is supposed to be located at infinity.

--- a/include/geom/cell_inf_prism.h
+++ b/include/geom/cell_inf_prism.h
@@ -74,6 +74,11 @@ public:
   }
 
   /**
+   * \returns \p INFPRISM.
+   */
+  virtual BaseElemType base_type () const override final { return INFPRISM; }
+
+  /**
    * \returns 4.  Infinite elements have one side less
    * than their conventional counterparts, since one
    * side is supposed to be located at infinity.

--- a/include/geom/cell_prism.h
+++ b/include/geom/cell_prism.h
@@ -68,6 +68,11 @@ public:
   }
 
   /**
+   * \returns \p PRISM.
+   */
+  virtual BaseElemType base_type () const override final { return PRISM; }
+
+  /**
    * \returns 6.  All prism-derivatives are guaranteed to have at
    * least 6 nodes.
    */

--- a/include/geom/cell_pyramid.h
+++ b/include/geom/cell_pyramid.h
@@ -72,6 +72,11 @@ public:
   }
 
   /**
+   * \returns \p PYRAMID.
+   */
+  virtual BaseElemType base_type () const override final { return PYRAMID; }
+
+  /**
    * \returns 5.  All pyramid-derivatives are guaranteed to have at
    * least 5 nodes.
    */

--- a/include/geom/cell_tet.h
+++ b/include/geom/cell_tet.h
@@ -69,6 +69,11 @@ public:
   }
 
   /**
+   * \returns \p TET.
+   */
+  virtual BaseElemType base_type () const override final { return TET; }
+
+  /**
    * \returns 4.
    */
   virtual unsigned int n_sides() const override final { return 4; }

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -64,6 +64,11 @@ public:
   virtual unsigned short dim () const override final { return 1; }
 
   /**
+   * \returns \p EDGE.
+   */
+  virtual BaseElemType base_type () const override { return EDGE; }
+
+  /**
    * \returns 2. Every edge is guaranteed to have at least 2 nodes.
    */
   virtual unsigned int n_nodes() const override { return 2; }

--- a/include/geom/edge_inf_edge2.h
+++ b/include/geom/edge_inf_edge2.h
@@ -77,6 +77,11 @@ public:
   }
 
   /**
+   * \returns \p INFEDGE.
+   */
+  virtual BaseElemType base_type () const override final { return INFEDGE; }
+
+  /**
    * \returns 1.
    */
   virtual unsigned int n_sub_elem() const override { return 1; }

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -581,6 +581,12 @@ public:
   virtual ElemType type () const = 0;
 
   /**
+   * \returns The base type of element that has been derived from
+   * this base class.
+   */
+  virtual BaseElemType base_type () const = 0;
+
+  /**
    * \returns The dimensionality of the object.
    */
   virtual unsigned short dim () const = 0;

--- a/include/geom/face_inf_quad.h
+++ b/include/geom/face_inf_quad.h
@@ -95,6 +95,11 @@ public:
   virtual unsigned short dim() const override final { return 2; }
 
   /**
+   * \returns \p INFQUAD.
+   */
+  virtual BaseElemType base_type () const override final { return INFQUAD; }
+
+  /**
    * \returns 3.  Infinite faces have one side less
    * than their conventional counterparts, since one
    * side is supposed to be located at infinity.

--- a/include/geom/face_quad.h
+++ b/include/geom/face_quad.h
@@ -80,6 +80,11 @@ public:
   }
 
   /**
+   * \returns \p QUAD.
+   */
+  virtual BaseElemType base_type () const override final { return QUAD; }
+
+  /**
    * \returns 4.  All quad-derivatives are guaranteed to have at
    * least 4 nodes.
    */

--- a/include/geom/face_tri.h
+++ b/include/geom/face_tri.h
@@ -81,6 +81,11 @@ public:
   }
 
   /**
+   * \returns \p TRI.
+   */
+  virtual BaseElemType base_type () const override final { return TRI; }
+
+  /**
    * \returns 3.  All tri-derivatives are guaranteed to have at
    * least 3 nodes.
    */

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -73,6 +73,11 @@ public:
   virtual unsigned short dim () const override { return 0; }
 
   /**
+   * \returns \p NODE.
+   */
+  virtual BaseElemType base_type () const override final { return NODE; }
+
+  /**
    * \returns 1.
    */
   virtual unsigned int n_nodes() const override { return 1; }

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -113,6 +113,9 @@ public:
   virtual ElemType type () const override
   { return REMOTEELEM; }
 
+  virtual BaseElemType base_type () const override
+  { return REMOTE; }
+
   virtual unsigned short dim () const override
   { libmesh_not_implemented(); return 0; }
 


### PR DESCRIPTION
Closes #2488

I'm not really sure what to do about a base type for `NodeElem` and `RemoteElem`, as we already have `ElemType::NODEELEM` and `ElemType::REMOTEELEM`. Thoughts?