### PR TITLE
Boundaryinfo equals fix

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -69,9 +69,12 @@ protected:
 
 public:
   /**
-   * Actual copying operation.
+   * Copy assignment operator
    *
-   * \note The copy will have a reference to the same Mesh as the original.
+   * \note \p this will still reference the same MeshBase it was
+   * constructed with.  Boundary data copied from other_boundary_info
+   * will refer to objects in this mesh which have the same
+   * DofObject::id() as the corresponding objects in the other mesh.
    */
   BoundaryInfo & operator=(const BoundaryInfo & other_boundary_info);
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -129,6 +129,10 @@ BoundaryInfo & BoundaryInfo::operator=(const BoundaryInfo & other_boundary_info)
   _edge_boundary_ids = other_boundary_info._edge_boundary_ids;
   _shellface_boundary_ids = other_boundary_info._shellface_boundary_ids;
 
+  _ss_id_to_name = other_boundary_info._ss_id_to_name;
+  _ns_id_to_name = other_boundary_info._ns_id_to_name;
+  _es_id_to_name = other_boundary_info._es_id_to_name;
+
   return *this;
 }
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -152,6 +152,9 @@ void BoundaryInfo::clear()
   _node_boundary_ids.clear();
   _edge_boundary_ids.clear();
   _shellface_boundary_ids.clear();
+  _ss_id_to_name.clear();
+  _ns_id_to_name.clear();
+  _es_id_to_name.clear();
 }
 
 

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -2029,6 +2029,13 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
   BoundaryInfo & boundary_info = mesh.get_boundary_info();
   const BoundaryInfo & cross_section_boundary_info = cross_section.get_boundary_info();
 
+  // Copy name maps from old to new boundary.  We won't copy the whole
+  // BoundaryInfo because that copies bc ids too, and we need to set
+  // those more carefully.
+  boundary_info.set_sideset_name_map() = cross_section_boundary_info.get_sideset_name_map();
+  boundary_info.set_nodeset_name_map() = cross_section_boundary_info.get_nodeset_name_map();
+  boundary_info.set_edgeset_name_map() = cross_section_boundary_info.get_edgeset_name_map();
+
   // If cross_section is distributed, so is its extrusion
   if (!cross_section.is_serial())
     mesh.delete_remote_elements();

--- a/tests/mesh/boundary_info.C
+++ b/tests/mesh/boundary_info.C
@@ -22,6 +22,8 @@ class BoundaryInfoTest : public CppUnit::TestCase {
 public:
   CPPUNIT_TEST_SUITE( BoundaryInfoTest );
 
+  CPPUNIT_TEST( testNameCopying );
+
 #if LIBMESH_DIM > 1
   CPPUNIT_TEST( testMesh );
 # ifdef LIBMESH_ENABLE_DIRICHLET
@@ -238,6 +240,42 @@ public:
     // Check that writing and reading preserves the edge boundary IDs
     BoundaryInfo & bi = mesh.get_boundary_info();
     CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(n_elem), bi.n_edge_conds());
+  }
+
+  void testNameCopying()
+  {
+      Mesh mesh(*TestCommWorld);
+      MeshTools::Generation::build_line(mesh,
+                                        8,
+                                        0., 1.,
+                                        EDGE2);
+
+      Mesh mesh2(mesh);
+
+      BoundaryInfo & bi = mesh.get_boundary_info();
+      bi.sideset_name(0) = "zero";
+      bi.sideset_name(1) = "one";
+      bi.sideset_name(2) = "two";
+      bi.sideset_name(3) = "three";
+      bi.nodeset_name(0) = "ZERO";
+      bi.nodeset_name(1) = "ONE";
+
+      BoundaryInfo bi2 {bi};
+      CPPUNIT_ASSERT_EQUAL(bi2.get_sideset_name(0), std::string("zero"));
+      CPPUNIT_ASSERT_EQUAL(bi2.get_sideset_name(1), std::string("one"));
+      CPPUNIT_ASSERT_EQUAL(bi2.get_sideset_name(2), std::string("two"));
+      CPPUNIT_ASSERT_EQUAL(bi2.get_sideset_name(3), std::string("three"));
+      CPPUNIT_ASSERT_EQUAL(bi2.get_nodeset_name(0), std::string("ZERO"));
+      CPPUNIT_ASSERT_EQUAL(bi2.get_nodeset_name(1), std::string("ONE"));
+
+      BoundaryInfo & bi3 = mesh2.get_boundary_info();
+      bi3 = bi;
+      CPPUNIT_ASSERT_EQUAL(bi3.get_sideset_name(0), std::string("zero"));
+      CPPUNIT_ASSERT_EQUAL(bi3.get_sideset_name(1), std::string("one"));
+      CPPUNIT_ASSERT_EQUAL(bi3.get_sideset_name(2), std::string("two"));
+      CPPUNIT_ASSERT_EQUAL(bi3.get_sideset_name(3), std::string("three"));
+      CPPUNIT_ASSERT_EQUAL(bi3.get_nodeset_name(0), std::string("ZERO"));
+      CPPUNIT_ASSERT_EQUAL(bi3.get_nodeset_name(1), std::string("ONE"));
   }
 
 #ifdef LIBMESH_ENABLE_DIRICHLET


### PR DESCRIPTION
A new unit test, intended to replicate the failure noted in #2630, in a commit after a bugfix for that failure.

@YaqiWang, could you try this and see if it works for your case too?

I'll merge this when CI is done either way; even if this turns out not to fix *that* bug, it at least fixes **a** bug.