### PR TITLE
Avoid calling DofObject::id() when id can be invalid.

### DIFF
--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -496,9 +496,9 @@ Node * ReplicatedMesh::add_node (Node * n)
 
   // If the user requests a valid id, either set the existing
   // container entry or resize the container to fit the new node.
-  const dof_id_type id = n->id();
-  if (id != DofObject::invalid_id)
+  if (n->valid_id())
     {
+      const dof_id_type id = n->id();
       if (id < _nodes.size())
         libmesh_assert(!_nodes[id]);
       else


### PR DESCRIPTION
This prevents different behavior in optimized vs. debug mode, since `DofObject::id()` asserts in dbg mode when `id` is invalid.