### PR TITLE
Add capability to read Exodus file header only

### DIFF
--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -754,6 +754,7 @@ include_HEADERS = \
         mesh/ensight_io.h \
         mesh/exodusII_io.h \
         mesh/exodusII_io_helper.h \
+        mesh/exodus_header_info.h \
         mesh/fro_io.h \
         mesh/gmsh_io.h \
         mesh/gmv_io.h \

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -175,6 +175,7 @@ include_HEADERS =  \
         mesh/ensight_io.h \
         mesh/exodusII_io.h \
         mesh/exodusII_io_helper.h \
+        mesh/exodus_header_info.h \
         mesh/fro_io.h \
         mesh/gmsh_io.h \
         mesh/gmv_io.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -165,6 +165,7 @@ BUILT_SOURCES = \
         ensight_io.h \
         exodusII_io.h \
         exodusII_io_helper.h \
+        exodus_header_info.h \
         fro_io.h \
         gmsh_io.h \
         gmv_io.h \
@@ -1023,6 +1024,9 @@ exodusII_io.h: $(top_srcdir)/include/mesh/exodusII_io.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 exodusII_io_helper.h: $(top_srcdir)/include/mesh/exodusII_io_helper.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+exodus_header_info.h: $(top_srcdir)/include/mesh/exodus_header_info.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 fro_io.h: $(top_srcdir)/include/mesh/fro_io.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -542,20 +542,20 @@ BUILT_SOURCES = auto_ptr.h default_coupling.h dirichlet_boundaries.h \
 	reference_elem.h remote_elem.h side.h sphere.h stored_range.h \
 	surface.h abaqus_io.h boundary_info.h boundary_mesh.h \
 	checkpoint_io.h distributed_mesh.h dyna_io.h ensight_io.h \
-	exodusII_io.h exodusII_io_helper.h fro_io.h gmsh_io.h gmv_io.h \
-	gnuplot_io.h inf_elem_builder.h matlab_io.h medit_io.h mesh.h \
-	mesh_base.h mesh_communication.h mesh_function.h \
-	mesh_generation.h mesh_input.h mesh_inserter_iterator.h \
-	mesh_modification.h mesh_output.h mesh_refinement.h \
-	mesh_serializer.h mesh_smoother.h mesh_smoother_laplace.h \
-	mesh_smoother_vsmoother.h mesh_subdivision_support.h \
-	mesh_tetgen_interface.h mesh_tetgen_wrapper.h mesh_tools.h \
-	mesh_triangle_holes.h mesh_triangle_interface.h \
-	mesh_triangle_wrapper.h namebased_io.h nemesis_io.h \
-	nemesis_io_helper.h off_io.h parallel_mesh.h patch.h \
-	postscript_io.h replicated_mesh.h serial_mesh.h \
-	sync_refinement_flags.h tecplot_io.h tetgen_io.h ucd_io.h \
-	unstructured_mesh.h unv_io.h vtk_io.h xdr_io.h \
+	exodusII_io.h exodusII_io_helper.h exodus_header_info.h \
+	fro_io.h gmsh_io.h gmv_io.h gnuplot_io.h inf_elem_builder.h \
+	matlab_io.h medit_io.h mesh.h mesh_base.h mesh_communication.h \
+	mesh_function.h mesh_generation.h mesh_input.h \
+	mesh_inserter_iterator.h mesh_modification.h mesh_output.h \
+	mesh_refinement.h mesh_serializer.h mesh_smoother.h \
+	mesh_smoother_laplace.h mesh_smoother_vsmoother.h \
+	mesh_subdivision_support.h mesh_tetgen_interface.h \
+	mesh_tetgen_wrapper.h mesh_tools.h mesh_triangle_holes.h \
+	mesh_triangle_interface.h mesh_triangle_wrapper.h \
+	namebased_io.h nemesis_io.h nemesis_io_helper.h off_io.h \
+	parallel_mesh.h patch.h postscript_io.h replicated_mesh.h \
+	serial_mesh.h sync_refinement_flags.h tecplot_io.h tetgen_io.h \
+	ucd_io.h unstructured_mesh.h unv_io.h vtk_io.h xdr_io.h \
 	analytic_function.h composite_fem_function.h \
 	composite_function.h const_fem_function.h const_function.h \
 	coupling_matrix.h dense_matrix.h dense_matrix_base.h \
