### PR TITLE
Side objects should set interior_parent(), not parent()

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -2308,7 +2308,10 @@ Elem::simple_build_side_ptr (const unsigned int i,
         face->set_node(n) = this->node_ptr(Subclass::side_nodes_map[i][n]);
     }
 
-  face->set_parent(nullptr);
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  if (!proxy) // proxy sides used to leave parent() set
+#endif
+    face->set_parent(nullptr);
   face->set_interior_parent(this);
 
   return face;

--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -639,7 +639,7 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
 
         // We need to look back at the full edge to figure out the normal
         // vector
-        const Elem * elem = side->parent();
+        const Elem * elem = side->interior_parent();
         libmesh_assert (elem);
         if (calculate_dxyz)
           {
@@ -755,7 +755,7 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
                 // For a 2D element living in 3D, there is a second tangent.
                 // For the second tangent, we need to refer to the full
                 // element's (not just the edge's) Jacobian.
-                const Elem * elem = side->parent();
+                const Elem * elem = side->interior_parent();
                 libmesh_assert(elem);
 
                 // Inverse map xyz[p] to a reference point on the parent...

--- a/src/fe/inf_fe_boundary.C
+++ b/src/fe/inf_fe_boundary.C
@@ -171,7 +171,7 @@ void InfFE<Dim,T_radial,T_base>::init_face_shape_functions(const std::vector<Poi
     this->update_base_elem(inf_side);
   else
     // in this case, I need the 2D base
-    this->update_base_elem(inf_side->parent());
+    this->update_base_elem(inf_side->interior_parent());
 
   // Initialize the base quadrature rule
   base_qrule->init(base_elem->type(), inf_side->p_level());

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -184,23 +184,7 @@ Order Hex20::default_order() const
 std::unique_ptr<Elem> Hex20::build_side_ptr (const unsigned int i,
                                              bool proxy )
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (proxy)
-    return libmesh_make_unique<Side<Quad8,Hex20>>(this,i);
-
-  else
-    {
-      std::unique_ptr<Elem> face = libmesh_make_unique<Quad8>();
-      face->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      face->set_p_level(this->p_level());
-#endif
-      for (auto n : face->node_index_range())
-        face->set_node(n) = this->node_ptr(Hex20::side_nodes_map[i][n]);
-
-      return face;
-    }
+  return this->simple_build_side_ptr<Quad8, Hex20>(i, proxy);
 }
 
 

--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -264,23 +264,7 @@ unsigned int Hex27::local_edge_node(unsigned int edge,
 std::unique_ptr<Elem> Hex27::build_side_ptr (const unsigned int i,
                                              bool proxy)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (proxy)
-    return libmesh_make_unique<Side<Quad9,Hex27>>(this,i);
-
-  else
-    {
-      std::unique_ptr<Elem> face = libmesh_make_unique<Quad9>();
-      face->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      face->set_p_level(this->p_level());
-#endif
-      for (auto n : face->node_index_range())
-        face->set_node(n) = this->node_ptr(Hex27::side_nodes_map[i][n]);
-
-      return face;
-    }
+  return this->simple_build_side_ptr<Quad9, Hex27>(i, proxy);
 }
 
 

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -161,23 +161,7 @@ Order Hex8::default_order() const
 std::unique_ptr<Elem> Hex8::build_side_ptr (const unsigned int i,
                                             bool proxy)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (proxy)
-    return libmesh_make_unique<Side<Quad4,Hex8>>(this,i);
-
-  else
-    {
-      std::unique_ptr<Elem> face = libmesh_make_unique<Quad4>();
-      face->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      face->set_p_level(this->p_level());
-#endif
-      for (auto n : face->node_index_range())
-        face->set_node(n) = this->node_ptr(Hex8::side_nodes_map[i][n]);
-
-      return face;
-    }
+  return this->simple_build_side_ptr<Quad4, Hex8>(i, proxy);
 }
 
 

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -239,7 +239,10 @@ std::unique_ptr<Elem> InfHex16::build_side_ptr (const unsigned int i,
         face->set_node(n) = this->node_ptr(InfHex16::side_nodes_map[i][n]);
     }
 
