### PR TITLE
Fixes for build_sphere(DistributedMesh)

### DIFF
--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -1867,6 +1867,10 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
   // Loop over the elements, refine, pop nodes to boundary.
   for (unsigned int r=0; r<nr; r++)
     {
+      // A DistributedMesh needs a little prep before refinement
+      if (!mesh.is_replicated())
+        mesh.prepare_for_use();
+
       mesh_refinement.uniformly_refine(1);
 
       for (const auto & elem : mesh.active_element_ptr_range())
@@ -1882,6 +1886,10 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
             }
     }
 
+  // A DistributedMesh needs a little prep before flattening
+  if (!mesh.is_replicated())
+    mesh.prepare_for_use();
+
   // The mesh now contains a refinement hierarchy due to the refinements
   // used to generate the grid.  In order to call other support functions
   // like all_tri() and all_second_order, you need a "flat" mesh file (with no
@@ -1893,6 +1901,10 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
     {
       if ((type == TRI6) || (type == TRI3))
         {
+          // A DistributedMesh needs a little prep before all_tri()
+          if (!mesh.is_replicated())
+            mesh.prepare_for_use();
+
           MeshTools::Modification::all_tri(mesh);
         }
     }

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -1936,8 +1936,11 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
 
 
   // The meshes could probably use some smoothing.
-  LaplaceMeshSmoother smoother(mesh);
-  smoother.smooth(n_smooth);
+  if (mesh.mesh_dimension() > 1)
+    {
+      LaplaceMeshSmoother smoother(mesh);
+      smoother.smooth(n_smooth);
+    }
 
   // We'll give the whole sphere surface a boundary id of 0
   for (const auto & elem : mesh.active_element_ptr_range())

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -953,7 +953,7 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
         // remote_elem links to the new elements.
         bool mesh_is_serial = mesh.is_serial();
 
