### PR TITLE
Fix adjoints example 5

### DIFF
--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -31,11 +31,16 @@
 // T(boundary;t) = 0
 
 // For these initial and boundary conditions, the exact solution
-// u = exp(-K pi^2 t) * sin(pi*x) * sin(pi*y)
+// u = exp(-K 2*pi^2 t) * sin(pi*x) * sin(pi*y)
 
 // We specify our Quantity of Interest (QoI) as
 // Q(u) = int_{domain} u(x,y;1) sin(pi*x) sin(pi*y) dx dy, and
 // are interested in computing the sensitivity dQ/dK
+
+// The exact value of this sensitivity is:
+// dQ/dK = int_{domain} du/dK sin(pi*x) sin(pi*y) dx dy
+// = int_{domain} (-2*pi^2 * exp(-K pi^2) ) sin^2(pi*x) sin^2(pi*y) dx dy
+// = (-2*pi^2 * exp(-K 2*pi^2) )/4 = -0.49022 
 
 // For this QoI, the continuous adjoint problem reads,
 // -partial(z)/partial(t) - K Laplacian(z) = 0

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -40,7 +40,7 @@
 // The exact value of this sensitivity is:
 // dQ/dK = int_{domain} du/dK sin(pi*x) sin(pi*y) dx dy
 // = int_{domain} (-2*pi^2 * exp(-K pi^2) ) sin^2(pi*x) sin^2(pi*y) dx dy
-// = (-2*pi^2 * exp(-K 2*pi^2) )/4 = -0.49022 
+// = (-2*pi^2 * exp(-K 2*pi^2) )/4 = -0.49022 (K = 1.e-3)
 
 // For this QoI, the continuous adjoint problem reads,
 // -partial(z)/partial(t) - K Laplacian(z) = 0
@@ -684,7 +684,7 @@ int main (int argc, char ** argv)
       // getting are what they should be
       // The 2e-4 tolerance is chosen to ensure success even with
       // 32-bit floats
-      if(std::abs(sensitivity_0_0 - (-5.37173)) >= 2.e-4)
+      if(std::abs(sensitivity_0_0 - (-4.8269)) >= 2.e-4)
         libmesh_error_msg("Mismatch in sensitivity gold value!");
 
 #ifdef NDEBUG

--- a/examples/adjoints/adjoints_ex5/element_qoi_derivative.C
+++ b/examples/adjoints/adjoints_ex5/element_qoi_derivative.C
@@ -76,5 +76,5 @@ void HeatSystem::element_qoi_derivative (DiffContext & context,
   // Loop over the qps
   for (unsigned int qp=0; qp != n_qpoints; qp++)
     for (unsigned int i=0; i != n_T_dofs; i++)
-      Q(i) += -JxW[qp] * old_adjoint[qp] * phi[i][qp];
+      Q(i) += -JxW[qp] * old_adjoint[qp] * phi[i][qp] * (1./(dynamic_cast<const HeatSystem &>(sys).deltat));
 }

--- a/examples/adjoints/adjoints_ex5/heatsystem.C
+++ b/examples/adjoints/adjoints_ex5/heatsystem.C
@@ -181,8 +181,7 @@ void HeatSystem::perturb_accumulate_residuals(ParameterVector & parameters_in)
       std::unique_ptr<NumericVector<Number>> R_minus = this->rhs->clone();
 
       // The contribution at a single time step would be [f(z;p+dp) - <partialu/partialt, z>(p+dp) - <g(u),z>(p+dp)] * dt
-      // But since we compute the residual already scaled by dt, there is no need for the * dt
-      R_minus_dp += -R_minus->dot(this->get_adjoint_solution(0));
+      R_minus_dp += -R_minus->dot(this->get_adjoint_solution(0))*this->deltat;
 
       *parameters_in[j] = old_parameter + dp;
 
@@ -192,7 +191,7 @@ void HeatSystem::perturb_accumulate_residuals(ParameterVector & parameters_in)
 
       std::unique_ptr<NumericVector<Number>> R_plus = this->rhs->clone();
 
-      R_plus_dp += -R_plus->dot(this->get_adjoint_solution(0));
+      R_plus_dp += -R_plus->dot(this->get_adjoint_solution(0))*this->deltat;
 
       *parameters_in[j] = old_parameter;
     }

--- a/include/error_estimation/adjoint_refinement_estimator.h
+++ b/include/error_estimation/adjoint_refinement_estimator.h
@@ -133,6 +133,19 @@ public:
   void set_residual_evaluation_physics(DifferentiablePhysics* set_physics)
   { this->_residual_evaluation_physics = set_physics; }
 
+  /**
+   * \returns A pointer to the DifferentiablePhysics object or \p nullptr if
+   * no external Physics object is attached.
+   */
+  DifferentiablePhysics * get_adjoint_evaluation_physics()
+  { return this->_adjoint_evaluation_physics; }
+
+  /**
+   * Set the _adjoint_evaluation_physics member to argument
+   */
+  void set_adjoint_evaluation_physics(DifferentiablePhysics* set_physics)
+  { this->_adjoint_evaluation_physics = set_physics; }
+
 protected:
 
   /**
@@ -140,6 +153,12 @@ protected:
    * Defaults to nullptr for backwards compatibility.
    */
   DifferentiablePhysics * _residual_evaluation_physics;
+
+  /**
+   * Pointer to object to use for adjoint assembly.
+   * Defaults to nullptr for backwards compatibility.
+   */
+  DifferentiablePhysics * _adjoint_evaluation_physics;
 
   /* A vector to hold the computed global QoI error estimate */
   std::vector<Number> computed_global_QoI_errors;

--- a/src/systems/diff_system.C
+++ b/src/systems/diff_system.C
@@ -353,6 +353,11 @@ bool DifferentiableSystem::have_second_order_scalar_vars() const
 void DifferentiableSystem::swap_physics ( DifferentiablePhysics * & swap_physics )
 {
   std::swap(this->_diff_physics, swap_physics);
+
+  // If the physics has been swapped, we will reassemble
+  // the matrix from scratch before doing an adjoint solve
+  // rather than just transposing
+  this->disable_cache();
 }
 
 


### PR DESCRIPTION
We had a few bugs in adjoints example 5.

1) The analytic solution had an error in an exponent, did not cause a big error in the QoI evaluation, but was making the sensitivity off by a factor of 2.
2) We were not scaling the mass matrix and adjoint weighted residuals correctly by deltat.

Bugs have been fixed, and gold value corrected.