### PR TITLE
Remove extra flags from pkgconfig Cflags.

### DIFF
--- a/contrib/utils/libmesh-dbg.pc.in
+++ b/contrib/utils/libmesh-dbg.pc.in
@@ -2,6 +2,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
+cxxflags_extra = @CXXFLAGS_DBG@
 
 Name: libmesh
 Description: The libMesh Finite Element Library
@@ -10,6 +11,6 @@ Version: @VERSION@
 Libs: -Wl,-rpath,${libdir} -L${libdir} -lmesh_dbg -ltimpi_dbg \
       @libmesh_installed_LIBS@ @libmesh_optional_LIBS@
 Libs.private:
-Cflags: @CPPFLAGS_DBG@ @CXXFLAGS_DBG@ \
+Cflags: @CPPFLAGS_DBG@ \
         -I${includedir} \
 	@libmesh_optional_INCLUDES@

--- a/contrib/utils/libmesh-devel.pc.in
+++ b/contrib/utils/libmesh-devel.pc.in
@@ -2,6 +2,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
+cxxflags_extra = @CXXFLAGS_DEVEL@
 
 Name: libmesh
 Description: The libMesh Finite Element Library
@@ -10,6 +11,6 @@ Version: @VERSION@
 Libs: -Wl,-rpath,${libdir} -L${libdir} -lmesh_devel -ltimpi_devel \
       @libmesh_installed_LIBS@ @libmesh_optional_LIBS@
 Libs.private:
-Cflags: @CPPFLAGS_DEVEL@ @CXXFLAGS_DEVEL@ \
+Cflags: @CPPFLAGS_DEVEL@ \
         -I${includedir} \
 	@libmesh_optional_INCLUDES@

--- a/contrib/utils/libmesh-oprof.pc.in
+++ b/contrib/utils/libmesh-oprof.pc.in
@@ -2,6 +2,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
+cxxflags_extra = @CXXFLAGS_OPROF@
 
 Name: libmesh
 Description: The libMesh Finite Element Library
@@ -10,6 +11,6 @@ Version: @VERSION@
 Libs: -Wl,-rpath,${libdir} -L${libdir} -lmesh_oprof -ltimpi_oprof \
       @libmesh_installed_LIBS@ @libmesh_optional_LIBS@
 Libs.private:
-Cflags: @CPPFLAGS_OPROF@ @CXXFLAGS_OPROF@ \
+Cflags: @CPPFLAGS_OPROF@ \
         -I${includedir} \
 	@libmesh_optional_INCLUDES@

--- a/contrib/utils/libmesh-opt.pc.in
+++ b/contrib/utils/libmesh-opt.pc.in
@@ -2,6 +2,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
+cxxflags_extra = @CXXFLAGS_OPT@
 
 Name: libmesh
 Description: The libMesh Finite Element Library
@@ -10,6 +11,6 @@ Version: @VERSION@
 Libs: -Wl,-rpath,${libdir} -L${libdir} -lmesh_opt -ltimpi_opt \
       @libmesh_installed_LIBS@ @libmesh_optional_LIBS@
 Libs.private:
-Cflags: @CPPFLAGS_OPT@ @CXXFLAGS_OPT@ \
+Cflags: @CPPFLAGS_OPT@ \
         -I${includedir} \
 	@libmesh_optional_INCLUDES@

--- a/contrib/utils/libmesh-prof.pc.in
+++ b/contrib/utils/libmesh-prof.pc.in
@@ -2,6 +2,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
+cxxflags_extra = @CXXFLAGS_PROF@
 
 Name: libmesh
 Description: The libMesh Finite Element Library
@@ -10,6 +11,6 @@ Version: @VERSION@
 Libs: -Wl,-rpath,${libdir} -L${libdir} -lmesh_prof -ltimpi_prof \
       @libmesh_installed_LIBS@ @libmesh_optional_LIBS@
 Libs.private:
-Cflags: @CPPFLAGS_PROF@ @CXXFLAGS_PROF@ \
+Cflags: @CPPFLAGS_PROF@ \
         -I${includedir} \
 	@libmesh_optional_INCLUDES@


### PR DESCRIPTION
Followup to #2604.

The convention for this field is to only list necessary (i.e., preprocessor) flags. I moved the other compilation flags into cxxflags_extra, which is analogous to where PETSc puts them.