### PR TITLE
Fixed valgrind issue with VecSetDM

### DIFF
--- a/src/solvers/petscdmlibmeshimpl.C
+++ b/src/solvers/petscdmlibmeshimpl.C
@@ -785,7 +785,13 @@ static PetscErrorCode DMCreateGlobalVector_libMesh(DM dm, Vec *x)
   else {
     ierr = VecDuplicate(v,x); CHKERRQ(ierr);
   }
+
+#if PETSC_RELEASE_LESS_THAN(3,13,0)
   ierr = PetscObjectCompose((PetscObject)*x,"DM",(PetscObject)dm); CHKERRQ(ierr);
+#else
+  ierr = VecSetDM(*x, dm);CHKERRQ(ierr);
+#endif
+
   PetscFunctionReturn(0);
 }
 


### PR DESCRIPTION
We should not compose object twice