### PR TITLE
Adding number of threads option to LibMeshInit.

### DIFF
--- a/include/base/libmesh.h
+++ b/include/base/libmesh.h
@@ -98,9 +98,9 @@ public:
    * parameter to use a user-specified MPI communicator.
    */
   LibMeshInit(int argc, const char * const * argv,
-              MPI_Comm COMM_WORLD_IN=MPI_COMM_WORLD);
+              MPI_Comm COMM_WORLD_IN=MPI_COMM_WORLD, int n_threads=-1);
 #else
-  LibMeshInit(int argc, const char * const * argv);
+  LibMeshInit(int argc, const char * const * argv, int n_threads=-1);
 #endif
 
   /**

--- a/include/base/libmesh.h
+++ b/include/base/libmesh.h
@@ -100,7 +100,8 @@ public:
   LibMeshInit(int argc, const char * const * argv,
               MPI_Comm COMM_WORLD_IN=MPI_COMM_WORLD, int n_threads=-1);
 #else
-  LibMeshInit(int argc, const char * const * argv, int n_threads=-1);
+  LibMeshInit(int argc, const char * const * argv,
+              int COMM_WORLD_IN=0, int n_threads=-1);
 #endif
 
   /**

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -330,12 +330,8 @@ void libmesh_terminate_handler()
 
 
 
-#ifndef LIBMESH_HAVE_MPI
-LibMeshInit::LibMeshInit (int argc, const char * const * argv, int n_threads)
-#else
 LibMeshInit::LibMeshInit (int argc, const char * const * argv,
-                          MPI_Comm COMM_WORLD_IN, int n_threads)
-#endif
+                          TIMPI::communicator COMM_WORLD_IN, int n_threads)
 {
   // should _not_ be initialized already.
   libmesh_assert (!libMesh::initialized());
@@ -479,6 +475,7 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
   libmesh_parallel_only(this->comm());
 
 #else
+  libmesh_ignore(COMM_WORLD_IN);
   this->_comm = new Parallel::Communicator(); // So comm() doesn't dereference null
 #endif
 

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -331,10 +331,10 @@ void libmesh_terminate_handler()
 
 
 #ifndef LIBMESH_HAVE_MPI
-LibMeshInit::LibMeshInit (int argc, const char * const * argv)
+LibMeshInit::LibMeshInit (int argc, const char * const * argv, int n_threads)
 #else
 LibMeshInit::LibMeshInit (int argc, const char * const * argv,
-                          MPI_Comm COMM_WORLD_IN)
+                          MPI_Comm COMM_WORLD_IN, int n_threads)
 #endif
 {
   // should _not_ be initialized already.
@@ -355,15 +355,15 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
     // multithreading competition.  If you would like to use MPI and multithreading
     // at the same time then (n_mpi_processes_per_node)x(n_threads) should be the
     //  number of processing cores per node.
-    std::vector<std::string> n_threads(2);
-    n_threads[0] = "--n_threads";
-    n_threads[1] = "--n-threads";
+    std::vector<std::string> n_threads_opt(2);
+    n_threads_opt[0] = "--n_threads";
+    n_threads_opt[1] = "--n-threads";
     libMesh::libMeshPrivateData::_n_threads =
-      libMesh::command_line_value (n_threads, -1);
+      libMesh::command_line_value(n_threads_opt, n_threads);
 
     if (libMesh::libMeshPrivateData::_n_threads == -1)
       {
-        for (auto & option : n_threads)
+        for (auto & option : n_threads_opt)
           if (command_line->search(option))
             libmesh_error_msg("Detected option " << option <<
                               " with no value.  Did you forget '='?");


### PR DESCRIPTION
Adding a parameter to set the number of threads used by libMesh explicitly to allow consistency in the number of threads used when using libMesh with other threaded applications. Specifically, if both the parent application and libMesh are using the `openmp` threading model, the call to `openmp_set_num_threads` in `LibMeshInit` can change the number of threads to an unintended value.

An alternative is to always make sure the `LibMeshInit` object gets created before the number of `openmp` threads is set in the parent application, but this seems to be a more flexible option.

The changes here will prefer the number of threads set by the `--n-threads` option in the command line arguments over the new parameter (`n_threads`) passed into `LibMeshInit`. If the `--n-threads` option is absent and the `n_threads` is it's default value (`-1`) then the number of threads will default to 1.