### PR TITLE
Fix an overzealous assertion in unpack_indexing

### DIFF
--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -610,7 +610,10 @@ void DofObject::unpack_indexing(std::vector<largest_id_type>::const_iterator beg
       const unsigned int ns = hdr >= 0 ? hdr : (-hdr-1);
       for (unsigned int i=1; i < ns; ++i)
         {
-          libmesh_assert_greater_equal (_idx_buf[i], _idx_buf[i-1]);
+          if (hdr > 0 || i > 1)
+            libmesh_assert_greater_equal (_idx_buf[i], _idx_buf[i-1]);
+          else
+            libmesh_assert_greater_equal (_idx_buf[i], ns);
           libmesh_assert_equal_to ((_idx_buf[i] - _idx_buf[i-1])%2, 0);
           libmesh_assert_less_equal (_idx_buf[i], _idx_buf.size());
         }


### PR DESCRIPTION
Doing distributed mesh distribution with extra integers in debug mode
would previously fail at i=1 here when the first assertion failed to
take into account our overloading of the sign bit at i=0.

This fixes https://github.com/idaholab/moose/pull/15241 for me.

Not sure what we should do to get better test coverage on this.  I'm considering just adding some extra integers to the mesh in one of our AMR examples, which would at least have triggered this bug in my own tests and in some of our non-default CI recipes.