### PR TITLE
Use new non-deprecated n_dofs overload

### DIFF
--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -1715,7 +1715,7 @@ void FEInterface::compute_data(const unsigned int dim,
 
 #endif
 
-  const unsigned int n_dof = n_dofs (dim, fe_t, elem);
+  const unsigned int n_dof = n_dofs (fe_t, elem);
   const Point & p = data.p;
   data.shape.resize(n_dof);
 


### PR DESCRIPTION
This fixes an error for me in our unit tests for --disable-deprecated builds.