### PR TITLE
Recognize more intel compilers

### DIFF
--- a/configure
+++ b/configure
@@ -6984,6 +6984,10 @@ fi
 
                   GXX_VERSION_STRING="`($CXX -V 2>&1) | grep 'Version '`"
                   case "$GXX_VERSION_STRING" in #(
+  *20.*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 20 >>>" >&5
+$as_echo "<<< C++ compiler is Intel(R) icc 20 >>>" >&6; }
+                            GXX_VERSION=intel_icc_v20.x ;; #(
   *19.*) :
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 19 >>>" >&5
 $as_echo "<<< C++ compiler is Intel(R) icc 19 >>>" >&6; }
@@ -8270,7 +8274,7 @@ else
                           PARANOID_FLAGS="$PARANOID_FLAGS -Wwrite-strings"
 
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         case "$GXX_VERSION" in #(
-  intel_icc_v13.x | intel_icc_v14.x | intel_icc_v15.x | intel_icc_v16.x | intel_icc_v17.x | intel_icc_v18.x) :
+  intel_icc_v13.x | intel_icc_v14.x | intel_icc_v15.x | intel_icc_v16.x | intel_icc_v17.x | intel_icc_v18.x | intel_icc_v19.x | intel_icc_v20.x) :
 
                                     PROFILING_FLAGS="-p"
                                     CXXFLAGS_DBG="$CXXFLAGS_DBG -w1 -g -wd175 -wd1476 -wd1505 -wd1572 -wd488 -wd161"

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -571,7 +571,7 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
                           dnl       Well, duh, when the tested value is computed...  OK when it
                           dnl       was from an assignment.
                           AS_CASE("$GXX_VERSION",
-                                  [intel_icc_v13.x | intel_icc_v14.x | intel_icc_v15.x | intel_icc_v16.x | intel_icc_v17.x | intel_icc_v18.x],
+                                  [intel_icc_v13.x | intel_icc_v14.x | intel_icc_v15.x | intel_icc_v16.x | intel_icc_v17.x | intel_icc_v18.x | intel_icc_v19.x],
                                   [
                                     PROFILING_FLAGS="-p"
                                     CXXFLAGS_DBG="$CXXFLAGS_DBG -w1 -g -wd175 -wd1476 -wd1505 -wd1572 -wd488 -wd161"

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -242,6 +242,8 @@ AC_DEFUN([DETERMINE_CXX_BRAND],
                 [
                   GXX_VERSION_STRING="`($CXX -V 2>&1) | grep 'Version '`"
                   AS_CASE("$GXX_VERSION_STRING",
+                  [*20.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 20 >>>)
+                            GXX_VERSION=intel_icc_v20.x],
                   [*19.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 19 >>>)
                             GXX_VERSION=intel_icc_v19.x],
                   [*18.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 18 >>>)
@@ -571,7 +573,7 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
                           dnl       Well, duh, when the tested value is computed...  OK when it
                           dnl       was from an assignment.
                           AS_CASE("$GXX_VERSION",
-                                  [intel_icc_v13.x | intel_icc_v14.x | intel_icc_v15.x | intel_icc_v16.x | intel_icc_v17.x | intel_icc_v18.x | intel_icc_v19.x],
+                                  [intel_icc_v13.x | intel_icc_v14.x | intel_icc_v15.x | intel_icc_v16.x | intel_icc_v17.x | intel_icc_v18.x | intel_icc_v19.x | intel_icc_v20.x],
                                   [
                                     PROFILING_FLAGS="-p"
                                     CXXFLAGS_DBG="$CXXFLAGS_DBG -w1 -g -wd175 -wd1476 -wd1505 -wd1572 -wd488 -wd161"


### PR DESCRIPTION
Not sure how useful this will be, since the newest patches don't support MetaPhysicL, the less-patched 19 that @lindsayad was using has bugs, and the new 20 I tried seems to have other bugs, but at least it's a step in the right direction.