### PR TITLE
Fix clang warnings

### DIFF
--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -95,12 +95,19 @@ public:
   /**
    * Special functions. This class does not manage any dynamically
    * allocated resources (file pointers, etc.) so it _should_ be
-   * default copy/move constructable and assignable, but I don't know
+   * default copy/move constructable, but I don't know
    * if any existing code actually uses these operations.
    */
   ExodusII_IO_Helper (const ExodusII_IO_Helper &) = default;
   ExodusII_IO_Helper (ExodusII_IO_Helper &&) = default;
   virtual ~ExodusII_IO_Helper();
+
+  /**
+   * This class contains references so it can't be default
+   * copy/move-assigned.
+   */
+  ExodusII_IO_Helper & operator= (const ExodusII_IO_Helper &) = delete;
+  ExodusII_IO_Helper & operator= (ExodusII_IO_Helper &&) = delete;
 
   /**
    * \returns The current element type.

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -100,8 +100,6 @@ public:
    */
   ExodusII_IO_Helper (const ExodusII_IO_Helper &) = default;
   ExodusII_IO_Helper (ExodusII_IO_Helper &&) = default;
-  ExodusII_IO_Helper & operator= (const ExodusII_IO_Helper &) = default;
-  ExodusII_IO_Helper & operator= (ExodusII_IO_Helper &&) = default;
   virtual ~ExodusII_IO_Helper();
 
   /**

--- a/include/parallel/parallel_ghost_sync.h
+++ b/include/parallel/parallel_ghost_sync.h
@@ -733,7 +733,7 @@ bool sync_node_data_by_element_id_once(MeshBase & mesh,
   bool data_changed = false;
 
   auto action_functor =
-    [&sync, &mesh, &requested_objs_elem_id_node_num, &data_changed]
+    [&sync, &mesh, &data_changed]
     (processor_id_type /* pid */,
      const std::vector<std::pair<dof_id_type, unsigned char>> & elem_id_node_num,
      const std::vector<typename SyncFunctor::datum> & data)

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1562,8 +1562,6 @@ public:
   // This class can be default copy/move constructed/assigned.
   ConstrainDirichlet (ConstrainDirichlet &&) = default;
   ConstrainDirichlet (const ConstrainDirichlet &) = default;
-  ConstrainDirichlet & operator= (const ConstrainDirichlet &) = default;
-  ConstrainDirichlet & operator= (ConstrainDirichlet &&) = default;
 
 
 

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1559,11 +1559,14 @@ public:
     dirichlets(dirichlets_in),
     add_fn(add_in) { }
 
-  // This class can be default copy/move constructed/assigned.
+  // This class can be default copy/move constructed.
   ConstrainDirichlet (ConstrainDirichlet &&) = default;
   ConstrainDirichlet (const ConstrainDirichlet &) = default;
 
-
+  // This class cannot be default copy/move assigned because it
+  // contains reference members.
+  ConstrainDirichlet & operator= (const ConstrainDirichlet &) = delete;
+  ConstrainDirichlet & operator= (ConstrainDirichlet &&) = delete;
 
   void operator()(const ConstElemRange & range) const
   {


### PR DESCRIPTION
Clang correctly detects that these are operators are implicitly deleted
because the compiler has no idea what we want to do with the reference
members of the class. So we should either remove these defaulted operators
or write our own assignment operators if that's what we want.

Also fix an unused lambda capture warning