-        if (mesh_has_boundary_data || mesh_is_serial)
+        if (mesh_has_boundary_data || !mesh_is_serial)
           {
             // Container to key boundary IDs handed back by the BoundaryInfo object.
             std::vector<boundary_id_type> bc_ids;
@@ -961,60 +961,59 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
             for (auto sn : elem->side_index_range())
               {
                 mesh.get_boundary_info().boundary_ids(elem, sn, bc_ids);
-                for (const auto & b_id : bc_ids)
-                  {
-                    if (mesh_is_serial && b_id == BoundaryInfo::invalid_id)
-                      continue;
 
-                    // Make a sorted list of node ids for elem->side(sn)
-                    std::unique_ptr<Elem> elem_side = elem->build_side_ptr(sn);
-                    std::vector<dof_id_type> elem_side_nodes(elem_side->n_nodes());
-                    for (unsigned int esn=0,
-                         n_esn = cast_int<unsigned int>(elem_side_nodes.size());
-                         esn != n_esn; ++esn)
-                      elem_side_nodes[esn] = elem_side->node_id(esn);
-                    std::sort(elem_side_nodes.begin(), elem_side_nodes.end());
+                if (bc_ids.empty() && elem->neighbor_ptr(sn) != remote_elem)
+                  continue;
 
-                    for (unsigned int i=0; i != max_subelems; ++i)
-                      if (subelem[i])
+                // Make a sorted list of node ids for elem->side(sn)
+                std::unique_ptr<Elem> elem_side = elem->build_side_ptr(sn);
+                std::vector<dof_id_type> elem_side_nodes(elem_side->n_nodes());
+                for (unsigned int esn=0,
+                     n_esn = cast_int<unsigned int>(elem_side_nodes.size());
+                     esn != n_esn; ++esn)
+                  elem_side_nodes[esn] = elem_side->node_id(esn);
+                std::sort(elem_side_nodes.begin(), elem_side_nodes.end());
+
+                for (unsigned int i=0; i != max_subelems; ++i)
+                  if (subelem[i])
+                    {
+                      for (auto subside : subelem[i]->side_index_range())
                         {
-                          for (auto subside : subelem[i]->side_index_range())
+                          std::unique_ptr<Elem> subside_elem = subelem[i]->build_side_ptr(subside);
+
+                          // Make a list of *vertex* node ids for this subside, see if they are all present
+                          // in elem->side(sn).  Note 1: we can't just compare elem->key(sn) to
+                          // subelem[i]->key(subside) in the Prism cases, since the new side is
+                          // a different type.  Note 2: we only use vertex nodes since, in the future,
+                          // a Hex20 or Prism15's QUAD8 face may be split into two Tri6 faces, and the
+                          // original face will not contain the mid-edge node.
+                          std::vector<dof_id_type> subside_nodes(subside_elem->n_vertices());
+                          for (unsigned int ssn=0,
+                               n_ssn = cast_int<unsigned int>(subside_nodes.size());
+                               ssn != n_ssn; ++ssn)
+                            subside_nodes[ssn] = subside_elem->node_id(ssn);
+                          std::sort(subside_nodes.begin(), subside_nodes.end());
+
+                          // std::includes returns true if every element of the second sorted range is
+                          // contained in the first sorted range.
+                          if (std::includes(elem_side_nodes.begin(), elem_side_nodes.end(),
+                                            subside_nodes.begin(), subside_nodes.end()))
                             {
-                              std::unique_ptr<Elem> subside_elem = subelem[i]->build_side_ptr(subside);
+                              for (const auto & b_id : bc_ids)
+                                if (b_id != BoundaryInfo::invalid_id)
+                                  {
+                                    new_bndry_ids.push_back(b_id);
+                                    new_bndry_elements.push_back(subelem[i].get());
+                                    new_bndry_sides.push_back(subside);
+                                  }
 
-                              // Make a list of *vertex* node ids for this subside, see if they are all present
-                              // in elem->side(sn).  Note 1: we can't just compare elem->key(sn) to
-                              // subelem[i]->key(subside) in the Prism cases, since the new side is
-                              // a different type.  Note 2: we only use vertex nodes since, in the future,
-                              // a Hex20 or Prism15's QUAD8 face may be split into two Tri6 faces, and the
-                              // original face will not contain the mid-edge node.
-                              std::vector<dof_id_type> subside_nodes(subside_elem->n_vertices());
-                              for (unsigned int ssn=0,
-                                   n_ssn = cast_int<unsigned int>(subside_nodes.size());
-                                   ssn != n_ssn; ++ssn)
-                                subside_nodes[ssn] = subside_elem->node_id(ssn);
-                              std::sort(subside_nodes.begin(), subside_nodes.end());
-
-                              // std::includes returns true if every element of the second sorted range is
-                              // contained in the first sorted range.
-                              if (std::includes(elem_side_nodes.begin(), elem_side_nodes.end(),
-                                                subside_nodes.begin(), subside_nodes.end()))
-                                {
-                                  if (b_id != BoundaryInfo::invalid_id)
-                                    {
-                                      new_bndry_ids.push_back(b_id);
-                                      new_bndry_elements.push_back(subelem[i].get());
-                                      new_bndry_sides.push_back(subside);
-                                    }
-
-                                  // If the original element had a RemoteElem neighbor on side 'sn',
-                                  // then the subelem has one on side 'subside'.
-                                  if (elem->neighbor_ptr(sn) == remote_elem)
-                                    subelem[i]->set_neighbor(subside, const_cast<RemoteElem*>(remote_elem));
-                                }
+                              // If the original element had a RemoteElem neighbor on side 'sn',
+                              // then the subelem has one on side 'subside'.
+                              if (elem->neighbor_ptr(sn) == remote_elem)
+                                subelem[i]->set_neighbor(subside, const_cast<RemoteElem*>(remote_elem));
                             }
                         }
-                  } // end for loop over boundary IDs
+                    } // end for loop over subelem
               } // end for loop over sides
 
             // Remove the original element from the BoundaryInfo structure.

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -280,6 +280,8 @@ void MeshTools::Modification::scale (MeshBase & mesh,
 
 void MeshTools::Modification::all_tri (MeshBase & mesh)
 {
+  libmesh_assert(mesh.is_prepared() || mesh.is_replicated());
+
   // The number of elements in the original mesh before any additions
   // or deletions.
   const dof_id_type n_orig_elem = mesh.n_elem();
@@ -1262,6 +1264,8 @@ void MeshTools::Modification::smooth (MeshBase & mesh,
 #ifdef LIBMESH_ENABLE_AMR
 void MeshTools::Modification::flatten(MeshBase & mesh)
 {
+  libmesh_assert(mesh.is_prepared() || mesh.is_replicated());
+
   // Algorithm:
   // .) For each active element in the mesh: construct a
   //    copy which is the same in every way *except* it is

--- a/tests/mesh/mesh_generation_test.C
+++ b/tests/mesh/mesh_generation_test.C
@@ -24,12 +24,22 @@ public:
   CPPUNIT_TEST( buildLineEdge2 );
   CPPUNIT_TEST( buildLineEdge3 );
   CPPUNIT_TEST( buildLineEdge4 );
+#  ifdef LIBMESH_ENABLE_AMR
+  CPPUNIT_TEST( buildSphereEdge2 );
+  CPPUNIT_TEST( buildSphereEdge3 );
+// CPPUNIT_TEST( buildSphereEdge4 ); Doesn't work with AMR yet
+#  endif
+
 #if LIBMESH_DIM > 1
   CPPUNIT_TEST( buildSquareTri3 );
   CPPUNIT_TEST( buildSquareTri6 );
   CPPUNIT_TEST( buildSquareQuad4 );
   CPPUNIT_TEST( buildSquareQuad8 );
   CPPUNIT_TEST( buildSquareQuad9 );
+#  ifdef LIBMESH_ENABLE_AMR
+  CPPUNIT_TEST( buildSphereTri3 );
+  CPPUNIT_TEST( buildSphereQuad4 );
+#  endif
 #endif
 #if LIBMESH_DIM > 2
   CPPUNIT_TEST( buildCubeTet4 );
@@ -43,6 +53,10 @@ public:
   CPPUNIT_TEST( buildCubePyramid5 );
   CPPUNIT_TEST( buildCubePyramid13 );
   CPPUNIT_TEST( buildCubePyramid14 );
+#  ifdef LIBMESH_ENABLE_AMR
+  CPPUNIT_TEST( buildSphereHex8 );
+//  CPPUNIT_TEST( buildSphereHex27 );
+#  endif
 #endif
 
   CPPUNIT_TEST_SUITE_END();
@@ -185,6 +199,17 @@ public:
     CPPUNIT_ASSERT(bbox.max()(2) >= Real(7.0));
   }
 
+  void testBuildSphere(unsigned int n_ref, ElemType type)
+  {
+    ReplicatedMesh rmesh(*TestCommWorld);
+    MeshTools::Generation::build_sphere (rmesh, 2.0, n_ref, type);
+
+    DistributedMesh dmesh(*TestCommWorld);
+    dmesh.allow_renumbering(false);
+    MeshTools::Generation::build_sphere (dmesh, 2.0, n_ref, type);
+  }
+
+
   typedef void (MeshGenerationTest::*Builder)(UnstructuredMesh&, unsigned int, ElemType);
 
   void tester(Builder f, unsigned int n, ElemType type)
@@ -205,11 +230,18 @@ public:
   void buildLineEdge3 ()     { tester(&MeshGenerationTest::testBuildLine, 5, EDGE3); }
   void buildLineEdge4 ()     { tester(&MeshGenerationTest::testBuildLine, 5, EDGE4); }
 
+  void buildSphereEdge2 ()     { testBuildSphere(2, EDGE2); }
+  void buildSphereEdge3 ()     { testBuildSphere(2, EDGE3); }
+  void buildSphereEdge4 ()     { testBuildSphere(2, EDGE4); }
+
   void buildSquareTri3 ()    { tester(&MeshGenerationTest::testBuildSquare, 3, TRI3); }
   void buildSquareTri6 ()    { tester(&MeshGenerationTest::testBuildSquare, 4, TRI6); }
   void buildSquareQuad4 ()   { tester(&MeshGenerationTest::testBuildSquare, 4, QUAD4); }
   void buildSquareQuad8 ()   { tester(&MeshGenerationTest::testBuildSquare, 4, QUAD8); }
   void buildSquareQuad9 ()   { tester(&MeshGenerationTest::testBuildSquare, 4, QUAD9); }
+
+  void buildSphereTri3 ()     { testBuildSphere(2, TRI3); }
+  void buildSphereQuad4 ()     { testBuildSphere(2, QUAD4); }
 
   void buildCubeTet4 ()      { tester(&MeshGenerationTest::testBuildCube, 2, TET4); }
   void buildCubeTet10 ()     { tester(&MeshGenerationTest::testBuildCube, 2, TET10); }
@@ -222,6 +254,9 @@ public:
   void buildCubePyramid5 ()  { tester(&MeshGenerationTest::testBuildCube, 2, PYRAMID5); }
   void buildCubePyramid13 () { tester(&MeshGenerationTest::testBuildCube, 2, PYRAMID13); }
   void buildCubePyramid14 () { tester(&MeshGenerationTest::testBuildCube, 2, PYRAMID14); }
+
+  void buildSphereHex8 ()     { testBuildSphere(2, HEX8); }
+  void buildSphereHex27 ()     { testBuildSphere(2, HEX27); }
 };
 
 

--- a/tests/mesh/mesh_generation_test.C
+++ b/tests/mesh/mesh_generation_test.C
@@ -55,7 +55,7 @@ public:
   CPPUNIT_TEST( buildCubePyramid14 );
 #  ifdef LIBMESH_ENABLE_AMR
   CPPUNIT_TEST( buildSphereHex8 );
-//  CPPUNIT_TEST( buildSphereHex27 );
+  CPPUNIT_TEST( buildSphereHex27 );
 #  endif
 #endif
 


### PR DESCRIPTION
Ironically, this fixes every supported element type *except* the HEX27 case which prompted this investigation in #2496 in the first place.  There's still one bug remaining in the all_second_order distributed unique_id handling that I haven't yet sorted out.  But I'm done for the day so we can at least get the other fixes into CI first.