### PR TITLE
Don't assert that ip level is <= boundary elem level

### DIFF
--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -793,11 +793,6 @@ const Elem * Elem::interior_parent () const
                   (interior_p == remote_elem) ||
                   (interior_p->dim() > this->dim()));
 
-  // We require consistency between AMR of interior and of boundary
-  // elements
-  if (interior_p && (interior_p != remote_elem))
-    libmesh_assert_less_equal (interior_p->level(), this->level());
-
   return interior_p;
 }
 
@@ -814,8 +809,6 @@ Elem * Elem::interior_parent ()
   libmesh_assert (!interior_p ||
                   (interior_p == remote_elem) ||
                   (interior_p->dim() > this->dim()));
-  if (interior_p && (interior_p != remote_elem))
-    libmesh_assert_less_equal (interior_p->level(), this->level());
 
   return interior_p;
 }


### PR DESCRIPTION
@jwpeterson actually has a potential use case for this, so I think he
can decide whether he agrees with this or not. His libMesh mortar
element generation code builds maps that would be voided upon mesh
refinement. Hence mortar generation should occur after the higher
dimensional mesh has been refined. If mortar generation happens after
mesh refinement then obviously the interior parent will have a higher
level than the mortar element. I think this is a valid use case