### PR TITLE
Support shell preconditioning matrix in eigen system

### DIFF
--- a/include/solvers/eigen_solver.h
+++ b/include/solvers/eigen_solver.h
@@ -198,6 +198,19 @@ public:
                                                                  const double tol,
                                                                  const unsigned int m_its) = 0;
 
+   /**
+    * Solves the standard eigenproblem involving the ShellMatrix \p matrix_A and
+    * the shell preconditioning matrix \p precond.
+    *
+    * \returns The number of converged eigenpairs and the number of
+    * iterations.
+    */
+   virtual std::pair<unsigned int, unsigned int> solve_standard (ShellMatrix<T> & matrix_A,
+                                                                 ShellMatrix<T> & precond,
+                                                                 int nev,
+                                                                 int ncv,
+                                                                 const double tol,
+                                                                 const unsigned int m_its) = 0;
 
   /**
    * Solves the generalized eigenproblem involving SparseMatrices \p matrix_A
@@ -269,6 +282,21 @@ public:
                                                                     int ncv,
                                                                     const double tol,
                                                                     const unsigned int m_its) = 0;
+
+  /**
+   * Solves the generalized eigenproblem involving ShellMatrices \p
+   * matrix_A, \p matrix_B and the shell preconditioning matrix.
+   *
+   * \returns The number of converged eigenpairs and the number of
+   * iterations.
+   */
+  virtual std::pair<unsigned int, unsigned int> solve_generalized (ShellMatrix<T> & matrix_A,
+                                                                   ShellMatrix<T> & matrix_B,
+                                                                   ShellMatrix<T> & precond,
+                                                                   int nev,
+                                                                   int ncv,
+                                                                   const double tol,
+                                                                   const unsigned int m_its) = 0;
 
 
   /**

--- a/include/solvers/slepc_eigen_solver.h
+++ b/include/solvers/slepc_eigen_solver.h
@@ -116,6 +116,18 @@ public:
                    const double tol,
                    const unsigned int m_its) override;
 
+   /**
+    * Same as above except that precond is a ShellMatrix
+    * in this case.
+    */
+   virtual std::pair<unsigned int, unsigned int>
+   solve_standard (ShellMatrix<T> & shell_matrix,
+                   ShellMatrix<T> & precond,
+                   int nev,
+                   int ncv,
+                   const double tol,
+                   const unsigned int m_its) override;
+
 
   /**
    * This function calls the SLEPc solver to compute
@@ -195,6 +207,14 @@ public:
                     const double tol,
                     const unsigned int m_its) override;
 
+  virtual std::pair<unsigned int, unsigned int>
+  solve_generalized(ShellMatrix<T> & matrix_A,
+                    ShellMatrix<T> & matrix_B,
+                    ShellMatrix<T> & precond,
+                    int nev,
+                    int ncv,
+                    const double tol,
+                    const unsigned int m_its) override;
 
   /**
    * \returns The real and imaginary part of the ith eigenvalue and

--- a/include/systems/eigen_system.h
+++ b/include/systems/eigen_system.h
@@ -166,6 +166,16 @@ public:
   void use_shell_matrices(bool use_shell_matrices) { _use_shell_matrices = use_shell_matrices; }
 
   /**
+   * \returns \p true if a shell preconditioning matrix is used
+   */
+  bool use_shell_precond_matrix() const { return _use_shell_precond_matrix; }
+
+  /**
+   * Set a flag to use a shell preconditioning matrix
+   */
+  void use_shell_precond_matrix(bool use_shell_precond_matrix) { _use_shell_precond_matrix = use_shell_precond_matrix; }
+
+  /**
    * The system matrix for standard eigenvalue problems.
    */
   std::unique_ptr<SparseMatrix<Number>> matrix_A;
@@ -189,6 +199,11 @@ public:
    * A preconditioning matrix
    */
   std::unique_ptr<SparseMatrix<Number>> precond_matrix;
+
+  /**
+   * A preconditioning shell matrix
+   */
+  std::unique_ptr<ShellMatrix<Number>> shell_precond_matrix;
 
   /**
    * The EigenSolver, defining which interface, i.e solver
@@ -253,6 +268,11 @@ private:
    * A boolean flag to indicate whether or not to use shell matrices
    */
   bool _use_shell_matrices;
+
+  /**
+   * A boolean flag to indicate whether or not to use a shell preconditioning matrix
+   */
+  bool _use_shell_precond_matrix;
 };
 
 

