### PR TITLE
RBConstruction change to element post-processing

### DIFF
--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -733,10 +733,8 @@ void RBConstruction::add_scaled_matrix_and_vector(Number scalar,
         }
 
       // Do any required user post-processing before symmetrizing
-      // and/or applying constraints. Only do the post processing
-      // if we are applying the dof constraints.
-      if (apply_dof_constraints)
-        this->post_process_elem_matrix_and_vector(context);
+      // and/or applying constraints.
+      this->post_process_elem_matrix_and_vector(context);
 
       // Need to symmetrize before imposing
       // periodic constraints


### PR DESCRIPTION
We should apply element post-processing (e.g. dof rotations) whether or not we
apply constraints.