### PR TITLE
parmetis.m4: Fix potential uninitialized variable

### DIFF
--- a/configure
+++ b/configure
@@ -37667,6 +37667,10 @@ fi
 
       if test "x$enableparmetis" = "xyes"; then :
 
+                              if test "x$petsc_have_parmetis" = "x"; then :
+  petsc_have_parmetis=0
+fi
+
 
                     if test "x$build_metis" = "xpetsc" && test $petsc_have_parmetis -gt 0; then :
 

--- a/m4/parmetis.m4
+++ b/m4/parmetis.m4
@@ -19,6 +19,10 @@ AC_DEFUN([CONFIGURE_PARMETIS],
   dnl where it might be installed...
   AS_IF([test "x$enableparmetis" = "xyes"],
         [
+          dnl Initialize $petsc_have_parmetis to 0 if not already set. It may be unset
+          dnl if the user configured with --disable-petsc
+          AS_IF([test "x$petsc_have_parmetis" = "x"], [petsc_have_parmetis=0])
+
           dnl We consider 4 different combinations of METIS/ParMETIS support in PETSc.
 
           dnl Case A: PETSc is built with both METIS and ParMETIS support. In this case we use both.


### PR DESCRIPTION
I ran across this issue while trying to enable internal Parmetis in a PETSc-disabled build.
