### PR TITLE
Disable warnings in fparser builds

### DIFF
--- a/configure
+++ b/configure
@@ -663,6 +663,8 @@ CPPUNIT_CFLAGS
 CPPUNIT_CONFIG
 LIBMESH_ENABLE_FPARSER_FALSE
 LIBMESH_ENABLE_FPARSER_TRUE
+FPARSER_NO_PSABI_FALSE
+FPARSER_NO_PSABI_TRUE
 FPARSER_SUPPORT_JIT_FALSE
 FPARSER_SUPPORT_JIT_TRUE
 FPARSER_SUPPORT_DEBUGGING_FALSE
@@ -40987,6 +40989,14 @@ else
   FPARSER_SUPPORT_JIT_FALSE=
 fi
 
+       if test "$GXX" = "yes" && test "x$REAL_GXX" != "x"; then
+  FPARSER_NO_PSABI_TRUE=
+  FPARSER_NO_PSABI_FALSE='#'
+else
+  FPARSER_NO_PSABI_TRUE='#'
+  FPARSER_NO_PSABI_FALSE=
+fi
+
 
 if test $enablefparser = yes; then :
   libmesh_contrib_INCLUDES="$FPARSER_INCLUDE $libmesh_contrib_INCLUDES"
@@ -41973,6 +41983,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${FPARSER_SUPPORT_JIT_TRUE}" && test -z "${FPARSER_SUPPORT_JIT_FALSE}"; then
   as_fn_error $? "conditional \"FPARSER_SUPPORT_JIT\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${FPARSER_NO_PSABI_TRUE}" && test -z "${FPARSER_NO_PSABI_FALSE}"; then
+  as_fn_error $? "conditional \"FPARSER_NO_PSABI\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${LIBMESH_ENABLE_FPARSER_TRUE}" && test -z "${LIBMESH_ENABLE_FPARSER_FALSE}"; then

--- a/contrib/fparser/Makefile.am
+++ b/contrib/fparser/Makefile.am
@@ -96,7 +96,7 @@ FPOPTIMIZER_CC_FILES=\
 EXTRA_DIST += $(FPOPTIMIZER_CC_FILES) fpoptimizer/fpoptimizer_header.txt fpoptimizer/fpoptimizer_footer.txt
 
 
-pkg_sources = fparser.cc fparser_ad.cc Faddeeva.cc Faddeeva.hh
+pkg_sources = fparser.cc fparser_ad.cc Faddeeva.cc Faddeeva.hh ignore_opcode_warnings.hh restore_opcode_warnings.hh
 pkg_sources += lib/sha1.cpp
 if FPARSER_SUPPORT_JIT
   pkg_cppflags += -DFPARSER_JIT_COMPILER="\"$(CXX) $(CXXFLAGS)\""
@@ -104,6 +104,12 @@ endif
 
 pkg_cppflags += $(FEATURE_FLAGS)
 
+# For GCC, the -Wno-psabi flag disables the warning:
+# "the ABI of passing structure with complex float member has changed in GCC 4.4"
+# which some fparser source files trigger.
+if FPARSER_NO_PSABI
+  pkg_cppflags += -Wno-psabi
+endif
 
 # util/tree_grammar_parser is a utility which is required to build
 # fpoptimizer/grammar_data.cc.  But this file itself is only needed

--- a/contrib/fparser/Makefile.in
+++ b/contrib/fparser/Makefile.in
@@ -95,17 +95,22 @@ target_triplet = @target@
 @FPARSER_SUPPORT_DEBUGGING_TRUE@am__append_1 = -DFUNCTIONPARSER_SUPPORT_DEBUGGING
 noinst_PROGRAMS = $(am__EXEEXT_1)
 @FPARSER_SUPPORT_JIT_TRUE@am__append_2 = -DFPARSER_JIT_COMPILER="\"$(CXX) $(CXXFLAGS)\""
-@FPARSER_DEVEL_TRUE@am__append_3 = fpoptimizer/grammar_data.cc
-@FPARSER_DEVEL_TRUE@am__append_4 = util/tree_grammar_parser \
+
+# For GCC, the -Wno-psabi flag disables the warning:
+# "the ABI of passing structure with complex float member has changed in GCC 4.4"
+# which some fparser source files trigger.
+@FPARSER_NO_PSABI_TRUE@am__append_3 = -Wno-psabi
+@FPARSER_DEVEL_TRUE@am__append_4 = fpoptimizer/grammar_data.cc
+@FPARSER_DEVEL_TRUE@am__append_5 = util/tree_grammar_parser \
 @FPARSER_DEVEL_TRUE@	util/bytecoderules_parser
