### PR TITLE
change to boost m4 file to ignore pedantic warnings from boost

### DIFF
--- a/configure
+++ b/configure
@@ -33612,7 +33612,11 @@ fi
           if test "x$install_internal_boost" = "xyes"; then :
   libmesh_contrib_INCLUDES="$BOOST_INCLUDE $libmesh_contrib_INCLUDES"
 else
-  libmesh_optional_INCLUDES="$BOOST_CPPFLAGS $libmesh_optional_INCLUDES"
+
+                   BOOST_CPPFLAGS=$(sed -e "s/^-I/-isystem/g" <<< $BOOST_CPPFLAGS)
+                   BOOST_CPPFLAGS=$(sed -e "s/ ^-I/ -isystem/g" <<< $BOOST_CPPFLAGS)
+                   libmesh_optional_INCLUDES="$BOOST_CPPFLAGS $libmesh_optional_INCLUDES"
+
 fi
 
 fi

--- a/m4/boost.m4
+++ b/m4/boost.m4
@@ -69,7 +69,11 @@ AC_DEFUN([CONFIGURE_BOOST],
         [
           AS_IF([test "x$install_internal_boost" = "xyes"],
                 [libmesh_contrib_INCLUDES="$BOOST_INCLUDE $libmesh_contrib_INCLUDES"],
-                [libmesh_optional_INCLUDES="$BOOST_CPPFLAGS $libmesh_optional_INCLUDES"])
+                [
+                   BOOST_CPPFLAGS=$(sed -e "s/^-I/-isystem/g" <<< $BOOST_CPPFLAGS)
+                   BOOST_CPPFLAGS=$(sed -e "s/ ^-I/ -isystem/g" <<< $BOOST_CPPFLAGS)
+                   libmesh_optional_INCLUDES="$BOOST_CPPFLAGS $libmesh_optional_INCLUDES"
+                ])
         ])
 
   AM_CONDITIONAL(LIBMESH_INSTALL_INTERNAL_BOOST, test x$install_internal_boost = xyes)


### PR DESCRIPTION
replace -I with -isystem to ignore warnings coming from boost.  Ben Spencer checked that this does suppress the warnings we were seeing when building grizzly with the moose stochastic_tools which were included boost.  @bwspenc @dschwen @aeslaughter @jwpeterson 

This closes Issue #2537