### PR TITLE
Make Elem::interior_parent always safe to call

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -1056,7 +1056,7 @@ public:
    * by storing the D-dimensional parent.  This method provides access to that
    * element.
    *
-   * This method is not safe to call if this->dim() == LIBMESH_DIM; in
+   * This method returns nullptr if this->dim() == LIBMESH_DIM; in
    * such cases no data storage for an interior parent pointer has
    * been allocated.
    */

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -770,7 +770,8 @@ void Elem::find_interior_neighbors(std::set<Elem *> & neighbor_set)
 const Elem * Elem::interior_parent () const
 {
   // interior parents make no sense for full-dimensional elements.
-  libmesh_assert_less (this->dim(), LIBMESH_DIM);
+  if (this->dim() >= LIBMESH_DIM)
+      return nullptr;
 
   // they USED TO BE only good for level-0 elements, but we now
   // support keeping interior_parent() valid on refined boundary
@@ -805,7 +806,9 @@ const Elem * Elem::interior_parent () const
 Elem * Elem::interior_parent ()
 {
   // See the const version for comments
-  libmesh_assert_less (this->dim(), LIBMESH_DIM);
+  if (this->dim() >= LIBMESH_DIM)
+      return nullptr;
+
   Elem * interior_p = _elemlinks[1+this->n_sides()];
 
   libmesh_assert (!interior_p ||


### PR DESCRIPTION
In the most general case, when calling `interior_parent` we may not know whether the element's dimension coincides with the system's dimension (`LIBMESH_DIM == elem->dim()`). This PR aims to make `interior_parent` always safe to call. 