### PR TITLE
Smooth libmesh for PETSc-3.13

### DIFF
--- a/src/solvers/petscdmlibmeshimpl.C
+++ b/src/solvers/petscdmlibmeshimpl.C
@@ -786,6 +786,7 @@ static PetscErrorCode DMCreateGlobalVector_libMesh(DM dm, Vec *x)
     ierr = VecDuplicate(v,x); CHKERRQ(ierr);
   }
   ierr = PetscObjectCompose((PetscObject)*x,"DM",(PetscObject)dm); CHKERRQ(ierr);
+  ierr = VecSetDM(*x, dm);CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 


### PR DESCRIPTION
In PETSc-3.13, PETSc check if `Vec` is consistent with `DM`. So we need to let `Vec` and `DM` know each other.