### PR TITLE
Xdr: Reset stream precision after writing an integral value

### DIFF
--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -736,6 +736,10 @@ void Xdr::do_write(std::vector<T> & a)
   std::size_t length = a.size();
   data(length, "# vector length");
 
+  // Use scientific precision with lots of digits for the original type T.
+  *out << std::scientific
+       << std::setprecision(std::numeric_limits<T>::max_digits10);
+
   for (T & a_i : a)
     {
       libmesh_assert(out.get());
@@ -750,6 +754,10 @@ void Xdr::do_write(std::vector<std::complex<T>> & a)
 {
   std::size_t length=a.size();
   data(length, "# vector length x 2 (complex)");
+
+  // Use scientific precision with lots of digits for the original type T.
+  *out << std::scientific
+       << std::setprecision(std::numeric_limits<T>::max_digits10);
 
   for (std::complex<T> & a_i : a)
     {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -111,7 +111,8 @@ unit_tests_sources = \
   systems/systems_test.C \
   utils/parameters_test.C \
   utils/point_locator_test.C \
-  utils/vectormap_test.C
+  utils/vectormap_test.C \
+  utils/xdr_test.C
 
 #EXTRA_DIST = base/getpot_test_input.in
 
@@ -250,7 +251,8 @@ CLEANFILES = cube_mesh.xda \
 	     elemental_from_nodal.e \
              write_sideset_data.e \
              write_edgeset_data.e \
-             read_header_test.e
+             read_header_test.e \
+             output.dat
 
 # need to link any data files for VPATH builds
 if LIBMESH_VPATH_BUILD

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -238,7 +238,7 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/systems_test.C \
 	utils/parameters_test.C utils/point_locator_test.C \
-	utils/vectormap_test.C 1_quad.dyn 25_quad.bxt \
+	utils/vectormap_test.C utils/xdr_test.C 1_quad.dyn 25_quad.bxt \
 	fparser/autodiff.C
 am__dirstamp = $(am__leading_dot)dirstamp
 am__objects_1 =
@@ -328,7 +328,8 @@ am__objects_3 = unit_tests_dbg-driver.$(OBJEXT) \
 	systems/unit_tests_dbg-systems_test.$(OBJEXT) \
 	utils/unit_tests_dbg-parameters_test.$(OBJEXT) \
 	utils/unit_tests_dbg-point_locator_test.$(OBJEXT) \
-	utils/unit_tests_dbg-vectormap_test.$(OBJEXT) $(am__objects_1) \
+	utils/unit_tests_dbg-vectormap_test.$(OBJEXT) \
+	utils/unit_tests_dbg-xdr_test.$(OBJEXT) $(am__objects_1) \
 	$(am__objects_2)
 @LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@am_unit_tests_dbg_OBJECTS = $(am__objects_3)
 unit_tests_dbg_OBJECTS = $(am_unit_tests_dbg_OBJECTS)
@@ -393,7 +394,7 @@ am__unit_tests_devel_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/systems_test.C \
 	utils/parameters_test.C utils/point_locator_test.C \
-	utils/vectormap_test.C 1_quad.dyn 25_quad.bxt \
+	utils/vectormap_test.C utils/xdr_test.C 1_quad.dyn 25_quad.bxt \
 	fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_4 = fparser/unit_tests_devel-autodiff.$(OBJEXT)
 am__objects_5 = unit_tests_devel-driver.$(OBJEXT) \
@@ -482,7 +483,8 @@ am__objects_5 = unit_tests_devel-driver.$(OBJEXT) \
 	utils/unit_tests_devel-parameters_test.$(OBJEXT) \
 	utils/unit_tests_devel-point_locator_test.$(OBJEXT) \
 	utils/unit_tests_devel-vectormap_test.$(OBJEXT) \
-	$(am__objects_1) $(am__objects_4)
+	utils/unit_tests_devel-xdr_test.$(OBJEXT) $(am__objects_1) \
+	$(am__objects_4)
 @LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@am_unit_tests_devel_OBJECTS = $(am__objects_5)
 unit_tests_devel_OBJECTS = $(am_unit_tests_devel_OBJECTS)
 @LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@unit_tests_devel_DEPENDENCIES = $(top_builddir)/libmesh_devel.la
@@ -542,7 +544,7 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/systems_test.C \
 	utils/parameters_test.C utils/point_locator_test.C \
-	utils/vectormap_test.C 1_quad.dyn 25_quad.bxt \
+	utils/vectormap_test.C utils/xdr_test.C 1_quad.dyn 25_quad.bxt \
 	fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_6 = fparser/unit_tests_oprof-autodiff.$(OBJEXT)
 am__objects_7 = unit_tests_oprof-driver.$(OBJEXT) \
@@ -631,7 +633,8 @@ am__objects_7 = unit_tests_oprof-driver.$(OBJEXT) \
 	utils/unit_tests_oprof-parameters_test.$(OBJEXT) \
 	utils/unit_tests_oprof-point_locator_test.$(OBJEXT) \
 	utils/unit_tests_oprof-vectormap_test.$(OBJEXT) \
-	$(am__objects_1) $(am__objects_6)
+	utils/unit_tests_oprof-xdr_test.$(OBJEXT) $(am__objects_1) \
+	$(am__objects_6)
 @LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPROF_MODE_TRUE@am_unit_tests_oprof_OBJECTS = $(am__objects_7)
 unit_tests_oprof_OBJECTS = $(am_unit_tests_oprof_OBJECTS)
 @LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPROF_MODE_TRUE@unit_tests_oprof_DEPENDENCIES = $(top_builddir)/libmesh_oprof.la
@@ -691,7 +694,7 @@ am__unit_tests_opt_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/systems_test.C \
 	utils/parameters_test.C utils/point_locator_test.C \
-	utils/vectormap_test.C 1_quad.dyn 25_quad.bxt \
+	utils/vectormap_test.C utils/xdr_test.C 1_quad.dyn 25_quad.bxt \
 	fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_8 = fparser/unit_tests_opt-autodiff.$(OBJEXT)
 am__objects_9 = unit_tests_opt-driver.$(OBJEXT) \
@@ -779,7 +782,8 @@ am__objects_9 = unit_tests_opt-driver.$(OBJEXT) \
 	systems/unit_tests_opt-systems_test.$(OBJEXT) \
 	utils/unit_tests_opt-parameters_test.$(OBJEXT) \
 	utils/unit_tests_opt-point_locator_test.$(OBJEXT) \
-	utils/unit_tests_opt-vectormap_test.$(OBJEXT) $(am__objects_1) \
+	utils/unit_tests_opt-vectormap_test.$(OBJEXT) \
+	utils/unit_tests_opt-xdr_test.$(OBJEXT) $(am__objects_1) \
 	$(am__objects_8)
 @LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPT_MODE_TRUE@am_unit_tests_opt_OBJECTS = $(am__objects_9)
 unit_tests_opt_OBJECTS = $(am_unit_tests_opt_OBJECTS)
@@ -840,7 +844,7 @@ am__unit_tests_prof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/systems_test.C \
 	utils/parameters_test.C utils/point_locator_test.C \
-	utils/vectormap_test.C 1_quad.dyn 25_quad.bxt \
+	utils/vectormap_test.C utils/xdr_test.C 1_quad.dyn 25_quad.bxt \
 	fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_10 = fparser/unit_tests_prof-autodiff.$(OBJEXT)
 am__objects_11 = unit_tests_prof-driver.$(OBJEXT) \
@@ -929,7 +933,8 @@ am__objects_11 = unit_tests_prof-driver.$(OBJEXT) \
 	utils/unit_tests_prof-parameters_test.$(OBJEXT) \
 	utils/unit_tests_prof-point_locator_test.$(OBJEXT) \
 	utils/unit_tests_prof-vectormap_test.$(OBJEXT) \
-	$(am__objects_1) $(am__objects_10)
+	utils/unit_tests_prof-xdr_test.$(OBJEXT) $(am__objects_1) \
+	$(am__objects_10)
 @LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_PROF_MODE_TRUE@am_unit_tests_prof_OBJECTS = $(am__objects_11)
 unit_tests_prof_OBJECTS = $(am_unit_tests_prof_OBJECTS)
 @LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_PROF_MODE_TRUE@unit_tests_prof_DEPENDENCIES = $(top_builddir)/libmesh_prof.la
@@ -1375,18 +1380,23 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po \
 	utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Po \
+	utils/$(DEPDIR)/unit_tests_dbg-xdr_test.Po \
 	utils/$(DEPDIR)/unit_tests_devel-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po \
 	utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po \
+	utils/$(DEPDIR)/unit_tests_devel-xdr_test.Po \
 	utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po \
 	utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Po \
+	utils/$(DEPDIR)/unit_tests_oprof-xdr_test.Po \
 	utils/$(DEPDIR)/unit_tests_opt-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po \
 	utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po \
+	utils/$(DEPDIR)/unit_tests_opt-xdr_test.Po \
 	utils/$(DEPDIR)/unit_tests_prof-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po \
-	utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po
+	utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po \
+	utils/$(DEPDIR)/unit_tests_prof-xdr_test.Po
 am__mv = mv -f
 CXXCOMPILE = $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
 	$(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
@@ -1889,7 +1899,8 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/systems_test.C \
 	utils/parameters_test.C utils/point_locator_test.C \
-	utils/vectormap_test.C $(data) $(am__append_1)
+	utils/vectormap_test.C utils/xdr_test.C $(data) \
+	$(am__append_1)
 data = 1_quad.dyn \
        25_quad.bxt
 
@@ -1926,8 +1937,8 @@ data = 1_quad.dyn \
 @LIBMESH_ENABLE_CPPUNIT_TRUE@TESTS = run_unit_tests.sh
 CLEANFILES = cube_mesh.xda slit_mesh.xda slit_solution.xda out.e \
 	mesh_with_soln.e elemental_from_nodal.e write_sideset_data.e \
-	write_edgeset_data.e read_header_test.e $(am__append_12) \
-	$(am__append_13)
+	write_edgeset_data.e read_header_test.e output.dat \
+	$(am__append_12) $(am__append_13)
 
 # need to link any data files for VPATH builds
 @LIBMESH_VPATH_BUILD_TRUE@BUILT_SOURCES = .linkstamp
@@ -2229,6 +2240,8 @@ utils/unit_tests_dbg-point_locator_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_dbg-vectormap_test.$(OBJEXT): utils/$(am__dirstamp) \
 	utils/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_dbg-xdr_test.$(OBJEXT): utils/$(am__dirstamp) \
+	utils/$(DEPDIR)/$(am__dirstamp)
 fparser/$(am__dirstamp):
 	@$(MKDIR_P) fparser
 	@: > fparser/$(am__dirstamp)
@@ -2419,6 +2432,8 @@ utils/unit_tests_devel-point_locator_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_devel-vectormap_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_devel-xdr_test.$(OBJEXT): utils/$(am__dirstamp) \
+	utils/$(DEPDIR)/$(am__dirstamp)
 fparser/unit_tests_devel-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
 	fparser/$(DEPDIR)/$(am__dirstamp)
 
@@ -2603,6 +2618,8 @@ utils/unit_tests_oprof-point_locator_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_oprof-vectormap_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_oprof-xdr_test.$(OBJEXT): utils/$(am__dirstamp) \
+	utils/$(DEPDIR)/$(am__dirstamp)
 fparser/unit_tests_oprof-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
 	fparser/$(DEPDIR)/$(am__dirstamp)
 
@@ -2787,6 +2804,8 @@ utils/unit_tests_opt-point_locator_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_opt-vectormap_test.$(OBJEXT): utils/$(am__dirstamp) \
 	utils/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_opt-xdr_test.$(OBJEXT): utils/$(am__dirstamp) \
+	utils/$(DEPDIR)/$(am__dirstamp)
 fparser/unit_tests_opt-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
 	fparser/$(DEPDIR)/$(am__dirstamp)
 
@@ -2970,6 +2989,8 @@ utils/unit_tests_prof-parameters_test.$(OBJEXT):  \
 utils/unit_tests_prof-point_locator_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_prof-vectormap_test.$(OBJEXT): utils/$(am__dirstamp) \
+	utils/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_prof-xdr_test.$(OBJEXT): utils/$(am__dirstamp) \
 	utils/$(DEPDIR)/$(am__dirstamp)
 fparser/unit_tests_prof-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
 	fparser/$(DEPDIR)/$(am__dirstamp)
@@ -3419,18 +3440,23 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-xdr_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-xdr_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-xdr_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-xdr_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-xdr_test.Po@am__quote@ # am--include-marker
 
 $(am__depfiles_remade):
 	@$(MKDIR_P) $(@D)
@@ -4666,6 +4692,20 @@ utils/unit_tests_dbg-vectormap_test.obj: utils/vectormap_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_dbg-vectormap_test.obj `if test -f 'utils/vectormap_test.C'; then $(CYGPATH_W) 'utils/vectormap_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/vectormap_test.C'; fi`
 
+utils/unit_tests_dbg-xdr_test.o: utils/xdr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_dbg-xdr_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_dbg-xdr_test.Tpo -c -o utils/unit_tests_dbg-xdr_test.o `test -f 'utils/xdr_test.C' || echo '$(srcdir)/'`utils/xdr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_dbg-xdr_test.Tpo utils/$(DEPDIR)/unit_tests_dbg-xdr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/xdr_test.C' object='utils/unit_tests_dbg-xdr_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_dbg-xdr_test.o `test -f 'utils/xdr_test.C' || echo '$(srcdir)/'`utils/xdr_test.C
+
+utils/unit_tests_dbg-xdr_test.obj: utils/xdr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_dbg-xdr_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_dbg-xdr_test.Tpo -c -o utils/unit_tests_dbg-xdr_test.obj `if test -f 'utils/xdr_test.C'; then $(CYGPATH_W) 'utils/xdr_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/xdr_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_dbg-xdr_test.Tpo utils/$(DEPDIR)/unit_tests_dbg-xdr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/xdr_test.C' object='utils/unit_tests_dbg-xdr_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_dbg-xdr_test.obj `if test -f 'utils/xdr_test.C'; then $(CYGPATH_W) 'utils/xdr_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/xdr_test.C'; fi`
+
 fparser/unit_tests_dbg-autodiff.o: fparser/autodiff.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT fparser/unit_tests_dbg-autodiff.o -MD -MP -MF fparser/$(DEPDIR)/unit_tests_dbg-autodiff.Tpo -c -o fparser/unit_tests_dbg-autodiff.o `test -f 'fparser/autodiff.C' || echo '$(srcdir)/'`fparser/autodiff.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fparser/$(DEPDIR)/unit_tests_dbg-autodiff.Tpo fparser/$(DEPDIR)/unit_tests_dbg-autodiff.Po
@@ -5883,6 +5923,20 @@ utils/unit_tests_devel-vectormap_test.obj: utils/vectormap_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/vectormap_test.C' object='utils/unit_tests_devel-vectormap_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_devel-vectormap_test.obj `if test -f 'utils/vectormap_test.C'; then $(CYGPATH_W) 'utils/vectormap_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/vectormap_test.C'; fi`
+
+utils/unit_tests_devel-xdr_test.o: utils/xdr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_devel-xdr_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_devel-xdr_test.Tpo -c -o utils/unit_tests_devel-xdr_test.o `test -f 'utils/xdr_test.C' || echo '$(srcdir)/'`utils/xdr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_devel-xdr_test.Tpo utils/$(DEPDIR)/unit_tests_devel-xdr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/xdr_test.C' object='utils/unit_tests_devel-xdr_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_devel-xdr_test.o `test -f 'utils/xdr_test.C' || echo '$(srcdir)/'`utils/xdr_test.C
+
+utils/unit_tests_devel-xdr_test.obj: utils/xdr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_devel-xdr_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_devel-xdr_test.Tpo -c -o utils/unit_tests_devel-xdr_test.obj `if test -f 'utils/xdr_test.C'; then $(CYGPATH_W) 'utils/xdr_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/xdr_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_devel-xdr_test.Tpo utils/$(DEPDIR)/unit_tests_devel-xdr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/xdr_test.C' object='utils/unit_tests_devel-xdr_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_devel-xdr_test.obj `if test -f 'utils/xdr_test.C'; then $(CYGPATH_W) 'utils/xdr_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/xdr_test.C'; fi`
 
 fparser/unit_tests_devel-autodiff.o: fparser/autodiff.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT fparser/unit_tests_devel-autodiff.o -MD -MP -MF fparser/$(DEPDIR)/unit_tests_devel-autodiff.Tpo -c -o fparser/unit_tests_devel-autodiff.o `test -f 'fparser/autodiff.C' || echo '$(srcdir)/'`fparser/autodiff.C
@@ -7102,6 +7156,20 @@ utils/unit_tests_oprof-vectormap_test.obj: utils/vectormap_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_oprof-vectormap_test.obj `if test -f 'utils/vectormap_test.C'; then $(CYGPATH_W) 'utils/vectormap_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/vectormap_test.C'; fi`
 
+utils/unit_tests_oprof-xdr_test.o: utils/xdr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_oprof-xdr_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_oprof-xdr_test.Tpo -c -o utils/unit_tests_oprof-xdr_test.o `test -f 'utils/xdr_test.C' || echo '$(srcdir)/'`utils/xdr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_oprof-xdr_test.Tpo utils/$(DEPDIR)/unit_tests_oprof-xdr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/xdr_test.C' object='utils/unit_tests_oprof-xdr_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_oprof-xdr_test.o `test -f 'utils/xdr_test.C' || echo '$(srcdir)/'`utils/xdr_test.C
+
+utils/unit_tests_oprof-xdr_test.obj: utils/xdr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_oprof-xdr_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_oprof-xdr_test.Tpo -c -o utils/unit_tests_oprof-xdr_test.obj `if test -f 'utils/xdr_test.C'; then $(CYGPATH_W) 'utils/xdr_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/xdr_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_oprof-xdr_test.Tpo utils/$(DEPDIR)/unit_tests_oprof-xdr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/xdr_test.C' object='utils/unit_tests_oprof-xdr_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_oprof-xdr_test.obj `if test -f 'utils/xdr_test.C'; then $(CYGPATH_W) 'utils/xdr_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/xdr_test.C'; fi`
+
 fparser/unit_tests_oprof-autodiff.o: fparser/autodiff.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT fparser/unit_tests_oprof-autodiff.o -MD -MP -MF fparser/$(DEPDIR)/unit_tests_oprof-autodiff.Tpo -c -o fparser/unit_tests_oprof-autodiff.o `test -f 'fparser/autodiff.C' || echo '$(srcdir)/'`fparser/autodiff.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fparser/$(DEPDIR)/unit_tests_oprof-autodiff.Tpo fparser/$(DEPDIR)/unit_tests_oprof-autodiff.Po
@@ -8319,6 +8387,20 @@ utils/unit_tests_opt-vectormap_test.obj: utils/vectormap_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/vectormap_test.C' object='utils/unit_tests_opt-vectormap_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_opt-vectormap_test.obj `if test -f 'utils/vectormap_test.C'; then $(CYGPATH_W) 'utils/vectormap_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/vectormap_test.C'; fi`
+
+utils/unit_tests_opt-xdr_test.o: utils/xdr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_opt-xdr_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_opt-xdr_test.Tpo -c -o utils/unit_tests_opt-xdr_test.o `test -f 'utils/xdr_test.C' || echo '$(srcdir)/'`utils/xdr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_opt-xdr_test.Tpo utils/$(DEPDIR)/unit_tests_opt-xdr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/xdr_test.C' object='utils/unit_tests_opt-xdr_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_opt-xdr_test.o `test -f 'utils/xdr_test.C' || echo '$(srcdir)/'`utils/xdr_test.C
+
+utils/unit_tests_opt-xdr_test.obj: utils/xdr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_opt-xdr_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_opt-xdr_test.Tpo -c -o utils/unit_tests_opt-xdr_test.obj `if test -f 'utils/xdr_test.C'; then $(CYGPATH_W) 'utils/xdr_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/xdr_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_opt-xdr_test.Tpo utils/$(DEPDIR)/unit_tests_opt-xdr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/xdr_test.C' object='utils/unit_tests_opt-xdr_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_opt-xdr_test.obj `if test -f 'utils/xdr_test.C'; then $(CYGPATH_W) 'utils/xdr_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/xdr_test.C'; fi`
 
 fparser/unit_tests_opt-autodiff.o: fparser/autodiff.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT fparser/unit_tests_opt-autodiff.o -MD -MP -MF fparser/$(DEPDIR)/unit_tests_opt-autodiff.Tpo -c -o fparser/unit_tests_opt-autodiff.o `test -f 'fparser/autodiff.C' || echo '$(srcdir)/'`fparser/autodiff.C
@@ -9538,6 +9620,20 @@ utils/unit_tests_prof-vectormap_test.obj: utils/vectormap_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_prof-vectormap_test.obj `if test -f 'utils/vectormap_test.C'; then $(CYGPATH_W) 'utils/vectormap_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/vectormap_test.C'; fi`
 
+utils/unit_tests_prof-xdr_test.o: utils/xdr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_prof-xdr_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_prof-xdr_test.Tpo -c -o utils/unit_tests_prof-xdr_test.o `test -f 'utils/xdr_test.C' || echo '$(srcdir)/'`utils/xdr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_prof-xdr_test.Tpo utils/$(DEPDIR)/unit_tests_prof-xdr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/xdr_test.C' object='utils/unit_tests_prof-xdr_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_prof-xdr_test.o `test -f 'utils/xdr_test.C' || echo '$(srcdir)/'`utils/xdr_test.C
+
+utils/unit_tests_prof-xdr_test.obj: utils/xdr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_prof-xdr_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_prof-xdr_test.Tpo -c -o utils/unit_tests_prof-xdr_test.obj `if test -f 'utils/xdr_test.C'; then $(CYGPATH_W) 'utils/xdr_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/xdr_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_prof-xdr_test.Tpo utils/$(DEPDIR)/unit_tests_prof-xdr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/xdr_test.C' object='utils/unit_tests_prof-xdr_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_prof-xdr_test.obj `if test -f 'utils/xdr_test.C'; then $(CYGPATH_W) 'utils/xdr_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/xdr_test.C'; fi`
+
 fparser/unit_tests_prof-autodiff.o: fparser/autodiff.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT fparser/unit_tests_prof-autodiff.o -MD -MP -MF fparser/$(DEPDIR)/unit_tests_prof-autodiff.Tpo -c -o fparser/unit_tests_prof-autodiff.o `test -f 'fparser/autodiff.C' || echo '$(srcdir)/'`fparser/autodiff.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fparser/$(DEPDIR)/unit_tests_prof-autodiff.Tpo fparser/$(DEPDIR)/unit_tests_prof-autodiff.Po
@@ -10337,18 +10433,23 @@ distclean: distclean-am
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_dbg-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_devel-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_oprof-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_opt-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_prof-xdr_test.Po
 	-rm -f Makefile
 distclean-am: clean-am distclean-compile distclean-generic \
 	distclean-tags
@@ -10819,18 +10920,23 @@ maintainer-clean: maintainer-clean-am
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_dbg-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_devel-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_oprof-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_opt-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_prof-xdr_test.Po
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic
 

--- a/tests/utils/xdr_test.C
+++ b/tests/utils/xdr_test.C
@@ -1,0 +1,63 @@
+// Unit test includes
+#include "libmesh_cppunit.h"
+#include "test_comm.h"
+
+// libMesh includes
+#include <libmesh/libmesh.h>
+#include <libmesh/xdr_cxx.h>
+#include <libmesh/int_range.h>
+#include <timpi/communicator.h>
+
+// C++ includes
+#include <vector>
+
+using namespace libMesh;
+
+class XdrTest : public CppUnit::TestCase {
+public:
+  CPPUNIT_TEST_SUITE( XdrTest );
+
+  CPPUNIT_TEST( testDataVec );
+
+  CPPUNIT_TEST_SUITE_END();
+
+private:
+
+public:
+  void setUp()
+  {}
+
+  void tearDown()
+  {}
+
+  void testDataVec ()
+  {
+    std::vector<Real> vec = {libMesh::pi, 2*libMesh::pi, 3*libMesh::pi};
+
+    // Test reading/writing on 1 processor
+    if (TestCommWorld->rank() == 0)
+      {
+        // Write to file
+        {
+          Xdr xdr("output.dat", WRITE);
+          xdr.data(vec, "# This is a comment");
+        }
+
+        // Read from file
+        {
+          Xdr xdr("output.dat", READ);
+          std::vector<Real> vec_in;
+          xdr.data(vec_in);
+
+          // Check that correct number of values were read in
+          CPPUNIT_ASSERT_EQUAL(vec_in.size(), vec.size());
+
+          // Check that values were written/read with sufficient accuracy
+          for (auto i : index_range(vec_in))
+            LIBMESH_ASSERT_FP_EQUAL(vec[i], vec_in[i], TOLERANCE);
+        }
+      }
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( XdrTest );


### PR DESCRIPTION
This fixes the following simple test for me, 
```
// libmesh includes
#include "libmesh/libmesh_common.h"
#include "libmesh/xdr_cxx.h"

// C++ includes
#include <vector>
#include <iostream>
#include <algorithm> // std::generate
#include <limits>
#include <iomanip> // std::setprecision

using namespace libMesh;

int main()
{
  std::vector<Real> vec(100);
  std::generate(vec.begin(), vec.end(), std::rand);

  Xdr xdr("output.dat", WRITE);
  xdr.data(vec, "# This is a comment");

  return 0;
}
```
which previously wrote a file which looked something like this:
```
100 # vector length
2e+09 8e+08 2e+09 2e+09 2e+09 4e+08 7e+08 2e+09 6e+08 ...
```
