### PR TITLE
Adjoint two step time solver and integrate adjoint sensitivity

### DIFF
--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -498,24 +498,13 @@ int main (int argc, char ** argv)
           // Solve the forward problem at time t, to obtain the solution at time t + dt
           system.solve();
 
-          if(param.timesolver_tolerance)
-          {
-            // Output the H1 norm of the computed solution
-            libMesh::out << "|U("
-                         << system.time + dynamic_cast<AdaptiveTimeSolver &>(*(system.time_solver)).completedtimestep_deltat
-                         << ")|= "
-                         << system.calculate_norm(*system.solution, 0, H1)
-                         << std::endl;
-          }
-          else
-          {
-            // Output the H1 norm of the computed solution
-            libMesh::out << "|U("
-                         << system.time + system.deltat
-                         << ")|= "
-                         << system.calculate_norm(*system.solution, 0, H1)
-                         << std::endl;
-          }
+
+          // Output the H1 norm of the computed solution
+          libMesh::out << "|U("
+                      << system.time + system.time_solver->last_complete_deltat()
+                      << ")|= "
+                      << system.calculate_norm(*system.solution, 0, H1)
+                      << std::endl;
 
           // Advance to the next timestep in a transient problem
           libMesh::out << "Advancing timestep" << std::endl << std::endl;
@@ -584,29 +573,18 @@ int main (int argc, char ** argv)
                        << std::endl;
 
           // Output the H1 norm of the retrieved primal solution from the last call
-        // to adjoint_advance_timestep
+          // to adjoint_advance_timestep
           libMesh::out << "|U("
                        << system.time
                        << ")|= "
                        << system.calculate_norm(*system.solution, 0, H1)
                        << std::endl;
 
-          if(param.timesolver_tolerance)
-          {
-            libMesh::out << "|U("
-                         << system.time - ((dynamic_cast<AdaptiveTimeSolver &>(*(system.time_solver)).completedtimestep_deltat)/2.)
+          libMesh::out << "|U("
+                         << system.time - (system.time_solver->last_complete_deltat())/((param.timesolver_tolerance) ? 2.0 : 1.0)
                          << ")|= "
                          << system.calculate_norm(system.get_vector("_old_nonlinear_solution"), 0, H1)
                          << std::endl;
-          }
-          else
-          {
-            libMesh::out << "|U("
-                         << system.time - system.deltat
-                         << ")|= "
-                         << system.calculate_norm(system.get_vector("_old_nonlinear_solution"), 0, H1)
-                         << std::endl;
-          }
 
           system.set_adjoint_already_solved(false);
 
@@ -617,9 +595,9 @@ int main (int argc, char ** argv)
           // unnecessarily in the error estimator
           system.set_adjoint_already_solved(true);
 
-  libMesh::out << "Saving adjoint and retrieving primal solutions at time t=" << system.time - system.deltat << std::endl;
+          libMesh::out << "Saving adjoint and retrieving primal solutions at time t=" << system.time - system.deltat << std::endl;
 
-  // The adjoint_advance_timestep function calls the retrieve and store
+          // The adjoint_advance_timestep function calls the retrieve and store
           // function of the memory_solution_history class via the
           // memory_solution_history object we declared earlier.  The
           // retrieve function sets the system primal vectors to their

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -666,7 +666,7 @@ int main (int argc, char ** argv)
       SensitivityData sensitivities(qois, system, system.get_parameter_vector());
 
       // Accumulator for the time integrated total sensitivity
-      Real total_sensitivity = 0.0;
+      Number total_sensitivity = 0.0;
 
       // Retrieve the primal and adjoint solutions at the current timestep
       system.time_solver->retrieve_timestep();

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -106,6 +106,8 @@
 #include "libmesh/gmv_io.h"
 #include "libmesh/exodusII_io.h"
 
+#include "libmesh/sensitivity_data.h"
+
 // SolutionHistory Includes
 #include "libmesh/solution_history.h"
 #include "libmesh/memory_solution_history.h"

