### PR TITLE
Don't swap LIBS and CPPFLAGS

### DIFF
--- a/configure
+++ b/configure
@@ -45247,25 +45247,25 @@ $as_echo
 for method in ${METHODS}; do
      case "${method}" in #(
   opt) :
-    $as_echo "CPPFLAGS...(opt)................... : $CPPFLAGS_OPT $CPPFLAGS"
-                       $as_echo "CXXFLAGS...(opt)................... : $CXXFLAGS_OPT $CXXFLAGS"
-                       $as_echo "CFLAGS.....(opt)................... : $CFLAGS_OPT $CFLAGS" ;; #(
+    $as_echo "CPPFLAGS...(opt)................... : $CPPFLAGS_OPT"
+                       $as_echo "CXXFLAGS...(opt)................... : $CXXFLAGS_OPT"
+                       $as_echo "CFLAGS.....(opt)................... : $CFLAGS_OPT" ;; #(
   devel) :
-    $as_echo "CPPFLAGS...(devel)................. : $CPPFLAGS_DEVEL $CPPFLAGS"
-                       $as_echo "CXXFLAGS...(devel)................. : $CXXFLAGS_DEVEL $CXXFLAGS"
-                       $as_echo "CFLAGS.....(devel)................. : $CFLAGS_DEVEL $CFLAGS" ;; #(
+    $as_echo "CPPFLAGS...(devel)................. : $CPPFLAGS_DEVEL"
+                       $as_echo "CXXFLAGS...(devel)................. : $CXXFLAGS_DEVEL"
+                       $as_echo "CFLAGS.....(devel)................. : $CFLAGS_DEVEL" ;; #(
   dbg) :
-    $as_echo "CPPFLAGS...(dbg)................... : $CPPFLAGS_DBG $CPPFLAGS"
-                       $as_echo "CXXFLAGS...(dbg)................... : $CXXFLAGS_DBG $CXXFLAGS"
-                       $as_echo "CFLAGS.....(dbg)................... : $CFLAGS_DBG $CFLAGS" ;; #(
+    $as_echo "CPPFLAGS...(dbg)................... : $CPPFLAGS_DBG"
+                       $as_echo "CXXFLAGS...(dbg)................... : $CXXFLAGS_DBG"
+                       $as_echo "CFLAGS.....(dbg)................... : $CFLAGS_DBG" ;; #(
   prof) :
-    $as_echo "CPPFLAGS...(prof).................. : $CPPFLAGS_PROF $CPPFLAGS"
-                       $as_echo "CXXFLAGS...(prof).................. : $CXXFLAGS_PROF $CXXFLAGS"
-                       $as_echo "CFLAGS.....(prof).................. : $CFLAGS_PROF $CFLAGS" ;; #(
+    $as_echo "CPPFLAGS...(prof).................. : $CPPFLAGS_PROF"
+                       $as_echo "CXXFLAGS...(prof).................. : $CXXFLAGS_PROF"
+                       $as_echo "CFLAGS.....(prof).................. : $CFLAGS_PROF" ;; #(
   oprof) :
-    $as_echo "CPPFLAGS...(oprof)................. : $CPPFLAGS_OPROF $CPPFLAGS"
-                       $as_echo "CXXFLAGS...(oprof)................. : $CXXFLAGS_OPROF $CXXFLAGS"
-                       $as_echo "CFLAGS.....(oprof)................. : $CFLAGS_OPROF $CFLAGS" ;; #(
+    $as_echo "CPPFLAGS...(oprof)................. : $CPPFLAGS_OPROF"
+                       $as_echo "CXXFLAGS...(oprof)................. : $CXXFLAGS_OPROF"
+                       $as_echo "CFLAGS.....(oprof)................. : $CFLAGS_OPROF" ;; #(
   *) :
      ;;
 esac

--- a/configure
+++ b/configure
@@ -34310,8 +34310,8 @@ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
-    LIBS=$tmpCPPFLAGS
-    CPPFLAGS=$tmpLIBS
+    LIBS=$tmpLIBS
+    CPPFLAGS=$tmpCPPFLAGS
 
 else
 

