### PR TITLE
Add 'extra_checks' parameter to FEMap::inverse_map()

### DIFF
--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -161,27 +161,32 @@ public:
    * computes the sequence \f$ \{ p_n \} \f$, and the iteration is
    * terminated when \f$ \|p - p_n\| < \mbox{\texttt{tolerance}} \f$
    *
-   * When secure==true, the following checks are enabled:
+   * When secure == true, the following checks are enabled:
    *
    * In DEBUG mode only:
    * .) dim==1,2: throw an error if det(J) <= 0 for any Newton iteration.
    * .) Print warning for every iteration beyond max_cnt in which the Newton scheme has not converged.
-   * .) Print a warning if p != map(inverse_map(p)) to within tolerance.
-   * .) Print a warning if the inverse-mapped point is not on the reference element to within tolerance.
    *
    * In !DEBUG mode only:
    * .) Print a _single_ warning (1 warning for the entire simulation)
-   *    if the Newton scheme ever requiers more than max_cnt iterations.
+   *    if the Newton scheme ever requires more than max_cnt iterations.
    *
    * In both DEBUG and !DEBUG modes:
    * .) dim==3: Throw an exception for singular Jacobian.
    * .) Throw an error if the Newton iteration has not converged in 2*max_cnt iterations.
+   *
+   * In addition to the checks above, the "extra_checks" parameter can
+   * be used to turn on some additional tests. In particular, when
+   * extra_checks == true *and* compiled in DEBUG mode:
+   * .) Print a warning if p != map(inverse_map(p)) to within tolerance.
+   * .) Print a warning if the inverse-mapped point is not on the reference element to within tolerance.
    */
   static Point inverse_map (const unsigned int dim,
                             const Elem * elem,
                             const Point & p,
                             const Real tolerance = TOLERANCE,
-                            const bool secure = true);
+                            const bool secure = true,
+                            const bool extra_checks = true);
 
   /**
    * Takes a number points in physical space (in the \p
@@ -196,7 +201,8 @@ public:
                            const std::vector<Point> & physical_points,
                            std::vector<Point> &       reference_points,
                            const Real tolerance = TOLERANCE,
-                           const bool secure = true);
+                           const bool secure = true,
+                           const bool extra_checks = true);
 
   /**
    * \returns The \p xyz spatial locations of the quadrature

--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -160,8 +160,22 @@ public:
    * how close is "good enough."  The map inversion iteration
    * computes the sequence \f$ \{ p_n \} \f$, and the iteration is
    * terminated when \f$ \|p - p_n\| < \mbox{\texttt{tolerance}} \f$
-   * The parameter secure (always assumed false in non-debug mode)
-   * switches on integrity-checks on the mapped points.
+   *
+   * When secure==true, the following checks are enabled:
+   *
+   * In DEBUG mode only:
+   * .) dim==1,2: throw an error if det(J) <= 0 for any Newton iteration.
+   * .) Print warning for every iteration beyond max_cnt in which the Newton scheme has not converged.
+   * .) Print a warning if p != map(inverse_map(p)) to within tolerance.
+   * .) Print a warning if the inverse-mapped point is not on the reference element to within tolerance.
+   *
+   * In !DEBUG mode only:
+   * .) Print a _single_ warning (1 warning for the entire simulation)
+   *    if the Newton scheme ever requiers more than max_cnt iterations.
+   *
+   * In both DEBUG and !DEBUG modes:
+   * .) dim==3: Throw an exception for singular Jacobian.
+   * .) Throw an error if the Newton iteration has not converged in 2*max_cnt iterations.
    */
   static Point inverse_map (const unsigned int dim,
                             const Elem * elem,
@@ -174,12 +188,8 @@ public:
    * physical_points vector) and finds their location on the reference
    * element for the input element \p elem.  The values on the
    * reference element are returned in the vector \p
-   * reference_points. The optional parameter \p tolerance defines how
-   * close is "good enough."  The map inversion iteration computes the
-   * sequence \f$ \{ p_n \} \f$, and the iteration is terminated when
-   * \f$ \|p - p_n\| < \mbox{\texttt{tolerance}} \f$
-   * The parameter secure (always assumed false in non-debug mode)
-   * switches on integrity-checks on the mapped points.
+   * reference_points. The other parameters have the same meaning
+   * as the single Point version of inverse_map() above.
    */
   static void inverse_map (unsigned int dim,
                            const Elem * elem,

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -1661,12 +1661,17 @@ Point FEMap::inverse_map (const unsigned int dim,
                           const Elem * elem,
                           const Point & physical_point,
                           const Real tolerance,
-                          const bool secure)
+                          const bool secure,
+                          const bool extra_checks)
 {
   libmesh_assert(elem);
   libmesh_assert_greater_equal (tolerance, 0.);
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+  // TODO: possibly use the extra_checks parameter in InfFEMap::inverse_map() as well.
+  libmesh_ignore(extra_checks);
+
   if (elem->infinite())
     return InfFEMap::inverse_map(dim, elem, physical_point, tolerance,
                                  secure);
@@ -2000,10 +2005,10 @@ Point FEMap::inverse_map (const unsigned int dim,
 
 
 
-  //  If we are in debug mode do two sanity checks.
+  //  If we are in debug mode and the user requested it, do two extra sanity checks.
 #ifdef DEBUG
 
-  if (secure)
+  if (extra_checks)
     {
       // Make sure the point \p p on the reference element actually
       // does map to the point \p physical_point within a tolerance.
@@ -2050,14 +2055,16 @@ void FEMap::inverse_map (const unsigned int dim,
                          const std::vector<Point> & physical_points,
                          std::vector<Point> &       reference_points,
                          const Real tolerance,
-                         const bool secure)
+                         const bool secure,
+                         const bool extra_checks)
 {
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   if (elem->infinite())
     {
-      InfFEMap::inverse_map(dim, elem, physical_points, reference_points, tolerance, secure);
-      return;
-      // libmesh_not_implemented();
+      // TODO: possibly use the extra_checks parameter in InfFEMap::inverse_map() as well.
+      libmesh_ignore(extra_checks);
+
+      return InfFEMap::inverse_map(dim, elem, physical_points, reference_points, tolerance, secure);
     }
 #endif
 
@@ -2073,7 +2080,7 @@ void FEMap::inverse_map (const unsigned int dim,
   // element of each point in physical space
   for (std::size_t p=0; p<n_points; p++)
     reference_points[p] =
-      inverse_map (dim, elem, physical_points[p], tolerance, secure);
+      inverse_map (dim, elem, physical_points[p], tolerance, secure, extra_checks);
 }
 
 


### PR DESCRIPTION
Narrows the scope of the `secure` flag, which was previously used for all the different kinds of checks, so that it now does not include the "sanity" checks which occur after the Newton iteration has converged. These additional post-convergence checks are now controlled by the `extra_checks` parameter. By default, `extra_checks == secure == true` so this is backwards-compatible with the previous behavior.

Also, improved the documentation of the `secure` flag, which was somewhat lacking previously.
