### PR TITLE
Use double curly braces constructing std::array

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -2738,7 +2738,7 @@ dof_id_type Elem::compute_key (dof_id_type n0,
                                dof_id_type n1,
                                dof_id_type n2)
 {
-  std::array<dof_id_type, 3> array = {n0, n1, n2};
+  std::array<dof_id_type, 3> array = {{n0, n1, n2}};
   std::sort(array.begin(), array.end());
   return Utility::hashword(array);
 }
@@ -2751,7 +2751,7 @@ dof_id_type Elem::compute_key (dof_id_type n0,
                                dof_id_type n2,
                                dof_id_type n3)
 {
-  std::array<dof_id_type, 4> array = {n0, n1, n2, n3};
+  std::array<dof_id_type, 4> array = {{n0, n1, n2, n3}};
   std::sort(array.begin(), array.end());
   return Utility::hashword(array);
 }


### PR DESCRIPTION
Help out old clang compilers for which -Werror -Wall triggers an
error, see https://civet.inl.gov/job/535324/