-@FPARSER_DEVEL_TRUE@am__append_5 = $(FPOPTIMIZER_CC_FILES)
-@FPARSER_DEVEL_TRUE@am__append_6 = $(BUILT_SOURCES)
-@FPARSER_DEVEL_FALSE@am__append_7 = fpoptimizer.cc
-@LIBMESH_DBG_MODE_TRUE@am__append_8 = libdbg.la
-@LIBMESH_DEVEL_MODE_TRUE@am__append_9 = libdevel.la
-@LIBMESH_OPT_MODE_TRUE@am__append_10 = libopt.la
-@LIBMESH_PROF_MODE_TRUE@am__append_11 = libprof.la
-@LIBMESH_OPROF_MODE_TRUE@am__append_12 = liboprof.la
+@FPARSER_DEVEL_TRUE@am__append_6 = $(FPOPTIMIZER_CC_FILES)
+@FPARSER_DEVEL_TRUE@am__append_7 = $(BUILT_SOURCES)
+@FPARSER_DEVEL_FALSE@am__append_8 = fpoptimizer.cc
+@LIBMESH_DBG_MODE_TRUE@am__append_9 = libdbg.la
+@LIBMESH_DEVEL_MODE_TRUE@am__append_10 = libdevel.la
+@LIBMESH_OPT_MODE_TRUE@am__append_11 = libopt.la
+@LIBMESH_PROF_MODE_TRUE@am__append_12 = libprof.la
+@LIBMESH_OPROF_MODE_TRUE@am__append_13 = liboprof.la
 subdir = contrib/fparser
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps =  \
@@ -172,14 +177,15 @@ PROGRAMS = $(noinst_PROGRAMS)
 LTLIBRARIES = $(noinst_LTLIBRARIES)
 libdbg_la_DEPENDENCIES =
 am__libdbg_la_SOURCES_DIST = fparser.cc fparser_ad.cc Faddeeva.cc \
-	Faddeeva.hh lib/sha1.cpp lib/crc32.hh lib/autoptr.hh \
-	lib/functional.hh fpoptimizer/hash.hh fpoptimizer/codetree.hh \
-	fpoptimizer/grammar.hh fpoptimizer/consts.hh \
-	fpoptimizer/optimize.hh fpoptimizer/opcodename.hh \
-	fpoptimizer/opcodename.cc fpoptimizer/bytecodesynth.hh \
-	fpoptimizer/bytecodesynth.cc fpoptimizer/valuerange.hh \
-	fpoptimizer/rangeestimation.hh fpoptimizer/constantfolding.hh \
-	fpoptimizer/logic_boolgroups.hh \
+	Faddeeva.hh ignore_opcode_warnings.hh \
+	restore_opcode_warnings.hh lib/sha1.cpp lib/crc32.hh \
+	lib/autoptr.hh lib/functional.hh fpoptimizer/hash.hh \
+	fpoptimizer/codetree.hh fpoptimizer/grammar.hh \
+	fpoptimizer/consts.hh fpoptimizer/optimize.hh \
+	fpoptimizer/opcodename.hh fpoptimizer/opcodename.cc \
+	fpoptimizer/bytecodesynth.hh fpoptimizer/bytecodesynth.cc \
+	fpoptimizer/valuerange.hh fpoptimizer/rangeestimation.hh \
+	fpoptimizer/constantfolding.hh fpoptimizer/logic_boolgroups.hh \
 	fpoptimizer/logic_collections.hh \
 	fpoptimizer/logic_ifoperations.hh \
 	fpoptimizer/logic_powoperations.hh \
@@ -229,14 +235,15 @@ libdbg_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
 @LIBMESH_DBG_MODE_TRUE@am_libdbg_la_rpath =
 libdevel_la_DEPENDENCIES =
 am__libdevel_la_SOURCES_DIST = fparser.cc fparser_ad.cc Faddeeva.cc \
