### PR TITLE
Edge::side_ptr(): remove inadvertant set_p_level() call

### DIFF
--- a/src/geom/edge.C
+++ b/src/geom/edge.C
@@ -61,9 +61,7 @@ void Edge::side_ptr (std::unique_ptr<Elem> & side,
   else
     {
       side->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      side->set_p_level(this->p_level());
-#endif
+
       side->set_node(0) = this->node_ptr(i);
     }
 }


### PR DESCRIPTION
This change was made by accident in f1782255be while I was trying to
update the various Elem::build_side_ptr() routines in #2592, so this
simply reverts that change.

There appears to be larger issues with the consistency of the
Elem::side_ptr() method and setting of the side's p_level, but this
change can at least be reverted before those are addressed.