### PR TITLE
Copy extra integers and mapping data whenever "copying" elements

### DIFF
--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -939,13 +939,24 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
             }
           } // end switch (etype)
 
-
-
-        // Be sure the correct IDs are also set for all subelems.
+        // Be sure the correct data is set for all subelems.
+        const unsigned int nei = elem->n_extra_integers();
         for (unsigned int i=0; i != max_subelems; ++i)
           if (subelem[i]) {
             subelem[i]->processor_id() = elem->processor_id();
             subelem[i]->subdomain_id() = elem->subdomain_id();
+
+            // Copy any extra element data.  Since the subelements
+            // haven't been added to the mesh yet any allocation has
+            // to be done manually.
+            subelem[i]->add_extra_integers(nei);
+            for (unsigned int i=0; i != nei; ++i)
+              subelem[i]->set_extra_integer(i, elem->get_extra_integer(i));
+
+
+            // Copy any mapping data.
+            subelem[i]->set_mapping_type(elem->mapping_type());
+            subelem[i]->set_mapping_data(elem->mapping_data());
           }
 
         // On a mesh with boundary data, we need to move that data to
@@ -1329,6 +1340,16 @@ void MeshTools::Modification::flatten(MeshBase & mesh)
               }
         }
 
+      // Copy any extra element data.  Since the copy hasn't been
+      // added to the mesh yet any allocation has to be done manually.
+      const unsigned int nei = elem->n_extra_integers();
+      copy->add_extra_integers(nei);
+      for (unsigned int i=0; i != nei; ++i)
+        copy->set_extra_integer(i, elem->get_extra_integer(i));
+
+      // Copy any mapping data.
+      copy->set_mapping_type(elem->mapping_type());
+      copy->set_mapping_data(elem->mapping_data());
 
       // We're done with this element
       mesh.delete_elem(elem);

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -950,8 +950,8 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
             // haven't been added to the mesh yet any allocation has
             // to be done manually.
             subelem[i]->add_extra_integers(nei);
-            for (unsigned int i=0; i != nei; ++i)
-              subelem[i]->set_extra_integer(i, elem->get_extra_integer(i));
+            for (unsigned int ei=0; ei != nei; ++ei)
+              subelem[ei]->set_extra_integer(ei, elem->get_extra_integer(ei));
 
 
             // Copy any mapping data.

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -191,6 +191,9 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
         el->set_unique_id(old->unique_id() + unique_id_offset);
 #endif
 
+        el->set_mapping_type(old->mapping_type());
+        el->set_mapping_data(old->mapping_data());
+
         //Hold onto it
         if (!skip_find_neighbors)
           {

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -980,6 +980,16 @@ void UnstructuredMesh::all_first_order ()
 #endif
       lo_elem->processor_id() = so_elem->processor_id();
       lo_elem->subdomain_id() = so_elem->subdomain_id();
+
+      const unsigned int nei = so_elem->n_extra_integers();
+      lo_elem->add_extra_integers(nei);
+      for (unsigned int i=0; i != nei; ++i)
+        lo_elem->set_extra_integer(i, so_elem->get_extra_integer(i));
+
+      // This is probably moot but shouldn't hurt
+      lo_elem->set_mapping_type(so_elem->mapping_type());
+      lo_elem->set_mapping_data(so_elem->mapping_data());
+
       this->insert_elem(std::move(lo_elem));
     }
 

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -756,6 +756,9 @@ void UnstructuredMesh::create_submesh (UnstructuredMesh & new_mesh,
       for (unsigned int i = 0; i != n_elem_ints; ++i)
         uelem->set_extra_integer(i, old_elem->get_extra_integer(i));
 
+      uelem->set_mapping_type(old_elem->mapping_type());
+      uelem->set_mapping_data(old_elem->mapping_data());
+
       Elem * new_elem = new_mesh.add_elem(std::move(uelem));
 
       libmesh_assert(new_elem);

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -1354,6 +1354,16 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
 #endif
       so_elem->processor_id() = lo_pid;
       so_elem->subdomain_id() = lo_elem->subdomain_id();
+
+      const unsigned int nei = so_elem->n_extra_integers();
+      so_elem->add_extra_integers(nei);
+      for (unsigned int i=0; i != nei; ++i)
+        so_elem->set_extra_integer(i, lo_elem->get_extra_integer(i));
+
+      // This might not help anything but shouldn't hurt.
+      so_elem->set_mapping_type(lo_elem->mapping_type());
+      so_elem->set_mapping_data(lo_elem->mapping_data());
+
       this->insert_elem(std::move(so_elem));
     }
 


### PR DESCRIPTION
This should fix #2644, in which @YaqiWang noticed that we hadn't updated all_second_order() to properly copy extra elem integer data from low order elements to the high order elements replacing them.

While I was at it I looked through the code for any similar failures elsewhere, and fixed those: extra integer data and/or mapping data wasn't being copied in flatten(), copy_nodes_and_elements(), create_submesh(), and all_first_order().

There's still one remaining fix to be made: mapping data isn't making it into Elem packed_range serialization, which should break parallel repartitioning on isogeometric meshes.  That's a slightly trickier fix so I'll leave it for a future PR.