### PR TITLE
Continue FEInterface refactoring for InfFEs

### DIFF
--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -809,9 +809,16 @@ private:
    * the calls to \p FE and \p InfFE.
    */
 
+  /**
+   * \deprecated Call the version of ifem_n_shape_functions() which
+   * takes a pointer-to-Elem instead.
+   */
   static unsigned int ifem_n_shape_functions(const unsigned int dim,
                                              const FEType & fe_t,
                                              const ElemType t);
+
+  static unsigned int ifem_n_shape_functions(const FEType & fe_t,
+                                             const Elem * elem);
 
   /**
    * \deprecated Call the version of ifem_n_dofs() which takes a

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -904,6 +904,10 @@ private:
                          const unsigned int i,
                          const Point & p);
 
+  /**
+   * \deprecated Call version that takes a pointer-to-Elem and does
+   * not require an explicit dim parameter instead.
+   */
   static Real ifem_shape_deriv(const unsigned int dim,
                                const FEType & fe_t,
                                const ElemType t,
@@ -911,8 +915,18 @@ private:
                                const unsigned int j,
                                const Point & p);
 
+  /**
+   * \deprecated Call version that takes a pointer-to-Elem and does
+   * not require an explicit dim parameter instead.
+   */
   static Real ifem_shape_deriv(const unsigned int dim,
                                const FEType & fe_t,
+                               const Elem * elem,
+                               const unsigned int i,
+                               const unsigned int j,
+                               const Point & p);
+
+  static Real ifem_shape_deriv(const FEType & fe_t,
                                const Elem * elem,
                                const unsigned int i,
                                const unsigned int j,

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -824,9 +824,17 @@ private:
   static unsigned int ifem_n_dofs(const FEType & fe_t,
                                   const Elem * elem);
 
+  /**
+   * \deprecated Call the version of ifem_n_dofs_at_node() which takes
+   * a pointer-to-Elem instead.
+   */
   static unsigned int ifem_n_dofs_at_node(const unsigned int dim,
                                           const FEType & fe_t,
                                           const ElemType t,
+                                          const unsigned int n);
+
+  static unsigned int ifem_n_dofs_at_node(const FEType & fe_t,
+                                          const Elem * elem,
                                           const unsigned int n);
 
   static unsigned int ifem_n_dofs_per_elem(const unsigned int dim,

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -837,9 +837,16 @@ private:
                                           const Elem * elem,
                                           const unsigned int n);
 
+  /**
+   * \deprecated Call the version of ifem_n_dofs_per_elem() which
+   * takes a pointer-to-Elem instead.
+   */
   static unsigned int ifem_n_dofs_per_elem(const unsigned int dim,
                                            const FEType & fe_t,
                                            const ElemType t);
+
+  static unsigned int ifem_n_dofs_per_elem(const FEType & fe_t,
+                                           const Elem * elem);
 
   static void ifem_nodal_soln(const unsigned int dim,
                               const FEType & fe_t,

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -879,18 +879,30 @@ private:
                                         const ElemType t,
                                         const Real eps);
 
+  /**
+   * \deprecated Call version that takes a pointer-to-Elem and does
+   * not require an explicit dim parameter instead.
+   */
   static Real ifem_shape(const unsigned int dim,
                          const FEType & fe_t,
                          const ElemType t,
                          const unsigned int i,
                          const Point & p);
 
+  /**
+   * \deprecated Call version that takes a pointer-to-Elem and does
+   * not require an explicit dim parameter instead.
+   */
   static Real ifem_shape(const unsigned int dim,
                          const FEType & fe_t,
                          const Elem * elem,
                          const unsigned int i,
                          const Point & p);
 
+  static Real ifem_shape(const FEType & fe_t,
+                         const Elem * t,
+                         const unsigned int i,
+                         const Point & p);
 
   static Real ifem_shape_deriv(const unsigned int dim,
                                const FEType & fe_t,

--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -684,9 +684,17 @@ protected:
    * in radial direction \p radial_shape (0 in the base, \f$ \ge 1 \f$ further
    * out) associated to the shape with global index \p i of an infinite element
    * of type \p inf_elem_type.
+   *
+   * \deprecated Call the version of this function that takes an Elem * instead.
    */
   static void compute_shape_indices (const FEType & fet,
                                      const ElemType inf_elem_type,
+                                     const unsigned int i,
+                                     unsigned int & base_shape,
+                                     unsigned int & radial_shape);
+
+  static void compute_shape_indices (const FEType & fet,
+                                     const Elem * inf_elem,
                                      const unsigned int i,
                                      unsigned int & base_shape,
                                      unsigned int & radial_shape);

--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -392,9 +392,16 @@ public:
   /**
    * \returns The number of dofs at infinite element node \p n
    * (not dof!) for an element of type \p t and order \p o.
+   *
+   * \deprecated Call the version of this function that takes an Elem*
+   * instead for consistency with other FEInterface::n_dofs() methods.
    */
   static unsigned int n_dofs_at_node(const FEType & fet,
                                      const ElemType inf_elem_type,
+                                     const unsigned int n);
+
+  static unsigned int n_dofs_at_node(const FEType & fet,
+                                     const Elem * inf_elem,
                                      const unsigned int n);
 
   /**

--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -369,10 +369,17 @@ public:
   /**
    * \returns The number of shape functions associated with
    * a finite element of type \p t and approximation order \p o.
+   *
+   * \deprecated Call the version of this function that takes a
+   * pointer-to-Elem instead.
    */
   static unsigned int n_shape_functions (const FEType & fet,
                                          const ElemType t)
   { return n_dofs(fet, t); }
+
+  static unsigned int n_shape_functions (const FEType & fet,
+                                         const Elem * inf_elem)
+  { return n_dofs(fet, inf_elem); }
 
   /**
    * \returns The number of shape functions associated with this

--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -407,9 +407,15 @@ public:
   /**
    * \returns The number of dofs interior to the element,
    * not associated with any interior nodes.
+   *
+   * \deprecated Call the version of this function that takes an Elem*
+   * instead for consistency with other FEInterface::n_dofs() methods.
    */
   static unsigned int n_dofs_per_elem(const FEType & fet,
                                       const ElemType inf_elem_type);
+
+  static unsigned int n_dofs_per_elem(const FEType & fet,
+                                      const Elem * inf_elem);
 
   /**
    * \returns The continuity of the element.

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -490,7 +490,7 @@ FEInterface::n_shape_functions(const FEType & fe_t,
    */
 
   if (is_InfFE_elem(elem->type()))
-    return ifem_n_shape_functions(dim, fe_t, elem->type());
+    return ifem_n_shape_functions(fe_t, elem);
 
 #endif
 
@@ -518,7 +518,7 @@ FEInterface::n_shape_functions(const FEType & fe_t,
    */
 
   if (is_InfFE_elem(elem->type()))
-    return ifem_n_shape_functions(dim, fe_t, elem->type());
+    return ifem_n_shape_functions(fe_t, elem);
 
 #endif
 

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -937,7 +937,7 @@ Real FEInterface::shape(const unsigned int dim,
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
   if (elem && is_InfFE_elem(elem->type()))
-    return ifem_shape(dim, fe_t, elem, i, p);
+    return ifem_shape(fe_t, elem, i, p);
 
 #endif
 
@@ -960,7 +960,7 @@ FEInterface::shape(const FEType & fe_t,
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
   if (elem && is_InfFE_elem(elem->type()))
-    return ifem_shape(dim, fe_t, elem, i, p);
+    return ifem_shape(fe_t, elem, i, p);
 
 #endif
 
@@ -988,7 +988,7 @@ FEInterface::shape(const FEType & fe_t,
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
   if (elem && is_InfFE_elem(elem->type()))
-    return ifem_shape(dim, fe_t, elem, i, p);
+    return ifem_shape(fe_t, elem, i, p);
 
 #endif
 
@@ -1065,7 +1065,7 @@ void FEInterface::shape<Real>(const unsigned int dim,
 
   if (elem && is_InfFE_elem(elem->type()))
     {
-      phi = ifem_shape(dim, fe_t, elem, i, p);
+      phi = ifem_shape(fe_t, elem, i, p);
       return;
     }
 #endif
@@ -1109,7 +1109,7 @@ void FEInterface::shape<Real>(const FEType & fe_t,
 
   if (is_InfFE_elem(elem->type()))
     {
-      phi = ifem_shape(dim, fe_t, elem->type(), i, p);
+      phi = ifem_shape(fe_t, elem, i, p);
       return;
     }
 
@@ -1153,7 +1153,7 @@ void FEInterface::shape<Real>(const FEType & fe_t,
 
   if (is_InfFE_elem(elem->type()))
     {
-      phi = ifem_shape(dim, fe_t, elem->type(), i, p);
+      phi = ifem_shape(fe_t, elem, i, p);
       return;
     }
 
@@ -1205,7 +1205,7 @@ void FEInterface::shapes<Real>(const unsigned int dim,
       FEType elevated = fe_t;
       elevated.order = static_cast<Order>(fe_t.order + add_p_level * elem->p_level());
       for (auto qpi : index_range(p))
-        phi[qpi] = ifem_shape(dim, elevated, elem, i, p[qpi]);
+        phi[qpi] = ifem_shape(elevated, elem, i, p[qpi]);
       return;
     }
 #endif

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -1566,7 +1566,7 @@ Real FEInterface::shape_deriv(const unsigned int dim,
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
   if (elem->infinite()){
-    return ifem_shape_deriv(dim, fe_t, elem, i, j, p);
+    return ifem_shape_deriv(fe_t, elem, i, j, p);
   }
 
 #endif
@@ -1603,7 +1603,7 @@ Real FEInterface::shape_deriv(const FEType & fe_t,
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
   if (is_InfFE_elem(elem->type())){
-    return ifem_shape_deriv(dim, fe_t, elem->type(), i, j, p);
+    return ifem_shape_deriv(fe_t, elem, i, j, p);
   }
 
 #endif
@@ -1632,7 +1632,7 @@ Real FEInterface::shape_deriv(const FEType & fe_t,
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
   if (elem->infinite()){
-    return ifem_shape_deriv(dim, fe_t, elem, i, j, p);
+    return ifem_shape_deriv(fe_t, elem, i, j, p);
   }
 
 #endif

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -735,7 +735,7 @@ FEInterface::n_dofs_per_elem(const FEType & fe_t,
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
   if (is_InfFE_elem(elem->type()))
-    return ifem_n_dofs_per_elem(dim, fe_t, elem->type());
+    return ifem_n_dofs_per_elem(fe_t, elem);
 
 #endif
 
@@ -758,7 +758,7 @@ FEInterface::n_dofs_per_elem(const FEType & fe_t,
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
   if (is_InfFE_elem(elem->type()))
-    return ifem_n_dofs_per_elem(dim, fe_t, elem->type());
+    return ifem_n_dofs_per_elem(fe_t, elem);
 
 #endif
 

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -668,7 +668,7 @@ FEInterface::n_dofs_at_node(const FEType & fe_t,
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
   if (is_InfFE_elem(elem->type()))
-    return ifem_n_dofs_at_node(dim, fe_t, elem->type(), n);
+    return ifem_n_dofs_at_node(fe_t, elem, n);
 
 #endif
 
@@ -692,7 +692,7 @@ FEInterface::n_dofs_at_node(const FEType & fe_t,
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
   if (is_InfFE_elem(elem->type()))
-    return ifem_n_dofs_at_node(dim, fe_t, elem->type(), n);
+    return ifem_n_dofs_at_node(fe_t, elem, n);
 
 #endif
 

--- a/src/fe/fe_interface_inf_fe.C
+++ b/src/fe/fe_interface_inf_fe.C
@@ -709,7 +709,10 @@ Real FEInterface::ifem_shape(const unsigned int dim,
                              const unsigned int i,
                              const Point & p)
 {
-   inf_fe_switch(shape(fe_t, t, i, p));
+  // TODO:
+  // libmesh_deprecated();
+
+  inf_fe_switch(shape(fe_t, t, i, p));
 }
 
 
@@ -721,7 +724,21 @@ Real FEInterface::ifem_shape(const unsigned int dim,
                              const unsigned int i,
                              const Point & p)
 {
-   inf_fe_switch( shape(fe_t, elem, i, p));
+  // TODO:
+  // libmesh_deprecated();
+
+  inf_fe_switch( shape(fe_t, elem, i, p));
+}
+
+Real FEInterface::ifem_shape(const FEType & fe_t,
+                             const Elem * elem,
+                             const unsigned int i,
+                             const Point & p)
+{
+  // The inf_fe_switch macro requires a "dim" parameter.
+  auto dim = elem->dim();
+
+  inf_fe_switch( shape(fe_t, elem, i, p));
 }
 
 Real FEInterface::ifem_shape_deriv (const unsigned int dim,

--- a/src/fe/fe_interface_inf_fe.C
+++ b/src/fe/fe_interface_inf_fe.C
@@ -39,6 +39,9 @@ unsigned int FEInterface::ifem_n_shape_functions(const unsigned int dim,
                                                  const FEType & fe_t,
                                                  const ElemType t)
 {
+  // TODO:
+  // libmesh_deprecated();
+
   switch (dim)
     {
       // 1D
@@ -64,6 +67,33 @@ unsigned int FEInterface::ifem_n_shape_functions(const unsigned int dim,
 }
 
 
+
+unsigned int FEInterface::ifem_n_shape_functions(const FEType & fe_t,
+                                                 const Elem * elem)
+{
+  switch (elem->dim())
+    {
+      // 1D
+    case 1:
+      /*
+       * Since InfFE<Dim,T_radial,T_map>::n_shape_functions(...)
+       * is actually independent of T_radial and T_map, we can use
+       * just any T_radial and T_map
+       */
+      return InfFE<1,JACOBI_20_00,CARTESIAN>::n_shape_functions(fe_t, elem);
+
+      // 2D
+    case 2:
+      return InfFE<2,JACOBI_20_00,CARTESIAN>::n_shape_functions(fe_t, elem);
+
+      // 3D
+    case 3:
+      return InfFE<3,JACOBI_20_00,CARTESIAN>::n_shape_functions(fe_t, elem);
+
+    default:
+      libmesh_error_msg("Unsupported dim = " << elem->dim());
+    }
+}
 
 
 

--- a/src/fe/fe_interface_inf_fe.C
+++ b/src/fe/fe_interface_inf_fe.C
@@ -748,7 +748,10 @@ Real FEInterface::ifem_shape_deriv (const unsigned int dim,
                                     const unsigned int j,
                                     const Point & p)
 {
-   inf_fe_switch(shape_deriv(fe_t, elem, i, j, p));
+  // TODO:
+  // libmesh_deprecated();
+
+  inf_fe_switch(shape_deriv(fe_t, elem, i, j, p));
 }
 
 
@@ -759,7 +762,24 @@ Real FEInterface::ifem_shape_deriv(const unsigned int dim,
                                    const unsigned int j,
                                    const Point & p)
 {
-   inf_fe_switch(shape_deriv(fe_t, t, i, j, p));
+  // TODO:
+  // libmesh_deprecated();
+
+  inf_fe_switch(shape_deriv(fe_t, t, i, j, p));
+}
+
+
+
+Real FEInterface::ifem_shape_deriv (const FEType & fe_t,
+                                    const Elem * elem,
+                                    const unsigned int i,
+                                    const unsigned int j,
+                                    const Point & p)
+{
+  // The inf_fe_switch macro requires a "dim" parameter.
+  auto dim = elem->dim();
+
+  inf_fe_switch(shape_deriv(fe_t, elem, i, j, p));
 }
 
 

--- a/src/fe/fe_interface_inf_fe.C
+++ b/src/fe/fe_interface_inf_fe.C
@@ -134,6 +134,9 @@ unsigned int FEInterface::ifem_n_dofs_at_node(const unsigned int dim,
                                               const ElemType t,
                                               const unsigned int n)
 {
+  // TODO:
+  // libmesh_deprecated();
+
   switch (dim)
     {
       // 1D
@@ -155,6 +158,36 @@ unsigned int FEInterface::ifem_n_dofs_at_node(const unsigned int dim,
 
     default:
       libmesh_error_msg("Unsupported dim = " << dim);
+    }
+}
+
+
+
+unsigned int FEInterface::ifem_n_dofs_at_node(const FEType & fe_t,
+                                              const Elem * elem,
+                                              const unsigned int n)
+{
+  switch (elem->dim())
+    {
+      // 1D
+    case 1:
+      /*
+       * Since InfFE<Dim,T_radial,T_map>::n_dofs_at_node(...)
+       * is actually independent of T_radial and T_map, we can use
+       * just any T_radial and T_map
+       */
+      return InfFE<1,JACOBI_20_00,CARTESIAN>::n_dofs_at_node(fe_t, elem, n);
+
+      // 2D
+    case 2:
+      return InfFE<2,JACOBI_20_00,CARTESIAN>::n_dofs_at_node(fe_t, elem, n);
+
+      // 3D
+    case 3:
+      return InfFE<3,JACOBI_20_00,CARTESIAN>::n_dofs_at_node(fe_t, elem, n);
+
+    default:
+      libmesh_error_msg("Unsupported dim = " << elem->dim());
     }
 }
 

--- a/src/fe/fe_interface_inf_fe.C
+++ b/src/fe/fe_interface_inf_fe.C
@@ -199,6 +199,9 @@ unsigned int FEInterface::ifem_n_dofs_per_elem(const unsigned int dim,
                                                const FEType & fe_t,
                                                const ElemType t)
 {
+  // TODO:
+  // libmesh_deprecated();
+
   switch (dim)
     {
       // 1D
@@ -220,6 +223,35 @@ unsigned int FEInterface::ifem_n_dofs_per_elem(const unsigned int dim,
 
     default:
       libmesh_error_msg("Unsupported dim = " << dim);
+    }
+}
+
+
+
+unsigned int FEInterface::ifem_n_dofs_per_elem(const FEType & fe_t,
+                                               const Elem * elem)
+{
+  switch (elem->dim())
+    {
+      // 1D
+    case 1:
+      /*
+       * Since InfFE<Dim,T_radial,T_map>::n_dofs(...)
+       * is actually independent of T_radial and T_map, we can use
+       * just any T_radial and T_map
+       */
+      return InfFE<1,JACOBI_20_00,CARTESIAN>::n_dofs_per_elem(fe_t, elem);
+
+      // 2D
+    case 2:
+      return InfFE<2,JACOBI_20_00,CARTESIAN>::n_dofs_per_elem(fe_t, elem);
+
+      // 3D
+    case 3:
+      return InfFE<3,JACOBI_20_00,CARTESIAN>::n_dofs_per_elem(fe_t, elem);
+
+    default:
+      libmesh_error_msg("Unsupported dim = " << elem->dim());
     }
 }
 

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -507,7 +507,7 @@ void InfFE<Dim,T_radial,T_map>::init_shape_functions(const std::vector<Point> & 
     for (unsigned int n=0; n<n_total_approx_shape_functions; n++)
       {
         compute_shape_indices (this->fe_type,
-                               inf_elem_type,
+                               inf_elem,
                                n,
                                _base_shape_index[n],
                                _radial_shape_index[n]);

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -217,6 +217,9 @@ Real InfFE<Dim,T_radial,T_map>::shape(const FEType & fet,
                                       const unsigned int i,
                                       const Point & p)
 {
+  // TODO - if possible, not sure if we can easily fully remove this function.
+  // libmesh_deprecated();
+
   libmesh_assert_not_equal_to (Dim, 0);
 
 #ifdef DEBUG
@@ -281,7 +284,7 @@ Real InfFE<Dim,T_radial,T_map>::shape(const FEType & fet,
   std::unique_ptr<const Elem> base_el (inf_elem->build_side_ptr(0));
 
   unsigned int i_base, i_radial;
-  compute_shape_indices(fet, inf_elem->type(), i, i_base, i_radial);
+  compute_shape_indices(fet, inf_elem, i, i_base, i_radial);
 
   if (Dim > 1)
     return FEInterface::shape(fet, base_el.get(), i_base, p)
@@ -318,6 +321,9 @@ Real InfFE<Dim,T_radial,T_map>::shape_deriv (const FEType & fe_t,
                                              const unsigned int j,
                                              const Point & p)
 {
+  // TODO - if possible, not sure if we can easily fully remove this function.
+  // libmesh_deprecated();
+
   libmesh_assert_not_equal_to (Dim, 0);
   libmesh_assert_greater (Dim,j);
 #ifdef DEBUG
@@ -388,7 +394,7 @@ Real InfFE<Dim,T_radial,T_map>::shape_deriv (const FEType & fe_t,
       //   Therefore we can do very useless things then:
       i_base=0;
     }
-  compute_shape_indices(fe_t, inf_elem->type(), i, i_base, i_radial);
+  compute_shape_indices(fe_t, inf_elem, i, i_base, i_radial);
 
   if (j== Dim -1)
     {
@@ -541,7 +547,7 @@ void InfFE<Dim,T_radial,T_map>::compute_data(const FEType & fet,
         {
           // compute base and radial shape indices
           unsigned int i_base, i_radial;
-          compute_shape_indices(fet, inf_elem->type(), i, i_base, i_radial);
+          compute_shape_indices(fet, inf_elem, i, i_base, i_radial);
 
           data.shape[i] = (InfFERadial::decay(Dim,v)                                    /* (1.-v)/2. in 3D          */
                            * FEInterface::shape(fet, base_el.get(), i_base, p)          /* S_n(s,t)                 */
@@ -930,36 +936,54 @@ void InfFE<Dim,T_radial,T_map>::compute_node_indices_fast (const ElemType inf_el
 
 template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
 void InfFE<Dim,T_radial,T_map>::compute_shape_indices (const FEType & fet,
+                                                       const Elem * inf_elem,
+                                                       const unsigned int i,
+                                                       unsigned int & base_shape,
+                                                       unsigned int & radial_shape)
+{
+  // (Temporarily) call version of this function taking an
+  // ElemType. Eventually there should only be one version of this
+  // function that takes an Elem*.
+  compute_shape_indices(fet, inf_elem->type(), i, base_shape, radial_shape);
+}
+
+
+
+template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
+void InfFE<Dim,T_radial,T_map>::compute_shape_indices (const FEType & fet,
                                                        const ElemType inf_elem_type,
                                                        const unsigned int i,
                                                        unsigned int & base_shape,
                                                        unsigned int & radial_shape)
 {
+  // TODO: eventually figure out a way to deprecated this
+  // function. Note that we can't go the other way around and have
+  // this function call the Elem* version because there's not really a
+  // clean way to create the required Elem object on the fly...
+  // libmesh_deprecated();
 
-  /*
-   * An example is provided:  the numbers in comments refer to
-   * a fictitious InfHex18.  The numbers are chosen as exemplary
-   * values.  There is currently no base approximation that
-   * requires this many dof's at nodes, sides, faces and in the element.
-   *
-   * the order of the shape functions is heavily related with the
-   * order the dofs are assigned in \p DofMap::distributed_dofs().
-   * Due to the infinite elements with higher-order base approximation,
-   * some more effort is necessary.
-   *
-   * numbering scheme:
-   * 1. all vertices in the base, assign node->n_comp() dofs to each vertex
-   * 2. all vertices further out: innermost loop: radial shapes,
-   *    then the base approximation shapes
-   * 3. all side nodes in the base, assign node->n_comp() dofs to each side node
-   * 4. all side nodes further out: innermost loop: radial shapes,
-   *    then the base approximation shapes
-   * 5. (all) face nodes in the base, assign node->n_comp() dofs to each face node
-   * 6. (all) face nodes further out: innermost loop: radial shapes,
-   *    then the base approximation shapes
-   * 7. element-associated dof in the base
-   * 8. element-associated dof further out
-   */
+  // An example is provided:  the numbers in comments refer to
+  // a fictitious InfHex18.  The numbers are chosen as exemplary
+  // values.  There is currently no base approximation that
+  // requires this many dof's at nodes, sides, faces and in the element.
+  //
+  // the order of the shape functions is heavily related with the
+  // order the dofs are assigned in \p DofMap::distributed_dofs().
+  // Due to the infinite elements with higher-order base approximation,
+  // some more effort is necessary.
+  //
+  // numbering scheme:
+  // 1. all vertices in the base, assign node->n_comp() dofs to each vertex
+  // 2. all vertices further out: innermost loop: radial shapes,
+  //    then the base approximation shapes
+  // 3. all side nodes in the base, assign node->n_comp() dofs to each side node
+  // 4. all side nodes further out: innermost loop: radial shapes,
+  //    then the base approximation shapes
+  // 5. (all) face nodes in the base, assign node->n_comp() dofs to each face node
+  // 6. (all) face nodes further out: innermost loop: radial shapes,
+  //    then the base approximation shapes
+  // 7. element-associated dof in the base
+  // 8. element-associated dof further out
 
   const unsigned int radial_order       = static_cast<unsigned int>(fet.radial_order.get_order()); // 4
   const unsigned int radial_order_p_one = radial_order+1;                                          // 5
@@ -1189,6 +1213,9 @@ INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, unsigned int, n_dofs_at_node(const FEType 
 INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, void, compute_shape_indices(const FEType &, const ElemType, const unsigned int, unsigned int &, unsigned int &));
 INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, void, compute_shape_indices(const FEType &, const ElemType, const unsigned int, unsigned int &, unsigned int &));
 INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, void, compute_shape_indices(const FEType &, const ElemType, const unsigned int, unsigned int &, unsigned int &));
+INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, void, compute_shape_indices(const FEType &, const Elem *, const unsigned int, unsigned int &, unsigned int &));
+INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, void, compute_shape_indices(const FEType &, const Elem *, const unsigned int, unsigned int &, unsigned int &));
+INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, void, compute_shape_indices(const FEType &, const Elem *, const unsigned int, unsigned int &, unsigned int &));
 INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, void, compute_node_indices(const ElemType, const unsigned int, unsigned int &, unsigned int &));
 INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, void, compute_node_indices(const ElemType, const unsigned int, unsigned int &, unsigned int &));
 INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, void, compute_node_indices(const ElemType, const unsigned int, unsigned int &, unsigned int &));

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -94,6 +94,9 @@ unsigned int InfFE<Dim,T_radial,T_map>::n_dofs_at_node (const FEType & fet,
                                                         const ElemType inf_elem_type,
                                                         const unsigned int n)
 {
+  // TODO:
+  // libmesh_deprecated();
+
   const ElemType base_et (InfFEBase::get_elem_type(inf_elem_type));
 
   unsigned int n_base, n_radial;
@@ -115,6 +118,25 @@ unsigned int InfFE<Dim,T_radial,T_map>::n_dofs_at_node (const FEType & fet,
 
 
 
+template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
+unsigned int InfFE<Dim,T_radial,T_map>::n_dofs_at_node (const FEType & fet,
+                                                        const Elem * inf_elem,
+                                                        const unsigned int n)
+{
+  // The "base" Elem is a non-infinite Elem corresponding to side 0 of
+  // the InfElem. This builds a "lightweight" proxy and so should be
+  // relatively fast.
+  auto base_elem = inf_elem->build_side_ptr(0);
+
+  unsigned int n_base, n_radial;
+  compute_node_indices(inf_elem->type(), n, n_base, n_radial);
+
+  if (Dim > 1)
+    return FEInterface::n_dofs_at_node(fet, base_elem.get(), n_base)
+      * InfFERadial::n_dofs_at_node(fet.radial_order, n_radial);
+  else
+    return InfFERadial::n_dofs_at_node(fet.radial_order, n_radial);
+}
 
 
 
@@ -1140,6 +1162,9 @@ INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, unsigned int, n_dofs_per_elem(const FEType
 INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, unsigned int, n_dofs_at_node(const FEType &, const ElemType, const unsigned int));
 INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, unsigned int, n_dofs_at_node(const FEType &, const ElemType, const unsigned int));
 INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, unsigned int, n_dofs_at_node(const FEType &, const ElemType, const unsigned int));
+INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, unsigned int, n_dofs_at_node(const FEType &, const Elem *, const unsigned int));
+INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, unsigned int, n_dofs_at_node(const FEType &, const Elem *, const unsigned int));
+INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, unsigned int, n_dofs_at_node(const FEType &, const Elem *, const unsigned int));
 INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, void, compute_shape_indices(const FEType &, const ElemType, const unsigned int, unsigned int &, unsigned int &));
 INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, void, compute_shape_indices(const FEType &, const ElemType, const unsigned int, unsigned int &, unsigned int &));
 INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, void, compute_shape_indices(const FEType &, const ElemType, const unsigned int, unsigned int &, unsigned int &));

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -144,6 +144,9 @@ template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
 unsigned int InfFE<Dim,T_radial,T_map>::n_dofs_per_elem (const FEType & fet,
                                                          const ElemType inf_elem_type)
 {
+  // TODO:
+  // libmesh_deprecated();
+
   const ElemType base_et (InfFEBase::get_elem_type(inf_elem_type));
 
   if (Dim > 1)
@@ -155,6 +158,21 @@ unsigned int InfFE<Dim,T_radial,T_map>::n_dofs_per_elem (const FEType & fet,
 
 
 
+template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
+unsigned int InfFE<Dim,T_radial,T_map>::n_dofs_per_elem (const FEType & fet,
+                                                         const Elem * inf_elem)
+{
+  // The "base" Elem is a non-infinite Elem corresponding to side 0 of
+  // the InfElem. This builds a "lightweight" proxy and so should be
+  // relatively fast.
+  auto base_elem = inf_elem->build_side_ptr(0);
+
+  if (Dim > 1)
+    return FEInterface::n_dofs_per_elem(fet, base_elem.get())
+      * InfFERadial::n_dofs_per_elem(fet.radial_order);
+  else
+    return InfFERadial::n_dofs_per_elem(fet.radial_order);
+}
 
 
 
@@ -1159,6 +1177,9 @@ INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, unsigned int, n_dofs(const FEType &, const
 INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, unsigned int, n_dofs_per_elem(const FEType &, const ElemType));
 INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, unsigned int, n_dofs_per_elem(const FEType &, const ElemType));
 INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, unsigned int, n_dofs_per_elem(const FEType &, const ElemType));
+INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, unsigned int, n_dofs_per_elem(const FEType &, const Elem *));
+INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, unsigned int, n_dofs_per_elem(const FEType &, const Elem *));
+INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, unsigned int, n_dofs_per_elem(const FEType &, const Elem *));
 INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, unsigned int, n_dofs_at_node(const FEType &, const ElemType, const unsigned int));
 INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, unsigned int, n_dofs_at_node(const FEType &, const ElemType, const unsigned int));
 INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, unsigned int, n_dofs_at_node(const FEType &, const ElemType, const unsigned int));


### PR DESCRIPTION
This goes along with the changes in #2606, updating the related InfFE interfaces. Nothing is officially `libmesh_deprecated()` by this commit, but hopefully I will update that soon as well.