--- a/examples/adjoints/adjoints_ex5/general.in
+++ b/examples/adjoints/adjoints_ex5/general.in
@@ -20,7 +20,7 @@ deltat = 0.1
 # Make this 0 to use a constant deltat
 timesolver_tolerance = 0.0
 timesolver_upper_tolerance = 0.0
-timesolver_maxgrowth = 1.09
+timesolver_maxgrowth = 1.12
 
 # The theta to use (i.e. 0.5 = Crank-Nicholson, 1.0 = Backward Euler)
 timesolver_theta = 1.0

--- a/examples/adjoints/adjoints_ex5/heatsystem.C
+++ b/examples/adjoints/adjoints_ex5/heatsystem.C
@@ -32,6 +32,7 @@
 #include "libmesh/zero_function.h"
 #include "libmesh/dirichlet_boundaries.h"
 #include "libmesh/dof_map.h"
+#include "libmesh/numeric_vector.h"
 
 void HeatSystem::init_data ()
 {

--- a/include/solvers/adaptive_time_solver.h
+++ b/include/solvers/adaptive_time_solver.h
@@ -72,7 +72,15 @@ public:
 
   virtual void solve() override = 0;
 
+  virtual std::pair<unsigned int, Real> adjoint_solve (const QoISet & qoi_indices) override = 0;
+
   virtual void advance_timestep() override;
+
+  virtual void adjoint_advance_timestep() override;
+
+  virtual void retrieve_timestep() override;
+
+  virtual void integrate_adjoint_sensitivity(const QoISet & qois, const ParameterVector & parameter_vector, SensitivityData & sensitivities) override = 0;
 
   /**
    * This method is passed on to the core_time_solver
@@ -179,6 +187,14 @@ public:
    * unlimited.
    */
   Real max_growth;
+
+  /**
+   * The adaptive time solver's have two notions of deltat. The deltat the solver
+   * ended up using for the completed timestep. And the deltat the solver determined
+   * would be workable for the coming timestep. The latter gets set as system.deltat.
+   * We need a variable to save the deltat used for the completed timesteo.
+   * */
+  Real completedtimestep_deltat;
 
   /**
    * This flag, which is true by default, grows (shrinks) the timestep

--- a/include/solvers/adaptive_time_solver.h
+++ b/include/solvers/adaptive_time_solver.h
@@ -82,6 +82,8 @@ public:
 
   virtual void integrate_adjoint_sensitivity(const QoISet & qois, const ParameterVector & parameter_vector, SensitivityData & sensitivities) override = 0;
 
+  virtual Real last_complete_deltat() { return completedtimestep_deltat; };
+
   /**
    * This method is passed on to the core_time_solver
    */

--- a/include/solvers/second_order_unsteady_solver.h
+++ b/include/solvers/second_order_unsteady_solver.h
@@ -22,6 +22,13 @@
 
 namespace libMesh
 {
+
+// Forward declarations
+template <typename T> class FunctionBase;
+template <typename T> class VectorValue;
+typedef VectorValue<Number> NumberVectorValue;
+typedef NumberVectorValue Gradient;
+
 /**
  * Generic class from which second order UnsteadySolvers should subclass.
  *

--- a/include/solvers/time_solver.h
+++ b/include/solvers/time_solver.h
@@ -22,12 +22,7 @@
 
 // Local includes
 #include "libmesh/libmesh_common.h"
-#include "libmesh/linear_solver.h"
-#include "libmesh/numeric_vector.h"
 #include "libmesh/reference_counted_object.h"
-#include "libmesh/solution_history.h"
-#include "libmesh/qoi_set.h"
-#include "libmesh/sensitivity_data.h"
 
 // C++ includes
 #include <memory>
@@ -41,7 +36,13 @@ class DiffSolver;
 class DifferentiablePhysics;
 class DifferentiableSystem;
 class ParameterVector;
+class SensitivityData;
+class SolutionHistory;
 class SystemNorm;
+class QoISet;
+
+template <typename T>
+class LinearSolver;
 
 /**
  * This is a generic class that defines a solver to handle

--- a/include/solvers/time_solver.h
+++ b/include/solvers/time_solver.h
@@ -28,6 +28,10 @@
 #include "libmesh/solution_history.h"
 #include "libmesh/qoi_set.h"
 
+// Sensitivity Calculation related includes
+#include "libmesh/parameter_vector.h"
+#include "libmesh/sensitivity_data.h"
+
 // C++ includes
 #include <memory>
 
@@ -131,6 +135,12 @@ public:
   virtual void retrieve_timestep();
 
   /**
+   * A method to integrate the adjoint sensitivity w.r.t a given parameter
+   * vector. int_{tstep_start}^{tstep_end} dQ/dp dt = int_{tstep_start}^{tstep_end} (\partialQ / \partial p) - ( \partial R (u,z) / \partial p ) dt
+   */
+  virtual void integrate_adjoint_sensitivity(const QoISet & qois, const ParameterVector & parameter_vector, SensitivityData & sensitivities);
+
+  /**
    * This method uses the DifferentiablePhysics
    * element_time_derivative(), element_constraint(), and
    * mass_residual() to build a full residual on an element.  What
@@ -231,6 +241,12 @@ public:
    * other than save no solution history
    */
   void set_solution_history(const SolutionHistory & _solution_history);
+
+  /**
+￼   * A getter function that returns a reference to the solution history
+￼   * object owned by TimeSolver
+￼   * */
+  SolutionHistory & get_solution_history();
 
   /**
    * Accessor for querying whether we need to do a primal

--- a/include/solvers/time_solver.h
+++ b/include/solvers/time_solver.h
@@ -27,9 +27,6 @@
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/solution_history.h"
 #include "libmesh/qoi_set.h"
-
-// Sensitivity Calculation related includes
-#include "libmesh/parameter_vector.h"
 #include "libmesh/sensitivity_data.h"
 
 // C++ includes

--- a/include/solvers/time_solver.h
+++ b/include/solvers/time_solver.h
@@ -262,6 +262,14 @@ public:
   void set_is_adjoint(bool _is_adjoint_value)
   { _is_adjoint = _is_adjoint_value; }
 
+  /**
+   * Function to return 'last_deltat()', returns system.deltat if
+   * fixed timestep solver is used, completed_deltat if the adaptive
+   * time solver is used.
+   */
+  virtual Real last_complete_deltat();
+
+
 protected:
 
   /**

--- a/include/solvers/twostep_time_solver.h
+++ b/include/solvers/twostep_time_solver.h
@@ -68,6 +68,16 @@ public:
   ~TwostepTimeSolver ();
 
   virtual void solve() override;
+
+  virtual std::pair<unsigned int, Real> adjoint_solve (const QoISet & qoi_indices) override;
+
+  /**
+   * A method to integrate the adjoint sensitivity w.r.t a given parameter
+   * vector. int_{tstep_start}^{tstep_end} dQ/dp dt = int_{tstep_start}^{tstep_end} (\partialQ / \partial p) - ( \partial R (u,z) / \partial p ) dt
+   * The midpoint rule is used to integrate each substep
+   */
+  virtual void integrate_adjoint_sensitivity(const QoISet & qois, const ParameterVector & parameter_vector, SensitivityData & sensitivities) override;
+
 };
 
 

--- a/include/solvers/unsteady_solver.h
+++ b/include/solvers/unsteady_solver.h
@@ -22,7 +22,6 @@
 
 // Local includes
 #include "libmesh/libmesh_common.h"
-#include "libmesh/numeric_vector.h"
 #include "libmesh/time_solver.h"
 
 // C++ includes
@@ -30,6 +29,9 @@
 
 namespace libMesh
 {
+
+// Forward declarations
+template <typename T> class NumericVector;
 
 /**
  * This is a generic class that defines a solver to handle

--- a/include/solvers/unsteady_solver.h
+++ b/include/solvers/unsteady_solver.h
@@ -95,6 +95,12 @@ public:
   virtual void advance_timestep () override;
 
   /**
+   * This method solves for the adjoint solution at the next adjoint timestep
+   * (or a steady state adjoint solve)
+   */
+  virtual std::pair<unsigned int, Real> adjoint_solve (const QoISet & qoi_indices) override;
+
+  /**
    * This method advances the adjoint solution to the previous
    * timestep, after an adjoint_solve() has been performed.  This will
    * be done before every UnsteadySolver::adjoint_solve().
@@ -106,6 +112,13 @@ public:
    * system.time
    */
   virtual void retrieve_timestep () override;
+
+  /**
+   * A method to integrate the adjoint sensitivity w.r.t a given parameter
+   * vector. int_{tstep_start}^{tstep_end} dQ/dp dt = int_{tstep_start}^{tstep_end} (\partialQ / \partial p) - ( \partial R (u,z) / \partial p ) dt
+   * The midpoint rule is used to numerically integrate the timestep
+   */
+  virtual void integrate_adjoint_sensitivity(const QoISet & qois, const ParameterVector & parameter_vector, SensitivityData & sensitivities) override;
 
   /**
    * This method should return the expected convergence order of the
@@ -151,6 +164,14 @@ public:
    * This is not a steady-state solver.
    */
   virtual bool is_steady() const override { return false; }
+
+  /**
+   * A setter for the first_adjoint_step boolean. Needed for nested time solvers.
+   */
+  void set_first_adjoint_step(bool first_adjoint_step_setting)
+  {
+    first_adjoint_step = first_adjoint_step_setting;
+  }
 
 protected:
 

--- a/src/solvers/adaptive_time_solver.C
+++ b/src/solvers/adaptive_time_solver.C
@@ -102,17 +102,17 @@ void AdaptiveTimeSolver::advance_timestep ()
   // The first access of advance_timestep happens via solve, not user code
   // It is used here to store any initial conditions data
   if (!first_solve)
-  {
-    _system.time += this->completedtimestep_deltat;
-  }
+    {
+      _system.time += this->completedtimestep_deltat;
+    }
   else
-  {
+    {
     // We are here because of a call to advance_timestep that happens
     // via solve, the very first solve. All we are doing here is storing
     // the initial condition. The actual solution computed via this solve
     // will be stored when we call advance_timestep in the user's timestep loop
     first_solve = false;
-  }
+    }
 
   // Remember that for the adaptive time solver, all SH operations
   // are handled by the core_time_solver's SH object
@@ -173,11 +173,6 @@ void AdaptiveTimeSolver::retrieve_timestep ()
   // Ask the core time solver to retrieve all the stored vectors
   // at the current time
   core_time_solver->retrieve_timestep();
-
-  // Dont forget to localize the old_nonlinear_solution !
-  _system.get_vector("_old_nonlinear_solution").localize
-    (*old_local_nonlinear_solution,
-    _system.get_dof_map().get_send_list());
 }
 
 Real AdaptiveTimeSolver::error_order () const

--- a/src/solvers/adaptive_time_solver.C
+++ b/src/solvers/adaptive_time_solver.C
@@ -19,6 +19,7 @@
 #include "libmesh/diff_system.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/numeric_vector.h"
+#include "libmesh/no_solution_history.h"
 
 namespace libMesh
 {
@@ -33,6 +34,7 @@ AdaptiveTimeSolver::AdaptiveTimeSolver (sys_type & s)
     max_deltat(0.),
     min_deltat(0.),
     max_growth(0.),
+    completedtimestep_deltat(1.),
     global_tolerance(true)
 {
   // the child class must populate core_time_solver
@@ -64,6 +66,16 @@ void AdaptiveTimeSolver::init()
   // needs to handle new vectors, diff_solver->init(), etc
   core_time_solver->init();
 
+  // Set the core_time_solver's solution history object to be the same one as
+  // that for the outer adaptive time solver
+  core_time_solver->set_solution_history((this->get_solution_history()));
+
+  // Now that we have set the SolutionHistory object for the coretimesolver,
+  // we set the SolutionHistory type for the timesolver to be NoSolutionHistory
+  // All storage and retrieval will be handled by the coretimesolver directly.
+  NoSolutionHistory outersolver_solution_history;
+  this->set_solution_history(outersolver_solution_history);
+
   // As an UnsteadySolver, we have an old_local_nonlinear_solution, but it
   // isn't pointing to the right place - fix it
   //
@@ -90,24 +102,22 @@ void AdaptiveTimeSolver::advance_timestep ()
   // The first access of advance_timestep happens via solve, not user code
   // It is used here to store any initial conditions data
   if (!first_solve)
-    {
-      // We call advance_timestep in user code after solve, so any solutions
-      // we will be storing will be for the next time instance
-      _system.time += _system.deltat;
-    }
-    else
-    {
-      // We are here because of a call to advance_timestep that happens
-      // via solve, the very first solve. All we are doing here is storing
-      // the initial condition. The actual solution computed via this solve
-      // will be stored when we call advance_timestep in the user's timestep loop
-      first_solve = false;
-    }
+  {
+    _system.time += this->completedtimestep_deltat;
+  }
+  else
+  {
+    // We are here because of a call to advance_timestep that happens
+    // via solve, the very first solve. All we are doing here is storing
+    // the initial condition. The actual solution computed via this solve
+    // will be stored when we call advance_timestep in the user's timestep loop
+    first_solve = false;
+  }
 
-  // If the user has attached a memory or file solution history object
-  // to the solver, this will store the current solution indexed with
-  // the current time
-  solution_history->store(false, _system.time);
+  // Remember that for the adaptive time solver, all SH operations
+  // are handled by the core_time_solver's SH object
+  // The outer solver's SH object is turned into a dummy NSH object
+  // after it has been used to initialize the core_time_solver's SH object
 
   NumericVector<Number> & old_nonlinear_soln =
     _system.get_vector("_old_nonlinear_solution");
@@ -121,7 +131,54 @@ void AdaptiveTimeSolver::advance_timestep ()
      _system.get_dof_map().get_send_list());
 }
 
+void AdaptiveTimeSolver::adjoint_advance_timestep ()
+{
+  // All calls to adjoint_advance_timestep are made in the user's
+  // code. This first call is made immediately after the adjoint initial conditions
+  // are set. This is in the user code outside the adjoint time loop.
+  if (!first_adjoint_step)
+    {
+      // The adjoint system has been solved. We need to store the adjoint solution and
+      // load the primal solutions for the next time instance (t - delta_ti).
+      _system.time -= this->completedtimestep_deltat;
+    }
+  else
+    {
+      // After setting the initial conditions, we have to retrieve the saved primal solutions
+      core_time_solver->get_solution_history().retrieve(true, _system.time);
 
+      // And store the adjoint initial condition, apart from the initial condition these retrieval
+      // and store operations are handled by the core time solver directly
+      core_time_solver->get_solution_history().store(true, _system.time);
+
+      // We also need to tell the core time solver that the adjoint initial conditions have been set
+      core_time_solver->set_first_adjoint_step(false);
+
+      // The first adjoint step simply saves the given adjoint initial condition
+      // So there is a store, but no solve, no actual timestep, so no need to change system time
+      first_adjoint_step = false;
+    }
+
+  // For an adaptive time solver, all solution history operations are handled
+  // by the core time solver.
+
+  // Dont forget to localize the old_nonlinear_solution !
+  _system.get_vector("_old_nonlinear_solution").localize
+    (*old_local_nonlinear_solution,
+    _system.get_dof_map().get_send_list());
+}
+
+void AdaptiveTimeSolver::retrieve_timestep ()
+{
+  // Ask the core time solver to retrieve all the stored vectors
+  // at the current time
+  core_time_solver->retrieve_timestep();
+
+  // Dont forget to localize the old_nonlinear_solution !
+  _system.get_vector("_old_nonlinear_solution").localize
+    (*old_local_nonlinear_solution,
+    _system.get_dof_map().get_send_list());
+}
 
 Real AdaptiveTimeSolver::error_order () const
 {

--- a/src/solvers/file_solution_history.C
+++ b/src/solvers/file_solution_history.C
@@ -40,7 +40,7 @@ void FileSolutionHistory::find_stored_entry(Real time)
   if (stored_solutions.begin() == stored_solutions.end())
     return;
 
-  libmesh_assert (stored_sols != stored_solutions.end());
+  //libmesh_assert (stored_sols != stored_solutions.end());
 
   // We will use the map::lower_bound operation to find the key which
   // is the least upper bound among all existing keys for time.
@@ -259,11 +259,25 @@ void FileSolutionHistory::retrieve(bool is_adjoint_solve, Real time)
 
 void FileSolutionHistory::erase(Real time)
 {
-  stored_solutions_iterator stored_sols_erase_it;
+  // We cant erase the stored_sols iterator which is used in other places
+  // So save its current value for the future
+  stored_solutions_iterator stored_sols_last = stored_sols;
 
-  stored_sols_erase_it = stored_solutions.find(time);
+  // This will map the stored_sols iterator to the current time
+  this->find_stored_entry(time);
 
-  stored_solutions.erase(stored_sols_erase_it);
+  // map::erase behaviour is undefined if the iterator is pointing
+  // to a non-existent element.
+  libmesh_assert(stored_sols != stored_solutions.end());
+
+  // We want to keep using the stored_sols iterator, so we have to create
+  // a new one to erase the concerned entry
+  stored_solutions_iterator stored_sols_copy = stored_sols;
+  stored_sols = stored_sols_last;
+  stored_sols--;
+
+  stored_solutions.erase(stored_sols_copy);
+
 }
 
 }

--- a/src/solvers/file_solution_history.C
+++ b/src/solvers/file_solution_history.C
@@ -40,8 +40,6 @@ void FileSolutionHistory::find_stored_entry(Real time)
   if (stored_solutions.begin() == stored_solutions.end())
     return;
 
-  //libmesh_assert (stored_sols != stored_solutions.end());
-
   // We will use the map::lower_bound operation to find the key which
   // is the least upper bound among all existing keys for time.
   // (key before map::lower_bound) < time < map::lower_bound, one of these
@@ -273,8 +271,10 @@ void FileSolutionHistory::erase(Real time)
   // We want to keep using the stored_sols iterator, so we have to create
   // a new one to erase the concerned entry
   stored_solutions_iterator stored_sols_copy = stored_sols;
-  stored_sols = stored_sols_last;
-  stored_sols--;
+
+  // If we're asking to erase the entry at stored_sols, then move stored_sols somewhere safer first
+  if(stored_sols == stored_sols_last)
+    stored_sols--;
 
   stored_solutions.erase(stored_sols_copy);
 

--- a/src/solvers/memory_solution_history.C
+++ b/src/solvers/memory_solution_history.C
@@ -37,8 +37,6 @@ void MemorySolutionHistory::find_stored_entry(Real time)
   if (stored_solutions.begin() == stored_solutions.end())
     return;
 
-  libmesh_assert (stored_sols != stored_solutions.end());
-
   // We will use the map::lower_bound operation to find the key which
   // is the least upper bound among all existing keys for time.
   // (key before map::lower_bound) < time < map::lower_bound, one of these
@@ -264,8 +262,10 @@ void MemorySolutionHistory::erase(Real time)
   // We want to keep using the stored_sols iterator, so we have to create
   // a new one to erase the concerned entry
   stored_solutions_iterator stored_sols_copy = stored_sols;
-  stored_sols = stored_sols_last;
-  stored_sols--;
+
+  // If we're asking to erase the entry at stored_sols, then move stored_sols somewhere safer first
+  if(stored_sols == stored_sols_last)
+    stored_sols--;
 
   stored_solutions.erase(stored_sols_copy);
 

--- a/src/solvers/memory_solution_history.C
+++ b/src/solvers/memory_solution_history.C
@@ -242,15 +242,33 @@ void MemorySolutionHistory::retrieve(bool is_adjoint_solve, Real time)
   // Of course, we will *always* have to get the actual solution
   std::string _solution("_solution");
   *(_system.solution) = *(saved_vectors[_solution]);
+
+  // We need to call update to put system in a consistent state
+  // with the solution that was read in
+  _system.update();
 }
 
 void MemorySolutionHistory::erase(Real time)
 {
-  stored_solutions_iterator stored_sols_erase_it;
+  // We cant erase the stored_sols iterator which is used in other places
+  // So save its current value for the future
+  stored_solutions_iterator stored_sols_last = stored_sols;
 
-  stored_sols_erase_it = stored_solutions.find(time);
+  // This will map the stored_sols iterator to the current time
+  this->find_stored_entry(time);
 
-  stored_solutions.erase(stored_sols_erase_it);
+  // map::erase behaviour is undefined if the iterator is pointing
+  // to a non-existent element.
+  libmesh_assert(stored_sols != stored_solutions.end());
+
+  // We want to keep using the stored_sols iterator, so we have to create
+  // a new one to erase the concerned entry
+  stored_solutions_iterator stored_sols_copy = stored_sols;
+  stored_sols = stored_sols_last;
+  stored_sols--;
+
+  stored_solutions.erase(stored_sols_copy);
+
 }
 
 }

