### PR TITLE
Add RawType specializations for some numeric types

### DIFF
--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -43,6 +43,7 @@
 
 #ifdef LIBMESH_HAVE_METAPHYSICL
 #include "metaphysicl/dualnumber_forward.h"
+#include "metaphysicl/raw_type.h"
 
 namespace std
 {
@@ -1157,7 +1158,26 @@ T DenseMatrix<T>::transpose (const unsigned int i,
 
 } // namespace libMesh
 
+#ifdef LIBMESH_HAVE_METAPHYSICL
+namespace MetaPhysicL
+{
+template <typename T>
+struct RawType<libMesh::DenseMatrix<T>>
+{
+  typedef libMesh::DenseMatrix<typename RawType<T>::value_type> value_type;
 
+  static value_type value (const libMesh::DenseMatrix<T> & in)
+    {
+      value_type ret(in.m(), in.n());
+      for (unsigned int i = 0; i < in.m(); ++i)
+        for (unsigned int j = 0; j < in.n(); ++j)
+          ret(i,j) = raw_value(in(i,j));
+
+      return ret;
+    }
+};
+}
+#endif
 
 
 #endif // LIBMESH_DENSE_MATRIX_H

--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -32,6 +32,10 @@
 #include "libmesh/restore_warnings.h"
 #endif
 
+#ifdef LIBMESH_HAVE_METAPHYSICL
+#include "metaphysicl/raw_type.h"
+#endif
+
 // C++ includes
 #include <vector>
 
@@ -681,5 +685,25 @@ void DenseVector<T>::get_principal_subvector (unsigned int sub_n,
 }
 
 } // namespace libMesh
+
+#ifdef LIBMESH_HAVE_METAPHYSICL
+namespace MetaPhysicL
+{
+template <typename T>
+struct RawType<libMesh::DenseVector<T>>
+{
+  typedef libMesh::DenseVector<typename RawType<T>::value_type> value_type;
+
+  static value_type value (const libMesh::DenseVector<T> & in)
+    {
+      value_type ret(in.size());
+      for (unsigned int i = 0; i < in.size(); ++i)
+          ret(i) = raw_value(in(i));
+
+      return ret;
+    }
+};
+}
+#endif
 
 #endif // LIBMESH_DENSE_VECTOR_H

--- a/include/numerics/tensor_value.h
+++ b/include/numerics/tensor_value.h
@@ -23,7 +23,9 @@
 // Local includes
 #include "libmesh/type_tensor.h"
 
-// C++ includes
+#ifdef LIBMESH_HAVE_METAPHYSICL
+#include "metaphysicl/raw_type.h"
+#endif
 
 namespace libMesh
 {
@@ -275,5 +277,26 @@ TensorValue<T>::TensorValue (const TypeTensor<Real> & p_re,
 
 
 } // namespace libMesh
+
+#ifdef LIBMESH_HAVE_METAPHYSICL
+namespace MetaPhysicL
+{
+template <typename T>
+struct RawType<libMesh::TensorValue<T>>
+{
+  typedef libMesh::TensorValue<typename RawType<T>::value_type> value_type;
+
+  static value_type value (const libMesh::TensorValue<T> & in)
+    {
+      value_type ret;
+      for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
+        for (unsigned int j = 0; j < LIBMESH_DIM; ++j)
+          ret(i,j) = raw_value(in(i,j));
+
+      return ret;
+    }
+};
+}
+#endif
 
 #endif // LIBMESH_TENSOR_VALUE_H

--- a/include/numerics/vector_value.h
+++ b/include/numerics/vector_value.h
@@ -23,6 +23,10 @@
 // Local includes
 #include "libmesh/type_vector.h"
 
+#ifdef LIBMESH_HAVE_METAPHYSICL
+#include "metaphysicl/raw_type.h"
+#endif
+
 // C++ includes
 
 namespace libMesh
@@ -125,8 +129,6 @@ public:
   { libmesh_assert_equal_to (p, Scalar(0)); this->zero(); return *this; }
 };
 
-
-
 /**
  * Useful typedefs to allow transparent switching
  * between Real and Complex data types.
@@ -220,5 +222,25 @@ VectorValue<T>::VectorValue (const TypeVector<Real> & p_re,
 
 
 } // namespace libMesh
+
+#ifdef LIBMESH_HAVE_METAPHYSICL
+namespace MetaPhysicL
+{
+template <typename T>
+struct RawType<libMesh::VectorValue<T>>
+{
+  typedef libMesh::VectorValue<typename RawType<T>::value_type> value_type;
+
+  static value_type value (const libMesh::VectorValue<T> & in)
+    {
+      value_type ret;
+      for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
+        ret(i) = raw_value(in(i));
+
+      return ret;
+    }
+};
+}
+#endif
 
 #endif // LIBMESH_VECTOR_VALUE_H


### PR DESCRIPTION
In MOOSE we sometimes want to copy from a DualNumber version
to a Real version in very generic templated methods, and
using MetaPhysicL::raw_value is the most convenient way to do it