### PR TITLE
Reduced Basis change: Optionally pre-evaluate theta functions

### DIFF
--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -490,6 +490,13 @@ public:
    */
   void set_convergence_assertion_flag(bool flag);
 
+  /**
+   * Get/set flag to pre-evaluate the theta functions
+   */
+  bool get_preevaluate_thetas_flag() const;
+  void set_preevaluate_thetas_flag(bool flag);
+
+
   //----------- PUBLIC DATA MEMBERS -----------//
 
   /**
@@ -805,6 +812,22 @@ protected:
    */
   void check_convergence(LinearSolver<Number> & input_solver);
 
+  /**
+   * Get/set the current training parameter index
+   */
+  unsigned int get_current_training_parameter_index() const;
+  void set_current_training_parameter_index(unsigned int index);
+
+  /**
+   * Return the evaluated theta functions at the given training parameter index.
+   */
+  const std::vector< Number >& get_evaluated_thetas(unsigned int training_parameter_index) const;
+
+  /*
+   * Pre-evaluate the theta functions on the entire (local) training parameter set.
+   */
+  void preevaluate_thetas();
+
   //----------- PROTECTED DATA MEMBERS -----------//
 
   /**
@@ -934,6 +957,23 @@ private:
    * create _untransformed_basis_functions.
    */
   std::unique_ptr<NumericVector<Number>> _untransformed_solution;
+
+  /**
+   * Flag to indicate if we preevaluate the theta functions
+   */
+  bool _preevaluate_thetas_flag;
+
+  /**
+   * The current training parameter index during reduced basis training.
+   */
+  unsigned int _current_training_parameter_index;
+
+  /**
+   * Storage of evaluated theta functions at a set of parameters. This
+   * can be used to store all of our theta functions at training samples
+   * instead of re-evaluating the same values repeatedly during training.
+   */
+  std::vector< std::vector< Number > > _evaluated_thetas;
 
 };
 

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -114,6 +114,7 @@ public:
    * solution coefficients in the member RB_solution.
    * \returns The EIM a posteriori error bound.
    */
+  using RBEvaluation::rb_solve;
   virtual Real rb_solve(unsigned int N) override;
 
   /**

--- a/include/reduced_basis/rb_evaluation.h
+++ b/include/reduced_basis/rb_evaluation.h
@@ -109,6 +109,13 @@ public:
   virtual Real rb_solve(unsigned int N);
 
   /**
+   * The same as above, except that we pass in evaluated_thetas
+   * instead of recomputing the theta values.
+   */
+  virtual Real rb_solve(unsigned int N,
+                        const std::vector< Number >* evaluated_thetas);
+
+  /**
    * \returns A scaling factor that we can use to provide a consistent
    * scaling of the RB error bound across different parameter values.
    */
@@ -119,6 +126,13 @@ public:
    * saved in RB_solution_vector.
    */
   virtual Real compute_residual_dual_norm(const unsigned int N);
+
+  /**
+   * The same as above, except that we pass in evaluated thetas
+   * instead of recomputing the theta values.
+   */
+  virtual Real compute_residual_dual_norm(const unsigned int N,
+                                          const std::vector< Number >* evaluated_thetas);
 
   /**
    * Specifies the residual scaling on the denominator to

--- a/include/reduced_basis/transient_rb_evaluation.h
+++ b/include/reduced_basis/transient_rb_evaluation.h
@@ -87,6 +87,7 @@ public:
    * with the N basis functions. Overridden
    * to perform a time-dependent solve.
    */
+  using RBEvaluation::rb_solve;
   virtual Real rb_solve(unsigned int N) override;
 
   /**
@@ -114,6 +115,7 @@ public:
    * saved in RB_solution. This function uses the cached time-independent
    * data.
    */