@@ -1365,6 +1365,9 @@ exodusII_io.h: $(top_srcdir)/include/mesh/exodusII_io.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 exodusII_io_helper.h: $(top_srcdir)/include/mesh/exodusII_io_helper.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+exodus_header_info.h: $(top_srcdir)/include/mesh/exodus_header_info.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 fro_io.h: $(top_srcdir)/include/mesh/fro_io.h

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -27,6 +27,7 @@
 #include "libmesh/mesh_output.h"
 #include "libmesh/parallel_object.h"
 #include "libmesh/boundary_info.h" // BoundaryInfo::BCTuple
+#include "libmesh/exodus_header_info.h"
 
 namespace libMesh
 {
@@ -75,6 +76,25 @@ public:
    * Works in 3D for \p TET4s, \p TET10s, \p HEX8s, and \p HEX27s.
    */
   virtual void read (const std::string & name) override;
+
+  /**
+   * Read only the header information, instead of the entire
+   * mesh. After the header is read, the file is closed and the
+   * MeshBase object remains unchanged. This capability is useful if
+   * you only need to know the mesh "metadata" and should be faster
+   * than reading in all the nodes and elems.
+   *
+   * The header information currently includes:
+   * .) Title string
+   * .) Mesh spatial dimension
+   * .) Number of nodes
+   * .) Number of elements
+   * .) Number of element blocks
+   * .) Number of node sets
+   * .) Number of side sets
+   * .) Number of edge blocks/edges
+   */
+  ExodusHeaderInfo read_header (const std::string & name);
 
   /**
    * This method implements writing a mesh to a specified file.

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -27,6 +27,7 @@
 #include "libmesh/point.h"
 #include "libmesh/boundary_info.h" // BoundaryInfo::BCTuple
 #include "libmesh/enum_elem_type.h" // INVALID_ELEM
+#include "libmesh/exodus_header_info.h"
 
 // C++ includes
 #include <iostream>
@@ -119,9 +120,16 @@ public:
   void open(const char * filename, bool read_only);
 
   /**
-   * Reads an \p ExodusII mesh file header.
+   * Reads an \p ExodusII mesh file header, leaving this object's
+   * internal data structures unchanged.
    */
-  void read_header();
+  ExodusHeaderInfo read_header() const;
+
+  /**
+   * Reads an \p ExodusII mesh file header, and stores required
+   * information on this object.
+   */
+  void read_and_store_header_info();
 
   /**
    * Reads the QA records from an ExodusII file.  We can use this to
@@ -501,36 +509,42 @@ public:
   // General error flag
   int ex_err;
 
+  // struct which contains data fields from the Exodus file header
+  ExodusHeaderInfo header_info;
+
+  // Problem title (Use vector<char> to emulate a char *)
+  std::vector<char> & title;
+
   // Number of dimensions in the mesh
-  int num_dim;
+  int & num_dim;
+
+  // Total number of nodes in the mesh
+  int & num_nodes;
+
+  // Total number of elements in the mesh
+  int & num_elem;
+
+  // Total number of element blocks
+  int & num_elem_blk;
+
+  // Total number of edges
+  int & num_edge;
+
+  // Total number of edge blocks. The sum of the number of edges in
+  // each block must equal num_edge.
+  int & num_edge_blk;
+
+  // Total number of node sets
+  int & num_node_sets;
+
+  // Total number of element sets
+  int & num_side_sets;
 
   // Number of global variables
   int num_global_vars;
 
   // Number of sideset variables
   int num_sideset_vars;
-
-  // Total number of nodes in the mesh
-  int num_nodes;
-
-  // Total number of elements in the mesh
-  int num_elem;
-
-  // Total number of element blocks
-  int num_elem_blk;
-
-  // Total number of edges
-  int num_edge;
-
-  // Total number of edge blocks. The sum of the number of edges in
-  // each block must equal num_edge.
-  int num_edge_blk;
-
-  // Total number of node sets
-  int num_node_sets;
-
-  // Total number of element sets
-  int num_side_sets;
 
   // Number of elements in this block
   int num_elem_this_blk;
@@ -613,9 +627,6 @@ public:
 
   // z locations of node points
   std::vector<Real> z;
-
-  //  Problem title (Use vector<char> to emulate a char *)
-  std::vector<char> title;
 
   // Type of element in a given block
   std::vector<char> elem_type;
@@ -830,11 +841,6 @@ private:
   std::map<ElemType, ExodusII_IO_Helper::Conversion> conversion_map;
   void init_conversion_map();
 };
-
-
-
-
-
 
 
 

--- a/include/mesh/exodus_header_info.h
+++ b/include/mesh/exodus_header_info.h
@@ -1,0 +1,88 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2020 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#ifndef LIBMESH_EXODUS_HEADER_INFO_H
+#define LIBMESH_EXODUS_HEADER_INFO_H
+
+// TIMPI includes
+#include "timpi/communicator.h"
+#include "timpi/parallel_implementation.h"
+
+// C++ includes
+#include <vector>
+
+namespace libMesh
+{
+
+/**
+ * This class is used as both an external data structure for passing
+ * around Exodus file header information, and for storing information
+ * internally in ExodusII_IO_Helper. It can't really be defined in
+ * either of those existing headers, so it has its own header...
+ */
+class ExodusHeaderInfo
+{
+public:
+  // All special functions can be defaulted for this simple class.
+  ExodusHeaderInfo () = default;
+  ExodusHeaderInfo (ExodusHeaderInfo &&) = default;
+  ExodusHeaderInfo (const ExodusHeaderInfo &) = default;
+  ExodusHeaderInfo & operator= (const ExodusHeaderInfo &) = default;
+  ExodusHeaderInfo & operator= (ExodusHeaderInfo &&) = default;
+  ~ExodusHeaderInfo() = default;
+
+  /**
+   * Broadcasts data from processor 0 to other procs using the
+   * provided Communicator.
+   */
+  void broadcast(const Parallel::Communicator & comm)
+  {
+    // broadcast vector<char> separately
+    comm.broadcast(title);
+
+    // Pack individual integers into vector
+    std::vector<int> buffer =
+      {num_dim, num_elem, num_elem_blk, num_node_sets,
+       num_side_sets, num_edge_blk, num_edge};
+
+    // broadcast integers
+    comm.broadcast(buffer);
+
+    // unpack
+    num_dim       = buffer[0];
+    num_elem      = buffer[1];
+    num_elem_blk  = buffer[2];
+    num_node_sets = buffer[3];
+    num_side_sets = buffer[4];
+    num_edge_blk  = buffer[5];
+    num_edge      = buffer[6];
+  }
+
+  std::vector<char> title;
+  int num_dim;
+  int num_nodes;
+  int num_elem;
+  int num_elem_blk;
+  int num_node_sets;
+  int num_side_sets;
+  int num_edge_blk;
+  int num_edge;
+};
+
+} // namespace libMesh
+
+#endif

