### PR TITLE
More FEInterface refactoring

### DIFF
--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -492,7 +492,6 @@ public:
   shape_function(const FEType & fe_t,
                  const Elem * elem);
 
-
   /**
    * \returns The \f$ j^{th} \f$ coordinate of the gradient of
    * the \f$ i^{th} \f$ shape function at point \p p.
@@ -502,6 +501,8 @@ public:
    *
    * \note On a p-refined element, \p fe_t.order should be the total
    * order of the element.
+   *
+   * \deprecated Call the version of this function taking an Elem* instead.
    */
   static Real shape_deriv(const unsigned int dim,
                           const FEType & fe_t,
@@ -519,6 +520,8 @@ public:
    *
    * \note On a p-refined element, \p fe_t.order should be the total
    * order of the element.
+   *
+   * \deprecated Call the version of this function taking an Elem* instead.
    */
   static Real shape_deriv (const unsigned int dim,
                            const FEType & fe_t,
@@ -526,6 +529,25 @@ public:
                            const unsigned int i,
                            const unsigned int j,
                            const Point & p);
+
+  /**
+   * Non-deprecated version of function above.
+   */
+  static Real shape_deriv(const FEType & fe_t,
+                          const Elem * elem,
+                          const unsigned int i,
+                          const unsigned int j,
+                          const Point & p);
+
+  /**
+   * Non-deprecated version of function above.
+   */
+  static Real shape_deriv(const FEType & fe_t,
+                          int extra_order,
+                          const Elem * elem,
+                          const unsigned int i,
+                          const unsigned int j,
+                          const Point & p);
 
   typedef Real (*shape_deriv_ptr) (const FEType fet,
                                    const Elem * elem,

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -239,6 +239,9 @@ public:
    * Automatically decides which finite element class to use.
    *
    * On a p-refined element, \p fe_t.order should be the base order of the element.
+   *
+   * \todo For consistency with other FEInterface routines, this function
+   * should be updated so that it does not take a \p dim argument.
    */
   static void dofs_on_side(const Elem * const elem,
                            const unsigned int dim,
@@ -252,6 +255,9 @@ public:
    * Automatically decides which finite element class to use.
    *
    * On a p-refined element, \p fe_t.order should be the base order of the element.
+   *
+   * \todo For consistency with other FEInterface routines, this function
+   * should be updated so that it does not take a \p dim argument.
    */
   static void dofs_on_edge(const Elem * const elem,
                            const unsigned int dim,
@@ -268,7 +274,12 @@ public:
    * \p nodal_soln should not be used, the vector
    * \p nodal_soln is returned empty.
    *
-   * On a p-refined element, \p fe_t.order should be the base order of the element.
+   * \note On a p-refined element, \p fe_t.order should be the base
+   * order of the element. The Elem::p_level(), if any, is accounted
+   * for internally by this routine.
+   *
+   * \todo For consistency with other FEInterface routines, this function
+   * should be updated so that it does not take a \p dim argument.
    */
   static void nodal_soln(const unsigned int dim,
                          const FEType & fe_t,
@@ -704,6 +715,9 @@ public:
    *
    * \note On a p-refined element, \p fe_t.order should be the base
    * order of the element.
+   *
+   * \todo For consistency with other FEInterface routines, this function
+   * should be updated so that it does not take a \p dim argument.
    */
   static void compute_data(const unsigned int dim,
                            const FEType & fe_t,

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -598,6 +598,9 @@ public:
    *
    * \note On a p-refined element, \p fe_t.order should be the total
    * order of the element.
+   *
+   * \deprecated Call version of this function which does not require
+   * \p dim and takes an Elem * instead.
    */
   static Real shape_second_deriv(const unsigned int dim,
                                  const FEType & fe_t,
@@ -620,6 +623,9 @@ public:
    *
    * \note On a p-refined element, \p fe_t.order should be the total
    * order of the element.
+   *
+   * \deprecated Call version of this function which does not require
+   * \p dim and takes an Elem * instead.
    */
   static Real shape_second_deriv (const unsigned int dim,
                                   const FEType & fe_t,
@@ -627,6 +633,25 @@ public:
                                   const unsigned int i,
                                   const unsigned int j,
                                   const Point & p);
+
+  /**
+   * Non-deprecated version of function above.
+   */
+  static Real shape_second_deriv(const FEType & fe_t,
+                                 const Elem * elem,
+                                 const unsigned int i,
+                                 const unsigned int j,
+                                 const Point & p);
+
+  /**
+   * Non-deprecated version of function above taking an \p extra_order parameter.
+   */
+  static Real shape_second_deriv(const FEType & fe_t,
+                                 int extra_order,
+                                 const Elem * elem,
+                                 const unsigned int i,
+                                 const unsigned int j,
+                                 const Point & p);
 
   typedef Real (*shape_second_deriv_ptr) (const FEType fet,
                                           const Elem * elem,

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -653,6 +653,11 @@ public:
                                  const unsigned int j,
                                  const Point & p);
 
+  /**
+   * Typedef for pointer to a function that returns FE shape function second derivative values.
+   * The \p p_level() of the passed-in \p elem is accounted for internally when
+   * the \p add_p_level flag is set to true. For more information, see fe.h.
+   */
   typedef Real (*shape_second_deriv_ptr) (const FEType fet,
                                           const Elem * elem,
                                           const unsigned int i,
@@ -663,11 +668,21 @@ public:
   /**
    * \returns A function which evaluates shape for the
    * requested FE type and dimension.
+   *
+   * \deprecated Call the version of this function that takes an Elem * instead.
    */
   static shape_second_deriv_ptr
   shape_second_deriv_function(const unsigned int dim,
                               const FEType & fe_t,
                               const ElemType t);
+
+  /**
+   * Non-deprecated version of the function above.
+   */
+  static shape_second_deriv_ptr
+  shape_second_deriv_function(const FEType & fe_t,
+                              const Elem * elem);
+
 #endif
 
   /**

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -443,8 +443,18 @@ public:
    * at point \p p. This method allows you to specify the dimension,
    * element type, and order directly.
    *
-   * \note On a p-refined element, \p fe_t.order should be the total
-   * order of the element.
+   * \note Pass \p true for \p add_p_level if you want the Elem::p_level()
+   * to be accounted for internally, pass false if you want fe_t.order to
+   * be used instead.
+   *
+   * \todo To be consistent with the other non-deprecated FEInterface
+   * routines, the shapes() and all_shapes() APIs should be updated so
+   * that they do not take \p dim as a parameter. This is a relatively
+   * large changeset with little benefit if we go the deprecation
+   * route, so it would probably be cleaner to just break backwards
+   * compatibility...  these functions seem to mainly be used
+   * internally by the library and changing them is unlikely to break
+   * application codes.
    */
   template<typename OutputType>
   static void shapes(const unsigned int dim,

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -463,6 +463,11 @@ public:
                          std::vector<std::vector<OutputType>> & phi,
                          const bool add_p_level = true);
 
+  /**
+   * Typedef for pointer to a function that returns FE shape function values.
+   * The \p p_level() of the passed-in \p elem is accounted for internally when
+   * the \p add_p_level flag is set to true. For more information, see fe.h.
+   */
   typedef Real (*shape_ptr) (const FEType fe_t,
                              const Elem * elem,
                              const unsigned int i,
@@ -472,11 +477,20 @@ public:
   /**
    * \returns A function which evaluates shape for the
    * requested FE type and dimension.
+   *
+   * \deprecated Call the version of this function taking an Elem* instead.
    */
   static shape_ptr
   shape_function(const unsigned int dim,
                  const FEType & fe_t,
                  const ElemType t);
+
+  /**
+   * Non-deprecated version of function above.
+   */
+  static shape_ptr
+  shape_function(const FEType & fe_t,
+                 const Elem * elem);
 
 
   /**

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -549,6 +549,11 @@ public:
                           const unsigned int j,
                           const Point & p);
 
+  /**
+   * Typedef for pointer to a function that returns FE shape function derivative values.
+   * The \p p_level() of the passed-in \p elem is accounted for internally when
+   * the \p add_p_level flag is set to true. For more information, see fe.h.
+   */
   typedef Real (*shape_deriv_ptr) (const FEType fet,
                                    const Elem * elem,
                                    const unsigned int i,
@@ -559,11 +564,20 @@ public:
   /**
    * \returns A function which evaluates shape for the
    * requested FE type and dimension.
+   *
+   * \deprecated Call the version of this function taking an Elem * instead.
    */
   static shape_deriv_ptr
   shape_deriv_function(const unsigned int dim,
                        const FEType & fe_t,
                        const ElemType t);
+
+  /**
+   * Non-deprecated version of the function above.
+   */
+  static shape_deriv_ptr
+  shape_deriv_function(const FEType & fe_t,
+                       const Elem * elem);
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   /**

--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -401,7 +401,6 @@ void FEMap::init_face_shape_functions(const std::vector<Point> & qp,
   // The element type and order to use in
   // the map
   const FEFamily mapping_family = FEMap::map_fe_type(*side);
-  const ElemType mapping_elem_type (side->type());
   const FEType map_fe_type(side->default_order(), mapping_family);
 
   // The number of quadrature points.
@@ -447,7 +446,7 @@ void FEMap::init_face_shape_functions(const std::vector<Point> & qp,
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   FEInterface::shape_second_deriv_ptr shape_second_deriv_ptr =
-    FEInterface::shape_second_deriv_function(Dim-1, map_fe_type, mapping_elem_type);
+    FEInterface::shape_second_deriv_function(map_fe_type, side);
 #endif
 
   for (unsigned int i=0; i<n_mapping_shape_functions; i++)
@@ -530,7 +529,6 @@ void FEMap::init_edge_shape_functions(const std::vector<Point> & qp,
   // The element type and order to use in
   // the map
   const FEFamily mapping_family = FEMap::map_fe_type(*edge);
-  const ElemType mapping_elem_type (edge->type());
   const FEType map_fe_type(edge->default_order(), mapping_family);
 
   // The number of quadrature points.
@@ -559,7 +557,7 @@ void FEMap::init_edge_shape_functions(const std::vector<Point> & qp,
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   FEInterface::shape_second_deriv_ptr shape_second_deriv_ptr =
-    FEInterface::shape_second_deriv_function(1, map_fe_type, mapping_elem_type);
+    FEInterface::shape_second_deriv_function(map_fe_type, edge);
 #endif // LIBMESH_ENABLE_SECOND_DERIVATIVES
 
   for (unsigned int i=0; i<n_mapping_shape_functions; i++)

--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -440,7 +440,7 @@ void FEMap::init_face_shape_functions(const std::vector<Point> & qp,
     }
 
   FEInterface::shape_ptr shape_ptr =
-    FEInterface::shape_function(Dim-1, map_fe_type,mapping_elem_type);
+    FEInterface::shape_function(map_fe_type, side);
 
   FEInterface::shape_deriv_ptr shape_deriv_ptr =
     FEInterface::shape_deriv_function(Dim-1, map_fe_type,mapping_elem_type);
@@ -552,7 +552,7 @@ void FEMap::init_edge_shape_functions(const std::vector<Point> & qp,
 #endif
 
   FEInterface::shape_ptr shape_ptr =
-    FEInterface::shape_function(1, map_fe_type, mapping_elem_type);
+    FEInterface::shape_function(map_fe_type, edge);
 
   FEInterface::shape_deriv_ptr shape_deriv_ptr =
     FEInterface::shape_deriv_function(1, map_fe_type, mapping_elem_type);

--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -443,7 +443,7 @@ void FEMap::init_face_shape_functions(const std::vector<Point> & qp,
     FEInterface::shape_function(map_fe_type, side);
 
   FEInterface::shape_deriv_ptr shape_deriv_ptr =
-    FEInterface::shape_deriv_function(Dim-1, map_fe_type,mapping_elem_type);
+    FEInterface::shape_deriv_function(map_fe_type, side);
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   FEInterface::shape_second_deriv_ptr shape_second_deriv_ptr =
@@ -555,7 +555,7 @@ void FEMap::init_edge_shape_functions(const std::vector<Point> & qp,
     FEInterface::shape_function(map_fe_type, edge);
 
   FEInterface::shape_deriv_ptr shape_deriv_ptr =
-    FEInterface::shape_deriv_function(1, map_fe_type, mapping_elem_type);
+    FEInterface::shape_deriv_function(map_fe_type, edge);
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   FEInterface::shape_second_deriv_ptr shape_second_deriv_ptr =

--- a/src/fe/fe_clough_shape_1D.C
+++ b/src/fe/fe_clough_shape_1D.C
@@ -72,11 +72,7 @@ void clough_compute_coefs(const Elem * elem)
 #endif
 
   const FEFamily mapping_family = FEMap::map_fe_type(*elem);
-
-  const Order mapping_order        (elem->default_order());
-  const ElemType mapping_elem_type (elem->type());
-
-  const FEType map_fe_type(mapping_order, mapping_family);
+  const FEType map_fe_type(elem->default_order(), mapping_family);
 
   // Note: we explicitly don't consider the elem->p_level() when
   // computing the number of mapping shape functions.
@@ -93,14 +89,14 @@ void clough_compute_coefs(const Elem * elem)
   std::vector<Real> dxidx(2);
 
   FEInterface::shape_deriv_ptr shape_deriv_ptr =
-    FEInterface::shape_deriv_function(2, map_fe_type, mapping_elem_type);
+    FEInterface::shape_deriv_function(map_fe_type, elem);
 
   for (int p = 0; p != 2; ++p)
     {
       for (int i = 0; i != n_mapping_shape_functions; ++i)
         {
           const Real ddxi = shape_deriv_ptr
-            (map_fe_type, elem, i, 0, dofpt[p], false);
+            (map_fe_type, elem, i, 0, dofpt[p], /*add_p_level=*/false);
           dxdxi[p] += dofpt[p](0) * ddxi;
         }
     }

--- a/src/fe/fe_clough_shape_2D.C
+++ b/src/fe/fe_clough_shape_2D.C
@@ -84,10 +84,7 @@ void clough_compute_coefs(const Elem * elem)
 #endif
 
   const FEFamily mapping_family = FEMap::map_fe_type(*elem);
-  const Order mapping_order        (elem->default_order());
-  const ElemType mapping_elem_type (elem->type());
-
-  const FEType map_fe_type(mapping_order, mapping_family);
+  const FEType map_fe_type(elem->default_order(), mapping_family);
 
   // Note: we explicitly don't consider the elem->p_level() when
   // computing the number of mapping shape functions.
@@ -108,7 +105,7 @@ void clough_compute_coefs(const Elem * elem)
   std::vector<Real> dxidx(6), detadx(6), dxidy(6), detady(6);
 
   FEInterface::shape_deriv_ptr shape_deriv_ptr =
-    FEInterface::shape_deriv_function(2, map_fe_type, mapping_elem_type);
+    FEInterface::shape_deriv_function(map_fe_type, elem);
 
   for (int p = 0; p != 6; ++p)
     {
@@ -116,9 +113,9 @@ void clough_compute_coefs(const Elem * elem)
       for (int i = 0; i != n_mapping_shape_functions; ++i)
         {
           const Real ddxi = shape_deriv_ptr
-            (map_fe_type, elem, i, 0, dofpt[p], false);
+            (map_fe_type, elem, i, 0, dofpt[p], /*add_p_level=*/false);
           const Real ddeta = shape_deriv_ptr
-            (map_fe_type, elem, i, 1, dofpt[p], false);
+            (map_fe_type, elem, i, 1, dofpt[p], /*add_p_level=*/false);
 
           //      libMesh::err << ddxi << ' ';
           //      libMesh::err << ddeta << std::endl;

--- a/src/fe/fe_hermite_shape_2D.C
+++ b/src/fe/fe_hermite_shape_2D.C
@@ -37,8 +37,6 @@ void hermite_compute_coefs(const Elem * elem, std::vector<std::vector<Real>> & d
                            )
 {
   const FEFamily mapping_family = FEMap::map_fe_type(*elem);
-  const ElemType mapping_elem_type (elem->type());
-
   const FEType map_fe_type(elem->default_order(), mapping_family);
 
   // Note: we explicitly don't consider the elem->p_level() when
@@ -46,12 +44,10 @@ void hermite_compute_coefs(const Elem * elem, std::vector<std::vector<Real>> & d
   const int n_mapping_shape_functions =
     FEInterface::n_shape_functions (map_fe_type, /*extra_order=*/0, elem);
 
-  std::vector<Point> dofpt;
-  dofpt.push_back(Point(-1,-1));
-  dofpt.push_back(Point(1,1));
+  static const Point dofpt[2] = {Point(-1,-1), Point(1,1)};
 
   FEInterface::shape_deriv_ptr shape_deriv_ptr =
-    FEInterface::shape_deriv_function(2, map_fe_type, mapping_elem_type);
+    FEInterface::shape_deriv_function(map_fe_type, elem);
 
   for (int p = 0; p != 2; ++p)
     {
@@ -64,9 +60,9 @@ void hermite_compute_coefs(const Elem * elem, std::vector<std::vector<Real>> & d
       for (int i = 0; i != n_mapping_shape_functions; ++i)
         {
           const Real ddxi = shape_deriv_ptr
-            (map_fe_type, elem, i, 0, dofpt[p], false);
+            (map_fe_type, elem, i, 0, dofpt[p], /*add_p_level=*/false);
           const Real ddeta = shape_deriv_ptr
-            (map_fe_type, elem, i, 1, dofpt[p], false);
+            (map_fe_type, elem, i, 1, dofpt[p], /*add_p_level=*/false);
 
           dxdxi[0][p] += elem->point(i)(0) * ddxi;
           dxdxi[1][p] += elem->point(i)(1) * ddeta;

--- a/src/fe/fe_hermite_shape_3D.C
+++ b/src/fe/fe_hermite_shape_3D.C
@@ -39,7 +39,6 @@ void hermite_compute_coefs(const Elem * elem, std::vector<std::vector<Real>> & d
                            )
 {
   const FEFamily mapping_family = FEMap::map_fe_type(*elem);
-  const ElemType mapping_elem_type (elem->type());
   const FEType map_fe_type(elem->default_order(), mapping_family);
 
   // Note: we explicitly don't consider the elem->p_level() when
@@ -50,7 +49,7 @@ void hermite_compute_coefs(const Elem * elem, std::vector<std::vector<Real>> & d
   static const Point dofpt[2] = {Point(-1,-1,-1), Point(1,1,1)};
 
   FEInterface::shape_deriv_ptr shape_deriv_ptr =
-    FEInterface::shape_deriv_function(3, map_fe_type, mapping_elem_type);
+    FEInterface::shape_deriv_function(map_fe_type, elem);
 
   for (int p = 0; p != 2; ++p)
     {
@@ -68,11 +67,11 @@ void hermite_compute_coefs(const Elem * elem, std::vector<std::vector<Real>> & d
       for (int i = 0; i != n_mapping_shape_functions; ++i)
         {
           const Real ddxi = shape_deriv_ptr
-            (map_fe_type, elem, i, 0, dofpt[p], false);
+            (map_fe_type, elem, i, 0, dofpt[p], /*add_p_level=*/false);
           const Real ddeta = shape_deriv_ptr
-            (map_fe_type, elem, i, 1, dofpt[p], false);
+            (map_fe_type, elem, i, 1, dofpt[p], /*add_p_level=*/false);
           const Real ddzeta = shape_deriv_ptr
-            (map_fe_type, elem, i, 2, dofpt[p], false);
+            (map_fe_type, elem, i, 2, dofpt[p], /*add_p_level=*/false);
 
           // dxdeta, dxdzeta, dydxi, dydzeta, dzdxi, dzdeta should all
           // be 0!

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -1508,6 +1508,22 @@ FEInterface::shape_function(const unsigned int dim,
 }
 
 
+
+FEInterface::shape_ptr
+FEInterface::shape_function(const FEType & fe_t,
+                            const Elem * elem)
+{
+  // dim is needed by the fe_switch macros below
+  auto dim = elem->dim();
+
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+  if (is_InfFE_elem(elem->type()))
+    inf_fe_switch(shape);
+#endif
+  fe_switch(shape);
+}
+
+
 Real FEInterface::shape_deriv(const unsigned int dim,
                               const FEType & fe_t,
                               const ElemType t,

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -1855,12 +1855,31 @@ FEInterface::shape_second_deriv_function(const unsigned int dim,
                                          const FEType & fe_t,
                                          const ElemType libmesh_inf_var(t))
 {
+  // TODO
+  // libmesh_deprecated();
+
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   if (is_InfFE_elem(t))
     libmesh_not_implemented();
 #endif
   fe_switch(shape_second_deriv);
 }
+
+
+
+FEInterface::shape_second_deriv_ptr
+FEInterface::shape_second_deriv_function(const FEType & fe_t,
+                                         const Elem * elem)
+{
+  auto dim = elem->dim();
+
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+  if (is_InfFE_elem(elem->type()))
+    libmesh_not_implemented();
+#endif
+  fe_switch(shape_second_deriv);
+}
+
 #endif //LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -1668,8 +1668,29 @@ FEInterface::shape_deriv_function(const unsigned int dim,
                                   const FEType & fe_t,
                                   const ElemType libmesh_inf_var(t))
 {
+  // TODO
+  // libmesh_deprecated();
+
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   if (is_InfFE_elem(t))
+  {
+    inf_fe_switch(shape_deriv);
+  }
+#endif
+  fe_switch(shape_deriv);
+}
+
+
+
+FEInterface::shape_deriv_ptr
+FEInterface::shape_deriv_function(const FEType & fe_t,
+                                  const Elem * elem)
+{
+  // dim is needed by the fe_switch macros below
+  auto dim = elem->dim();
+
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+  if (is_InfFE_elem(elem->type()))
   {
     inf_fe_switch(shape_deriv);
   }

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -1707,6 +1707,9 @@ Real FEInterface::shape_second_deriv(const unsigned int dim,
                                      const unsigned int j,
                                      const Point & p)
 {
+  // TODO:
+  // libmesh_deprecated();
+
   libmesh_assert_greater_equal (dim*(dim-1),j);
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   if (is_InfFE_elem(t))
@@ -1739,6 +1742,9 @@ Real FEInterface::shape_second_deriv(const unsigned int dim,
                                      const unsigned int j,
                                      const Point & p)
 {
+  // TODO:
+  // libmesh_deprecated();
+
   libmesh_assert_greater_equal (dim*(dim-1),j);
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   if (elem->infinite())
@@ -1762,6 +1768,86 @@ Real FEInterface::shape_second_deriv(const unsigned int dim,
     }
   return 0;
 }
+
+
+
+Real FEInterface::shape_second_deriv(const FEType & fe_t,
+                                     const Elem * elem,
+                                     const unsigned int i,
+                                     const unsigned int j,
+                                     const Point & p)
+{
+  auto dim = elem->dim();
+
+  libmesh_assert_greater_equal (dim*(dim-1),j);
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+  if (is_InfFE_elem(elem->type()))
+    libmesh_not_implemented();
+#endif
+
+  // We are calling FE::shape_second_deriv() with the final argument
+  // == true so that the Elem::p_level() is accounted for
+  // automatically internally.
+  switch(dim)
+    {
+    case 0:
+      fe_family_switch (0, shape_second_deriv(elem, fe_t.order, i, j, p, true), return , ;);
+    case 1:
+      fe_family_switch (1, shape_second_deriv(elem, fe_t.order, i, j, p, true), return , ;);
+    case 2:
+      fe_family_switch (2, shape_second_deriv(elem, fe_t.order, i, j, p, true), return , ;);
+    case 3:
+      fe_family_switch (3, shape_second_deriv(elem, fe_t.order, i, j, p, true), return , ;);
+    default:
+      libmesh_error_msg("Invalid dimension = " << dim);
+    }
+
+  // We'll never get here
+  return 0;
+}
+
+
+
+Real FEInterface::shape_second_deriv(const FEType & fe_t,
+                                     int extra_order,
+                                     const Elem * elem,
+                                     const unsigned int i,
+                                     const unsigned int j,
+                                     const Point & p)
+{
+  auto dim = elem->dim();
+
+  libmesh_assert_greater_equal (dim*(dim-1),j);
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+  if (elem->infinite())
+    libmesh_not_implemented();
+#endif
+
+  // Ignore Elem::p_level() when computing total order, use
+  // extra_order instead.
+  auto total_order = static_cast<Order>(fe_t.order + extra_order);
+
+  // We are calling FE::shape_second_deriv() with the final argument
+  // == false so that the Elem::p_level() is ignored and the
+  // total_order we compute is used instead.
+  switch(dim)
+    {
+    case 0:
+      fe_family_switch (0, shape_second_deriv(elem, total_order, i, j, p, false), return , ;);
+    case 1:
+      fe_family_switch (1, shape_second_deriv(elem, total_order, i, j, p, false), return , ;);
+    case 2:
+      fe_family_switch (2, shape_second_deriv(elem, total_order, i, j, p, false), return , ;);
+    case 3:
+      fe_family_switch (3, shape_second_deriv(elem, total_order, i, j, p, false), return , ;);
+    default:
+      libmesh_error_msg("Invalid dimension = " << dim);
+    }
+
+  // We'll never get here
+  return 0;
+}
+
 
 
 FEInterface::shape_second_deriv_ptr

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -236,7 +236,7 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
   bool is_linear = elem->is_linear();
 
   FEInterface::shape_ptr shape_ptr =
-    FEInterface::shape_function(Dim, map_fe_type, mapping_elem_type);
+    FEInterface::shape_function(map_fe_type, elem);
 
   FEInterface::shape_deriv_ptr shape_deriv_ptr =
     FEInterface::shape_deriv_function(Dim, map_fe_type, mapping_elem_type);
@@ -2103,7 +2103,6 @@ Point FEMap::map (const unsigned int dim,
   Point p;
 
   const FEFamily mapping_family = FEMap::map_fe_type(*elem);
-  const ElemType type     = elem->type();
   const FEType fe_type (elem->default_order(), mapping_family);
 
   // Do not consider the Elem::p_level(), if any, when computing the
@@ -2111,7 +2110,7 @@ Point FEMap::map (const unsigned int dim,
   const unsigned int n_sf = FEInterface::n_shape_functions(fe_type, /*extra_order=*/0, elem);
 
   FEInterface::shape_ptr shape_ptr =
-    FEInterface::shape_function(dim, fe_type, type);
+    FEInterface::shape_function(fe_type, elem);
 
   // Lagrange basis functions are used for mapping
   for (unsigned int i=0; i<n_sf; i++)

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -122,7 +122,6 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
   // The element type and order to use in
   // the map
   const FEFamily mapping_family = FEMap::map_fe_type(*elem);
-  const ElemType mapping_elem_type (elem->type());
   const FEType map_fe_type(elem->default_order(), mapping_family);
 
   // Number of shape functions used to construct the map
@@ -243,7 +242,7 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   FEInterface::shape_second_deriv_ptr shape_second_deriv_ptr =
-    FEInterface::shape_second_deriv_function(Dim, map_fe_type, mapping_elem_type);
+    FEInterface::shape_second_deriv_function(map_fe_type, elem);
 #endif // ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
   switch (Dim)

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -2093,6 +2093,7 @@ Point FEMap::map (const unsigned int dim,
                   const Point & reference_point)
 {
   libmesh_assert(elem);
+  libmesh_ignore(dim);
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   if (elem->infinite())

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -239,7 +239,7 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
     FEInterface::shape_function(map_fe_type, elem);
 
   FEInterface::shape_deriv_ptr shape_deriv_ptr =
-    FEInterface::shape_deriv_function(Dim, map_fe_type, mapping_elem_type);
+    FEInterface::shape_deriv_function(map_fe_type, elem);
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   FEInterface::shape_second_deriv_ptr shape_second_deriv_ptr =
@@ -2128,6 +2128,7 @@ Point FEMap::map_deriv (const unsigned int dim,
                         const Point & reference_point)
 {
   libmesh_assert(elem);
+  libmesh_ignore(dim);
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   if (elem->infinite())
@@ -2137,7 +2138,6 @@ Point FEMap::map_deriv (const unsigned int dim,
   Point p;
 
   const FEFamily mapping_family = FEMap::map_fe_type(*elem);
-  const ElemType type     = elem->type();
   const FEType fe_type (elem->default_order(), mapping_family);
 
   // Do not consider the Elem::p_level(), if any, when computing the
@@ -2146,13 +2146,13 @@ Point FEMap::map_deriv (const unsigned int dim,
     FEInterface::n_shape_functions(fe_type, /*total_order=*/0, elem);
 
   FEInterface::shape_deriv_ptr shape_deriv_ptr =
-    FEInterface::shape_deriv_function(dim, fe_type, type);
+    FEInterface::shape_deriv_function(fe_type, elem);
 
   // Lagrange basis functions are used for mapping
   for (unsigned int i=0; i<n_sf; i++)
     p.add_scaled (elem->point(i),
                   shape_deriv_ptr(fe_type, elem, i, j, reference_point,
-                                  false));
+                                  /*add_p_level=*/false));
 
   return p;
 }

--- a/src/fe/fe_rational_shape_1D.C
+++ b/src/fe/fe_rational_shape_1D.C
@@ -119,11 +119,9 @@ Real FE<1,RATIONAL_BERNSTEIN>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   int extra_order = add_p_level * elem->p_level();
-  const Order totalorder = static_cast<Order>(order + extra_order);
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, _underlying_fe_family);
-  FEType p_refined_fe_type(totalorder, _underlying_fe_family);
 
   const unsigned int n_sf =
     FEInterface::n_shape_functions(fe_type, extra_order, elem);
@@ -146,7 +144,7 @@ Real FE<1,RATIONAL_BERNSTEIN>::shape_deriv(const Elem * elem,
       Real weighted_shape = node_weights[sf] *
         FEInterface::shape(fe_type, extra_order, elem, sf, p);
       Real weighted_grad = node_weights[sf] *
-        FEInterface::shape_deriv(1, p_refined_fe_type, elem, sf, 0, p);
+        FEInterface::shape_deriv(fe_type, extra_order, elem, sf, 0, p);
       weighted_sum += weighted_shape;
       weighted_grad_sum += weighted_grad;
       if (sf == i)
@@ -234,7 +232,7 @@ Real FE<1,RATIONAL_BERNSTEIN>::shape_second_deriv(const Elem * elem,
       Real weighted_shape = node_weights[sf] *
         FEInterface::shape(fe_type, extra_order, elem, sf, p);
       Real weighted_grad = node_weights[sf] *
-        FEInterface::shape_deriv(1, p_refined_fe_type, elem, sf, 0, p);
+        FEInterface::shape_deriv(fe_type, extra_order, elem, sf, 0, p);
       Real weighted_hess = node_weights[sf] *
         FEInterface::shape_second_deriv(1, p_refined_fe_type, elem, sf, 0, p);
       weighted_sum += weighted_shape;

--- a/src/fe/fe_rational_shape_1D.C
+++ b/src/fe/fe_rational_shape_1D.C
@@ -204,11 +204,9 @@ Real FE<1,RATIONAL_BERNSTEIN>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   int extra_order = add_p_level * elem->p_level();
-  const Order totalorder = static_cast<Order>(order + extra_order);
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, _underlying_fe_family);
-  FEType p_refined_fe_type(totalorder, _underlying_fe_family);
 
   const unsigned int n_sf =
     FEInterface::n_shape_functions(fe_type, extra_order, elem);
@@ -234,7 +232,7 @@ Real FE<1,RATIONAL_BERNSTEIN>::shape_second_deriv(const Elem * elem,
       Real weighted_grad = node_weights[sf] *
         FEInterface::shape_deriv(fe_type, extra_order, elem, sf, 0, p);
       Real weighted_hess = node_weights[sf] *
-        FEInterface::shape_second_deriv(1, p_refined_fe_type, elem, sf, 0, p);
+        FEInterface::shape_second_deriv(fe_type, extra_order, elem, sf, 0, p);
       weighted_sum += weighted_shape;
       weighted_grad_sum += weighted_grad;
       weighted_hess_sum += weighted_hess;

--- a/src/fe/fe_rational_shape_2D.C
+++ b/src/fe/fe_rational_shape_2D.C
@@ -115,11 +115,9 @@ Real FE<2,RATIONAL_BERNSTEIN>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   int extra_order = add_p_level * elem->p_level();
-  const Order totalorder = static_cast<Order>(order + extra_order);
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, _underlying_fe_family);
-  FEType p_refined_fe_type(totalorder, _underlying_fe_family);
 
   const unsigned int n_sf =
     FEInterface::n_shape_functions(fe_type, extra_order, elem);
@@ -142,7 +140,7 @@ Real FE<2,RATIONAL_BERNSTEIN>::shape_deriv(const Elem * elem,
       Real weighted_shape = node_weights[sf] *
         FEInterface::shape(fe_type, extra_order, elem, sf, p);
       Real weighted_grad = node_weights[sf] *
-        FEInterface::shape_deriv(2, p_refined_fe_type, elem, sf, j, p);
+        FEInterface::shape_deriv(fe_type, extra_order, elem, sf, j, p);
       weighted_sum += weighted_shape;
       weighted_grad_sum += weighted_grad;
       if (sf == i)
@@ -247,7 +245,7 @@ Real FE<2,RATIONAL_BERNSTEIN>::shape_second_deriv(const Elem * elem,
       Real weighted_shape = node_weights[sf] *
         FEInterface::shape(fe_type, extra_order, elem, sf, p);
       Real weighted_grada = node_weights[sf] *
-        FEInterface::shape_deriv(2, p_refined_fe_type, elem, sf, j1, p);
+        FEInterface::shape_deriv(fe_type, extra_order, elem, sf, j1, p);
       Real weighted_hess = node_weights[sf] *
         FEInterface::shape_second_deriv(2, p_refined_fe_type, elem, sf, j, p);
       weighted_sum += weighted_shape;
@@ -257,7 +255,7 @@ Real FE<2,RATIONAL_BERNSTEIN>::shape_second_deriv(const Elem * elem,
         {
           weighted_gradb = (j1 == j2) ? weighted_grada :
             node_weights[sf] *
-             FEInterface::shape_deriv(2, p_refined_fe_type, elem, sf, j2, p);
+            FEInterface::shape_deriv(fe_type, extra_order, elem, sf, j2, p);
           weighted_grada_sum += weighted_grada;
         }
       weighted_hess_sum += weighted_hess;

--- a/src/fe/fe_rational_shape_2D.C
+++ b/src/fe/fe_rational_shape_2D.C
@@ -216,11 +216,9 @@ Real FE<2,RATIONAL_BERNSTEIN>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   int extra_order = add_p_level * elem->p_level();
-  const Order totalorder = static_cast<Order>(order + extra_order);
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, _underlying_fe_family);
-  FEType p_refined_fe_type(totalorder, _underlying_fe_family);
 
   const unsigned int n_sf =
     FEInterface::n_shape_functions(fe_type, extra_order, elem);
@@ -247,7 +245,7 @@ Real FE<2,RATIONAL_BERNSTEIN>::shape_second_deriv(const Elem * elem,
       Real weighted_grada = node_weights[sf] *
         FEInterface::shape_deriv(fe_type, extra_order, elem, sf, j1, p);
       Real weighted_hess = node_weights[sf] *
-        FEInterface::shape_second_deriv(2, p_refined_fe_type, elem, sf, j, p);
+        FEInterface::shape_second_deriv(fe_type, extra_order, elem, sf, j, p);
       weighted_sum += weighted_shape;
       weighted_grada_sum += weighted_grada;
       Real weighted_gradb = weighted_grada;

--- a/src/fe/fe_rational_shape_3D.C
+++ b/src/fe/fe_rational_shape_3D.C
@@ -113,11 +113,9 @@ Real FE<3,RATIONAL_BERNSTEIN>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   int extra_order = add_p_level * elem->p_level();
-  const Order totalorder = static_cast<Order>(order + extra_order);
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, _underlying_fe_family);
-  FEType p_refined_fe_type(totalorder, _underlying_fe_family);
 
   const unsigned int n_sf =
     FEInterface::n_shape_functions(fe_type, extra_order, elem);
@@ -140,7 +138,7 @@ Real FE<3,RATIONAL_BERNSTEIN>::shape_deriv(const Elem * elem,
       Real weighted_shape = node_weights[sf] *
         FEInterface::shape(fe_type, extra_order, elem, sf, p);
       Real weighted_grad = node_weights[sf] *
-        FEInterface::shape_deriv(3, p_refined_fe_type, elem, sf, j, p);
+        FEInterface::shape_deriv(fe_type, extra_order, elem, sf, j, p);
       weighted_sum += weighted_shape;
       weighted_grad_sum += weighted_grad;
       if (sf == i)
@@ -257,7 +255,7 @@ Real FE<3,RATIONAL_BERNSTEIN>::shape_second_deriv(const Elem * elem,
       Real weighted_shape = node_weights[sf] *
         FEInterface::shape(fe_type, extra_order, elem, sf, p);
       Real weighted_grada = node_weights[sf] *
-        FEInterface::shape_deriv(3, p_refined_fe_type, elem, sf, j1, p);
+        FEInterface::shape_deriv(fe_type, extra_order, elem, sf, j1, p);
       Real weighted_hess = node_weights[sf] *
         FEInterface::shape_second_deriv(3, p_refined_fe_type, elem, sf, j, p);
       weighted_sum += weighted_shape;
@@ -267,7 +265,7 @@ Real FE<3,RATIONAL_BERNSTEIN>::shape_second_deriv(const Elem * elem,
         {
           weighted_gradb = (j1 == j2) ? weighted_grada :
             node_weights[sf] *
-             FEInterface::shape_deriv(3, p_refined_fe_type, elem, sf, j2, p);
+            FEInterface::shape_deriv(fe_type, extra_order, elem, sf, j2, p);
           weighted_grada_sum += weighted_grada;
         }
       weighted_hess_sum += weighted_hess;

--- a/src/fe/fe_rational_shape_3D.C
+++ b/src/fe/fe_rational_shape_3D.C
@@ -226,11 +226,9 @@ Real FE<3,RATIONAL_BERNSTEIN>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   int extra_order = add_p_level * elem->p_level();
-  const Order totalorder = static_cast<Order>(order + extra_order);
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, _underlying_fe_family);
-  FEType p_refined_fe_type(totalorder, _underlying_fe_family);
 
   const unsigned int n_sf =
     FEInterface::n_shape_functions(fe_type, extra_order, elem);
@@ -257,7 +255,7 @@ Real FE<3,RATIONAL_BERNSTEIN>::shape_second_deriv(const Elem * elem,
       Real weighted_grada = node_weights[sf] *
         FEInterface::shape_deriv(fe_type, extra_order, elem, sf, j1, p);
       Real weighted_hess = node_weights[sf] *
-        FEInterface::shape_second_deriv(3, p_refined_fe_type, elem, sf, j, p);
+        FEInterface::shape_second_deriv(fe_type, extra_order, elem, sf, j, p);
       weighted_sum += weighted_shape;
       weighted_grada_sum += weighted_grada;
       Real weighted_gradb = weighted_grada;

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -359,7 +359,7 @@ Real InfFE<Dim,T_radial,T_map>::shape_deriv (const FEType & fe_t,
 
       return FEInterface::shape(fe_t, base_el.get(), i_base, p)*RadialDeriv;
     }
-  return FEInterface::shape_deriv(Dim-1, fe_t, base_el.get(), i_base, j, p)
+  return FEInterface::shape_deriv(fe_t, base_el.get(), i_base, j, p)
     * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
     * InfFERadial::decay(Dim,v);
 }
@@ -512,14 +512,14 @@ void InfFE<Dim,T_radial,T_map>::compute_data(const FEType & fet,
           if (data.need_derivative())
             {
               data.dshape[i](0)     = (InfFERadial::decay(Dim,v)
-                                       * FEInterface::shape_deriv(Dim-1, fet, base_el.get(), i_base, 0, p)
+                                       * FEInterface::shape_deriv(fet, base_el.get(), i_base, 0, p)
                                        * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial))
                                        * time_harmonic;
 
               if (Dim > 2)
                 {
                   data.dshape[i](1)   = (InfFERadial::decay(Dim,v)
-                                         * FEInterface::shape_deriv(Dim-1, fet, base_el.get(), i_base, 1, p)
+                                         * FEInterface::shape_deriv(fet, base_el.get(), i_base, 1, p)
                                          * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial))
                                          * time_harmonic;
 


### PR DESCRIPTION
I added a few `\todos` on FEInterface APIs we should eventually update to do away with the unnecessary `dim` arg, but didn't go for a full-blown deprecation of these since they did not otherwise have confusing/easy to misuse `p_level()` behavior. My preference would be to simply update those APIs in a backwards-incompatible way at some point, possibly after a new release is tagged.

Still remaining: extend the refactoring to cover the related `InfFE` APIs.
