### PR TITLE
Add new InfFE::n_dofs() overload, deprecate old version

### DIFF
--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -577,9 +577,16 @@ private:
                                              const FEType & fe_t,
                                              const ElemType t);
 
+  /**
+   * \deprecated Call the version of ifem_n_dofs() which takes a
+   * pointer-to-Elem instead.
+   */
   static unsigned int ifem_n_dofs(const unsigned int dim,
                                   const FEType & fe_t,
                                   const ElemType t);
+
+  static unsigned int ifem_n_dofs(const FEType & fe_t,
+                                  const Elem * elem);
 
   static unsigned int ifem_n_dofs_at_node(const unsigned int dim,
                                           const FEType & fe_t,

--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -379,9 +379,15 @@ public:
    * infinite element.  Currently, we have \p o_radial+1 modes in
    * radial direction, and \code FE<Dim-1,T>::n_dofs(...) \endcode
    * in the base.
+   *
+   * \deprecated Call the version of this function that takes an Elem*
+   * instead for consistency with other FEInterface::n_dofs() methods.
    */
   static unsigned int n_dofs(const FEType & fet,
                              const ElemType inf_elem_type);
+
+  static unsigned int n_dofs(const FEType & fet,
+                             const Elem * inf_elem);
 
   /**
    * \returns The number of dofs at infinite element node \p n

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -479,8 +479,7 @@ unsigned int FEInterface::n_dofs(const unsigned int dim,
                                  const FEType & fe_t,
                                  const ElemType t)
 {
-  // TODO:
-  // libmesh_deprecated();
+  libmesh_deprecated();
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
@@ -502,8 +501,7 @@ FEInterface::n_dofs (const unsigned int dim,
                      const FEType & fe_t,
                      const Elem * elem)
 {
-  // TODO:
-  // libmesh_deprecated();
+  libmesh_deprecated();
 
   FEType p_refined_fe_t = fe_t;
   p_refined_fe_t.order = static_cast<Order>(p_refined_fe_t.order + elem->p_level());

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -521,9 +521,9 @@ FEInterface::n_dofs(const FEType & fe_t,
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
-  // FIXME: Can/should InfElems account for p_level()?
+  // InfElems currently don't support p_level()
   if (is_InfFE_elem(elem->type()))
-    return ifem_n_dofs(dim, fe_t, elem->type());
+    return ifem_n_dofs(fe_t, elem);
 
 #endif
 
@@ -545,9 +545,9 @@ FEInterface::n_dofs(const FEType & fe_t,
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
-  // FIXME: Can/should InfElems account for p_level()?
+  // InfElems currently don't support p_level()
   if (is_InfFE_elem(elem->type()))
-    return ifem_n_dofs(dim, fe_t, elem->type());
+    return ifem_n_dofs(fe_t, elem);
 
 #endif
 

--- a/src/fe/fe_interface_inf_fe.C
+++ b/src/fe/fe_interface_inf_fe.C
@@ -71,8 +71,7 @@ unsigned int FEInterface::ifem_n_dofs(const unsigned int dim,
                                       const FEType & fe_t,
                                       const ElemType t)
 {
-  // TODO:
-  // libmesh_deprecated();
+  libmesh_deprecated();
 
   switch (dim)
     {

--- a/src/fe/fe_interface_inf_fe.C
+++ b/src/fe/fe_interface_inf_fe.C
@@ -25,6 +25,7 @@
 #include "libmesh/fe_interface.h"
 #include "libmesh/fe_interface_macros.h"
 #include "libmesh/inf_fe.h"
+#include "libmesh/elem.h"
 
 namespace libMesh
 {
@@ -70,6 +71,9 @@ unsigned int FEInterface::ifem_n_dofs(const unsigned int dim,
                                       const FEType & fe_t,
                                       const ElemType t)
 {
+  // TODO:
+  // libmesh_deprecated();
+
   switch (dim)
     {
       // 1D
@@ -94,6 +98,35 @@ unsigned int FEInterface::ifem_n_dofs(const unsigned int dim,
     }
 }
 
+
+
+unsigned int
+FEInterface::ifem_n_dofs(const FEType & fe_t,
+                         const Elem * elem)
+{
+  switch (elem->dim())
+    {
+      // 1D
+    case 1:
+      /*
+       * Since InfFE<Dim,T_radial,T_map>::n_dofs(...)
+       * is actually independent of T_radial and T_map, we can use
+       * just any T_radial and T_map
+       */
+      return InfFE<1,JACOBI_20_00,CARTESIAN>::n_dofs(fe_t, elem->type());
+
+      // 2D
+    case 2:
+      return InfFE<2,JACOBI_20_00,CARTESIAN>::n_dofs(fe_t, elem->type());
+
+      // 3D
+    case 3:
+      return InfFE<3,JACOBI_20_00,CARTESIAN>::n_dofs(fe_t, elem->type());
+
+    default:
+      libmesh_error_msg("Unsupported dim = " << elem->dim());
+    }
+}
 
 
 