--- a/include/mesh/nemesis_io_helper.h
+++ b/include/mesh/nemesis_io_helper.h
@@ -87,7 +87,7 @@ public:
   /**
    * Fills: num_nodes_global, num_elems_global, num_elem_blks_global,
    * num_node_sets_global, num_side_sets_global
-   * Call after: read_header()
+   * Call after: read_and_store_header_info()
    * Call before: Any other get_* function from this class
    */
   void get_init_global();

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1238,6 +1238,11 @@ void ExodusII_IO_Helper::close()
           ex_err = exII::ex_close(ex_id);
           EX_CHECK_ERR(ex_err, "Error closing Exodus file.");
           message("Exodus file closed successfully.");
+
+          // Now that the file is closed, it's no longer opened for
+          // reading or writing.
+          opened_for_writing = false;
+          opened_for_reading = false;
         }
     }
 }

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -200,7 +200,7 @@ void Nemesis_IO::read (const std::string & base_filename)
   //  num_elem_blk
   //  num_node_sets
   //  num_side_sets
-  nemhelper->read_header();
+  nemhelper->read_and_store_header_info();
   nemhelper->print_header();
 
   // Get global information: number of nodes, elems, blocks, nodesets and sidesets
@@ -944,7 +944,7 @@ void Nemesis_IO::read (const std::string & base_filename)
 
   // Read *local* sideset info the same way it is done in
   // exodusII_io_helper.  May be called any time after
