### PR TITLE
Non-proxy sides should have same p_level() as Elem they are built from.

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -2297,7 +2297,9 @@ Elem::simple_build_side_ptr (std::unique_ptr<Elem> & side,
   else
     {
       side->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      side->set_p_level(this->p_level());
+#endif
       for (auto n : side->node_index_range())
         side->set_node(n) = this->node_ptr(Subclass::side_nodes_map[i][n]);
     }

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -193,7 +193,9 @@ std::unique_ptr<Elem> Hex20::build_side_ptr (const unsigned int i,
     {
       std::unique_ptr<Elem> face = libmesh_make_unique<Quad8>();
       face->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      face->set_p_level(this->p_level());
+#endif
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Hex20::side_nodes_map[i][n]);
 

--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -273,7 +273,9 @@ std::unique_ptr<Elem> Hex27::build_side_ptr (const unsigned int i,
     {
       std::unique_ptr<Elem> face = libmesh_make_unique<Quad9>();
       face->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      face->set_p_level(this->p_level());
+#endif
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Hex27::side_nodes_map[i][n]);
 

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -170,7 +170,9 @@ std::unique_ptr<Elem> Hex8::build_side_ptr (const unsigned int i,
     {
       std::unique_ptr<Elem> face = libmesh_make_unique<Quad4>();
       face->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      face->set_p_level(this->p_level());
+#endif
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Hex8::side_nodes_map[i][n]);
 

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -231,7 +231,9 @@ std::unique_ptr<Elem> InfHex16::build_side_ptr (const unsigned int i,
         }
 
       face->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      face->set_p_level(this->p_level());
+#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(InfHex16::side_nodes_map[i][n]);

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -252,7 +252,9 @@ std::unique_ptr<Elem> InfHex18::build_side_ptr (const unsigned int i,
         }
 
       face->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      face->set_p_level(this->p_level());
+#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(InfHex18::side_nodes_map[i][n]);

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -194,7 +194,9 @@ std::unique_ptr<Elem> InfHex8::build_side_ptr (const unsigned int i,
         }
 
       face->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      face->set_p_level(this->p_level());
+#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(InfHex8::side_nodes_map[i][n]);

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -220,7 +220,9 @@ std::unique_ptr<Elem> InfPrism12::build_side_ptr (const unsigned int i,
         }
 
       face->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      face->set_p_level(this->p_level());
+#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(InfPrism12::side_nodes_map[i][n]);

--- a/src/geom/cell_inf_prism6.C
+++ b/src/geom/cell_inf_prism6.C
@@ -193,7 +193,9 @@ std::unique_ptr<Elem> InfPrism6::build_side_ptr (const unsigned int i,
         }
 
       face->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      face->set_p_level(this->p_level());
+#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(InfPrism6::side_nodes_map[i][n]);

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -243,7 +243,9 @@ std::unique_ptr<Elem> Prism15::build_side_ptr (const unsigned int i,
         }
 
       face->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      face->set_p_level(this->p_level());
+#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Prism15::side_nodes_map[i][n]);

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -282,7 +282,9 @@ std::unique_ptr<Elem> Prism18::build_side_ptr (const unsigned int i,
         }
 
       face->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      face->set_p_level(this->p_level());
+#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Prism18::side_nodes_map[i][n]);

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -203,7 +203,9 @@ std::unique_ptr<Elem> Prism6::build_side_ptr (const unsigned int i,
         }
 
       face->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      face->set_p_level(this->p_level());
+#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Prism6::side_nodes_map[i][n]);

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -226,7 +226,9 @@ std::unique_ptr<Elem> Pyramid13::build_side_ptr (const unsigned int i, bool prox
         }
 
       face->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      face->set_p_level(this->p_level());
+#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Pyramid13::side_nodes_map[i][n]);

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -252,7 +252,9 @@ std::unique_ptr<Elem> Pyramid14::build_side_ptr (const unsigned int i, bool prox
         }
 
       face->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      face->set_p_level(this->p_level());
+#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Pyramid14::side_nodes_map[i][n]);

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -191,7 +191,9 @@ std::unique_ptr<Elem> Pyramid5::build_side_ptr (const unsigned int i,
         }
 
       face->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      face->set_p_level(this->p_level());
+#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Pyramid5::side_nodes_map[i][n]);

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -222,7 +222,9 @@ std::unique_ptr<Elem> Tet10::build_side_ptr (const unsigned int i,
     {
       std::unique_ptr<Elem> face = libmesh_make_unique<Tri6>();
       face->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      face->set_p_level(this->p_level());
+#endif
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Tet10::side_nodes_map[i][n]);
 

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -172,7 +172,9 @@ std::unique_ptr<Elem> Tet4::build_side_ptr (const unsigned int i,
     {
       std::unique_ptr<Elem> face = libmesh_make_unique<Tri3>();
       face->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      face->set_p_level(this->p_level());
+#endif
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Tet4::side_nodes_map[i][n]);
 

--- a/src/geom/edge.C
+++ b/src/geom/edge.C
@@ -61,7 +61,9 @@ void Edge::side_ptr (std::unique_ptr<Elem> & side,
   else
     {
       side->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      side->set_p_level(this->p_level());
+#endif
       side->set_node(0) = this->node_ptr(i);
     }
 }

--- a/src/geom/face_inf_quad4.C
+++ b/src/geom/face_inf_quad4.C
@@ -234,7 +234,9 @@ std::unique_ptr<Elem> InfQuad4::build_side_ptr (const unsigned int i,
         }
 
       edge->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      edge->set_p_level(this->p_level());
+#endif
       // Set the nodes
       for (auto n : edge->node_index_range())
         edge->set_node(n) = this->node_ptr(InfQuad4::side_nodes_map[i][n]);
@@ -281,7 +283,9 @@ void InfQuad4::build_side_ptr (std::unique_ptr<Elem> & side,
     }
 
   side->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+  side->set_p_level(this->p_level());
+#endif
   // Set the nodes
   for (auto n : side->node_index_range())
     side->set_node(n) = this->node_ptr(InfQuad4::side_nodes_map[i][n]);

--- a/src/geom/face_inf_quad6.C
+++ b/src/geom/face_inf_quad6.C
@@ -214,7 +214,9 @@ std::unique_ptr<Elem> InfQuad6::build_side_ptr (const unsigned int i,
         }
 
       edge->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      edge->set_p_level(this->p_level());
+#endif
       // Set the nodes
       for (auto n : edge->node_index_range())
         edge->set_node(n) = this->node_ptr(InfQuad6::side_nodes_map[i][n]);
@@ -261,7 +263,9 @@ void InfQuad6::build_side_ptr (std::unique_ptr<Elem> & side,
     }
 
   side->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+  side->set_p_level(this->p_level());
+#endif
   // Set the nodes
   for (auto n : side->node_index_range())
     side->set_node(n) = this->node_ptr(InfQuad6::side_nodes_map[i][n]);

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -158,7 +158,9 @@ std::unique_ptr<Elem> Quad4::build_side_ptr (const unsigned int i,
     {
       std::unique_ptr<Elem> edge = libmesh_make_unique<Edge2>();
       edge->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      edge->set_p_level(this->p_level());
+#endif
       // Set the nodes
       for (auto n : edge->node_index_range())
         edge->set_node(n) = this->node_ptr(Quad4::side_nodes_map[i][n]);
@@ -179,7 +181,9 @@ void Quad4::build_side_ptr (std::unique_ptr<Elem> & side,
   else
     {
       side->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      side->set_p_level(this->p_level());
+#endif
       for (auto n : side->node_index_range())
         side->set_node(n) = this->node_ptr(Quad4::side_nodes_map[i][n]);
     }

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -232,7 +232,9 @@ std::unique_ptr<Elem> Quad8::build_side_ptr (const unsigned int i,
     {
       std::unique_ptr<Elem> edge = libmesh_make_unique<Edge3>();
       edge->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      edge->set_p_level(this->p_level());
+#endif
       // Set the nodes
       for (auto n : edge->node_index_range())
         edge->set_node(n) = this->node_ptr(Quad8::side_nodes_map[i][n]);

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -250,7 +250,9 @@ std::unique_ptr<Elem> Quad9::build_side_ptr (const unsigned int i,
     {
       std::unique_ptr<Elem> edge = libmesh_make_unique<Edge3>();
       edge->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      edge->set_p_level(this->p_level());
+#endif
       // Set the nodes
       for (auto n : edge->node_index_range())
         edge->set_node(n) = this->node_ptr(Quad9::side_nodes_map[i][n]);

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -140,7 +140,9 @@ std::unique_ptr<Elem> Tri3::build_side_ptr (const unsigned int i,
     {
       std::unique_ptr<Elem> edge = libmesh_make_unique<Edge2>();
       edge->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      edge->set_p_level(this->p_level());
+#endif
       // Set the nodes
       for (auto n : edge->node_index_range())
         edge->set_node(n) = this->node_ptr(Tri3::side_nodes_map[i][n]);

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -216,7 +216,9 @@ std::unique_ptr<Elem> Tri6::build_side_ptr (const unsigned int i,
     {
       std::unique_ptr<Elem> edge = libmesh_make_unique<Edge3>();
       edge->subdomain_id() = this->subdomain_id();
-
+#ifdef LIBMESH_ENABLE_AMR
+      edge->set_p_level(this->p_level());
+#endif
       // Set the nodes
       for (auto n : edge->node_index_range())
         edge->set_node(n) = this->node_ptr(Tri6::side_nodes_map[i][n]);

--- a/tests/geom/side_test.C
+++ b/tests/geom/side_test.C
@@ -54,6 +54,12 @@ private:
 public:
   void setUp() {
     elem.set_id() = 0;
+#ifdef LIBMESH_ENABLE_AMR
+    // Do tests with an Elem having a non-default p_level to ensure
+    // that sides which are built have a matching p_level. p-refinement
+    // is only avaiable if LIBMESH_ENABLE_AMR is defined.
+    elem.set_p_level(1);
+#endif
     Point dummy;
     for (auto i : elem.node_index_range())
       {
@@ -147,6 +153,12 @@ public:
         std::unique_ptr<Elem> side = elem.build_side_ptr(s);
 
         CPPUNIT_ASSERT(side->type() == side_type);
+        CPPUNIT_ASSERT(side->subdomain_id() == elem.subdomain_id());
+
+#ifdef LIBMESH_ENABLE_AMR
+        // p-refinement is only avaiable if LIBMESH_ENABLE_AMR is defined.
+        CPPUNIT_ASSERT(side->p_level() == elem.p_level());
+#endif
       }
   }
 


### PR DESCRIPTION
Proxy sides built through the Side<X,Y> helper class should already
report a matching p_level() since they "inherit" it from the class
which creates them.