+  using RBEvaluation::compute_residual_dual_norm;
   virtual Real compute_residual_dual_norm(const unsigned int N) override;
 
   /**

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -85,7 +85,8 @@ RBConstruction::RBConstruction (EquationSystems & es,
     rel_training_tolerance(1.e-4),
     abs_training_tolerance(1.e-12),
     normalize_rb_bound_in_greedy(false),
-    RB_training_type("Greedy")
+    RB_training_type("Greedy"),
+    _preevaluate_thetas_flag(false)
 {
   // set assemble_before_solve flag to false
   // so that we control matrix assembly.
@@ -1110,6 +1111,9 @@ Real RBConstruction::train_reduced_basis_with_greedy(const bool resize_rb_eval_d
       return 0.;
     }
 
+  // Optionally pre-evaluate the theta functions on the entire (local) training parameter set.
+  if (get_preevaluate_thetas_flag())
+    preevaluate_thetas();
 
   if(!skip_residual_in_train_reduced_basis)
     {
@@ -1597,7 +1601,17 @@ Real RBConstruction::get_RB_error_bound()
 {
   get_rb_evaluation().set_parameters( get_parameters() );
 
-  Real error_bound = get_rb_evaluation().rb_solve(get_rb_evaluation().get_n_basis_functions());
+  Real error_bound = 0.;
+  if (get_preevaluate_thetas_flag())
+    {
+      // Obtain the pre-evaluated theta functions from the current training parameter index
+      const auto & evaluated_thetas = get_evaluated_thetas(get_current_training_parameter_index());
+      error_bound = get_rb_evaluation().rb_solve(get_rb_evaluation().get_n_basis_functions(),
+                                                 &evaluated_thetas);
+    }
+  else
+    error_bound = get_rb_evaluation().rb_solve(get_rb_evaluation().get_n_basis_functions());
+
 
   if (normalize_rb_bound_in_greedy)
     {
@@ -1666,6 +1680,12 @@ Real RBConstruction::compute_max_error_bound()
       // Load training parameter i, this is only loaded
       // locally since the RB solves are local.
       set_params_from_training_set( first_index+i );
+
+      // In case we pre-evaluate the theta functions,
+      // also keep track of the current training parameter index.
+      if (get_preevaluate_thetas_flag())
+        set_current_training_parameter_index(first_index+i);
+
 
       training_error_bounds[i] = get_RB_error_bound();
 
@@ -2514,6 +2534,61 @@ bool RBConstruction::get_convergence_assertion_flag() const
 void RBConstruction::set_convergence_assertion_flag(bool flag)
 {
   assert_convergence = flag;
+}
+
+bool RBConstruction::get_preevaluate_thetas_flag() const
+{
+  return _preevaluate_thetas_flag;
+}
+
+void RBConstruction::set_preevaluate_thetas_flag(bool flag)
+{
+  _preevaluate_thetas_flag = flag;
+}
+
+unsigned int RBConstruction::get_current_training_parameter_index() const
+{
+  return _current_training_parameter_index;
+}
+
+void RBConstruction::set_current_training_parameter_index(unsigned int index)
+{
+  _current_training_parameter_index = index;
+}
+
+const std::vector< Number >& RBConstruction::get_evaluated_thetas(unsigned int training_parameter_index) const
+{
+  const numeric_index_type first_index = get_first_local_training_index();
+  libmesh_assert(training_parameter_index >= first_index);
+
+  const numeric_index_type local_index = training_parameter_index - first_index;
+  libmesh_assert(local_index < _evaluated_thetas.size());
+
+  return _evaluated_thetas[local_index];
+}
+
+void RBConstruction::preevaluate_thetas()
+{
+  _evaluated_thetas.resize(get_local_n_training_samples());
+
+  auto & rb_theta_expansion = get_rb_evaluation().get_rb_theta_expansion();
+  const unsigned int n_A_terms = rb_theta_expansion.get_n_A_terms();
+  const unsigned int n_F_terms = rb_theta_expansion.get_n_F_terms();
+
+  const numeric_index_type first_index = get_first_local_training_index();
+  for (unsigned int i=0; i<get_local_n_training_samples(); i++)
+    {
+      // Load training parameter i, this is only loaded
+      // locally since the RB solves are local.
+      set_params_from_training_set( first_index+i );
+      const RBParameters & mu = get_parameters();
+
+      _evaluated_thetas[i].resize(n_A_terms + n_F_terms);
+      for (unsigned int q_a=0; q_a<n_A_terms; q_a++)
+        _evaluated_thetas[i][q_a] = rb_theta_expansion.eval_A_theta(q_a, mu);
+      for (unsigned int q_f=0; q_f<n_F_terms; q_f++)
+        _evaluated_thetas[i][n_A_terms + q_f] = rb_theta_expansion.eval_F_theta(q_f, mu);
+    }
 }
 
 } // namespace libMesh

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -2569,6 +2569,8 @@ const std::vector< Number >& RBConstruction::get_evaluated_thetas(unsigned int t
 
 void RBConstruction::preevaluate_thetas()
 {
+  LOG_SCOPE("preevaluate_thetas()", "RBConstruction");
+
   _evaluated_thetas.resize(get_local_n_training_samples());
 
   auto & rb_theta_expansion = get_rb_evaluation().get_rb_theta_expansion();

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -208,10 +208,23 @@ NumericVector<Number> & RBEvaluation::get_basis_function(unsigned int i)
 
 Real RBEvaluation::rb_solve(unsigned int N)
 {
+  return rb_solve(N, nullptr);
+}
+
+Real RBEvaluation::rb_solve(unsigned int N,
+                            const std::vector< Number >* evaluated_thetas)
+{
   LOG_SCOPE("rb_solve()", "RBEvaluation");
 
   if (N > get_n_basis_functions())
     libmesh_error_msg("ERROR: N cannot be larger than the number of basis functions in rb_solve");
+
+  // In case the theta functions have been pre-evaluated, first check the size for consistency
+  if (evaluated_thetas)
+    {
+      if (evaluated_thetas->size() != rb_theta_expansion->get_n_A_terms() + rb_theta_expansion->get_n_F_terms())
+        libmesh_error_msg("ERROR: Evaluated thetas have wrong size");
+    }
 
   const RBParameters & mu = get_parameters();
 
@@ -227,7 +240,10 @@ Real RBEvaluation::rb_solve(unsigned int N)
     {
       RB_Aq_vector[q_a].get_principal_submatrix(N, RB_Aq_a);
 
-      RB_system_matrix.add(rb_theta_expansion->eval_A_theta(q_a, mu), RB_Aq_a);
+      if (evaluated_thetas)
+        RB_system_matrix.add((*evaluated_thetas)[q_a], RB_Aq_a);
+      else
+        RB_system_matrix.add(rb_theta_expansion->eval_A_theta(q_a, mu), RB_Aq_a);
     }
 
   // Assemble the RB rhs
@@ -239,7 +255,10 @@ Real RBEvaluation::rb_solve(unsigned int N)
     {
       RB_Fq_vector[q_f].get_principal_subvector(N, RB_Fq_f);
 
-      RB_rhs.add(rb_theta_expansion->eval_F_theta(q_f, mu), RB_Fq_f);
+      if (evaluated_thetas)
+        RB_rhs.add((*evaluated_thetas)[q_f+rb_theta_expansion->get_n_A_terms()], RB_Fq_f);
+      else
+        RB_rhs.add(rb_theta_expansion->eval_F_theta(q_f, mu), RB_Fq_f);
     }
 
   // Solve the linear system
@@ -263,7 +282,7 @@ Real RBEvaluation::rb_solve(unsigned int N)
   if (evaluate_RB_error_bound) // Calculate the error bounds
     {
       // Evaluate the dual norm of the residual for RB_solution_vector
-      Real epsilon_N = compute_residual_dual_norm(N);
+      Real epsilon_N = compute_residual_dual_norm(N, evaluated_thetas);
 
       // Get lower bound for coercivity constant
       const Real alpha_LB = get_stability_lower_bound();
@@ -299,50 +318,81 @@ Real RBEvaluation::get_error_bound_normalization()
   return normalization;
 }
 
-Real RBEvaluation::compute_residual_dual_norm(const unsigned int N)
+ Real RBEvaluation::compute_residual_dual_norm(const unsigned int N)
+{
+  return compute_residual_dual_norm(N, nullptr);
+}
+
+Real RBEvaluation::compute_residual_dual_norm(const unsigned int N,
+                                              const std::vector< Number >* evaluated_thetas)
 {
   LOG_SCOPE("compute_residual_dual_norm()", "RBEvaluation");
 
+  // In case the theta functions have been pre-evaluated, first check the size for consistency
+  if (evaluated_thetas)
+    {
+      if (evaluated_thetas->size() != rb_theta_expansion->get_n_A_terms() + rb_theta_expansion->get_n_F_terms())
+        libmesh_error_msg("ERROR: Evaluated thetas have wrong size");
+    }
+
   const RBParameters & mu = get_parameters();
+
+  const unsigned int n_A_terms = rb_theta_expansion->get_n_A_terms();
+  const unsigned int n_F_terms = rb_theta_expansion->get_n_F_terms();
 
   // Use the stored representor inner product values
   // to evaluate the residual norm
   Number residual_norm_sq = 0.;
 
   unsigned int q=0;
-  for (unsigned int q_f1=0; q_f1<rb_theta_expansion->get_n_F_terms(); q_f1++)
+  for (unsigned int q_f1=0; q_f1<n_F_terms; q_f1++)
     {
-      for (unsigned int q_f2=q_f1; q_f2<rb_theta_expansion->get_n_F_terms(); q_f2++)
+      const Number val_q_f1 = (evaluated_thetas) ? (*evaluated_thetas)[q_f1 + n_A_terms]
+                                                 : rb_theta_expansion->eval_F_theta(q_f1, mu);
+
+      for (unsigned int q_f2=q_f1; q_f2<n_F_terms; q_f2++)
         {
+          const Number val_q_f2 = (evaluated_thetas) ? (*evaluated_thetas)[q_f2 + n_A_terms]
+                                                     : rb_theta_expansion->eval_F_theta(q_f2, mu);
+
           Real delta = (q_f1==q_f2) ? 1. : 2.;
-          residual_norm_sq += delta * libmesh_real(
-                                                   rb_theta_expansion->eval_F_theta(q_f1, mu)
-                                                   * libmesh_conj(rb_theta_expansion->eval_F_theta(q_f2, mu)) * Fq_representor_innerprods[q] );
+          residual_norm_sq += delta * libmesh_real(val_q_f1 * libmesh_conj(val_q_f2) * Fq_representor_innerprods[q] );
 
           q++;
         }
     }
 
-  for (unsigned int q_f=0; q_f<rb_theta_expansion->get_n_F_terms(); q_f++)
+  for (unsigned int q_f=0; q_f<n_F_terms; q_f++)
     {
-      for (unsigned int q_a=0; q_a<rb_theta_expansion->get_n_A_terms(); q_a++)
+      const Number val_q_f = (evaluated_thetas) ? (*evaluated_thetas)[q_f + n_A_terms]
+                                                : rb_theta_expansion->eval_F_theta(q_f, mu);
+
+      for (unsigned int q_a=0; q_a<n_A_terms; q_a++)
         {
+          const Number val_q_a = (evaluated_thetas) ? (*evaluated_thetas)[q_a]
+                                                    : rb_theta_expansion->eval_A_theta(q_a, mu);
+
           for (unsigned int i=0; i<N; i++)
             {
               Real delta = 2.;
               residual_norm_sq +=
-                delta * libmesh_real( rb_theta_expansion->eval_F_theta(q_f, mu) *
-                                      libmesh_conj(rb_theta_expansion->eval_A_theta(q_a, mu)) *
+                delta * libmesh_real( val_q_f * libmesh_conj(val_q_a) *
                                       libmesh_conj(RB_solution(i)) * Fq_Aq_representor_innerprods[q_f][q_a][i] );
             }
         }
     }
 
   q=0;
-  for (unsigned int q_a1=0; q_a1<rb_theta_expansion->get_n_A_terms(); q_a1++)
+  for (unsigned int q_a1=0; q_a1<n_A_terms; q_a1++)
     {
-      for (unsigned int q_a2=q_a1; q_a2<rb_theta_expansion->get_n_A_terms(); q_a2++)
+      const Number val_q_a1 = (evaluated_thetas) ? (*evaluated_thetas)[q_a1]
+                                                 : rb_theta_expansion->eval_A_theta(q_a1, mu);
+
+      for (unsigned int q_a2=q_a1; q_a2<n_A_terms; q_a2++)
         {
+          const Number val_q_a2 = (evaluated_thetas) ? (*evaluated_thetas)[q_a2]
+                                                     : rb_theta_expansion->eval_A_theta(q_a2, mu);
+
           Real delta = (q_a1==q_a2) ? 1. : 2.;
 
           for (unsigned int i=0; i<N; i++)
@@ -350,8 +400,7 @@ Real RBEvaluation::compute_residual_dual_norm(const unsigned int N)
               for (unsigned int j=0; j<N; j++)
                 {
                   residual_norm_sq +=
-                    delta * libmesh_real( libmesh_conj(rb_theta_expansion->eval_A_theta(q_a1, mu)) *
-                                          rb_theta_expansion->eval_A_theta(q_a2, mu) *
+                    delta * libmesh_real( libmesh_conj(val_q_a1) * val_q_a2 *
                                           libmesh_conj(RB_solution(i)) * RB_solution(j) * Aq_Aq_representor_innerprods[q][i][j] );
                 }
             }


### PR DESCRIPTION
For the sake of efficiency we can pre-evaluate the theta functions and store the results. This can be helpful for the RB greedy algorithm since in that case we re-evaluate many times for the same set of training parameters.