### PR TITLE
The 'extra_checks' parameter should match 'secure' for backwards comp…

### DIFF
--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -424,7 +424,7 @@ public:
                             const Real tolerance = TOLERANCE,
                             const bool secure = true) {
     // libmesh_deprecated(); // soon
-    return FEMap::inverse_map(Dim, elem, p, tolerance, secure);
+    return FEMap::inverse_map(Dim, elem, p, tolerance, secure, secure);
   }
 
   static void inverse_map (const Elem * elem,
@@ -434,7 +434,7 @@ public:
                            const bool secure = true) {
     // libmesh_deprecated(); // soon
     FEMap::inverse_map(Dim, elem, physical_points, reference_points,
-                       tolerance, secure);
+                       tolerance, secure, secure);
   }
 
   /**

--- a/src/fe/inf_fe_map.C
+++ b/src/fe/inf_fe_map.C
@@ -213,7 +213,7 @@ Point InfFEMap::inverse_map (const unsigned int dim,
   // Now we have the intersection-point (projection of physical point onto base-element).
   // Lets compute its internal coordinates (being p(0) and p(1)):
   p= FEMap::inverse_map(dim-1, base_elem.get(), intersection,
-                        tolerance, secure);
+                        tolerance, secure, secure);
 
   // 4.
   // Now that we have the local coordinates in the base,

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -2207,7 +2207,8 @@ bool Elem::point_test(const Point & p, Real box_tol, Real map_tol) const
                                                 this,
                                                 p,
                                                 0.1*map_tol, // <- this is |dx| tolerance, the Newton residual should be ~ |dx|^2
-                                                /*secure=*/ false);
+                                                /*secure=*/ false,
+                                                /*extra_checks=*/ false);
 
   // Check that the refspace point maps back to p!  This is only necessary
   // for 1D and 2D elements, 3D elements always live in 3D.

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -2060,7 +2060,7 @@ Number System::point_value(unsigned int var,
 
   FEType fe_type = dof_map.variable_type(var);
 
-  // Map the physical co-ordinates to the master co-ordinates using the inverse_map from fe_interface.h.
+  // Map the physical co-ordinates to the master co-ordinates
   Point coor = FEMap::inverse_map(e.dim(), &e, p);
 
   // get the shape function value via the FEInterface to also handle the case
@@ -2193,7 +2193,7 @@ Gradient System::point_gradient(unsigned int var,
 
   FEType fe_type = dof_map.variable_type(var);
 
-  // Map the physical co-ordinates to the master co-ordinates using the inverse_map from fe_interface.h.
+  // Map the physical co-ordinates to the master co-ordinates
   Point coor = FEMap::inverse_map(dim, &e, p);
 
   // get the shape function value via the FEInterface to also handle the case
@@ -2341,7 +2341,7 @@ Tensor System::point_hessian(unsigned int var,
   // Build a FE again so we can calculate u(p)
   std::unique_ptr<FEBase> fe (FEBase::build(e.dim(), fe_type));
 
-  // Map the physical co-ordinates to the master co-ordinates using the inverse_map from fe_interface.h
+  // Map the physical co-ordinates to the master co-ordinates
   // Build a vector of point co-ordinates to send to reinit
   std::vector<Point> coor(1, FEMap::inverse_map(e.dim(), &e, p));
 


### PR DESCRIPTION
…atibility.

This means we have to explicitly set 'extra_checks' to false in cases
where 'secure' is set to false. Also fixed up some documentation that
still referred to the now deprecated FEInterface::inverse_map().

Refs #2498