### PR TITLE
AbaqusIO: Add support for "MASS" elements and "NODE" sidesets.

### DIFF
--- a/include/mesh/abaqus_io.h
+++ b/include/mesh/abaqus_io.h
@@ -156,7 +156,9 @@ private:
    * by a "*Surface" section in the file, and then a list of element ID
    * and side IDs for the set.
    */
-  void read_sideset(std::string sideset_name, sideset_container_t & container);
+  void read_sideset(const std::string & sideset_name,
+                    const std::string & sideset_type,
+                    sideset_container_t & container);
 
   /**
    * This function assigns boundary IDs to node sets based on the


### PR DESCRIPTION
* MASS elements are used to represent point masses in Abaqus
  models. We just store these as NodeElems currently, nothing else
  special is done for them. We also do not consider NodeElems when
  searching for Elems that provide BCs.
* Recognize/parse sidsets which are generated from nodesets. We don't
  yet fully support this feature, I need to look further into what it
  means to generate a sideset from a nodeset in Abaqus to determine
  whether we can handle it in the reader (it will probably require
  a Nodes-to-Elems map or something along those lines).