-	Faddeeva.hh lib/sha1.cpp lib/crc32.hh lib/autoptr.hh \
-	lib/functional.hh fpoptimizer/hash.hh fpoptimizer/codetree.hh \
-	fpoptimizer/grammar.hh fpoptimizer/consts.hh \
-	fpoptimizer/optimize.hh fpoptimizer/opcodename.hh \
-	fpoptimizer/opcodename.cc fpoptimizer/bytecodesynth.hh \
-	fpoptimizer/bytecodesynth.cc fpoptimizer/valuerange.hh \
-	fpoptimizer/rangeestimation.hh fpoptimizer/constantfolding.hh \
-	fpoptimizer/logic_boolgroups.hh \
+	Faddeeva.hh ignore_opcode_warnings.hh \
+	restore_opcode_warnings.hh lib/sha1.cpp lib/crc32.hh \
+	lib/autoptr.hh lib/functional.hh fpoptimizer/hash.hh \
+	fpoptimizer/codetree.hh fpoptimizer/grammar.hh \
+	fpoptimizer/consts.hh fpoptimizer/optimize.hh \
+	fpoptimizer/opcodename.hh fpoptimizer/opcodename.cc \
+	fpoptimizer/bytecodesynth.hh fpoptimizer/bytecodesynth.cc \
+	fpoptimizer/valuerange.hh fpoptimizer/rangeestimation.hh \
+	fpoptimizer/constantfolding.hh fpoptimizer/logic_boolgroups.hh \
 	fpoptimizer/logic_collections.hh \
 	fpoptimizer/logic_ifoperations.hh \
 	fpoptimizer/logic_powoperations.hh \
@@ -281,14 +288,15 @@ libdevel_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
 @LIBMESH_DEVEL_MODE_TRUE@am_libdevel_la_rpath =
 liboprof_la_DEPENDENCIES =
 am__liboprof_la_SOURCES_DIST = fparser.cc fparser_ad.cc Faddeeva.cc \
-	Faddeeva.hh lib/sha1.cpp lib/crc32.hh lib/autoptr.hh \
-	lib/functional.hh fpoptimizer/hash.hh fpoptimizer/codetree.hh \
-	fpoptimizer/grammar.hh fpoptimizer/consts.hh \
-	fpoptimizer/optimize.hh fpoptimizer/opcodename.hh \
-	fpoptimizer/opcodename.cc fpoptimizer/bytecodesynth.hh \
-	fpoptimizer/bytecodesynth.cc fpoptimizer/valuerange.hh \
-	fpoptimizer/rangeestimation.hh fpoptimizer/constantfolding.hh \
-	fpoptimizer/logic_boolgroups.hh \
+	Faddeeva.hh ignore_opcode_warnings.hh \
+	restore_opcode_warnings.hh lib/sha1.cpp lib/crc32.hh \
+	lib/autoptr.hh lib/functional.hh fpoptimizer/hash.hh \
+	fpoptimizer/codetree.hh fpoptimizer/grammar.hh \
+	fpoptimizer/consts.hh fpoptimizer/optimize.hh \
+	fpoptimizer/opcodename.hh fpoptimizer/opcodename.cc \
+	fpoptimizer/bytecodesynth.hh fpoptimizer/bytecodesynth.cc \
+	fpoptimizer/valuerange.hh fpoptimizer/rangeestimation.hh \
+	fpoptimizer/constantfolding.hh fpoptimizer/logic_boolgroups.hh \
 	fpoptimizer/logic_collections.hh \
 	fpoptimizer/logic_ifoperations.hh \
 	fpoptimizer/logic_powoperations.hh \
@@ -333,14 +341,15 @@ liboprof_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
 @LIBMESH_OPROF_MODE_TRUE@am_liboprof_la_rpath =
 libopt_la_DEPENDENCIES =
 am__libopt_la_SOURCES_DIST = fparser.cc fparser_ad.cc Faddeeva.cc \
