### PR TITLE
trilinos.m4: fix bug in Trilinos 9 test for NOX

### DIFF
--- a/configure
+++ b/configure
@@ -35652,7 +35652,7 @@ else
   enablenox=no
 fi
 
-          if test "$enablenox" != "xno"; then :
+          if test "x$enablenox" != "xno"; then :
 
                   enablenox=yes
 

--- a/m4/trilinos.m4
+++ b/m4/trilinos.m4
@@ -294,7 +294,7 @@ AC_DEFUN([CONFIGURE_TRILINOS_9],
                 [NOX_MAKEFILE_EXPORT=$withnoxdir/packages/nox/Makefile.export.nox],
                 [enablenox=no])
 
-          AS_IF([test "$enablenox" != "xno"],
+          AS_IF([test "x$enablenox" != "xno"],
                 [
                   enablenox=yes
                   AC_DEFINE(TRILINOS_HAVE_NOX, 1, [Flag indicating whether the library shall be compiled to use the Nox solver collection])


### PR DESCRIPTION
I doubt this really affects anyone (Trilinos 9 is from 2008), but this test does actually run during configure and otherwise provides a false positive for the `LIBMESH_TRILINOS_HAVE_NOX` define, so good to avoid that if possible.
