### PR TITLE
Dirichlet fix

### DIFF
--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -451,6 +451,7 @@ private:
                   is_boundary_node[n] = true;
                   is_boundary_nodeset[n] = true;
                   has_dirichlet_constraint = true;
+                  break;
                 }
           }
 
@@ -469,6 +470,8 @@ private:
                   for (unsigned int n = 0; n != n_nodes; ++n)
                     if (elem->is_node_on_edge(n,e))
                       is_boundary_node[n] = true;
+
+                  break;
                 }
           }
 
@@ -483,6 +486,7 @@ private:
                 {
                   is_boundary_shellface[shellface] = true;
                   has_dirichlet_constraint = true;
+                  break;
                 }
           }
 

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -465,6 +465,10 @@ private:
                 {
                   is_boundary_edge[e] = true;
                   has_dirichlet_constraint = true;
+
+                  for (unsigned int n = 0; n != n_nodes; ++n)
+                    if (elem->is_node_on_edge(n,e))
+                      is_boundary_node[n] = true;
                 }
           }
 


### PR DESCRIPTION
This should fix the OOB array access I see after #2567, as well as make sure the proper constraint equations get set earlier in the method.

Wait to merge this until I confirm that my own testing all passes, since for some reason CI wasn't triggering (or at least wasn't getting a segfault from) this bug.