-	Faddeeva.hh lib/sha1.cpp lib/crc32.hh lib/autoptr.hh \
-	lib/functional.hh fpoptimizer/hash.hh fpoptimizer/codetree.hh \
-	fpoptimizer/grammar.hh fpoptimizer/consts.hh \
-	fpoptimizer/optimize.hh fpoptimizer/opcodename.hh \
-	fpoptimizer/opcodename.cc fpoptimizer/bytecodesynth.hh \
-	fpoptimizer/bytecodesynth.cc fpoptimizer/valuerange.hh \
-	fpoptimizer/rangeestimation.hh fpoptimizer/constantfolding.hh \
-	fpoptimizer/logic_boolgroups.hh \
+	Faddeeva.hh ignore_opcode_warnings.hh \
+	restore_opcode_warnings.hh lib/sha1.cpp lib/crc32.hh \
+	lib/autoptr.hh lib/functional.hh fpoptimizer/hash.hh \
+	fpoptimizer/codetree.hh fpoptimizer/grammar.hh \
+	fpoptimizer/consts.hh fpoptimizer/optimize.hh \
+	fpoptimizer/opcodename.hh fpoptimizer/opcodename.cc \
+	fpoptimizer/bytecodesynth.hh fpoptimizer/bytecodesynth.cc \
+	fpoptimizer/valuerange.hh fpoptimizer/rangeestimation.hh \
+	fpoptimizer/constantfolding.hh fpoptimizer/logic_boolgroups.hh \
 	fpoptimizer/logic_collections.hh \
 	fpoptimizer/logic_ifoperations.hh \
 	fpoptimizer/logic_powoperations.hh \
@@ -385,14 +394,15 @@ libopt_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
 @LIBMESH_OPT_MODE_TRUE@am_libopt_la_rpath =
 libprof_la_DEPENDENCIES =
 am__libprof_la_SOURCES_DIST = fparser.cc fparser_ad.cc Faddeeva.cc \
-	Faddeeva.hh lib/sha1.cpp lib/crc32.hh lib/autoptr.hh \
-	lib/functional.hh fpoptimizer/hash.hh fpoptimizer/codetree.hh \
-	fpoptimizer/grammar.hh fpoptimizer/consts.hh \
-	fpoptimizer/optimize.hh fpoptimizer/opcodename.hh \
-	fpoptimizer/opcodename.cc fpoptimizer/bytecodesynth.hh \
-	fpoptimizer/bytecodesynth.cc fpoptimizer/valuerange.hh \
-	fpoptimizer/rangeestimation.hh fpoptimizer/constantfolding.hh \
-	fpoptimizer/logic_boolgroups.hh \
+	Faddeeva.hh ignore_opcode_warnings.hh \
+	restore_opcode_warnings.hh lib/sha1.cpp lib/crc32.hh \
+	lib/autoptr.hh lib/functional.hh fpoptimizer/hash.hh \
+	fpoptimizer/codetree.hh fpoptimizer/grammar.hh \
+	fpoptimizer/consts.hh fpoptimizer/optimize.hh \
+	fpoptimizer/opcodename.hh fpoptimizer/opcodename.cc \
+	fpoptimizer/bytecodesynth.hh fpoptimizer/bytecodesynth.cc \
+	fpoptimizer/valuerange.hh fpoptimizer/rangeestimation.hh \
+	fpoptimizer/constantfolding.hh fpoptimizer/logic_boolgroups.hh \
 	fpoptimizer/logic_collections.hh \
 	fpoptimizer/logic_ifoperations.hh \
 	fpoptimizer/logic_powoperations.hh \
@@ -1062,7 +1072,7 @@ vtkbuild = @vtkbuild@
 vtkmajor = @vtkmajor@
 vtkversion = @vtkversion@
 pkg_cppflags = -I$(srcdir)/fpoptimizer $(am__append_2) \
-	$(FEATURE_FLAGS)
+	$(FEATURE_FLAGS) $(am__append_3)
 #FEATURE_FLAGS += -DFP_SUPPORT_TR1_MATH_FUNCS
 
 #FEATURE_FLAGS += -DFP_USE_THREAD_SAFE_EVAL
@@ -1084,13 +1094,13 @@ EXTRA_DIST = util/bytecoderules.dat util/bytecoderules_header.txt \
 	fpoptimizer/treerules.dat $(FPOPTIMIZER_CC_FILES) \
 	fpoptimizer/fpoptimizer_header.txt \
 	fpoptimizer/fpoptimizer_footer.txt
