### PR TITLE
Add version of FEInterface::shape() which accounts for Elem::p_level() internally

### DIFF
--- a/examples/fem_system/fem_system_ex1/naviersystem.C
+++ b/examples/fem_system/fem_system_ex1/naviersystem.C
@@ -476,7 +476,7 @@ bool NavierSystem::side_constraint (bool request_jacobian,
       std::vector<Real> point_phi(n_p_dofs);
       for (unsigned int i=0; i != n_p_dofs; i++)
         {
-          point_phi[i] = FEInterface::shape(dim, fe_type, &c.get_elem(), i, p_master);
+          point_phi[i] = FEInterface::shape(fe_type, &c.get_elem(), i, p_master);
         }
 
       for (unsigned int i=0; i != n_p_dofs; i++)

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -324,6 +324,10 @@ public:
    *
    * \note On a p-refined element, \p fe_t.order should be the total
    * order of the element.
+   *
+   * \deprecated Use the version of this function that accounts for
+   * Elem::p_level() internally or the version which takes an
+   * extra_order parameter.
    */
   static Real shape(const unsigned int dim,
                     const FEType & fe_t,
@@ -339,9 +343,32 @@ public:
    *
    * \note On a p-refined element, \p fe_t.order should be the base
    * order of the element.
+   *
+   * \deprecated Use the version of this function that accounts for
+   * Elem::p_level() internally or the version which takes an
+   * extra_order parameter.
    */
   static Real shape(const unsigned int dim,
                     const FEType & fe_t,
+                    const Elem * elem,
+                    const unsigned int i,
+                    const Point & p);
+
+  /**
+   * Non-deprecated version of the shape() function. The
+   * Elem::p_level() is accounted for internally.
+   */
+  static Real shape(const FEType & fe_t,
+                    const Elem * elem,
+                    const unsigned int i,
+                    const Point & p);
+
+  /**
+   * Non-deprecated version of the shape() function. The
+   * Elem::p_level() is ignored and extra_order is used instead.
+   */
+  static Real shape(const FEType & fe_t,
+                    int extra_order,
                     const Elem * elem,
                     const unsigned int i,
                     const Point & p);

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -381,6 +381,10 @@ public:
    *
    * \note On a p-refined element, \p fe_t.order should be the total
    * order of the element.
+   *
+   * \deprecated Use the version of this function that accounts for
+   * Elem::p_level() internally or the version which takes an
+   * extra_order parameter.
    */
   template<typename OutputType>
   static void shape(const unsigned int dim,
@@ -398,10 +402,37 @@ public:
    *
    * \note On a p-refined element, \p fe_t.order should be the total
    * order of the element.
+   *
+   * \deprecated Use the version of this function that accounts for
+   * Elem::p_level() internally or the version which takes an
+   * extra_order parameter.
    */
   template<typename OutputType>
   static void shape(const unsigned int dim,
                     const FEType & fe_t,
+                    const Elem * elem,
+                    const unsigned int i,
+                    const Point & p,
+                    OutputType & phi);
+
+  /**
+   * Non-deprecated version of templated shape() function that
+   * accounts for Elem::p_level() internally.
+   */
+  template<typename OutputType>
+  static void shape(const FEType & fe_t,
+                    const Elem * elem,
+                    const unsigned int i,
+                    const Point & p,
+                    OutputType & phi);
+
+  /**
+   * Non-deprecated version of templated shape() function that ignores
+   * Elem::p_level() and instead uses extra_order internally.
+   */
+  template<typename OutputType>
+  static void shape(const FEType & fe_t,
+                    int extra_order,
                     const Elem * elem,
                     const unsigned int i,
                     const Point & p,

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -932,9 +932,10 @@ void FEAbstract::compute_node_constraints (NodeConstraints & constraints,
                   const Node * their_node = parent_nodes[their_side_n];
                   libmesh_assert(their_node);
 
-                  const Real their_value = FEInterface::shape(Dim-1,
-                                                              fe_type,
-                                                              parent_side->type(),
+                  // Do not use the p_level(), if any, that is inherited by the side.
+                  const Real their_value = FEInterface::shape(fe_type,
+                                                              /*extra_order=*/0,
+                                                              parent_side.get(),
                                                               their_side_n,
                                                               mapped_point);
 
@@ -1172,9 +1173,10 @@ void FEAbstract::compute_periodic_node_constraints (NodeConstraints & constraint
                           const Node * their_node = neigh_nodes[their_side_n];
                           libmesh_assert(their_node);
 
-                          const Real their_value = FEInterface::shape(Dim-1,
-                                                                      fe_type,
-                                                                      neigh_side->type(),
+                          // Do not use the p_level(), if any, that is inherited by the side.
+                          const Real their_value = FEInterface::shape(fe_type,
+                                                                      /*extra_order=*/0,
+                                                                      neigh_side.get(),
                                                                       their_side_n,
                                                                       mapped_point);
 

--- a/src/fe/fe_bernstein.C
+++ b/src/fe/fe_bernstein.C
@@ -39,8 +39,7 @@ namespace {
 void bernstein_nodal_soln(const Elem * elem,
                           const Order order,
                           const std::vector<Number> & elem_soln,
-                          std::vector<Number> &       nodal_soln,
-                          unsigned Dim)
+                          std::vector<Number> & nodal_soln)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -52,7 +51,6 @@ void bernstein_nodal_soln(const Elem * elem,
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, BERNSTEIN);
-  FEType p_refined_fe_type(totalorder, BERNSTEIN);
 
   switch (totalorder)
     {
@@ -96,7 +94,7 @@ void bernstein_nodal_soln(const Elem * elem,
             // u_i = Sum (alpha_i phi_i)
             for (unsigned int i=0; i<n_sf; i++)
               nodal_soln[n] += elem_soln[i] *
-                FEInterface::shape(Dim, p_refined_fe_type, elem, i, refspace_nodes[n]);
+                FEInterface::shape(fe_type, elem, i, refspace_nodes[n]);
           }
 
         return;
@@ -388,28 +386,28 @@ void FE<0,BERNSTEIN>::nodal_soln(const Elem * elem,
                                  const Order order,
                                  const std::vector<Number> & elem_soln,
                                  std::vector<Number> & nodal_soln)
-{ bernstein_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/0); }
+{ bernstein_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<1,BERNSTEIN>::nodal_soln(const Elem * elem,
                                  const Order order,
                                  const std::vector<Number> & elem_soln,
                                  std::vector<Number> & nodal_soln)
-{ bernstein_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/1); }
+{ bernstein_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<2,BERNSTEIN>::nodal_soln(const Elem * elem,
                                  const Order order,
                                  const std::vector<Number> & elem_soln,
                                  std::vector<Number> & nodal_soln)
-{ bernstein_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/2); }
+{ bernstein_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<3,BERNSTEIN>::nodal_soln(const Elem * elem,
                                  const Order order,
                                  const std::vector<Number> & elem_soln,
                                  std::vector<Number> & nodal_soln)
-{ bernstein_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/3); }
+{ bernstein_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 
 // Full specialization of n_dofs() function for every dimension

--- a/src/fe/fe_clough.C
+++ b/src/fe/fe_clough.C
@@ -35,8 +35,7 @@ namespace {
 void clough_nodal_soln(const Elem * elem,
                        const Order order,
                        const std::vector<Number> & elem_soln,
-                       std::vector<Number> &       nodal_soln,
-                       unsigned Dim)
+                       std::vector<Number> &       nodal_soln)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -48,7 +47,6 @@ void clough_nodal_soln(const Elem * elem,
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, CLOUGH);
-  FEType p_refined_fe_type(totalorder, CLOUGH);
 
   switch (totalorder)
     {
@@ -57,7 +55,6 @@ void clough_nodal_soln(const Elem * elem,
       // Piecewise cubic shape functions
     case THIRD:
       {
-
         const unsigned int n_sf =
           FEInterface::n_shape_functions(fe_type, elem);
 
@@ -75,7 +72,7 @@ void clough_nodal_soln(const Elem * elem,
             // u_i = Sum (alpha_i phi_i)
             for (unsigned int i=0; i<n_sf; i++)
               nodal_soln[n] += elem_soln[i] *
-                FEInterface::shape(Dim, p_refined_fe_type, elem, i, refspace_nodes[n]);
+                FEInterface::shape(fe_type, elem, i, refspace_nodes[n]);
           }
 
         return;
@@ -241,28 +238,28 @@ void FE<0,CLOUGH>::nodal_soln(const Elem * elem,
                               const Order order,
                               const std::vector<Number> & elem_soln,
                               std::vector<Number> & nodal_soln)
-{ clough_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/0); }
+{ clough_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<1,CLOUGH>::nodal_soln(const Elem * elem,
                               const Order order,
                               const std::vector<Number> & elem_soln,
                               std::vector<Number> & nodal_soln)
-{ clough_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/1); }
+{ clough_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<2,CLOUGH>::nodal_soln(const Elem * elem,
                               const Order order,
                               const std::vector<Number> & elem_soln,
                               std::vector<Number> & nodal_soln)
-{ clough_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/2); }
+{ clough_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<3,CLOUGH>::nodal_soln(const Elem * elem,
                               const Order order,
                               const std::vector<Number> & elem_soln,
                               std::vector<Number> & nodal_soln)
-{ clough_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/3); }
+{ clough_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 
 // Full specialization of n_dofs() function for every dimension

--- a/src/fe/fe_hermite.C
+++ b/src/fe/fe_hermite.C
@@ -35,8 +35,7 @@ namespace {
 void hermite_nodal_soln(const Elem * elem,
                         const Order order,
                         const std::vector<Number> & elem_soln,
-                        std::vector<Number> &       nodal_soln,
-                        unsigned Dim)
+                        std::vector<Number> & nodal_soln)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -44,11 +43,8 @@ void hermite_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = static_cast<Order>(order + elem->p_level());
-
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, HERMITE);
-  FEType p_refined_fe_type(totalorder, HERMITE);
 
   const unsigned int n_sf =
     FEInterface::n_shape_functions(fe_type, elem);
@@ -67,7 +63,7 @@ void hermite_nodal_soln(const Elem * elem,
       // u_i = Sum (alpha_i phi_i)
       for (unsigned int i=0; i<n_sf; i++)
         nodal_soln[n] += elem_soln[i] *
-          FEInterface::shape(Dim, p_refined_fe_type, elem, i, refspace_nodes[n]);
+          FEInterface::shape(fe_type, elem, i, refspace_nodes[n]);
     }
 } // hermite_nodal_soln()
 
@@ -288,28 +284,28 @@ void FE<0,HERMITE>::nodal_soln(const Elem * elem,
                                const Order order,
                                const std::vector<Number> & elem_soln,
                                std::vector<Number> & nodal_soln)
-{ hermite_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/0); }
+{ hermite_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<1,HERMITE>::nodal_soln(const Elem * elem,
                                const Order order,
                                const std::vector<Number> & elem_soln,
                                std::vector<Number> & nodal_soln)
-{ hermite_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/1); }
+{ hermite_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<2,HERMITE>::nodal_soln(const Elem * elem,
                                const Order order,
                                const std::vector<Number> & elem_soln,
                                std::vector<Number> & nodal_soln)
-{ hermite_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/2); }
+{ hermite_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<3,HERMITE>::nodal_soln(const Elem * elem,
                                const Order order,
                                const std::vector<Number> & elem_soln,
                                std::vector<Number> & nodal_soln)
-{ hermite_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/3); }
+{ hermite_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 
 

--- a/src/fe/fe_hierarchic.C
+++ b/src/fe/fe_hierarchic.C
@@ -35,8 +35,7 @@ namespace {
 void hierarchic_nodal_soln(const Elem * elem,
                            const Order order,
                            const std::vector<Number> & elem_soln,
-                           std::vector<Number> &       nodal_soln,
-                           unsigned Dim)
+                           std::vector<Number> & nodal_soln)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -48,7 +47,6 @@ void hierarchic_nodal_soln(const Elem * elem,
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, HIERARCHIC);
-  FEType p_refined_fe_type(totalorder, HIERARCHIC);
 
   switch (totalorder)
     {
@@ -70,7 +68,6 @@ void hierarchic_nodal_soln(const Elem * elem,
       // explicitly.
     default:
       {
-
         const unsigned int n_sf =
           FEInterface::n_shape_functions(fe_type, elem);
 
@@ -88,7 +85,7 @@ void hierarchic_nodal_soln(const Elem * elem,
             // u_i = Sum (alpha_i phi_i)
             for (unsigned int i=0; i<n_sf; i++)
               nodal_soln[n] += elem_soln[i] *
-                FEInterface::shape(Dim, p_refined_fe_type, elem, i, refspace_nodes[n]);
+                FEInterface::shape(fe_type, elem, i, refspace_nodes[n]);
           }
 
         return;
@@ -323,28 +320,28 @@ void FE<0,HIERARCHIC>::nodal_soln(const Elem * elem,
                                   const Order order,
                                   const std::vector<Number> & elem_soln,
                                   std::vector<Number> & nodal_soln)
-{ hierarchic_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/0); }
+{ hierarchic_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<1,HIERARCHIC>::nodal_soln(const Elem * elem,
                                   const Order order,
                                   const std::vector<Number> & elem_soln,
                                   std::vector<Number> & nodal_soln)
-{ hierarchic_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/1); }
+{ hierarchic_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<2,HIERARCHIC>::nodal_soln(const Elem * elem,
                                   const Order order,
                                   const std::vector<Number> & elem_soln,
                                   std::vector<Number> & nodal_soln)
-{ hierarchic_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/2); }
+{ hierarchic_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<3,HIERARCHIC>::nodal_soln(const Elem * elem,
                                   const Order order,
                                   const std::vector<Number> & elem_soln,
                                   std::vector<Number> & nodal_soln)
-{ hierarchic_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/3); }
+{ hierarchic_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 
 // Full specialization of n_dofs() function for every dimension

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -964,14 +964,13 @@ FEInterface::shape(const FEType & fe_t,
 
 #endif
 
-  // Account for Elem::p_level() when computing total_order
+  // We are calling
   //
-  // Note: When calling FE<X,Y>::shape(ElemType, order, unsigned, Point),
-  // we are responsible for computing the total order ourselves.  See
-  // fe.h for more details.
-  auto total_order = static_cast<Order>(fe_t.order + elem->p_level());
-
-  fe_switch(shape(elem->type(), total_order, i, p));
+  // FE<X,Y>::shape(Elem *, Order, unsigned, Point, true)
+  //
+  // with the last parameter set to "true" so that the Elem::p_level()
+  // is accounted for internally. See fe.h for more details.
+  fe_switch(shape(elem, fe_t.order, i, p, true));
 }
 
 
@@ -993,14 +992,16 @@ FEInterface::shape(const FEType & fe_t,
 
 #endif
 
-  // Ignore Elem::p_level() and instead use extra_order to compute total_order.
+  // We are calling
   //
-  // Note: When calling FE<X,Y>::shape(ElemType, order, unsigned, Point),
-  // we are responsible for computing the total order ourselves.  See
-  // fe.h for more details.
+  // FE<X,Y>::shape(Elem *, Order, unsigned, Point, false)
+  //
+  // with the last parameter set to "false" so that the
+  // Elem::p_level() is not used internally and the "total_order" that
+  // we compute is used instead. See fe.h for more details.
   auto total_order = static_cast<Order>(fe_t.order + extra_order);
 
-  fe_switch(shape(elem->type(), total_order, i, p));
+  fe_switch(shape(elem, total_order, i, p, false));
 }
 
 
@@ -1114,24 +1115,21 @@ void FEInterface::shape<Real>(const FEType & fe_t,
 
 #endif
 
-  // Account for Elem::p_level() when computing total_order
-  auto total_order = static_cast<Order>(fe_t.order + elem->p_level());
-
-  // Below we call FE<X,Y>::shape(ElemType, Order, unsigned, Point)
-  // which requires us to compute the total Order ourselves./
+  // Below we call FE<X,Y>::shape(Elem *, Order, unsigned, Point, true)
+  // so that the Elem::p_level() is accounted for internally.
   switch(dim)
     {
     case 0:
-      fe_scalar_vec_error_switch(0, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      fe_scalar_vec_error_switch(0, shape(elem, fe_t.order, i, p, true), phi = , ; break;);
       break;
     case 1:
-      fe_scalar_vec_error_switch(1, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      fe_scalar_vec_error_switch(1, shape(elem, fe_t.order, i, p, true), phi = , ; break;);
       break;
     case 2:
-      fe_scalar_vec_error_switch(2, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      fe_scalar_vec_error_switch(2, shape(elem, fe_t.order, i, p, true), phi = , ; break;);
       break;
     case 3:
-      fe_scalar_vec_error_switch(3, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      fe_scalar_vec_error_switch(3, shape(elem, fe_t.order, i, p, true), phi = , ; break;);
       break;
     default:
       libmesh_error_msg("Invalid dimension = " << dim);
@@ -1164,21 +1162,25 @@ void FEInterface::shape<Real>(const FEType & fe_t,
   // Ignore Elem::p_level() and instead use extra_order to compute total_order
   auto total_order = static_cast<Order>(fe_t.order + extra_order);
 
-  // Below we call FE<X,Y>::shape(ElemType, Order, unsigned, Point)
-  // which requires us to compute the total Order ourselves./
+  // Below we call
+  //
+  // FE<X,Y>::shape(Elem *, Order, unsigned, Point, false)
+  //
+  // so that the Elem::p_level() is ignored and the total_order that
+  // we compute is used instead.
   switch(dim)
     {
     case 0:
-      fe_scalar_vec_error_switch(0, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      fe_scalar_vec_error_switch(0, shape(elem, total_order, i, p, false), phi = , ; break;);
       break;
     case 1:
-      fe_scalar_vec_error_switch(1, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      fe_scalar_vec_error_switch(1, shape(elem, total_order, i, p, false), phi = , ; break;);
       break;
     case 2:
-      fe_scalar_vec_error_switch(2, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      fe_scalar_vec_error_switch(2, shape(elem, total_order, i, p, false), phi = , ; break;);
       break;
     case 3:
-      fe_scalar_vec_error_switch(3, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      fe_scalar_vec_error_switch(3, shape(elem, total_order, i, p, false), phi = , ; break;);
       break;
     default:
       libmesh_error_msg("Invalid dimension = " << dim);
@@ -1335,22 +1337,26 @@ void FEInterface::shape<RealGradient>(const FEType & fe_t,
 
   auto dim = elem->dim();
 
-  // Account for Elem::p_level() when computing total_order
-  auto total_order = static_cast<Order>(fe_t.order + elem->p_level());
+  // We are calling
+  //
+  // FE<X,Y>::shape(Elem *, Order, unsigned, Point, true)
+  //
+  // with the last parameter set to "true" so that the Elem::p_level()
+  // is accounted for internally. See fe.h for more details.
 
   switch(dim)
     {
     case 0:
-      fe_vector_scalar_error_switch(0, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      fe_vector_scalar_error_switch(0, shape(elem, fe_t.order, i, p, true), phi = , ; break;);
       break;
     case 1:
-      fe_vector_scalar_error_switch(1, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      fe_vector_scalar_error_switch(1, shape(elem, fe_t.order, i, p, true), phi = , ; break;);
       break;
     case 2:
-      fe_vector_scalar_error_switch(2, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      fe_vector_scalar_error_switch(2, shape(elem, fe_t.order, i, p, true), phi = , ; break;);
       break;
     case 3:
-      fe_vector_scalar_error_switch(3, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      fe_vector_scalar_error_switch(3, shape(elem, fe_t.order, i, p, true), phi = , ; break;);
       break;
     default:
       libmesh_error_msg("Invalid dimension = " << dim);
@@ -1377,22 +1383,28 @@ void FEInterface::shape<RealGradient>(const FEType & fe_t,
 
   auto dim = elem->dim();
 
-  // Ignore Elem::p_level() and use extra_order to compute total_order
+  // We are calling
+  //
+  // FE<X,Y>::shape(Elem *, Order, unsigned, Point, false)
+  //
+  // with the last parameter set to "false" so that the
+  // Elem::p_level() is not used internally and the "total_order" that
+  // we compute is used instead. See fe.h for more details.
   auto total_order = static_cast<Order>(fe_t.order + extra_order);
 
   switch(dim)
     {
     case 0:
-      fe_vector_scalar_error_switch(0, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      fe_vector_scalar_error_switch(0, shape(elem, total_order, i, p, false), phi = , ; break;);
       break;
     case 1:
-      fe_vector_scalar_error_switch(1, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      fe_vector_scalar_error_switch(1, shape(elem, total_order, i, p, false), phi = , ; break;);
       break;
     case 2:
-      fe_vector_scalar_error_switch(2, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      fe_vector_scalar_error_switch(2, shape(elem, total_order, i, p, false), phi = , ; break;);
       break;
     case 3:
-      fe_vector_scalar_error_switch(3, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      fe_vector_scalar_error_switch(3, shape(elem, total_order, i, p, false), phi = , ; break;);
       break;
     default:
       libmesh_error_msg("Invalid dimension = " << dim);

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -910,6 +910,9 @@ Real FEInterface::shape(const unsigned int dim,
                         const unsigned int i,
                         const Point & p)
 {
+  // TODO:
+  // libmesh_deprecated();
+
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
   if (is_InfFE_elem(t))
@@ -928,6 +931,9 @@ Real FEInterface::shape(const unsigned int dim,
                         const unsigned int i,
                         const Point & p)
 {
+  // TODO:
+  // libmesh_deprecated();
+
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
   if (elem && is_InfFE_elem(elem->type()))
@@ -939,6 +945,65 @@ Real FEInterface::shape(const unsigned int dim,
 
   fe_switch(shape(elem,o,i,p));
 }
+
+
+
+Real
+FEInterface::shape(const FEType & fe_t,
+                   const Elem * elem,
+                   const unsigned int i,
+                   const Point & p)
+{
+  // dim is required by the fe_switch macro
+  auto dim = elem->dim();
+
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+  if (elem && is_InfFE_elem(elem->type()))
+    return ifem_shape(dim, fe_t, elem, i, p);
+
+#endif
+
+  // Account for Elem::p_level() when computing total_order
+  //
+  // Note: When calling FE<X,Y>::shape(ElemType, order, unsigned, Point),
+  // we are responsible for computing the total order ourselves.  See
+  // fe.h for more details.
+  auto total_order = static_cast<Order>(fe_t.order + elem->p_level());
+
+  fe_switch(shape(elem->type(), total_order, i, p));
+}
+
+
+
+Real
+FEInterface::shape(const FEType & fe_t,
+                   int extra_order,
+                   const Elem * elem,
+                   const unsigned int i,
+                   const Point & p)
+{
+  // dim is required by the fe_switch macro
+  auto dim = elem->dim();
+
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+  if (elem && is_InfFE_elem(elem->type()))
+    return ifem_shape(dim, fe_t, elem, i, p);
+
+#endif
+
+  // Ignore Elem::p_level() and instead use extra_order to compute total_order.
+  //
+  // Note: When calling FE<X,Y>::shape(ElemType, order, unsigned, Point),
+  // we are responsible for computing the total order ourselves.  See
+  // fe.h for more details.
+  auto total_order = static_cast<Order>(fe_t.order + extra_order);
+
+  fe_switch(shape(elem->type(), total_order, i, p));
+}
+
+
 
 template<>
 void FEInterface::shape<Real>(const unsigned int dim,

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -1013,6 +1013,9 @@ void FEInterface::shape<Real>(const unsigned int dim,
                               const Point & p,
                               Real & phi)
 {
+  // TODO
+  // libmesh_deprecated();
+
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
   if (is_InfFE_elem(t))
@@ -1054,6 +1057,9 @@ void FEInterface::shape<Real>(const unsigned int dim,
                               const Point & p,
                               Real & phi)
 {
+  // TODO
+  // libmesh_deprecated();
+
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
   if (elem && is_InfFE_elem(elem->type()))
@@ -1085,6 +1091,100 @@ void FEInterface::shape<Real>(const unsigned int dim,
 
   return;
 }
+
+
+
+template<>
+void FEInterface::shape<Real>(const FEType & fe_t,
+                              const Elem * elem,
+                              const unsigned int i,
+                              const Point & p,
+                              Real & phi)
+{
+  // dim is required by the fe_switch macro
+  auto dim = elem->dim();
+
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+  if (is_InfFE_elem(elem->type()))
+    {
+      phi = ifem_shape(dim, fe_t, elem->type(), i, p);
+      return;
+    }
+
+#endif
+
+  // Account for Elem::p_level() when computing total_order
+  auto total_order = static_cast<Order>(fe_t.order + elem->p_level());
+
+  // Below we call FE<X,Y>::shape(ElemType, Order, unsigned, Point)
+  // which requires us to compute the total Order ourselves./
+  switch(dim)
+    {
+    case 0:
+      fe_scalar_vec_error_switch(0, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      break;
+    case 1:
+      fe_scalar_vec_error_switch(1, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      break;
+    case 2:
+      fe_scalar_vec_error_switch(2, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      break;
+    case 3:
+      fe_scalar_vec_error_switch(3, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      break;
+    default:
+      libmesh_error_msg("Invalid dimension = " << dim);
+    }
+}
+
+
+
+template<>
+void FEInterface::shape<Real>(const FEType & fe_t,
+                              int extra_order,
+                              const Elem * elem,
+                              const unsigned int i,
+                              const Point & p,
+                              Real & phi)
+{
+  // dim is required by the fe_switch macro
+  auto dim = elem->dim();
+
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+  if (is_InfFE_elem(elem->type()))
+    {
+      phi = ifem_shape(dim, fe_t, elem->type(), i, p);
+      return;
+    }
+
+#endif
+
+  // Ignore Elem::p_level() and instead use extra_order to compute total_order
+  auto total_order = static_cast<Order>(fe_t.order + extra_order);
+
+  // Below we call FE<X,Y>::shape(ElemType, Order, unsigned, Point)
+  // which requires us to compute the total Order ourselves./
+  switch(dim)
+    {
+    case 0:
+      fe_scalar_vec_error_switch(0, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      break;
+    case 1:
+      fe_scalar_vec_error_switch(1, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      break;
+    case 2:
+      fe_scalar_vec_error_switch(2, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      break;
+    case 3:
+      fe_scalar_vec_error_switch(3, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      break;
+    default:
+      libmesh_error_msg("Invalid dimension = " << dim);
+    }
+}
+
 
 
 template<>
@@ -1185,7 +1285,10 @@ void FEInterface::shape<RealGradient>(const unsigned int dim,
                                       const Point & p,
                                       RealGradient & phi)
 {
-  // This even does not handle infinite elements at all!?
+  // TODO:
+  // libmesh_deprecated();
+
+  // This API does not currently support infinite elements.
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   if (is_InfFE_elem(t))
   {
@@ -1211,9 +1314,91 @@ void FEInterface::shape<RealGradient>(const unsigned int dim,
     default:
       libmesh_error_msg("Invalid dimension = " << dim);
     }
-
-  return;
 }
+
+
+
+template<>
+void FEInterface::shape<RealGradient>(const FEType & fe_t,
+                                      const Elem * elem,
+                                      const unsigned int i,
+                                      const Point & p,
+                                      RealGradient & phi)
+{
+  // This API does not currently support infinite elements.
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+  if (is_InfFE_elem(elem->type()))
+  {
+     libmesh_not_implemented();
+  }
+#endif
+
+  auto dim = elem->dim();
+
+  // Account for Elem::p_level() when computing total_order
+  auto total_order = static_cast<Order>(fe_t.order + elem->p_level());
+
+  switch(dim)
+    {
+    case 0:
+      fe_vector_scalar_error_switch(0, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      break;
+    case 1:
+      fe_vector_scalar_error_switch(1, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      break;
+    case 2:
+      fe_vector_scalar_error_switch(2, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      break;
+    case 3:
+      fe_vector_scalar_error_switch(3, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      break;
+    default:
+      libmesh_error_msg("Invalid dimension = " << dim);
+    }
+}
+
+
+
+template<>
+void FEInterface::shape<RealGradient>(const FEType & fe_t,
+                                      int extra_order,
+                                      const Elem * elem,
+                                      const unsigned int i,
+                                      const Point & p,
+                                      RealGradient & phi)
+{
+  // This API does not currently support infinite elements.
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+  if (is_InfFE_elem(elem->type()))
+  {
+     libmesh_not_implemented();
+  }
+#endif
+
+  auto dim = elem->dim();
+
+  // Ignore Elem::p_level() and use extra_order to compute total_order
+  auto total_order = static_cast<Order>(fe_t.order + extra_order);
+
+  switch(dim)
+    {
+    case 0:
+      fe_vector_scalar_error_switch(0, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      break;
+    case 1:
+      fe_vector_scalar_error_switch(1, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      break;
+    case 2:
+      fe_vector_scalar_error_switch(2, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      break;
+    case 3:
+      fe_vector_scalar_error_switch(3, shape(elem->type(), total_order, i, p), phi = , ; break;);
+      break;
+    default:
+      libmesh_error_msg("Invalid dimension = " << dim);
+    }
+}
+
 
 
 template<>
@@ -1470,6 +1655,8 @@ void FEInterface::shape<RealGradient>(const unsigned int dim,
                                       const Point & p,
                                       RealGradient & phi)
 {
+  // TODO
+  // libmesh_deprecated();
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   if (elem->infinite())

--- a/src/fe/fe_l2_hierarchic.C
+++ b/src/fe/fe_l2_hierarchic.C
@@ -35,8 +35,7 @@ namespace {
 void l2_hierarchic_nodal_soln(const Elem * elem,
                               const Order order,
                               const std::vector<Number> & elem_soln,
-                              std::vector<Number> &       nodal_soln,
-                              unsigned Dim)
+                              std::vector<Number> & nodal_soln)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -48,7 +47,6 @@ void l2_hierarchic_nodal_soln(const Elem * elem,
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, L2_HIERARCHIC);
-  FEType p_refined_fe_type(totalorder, L2_HIERARCHIC);
 
   switch (totalorder)
     {
@@ -87,7 +85,7 @@ void l2_hierarchic_nodal_soln(const Elem * elem,
             // u_i = Sum (alpha_i phi_i)
             for (unsigned int i=0; i<n_sf; i++)
               nodal_soln[n] += elem_soln[i] *
-                FEInterface::shape(Dim, p_refined_fe_type, elem, i, refspace_nodes[n]);
+                FEInterface::shape(fe_type, elem, i, refspace_nodes[n]);
           }
 
         return;
@@ -145,28 +143,28 @@ void FE<0,L2_HIERARCHIC>::nodal_soln(const Elem * elem,
                                      const Order order,
                                      const std::vector<Number> & elem_soln,
                                      std::vector<Number> & nodal_soln)
-{ l2_hierarchic_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/0); }
+{ l2_hierarchic_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<1,L2_HIERARCHIC>::nodal_soln(const Elem * elem,
                                      const Order order,
                                      const std::vector<Number> & elem_soln,
                                      std::vector<Number> & nodal_soln)
-{ l2_hierarchic_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/1); }
+{ l2_hierarchic_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<2,L2_HIERARCHIC>::nodal_soln(const Elem * elem,
                                      const Order order,
                                      const std::vector<Number> & elem_soln,
                                      std::vector<Number> & nodal_soln)
-{ l2_hierarchic_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/2); }
+{ l2_hierarchic_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<3,L2_HIERARCHIC>::nodal_soln(const Elem * elem,
                                      const Order order,
                                      const std::vector<Number> & elem_soln,
                                      std::vector<Number> & nodal_soln)
-{ l2_hierarchic_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/3); }
+{ l2_hierarchic_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 // Full specialization of n_dofs() function for every dimension
 template <> unsigned int FE<0,L2_HIERARCHIC>::n_dofs(const ElemType t, const Order o) { return l2_hierarchic_n_dofs(t, o); }

--- a/src/fe/fe_monomial.C
+++ b/src/fe/fe_monomial.C
@@ -32,8 +32,7 @@ namespace {
 void monomial_nodal_soln(const Elem * elem,
                          const Order order,
                          const std::vector<Number> & elem_soln,
-                         std::vector<Number> &       nodal_soln,
-                         const unsigned Dim)
+                         std::vector<Number> & nodal_soln)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -65,7 +64,6 @@ void monomial_nodal_soln(const Elem * elem,
       {
         // FEType object to be passed to various FEInterface functions below.
         FEType fe_type(order, MONOMIAL);
-        FEType p_refined_fe_type(totalorder, MONOMIAL);
 
         const unsigned int n_sf =
           FEInterface::n_shape_functions(fe_type, elem);
@@ -84,7 +82,7 @@ void monomial_nodal_soln(const Elem * elem,
             // u_i = Sum (alpha_i phi_i)
             for (unsigned int i=0; i<n_sf; i++)
               nodal_soln[n] += elem_soln[i] *
-                FEInterface::shape(Dim, p_refined_fe_type, elem, i, refspace_nodes[n]);
+                FEInterface::shape(fe_type, elem, i, refspace_nodes[n]);
           }
 
         return;
@@ -349,28 +347,28 @@ void FE<0,MONOMIAL>::nodal_soln(const Elem * elem,
                                 const Order order,
                                 const std::vector<Number> & elem_soln,
                                 std::vector<Number> & nodal_soln)
-{ monomial_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/0); }
+{ monomial_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<1,MONOMIAL>::nodal_soln(const Elem * elem,
                                 const Order order,
                                 const std::vector<Number> & elem_soln,
                                 std::vector<Number> & nodal_soln)
-{ monomial_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/1); }
+{ monomial_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<2,MONOMIAL>::nodal_soln(const Elem * elem,
                                 const Order order,
                                 const std::vector<Number> & elem_soln,
                                 std::vector<Number> & nodal_soln)
-{ monomial_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/2); }
+{ monomial_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<3,MONOMIAL>::nodal_soln(const Elem * elem,
                                 const Order order,
                                 const std::vector<Number> & elem_soln,
                                 std::vector<Number> & nodal_soln)
-{ monomial_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/3); }
+{ monomial_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 
 // Full specialization of n_dofs() function for every dimension

--- a/src/fe/fe_monomial_vec.C
+++ b/src/fe/fe_monomial_vec.C
@@ -94,7 +94,6 @@ monomial_vec_nodal_soln(const Elem * elem,
     {
       // FEType object to be passed to various FEInterface functions below.
       FEType fe_type(order, MONOMIAL);
-      FEType p_refined_fe_type(totalorder, MONOMIAL);
 
       const unsigned int n_sf = FEInterface::n_shape_functions(fe_type, elem);
 
@@ -113,7 +112,7 @@ monomial_vec_nodal_soln(const Elem * elem,
           // u_i = Sum (alpha_i phi_i)
           for (unsigned int i = 0; i < n_sf; i++)
             nodal_soln[d + dim * n] += elem_soln[d + dim * i] *
-                                       FEInterface::shape(dim, p_refined_fe_type, elem, i, refspace_nodes[n]);
+                                       FEInterface::shape(fe_type, elem, i, refspace_nodes[n]);
         }
 
       return;

--- a/src/fe/fe_rational.C
+++ b/src/fe/fe_rational.C
@@ -36,8 +36,7 @@ static const FEFamily _underlying_fe_family = BERNSTEIN;
 void rational_nodal_soln(const Elem * elem,
                          const Order order,
                          const std::vector<Number> & elem_soln,
-                         std::vector<Number> &       nodal_soln,
-                         unsigned Dim)
+                         std::vector<Number> & nodal_soln)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -93,7 +92,7 @@ void rational_nodal_soln(const Elem * elem,
             for (unsigned int i=0; i<n_sf; i++)
               {
                 weighted_shape[i] = node_weights[i] *
-                  FEInterface::shape(Dim, p_refined_fe_type, elem, i, refspace_nodes[n]);
+                  FEInterface::shape(fe_type, elem, i, refspace_nodes[n]);
                 weighted_sum += weighted_shape[i];
               }
 
@@ -121,28 +120,28 @@ void FE<0,RATIONAL_BERNSTEIN>::nodal_soln(const Elem * elem,
                                           const Order order,
                                           const std::vector<Number> & elem_soln,
                                           std::vector<Number> & nodal_soln)
-{ rational_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/0); }
+{ rational_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<1,RATIONAL_BERNSTEIN>::nodal_soln(const Elem * elem,
                                             const Order order,
                                             const std::vector<Number> & elem_soln,
                                             std::vector<Number> & nodal_soln)
-{ rational_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/1); }
+{ rational_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<2,RATIONAL_BERNSTEIN>::nodal_soln(const Elem * elem,
                                             const Order order,
                                             const std::vector<Number> & elem_soln,
                                             std::vector<Number> & nodal_soln)
-{ rational_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/2); }
+{ rational_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<3,RATIONAL_BERNSTEIN>::nodal_soln(const Elem * elem,
                                             const Order order,
                                             const std::vector<Number> & elem_soln,
                                             std::vector<Number> & nodal_soln)
-{ rational_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/3); }
+{ rational_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 
 // Full specialization of n_dofs() function for every dimension

--- a/src/fe/fe_rational_shape_1D.C
+++ b/src/fe/fe_rational_shape_1D.C
@@ -49,11 +49,9 @@ Real FE<1,RATIONAL_BERNSTEIN>::shape(const Elem * elem,
   libmesh_assert(elem);
 
   int extra_order = add_p_level * elem->p_level();
-  const Order totalorder = static_cast<Order>(order + extra_order);
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, _underlying_fe_family);
-  FEType p_refined_fe_type(totalorder, _underlying_fe_family);
 
   const unsigned int n_sf =
     FEInterface::n_shape_functions(fe_type, extra_order, elem);
@@ -73,7 +71,7 @@ Real FE<1,RATIONAL_BERNSTEIN>::shape(const Elem * elem,
   for (unsigned int sf=0; sf<n_sf; sf++)
     {
       Real weighted_shape = node_weights[sf] *
-        FEInterface::shape(1, p_refined_fe_type, elem, sf, p);
+        FEInterface::shape(fe_type, extra_order, elem, sf, p);
       weighted_sum += weighted_shape;
       if (sf == i)
         weighted_shape_i = weighted_shape;
@@ -146,7 +144,7 @@ Real FE<1,RATIONAL_BERNSTEIN>::shape_deriv(const Elem * elem,
   for (unsigned int sf=0; sf<n_sf; sf++)
     {
       Real weighted_shape = node_weights[sf] *
-        FEInterface::shape(1, p_refined_fe_type, elem, sf, p);
+        FEInterface::shape(fe_type, extra_order, elem, sf, p);
       Real weighted_grad = node_weights[sf] *
         FEInterface::shape_deriv(1, p_refined_fe_type, elem, sf, 0, p);
       weighted_sum += weighted_shape;
@@ -234,7 +232,7 @@ Real FE<1,RATIONAL_BERNSTEIN>::shape_second_deriv(const Elem * elem,
   for (unsigned int sf=0; sf<n_sf; sf++)
     {
       Real weighted_shape = node_weights[sf] *
-        FEInterface::shape(1, p_refined_fe_type, elem, sf, p);
+        FEInterface::shape(fe_type, extra_order, elem, sf, p);
       Real weighted_grad = node_weights[sf] *
         FEInterface::shape_deriv(1, p_refined_fe_type, elem, sf, 0, p);
       Real weighted_hess = node_weights[sf] *

--- a/src/fe/fe_rational_shape_2D.C
+++ b/src/fe/fe_rational_shape_2D.C
@@ -47,11 +47,9 @@ Real FE<2,RATIONAL_BERNSTEIN>::shape(const Elem * elem,
   libmesh_assert(elem);
 
   int extra_order = add_p_level * elem->p_level();
-  const Order totalorder = static_cast<Order>(order + extra_order);
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, _underlying_fe_family);
-  FEType p_refined_fe_type(totalorder, _underlying_fe_family);
 
   const unsigned int n_sf =
     FEInterface::n_shape_functions(fe_type, extra_order, elem);
@@ -71,7 +69,7 @@ Real FE<2,RATIONAL_BERNSTEIN>::shape(const Elem * elem,
   for (unsigned int sf=0; sf<n_sf; sf++)
     {
       Real weighted_shape = node_weights[sf] *
-        FEInterface::shape(2, p_refined_fe_type, elem, sf, p);
+        FEInterface::shape(fe_type, extra_order, elem, sf, p);
       weighted_sum += weighted_shape;
       if (sf == i)
         weighted_shape_i = weighted_shape;
@@ -142,7 +140,7 @@ Real FE<2,RATIONAL_BERNSTEIN>::shape_deriv(const Elem * elem,
   for (unsigned int sf=0; sf<n_sf; sf++)
     {
       Real weighted_shape = node_weights[sf] *
-        FEInterface::shape(2, p_refined_fe_type, elem, sf, p);
+        FEInterface::shape(fe_type, extra_order, elem, sf, p);
       Real weighted_grad = node_weights[sf] *
         FEInterface::shape_deriv(2, p_refined_fe_type, elem, sf, j, p);
       weighted_sum += weighted_shape;
@@ -247,7 +245,7 @@ Real FE<2,RATIONAL_BERNSTEIN>::shape_second_deriv(const Elem * elem,
   for (unsigned int sf=0; sf<n_sf; sf++)
     {
       Real weighted_shape = node_weights[sf] *
-        FEInterface::shape(2, p_refined_fe_type, elem, sf, p);
+        FEInterface::shape(fe_type, extra_order, elem, sf, p);
       Real weighted_grada = node_weights[sf] *
         FEInterface::shape_deriv(2, p_refined_fe_type, elem, sf, j1, p);
       Real weighted_hess = node_weights[sf] *

--- a/src/fe/fe_rational_shape_3D.C
+++ b/src/fe/fe_rational_shape_3D.C
@@ -47,11 +47,9 @@ Real FE<3,RATIONAL_BERNSTEIN>::shape(const Elem * elem,
   libmesh_assert(elem);
 
   int extra_order = add_p_level * elem->p_level();
-  const Order totalorder = static_cast<Order>(order + extra_order);
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, _underlying_fe_family);
-  FEType p_refined_fe_type(totalorder, _underlying_fe_family);
 
   const unsigned int n_sf =
     FEInterface::n_shape_functions(fe_type, extra_order, elem);
@@ -71,7 +69,7 @@ Real FE<3,RATIONAL_BERNSTEIN>::shape(const Elem * elem,
   for (unsigned int sf=0; sf<n_sf; sf++)
     {
       Real weighted_shape = node_weights[sf] *
-        FEInterface::shape(3, p_refined_fe_type, elem, sf, p);
+        FEInterface::shape(fe_type, extra_order, elem, sf, p);
       weighted_sum += weighted_shape;
       if (sf == i)
         weighted_shape_i = weighted_shape;
@@ -140,7 +138,7 @@ Real FE<3,RATIONAL_BERNSTEIN>::shape_deriv(const Elem * elem,
   for (unsigned int sf=0; sf<n_sf; sf++)
     {
       Real weighted_shape = node_weights[sf] *
-        FEInterface::shape(3, p_refined_fe_type, elem, sf, p);
+        FEInterface::shape(fe_type, extra_order, elem, sf, p);
       Real weighted_grad = node_weights[sf] *
         FEInterface::shape_deriv(3, p_refined_fe_type, elem, sf, j, p);
       weighted_sum += weighted_shape;
@@ -257,7 +255,7 @@ Real FE<3,RATIONAL_BERNSTEIN>::shape_second_deriv(const Elem * elem,
   for (unsigned int sf=0; sf<n_sf; sf++)
     {
       Real weighted_shape = node_weights[sf] *
-        FEInterface::shape(3, p_refined_fe_type, elem, sf, p);
+        FEInterface::shape(fe_type, extra_order, elem, sf, p);
       Real weighted_grada = node_weights[sf] *
         FEInterface::shape_deriv(3, p_refined_fe_type, elem, sf, j1, p);
       Real weighted_hess = node_weights[sf] *

--- a/src/fe/fe_szabab.C
+++ b/src/fe/fe_szabab.C
@@ -38,8 +38,7 @@ namespace {
 void szabab_nodal_soln(const Elem * elem,
                        const Order order,
                        const std::vector<Number> & elem_soln,
-                       std::vector<Number> &       nodal_soln,
-                       unsigned Dim)
+                       std::vector<Number> & nodal_soln)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -51,7 +50,6 @@ void szabab_nodal_soln(const Elem * elem,
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, SZABAB);
-  FEType p_refined_fe_type(totalorder, SZABAB);
 
   switch (totalorder)
     {
@@ -79,7 +77,6 @@ void szabab_nodal_soln(const Elem * elem,
     case SIXTH:
     case SEVENTH:
       {
-
         const unsigned int n_sf =
           FEInterface::n_shape_functions(fe_type, elem);
 
@@ -97,7 +94,7 @@ void szabab_nodal_soln(const Elem * elem,
             // u_i = Sum (alpha_i phi_i)
             for (unsigned int i=0; i<n_sf; i++)
               nodal_soln[n] += elem_soln[i] *
-                FEInterface::shape(Dim, p_refined_fe_type, elem, i, refspace_nodes[n]);
+                FEInterface::shape(fe_type, elem, i, refspace_nodes[n]);
           }
 
         return;
@@ -1226,28 +1223,28 @@ void FE<0,SZABAB>::nodal_soln(const Elem * elem,
                               const Order order,
                               const std::vector<Number> & elem_soln,
                               std::vector<Number> & nodal_soln)
-{ szabab_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/0); }
+{ szabab_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<1,SZABAB>::nodal_soln(const Elem * elem,
                               const Order order,
                               const std::vector<Number> & elem_soln,
                               std::vector<Number> & nodal_soln)
-{ szabab_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/1); }
+{ szabab_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<2,SZABAB>::nodal_soln(const Elem * elem,
                               const Order order,
                               const std::vector<Number> & elem_soln,
                               std::vector<Number> & nodal_soln)
-{ szabab_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/2); }
+{ szabab_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<3,SZABAB>::nodal_soln(const Elem * elem,
                               const Order order,
                               const std::vector<Number> & elem_soln,
                               std::vector<Number> & nodal_soln)
-{ szabab_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/3); }
+{ szabab_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 
 // Full specialization of n_dofs() function for every dimension

--- a/src/fe/fe_xyz.C
+++ b/src/fe/fe_xyz.C
@@ -37,8 +37,7 @@ namespace {
 void xyz_nodal_soln(const Elem * elem,
                     const Order order,
                     const std::vector<Number> & elem_soln,
-                    std::vector<Number> &       nodal_soln,
-                    unsigned Dim)
+                    std::vector<Number> & nodal_soln)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -68,7 +67,6 @@ void xyz_nodal_soln(const Elem * elem,
       {
         // FEType object to be passed to various FEInterface functions below.
         FEType fe_type(order, XYZ);
-        FEType p_refined_fe_type(totalorder, XYZ);
 
         const unsigned int n_sf =
           FEInterface::n_shape_functions(fe_type, elem);
@@ -83,7 +81,7 @@ void xyz_nodal_soln(const Elem * elem,
             // u_i = Sum (alpha_i phi_i)
             for (unsigned int i=0; i<n_sf; i++)
               nodal_soln[n] += elem_soln[i] *
-                FEInterface::shape(Dim, p_refined_fe_type, elem, i, elem->point(n));
+                FEInterface::shape(fe_type, elem, i, elem->point(n));
           }
 
         return;
@@ -877,28 +875,28 @@ void FE<0,XYZ>::nodal_soln(const Elem * elem,
                            const Order order,
                            const std::vector<Number> & elem_soln,
                            std::vector<Number> & nodal_soln)
-{ xyz_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/0); }
+{ xyz_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<1,XYZ>::nodal_soln(const Elem * elem,
                            const Order order,
                            const std::vector<Number> & elem_soln,
                            std::vector<Number> & nodal_soln)
-{ xyz_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/1); }
+{ xyz_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<2,XYZ>::nodal_soln(const Elem * elem,
                            const Order order,
                            const std::vector<Number> & elem_soln,
                            std::vector<Number> & nodal_soln)
-{ xyz_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/2); }
+{ xyz_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 template <>
 void FE<3,XYZ>::nodal_soln(const Elem * elem,
                            const Order order,
                            const std::vector<Number> & elem_soln,
                            std::vector<Number> & nodal_soln)
-{ xyz_nodal_soln(elem, order, elem_soln, nodal_soln, /*Dim=*/3); }
+{ xyz_nodal_soln(elem, order, elem_soln, nodal_soln); }
 
 
 

--- a/src/fe/hcurl_fe_transformation.C
+++ b/src/fe/hcurl_fe_transformation.C
@@ -86,8 +86,10 @@ void HCurlFETransformation<OutputShape>::map_phi(const unsigned int dim,
               // Need to temporarily cache reference shape functions
               // TODO: PB: Might be worth trying to build phi_ref separately to see
               //           if we can get vectorization
+              // We are computing mapping basis functions, so we explicitly ignore
+              // any non-zero p_level() the Elem might have.
               OutputShape phi_ref;
-              FEInterface::shape<OutputShape>(2, fe.get_fe_type(), elem, i, qp[p], phi_ref);
+              FEInterface::shape(fe.get_fe_type(), /*extra_order=*/0, elem, i, qp[p], phi_ref);
 
               phi[i][p](0) = dxidx_map[p]*phi_ref.slice(0) + detadx_map[p]*phi_ref.slice(1);
 
@@ -128,8 +130,10 @@ void HCurlFETransformation<OutputShape>::map_phi(const unsigned int dim,
               // Need to temporarily cache reference shape functions
               // TODO: PB: Might be worth trying to build phi_ref separately to see
               //           if we can get vectorization
+              // We are computing mapping basis functions, so we explicitly ignore
+              // any non-zero p_level() the Elem might have.
               OutputShape phi_ref;
-              FEInterface::shape<OutputShape>(3, fe.get_fe_type(), elem, i, qp[p], phi_ref);
+              FEInterface::shape(fe.get_fe_type(), /*extra_order=*/0, elem, i, qp[p], phi_ref);
 
               phi[i][p].slice(0) = dxidx_map[p]*phi_ref.slice(0) + detadx_map[p]*phi_ref.slice(1)
                 + dzetadx_map[p]*phi_ref.slice(2);

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -244,7 +244,7 @@ Real InfFE<Dim,T_radial,T_map>::shape(const FEType & fet,
   compute_shape_indices(fet, inf_elem->type(), i, i_base, i_radial);
 
   if (Dim > 1)
-    return FEInterface::shape(Dim-1, fet, base_el.get(), i_base, p)
+    return FEInterface::shape(fet, base_el.get(), i_base, p)
       * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
       * InfFERadial::decay(Dim,v);
   else
@@ -357,7 +357,7 @@ Real InfFE<Dim,T_radial,T_map>::shape_deriv (const FEType & fe_t,
         + InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
         * InfFERadial::decay_deriv(v);
 
-      return FEInterface::shape(Dim-1, fe_t, base_el.get(), i_base, p)*RadialDeriv;
+      return FEInterface::shape(fe_t, base_el.get(), i_base, p)*RadialDeriv;
     }
   return FEInterface::shape_deriv(Dim-1, fe_t, base_el.get(), i_base, j, p)
     * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
@@ -504,7 +504,7 @@ void InfFE<Dim,T_radial,T_map>::compute_data(const FEType & fet,
           compute_shape_indices(fet, inf_elem->type(), i, i_base, i_radial);
 
           data.shape[i] = (InfFERadial::decay(Dim,v)                                    /* (1.-v)/2. in 3D          */
-                           * FEInterface::shape(Dim-1, fet, base_el.get(), i_base, p)   /* S_n(s,t)                 */
+                           * FEInterface::shape(fet, base_el.get(), i_base, p)          /* S_n(s,t)                 */
                            * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial))    /* L_n(v)                   */
                            * time_harmonic;                                             /* e^(i*k*phase(s,t,v)      */
 
@@ -526,7 +526,7 @@ void InfFE<Dim,T_radial,T_map>::compute_data(const FEType & fet,
                 }
               data.dshape[i](Dim-1)  = (InfFERadial::decay_deriv(v) * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
                                         +InfFERadial::decay(Dim,v) * InfFE<Dim,T_radial,T_map>::eval_deriv(v, o_radial, i_radial))
-                                        * FEInterface::shape(Dim-1, fet, base_el.get(), i_base, p) * time_harmonic;
+                                        * FEInterface::shape(fet, base_el.get(), i_base, p) * time_harmonic;
 
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS
               // derivative of time_harmonic (works for harmonic behavior only):


### PR DESCRIPTION
There are two existing `FEInterface::shape()` implementations which differ in what they expect the input `FEType`'s order to be (total order for `ElemType` version, base order for `Elem*` version). This is a bit confusing/easy to forget, so these functions are now deprecated and instead one should call one of:
```
static Real shape(const FEType & fe_t,
                  const Elem * elem,
                  const unsigned int i,
                  const Point & p);

static Real shape(const FEType & fe_t,
                  int extra_order,
                  const Elem * elem,
                  const unsigned int i,
                  const Point & p);
```
The former accounts for `Elem::p_level()` internally automatically, the latter ignores `Elem::p_level()` and uses the specified `extra_order` instead. The idea is that you will only call this latter version if you know what you are doing, a majority of users will simply call the first version.
