### PR TITLE
RB fix to EIM greedy

### DIFF
--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -563,6 +563,15 @@ public:
   bool exit_on_repeated_greedy_parameters;
 
   /**
+   * Boolean flag to indicate whether we exit the greedy if
+   * we encounter a zero basis function. We do this by
+   * default, but in some cases (e.g. RBEIMConstruction)
+   * we do not since a zero basis function in EIM does not
+   * necessarily indicate that we have converged.
+   */
+  bool exit_on_zero_basis_function;
+
+  /**
    * Boolean flag to indicate whether we impose "fluxes"
    * (i.e. element boundary contributions to the weak form)
    * on internal element boundaries in the assembly routines.

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -68,6 +68,7 @@ RBConstruction::RBConstruction (EquationSystems & es,
     inner_product_matrix(SparseMatrix<Number>::build(es.comm())),
     skip_residual_in_train_reduced_basis(false),
     exit_on_repeated_greedy_parameters(true),
+    exit_on_zero_basis_function(true),
     impose_internal_fluxes(false),
     skip_degenerate_sides(true),
     compute_RB_inner_product(false),
@@ -1152,22 +1153,10 @@ Real RBConstruction::train_reduced_basis_with_greedy(const bool resize_rb_eval_d
       // Perform an Offline truth solve for the current parameter
       truth_solve(-1);
 
-      if (solution->l2_norm() == 0.)
+      if (exit_on_zero_basis_function && (solution->l2_norm() == 0.))
         {
-          if (count==0 && !use_empty_rb_solve_in_greedy)
-            {
-              // Do nothing in this case because when we are not using
-              // an empty RB solve in the greedy then the first solve
-              // that is performed is at a randomly selected parameter
-              // value which could give a zero solution, but this does
-              // not imply that we have converged. This situation can
-              // occur in RBEIMConstruction, for example.
-            }
-            else
-            {
-              libMesh::out << "Zero basis function encountered hence ending basis enrichment" << std::endl;
-              break;
-            }
+          libMesh::out << "Zero basis function encountered hence ending basis enrichment" << std::endl;
+          break;
         }
 
       // Add orthogonal part of the snapshot to the RB space

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -64,6 +64,11 @@ RBEIMConstruction::RBEIMConstruction (EquationSystems & es,
   // "rb space" with EIM
   use_empty_rb_solve_in_greedy = false;
 
+  // Do not exit the greedy when we encounter a zero
+  // basis function, since in the case of EIM this does
+  // not necessarily mean that we have converged
+  exit_on_zero_basis_function = false;
+
   // Indicate that we need to compute the RB
   // inner product matrix in this case
   compute_RB_inner_product = true;


### PR DESCRIPTION
We should not exit the RB EIM greedy early due to a zero basis function.