### PR TITLE
Add DirichletBoundary copy assignment operator.

### DIFF
--- a/include/base/dirichlet_boundaries.h
+++ b/include/base/dirichlet_boundaries.h
@@ -160,10 +160,17 @@ public:
                     VariableIndexing type = SYSTEM_VARIABLE_ORDER);
 
   /**
-   * Copy constructor.  Deep copies (clones) functors; shallow copies
-   * any System reference
+   * Copy assignment/constructor.  Deep copies (clones) functors;
+   * shallow copies any System reference
    */
   DirichletBoundary (const DirichletBoundary & dirichlet_in);
+  DirichletBoundary & operator= (const DirichletBoundary &);
+
+  /**
+   * This class is default move-assignable and move-constructible.
+   */
+  DirichletBoundary (DirichletBoundary &&) = default;
+  DirichletBoundary & operator= (DirichletBoundary &&) = default;
 
   /**
    * Standard destructor

--- a/src/base/dirichlet_boundary.C
+++ b/src/base/dirichlet_boundary.C
@@ -196,7 +196,16 @@ DirichletBoundary(const DirichletBoundary & d_in) :
 }
 
 
-DirichletBoundary::~DirichletBoundary () {}
+DirichletBoundary & DirichletBoundary::operator= (const DirichletBoundary & rhs)
+{
+  // Implementation in terms of the copy constructor to avoid code duplication.
+  DirichletBoundary tmp(rhs);
+  std::swap(tmp, *this); // class must be "MoveAssignable" and "MoveConstructible" for std::swap to work.
+  return *this;
+}
+
+
+DirichletBoundary::~DirichletBoundary () = default;
 
 } // namespace libMesh
 


### PR DESCRIPTION
Also add defaulted destructor, move constructor, and assignment
operators.  As far as I understand it, you can std::swap a class T
which is both move-constructible and move-assignable, but I'm not sure
if this is guaranteed to work in C++11 or if some later standard is
required. If it works for our "min" compilers, then I'm happy.

https://en.cppreference.com/w/cpp/algorithm/swap