### PR TITLE
Second part of the DirichletBoundary refactoring

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,7 @@
 This is the output of "git shortlog -ns", updated periodically.
 
-  7514  Roy H. Stogner
-  6598  John W. Peterson
+  7517  Roy H. Stogner
+  6607  John W. Peterson
   2730  Benjamin S. Kirk
    792  David Knezevic
    391  Paul T. Bauman


### PR DESCRIPTION
This PR reorders the loops in `ConstrainDirichlet::operator()` so that there is only one loop over the elements. The diff looks large but almost all of that is reindentation of the `apply_dirichlet_impl()` function. For a more manageable diff you can pull the branch and run:
```
git diff dee0a3ec8..23d7cf5eb
```
The history is also messy so once we this is working and we are happy with it, I'll squash everything down to 2 commits, one with actual changes and one with reindenting.
