### PR TITLE
Add version of FEInterface::n_dofs_at_node() taking an Elem*

### DIFF
--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -171,6 +171,16 @@ public:
                                      const unsigned int n);
 
   /**
+   * \returns The number of dofs at node n for a finite element
+   * of type \p fe_t. Ignores Elem::p_level() and computes a total Order
+   * given by fe_t.order + extra_order when determining the number of DOFs.
+   */
+  static unsigned int n_dofs_at_node(const FEType & fe_t,
+                                     const int extra_order,
+                                     const Elem * elem,
+                                     const unsigned int n);
+
+  /**
    * \returns The number of dofs interior to the element,
    * not associated with any interior nodes.
    * Automatically decides which finite element class to use.

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -157,10 +157,21 @@ public:
   /**
    * \returns A function which evaluates n_dofs_at_node for the
    * requested FE type and dimension.
+   *
+   * \deprecated Use the version of this function that takes an Elem*
+   * for consistency. The behavior is otherwise exactly the same,
+   * since this function does not depend on the Elem::p_level().
    */
   static n_dofs_at_node_ptr
   n_dofs_at_node_function(const unsigned int dim,
                           const FEType & fe_t);
+
+  /**
+   * Non-deprecated version of function above.
+   */
+  static n_dofs_at_node_ptr
+  n_dofs_at_node_function(const FEType & fe_t,
+                          const Elem * elem);
 
   /**
    * \returns The number of dofs at node n for a finite element

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -140,6 +140,10 @@ public:
    * Automatically decides which finite element class to use.
    *
    * On a p-refined element, \p fe_t.order should be the total order of the element.
+   *
+   * \deprecated Call the version of n_dofs_at_node() taking an Elem *
+   * instead, this one accounts for Elem::p_level() internally rather
+   * than requiring the user to do it.
    */
   static unsigned int n_dofs_at_node(const unsigned int dim,
                                      const FEType & fe_t,
@@ -157,6 +161,14 @@ public:
   static n_dofs_at_node_ptr
   n_dofs_at_node_function(const unsigned int dim,
                           const FEType & fe_t);
+
+  /**
+   * \returns The number of dofs at node n for a finite element
+   * of type \p fe_t. Accounts for Elem::p_level() internally.
+   */
+  static unsigned int n_dofs_at_node(const FEType & fe_t,
+                                     const Elem * elem,
+                                     const unsigned int n);
 
   /**
    * \returns The number of dofs interior to the element,

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -2202,7 +2202,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectVert
                   // shape functions
                   libmesh_assert_equal_to
                     (FEInterface::n_dofs_at_node
-                      (dim, base_fe_type, elem.type(),
+                      (base_fe_type, &elem,
                        elem.get_node_index(&vertex)),
                     (unsigned int)(1 + dim));
                   const FValue val =

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -1546,24 +1546,26 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::SortAndCopy
           if (!var.active_on_subdomain(elem->subdomain_id()))
             continue;
           FEType fe_type = var.type();
-          fe_type.order =
-            libMesh::Order (fe_type.order + elem->p_level());
+          FEType p_refined_fe_type = var.type();
+          p_refined_fe_type.order =
+            libMesh::Order (p_refined_fe_type.order + elem->p_level());
+
           const ElemType elem_type = elem->type();
 
-          if (FEInterface::n_dofs_at_node(dim, fe_type, elem_type, 0))
+          if (FEInterface::n_dofs_at_node(fe_type, elem, 0))
             vertex_vars.insert(vertex_vars.end(), v_num);
 
           // The first non-vertex node is always an edge node if those
           // exist.  All edge nodes have the same number of DoFs
           if (has_edge_nodes)
-            if (FEInterface::n_dofs_at_node(dim, fe_type, elem_type, n_vertices))
+            if (FEInterface::n_dofs_at_node(fe_type, elem, n_vertices))
               edge_vars.insert(edge_vars.end(), v_num);
 
           if (has_side_nodes)
             {
               if (dim != 3)
                 {
-                  if (FEInterface::n_dofs_at_node(dim, fe_type, elem_type, n_vertices))
+                  if (FEInterface::n_dofs_at_node(fe_type, elem, n_vertices))
                     side_vars.insert(side_vars.end(), v_num);
                 }
               else
@@ -1571,17 +1573,16 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::SortAndCopy
                 // DoFs!  We'll loop over all sides to be safe.
                 for (unsigned int n = 0; n != n_nodes; ++n)
                   if (elem->is_face(n))
-                    if (FEInterface::n_dofs_at_node(dim, fe_type,
-                                                    elem_type, n))
+                    if (FEInterface::n_dofs_at_node(fe_type, elem, n))
                       {
                         side_vars.insert(side_vars.end(), v_num);
                         break;
                       }
             }
 
-          if (FEInterface::n_dofs_per_elem(dim, fe_type, elem_type) ||
+          if (FEInterface::n_dofs_per_elem(dim, p_refined_fe_type, elem_type) ||
               (has_interior_nodes &&
-               FEInterface::n_dofs_at_node(dim, fe_type, elem_type, n_nodes-1)))
+               FEInterface::n_dofs_at_node(fe_type, elem, n_nodes-1)))
             {
 #ifdef LIBMESH_ENABLE_AMR
               // We may have already just copied constant monomials,

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2402,7 +2402,7 @@ void DofMap::_dof_indices (const Elem & elem,
           const unsigned int nc =
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
             is_inf ?
-            FEInterface::n_dofs_at_node(dim, p_refined_fe_type, type, n) :
+            FEInterface::n_dofs_at_node(var.type(), p_level, &elem, n) :
 #endif
             ndan (type, p_refined_fe_type.order, n);
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -611,7 +611,6 @@ void DofMap::reinit(MeshBase & mesh)
             continue;
 
           const ElemType type = elem->type();
-          const unsigned int dim = elem->dim();
 
           FEType fe_type = base_fe_type;
 
@@ -646,9 +645,6 @@ void DofMap::reinit(MeshBase & mesh)
             }
 #endif
 
-          fe_type.order = static_cast<Order>(fe_type.order +
-                                             elem->p_level());
-
           // Allocate the vertex DOFs
           for (auto n : elem->node_index_range())
             {
@@ -660,8 +656,7 @@ void DofMap::reinit(MeshBase & mesh)
                     node.n_comp_group(sys_num, vg);
 
                   const unsigned int vertex_dofs =
-                    std::max(FEInterface::n_dofs_at_node(dim, fe_type,
-                                                         type, n),
+                    std::max(FEInterface::n_dofs_at_node(fe_type, elem, n),
                              old_node_dofs);
 
                   // Some discontinuous FEs have no vertex dofs
@@ -718,7 +713,7 @@ void DofMap::reinit(MeshBase & mesh)
                 cast_int<unsigned int>(node.vg_dof_base (sys_num,vg)):0;
 
               const unsigned int new_node_dofs =
-                FEInterface::n_dofs_at_node(dim, fe_type, type, n);
+                FEInterface::n_dofs_at_node(base_fe_type, elem, n);
 
               // We've already allocated vertex DOFs
               if (elem->is_vertex(n))

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2383,7 +2383,7 @@ void DofMap::_dof_indices (const Elem & elem,
       // pointer, it is only needed when the function is called (see
       // below).
       const FEInterface::n_dofs_at_node_ptr ndan =
-        FEInterface::n_dofs_at_node_function(dim, fe_type);
+        FEInterface::n_dofs_at_node_function(fe_type, &elem);
 
       // Get the node-based DOF numbers
       for (unsigned int n=0; n != n_nodes; n++)
@@ -2661,7 +2661,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
                       FEInterface::extra_hanging_dofs(fe_type);
 
                     const FEInterface::n_dofs_at_node_ptr ndan =
-                      FEInterface::n_dofs_at_node_function(dim, fe_type);
+                      FEInterface::n_dofs_at_node_function(fe_type, elem);
 
                     // Get the node-based DOF numbers
                     for (unsigned int n=0; n<n_nodes; n++)

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2677,7 +2677,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
                           is_inf ?
                           FEInterface::n_dofs_at_node(var.type(), elem->p_level() + p_adjustment, elem, n) :
 #endif
-                          ndan (type, fe_type.order, n);
+                          ndan (type, static_cast<Order>(var.type().order + elem->p_level() + p_adjustment), n);
 
                         const int n_comp = old_dof_obj->n_comp_group(sys_num,vg);
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2670,7 +2670,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
                         const unsigned int nc =
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
                           is_inf ?
-                          FEInterface::n_dofs_at_node(dim, fe_type, type, n) :
+                          FEInterface::n_dofs_at_node(var.type(), elem->p_level() + p_adjustment, elem, n) :
 #endif
                           ndan (type, fe_type.order, n);
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2650,10 +2650,12 @@ void DofMap::old_dof_indices (const Elem * const elem,
                       {
                         p_adjustment = 1;
                       }
+
+                    // Compute the net amount of "extra" order, including Elem::p_level()
+                    int extra_order = elem->p_level() + p_adjustment;
+
                     FEType fe_type = var.type();
-                    fe_type.order = static_cast<Order>(fe_type.order +
-                                                       elem->p_level() +
-                                                       p_adjustment);
+                    fe_type.order = static_cast<Order>(fe_type.order + extra_order);
 
                     const bool extra_hanging_dofs =
                       FEInterface::extra_hanging_dofs(fe_type);
@@ -2675,9 +2677,9 @@ void DofMap::old_dof_indices (const Elem * const elem,
                         const unsigned int nc =
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
                           is_inf ?
-                          FEInterface::n_dofs_at_node(var.type(), elem->p_level() + p_adjustment, elem, n) :
+                          FEInterface::n_dofs_at_node(var.type(), extra_order, elem, n) :
 #endif
-                          ndan (type, static_cast<Order>(var.type().order + elem->p_level() + p_adjustment), n);
+                          ndan (type, static_cast<Order>(var.type().order + extra_order), n);
 
                         const int n_comp = old_dof_obj->n_comp_group(sys_num,vg);
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2276,9 +2276,6 @@ void DofMap::_node_dof_indices (const Elem & elem,
 
   LOG_SCOPE("_node_dof_indices()", "DofMap");
 
-  const ElemType type = elem.type();
-  const unsigned int dim = elem.dim();
-
   const unsigned int sys_num = this->sys_number();
   const std::pair<unsigned int, unsigned int>
     vg_and_offset = obj.var_to_vg_and_offset(sys_num,vn);
@@ -2288,8 +2285,6 @@ void DofMap::_node_dof_indices (const Elem & elem,
 
   const VariableGroup & var = this->variable_group(vg);
   FEType fe_type = var.type();
-  fe_type.order = static_cast<Order>(fe_type.order +
-                                     elem.p_level());
   const bool extra_hanging_dofs =
     FEInterface::extra_hanging_dofs(fe_type);
 
@@ -2298,7 +2293,7 @@ void DofMap::_node_dof_indices (const Elem & elem,
   // it can falsely identify a DOF at the mid-edge node. This is why
   // we go through FEInterface instead of obj->n_comp() directly.
   const unsigned int nc =
-    FEInterface::n_dofs_at_node(dim, fe_type, type, n);
+    FEInterface::n_dofs_at_node(fe_type, &elem, n);
 
   // If this is a non-vertex on a hanging node with extra
   // degrees of freedom, we use the non-vertex dofs (which

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -4909,13 +4909,7 @@ void DofMap::constrain_p_dofs (unsigned int var,
   libmesh_assert_less (s, elem->n_sides());
 
   const unsigned int sys_num = this->sys_number();
-  const unsigned int dim = elem->dim();
-  ElemType type = elem->type();
-  FEType low_p_fe_type = this->variable_type(var);
-  FEType high_p_fe_type = this->variable_type(var);
-  low_p_fe_type.order = static_cast<Order>(low_p_fe_type.order + p);
-  high_p_fe_type.order = static_cast<Order>(high_p_fe_type.order +
-                                            elem->p_level());
+  FEType fe_type = this->variable_type(var);
 
   const unsigned int n_nodes = elem->n_nodes();
   for (unsigned int n = 0; n != n_nodes; ++n)
@@ -4923,9 +4917,9 @@ void DofMap::constrain_p_dofs (unsigned int var,
       {
         const Node & node = elem->node_ref(n);
         const unsigned int low_nc =
-          FEInterface::n_dofs_at_node (dim, low_p_fe_type, type, n);
+          FEInterface::n_dofs_at_node (fe_type, p, elem, n);
         const unsigned int high_nc =
-          FEInterface::n_dofs_at_node (dim, high_p_fe_type, type, n);
+          FEInterface::n_dofs_at_node (fe_type, elem, n);
 
         // since we may be running this method concurrently
         // on multiple threads we need to acquire a lock

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -611,6 +611,30 @@ FEInterface::n_dofs_at_node(const FEType & fe_t,
 
 
 
+unsigned int
+FEInterface::n_dofs_at_node(const FEType & fe_t,
+                            const int extra_order,
+                            const Elem * elem,
+                            const unsigned int n)
+{
+  // dim is required by the fe_with_vec_switch macro
+  auto dim = elem->dim();
+
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+  if (is_InfFE_elem(elem->type()))
+    return ifem_n_dofs_at_node(dim, fe_t, elem->type(), n);
+
+#endif
+
+  // Ignore Elem::p_level() and instead use extra_order to compute total_order.
+  auto total_order = static_cast<Order>(fe_t.order + extra_order);
+
+  fe_with_vec_switch(n_dofs_at_node(elem->type(), total_order, n));
+}
+
+
+
 unsigned int FEInterface::n_dofs_per_elem(const unsigned int dim,
                                           const FEType & fe_t,
                                           const ElemType t)

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -562,6 +562,9 @@ unsigned int FEInterface::n_dofs_at_node(const unsigned int dim,
                                          const ElemType t,
                                          const unsigned int n)
 {
+  // TODO:
+  // libmesh_deprecated();
+
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
   if (is_InfFE_elem(t))
@@ -585,6 +588,26 @@ FEInterface::n_dofs_at_node_function(const unsigned int dim,
 
 
 
+unsigned int
+FEInterface::n_dofs_at_node(const FEType & fe_t,
+                            const Elem * elem,
+                            const unsigned int n)
+{
+  // dim is required by the fe_with_vec_switch macro
+  auto dim = elem->dim();
+
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+  if (is_InfFE_elem(elem->type()))
+    return ifem_n_dofs_at_node(dim, fe_t, elem->type(), n);
+
+#endif
+
+  // Account for Elem::p_level() when computing total_order
+  auto total_order = static_cast<Order>(fe_t.order + elem->p_level());
+
+  fe_with_vec_switch(n_dofs_at_node(elem->type(), total_order, n));
+}
 
 
 

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -583,6 +583,20 @@ FEInterface::n_dofs_at_node_ptr
 FEInterface::n_dofs_at_node_function(const unsigned int dim,
                                      const FEType & fe_t)
 {
+  libmesh_deprecated();
+
+  fe_with_vec_switch(n_dofs_at_node);
+}
+
+
+
+FEInterface::n_dofs_at_node_ptr
+FEInterface::n_dofs_at_node_function(const FEType & fe_t,
+                                     const Elem * elem)
+{
+  // dim is required by the fe_with_vec_switch macro
+  auto dim = elem->dim();
+
   fe_with_vec_switch(n_dofs_at_node);
 }
 

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -1578,9 +1578,6 @@ void BoundaryProjectSolution::operator()(const ConstElemRange & range) const
           std::vector<char> dof_is_fixed(n_dofs, false); // bools
           std::vector<int> free_dof(n_dofs, 0);
 
-          // The element type
-          const ElemType elem_type = elem->type();
-
           // Zero the interpolated values
           Ue.resize (n_dofs); Ue.zero();
 
@@ -1596,9 +1593,11 @@ void BoundaryProjectSolution::operator()(const ConstElemRange & range) const
             {
               // FIXME: this should go through the DofMap,
               // not duplicate dof_indices code badly!
+
+              // This call takes into account elem->p_level() internally.
               const unsigned int nc =
-                FEInterface::n_dofs_at_node (dim, fe_type, elem_type,
-                                             n);
+                FEInterface::n_dofs_at_node (fe_type, elem, n);
+
               if ((!elem->is_vertex(n) || !is_boundary_node[n]) &&
                   !is_boundary_nodeset[n])
                 {


### PR DESCRIPTION
Similarly to #2593, the old version is not officially deprecated yet until I update the `InfFE` side. I  found/fixed instances where `Elem::p_level()` was not properly accounted for in f37da868e and 10ea5583d26faf2d72aa9a264cfd53228af4f886 but for the most part this is just a straight refactoring that will eventually make the code easier to use.
