### PR TITLE
RBConstruction update to store an untransformed basis.

### DIFF
--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -593,6 +593,16 @@ public:
   bool store_non_dirichlet_operators;
 
   /**
+   * Boolean flag to indicate whether we store a second copy of the
+   * basis without constraints or dof transformations applied to it.
+   * This is necessary when we have dof transformations and need
+   * to calculate the residual R(U) = C^T F - C^T A C U, since we
+   * need to evaluate R(U) using the untransformed basis U rather
+   * than C U to avoid "double applying" dof transformations in C.
+   */
+  bool store_untransformed_basis;
+
+  /**
    * A boolean flag to indicate whether or not we initialize the
    * Greedy algorithm by performing rb_solves on the training set
    * with an "empty" (i.e. N=0) reduced basis space.
@@ -904,6 +914,21 @@ private:
    *  - POD: Proper Orthogonal Decomposition
    */
   std::string RB_training_type;
+
+  /**
+   * In cases where we have dof transformations such as a change of
+   * coordinates at some nodes we need to store an extra set of basis
+   * functions which have not had dof transformations applied to them.
+   * These vectors are required in order to compute the residual in
+   * the error indicator.
+   */
+  std::vector<std::unique_ptr<NumericVector<Number>>> _untransformed_basis_functions;
+
+  /**
+   * We also store a copy of the untransformed solution in order to
+   * create _untransformed_basis_functions.
+   */
+  std::unique_ptr<NumericVector<Number>> _untransformed_solution;
 
 };
 


### PR DESCRIPTION
In some cases we need to store a second basis with no transformations or constraints applied to it (e.g. dof rotations) to enable us to compute terms without "doubly applying" the dof transformations.