--- a/src/fe/fe_interface_inf_fe.C
+++ b/src/fe/fe_interface_inf_fe.C
@@ -112,15 +112,15 @@ FEInterface::ifem_n_dofs(const FEType & fe_t,
        * is actually independent of T_radial and T_map, we can use
        * just any T_radial and T_map
        */
-      return InfFE<1,JACOBI_20_00,CARTESIAN>::n_dofs(fe_t, elem->type());
+      return InfFE<1,JACOBI_20_00,CARTESIAN>::n_dofs(fe_t, elem);
 
       // 2D
     case 2:
-      return InfFE<2,JACOBI_20_00,CARTESIAN>::n_dofs(fe_t, elem->type());
+      return InfFE<2,JACOBI_20_00,CARTESIAN>::n_dofs(fe_t, elem);
 
       // 3D
     case 3:
-      return InfFE<3,JACOBI_20_00,CARTESIAN>::n_dofs(fe_t, elem->type());
+      return InfFE<3,JACOBI_20_00,CARTESIAN>::n_dofs(fe_t, elem);
 
     default:
       libmesh_error_msg("Unsupported dim = " << elem->dim());

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -58,6 +58,9 @@ template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
 unsigned int InfFE<Dim,T_radial,T_map>::n_dofs (const FEType & fet,
                                                 const ElemType inf_elem_type)
 {
+  // TODO:
+  // libmesh_deprecated();
+
   const ElemType base_et (InfFEBase::get_elem_type(inf_elem_type));
 
   if (Dim > 1)
@@ -69,6 +72,21 @@ unsigned int InfFE<Dim,T_radial,T_map>::n_dofs (const FEType & fet,
 
 
 
+template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
+unsigned int InfFE<Dim,T_radial,T_map>::n_dofs(const FEType & fet,
+                                               const Elem * inf_elem)
+{
+  // The "base" Elem is a non-infinite Elem corresponding to side 0 of
+  // the InfElem. This builds a "lightweight" proxy and so should be
+  // relatively fast.
+  auto base_elem = inf_elem->build_side_ptr(0);
+
+  if (Dim > 1)
+    return FEInterface::n_dofs(fet, base_elem.get()) *
+      InfFERadial::n_dofs(fet.radial_order);
+  else
+    return InfFERadial::n_dofs(fet.radial_order);
+}
 
 
 
@@ -1114,6 +1132,9 @@ void InfFE<Dim,T_radial,T_map>::compute_shape_indices (const FEType & fet,
 INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, unsigned int, n_dofs(const FEType &, const ElemType));
 INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, unsigned int, n_dofs(const FEType &, const ElemType));
 INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, unsigned int, n_dofs(const FEType &, const ElemType));
+INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, unsigned int, n_dofs(const FEType &, const Elem*));
+INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, unsigned int, n_dofs(const FEType &, const Elem*));
+INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, unsigned int, n_dofs(const FEType &, const Elem*));
 INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, unsigned int, n_dofs_per_elem(const FEType &, const ElemType));
 INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, unsigned int, n_dofs_per_elem(const FEType &, const ElemType));
 INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, unsigned int, n_dofs_per_elem(const FEType &, const ElemType));

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -58,8 +58,7 @@ template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
 unsigned int InfFE<Dim,T_radial,T_map>::n_dofs (const FEType & fet,
                                                 const ElemType inf_elem_type)
 {
-  // TODO:
-  // libmesh_deprecated();
+  libmesh_deprecated();
 
   const ElemType base_et (InfFEBase::get_elem_type(inf_elem_type));
 


### PR DESCRIPTION
This is similar to the refactoring in #2593, but for `InfFEs`. This makes it so that `InfFE::n_dofs()` and related helper functions now take an `Elem*` instead of an `ElemType`, and deprecates previous versions. This at least compiles for me, but it would be good if people that actually use `InfFEs`, like @BalticPinguin, can also take a look.
