### PR TITLE
Generalize DifferentiableSystem::adjoint_solve

### DIFF
--- a/include/solvers/time_solver.h
+++ b/include/solvers/time_solver.h
@@ -26,6 +26,7 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/solution_history.h"
+#include "libmesh/qoi_set.h"
 
 // C++ includes
 #include <memory>
@@ -109,6 +110,12 @@ public:
    * time step selection may require some solve() steps to be repeated.
    */
   virtual void advance_timestep ();
+
+  /**
+   * This method solves for the adjoint solution at the next adjoint timestep
+   * (or a steady state adjoint solve)
+   */
+  virtual std::pair<unsigned int, Real> adjoint_solve (const QoISet & qoi_indices);
 
   /**
    * This method advances the adjoint solution to the previous

--- a/src/solvers/file_solution_history.C
+++ b/src/solvers/file_solution_history.C
@@ -32,7 +32,8 @@ FileSolutionHistory::~FileSolutionHistory ()
 }
 
 // This function finds, if it can, the entry where we're supposed to
-// be storing data
+// be storing data, leaves stored_sols unchanged if it cant find an entry
+// with the key corresponding to time.
 void FileSolutionHistory::find_stored_entry(Real time)
 {
   if (stored_solutions.begin() == stored_solutions.end())
@@ -40,21 +41,48 @@ void FileSolutionHistory::find_stored_entry(Real time)
 
   libmesh_assert (stored_sols != stored_solutions.end());
 
-  // We will use the map::lower_bound operation to find the least key, which
-  // is the least upper bound among all the keys for the time of our interest.
+  // We will use the map::lower_bound operation to find the key which
+  // is the least upper bound among all existing keys for time.
   // (key before map::lower_bound) < time < map::lower_bound, one of these
-  // will be within TOLERANCE of time (unless we are creating a new map entry)
+  // should be within TOLERANCE of time (unless we are creating a new map entry)
+  // If the lower bound iterator points to:
+  // begin -> we are looking for the solution at the initial time
+  // end -> we are creating a new entry
+  // anything else, we are looking for an existing entry
   stored_solutions_iterator lower_bound_it = stored_solutions.lower_bound(time);
 
-  // Set the stored sols iterator to whichever key is within TOLERANCE of time
+  // For the key right before the lower bound
+  stored_solutions_iterator lower_bound_it_decremented;
+
+  // If we are at end, we are creating a new entry, nothing more to do
+  if(lower_bound_it == stored_solutions.end())
+  {
+    return;
+  }
+  else if(lower_bound_it == stored_solutions.begin()) // At the beginning, so we cant go back any further
+  {
+    stored_sols = stored_solutions.begin();
+    return;
+  }
+  else // A decremented iterator, to perform the sandwich test for the key closest to time
+  {
+    lower_bound_it_decremented = std::prev(lower_bound_it);
+  }
+
+  // Set the stored sols iterator as per the key which is within TOLERANCE of time
   if(std::abs(lower_bound_it->first - time) < TOLERANCE)
   {
-    stored_sols = stored_solutions.find(time);
+    stored_sols = lower_bound_it;
   }
-  else if(std::abs((--lower_bound_it)->first - time) < TOLERANCE)
+  else if(std::abs(lower_bound_it_decremented->first - time) < TOLERANCE)
   {
-    stored_sols = stored_solutions.find(time);
+    stored_sols = lower_bound_it_decremented;
   }
+  else
+  {
+    libmesh_error_msg("Failed to set stored solutions iterator to a valid value.");
+  }
+
 
 }
 

--- a/src/solvers/file_solution_history.C
+++ b/src/solvers/file_solution_history.C
@@ -23,6 +23,7 @@
 #include "libmesh/diff_system.h"
 
 #include <cmath>
+#include <iterator>
 
 namespace libMesh
 {

--- a/src/solvers/memory_solution_history.C
+++ b/src/solvers/memory_solution_history.C
@@ -38,20 +38,46 @@ void MemorySolutionHistory::find_stored_entry(Real time)
 
   libmesh_assert (stored_sols != stored_solutions.end());
 
-  // We will use the map::lower_bound operation to find the least key, which
-  // is the least upper bound among all the keys for the time of our interest.
+  // We will use the map::lower_bound operation to find the key which
+  // is the least upper bound among all existing keys for time.
   // (key before map::lower_bound) < time < map::lower_bound, one of these
-  // will be within TOLERANCE of time (unless we are creating a new map entry)
+  // should be within TOLERANCE of time (unless we are creating a new map entry)
+  // If the lower bound iterator points to:
+  // begin -> we are looking for the solution at the initial time
+  // end -> we are creating a new entry
+  // anything else, we are looking for an existing entry
   stored_solutions_iterator lower_bound_it = stored_solutions.lower_bound(time);
 
-  // Set the stored sols iterator to whichever key is within TOLERANCE of time
+  // For the key right before the lower bound
+  stored_solutions_iterator lower_bound_it_decremented;
+
+  // If we are at end, we are creating a new entry, nothing more to do
+  if(lower_bound_it == stored_solutions.end())
+  {
+    return;
+  }
+  else if(lower_bound_it == stored_solutions.begin()) // At the beginning, so we cant go back any further
+  {
+    stored_sols = stored_solutions.begin();
+    return;
+  }
+  else // A decremented iterator, to perform the sandwich test for the key closest to time
+  {
+    lower_bound_it_decremented = std::prev(lower_bound_it);
+  }
+
+  // Set the stored sols iterator as per the key which is within TOLERANCE of time
   if(std::abs(lower_bound_it->first - time) < TOLERANCE)
   {
-    stored_sols = stored_solutions.find(time);
+    stored_sols = lower_bound_it;
   }
-  else if(std::abs((--lower_bound_it)->first - time) < TOLERANCE)
+  else if(std::abs(lower_bound_it_decremented->first - time) < TOLERANCE)
   {
-    stored_sols = stored_solutions.find(time);
+    stored_sols = lower_bound_it_decremented;
+  }
+  else
+  {
+    libmesh_error_msg("Failed to set stored solutions iterator to a valid value.");
   }
 
 }

--- a/src/solvers/memory_solution_history.C
+++ b/src/solvers/memory_solution_history.C
@@ -21,6 +21,7 @@
 #include "libmesh/diff_system.h"
 
 #include <cmath>
+#include <iterator>
 
 namespace libMesh
 {

--- a/src/solvers/time_solver.C
+++ b/src/solvers/time_solver.C
@@ -102,6 +102,14 @@ void TimeSolver::advance_timestep ()
 {
 }
 
+std::pair<unsigned int, Real> TimeSolver::adjoint_solve (const QoISet & qoi_indices)
+{
+  libmesh_assert(this->diff_solver().get());
+  libmesh_assert_equal_to (&(this->diff_solver()->system()), &(this->system()));
+
+  return this->_system.ImplicitSystem::adjoint_solve(qoi_indices);
+}
+
 void TimeSolver::adjoint_advance_timestep ()
 {
 }

--- a/src/systems/diff_system.C
+++ b/src/systems/diff_system.C
@@ -167,7 +167,9 @@ std::pair<unsigned int, Real> DifferentiableSystem::adjoint_solve (const QoISet 
   // we are solving the adjoint problem
   this->get_time_solver().set_is_adjoint(true);
 
-  return this->ImplicitSystem::adjoint_solve(qoi_indices);
+  return time_solver->adjoint_solve(qoi_indices);
+
+  //return this->ImplicitSystem::adjoint_solve(qoi_indices);
 }
 
 


### PR DESCRIPTION
1) Adjoint solve methods can now be overloaded by TimeSolver subclasses, will mirror the forward timestepping scheme.
2) Fixed handing of corner cases generated by use of map::lower_bound in SoiutionHistory subclasses.