### PR TITLE
Let user control sorting method used by BoundaryInfo::build_side_list()

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -673,8 +673,8 @@ public:
    * potentially be in different orders on different procs.
    */
   typedef std::tuple<dof_id_type, boundary_id_type> NodeBCTuple;
-  enum NodeBCTupleSortBy : int {NODE_ID, BOUNDARY_ID, UNSORTED};
-  std::vector<NodeBCTuple> build_node_list(NodeBCTupleSortBy sort_by = NODE_ID) const;
+  enum class NodeBCTupleSortBy {NODE_ID, BOUNDARY_ID, UNSORTED};
+  std::vector<NodeBCTuple> build_node_list(NodeBCTupleSortBy sort_by = NodeBCTupleSortBy::NODE_ID) const;
 
   /**
    * Adds nodes with boundary ids based on the side's boundary
@@ -716,8 +716,8 @@ public:
    * different processors when running in parallel.
    */
   typedef std::tuple<dof_id_type, unsigned short int, boundary_id_type> BCTuple;
-  enum BCTupleSortBy : int {ELEM_ID, SIDE_ID, BOUNDARY_ID, UNSORTED};
-  std::vector<BCTuple> build_side_list(BCTupleSortBy sort_by = ELEM_ID) const;
+  enum class BCTupleSortBy {ELEM_ID, SIDE_ID, BOUNDARY_ID, UNSORTED};
+  std::vector<BCTuple> build_side_list(BCTupleSortBy sort_by = BCTupleSortBy::ELEM_ID) const;
 
   /**
    * Creates a list of active element numbers, sides, and ids for those sides.

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -670,7 +670,7 @@ public:
    * The "sort_by" parameter controls how the resulting list of tuples
    * is sorted.  It is possible (but not recommended) to choose
    * UNSORTED, since in that case the resulting vectors will
-   * potentially be in different ordres on different procs.
+   * potentially be in different orders on different procs.
    */
   typedef std::tuple<dof_id_type, boundary_id_type> NodeBCTuple;
   enum NodeBCTupleSortBy : int {NODE_ID, BOUNDARY_ID, UNSORTED};
@@ -708,9 +708,16 @@ public:
    * As above, but the library creates and fills in a vector of
    * (elem-id, side-id, bc-id) triplets and returns it to the user,
    * taking advantage of guaranteed RVO.
+   *
+   * The returned vector is sorted by element id by default, but this
+   * can be changed by passing SIDE_ID, BOUNDARY_ID, or UNSORTED to
+   * this function. Note: choosing UNSORTED is not recommended since
+   * the resulting list will potentially be in different orders on
+   * different processors when running in parallel.
    */
   typedef std::tuple<dof_id_type, unsigned short int, boundary_id_type> BCTuple;
-  std::vector<BCTuple> build_side_list() const;
+  enum BCTupleSortBy : int {ELEM_ID, SIDE_ID, BOUNDARY_ID, UNSORTED};
+  std::vector<BCTuple> build_side_list(BCTupleSortBy sort_by = ELEM_ID) const;
 
   /**
    * Creates a list of active element numbers, sides, and ids for those sides.

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -2021,7 +2021,7 @@ void BoundaryInfo::build_side_list (std::vector<dof_id_type> & el,
 
 
 std::vector<BoundaryInfo::BCTuple>
-BoundaryInfo::build_side_list() const
+BoundaryInfo::build_side_list(BCTupleSortBy sort_by) const
 {
   std::vector<BCTuple> bc_triples;
   bc_triples.reserve(_boundary_side_id.size());
@@ -2033,7 +2033,16 @@ BoundaryInfo::build_side_list() const
   // the _boundary_side_id multimap are in, and in particular might be
   // in different orders on different processors. To avoid this
   // inconsistency, we'll sort using the default operator< for tuples.
-  std::sort(bc_triples.begin(), bc_triples.end());
+  if (sort_by == ELEM_ID)
+    std::sort(bc_triples.begin(), bc_triples.end());
+  else if (sort_by == SIDE_ID)
+    std::sort(bc_triples.begin(), bc_triples.end(),
+              [](const BCTuple & left, const BCTuple & right)
+              {return std::get<1>(left) < std::get<1>(right);});
+  else if (sort_by == BOUNDARY_ID)
+    std::sort(bc_triples.begin(), bc_triples.end(),
+              [](const BCTuple & left, const BCTuple & right)
+              {return std::get<2>(left) < std::get<2>(right);});
 
   return bc_triples;
 }

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1751,9 +1751,9 @@ BoundaryInfo::build_node_list(NodeBCTupleSortBy sort_by) const
 
   // This list is currently in memory address (arbitrary) order, so
   // sort, using the specified ordering, to make it consistent on all procs.
-  if (sort_by == NODE_ID)
+  if (sort_by == NodeBCTupleSortBy::NODE_ID)
     std::sort(bc_tuples.begin(), bc_tuples.end());
-  else if (sort_by == BOUNDARY_ID)
+  else if (sort_by == NodeBCTupleSortBy::BOUNDARY_ID)
     std::sort(bc_tuples.begin(), bc_tuples.end(),
               [](const NodeBCTuple & left, const NodeBCTuple & right)
               {return std::get<1>(left) < std::get<1>(right);});
@@ -2033,13 +2033,13 @@ BoundaryInfo::build_side_list(BCTupleSortBy sort_by) const
   // the _boundary_side_id multimap are in, and in particular might be
   // in different orders on different processors. To avoid this
   // inconsistency, we'll sort using the default operator< for tuples.
-  if (sort_by == ELEM_ID)
+  if (sort_by == BCTupleSortBy::ELEM_ID)
     std::sort(bc_triples.begin(), bc_triples.end());
-  else if (sort_by == SIDE_ID)
+  else if (sort_by == BCTupleSortBy::SIDE_ID)
     std::sort(bc_triples.begin(), bc_triples.end(),
               [](const BCTuple & left, const BCTuple & right)
               {return std::get<1>(left) < std::get<1>(right);});
-  else if (sort_by == BOUNDARY_ID)
+  else if (sort_by == BCTupleSortBy::BOUNDARY_ID)
     std::sort(bc_triples.begin(), bc_triples.end(),
               [](const BCTuple & left, const BCTuple & right)
               {return std::get<2>(left) < std::get<2>(right);});


### PR DESCRIPTION
This is the same idea as the change in #2444 for build_node_list().