-BUILT_SOURCES = extrasrc/fp_opcode_add.inc $(am__append_3)
+BUILT_SOURCES = extrasrc/fp_opcode_add.inc $(am__append_4)
 
 #  util_cpp_compress_CXXFLAGS = # nothing fancy - don't use our compile flags for this utility code lest it be horribly slow
 #  util_cpp_compress_SOURCES  = util/cpp_compress.hh util/cpp_compress.cc util/cpp_compress_main.cc
 
 # when doing 'make clean' we need to remove the generated sources
-CLEANFILES = fpoptimizer/grammar_data.cc $(am__append_6)
+CLEANFILES = fpoptimizer/grammar_data.cc $(am__append_7)
 # in case they weren't conditionally cleaned:
 # DISTCLEANFILES += util/cpp_compress
 DISTCLEANFILES = util/bytecoderules_parser util/tree_grammar_parser
@@ -1135,7 +1145,8 @@ FPOPTIMIZER_CC_FILES = \
 	    fpoptimizer/optimize_main.cc
 
 pkg_sources = fparser.cc fparser_ad.cc Faddeeva.cc Faddeeva.hh \
-	lib/sha1.cpp $(am__append_5) $(am__append_7)
+	ignore_opcode_warnings.hh restore_opcode_warnings.hh \
+	lib/sha1.cpp $(am__append_6) $(am__append_8)
 
 # util/tree_grammar_parser is a utility which is required to build
 # fpoptimizer/grammar_data.cc.  But this file itself is only needed
@@ -1199,8 +1210,8 @@ AM_LDFLAGS = $(libmesh_LDFLAGS)
 #
 # Building the flavors
 #
-noinst_LTLIBRARIES = $(am__append_8) $(am__append_9) $(am__append_10) \
-	$(am__append_11) $(am__append_12)
+noinst_LTLIBRARIES = $(am__append_9) $(am__append_10) $(am__append_11) \
+	$(am__append_12) $(am__append_13)
 @LIBMESH_DBG_MODE_TRUE@libdbg_la_SOURCES = $(pkg_sources)
 @LIBMESH_DBG_MODE_TRUE@libdbg_la_CPPFLAGS = $(CPPFLAGS_DBG) $(AM_CPPFLAGS)
 @LIBMESH_DBG_MODE_TRUE@libdbg_la_CXXFLAGS = $(CXXFLAGS_DBG)

--- a/contrib/fparser/Makefile.orig
+++ b/contrib/fparser/Makefile.orig
@@ -95,6 +95,7 @@ CPPFLAGS=$(FEATURE_FLAGS) -I$(LIBMESH_DIR)/include/libmesh
 CXXFLAGS=-Wall -W -pedantic -ansi $(OPTIMIZATION)
 #CXXFLAGS += -Wunreachable-code
 #CXXFLAGS += -std=c++0x
+CXXFLAGS += -std=c++11
 
 #CXXFLAGS += -Weffc++
 

--- a/contrib/fparser/fparser.cc
+++ b/contrib/fparser/fparser.cc
@@ -1649,13 +1649,9 @@ inline void FunctionParserBase<Value_t>::AddFunctionOpcode(unsigned opcode)
 #define FP_FLOAT_VERSION 1
 #define FP_COMPLEX_VERSION 0
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma clang diagnostic ignored "-Wc99-extensions"
-#pragma GCC diagnostic ignored "-Wmisleading-indentation"
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#include "ignore_opcode_warnings.hh"
 #include "extrasrc/fp_opcode_add.inc"
-#pragma GCC diagnostic pop
+#include "restore_opcode_warnings.hh"
 
 #undef FP_COMPLEX_VERSION
 #undef FP_FLOAT_VERSION
@@ -1669,13 +1665,9 @@ inline void FunctionParserBase<long>::AddFunctionOpcode(unsigned opcode)
 #define FP_FLOAT_VERSION 0
 #define FP_COMPLEX_VERSION 0
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma clang diagnostic ignored "-Wc99-extensions"
-#pragma GCC diagnostic ignored "-Wmisleading-indentation"
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#include "ignore_opcode_warnings.hh"
 #include "extrasrc/fp_opcode_add.inc"
-#pragma GCC diagnostic pop
+#include "restore_opcode_warnings.hh"
 
 #undef FP_COMPLEX_VERSION
 #undef FP_FLOAT_VERSION