-  // nem_helper->read_header(); This sets num_side_sets and resizes
+  // nem_helper->read_and_store_header_info(); This sets num_side_sets and resizes
   // elem_list, side_list, and id_list to num_elem_all_sidesets.  Note
   // that there appears to be the same number of sidesets in each file
   // but they all have different numbers of entries (some are empty).
@@ -1282,7 +1282,7 @@ void Nemesis_IO::prepare_to_write_nodal_data (const std::string & fname,
           // fields, such as the number of nodes and the number of
           // elements, are correctly initialized for the subsequent
           // call to write the nodal solution.
-          nemhelper->read_header();
+          nemhelper->read_and_store_header_info();
         }
       else
         {

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -2394,10 +2394,10 @@ void Nemesis_IO_Helper::write_nodal_solution(const std::vector<Number> & values,
       write_nodal_values(3*c+2,imag_parts,timestep);
       write_nodal_values(3*c+3,magnitudes,timestep);
 #else
-      std::vector<Number> cur_soln(num_nodes);
+      std::vector<Number> cur_soln(this->num_nodes);
 
       // Copy out this variable's solution
-      for (int i=0; i<num_nodes; i++)
+      for (int i=0; i<this->num_nodes; i++)
         cur_soln[i] = values[this->exodus_node_num_to_libmesh[i]*num_vars + c];
 
       write_nodal_values(c+1,cur_soln,timestep);
@@ -2430,9 +2430,9 @@ void Nemesis_IO_Helper::write_nodal_solution(const NumericVector<Number> & paral
         cast_int<int>(std::distance(output_names.begin(), pos));
 
       // Fill up a std::vector with the dofs for the current variable
-      std::vector<numeric_index_type> required_indices(num_nodes);
+      std::vector<numeric_index_type> required_indices(this->num_nodes);
 
-      for (int i=0; i<num_nodes; i++)
+      for (int i=0; i<this->num_nodes; i++)
         required_indices[i] = static_cast<dof_id_type>(this->exodus_node_num_to_libmesh[i]) * num_vars + c;
 
       // Get the dof values required to write just our local part of
@@ -2495,18 +2495,18 @@ void Nemesis_IO_Helper::write_nodal_solution(const EquationSystems & es,
         cast_int<int>(std::distance(output_names.begin(), pos));
 
       // Fill up a std::vector with the dofs for the current variable
-      std::vector<numeric_index_type> required_indices(num_nodes);
+      std::vector<numeric_index_type> required_indices(this->num_nodes);
 
       const FEType type = sys.variable_type(var);
       if (type.family == SCALAR)
         {
           std::vector<numeric_index_type> scalar_indices;
           sys.get_dof_map().SCALAR_dof_indices(scalar_indices, var);
-          for (int i=0; i<num_nodes; i++)
+          for (int i=0; i<this->num_nodes; i++)
             required_indices[i] = scalar_indices[0];
         }
       else
-        for (int i=0; i<num_nodes; i++)
+        for (int i=0; i<this->num_nodes; i++)
           {
             const Node & node = mesh.node_ref(this->exodus_node_num_to_libmesh[i]);
             required_indices[i] = node.dof_number(sys_num, var, 0);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -229,7 +229,8 @@ CLEANFILES = cube_mesh.xda \
 	     mesh_with_soln.e \
 	     elemental_from_nodal.e \
              write_sideset_data.e \
-             write_edgeset_data.e
+             write_edgeset_data.e \
+             read_header_test.e
 
 # need to link any data files for VPATH builds
 if LIBMESH_VPATH_BUILD

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -1839,7 +1839,8 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 @LIBMESH_ENABLE_CPPUNIT_TRUE@TESTS = run_unit_tests.sh
 CLEANFILES = cube_mesh.xda slit_mesh.xda slit_solution.xda out.e \
 	mesh_with_soln.e elemental_from_nodal.e write_sideset_data.e \
-	write_edgeset_data.e $(am__append_12) $(am__append_13)
+	write_edgeset_data.e read_header_test.e $(am__append_12) \
+	$(am__append_13)
 
 # need to link any data files for VPATH builds
 @LIBMESH_VPATH_BUILD_TRUE@BUILT_SOURCES = .linkstamp

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -35,11 +35,12 @@ public:
 #if LIBMESH_DIM > 1
 #ifdef LIBMESH_HAVE_EXODUS_API
   CPPUNIT_TEST( testExodusCopyElementSolution );
+  CPPUNIT_TEST( testExodusReadHeader );
 #ifndef LIBMESH_USE_COMPLEX_NUMBERS
   // Eventually this will support complex numbers.
   CPPUNIT_TEST( testExodusWriteElementDataFromDiscontinuousNodalData );
-#endif
-#endif
+#endif // LIBMESH_USE_COMPLEX_NUMBERS
+#endif // LIBMESH_HAVE_EXODUS_API
   CPPUNIT_TEST( testDynaReadElem );
   CPPUNIT_TEST( testDynaReadPatch );
 
@@ -58,6 +59,41 @@ public:
   {}
 
 #ifdef LIBMESH_HAVE_EXODUS_API
+  void testExodusReadHeader ()
+  {
+    // first scope: write file
+    {
+      ReplicatedMesh mesh(*TestCommWorld);
+      MeshTools::Generation::build_square (mesh, 3, 3, 0., 1., 0., 1.);
+      ExodusII_IO exii(mesh);
+      mesh.write("read_header_test.e");
+    }
+
+    // Make sure that the writing is done before the reading starts.
+    TestCommWorld->barrier();
+
+    // second scope: read header
+    // Note: The header information is read from file on processor 0
+    // and then broadcast to the other procs, so with this test we are
+    // checking both that the header information is read correctly and
+    // that it is correctly communicated to other procs.
+    {
+      ReplicatedMesh mesh(*TestCommWorld);
+      ExodusII_IO exii(mesh);
+      ExodusHeaderInfo header_info = exii.read_header("read_header_test.e");
+
+      // Make sure the header information is as expected.
+      CPPUNIT_ASSERT_EQUAL(std::string(header_info.title.data()), std::string("read_header_test.e"));
+      CPPUNIT_ASSERT_EQUAL(header_info.num_dim, 2);
+      CPPUNIT_ASSERT_EQUAL(header_info.num_elem, 9);
+      CPPUNIT_ASSERT_EQUAL(header_info.num_elem_blk, 1);
+      CPPUNIT_ASSERT_EQUAL(header_info.num_node_sets, 0);
+      CPPUNIT_ASSERT_EQUAL(header_info.num_side_sets, 4);
+      CPPUNIT_ASSERT_EQUAL(header_info.num_edge_blk, 0);
+      CPPUNIT_ASSERT_EQUAL(header_info.num_edge, 0);
+    }
+  }
+
   void testExodusCopyElementSolution ()
   {
     {


### PR DESCRIPTION
This is useful if you just need to know how many Nodes or Elems a Mesh has but don't want to spend the time reading/processing the entire Exodus file. Also added a unit test of the new capability.