### PR TITLE
FEMSystem assert should work with new casts

### DIFF
--- a/include/systems/fem_system.h
+++ b/include/systems/fem_system.h
@@ -272,7 +272,7 @@ void FEMSystem::set_numerical_jacobian_h_for_var(unsigned int var_num,
   if (_numerical_jacobian_h_for_var.size() <= var_num)
     _numerical_jacobian_h_for_var.resize(var_num+1,Real(0));
 
-  libmesh_assert_greater(new_h, 0);
+  libmesh_assert_greater(new_h, Real(0));
 
   _numerical_jacobian_h_for_var[var_num] = new_h;
 }


### PR DESCRIPTION
This assertion has been overzealous since #2252, due to the casting
changes causing unintended rounding.

I really need to get automated testing with GRINS running again.