@@ -1690,13 +1682,9 @@ inline void FunctionParserBase<GmpInt>::AddFunctionOpcode(unsigned opcode)
 #define FP_FLOAT_VERSION 0
 #define FP_COMPLEX_VERSION 0
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma clang diagnostic ignored "-Wc99-extensions"
-#pragma GCC diagnostic ignored "-Wmisleading-indentation"
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#include "ignore_opcode_warnings.hh"
 #include "extrasrc/fp_opcode_add.inc"
-#pragma GCC diagnostic pop
+#include "restore_opcode_warnings.hh"
 
 #undef FP_COMPLEX_VERSION
 #undef FP_FLOAT_VERSION
@@ -1711,13 +1699,9 @@ inline void FunctionParserBase<std::complex<double> >::AddFunctionOpcode(unsigne
 #define FP_FLOAT_VERSION 1
 #define FP_COMPLEX_VERSION 1
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma clang diagnostic ignored "-Wc99-extensions"
-#pragma GCC diagnostic ignored "-Wmisleading-indentation"
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#include "ignore_opcode_warnings.hh"
 #include "extrasrc/fp_opcode_add.inc"
-#pragma GCC diagnostic pop
+#include "restore_opcode_warnings.hh"
 
 #undef FP_COMPLEX_VERSION
 #undef FP_FLOAT_VERSION
@@ -1732,13 +1716,9 @@ inline void FunctionParserBase<std::complex<float> >::AddFunctionOpcode(unsigned
 #define FP_FLOAT_VERSION 1
 #define FP_COMPLEX_VERSION 1
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma clang diagnostic ignored "-Wc99-extensions"
-#pragma GCC diagnostic ignored "-Wmisleading-indentation"
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#include "ignore_opcode_warnings.hh"
 #include "extrasrc/fp_opcode_add.inc"
-#pragma GCC diagnostic pop
+#include "restore_opcode_warnings.hh"
 
 #undef FP_COMPLEX_VERSION
 #undef FP_FLOAT_VERSION
@@ -1753,13 +1733,9 @@ inline void FunctionParserBase<std::complex<long double> >::AddFunctionOpcode(un
 #define FP_FLOAT_VERSION 1
 #define FP_COMPLEX_VERSION 1
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma clang diagnostic ignored "-Wc99-extensions"
-#pragma GCC diagnostic ignored "-Wmisleading-indentation"
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#include "ignore_opcode_warnings.hh"
 #include "extrasrc/fp_opcode_add.inc"
-#pragma GCC diagnostic pop
+#include "restore_opcode_warnings.hh"
 
 #undef FP_COMPLEX_VERSION
 #undef FP_FLOAT_VERSION

--- a/contrib/fparser/fparser_ad.cc
+++ b/contrib/fparser/fparser_ad.cc
@@ -22,6 +22,16 @@ using namespace FPoptimizer_CodeTree;
 
 #include "lib/sha1.h"
 
+// There are several case statements in this file where we
+// intentionally want to fall through, so let's not get warned about
+// each one.
+#ifdef __GNUC__
+#if (__GNUC__ > 6)
+#  pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
+#endif
+
+
 /**
  * The internals of the automatic differentiation algorithm are encapsulated in this class
  * and hidden from the public interface, as the installed FParser version does not have access

--- a/contrib/fparser/fpoptimizer.cc
+++ b/contrib/fparser/fpoptimizer.cc
@@ -1472,6 +1472,15 @@ namespace FPoptimizer_ByteCode
 #line 1 "fpoptimizer/bytecodesynth.cc"
 // line removed for fpoptimizer.cc: #include "bytecodesynth.hh"
 
+// There are several case statements in this file where we
+// intentionally want to fall through, so let's not get warned about
+// each one.
+#ifdef __GNUC__
+#if (__GNUC__ > 6)
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
+#endif
+
 #ifdef FP_SUPPORT_OPTIMIZER
 
 // line removed for fpoptimizer.cc: #include "opcodename.hh"
@@ -8161,6 +8170,15 @@ namespace FPoptimizer_Grammar
 // line removed for fpoptimizer.cc: #include "extrasrc/fptypes.hh"
 // line removed for fpoptimizer.cc: #include "../lib/crc32.hh"
 
+// There are several case statements in this file where we
+// intentionally want to fall through, so let's not get warned about
+// each one.
+#ifdef __GNUC__
+#if (__GNUC__ > 6)
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
+#endif
+
 #ifdef FP_SUPPORT_OPTIMIZER
 
 using namespace FUNCTIONPARSERTYPES;
@@ -8906,6 +8924,15 @@ namespace FPoptimizer_CodeTree
 
 // line removed for fpoptimizer.cc: #include "consts.hh"
 // line removed for fpoptimizer.cc: #include "fparser.hh"
+
+// There are several case statements in this file where we
+// intentionally want to fall through, so let's not get warned about
+// each one.
+#ifdef __GNUC__
+#if (__GNUC__ > 6)
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
+#endif
 
 #ifdef FP_SUPPORT_OPTIMIZER
 

--- a/contrib/fparser/fpoptimizer/bytecodesynth.cc
+++ b/contrib/fparser/fpoptimizer/bytecodesynth.cc
@@ -1,5 +1,14 @@
 #include "bytecodesynth.hh"
 
+// There are several case statements in this file where we
+// intentionally want to fall through, so let's not get warned about
+// each one.
+#ifdef __GNUC__
+#if (__GNUC__ > 6)
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
+#endif
+
 #ifdef FP_SUPPORT_OPTIMIZER
 
 #include "opcodename.hh"

--- a/contrib/fparser/fpoptimizer/hash.cc
+++ b/contrib/fparser/fpoptimizer/hash.cc
@@ -6,6 +6,15 @@
 #include "extrasrc/fptypes.hh"
 #include "../lib/crc32.hh"
 
+// There are several case statements in this file where we
+// intentionally want to fall through, so let's not get warned about
+// each one.
+#ifdef __GNUC__
+#if (__GNUC__ > 6)
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
+#endif
+
 #ifdef FP_SUPPORT_OPTIMIZER
 
 using namespace FUNCTIONPARSERTYPES;

--- a/contrib/fparser/fpoptimizer/readbytecode.cc
+++ b/contrib/fparser/fpoptimizer/readbytecode.cc
@@ -10,6 +10,15 @@
 #include "consts.hh"
 #include "fparser.hh"
 
+// There are several case statements in this file where we
+// intentionally want to fall through, so let's not get warned about
+// each one.
+#ifdef __GNUC__
+#if (__GNUC__ > 6)
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
+#endif
+
 #ifdef FP_SUPPORT_OPTIMIZER
 
 using namespace FUNCTIONPARSERTYPES;

--- a/contrib/fparser/ignore_opcode_warnings.hh
+++ b/contrib/fparser/ignore_opcode_warnings.hh
@@ -1,0 +1,16 @@
+// Note: no include guards, we want this to be included multiple times within a single translation unit.
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wmisleading-indentation"
+
+#if (__GNUC__ > 6)
+#  pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wc99-extensions"
+#endif
+

--- a/contrib/fparser/restore_opcode_warnings.hh
+++ b/contrib/fparser/restore_opcode_warnings.hh
@@ -1,0 +1,9 @@
+// Note: no include guards, we want this to be included multiple times within a single translation unit.
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif

--- a/m4/fparser.m4
+++ b/m4/fparser.m4
@@ -90,4 +90,7 @@ AC_DEFUN([CONFIGURE_FPARSER],
   AM_CONDITIONAL(FPARSER_DEVEL,                test x$enablefparserdevel = xyes)
   AM_CONDITIONAL(FPARSER_SUPPORT_DEBUGGING,    test x$enablefparserdebugging = xyes)
   AM_CONDITIONAL(FPARSER_SUPPORT_JIT,    test x$enablefparserjit = xyes)
+  dnl Turn on the -Wno_psabi flag when compiling with GCC to avoid warning:
+  dnl "the ABI of passing structure with complex float member has changed in GCC 4.4"
+  AM_CONDITIONAL(FPARSER_NO_PSABI, test "$GXX" = "yes" && test "x$REAL_GXX" != "x")
 ])


### PR DESCRIPTION
This gets rid of the warnings described in #2613, plus the 
```
the ABI of passing structure with complex float member has changed in GCC 4.4
```
one that has been showing up for a while now.
