### PR TITLE
Add Quad::quality(TWIST) test

### DIFF
--- a/include/enums/enum_elem_quality.h
+++ b/include/enums/enum_elem_quality.h
@@ -47,7 +47,8 @@ enum ElemQuality : int {
                   ASPECT_RATIO_BETA,
                   ASPECT_RATIO_GAMMA,
                   SIZE,
-                  JACOBIAN};
+                  JACOBIAN,
+                  TWIST};
 }
 
 #endif


### PR DESCRIPTION
This is useful for detecting invalid elements. A Quad either fails this quality test (0) or passes it (1), there is not a continuous range of output values like for the other quality measures.