-  face->set_parent(nullptr);
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  if (!proxy) // proxy sides used to leave parent() set
+#endif
+    face->set_parent(nullptr);
   face->set_interior_parent(this);
 
   return face;

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -181,20 +181,27 @@ std::unique_ptr<Elem> InfHex16::build_side_ptr (const unsigned int i,
 {
   libmesh_assert_less (i, this->n_sides());
 
+  std::unique_ptr<Elem> face;
   if (proxy)
     {
       switch (i)
         {
           // base
         case 0:
-          return libmesh_make_unique<Side<Quad8,InfHex16>>(this,i);
+          {
+            face = libmesh_make_unique<Side<Quad8,InfHex16>>(this,i);
+            break;
+          }
 
           // ifem sides
         case 1:
         case 2:
         case 3:
         case 4:
-          return libmesh_make_unique<Side<InfQuad6,InfHex16>>(this,i);
+          {
+            face = libmesh_make_unique<Side<InfQuad6,InfHex16>>(this,i);
+            break;
+          }
 
         default:
           libmesh_error_msg("Invalid side i = " << i);
@@ -203,16 +210,13 @@ std::unique_ptr<Elem> InfHex16::build_side_ptr (const unsigned int i,
 
   else
     {
-      // Return value
-      std::unique_ptr<Elem> face;
-
       // Think of a unit cube: (-1,1) x (-1,1) x (1,1)
       switch (i)
         {
           // the base face
         case 0:
           {
-            face = libmesh_make_unique<Quad8>();
+            face = libmesh_make_unique<Quad8>(this);
             break;
           }
 
@@ -222,7 +226,7 @@ std::unique_ptr<Elem> InfHex16::build_side_ptr (const unsigned int i,
         case 3:
         case 4:
           {
-            face = libmesh_make_unique<InfQuad6>();
+            face = libmesh_make_unique<InfQuad6>(this);
             break;
           }
 
@@ -230,16 +234,15 @@ std::unique_ptr<Elem> InfHex16::build_side_ptr (const unsigned int i,
           libmesh_error_msg("Invalid side i = " << i);
         }
 
-      face->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      face->set_p_level(this->p_level());
-#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(InfHex16::side_nodes_map[i][n]);
-
-      return face;
     }
+
+  face->set_parent(nullptr);
+  face->set_interior_parent(this);
+
+  return face;
 }
 
 

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -259,7 +259,10 @@ std::unique_ptr<Elem> InfHex18::build_side_ptr (const unsigned int i,
         face->set_node(n) = this->node_ptr(InfHex18::side_nodes_map[i][n]);
     }
 
-  face->set_parent(nullptr);
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  if (!proxy) // proxy sides used to leave parent() set
+#endif
+    face->set_parent(nullptr);
   face->set_interior_parent(this);
 
   return face;

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -202,20 +202,27 @@ std::unique_ptr<Elem> InfHex18::build_side_ptr (const unsigned int i,
 {
   libmesh_assert_less (i, this->n_sides());
 
+  std::unique_ptr<Elem> face;
   if (proxy)
     {
       switch (i)
         {
           // base
         case 0:
-          return libmesh_make_unique<Side<Quad9,InfHex18>>(this,i);
+          {
+            face = libmesh_make_unique<Side<Quad9,InfHex18>>(this,i);
+            break;
+          }
 
           // ifem sides
         case 1:
         case 2:
         case 3:
         case 4:
-          return libmesh_make_unique<Side<InfQuad6,InfHex18>>(this,i);
+          {
+            face = libmesh_make_unique<Side<InfQuad6,InfHex18>>(this,i);
+            break;
+          }
 
         default:
           libmesh_error_msg("Invalid side i = " << i);
@@ -224,16 +231,13 @@ std::unique_ptr<Elem> InfHex18::build_side_ptr (const unsigned int i,
 
   else
     {
-      // Return value
-      std::unique_ptr<Elem> face;
-
       // Think of a unit cube: (-1,1) x (-1,1) x (1,1)
       switch (i)
         {
           // the base face
         case 0:
           {
-            face = libmesh_make_unique<Quad9>();
+            face = libmesh_make_unique<Quad9>(this);
             break;
           }
 
@@ -243,7 +247,7 @@ std::unique_ptr<Elem> InfHex18::build_side_ptr (const unsigned int i,
         case 3:
         case 4:
           {
-            face = libmesh_make_unique<InfQuad6>();
+            face = libmesh_make_unique<InfQuad6>(this);
             break;
           }
 
@@ -251,16 +255,14 @@ std::unique_ptr<Elem> InfHex18::build_side_ptr (const unsigned int i,
           libmesh_error_msg("Invalid side i = " << i);
         }
 
-      face->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      face->set_p_level(this->p_level());
-#endif
-      // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(InfHex18::side_nodes_map[i][n]);
-
-      return face;
     }
+
+  face->set_parent(nullptr);
+  face->set_interior_parent(this);
+
+  return face;
 }
 
 

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -145,20 +145,27 @@ std::unique_ptr<Elem> InfHex8::build_side_ptr (const unsigned int i,
 {
   libmesh_assert_less (i, this->n_sides());
 
+  std::unique_ptr<Elem> face;
   if (proxy)
     {
       switch (i)
         {
           // base
         case 0:
-          return libmesh_make_unique<Side<Quad4,InfHex8>>(this,i);
+          {
+            face = libmesh_make_unique<Side<Quad4,InfHex8>>(this,i);
+            break;
+          }
 
           // ifem sides
         case 1:
         case 2:
         case 3:
         case 4:
-          return libmesh_make_unique<Side<InfQuad4,InfHex8>>(this,i);
+          {
+            face = libmesh_make_unique<Side<InfQuad4,InfHex8>>(this,i);
+            break;
+          }
 
         default:
           libmesh_error_msg("Invalid side i = " << i);
@@ -167,9 +174,6 @@ std::unique_ptr<Elem> InfHex8::build_side_ptr (const unsigned int i,
 
   else
     {
-      // Return value
-      std::unique_ptr<Elem> face;
-
       // Think of a unit cube: (-1,1) x (-1,1) x (1,1)
       switch (i)
         {
@@ -193,16 +197,15 @@ std::unique_ptr<Elem> InfHex8::build_side_ptr (const unsigned int i,
           libmesh_error_msg("Invalid side i = " << i);
         }
 
-      face->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      face->set_p_level(this->p_level());
-#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(InfHex8::side_nodes_map[i][n]);
-
-      return face;
     }
+
+  face->set_parent(nullptr);
+  face->set_interior_parent(this);
+
+  return face;
 }
 
 

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -202,7 +202,10 @@ std::unique_ptr<Elem> InfHex8::build_side_ptr (const unsigned int i,
         face->set_node(n) = this->node_ptr(InfHex8::side_nodes_map[i][n]);
     }
 
-  face->set_parent(nullptr);
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  if (!proxy) // proxy sides used to leave parent() set
+#endif
+    face->set_parent(nullptr);
   face->set_interior_parent(this);
 
   return face;

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -175,19 +175,26 @@ std::unique_ptr<Elem> InfPrism12::build_side_ptr (const unsigned int i,
 {
   libmesh_assert_less (i, this->n_sides());
 
+  std::unique_ptr<Elem> face;
   if (proxy)
     {
       switch (i)
         {
           // base
         case 0:
-          return libmesh_make_unique<Side<Tri6,InfPrism12>>(this,i);
+          {
+            face = libmesh_make_unique<Side<Tri6,InfPrism12>>(this,i);
+            break;
+          }
 
           // ifem sides
         case 1:
         case 2:
         case 3:
-          return libmesh_make_unique<Side<InfQuad6,InfPrism12>>(this,i);
+          {
+            face = libmesh_make_unique<Side<InfQuad6,InfPrism12>>(this,i);
+            break;
+          }
 
         default:
           libmesh_error_msg("Invalid side i = " << i);
@@ -196,9 +203,6 @@ std::unique_ptr<Elem> InfPrism12::build_side_ptr (const unsigned int i,
 
   else
     {
-      // Return value
-      std::unique_ptr<Elem> face;
-
       switch (i)
         {
         case 0: // the triangular face at z=-1, base face
@@ -219,16 +223,15 @@ std::unique_ptr<Elem> InfPrism12::build_side_ptr (const unsigned int i,
           libmesh_error_msg("Invalid side i = " << i);
         }
 
-      face->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      face->set_p_level(this->p_level());
-#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(InfPrism12::side_nodes_map[i][n]);
-
-      return face;
     }
+
+  face->set_parent(nullptr);
+  face->set_interior_parent(this);
+
+  return face;
 }
 
 

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -228,7 +228,10 @@ std::unique_ptr<Elem> InfPrism12::build_side_ptr (const unsigned int i,
         face->set_node(n) = this->node_ptr(InfPrism12::side_nodes_map[i][n]);
     }
 
-  face->set_parent(nullptr);
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  if (!proxy) // proxy sides used to leave parent() set
+#endif
+    face->set_parent(nullptr);
   face->set_interior_parent(this);
 
   return face;

--- a/src/geom/cell_inf_prism6.C
+++ b/src/geom/cell_inf_prism6.C
@@ -201,7 +201,10 @@ std::unique_ptr<Elem> InfPrism6::build_side_ptr (const unsigned int i,
         face->set_node(n) = this->node_ptr(InfPrism6::side_nodes_map[i][n]);
     }
 
-  face->set_parent(nullptr);
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  if (!proxy) // proxy sides used to leave parent() set
+#endif
+    face->set_parent(nullptr);
   face->set_interior_parent(this);
 
   return face;

--- a/src/geom/cell_inf_prism6.C
+++ b/src/geom/cell_inf_prism6.C
@@ -148,19 +148,26 @@ std::unique_ptr<Elem> InfPrism6::build_side_ptr (const unsigned int i,
 {
   libmesh_assert_less (i, this->n_sides());
 
+  std::unique_ptr<Elem> face;
   if (proxy)
     {
       switch (i)
         {
           // base
         case 0:
-          return libmesh_make_unique<Side<Tri3,InfPrism6>>(this,i);
+          {
+            face = libmesh_make_unique<Side<Tri3,InfPrism6>>(this,i);
+            break;
+          }
 
           // ifem sides
         case 1:
         case 2:
         case 3:
-          return libmesh_make_unique<Side<InfQuad4,InfPrism6>>(this,i);
+          {
+            face = libmesh_make_unique<Side<InfQuad4,InfPrism6>>(this,i);
+            break;
+          }
 
         default:
           libmesh_error_msg("Invalid side i = " << i);
@@ -169,9 +176,6 @@ std::unique_ptr<Elem> InfPrism6::build_side_ptr (const unsigned int i,
 
   else
     {
-      // Return value
-      std::unique_ptr<Elem> face;
-
       switch (i)
         {
         case 0: // the triangular face at z=-1, base face
@@ -192,16 +196,15 @@ std::unique_ptr<Elem> InfPrism6::build_side_ptr (const unsigned int i,
           libmesh_error_msg("Invalid side i = " << i);
         }
 
-      face->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      face->set_p_level(this->p_level());
-#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(InfPrism6::side_nodes_map[i][n]);
-
-      return face;
     }
+
+  face->set_parent(nullptr);
+  face->set_interior_parent(this);
+
+  return face;
 }
 
 

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -251,7 +251,10 @@ std::unique_ptr<Elem> Prism15::build_side_ptr (const unsigned int i,
         face->set_node(n) = this->node_ptr(Prism15::side_nodes_map[i][n]);
     }
 
-  face->set_parent(nullptr);
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  if (!proxy) // proxy sides used to leave parent() set
+#endif
+    face->set_parent(nullptr);
   face->set_interior_parent(this);
 
   return face;

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -200,18 +200,25 @@ std::unique_ptr<Elem> Prism15::build_side_ptr (const unsigned int i,
 {
   libmesh_assert_less (i, this->n_sides());
 
+  std::unique_ptr<Elem> face;
   if (proxy)
     {
       switch (i)
         {
         case 0:  // the triangular face at z=-1
         case 4:
-          return libmesh_make_unique<Side<Tri6,Prism15>>(this,i);
+          {
+            face = libmesh_make_unique<Side<Tri6,Prism15>>(this,i);
+            break;
+          }
 
         case 1:
         case 2:
         case 3:
-          return libmesh_make_unique<Side<Quad8,Prism15>>(this,i);
+          {
+            face = libmesh_make_unique<Side<Quad8,Prism15>>(this,i);
+            break;
+          }
 
         default:
           libmesh_error_msg("Invalid side i = " << i);
@@ -220,9 +227,6 @@ std::unique_ptr<Elem> Prism15::build_side_ptr (const unsigned int i,
 
   else
     {
-      // Return value
-      std::unique_ptr<Elem> face;
-
       switch (i)
         {
         case 0: // the triangular face at z=-1
@@ -242,16 +246,15 @@ std::unique_ptr<Elem> Prism15::build_side_ptr (const unsigned int i,
           libmesh_error_msg("Invalid side i = " << i);
         }
 
-      face->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      face->set_p_level(this->p_level());
-#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Prism15::side_nodes_map[i][n]);
-
-      return face;
     }
+
+  face->set_parent(nullptr);
+  face->set_interior_parent(this);
+
+  return face;
 }
 
 

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -239,18 +239,25 @@ std::unique_ptr<Elem> Prism18::build_side_ptr (const unsigned int i,
 {
   libmesh_assert_less (i, this->n_sides());
 
+  std::unique_ptr<Elem> face;
   if (proxy)
     {
       switch(i)
         {
         case 0:
         case 4:
-          return libmesh_make_unique<Side<Tri6,Prism18>>(this,i);
+          {
+            face = libmesh_make_unique<Side<Tri6,Prism18>>(this,i);
+            break;
+          }
 
         case 1:
         case 2:
         case 3:
-          return libmesh_make_unique<Side<Quad9,Prism18>>(this,i);
+          {
+            face = libmesh_make_unique<Side<Quad9,Prism18>>(this,i);
+            break;
+          }
 
         default:
           libmesh_error_msg("Invalid side i = " << i);
@@ -259,9 +266,6 @@ std::unique_ptr<Elem> Prism18::build_side_ptr (const unsigned int i,
 
   else
     {
-      // Return value
-      std::unique_ptr<Elem> face;
-
       switch (i)
         {
         case 0: // the triangular face at z=-1
@@ -281,16 +285,15 @@ std::unique_ptr<Elem> Prism18::build_side_ptr (const unsigned int i,
           libmesh_error_msg("Invalid side i = " << i);
         }
 
-      face->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      face->set_p_level(this->p_level());
-#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Prism18::side_nodes_map[i][n]);
-
-      return face;
     }
+
+  face->set_parent(nullptr);
+  face->set_interior_parent(this);
+
+  return face;
 }
 
 

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -290,7 +290,10 @@ std::unique_ptr<Elem> Prism18::build_side_ptr (const unsigned int i,
         face->set_node(n) = this->node_ptr(Prism18::side_nodes_map[i][n]);
     }
 
-  face->set_parent(nullptr);
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  if (!proxy) // proxy sides used to leave parent() set
+#endif
+    face->set_parent(nullptr);
   face->set_interior_parent(this);
 
   return face;

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -211,7 +211,10 @@ std::unique_ptr<Elem> Prism6::build_side_ptr (const unsigned int i,
         face->set_node(n) = this->node_ptr(Prism6::side_nodes_map[i][n]);
     }
 
-  face->set_parent(nullptr);
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  if (!proxy) // proxy sides used to leave parent() set
+#endif
+    face->set_parent(nullptr);
   face->set_interior_parent(this);
 
   return face;

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -160,18 +160,25 @@ std::unique_ptr<Elem> Prism6::build_side_ptr (const unsigned int i,
 {
   libmesh_assert_less (i, this->n_sides());
 
+  std::unique_ptr<Elem> face;
   if (proxy)
     {
       switch(i)
         {
         case 0:
         case 4:
-          return libmesh_make_unique<Side<Tri3,Prism6>>(this,i);
+          {
+            face = libmesh_make_unique<Side<Tri3,Prism6>>(this,i);
+            break;
+          }
 
         case 1:
         case 2:
         case 3:
-          return libmesh_make_unique<Side<Quad4,Prism6>>(this,i);
+          {
+            face = libmesh_make_unique<Side<Quad4,Prism6>>(this,i);
+            break;
+          }
 
         default:
           libmesh_error_msg("Invalid side i = " << i);
@@ -180,9 +187,6 @@ std::unique_ptr<Elem> Prism6::build_side_ptr (const unsigned int i,
 
   else
     {
-      // Return value
-      std::unique_ptr<Elem> face;
-
       switch (i)
         {
         case 0: // the triangular face at z=-1
@@ -202,16 +206,15 @@ std::unique_ptr<Elem> Prism6::build_side_ptr (const unsigned int i,
           libmesh_error_msg("Invalid side i = " << i);
         }
 
-      face->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      face->set_p_level(this->p_level());
-#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Prism6::side_nodes_map[i][n]);
-
-      return face;
     }
+
+  face->set_parent(nullptr);
+  face->set_interior_parent(this);
+
+  return face;
 }
 
 

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -183,6 +183,7 @@ std::unique_ptr<Elem> Pyramid13::build_side_ptr (const unsigned int i, bool prox
 {
   libmesh_assert_less (i, this->n_sides());
 
+  std::unique_ptr<Elem> face;
   if (proxy)
     {
       switch (i)
@@ -191,10 +192,16 @@ std::unique_ptr<Elem> Pyramid13::build_side_ptr (const unsigned int i, bool prox
         case 1:
         case 2:
         case 3:
-          return libmesh_make_unique<Side<Tri6,Pyramid13>>(this,i);
+          {
+            face = libmesh_make_unique<Side<Tri6,Pyramid13>>(this,i);
+            break;
+          }
 
         case 4:
-          return libmesh_make_unique<Side<Quad8,Pyramid13>>(this,i);
+          {
+            face = libmesh_make_unique<Side<Quad8,Pyramid13>>(this,i);
+            break;
+          }
 
         default:
           libmesh_error_msg("Invalid side i = " << i);
@@ -203,9 +210,6 @@ std::unique_ptr<Elem> Pyramid13::build_side_ptr (const unsigned int i, bool prox
 
   else
     {
-      // Return value
-      std::unique_ptr<Elem> face;
-
       switch (i)
         {
         case 0: // triangular face 1
@@ -225,16 +229,15 @@ std::unique_ptr<Elem> Pyramid13::build_side_ptr (const unsigned int i, bool prox
           libmesh_error_msg("Invalid side i = " << i);
         }
 
-      face->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      face->set_p_level(this->p_level());
-#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Pyramid13::side_nodes_map[i][n]);
-
-      return face;
     }
+
+  face->set_parent(nullptr);
+  face->set_interior_parent(this);
+
+  return face;
 }
 
 

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -234,7 +234,10 @@ std::unique_ptr<Elem> Pyramid13::build_side_ptr (const unsigned int i, bool prox
         face->set_node(n) = this->node_ptr(Pyramid13::side_nodes_map[i][n]);
     }
 
-  face->set_parent(nullptr);
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  if (!proxy) // proxy sides used to leave parent() set
+#endif
+    face->set_parent(nullptr);
   face->set_interior_parent(this);
 
   return face;

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -260,7 +260,10 @@ std::unique_ptr<Elem> Pyramid14::build_side_ptr (const unsigned int i, bool prox
         face->set_node(n) = this->node_ptr(Pyramid14::side_nodes_map[i][n]);
     }
 
-  face->set_parent(nullptr);
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  if (!proxy) // proxy sides used to leave parent() set
+#endif
+    face->set_parent(nullptr);
   face->set_interior_parent(this);
 
   return face;

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -209,6 +209,7 @@ std::unique_ptr<Elem> Pyramid14::build_side_ptr (const unsigned int i, bool prox
 {
   libmesh_assert_less (i, this->n_sides());
 
+  std::unique_ptr<Elem> face;
   if (proxy)
     {
       switch (i)
@@ -217,10 +218,16 @@ std::unique_ptr<Elem> Pyramid14::build_side_ptr (const unsigned int i, bool prox
         case 1:
         case 2:
         case 3:
-          return libmesh_make_unique<Side<Tri6,Pyramid14>>(this,i);
+          {
+            face = libmesh_make_unique<Side<Tri6,Pyramid14>>(this,i);
+            break;
+          }
 
         case 4:
-          return libmesh_make_unique<Side<Quad9,Pyramid14>>(this,i);
+          {
+            face = libmesh_make_unique<Side<Quad9,Pyramid14>>(this,i);
+            break;
+          }
 
         default:
           libmesh_error_msg("Invalid side i = " << i);
@@ -229,9 +236,6 @@ std::unique_ptr<Elem> Pyramid14::build_side_ptr (const unsigned int i, bool prox
 
   else
     {
-      // Return value
-      std::unique_ptr<Elem> face;
-
       switch (i)
         {
         case 0: // triangular face 1
@@ -251,16 +255,15 @@ std::unique_ptr<Elem> Pyramid14::build_side_ptr (const unsigned int i, bool prox
           libmesh_error_msg("Invalid side i = " << i);
         }
 
-      face->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      face->set_p_level(this->p_level());
-#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Pyramid14::side_nodes_map[i][n]);
-
-      return face;
     }
+
+  face->set_parent(nullptr);
+  face->set_interior_parent(this);
+
+  return face;
 }
 
 

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -148,6 +148,7 @@ std::unique_ptr<Elem> Pyramid5::build_side_ptr (const unsigned int i,
 {
   libmesh_assert_less (i, this->n_sides());
 
+  std::unique_ptr<Elem> face;
   if (proxy)
     {
       switch (i)
@@ -156,10 +157,16 @@ std::unique_ptr<Elem> Pyramid5::build_side_ptr (const unsigned int i,
         case 1:
         case 2:
         case 3:
-          return libmesh_make_unique<Side<Tri3,Pyramid5>>(this,i);
+          {
+            face = libmesh_make_unique<Side<Tri3,Pyramid5>>(this,i);
+            break;
+          }
 
         case 4:
-          return libmesh_make_unique<Side<Quad4,Pyramid5>>(this,i);
+          {
+            face = libmesh_make_unique<Side<Quad4,Pyramid5>>(this,i);
+            break;
+          }
 
         default:
           libmesh_error_msg("Invalid side i = " << i);
@@ -168,9 +175,6 @@ std::unique_ptr<Elem> Pyramid5::build_side_ptr (const unsigned int i,
 
   else
     {
-      // Return value
-      std::unique_ptr<Elem> face;
-
       switch (i)
         {
         case 0: // triangular face 1
@@ -190,16 +194,15 @@ std::unique_ptr<Elem> Pyramid5::build_side_ptr (const unsigned int i,
           libmesh_error_msg("Invalid side i = " << i);
         }
 
-      face->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      face->set_p_level(this->p_level());
-#endif
       // Set the nodes
       for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Pyramid5::side_nodes_map[i][n]);
-
-      return face;
     }
+
+  face->set_parent(nullptr);
+  face->set_interior_parent(this);
+
+  return face;
 }
 
 

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -199,7 +199,10 @@ std::unique_ptr<Elem> Pyramid5::build_side_ptr (const unsigned int i,
         face->set_node(n) = this->node_ptr(Pyramid5::side_nodes_map[i][n]);
     }
 
-  face->set_parent(nullptr);
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  if (!proxy) // proxy sides used to leave parent() set
+#endif
+    face->set_parent(nullptr);
   face->set_interior_parent(this);
 
   return face;

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -213,23 +213,7 @@ unsigned int Tet10::local_edge_node(unsigned int edge,
 std::unique_ptr<Elem> Tet10::build_side_ptr (const unsigned int i,
                                              bool proxy)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (proxy)
-    return libmesh_make_unique<Side<Tri6,Tet10>>(this,i);
-
-  else
-    {
-      std::unique_ptr<Elem> face = libmesh_make_unique<Tri6>();
-      face->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      face->set_p_level(this->p_level());
-#endif
-      for (auto n : face->node_index_range())
-        face->set_node(n) = this->node_ptr(Tet10::side_nodes_map[i][n]);
-
-      return face;
-    }
+  return this->simple_build_side_ptr<Tri6, Tet10>(i, proxy);
 }
 
 

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -163,23 +163,7 @@ Order Tet4::default_order() const
 std::unique_ptr<Elem> Tet4::build_side_ptr (const unsigned int i,
                                             bool proxy)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (proxy)
-    return libmesh_make_unique<Side<Tri3,Tet4>>(this,i);
-
-  else
-    {
-      std::unique_ptr<Elem> face = libmesh_make_unique<Tri3>();
-      face->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      face->set_p_level(this->p_level());
-#endif
-      for (auto n : face->node_index_range())
-        face->set_node(n) = this->node_ptr(Tet4::side_nodes_map[i][n]);
-
-      return face;
-    }
+  return this->simple_build_side_ptr<Tri3, Tet4>(i, proxy);
 }
 
 

--- a/src/geom/edge.C
+++ b/src/geom/edge.C
@@ -76,6 +76,10 @@ std::unique_ptr<Elem> Edge::build_side_ptr (const unsigned int i, bool)
   libmesh_assert_less (i, 2);
   std::unique_ptr<Elem> nodeelem = libmesh_make_unique<NodeElem>(this);
   nodeelem->set_node(0) = this->node_ptr(i);
+
+  nodeelem->set_parent(nullptr);
+  nodeelem->set_interior_parent(this);
+
   return nodeelem;
 }
 

--- a/src/geom/edge.C
+++ b/src/geom/edge.C
@@ -77,7 +77,9 @@ std::unique_ptr<Elem> Edge::build_side_ptr (const unsigned int i, bool)
   std::unique_ptr<Elem> nodeelem = libmesh_make_unique<NodeElem>(this);
   nodeelem->set_node(0) = this->node_ptr(i);
 
+#ifndef LIBMESH_ENABLE_DEPRECATED
   nodeelem->set_parent(nullptr);
+#endif
   nodeelem->set_interior_parent(this);
 
   return nodeelem;

--- a/src/geom/face_inf_quad4.C
+++ b/src/geom/face_inf_quad4.C
@@ -242,7 +242,10 @@ std::unique_ptr<Elem> InfQuad4::build_side_ptr (const unsigned int i,
         edge->set_node(n) = this->node_ptr(InfQuad4::side_nodes_map[i][n]);
     }
 
-  edge->set_parent(nullptr);
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  if (!proxy) // proxy sides used to leave parent() set
+#endif
+    edge->set_parent(nullptr);
   edge->set_interior_parent(this);
 
   return edge;

--- a/src/geom/face_inf_quad4.C
+++ b/src/geom/face_inf_quad4.C
@@ -190,18 +190,25 @@ std::unique_ptr<Elem> InfQuad4::build_side_ptr (const unsigned int i,
 {
   // libmesh_assert_less (i, this->n_sides());
 
+  std::unique_ptr<Elem> edge;
   if (proxy)
     {
       switch (i)
         {
           // base
         case 0:
-          return libmesh_make_unique<Side<Edge2,InfQuad4>>(this,i);
+          {
+            edge = libmesh_make_unique<Side<Edge2,InfQuad4>>(this,i);
+            break;
+          }
 
           // ifem edges
         case 1:
         case 2:
-          return libmesh_make_unique<Side<InfEdge2,InfQuad4>>(this,i);
+          {
+            edge = libmesh_make_unique<Side<InfEdge2,InfQuad4>>(this,i);
+            break;
+          }
 
         default:
           libmesh_error_msg("Invalid side i = " << i);
@@ -210,9 +217,6 @@ std::unique_ptr<Elem> InfQuad4::build_side_ptr (const unsigned int i,
 
   else
     {
-      // Return value
-      std::unique_ptr<Elem> edge;
-
       switch (i)
         {
         case 0:
@@ -233,16 +237,15 @@ std::unique_ptr<Elem> InfQuad4::build_side_ptr (const unsigned int i,
           libmesh_error_msg("Invalid side i = " << i);
         }
 
-      edge->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      edge->set_p_level(this->p_level());
-#endif
       // Set the nodes
       for (auto n : edge->node_index_range())
         edge->set_node(n) = this->node_ptr(InfQuad4::side_nodes_map[i][n]);
-
-      return edge;
     }
+
+  edge->set_parent(nullptr);
+  edge->set_interior_parent(this);
+
+  return edge;
 }
 
 

--- a/src/geom/face_inf_quad6.C
+++ b/src/geom/face_inf_quad6.C
@@ -172,16 +172,23 @@ std::unique_ptr<Elem> InfQuad6::build_side_ptr (const unsigned int i,
 {
   // libmesh_assert_less (i, this->n_sides());
 
+  std::unique_ptr<Elem> edge;
   if (proxy)
     {
       switch (i)
         {
         case 0:
-          return libmesh_make_unique<Side<Edge3,InfQuad6>>(this,i);
+          {
+            edge = libmesh_make_unique<Side<Edge3,InfQuad6>>(this,i);
+            break;
+          }
 
         case 1:
         case 2:
-          return libmesh_make_unique<Side<InfEdge2,InfQuad6>>(this,i);
+          {
+            edge = libmesh_make_unique<Side<InfEdge2,InfQuad6>>(this,i);
+            break;
+          }
 
         default:
           libmesh_error_msg("Invalid side i = " << i);
@@ -190,9 +197,6 @@ std::unique_ptr<Elem> InfQuad6::build_side_ptr (const unsigned int i,
 
   else
     {
-      // Return value
-      std::unique_ptr<Elem> edge;
-
       switch (i)
         {
         case 0:
@@ -213,16 +217,15 @@ std::unique_ptr<Elem> InfQuad6::build_side_ptr (const unsigned int i,
           libmesh_error_msg("Invalid side i = " << i);
         }
 
-      edge->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      edge->set_p_level(this->p_level());
-#endif
       // Set the nodes
       for (auto n : edge->node_index_range())
         edge->set_node(n) = this->node_ptr(InfQuad6::side_nodes_map[i][n]);
-
-      return edge;
     }
+
+  edge->set_parent(nullptr);
+  edge->set_interior_parent(this);
+
+  return edge;
 }
 
 

--- a/src/geom/face_inf_quad6.C
+++ b/src/geom/face_inf_quad6.C
@@ -222,7 +222,10 @@ std::unique_ptr<Elem> InfQuad6::build_side_ptr (const unsigned int i,
         edge->set_node(n) = this->node_ptr(InfQuad6::side_nodes_map[i][n]);
     }
 
-  edge->set_parent(nullptr);
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  if (!proxy) // proxy sides used to leave parent() set
+#endif
+    edge->set_parent(nullptr);
   edge->set_interior_parent(this);
 
   return edge;

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -149,24 +149,7 @@ Order Quad4::default_order() const
 std::unique_ptr<Elem> Quad4::build_side_ptr (const unsigned int i,
                                              bool proxy)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (proxy)
-    return libmesh_make_unique<Side<Edge2,Quad4>>(this,i);
-
-  else
-    {
-      std::unique_ptr<Elem> edge = libmesh_make_unique<Edge2>();
-      edge->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      edge->set_p_level(this->p_level());
-#endif
-      // Set the nodes
-      for (auto n : edge->node_index_range())
-        edge->set_node(n) = this->node_ptr(Quad4::side_nodes_map[i][n]);
-
-      return edge;
-    }
+  return this->simple_build_side_ptr<Edge2, Quad4>(i, proxy);
 }
 
 

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -223,24 +223,7 @@ unsigned int Quad8::local_side_node(unsigned int side,
 std::unique_ptr<Elem> Quad8::build_side_ptr (const unsigned int i,
                                              bool proxy)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (proxy)
-    return libmesh_make_unique<Side<Edge3,Quad8>>(this,i);
-
-  else
-    {
-      std::unique_ptr<Elem> edge = libmesh_make_unique<Edge3>();
-      edge->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      edge->set_p_level(this->p_level());
-#endif
-      // Set the nodes
-      for (auto n : edge->node_index_range())
-        edge->set_node(n) = this->node_ptr(Quad8::side_nodes_map[i][n]);
-
-      return edge;
-    }
+  return this->simple_build_side_ptr<Edge3, Quad8>(i, proxy);
 }
 
 

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -241,24 +241,7 @@ unsigned int Quad9::local_side_node(unsigned int side,
 std::unique_ptr<Elem> Quad9::build_side_ptr (const unsigned int i,
                                              bool proxy)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (proxy)
-    return libmesh_make_unique<Side<Edge3,Quad9>>(this,i);
-
-  else
-    {
-      std::unique_ptr<Elem> edge = libmesh_make_unique<Edge3>();
-      edge->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      edge->set_p_level(this->p_level());
-#endif
-      // Set the nodes
-      for (auto n : edge->node_index_range())
-        edge->set_node(n) = this->node_ptr(Quad9::side_nodes_map[i][n]);
-
-      return edge;
-    }
+  return this->simple_build_side_ptr<Edge3, Quad9>(i, proxy);
 }
 
 

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -131,24 +131,7 @@ Order Tri3::default_order() const
 std::unique_ptr<Elem> Tri3::build_side_ptr (const unsigned int i,
                                             bool proxy)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (proxy)
-    return libmesh_make_unique<Side<Edge2,Tri3>>(this,i);
-
-  else
-    {
-      std::unique_ptr<Elem> edge = libmesh_make_unique<Edge2>();
-      edge->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      edge->set_p_level(this->p_level());
-#endif
-      // Set the nodes
-      for (auto n : edge->node_index_range())
-        edge->set_node(n) = this->node_ptr(Tri3::side_nodes_map[i][n]);
-
-      return edge;
-    }
+  return this->simple_build_side_ptr<Edge2, Tri3>(i, proxy);
 }
 
 

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -207,24 +207,7 @@ unsigned int Tri6::local_side_node(unsigned int side,
 std::unique_ptr<Elem> Tri6::build_side_ptr (const unsigned int i,
                                             bool proxy)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (proxy)
-    return libmesh_make_unique<Side<Edge3,Tri6>>(this,i);
-
-  else
-    {
-      std::unique_ptr<Elem> edge = libmesh_make_unique<Edge3>();
-      edge->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      edge->set_p_level(this->p_level());
-#endif
-      // Set the nodes
-      for (auto n : edge->node_index_range())
-        edge->set_node(n) = this->node_ptr(Tri6::side_nodes_map[i][n]);
-
-      return edge;
-    }
+  return this->simple_build_side_ptr<Edge3, Tri6>(i, proxy);
 }
 
 


### PR DESCRIPTION
For me this fixes the regression we were talking about in https://github.com/idaholab/moose/pull/15389 , which turned out to be caused by the interaction of parent() pointer settings on side objects with the ancestor-editing code in set_p_level(), as triggered by https://github.com/libMesh/libmesh/pull/2592

This PR is the right long-term fix: to use interior_parent() instead of parent() for that link on side elements, just as we've done for years on boundary mesh elements.  Hopefully that doesn't break compatibility for user codes; in the library itself there were only two or three places checking parent().  If there is any breakage then we'll need to work out a more tedious transition plan...