### PR TITLE
Fix statistics *.py for python 3

### DIFF
--- a/doc/statistics/github_traffic_base.py
+++ b/doc/statistics/github_traffic_base.py
@@ -68,7 +68,7 @@ class PlotData(object):
     # Convert date strings into numbers.
     date_nums = []
     for d in date_strings:
-      date_nums.append(date2num(datetime.strptime(d, '%Y-%b-%d')))
+      date_nums.append(date2num(datetime.strptime(d.decode('UTF-8'), '%Y-%b-%d')))
 
     # Initialize an array with 1, 7, 14, ...
     N = len(date_strings)
@@ -134,8 +134,8 @@ class PlotData(object):
     # Generate date numbers at monthly intervals starting from '2014-Feb-17'
     now = datetime.now()
     month_intervals = [735281] # date2num for '2014-Feb-17'
-    for yr in xrange(2014, now.year+1):
-      for mo in xrange(1, 13):
+    for yr in range(2014, now.year+1):
+      for mo in range(1, 13):
         # Skip Jan 2014
         if (yr==2014 and mo==1):
           continue

--- a/doc/statistics/libmesh_citations_monthly.py
+++ b/doc/statistics/libmesh_citations_monthly.py
@@ -136,7 +136,7 @@ def plot_one_year(year, data, color):
     x = []
     y = []
     start_date = datetime.datetime.strptime(str(year) + '-01-01', '%Y-%m-%d')
-    for i in xrange(0, len(data), 2):
+    for i in range(0, len(data), 2):
         end_date = datetime.datetime.strptime(data[i], '%Y-%m-%d')
         # Compute the number of months between two dates:
         num_months = (end_date.year - start_date.year) * 12 + (end_date.month - start_date.month)

--- a/doc/statistics/libmesh_mailinglists.py
+++ b/doc/statistics/libmesh_mailinglists.py
@@ -338,7 +338,7 @@ year_labels = ['2003', '2005', '2007', '2009', '2011', '2013', '2015', '2017', '
 # trial and error because it lined up the tick marks fairly well, but I don't
 # understand the logic behind it.
 xticks = [.55]
-for i in xrange(1, len(year_labels)):
+for i in range(1, len(year_labels)):
   xticks.append(xticks[i-1] + 24) # 2 years = 24 months
 
 # Center the ticks slightly


### PR DESCRIPTION
Python 3 doesn't understand xrange; range is what we want (although this
is slower in Python 2 and they could easily have retained the name
xrange as an option for backwards compatibility COME ON)

numpy byte strings now need to be decoded to give Python unicode
strings.

@jwpeterson - you have a Python 2 install you can check this on?  Everything I have root on seems to be new enough that python2 matplotlib isn't in the repos anymore; everything old I can find doesn't have matplotlib installed.