--- a/m4/config_summary.m4
+++ b/m4/config_summary.m4
@@ -30,21 +30,21 @@ AS_ECHO(["Build Methods...................... : $METHODS"])
 AS_ECHO([])
 for method in ${METHODS}; do
      AS_CASE("${method}",
-             [opt],   [AS_ECHO(["CPPFLAGS...(opt)................... : $CPPFLAGS_OPT $CPPFLAGS"])
-                       AS_ECHO(["CXXFLAGS...(opt)................... : $CXXFLAGS_OPT $CXXFLAGS"])
-                       AS_ECHO(["CFLAGS.....(opt)................... : $CFLAGS_OPT $CFLAGS"])],
-             [devel], [AS_ECHO(["CPPFLAGS...(devel)................. : $CPPFLAGS_DEVEL $CPPFLAGS"])
-                       AS_ECHO(["CXXFLAGS...(devel)................. : $CXXFLAGS_DEVEL $CXXFLAGS"])
-                       AS_ECHO(["CFLAGS.....(devel)................. : $CFLAGS_DEVEL $CFLAGS"])],
-             [dbg],   [AS_ECHO(["CPPFLAGS...(dbg)................... : $CPPFLAGS_DBG $CPPFLAGS"])
-                       AS_ECHO(["CXXFLAGS...(dbg)................... : $CXXFLAGS_DBG $CXXFLAGS"])
-                       AS_ECHO(["CFLAGS.....(dbg)................... : $CFLAGS_DBG $CFLAGS"])],
-             [prof],  [AS_ECHO(["CPPFLAGS...(prof).................. : $CPPFLAGS_PROF $CPPFLAGS"])
-                       AS_ECHO(["CXXFLAGS...(prof).................. : $CXXFLAGS_PROF $CXXFLAGS"])
-                       AS_ECHO(["CFLAGS.....(prof).................. : $CFLAGS_PROF $CFLAGS"])],
-             [oprof], [AS_ECHO(["CPPFLAGS...(oprof)................. : $CPPFLAGS_OPROF $CPPFLAGS"])
-                       AS_ECHO(["CXXFLAGS...(oprof)................. : $CXXFLAGS_OPROF $CXXFLAGS"])
-                       AS_ECHO(["CFLAGS.....(oprof)................. : $CFLAGS_OPROF $CFLAGS"])])
+             [opt],   [AS_ECHO(["CPPFLAGS...(opt)................... : $CPPFLAGS_OPT"])
+                       AS_ECHO(["CXXFLAGS...(opt)................... : $CXXFLAGS_OPT"])
+                       AS_ECHO(["CFLAGS.....(opt)................... : $CFLAGS_OPT"])],
+             [devel], [AS_ECHO(["CPPFLAGS...(devel)................. : $CPPFLAGS_DEVEL"])
+                       AS_ECHO(["CXXFLAGS...(devel)................. : $CXXFLAGS_DEVEL"])
+                       AS_ECHO(["CFLAGS.....(devel)................. : $CFLAGS_DEVEL"])],
+             [dbg],   [AS_ECHO(["CPPFLAGS...(dbg)................... : $CPPFLAGS_DBG"])
+                       AS_ECHO(["CXXFLAGS...(dbg)................... : $CXXFLAGS_DBG"])
+                       AS_ECHO(["CFLAGS.....(dbg)................... : $CFLAGS_DBG"])],
+             [prof],  [AS_ECHO(["CPPFLAGS...(prof).................. : $CPPFLAGS_PROF"])
+                       AS_ECHO(["CXXFLAGS...(prof).................. : $CXXFLAGS_PROF"])
+                       AS_ECHO(["CFLAGS.....(prof).................. : $CFLAGS_PROF"])],
+             [oprof], [AS_ECHO(["CPPFLAGS...(oprof)................. : $CPPFLAGS_OPROF"])
+                       AS_ECHO(["CXXFLAGS...(oprof)................. : $CXXFLAGS_OPROF"])
+                       AS_ECHO(["CFLAGS.....(oprof)................. : $CFLAGS_OPROF"])])
 
      dnl blank line
      AS_ECHO([])

--- a/m4/mpi.m4
+++ b/m4/mpi.m4
@@ -244,8 +244,8 @@ AS_IF(
                   enablempi=no
                 ])
     AC_LANG_POP([C++])
-    LIBS=$tmpCPPFLAGS
-    CPPFLAGS=$tmpLIBS
+    LIBS=$tmpLIBS
+    CPPFLAGS=$tmpCPPFLAGS
   ],
   dnl We weren't supplied --with-mpi and no MPI environment variables were set. Also we didn't
   dnl get any MPI info from a PETSc install. Let's check to see if CXX natively supports MPI


### PR DESCRIPTION
This may be at the root of how a bad CPPFLAGS setting was getting
incorporated into libMesh builds using Conda