### PR TITLE
Implement InfQuad4::build_side_ptr() in terms of base class side_ptr()

### DIFF
--- a/src/geom/face_inf_quad4.C
+++ b/src/geom/face_inf_quad4.C
@@ -256,45 +256,7 @@ std::unique_ptr<Elem> InfQuad4::build_side_ptr (const unsigned int i,
 void InfQuad4::build_side_ptr (std::unique_ptr<Elem> & side,
                                const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  // Think of a unit cube: (-1,1) x (-1,1) x (1,1)
-  switch (i)
-    {
-      // the base face
-    case 0:
-      {
-        if (!side.get() || side->type() != EDGE2)
-          {
-            side = this->build_side_ptr(i, false);
-            return;
-          }
-        break;
-      }
-
-      // connecting to another infinite element
-    case 1:
-    case 2:
-      {
-        if (!side.get() || side->type() != INFEDGE2)
-          {
-            side = this->build_side_ptr(i, false);
-            return;
-          }
-        break;
-      }
-
-    default:
-      libmesh_error_msg("Invalid side i = " << i);
-    }
-
-  side->subdomain_id() = this->subdomain_id();
-#ifdef LIBMESH_ENABLE_AMR
-  side->set_p_level(this->p_level());
-#endif
-  // Set the nodes
-  for (auto n : side->node_index_range())
-    side->set_node(n) = this->node_ptr(InfQuad4::side_nodes_map[i][n]);
+  this->side_ptr(side, i);
 }
 
 


### PR DESCRIPTION
This seems to be equivalent to what's done for the other low-order
InfElem classes, for example:

* InfPrism6::build_side_ptr(side, i) calls InfPrism::side_ptr(side, i)
* InfHex8::build_side_ptr(side, i) calls InfHex::build_side(side, i))