### PR TITLE
Small fix to RBConstruction

### DIFF
--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -1152,10 +1152,22 @@ Real RBConstruction::train_reduced_basis_with_greedy(const bool resize_rb_eval_d
       // Perform an Offline truth solve for the current parameter
       truth_solve(-1);
 
-      if(solution->l2_norm() == 0.)
+      if (solution->l2_norm() == 0.)
         {
-          libMesh::out << "Zero basis function encountered hence ending basis enrichment" << std::endl;
-          break;
+          if (count==0 && !use_empty_rb_solve_in_greedy)
+            {
+              // Do nothing in this case because when we are not using
+              // an empty RB solve in the greedy then the first solve
+              // that is performed is at a randomly selected parameter
+              // value which could give a zero solution, but this does
+              // not imply that we have converged. This situation can
+              // occur in RBEIMConstruction, for example.
+            }
+            else
+            {
+              libMesh::out << "Zero basis function encountered hence ending basis enrichment" << std::endl;
+              break;
+            }
         }
 
       // Add orthogonal part of the snapshot to the RB space


### PR DESCRIPTION
We recently made a small change to train_reduced_basis to break out if we encountered a zero solution. This is normally fine, but it can cause an issue in the case that we have use_empty_rb_solve_in_greedy=false, such as in RBEIMConstruction. This is a fix for that case.