### PR TITLE
Respect original order of DirichletBoundary objects.

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1307,6 +1307,16 @@ public:
 
   /**
    * Adds a copy of the specified Dirichlet boundary to the system.
+   *
+   * The constraints implied by DirichletBoundary objects are imposed
+   * in the same order in which DirichletBoundary objects are added to
+   * the DofMap. When multiple DirichletBoundary objects would impose
+   * competing constraints on a given DOF, the *first*
+   * DirichletBoundary to constrain the DOF "wins". This distinction
+   * is important when e.g. two surfaces (sidesets) intersect. The
+   * nodes on the intersection will be constrained according to
+   * whichever sideset's DirichletBoundary object was added to the
+   * DofMap first.
    */
   void add_dirichlet_boundary (const DirichletBoundary & dirichlet_boundary);
 


### PR DESCRIPTION
The refactoring in #2574 caused the DirichletBoundary objects'
constraints to be applied in an "arbitrary" order rather than the
order in which they were actually added to the DofMap.  Since users
may have been implicitly or explicitly relying on this ordering to
break "ties" in cases where multiple constraints were applied to the
same DOF, we should try to maintain that order, even though it was not
guaranteed previously. I also updated the documentation to make this
ordering guarantee an official part of the DofMap API.

* Add 'boundary_id_to_ordered_dirichlet_boundaries' which is ordered
  based on the original vector ordering.
* Add 'ordered_dbs' container to SingleElemBoundaryInfo struct.
* Update comment for DofMap::add_dirichlet_boundary()