### PR TITLE
Fix flux error estimates when flux weights not in approximation space

### DIFF
--- a/examples/adjoints/adjoints_ex6/adjoints_ex6.C
+++ b/examples/adjoints/adjoints_ex6/adjoints_ex6.C
@@ -283,9 +283,6 @@ int main (int argc, char ** argv)
 
   equation_systems.init ();
 
-  // Add an adjoint_solution0 vector to the system
-  system.add_vector("adjoint_solution0", false, GHOSTED);
-
   // Print information about the mesh and system to the screen.
   mesh.print_info();
   equation_systems.print_info();

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1703,6 +1703,18 @@ public:
    */
   void zero_variable (NumericVector<Number> & v, unsigned int var_num) const;
 
+  /**
+   * Setter and getter functions for project_with_constraints boolean
+   */
+  bool get_project_with_constraints()
+  {
+    return project_with_constraints;
+  }
+
+  void set_project_with_constraints(bool _project_with_constraints)
+  {
+    project_with_constraints = _project_with_constraints;
+  }
 
   /**
    * \returns A writable reference to a boolean that determines if this system
@@ -2057,6 +2069,11 @@ private:
    * \p true, then \p EquationSystems::write will ignore this system.
    */
   bool _hide_output;
+
+  /**
+   * Do we want to apply constraints while projecting vectors ?
+   */
+  bool project_with_constraints;
 };
 
 

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -198,13 +198,13 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
           auto old_adjoint_vector_projection_setting = system.vector_preservation(adjoint_vector_name);
 
           // Save for restoration later on
-          old_adjoints_projection_settings.emplace_back(old_adjoint_vector_projection_setting);
+          old_adjoints_projection_settings.push_back(old_adjoint_vector_projection_setting);
 
           // Set the preservation to true for the upcoming reinits
           system.set_vector_preservation(adjoint_vector_name, true);
         }
       else
-        old_adjoints_projection_settings.emplace_back(NULL);
+        old_adjoints_projection_settings.push_back(NULL);
     }
 
   // And we'll need to temporarily change solution projection settings

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -188,7 +188,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
   // the user is treating them in their code
   // The adjoint lift function we have defined above is set to be preserved
   // by default
-  std::vector<bool> old_adjoints_projection_settings;
+  std::vector<bool> old_adjoints_projection_settings(system.n_qois());
   for (auto j : IntRange<unsigned int>(0, system.n_qois()))
     {
       if (_qoi_set.has_index(j))
@@ -198,13 +198,11 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
           auto old_adjoint_vector_projection_setting = system.vector_preservation(adjoint_vector_name);
 
           // Save for restoration later on
-          old_adjoints_projection_settings.push_back(old_adjoint_vector_projection_setting);
+          old_adjoints_projection_settings[j] = old_adjoint_vector_projection_setting;
 
           // Set the preservation to true for the upcoming reinits
           system.set_vector_preservation(adjoint_vector_name, true);
         }
-      else
-        old_adjoints_projection_settings.push_back(NULL);
     }
 
   // And we'll need to temporarily change solution projection settings

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -92,7 +92,8 @@ System::System (EquationSystems & es,
   _identify_variable_groups         (true),
   _additional_data_written          (false),
   adjoint_already_solved            (false),
-  _hide_output                      (false)
+  _hide_output                      (false),
+  project_with_constraints          (true)
 {
 }
 

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -455,12 +455,20 @@ void System::project_vector (const NumericVector<Number> & old_v,
       new_v.close();
     }
 
-  if (is_adjoint == -1)
-    this->get_dof_map().enforce_constraints_exactly(*this, &new_v);
-  else if (is_adjoint >= 0)
-    this->get_dof_map().enforce_adjoint_constraints_exactly(new_v,
-                                                            is_adjoint);
 
+  // Apply constraints only if we we are asked to
+  if(this->project_with_constraints)
+  {
+    if (is_adjoint == -1)
+    {
+      this->get_dof_map().enforce_constraints_exactly(*this, &new_v);
+    }
+    else if (is_adjoint >= 0)
+    {
+      this->get_dof_map().enforce_adjoint_constraints_exactly(new_v,
+                                                            is_adjoint);
+    }
+  }
 #else
 
   // AMR is disabled: simply copy the vector


### PR DESCRIPTION
To capture boundary data representation errors with adjoints, we needed to avoid applying adjoint Dirichlet boundary conditions on the coarse scale adjoint vectors in the projection step after enriching the mesh.

Also fixed a bug in adjoints example 6 which was preventing the coarse adjoints from being projected at all.

Tested on fixed adjoints example 6, matches error estimation identities, expected effectivities and gives an OOM improvement in boundary flux QoI convergence.