--- a/src/solvers/newmark_solver.C
+++ b/src/solvers/newmark_solver.C
@@ -15,10 +15,12 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-#include "libmesh/diff_system.h"
 #include "libmesh/newmark_solver.h"
-#include "libmesh/dof_map.h"
+
 #include "libmesh/diff_solver.h"
+#include "libmesh/diff_system.h"
+#include "libmesh/dof_map.h"
+#include "libmesh/numeric_vector.h"
 
 namespace libMesh
 {

--- a/src/solvers/second_order_unsteady_solver.C
+++ b/src/solvers/second_order_unsteady_solver.C
@@ -19,6 +19,7 @@
 
 #include "libmesh/diff_system.h"
 #include "libmesh/dof_map.h"
+#include "libmesh/numeric_vector.h"
 
 namespace libMesh
 {

--- a/src/solvers/time_solver.C
+++ b/src/solvers/time_solver.C
@@ -15,10 +15,11 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
+#include "libmesh/time_solver.h"
+
 #include "libmesh/diff_solver.h"
 #include "libmesh/diff_system.h"
 #include "libmesh/linear_solver.h"
-#include "libmesh/time_solver.h"
 #include "libmesh/no_solution_history.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
 

--- a/src/solvers/time_solver.C
+++ b/src/solvers/time_solver.C
@@ -123,6 +123,11 @@ void TimeSolver::integrate_adjoint_sensitivity(const QoISet & qois, const Parame
   return;
 }
 
+Real TimeSolver::last_complete_deltat()
+{
+  return _system.deltat;
+}
+
 void TimeSolver::adjoint_advance_timestep ()
 {
 }

--- a/src/solvers/time_solver.C
+++ b/src/solvers/time_solver.C
@@ -98,6 +98,11 @@ void TimeSolver::set_solution_history (const SolutionHistory & _solution_history
   solution_history = _solution_history.clone();
 }
 
+SolutionHistory & TimeSolver::get_solution_history ()
+{
+  return *solution_history;
+}
+
 void TimeSolver::advance_timestep ()
 {
 }
@@ -108,6 +113,14 @@ std::pair<unsigned int, Real> TimeSolver::adjoint_solve (const QoISet & qoi_indi
   libmesh_assert_equal_to (&(this->diff_solver()->system()), &(this->system()));
 
   return this->_system.ImplicitSystem::adjoint_solve(qoi_indices);
+}
+
+void TimeSolver::integrate_adjoint_sensitivity(const QoISet & qois, const ParameterVector & parameter_vector, SensitivityData & sensitivities)
+{
+  // Base class assumes a direct steady state sensitivity calculation
+  this->_system.ImplicitSystem::adjoint_qoi_parameter_sensitivity(qois, parameter_vector, sensitivities);
+
+  return;
 }
 
 void TimeSolver::adjoint_advance_timestep ()

--- a/src/solvers/twostep_time_solver.C
+++ b/src/solvers/twostep_time_solver.C
@@ -17,11 +17,15 @@
 
 
 #include "libmesh/twostep_time_solver.h"
+
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 #include "libmesh/diff_system.h"
+#include "libmesh/enum_norm_type.h"
 #include "libmesh/euler_solver.h"
 #include "libmesh/numeric_vector.h"
-#include "libmesh/auto_ptr.h" // libmesh_make_unique
-#include "libmesh/enum_norm_type.h"
+#include "libmesh/parameter_vector.h"
+#include "libmesh/sensitivity_data.h"
+#include "libmesh/solution_history.h"
 
 namespace libMesh
 {

--- a/src/solvers/unsteady_solver.C
+++ b/src/solvers/unsteady_solver.C
@@ -16,11 +16,15 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
+#include "libmesh/unsteady_solver.h"
+
 #include "libmesh/diff_solver.h"
 #include "libmesh/diff_system.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/numeric_vector.h"
-#include "libmesh/unsteady_solver.h"
+#include "libmesh/parameter_vector.h"
+#include "libmesh/sensitivity_data.h"
+#include "libmesh/solution_history.h"
 
 namespace libMesh
 {

--- a/src/systems/continuation_system.C
+++ b/src/systems/continuation_system.C
@@ -21,6 +21,7 @@
 #include "libmesh/linear_solver.h"
 #include "libmesh/time_solver.h"
 #include "libmesh/newton_solver.h"
+#include "libmesh/numeric_vector.h"
 #include "libmesh/sparse_matrix.h"
 
 namespace libMesh

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -17,17 +17,19 @@
 
 
 
+#include "libmesh/fem_context.h"
+
 #include "libmesh/boundary_info.h"
+#include "libmesh/diff_system.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/elem.h"
 #include "libmesh/fe_base.h"
 #include "libmesh/fe_interface.h"
-#include "libmesh/fem_context.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_base.h"
+#include "libmesh/numeric_vector.h"
 #include "libmesh/quadrature.h"
 #include "libmesh/system.h"
-#include "libmesh/diff_system.h"
 #include "libmesh/time_solver.h"
 #include "libmesh/unsteady_solver.h" // For euler_residual
 

--- a/tests/solvers/time_solver_test_common.h
+++ b/tests/solvers/time_solver_test_common.h
@@ -1,10 +1,11 @@
+#include <libmesh/auto_ptr.h> // libmesh_make_unique
 #include <libmesh/dof_map.h>
-#include <libmesh/fem_system.h>
-#include <libmesh/newton_solver.h>
 #include <libmesh/enum_solver_type.h>
 #include <libmesh/enum_preconditioner_type.h>
+#include <libmesh/fem_system.h>
+#include <libmesh/newton_solver.h>
+#include <libmesh/numeric_vector.h>
 #include <libmesh/parallel.h>
-#include <libmesh/auto_ptr.h> // libmesh_make_unique
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"


### PR DESCRIPTION
1) The method TimeSolver::adjoint_solve is now overloaded and we now automatically use an adjoint timestepping scheme (fixed or adaptive-2-step) consistent with what was done for the primal.
2) For the integration of the adjoint sensitivity we now have an overloaded TimeSolver::integrate_adjoint_sensitivity, which like adjoint_solve evaluates the time integral in a manner consistent with the underlying time stepping scheme.
3) The direct use of ImplicitSystem::adjoint_qoi_parameter_sensitivity to evaluate the sensitivity at each time shot revealed a sign error in the 'gold' sensitivity value and this was fixed in the adjoints example 5.