--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -176,7 +176,40 @@ SlepcEigenSolver<T>::solve_standard (ShellMatrix<T> & shell_matrix,
   // Make sure the SparseMatrix passed in is really a PetscMatrix
   PetscMatrix<T> * precond = dynamic_cast<PetscMatrix<T> *>(&precond_in);
 
-  PetscShellMatrix<T> * matrix = static_cast<PetscShellMatrix<T> *> (&shell_matrix);
+  if (!precond)
+    libmesh_error_msg("Error: input preconditioning matrix to solve_standard() must be a PetscMatrix.");
+
+  PetscShellMatrix<T> * matrix = dynamic_cast<PetscShellMatrix<T> *> (&shell_matrix);
+
+  if (!matrix)
+    libmesh_error_msg("Error: input operator matrix to solve_standard() must be a PetscShellMatrix.");
+
+  return _solve_standard_helper(matrix->mat(), precond->mat(), nev, ncv, tol, m_its);
+}
+
+template <typename T>
+std::pair<unsigned int, unsigned int>
+SlepcEigenSolver<T>::solve_standard (ShellMatrix<T> & shell_matrix,
+                                     ShellMatrix<T> & precond_in,
+                                     int nev,                  // number of requested eigenpairs
+                                     int ncv,                  // number of basis vectors
+                                     const double tol,         // solver tolerance
+                                     const unsigned int m_its) // maximum number of iterations
+{
+  this->clear ();
+
+  this->init ();
+
+  // Make sure the SparseMatrix passed in is really a PetscMatrix
+  PetscShellMatrix<T> * precond = dynamic_cast<PetscShellMatrix<T> *>(&precond_in);
+
+  if (!precond)
+    libmesh_error_msg("Error: input preconditioning matrix to solve_standard() must be a PetscShellMatrix.");
+
+  PetscShellMatrix<T> * matrix = dynamic_cast<PetscShellMatrix<T> *> (&shell_matrix);
+
+  if (!matrix)
+    libmesh_error_msg("Error: input operator matrix to solve_standard() must be a PetscShellMatrix.");
 
   return _solve_standard_helper(matrix->mat(), precond->mat(), nev, ncv, tol, m_its);
 }
@@ -506,11 +539,53 @@ SlepcEigenSolver<T>::solve_generalized (ShellMatrix<T> & shell_matrix_A,
   this->init ();
 
   // Make sure the SparseMatrix passed in is really a PetscMatrix
-  PetscMatrix<T> * precond = static_cast<PetscMatrix<T> *>(&precond_in);
+  PetscMatrix<T> * precond = dynamic_cast<PetscMatrix<T> *>(&precond_in);
 
-  PetscShellMatrix<T> * matrix_A = static_cast<PetscShellMatrix<T> *> (&shell_matrix_A);
+  if (!precond)
+    libmesh_error_msg("Error: input preconditioning matrix to solve_generalized() must be of type PetscMatrix.");
 
-  PetscShellMatrix<T> * matrix_B = static_cast<PetscShellMatrix<T> *> (&shell_matrix_B);
+  PetscShellMatrix<T> * matrix_A = dynamic_cast<PetscShellMatrix<T> *> (&shell_matrix_A);
+
+  if (!matrix_A)
+    libmesh_error_msg("Error: input operator A to solve_generalized() must be of type PetscShellMatrix.");
+
+  PetscShellMatrix<T> * matrix_B = dynamic_cast<PetscShellMatrix<T> *> (&shell_matrix_B);
+
+  if (!matrix_B)
+    libmesh_error_msg("Error: input operator B to solve_generalized() must be of type PetscShellMatrix.");
+
+  return _solve_generalized_helper (matrix_A->mat(), matrix_B->mat(), precond->mat(), nev, ncv, tol, m_its);
+}
+
+template <typename T>
+std::pair<unsigned int, unsigned int>
+SlepcEigenSolver<T>::solve_generalized (ShellMatrix<T> & shell_matrix_A,
+                                        ShellMatrix<T> & shell_matrix_B,
+                                        ShellMatrix<T> & precond_in,
+                                        int nev,                  // number of requested eigenpairs
+                                        int ncv,                  // number of basis vectors
+                                        const double tol,         // solver tolerance
+                                        const unsigned int m_its) // maximum number of iterations
+{
+  this->clear();
+
+  this->init ();
+
+  // Make sure the ShellMatrix passed in is really a PetscShellMatrix
+  PetscShellMatrix<T> * precond = dynamic_cast<PetscShellMatrix<T> *>(&precond_in);
+
+  if (!precond)
+    libmesh_error_msg("Error: input preconditioning matrix to solve_generalized() must be of type PetscShellMatrix.");
+
+  PetscShellMatrix<T> * matrix_A = dynamic_cast<PetscShellMatrix<T> *> (&shell_matrix_A);
+
+  if (!matrix_A)
+    libmesh_error_msg("Error: input operator A to solve_generalized() must be of type PetscShellMatrix.");
+
+  PetscShellMatrix<T> * matrix_B = dynamic_cast<PetscShellMatrix<T> *> (&shell_matrix_B);
+
+  if (!matrix_B)
+    libmesh_error_msg("Error: input operator B to solve_generalized() must be of type PetscShellMatrix.");
 
   return _solve_generalized_helper (matrix_A->mat(), matrix_B->mat(), precond->mat(), nev, ncv, tol, m_its);
 }


### PR DESCRIPTION
If users are going to add a customized preconditioner, we should allow them to do whatever they want. Sometimes we do not like to store the matrix explicitly.

For example, @YaqiWang wants to construct a transport sweeper where the preconditioning matrix is not formed.