### PR TITLE
DofMap::add_constraint_row(): assert there is no diagonal entry

### DIFF
--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1372,6 +1372,13 @@ void DofMap::add_constraint_row (const dof_id_type dof_number,
       libmesh_error_msg("ERROR: DOF " << dof_number << " was already constrained!");
 
   libmesh_assert_less(dof_number, this->n_dofs());
+
+  // There is an implied "1" on the diagonal of the constraint row, and the user
+  // should not try to manually set _any_ value on the diagonal.
+  libmesh_assert_msg(!constraint_row.count(dof_number),
+                     "Error: constraint_row for dof " << dof_number <<
+                     " should not contain an entry for dof " << dof_number);
+
 #ifndef NDEBUG
   for (const auto & pr : constraint_row)
     libmesh_assert_less(pr.first, this->n_dofs());


### PR DESCRIPTION
I ran into an issue where it's not just redundant to set a constraint row entry matching the dof currently being constrained, it actually leads to incorrect constraints being generated. Currently this check runs for every call to `DofMap::add_constraint_row()` in debug mode since I don't expect it to be a common issue in general.
