### PR TITLE
Add hash specialization for FEType

### DIFF
--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -1019,6 +1019,7 @@ include_HEADERS = \
         utils/compare_types.h \
         utils/enum_to_string.h \
         utils/error_vector.h \
+        utils/hashing.h \
         utils/hashword.h \
         utils/ignore_warnings.h \
         utils/int_range.h \

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -26,15 +26,18 @@
 #include "libmesh/enum_order.h"
 #include "libmesh/enum_fe_family.h" // LAGRANGE
 #include "libmesh/enum_inf_map_type.h" // CARTESIAN
+#include "libmesh/hashing.h"
 
 // C++ includes
 #include <memory>
+#include <functional>
 
 namespace libMesh
 {
 
 // Forward declarations
 class QBase;
+class FEType;
 
 /**
  * This provides a shim class that wraps the Order enum.
@@ -86,6 +89,7 @@ private:
    */
   int _order;
 
+  friend struct std::hash<FEType>;
 };
 
 /**
@@ -363,5 +367,20 @@ Order FEType::unweighted_quadrature_order () const
 
 } // namespace libMesh
 
+namespace std
+{
+template <>
+struct hash<libMesh::FEType>
+{
+  std::size_t operator()(const libMesh::FEType & fe_type) const
+    {
+      std::size_t seed = 0;
+      // Old compiler versions seem to need the static_cast
+      libMesh::boostcopy::hash_combine(seed, static_cast<int>(fe_type.family));
+      libMesh::boostcopy::hash_combine(seed, fe_type.order._order);
+      return seed;
+    }
+};
+}
 
 #endif // LIBMESH_FE_TYPE_H

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -438,6 +438,7 @@ include_HEADERS =  \
         utils/compare_types.h \
         utils/enum_to_string.h \
         utils/error_vector.h \
+        utils/hashing.h \
         utils/hashword.h \
         utils/ignore_warnings.h \
         utils/int_range.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -434,6 +434,7 @@ BUILT_SOURCES = \
         compare_types.h \
         enum_to_string.h \
         error_vector.h \
+        hashing.h \
         hashword.h \
         ignore_warnings.h \
         int_range.h \
@@ -1832,6 +1833,9 @@ enum_to_string.h: $(top_srcdir)/include/utils/enum_to_string.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 error_vector.h: $(top_srcdir)/include/utils/error_vector.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+hashing.h: $(top_srcdir)/include/utils/hashing.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 hashword.h: $(top_srcdir)/include/utils/hashword.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -641,8 +641,8 @@ BUILT_SOURCES = auto_ptr.h default_coupling.h dirichlet_boundaries.h \
 	post_wait_dereference_shared_ptr.h post_wait_dereference_tag.h \
 	post_wait_free_buffer.h post_wait_unpack_buffer.h \
 	post_wait_work.h request.h standard_type.h status.h \
-	compare_types.h enum_to_string.h error_vector.h hashword.h \
-	ignore_warnings.h int_range.h jacobi_polynomials.h \
+	compare_types.h enum_to_string.h error_vector.h hashing.h \
+	hashword.h ignore_warnings.h int_range.h jacobi_polynomials.h \
 	libmesh_nullptr.h location_maps.h mapvector.h \
 	null_output_iterator.h number_lookups.h ostream_proxy.h \
 	parameters.h perf_log.h perfmon.h plt_loader.h \
@@ -2174,6 +2174,9 @@ enum_to_string.h: $(top_srcdir)/include/utils/enum_to_string.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 error_vector.h: $(top_srcdir)/include/utils/error_vector.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+hashing.h: $(top_srcdir)/include/utils/hashing.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 hashword.h: $(top_srcdir)/include/utils/hashword.h

--- a/include/utils/hashing.h
+++ b/include/utils/hashing.h
@@ -1,0 +1,44 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2020 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#ifndef LIBMESH_HASHING_H
+#define LIBMESH_HASHING_H
+
+#include "libmesh/hashword.h"
+
+#include <functional>
+
+namespace libMesh
+{
+namespace boostcopy
+{
+
+inline void hash_combine_impl(std::size_t & seed, std::size_t value)
+{
+  seed ^= value + 0x9e3779b9 + (seed<<6) + (seed>>2);
+}
+
+template <typename T>
+inline void hash_combine(std::size_t & seed, const T & value)
+{
+  hash_combine_impl(seed, std::hash<T>{}(value));
+}
+
+}
+}
+
+#endif // LIBMESH_HASHING_H


### PR DESCRIPTION
I was looking into changing all our `std::maps` in MOOSE's Assembly class to `std::unordered_maps` because I was seeing `std::map::operator[]` show up in profiling, so I needed to make `FEType` hashable. Unfortunately it appears that it's actually a little slower in the simple diffusion case I was profiling with `_Hashtable::_M_find_before_node` coming from `std::unordered_map::find` being the main culprit. So probably not gonna switch in that case. However, maybe this could be useful someday...