### PR TITLE
Quad4::build_side_ptr() should call simple_build_side_ptr()

### DIFF
--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -157,19 +157,7 @@ std::unique_ptr<Elem> Quad4::build_side_ptr (const unsigned int i,
 void Quad4::build_side_ptr (std::unique_ptr<Elem> & side,
                             const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (!side.get() || side->type() != EDGE2)
-    side = this->build_side_ptr(i, false);
-  else
-    {
-      side->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-      side->set_p_level(this->p_level());
-#endif
-      for (auto n : side->node_index_range())
-        side->set_node(n) = this->node_ptr(Quad4::side_nodes_map[i][n]);
-    }
+  this->simple_build_side_ptr<Quad4>(side, i, EDGE2);
 }
 
 


### PR DESCRIPTION
This makes the in-place Quad4::build_side_ptr() consistent with other
Elem types that have a single type of side.