### PR TITLE
Don't undef or define MPI_REAL

### DIFF
--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -103,10 +103,6 @@ void report_error(const char * file, int line, const char * date, const char * t
 #  undef COMPLEX
 #endif
 
-#ifdef MPI_REAL
-#  undef MPI_REAL
-#endif
-
 // Check to see if TOLERANCE has been defined by another
 // package, if so we might want to change the name...
 #ifdef TOLERANCE
@@ -126,30 +122,27 @@ typedef LIBMESH_DEFAULT_SCALAR_TYPE Real;
 
 #ifdef LIBMESH_DEFAULT_SINGLE_PRECISION
 static const Real TOLERANCE = 2.5e-3;
-# define MPI_REAL MPI_FLOAT
 # if defined (LIBMESH_DEFAULT_TRIPLE_PRECISION) || \
      defined (LIBMESH_DEFAULT_QUADRUPLE_PRECISION)
 #  error Cannot define multiple precision levels
 # endif
 #endif
+
 #ifdef LIBMESH_DEFAULT_TRIPLE_PRECISION
 static const Real TOLERANCE = 1.e-8;
-# define MPI_REAL MPI_LONG_DOUBLE
 # if defined (LIBMESH_DEFAULT_QUADRUPLE_PRECISION)
 #  error Cannot define multiple precision levels
 # endif
 #endif
+
 #ifdef LIBMESH_DEFAULT_QUADRUPLE_PRECISION
 static const Real TOLERANCE = 1.e-11;
-# ifdef LIBMESH_HAVE_MPI
-#  define MPI_REAL libMesh::Parallel::StandardType<Real>()
-# endif
 #endif
+
 #if !defined (LIBMESH_DEFAULT_SINGLE_PRECISION) && \
     !defined (LIBMESH_DEFAULT_TRIPLE_PRECISION) && \
     !defined (LIBMESH_DEFAULT_QUADRUPLE_PRECISION)
 static const Real TOLERANCE = 1.e-6;
-# define MPI_REAL MPI_DOUBLE
 #endif
 
 // Define the type to use for complex numbers


### PR DESCRIPTION
MPI_REAL is part of the MPI standard, and trying to redefine it is
bad.

I've always been a bit dubious about this, but I've finally found an
MPI implementation with which it breaks, with a "redefined macro"
warning that dies on --enable-werror.

Fortunately, we seem to have long since stopped using MPI_REAL in
libMesh, in favor of TIMPI::StandardType autodetection and such.  I
don't see any uses in MOOSE or GRINS either.