### PR TITLE
Major refresh of the EIM framework

### DIFF
--- a/contrib/capnproto/rb_data.capnp
+++ b/contrib/capnproto/rb_data.capnp
@@ -112,7 +112,8 @@ struct RBEIMEvaluationReal @0xf8121d2237427a80 {
   interpolationSubdomainId @5 :List(Integer);
   interpolationElemId      @6 :List(Integer);
   interpolationQp          @7 :List(Integer);
-  interpolationMatrix      @8 :List(Real);
+  interpolationXyzPerturb  @8 :List(List(Point3D));
+  interpolationMatrix      @9 :List(Real);
 }
 struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   nBfs                     @0 :Integer;
@@ -123,5 +124,6 @@ struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   interpolationSubdomainId @5 :List(Integer);
   interpolationElemId      @6 :List(Integer);
   interpolationQp          @7 :List(Integer);
-  interpolationMatrix      @8 :List(Complex);
+  interpolationXyzPerturb  @8 :List(List(Point3D));
+  interpolationMatrix      @9 :List(Complex);
 }

--- a/contrib/capnproto/rb_data.capnp
+++ b/contrib/capnproto/rb_data.capnp
@@ -37,12 +37,6 @@ struct Point3D @0xde7dfcf8ecccaa90 {
   z @2 :Real;
 }
 
-struct MeshElem @0xcd01b7bd6045605d {
-  type         @0 :Text;
-  points       @1 :List(Point3D);
-  subdomainId  @2 :Integer;
-}
-
 struct RBSCMEvaluation @0xb8dd038628a64b16 {
   parameterRanges    @0 :ParameterRanges;
   discreteParameters @1 :DiscreteParameterList;
@@ -110,18 +104,24 @@ struct TransientRBEvaluationComplex @0x856e1656058c2e19 {
 }
 
 struct RBEIMEvaluationReal @0xf8121d2237427a80 {
-  rbEvaluation                @0 :RBEvaluationReal;
-  interpolationElemIds        @1 :List(Integer);
-  interpolationMatrix         @2 :List(Real);
-  interpolationPointsElems    @3 :List(MeshElem);
-  interpolationPointsVar      @4 :List(Integer);
-  interpolationPoints         @5 :List(Point3D);
+  nBfs                     @0 :Integer;
+  parameterRanges          @1 :ParameterRanges;
+  discreteParameters       @2 :DiscreteParameterList;
+  interpolationXyz         @3 :List(Point3D);
+  interpolationComp        @4 :List(Integer);
+  interpolationSubdomainId @5 :List(Integer);
+  interpolationElemId      @6 :List(Integer);
+  interpolationQp          @7 :List(Integer);
+  interpolationMatrix      @8 :List(Real);
 }
 struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
-  rbEvaluation                @0 :RBEvaluationComplex;
-  interpolationElemIds        @1 :List(Integer);
-  interpolationMatrix         @2 :List(Complex);
-  interpolationPointsElems    @3 :List(MeshElem);
-  interpolationPointsVar      @4 :List(Integer);
-  interpolationPoints         @5 :List(Point3D);
+  nBfs                     @0 :Integer;
+  parameterRanges          @1 :ParameterRanges;
+  discreteParameters       @2 :DiscreteParameterList;
+  interpolationXyz         @3 :List(Point3D);
+  interpolationComp        @4 :List(Integer);
+  interpolationSubdomainId @5 :List(Integer);
+  interpolationElemId      @6 :List(Integer);
+  interpolationQp          @7 :List(Integer);
+  interpolationMatrix      @8 :List(Complex);
 }

--- a/examples/reduced_basis/reduced_basis_ex4/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex4/assembly.h
@@ -47,7 +47,8 @@ struct ShiftedGaussian : public RBParametrizedFunction
   Number evaluate(const RBParameters & mu,
                   unsigned int /*comp*/,
                   const Point & p,
-                  subdomain_id_type /*subdomain_id*/)
+                  subdomain_id_type /*subdomain_id*/,
+                  const std::vector<Point> & /*p_perturb*/)
   {
     Real center_x = mu.get_value("center_x");
     Real center_y = mu.get_value("center_y");

--- a/examples/reduced_basis/reduced_basis_ex4/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex4/assembly.h
@@ -38,9 +38,14 @@ using libMesh::FEBase;
 
 struct ShiftedGaussian : public RBParametrizedFunction
 {
-  virtual Number evaluate(const RBParameters & mu,
-                          const Point & p,
-                          const Elem &)
+  unsigned int get_n_components() const
+  {
+    return 1;
+  }
+
+  Number evaluate(const RBParameters & mu,
+                  const Point & p,
+                  subdomain_id_type /*subdomain_id*/)
   {
     Real center_x = mu.get_value("center_x");
     Real center_y = mu.get_value("center_y");

--- a/examples/reduced_basis/reduced_basis_ex4/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex4/assembly.h
@@ -26,7 +26,7 @@ using libMesh::Number;
 using libMesh::Point;
 using libMesh::RBAssemblyExpansion;
 using libMesh::RBEIMAssembly;
-using libMesh::RBEIMConstruction;
+using libMesh::RBEIMEvaluation;
 using libMesh::RBParametrizedFunction;
 using libMesh::RBParameters;
 using libMesh::RBTheta;
@@ -35,6 +35,7 @@ using libMesh::Real;
 using libMesh::RealGradient;
 using libMesh::Elem;
 using libMesh::FEBase;
+using libMesh::subdomain_id_type;
 
 struct ShiftedGaussian : public RBParametrizedFunction
 {
@@ -44,6 +45,7 @@ struct ShiftedGaussian : public RBParametrizedFunction
   }
 
   Number evaluate(const RBParameters & mu,
+                  unsigned int /*comp*/,
                   const Point & p,
                   subdomain_id_type /*subdomain_id*/)
   {
@@ -113,9 +115,9 @@ struct EIM_IP_assembly : ElemAssembly
 
 struct EIM_F : RBEIMAssembly
 {
-  EIM_F(RBEIMConstruction & rb_eim_con_in,
+  EIM_F(RBEIMEvaluation & rb_eim_eval_in,
         unsigned int basis_function_index_in) :
-    RBEIMAssembly(rb_eim_con_in,
+    RBEIMAssembly(rb_eim_eval_in,
                   basis_function_index_in)
   {}
 
@@ -138,9 +140,8 @@ struct EIM_F : RBEIMAssembly
     const unsigned int n_u_dofs = c.get_dof_indices(u_var).size();
 
     std::vector<Number> eim_values;
-    evaluate_basis_function(eim_var,
-                            c.get_elem(),
-                            c.get_element_qrule().get_points(),
+    evaluate_basis_function(c.get_elem().id(),
+                            eim_var,
                             eim_values);
 
     for (unsigned int qp=0; qp != c.get_element_qrule().n_points(); qp++)

--- a/examples/reduced_basis/reduced_basis_ex4/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex4/assembly.h
@@ -26,7 +26,7 @@ using libMesh::Number;
 using libMesh::Point;
 using libMesh::RBAssemblyExpansion;
 using libMesh::RBEIMAssembly;
-using libMesh::RBEIMEvaluation;
+using libMesh::RBEIMConstruction;
 using libMesh::RBParametrizedFunction;
 using libMesh::RBParameters;
 using libMesh::RBTheta;
@@ -116,9 +116,9 @@ struct EIM_IP_assembly : ElemAssembly
 
 struct EIM_F : RBEIMAssembly
 {
-  EIM_F(RBEIMEvaluation & rb_eim_eval_in,
+  EIM_F(RBEIMConstruction & rb_eim_con_in,
         unsigned int basis_function_index_in) :
-    RBEIMAssembly(rb_eim_eval_in,
+    RBEIMAssembly(rb_eim_con_in,
                   basis_function_index_in)
   {}
 

--- a/examples/reduced_basis/reduced_basis_ex4/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex4/assembly.h
@@ -12,11 +12,15 @@
 #include "libmesh/dense_vector.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/elem.h"
+#include "libmesh/utility.h"
 
 // rbOOmit includes
 #include "libmesh/rb_assembly_expansion.h"
 #include "libmesh/rb_eim_theta.h"
 #include "libmesh/rb_parametrized_function.h"
+
+// C++ includes
+#include <cmath>
 
 // Bring in bits from the libMesh namespace.
 // Just the bits we're using, since this is a header.
@@ -36,6 +40,7 @@ using libMesh::RealGradient;
 using libMesh::Elem;
 using libMesh::FEBase;
 using libMesh::subdomain_id_type;
+using libMesh::Utility::pow;
 
 struct ShiftedGaussian : public RBParametrizedFunction
 {
@@ -44,14 +49,15 @@ struct ShiftedGaussian : public RBParametrizedFunction
     return 1;
   }
 
-  std::vector<Number> evaluate(const RBParameters & mu,
-                               const Point & p,
-                               subdomain_id_type /*subdomain_id*/,
-                               const std::vector<Point> & /*p_perturb*/)
+  virtual std::vector<Number>
+  evaluate(const RBParameters & mu,
+           const Point & p,
+           subdomain_id_type /*subdomain_id*/,
+           const std::vector<Point> & /*p_perturb*/) override
   {
     Real center_x = mu.get_value("center_x");
     Real center_y = mu.get_value("center_y");
-    return std::vector<Number> {exp(-2.*(pow(center_x-p(0),2.) + pow(center_y-p(1),2.)))};
+    return std::vector<Number> { std::exp(-2. * (pow<2>(center_x - p(0)) + pow<2>(center_y - p(1)))) };
   }
 };
 

--- a/examples/reduced_basis/reduced_basis_ex4/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex4/assembly.h
@@ -44,15 +44,14 @@ struct ShiftedGaussian : public RBParametrizedFunction
     return 1;
   }
 
-  Number evaluate(const RBParameters & mu,
-                  unsigned int /*comp*/,
-                  const Point & p,
-                  subdomain_id_type /*subdomain_id*/,
-                  const std::vector<Point> & /*p_perturb*/)
+  std::vector<Number> evaluate(const RBParameters & mu,
+                               const Point & p,
+                               subdomain_id_type /*subdomain_id*/,
+                               const std::vector<Point> & /*p_perturb*/)
   {
     Real center_x = mu.get_value("center_x");
     Real center_y = mu.get_value("center_y");
-    return exp(-2.*(pow(center_x-p(0),2.) + pow(center_y-p(1),2.)));
+    return std::vector<Number> {exp(-2.*(pow(center_x-p(0),2.) + pow(center_y-p(1),2.)))};
   }
 };
 

--- a/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
@@ -28,8 +28,7 @@ public:
   SimpleEIMEvaluation(const libMesh::Parallel::Communicator & comm) :
     RBEIMEvaluation(comm)
   {
-    std::unique_ptr<RBParametrizedFunction> sg = std::make_unique<ShiftedGaussian>();
-    set_parametrized_function(std::move(sg));
+    set_parametrized_function(std::make_unique<ShiftedGaussian>());
   }
 };
 

--- a/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
@@ -62,7 +62,7 @@ public:
    */
   virtual std::unique_ptr<ElemAssembly> build_eim_assembly(unsigned int index)
   {
-    return std::make_unique<EIM_F>(get_rb_eim_evaluation(), index);
+    return std::make_unique<EIM_F>(*this, index);
   }
 };
 

--- a/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
@@ -14,9 +14,6 @@
 using libMesh::EquationSystems;
 using libMesh::RBEIMEvaluation;
 using libMesh::RBEIMConstruction;
-#ifndef LIBMESH_HAVE_CXX14_MAKE_UNIQUE
-using libMesh::make_unique;
-#endif
 
 // A simple subclass of RBEIMEvaluation. Overload
 // evaluate_parametrized_function to define the
@@ -28,7 +25,7 @@ public:
   SimpleEIMEvaluation(const libMesh::Parallel::Communicator & comm) :
     RBEIMEvaluation(comm)
   {
-    set_parametrized_function(std::make_unique<ShiftedGaussian>());
+    set_parametrized_function(libmesh_make_unique<ShiftedGaussian>());
   }
 };
 
@@ -62,7 +59,7 @@ public:
    */
   virtual std::unique_ptr<ElemAssembly> build_eim_assembly(unsigned int index)
   {
-    return std::make_unique<EIM_F>(*this, index);
+    return libmesh_make_unique<EIM_F>(*this, index);
   }
 };
 

--- a/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
@@ -13,6 +13,7 @@
 // Just the bits we're using, since this is a header.
 using libMesh::EquationSystems;
 using libMesh::RBEIMEvaluation;
+using libMesh::RBEIMConstruction;
 #ifndef LIBMESH_HAVE_CXX14_MAKE_UNIQUE
 using libMesh::make_unique;
 #endif
@@ -27,13 +28,9 @@ public:
   SimpleEIMEvaluation(const libMesh::Parallel::Communicator & comm) :
     RBEIMEvaluation(comm)
   {
-    attach_parametrized_function(&sg);
+    std::unique_ptr<RBParametrizedFunction> sg = std::make_unique<ShiftedGaussian>();
+    set_parametrized_function(std::move(sg));
   }
-
-  /**
-   * Parametrized function that we approximate with EIM
-   */
-  ShiftedGaussian sg;
 };
 
 // A simple subclass of RBEIMConstruction.
@@ -47,21 +44,8 @@ public:
   SimpleEIMConstruction (EquationSystems & es,
                          const std::string & name_in,
                          const unsigned int number_in)
-    : Parent(es, name_in, number_in)
+    : RBEIMConstruction(es, name_in, number_in)
   {
-  }
-
-  /**
-   * The type of the parent.
-   */
-  typedef RBEIMConstruction Parent;
-
-  /**
-   * Provide an implementation of build_eim_assembly
-   */
-  virtual std::unique_ptr<ElemAssembly> build_eim_assembly(unsigned int index)
-  {
-    return libmesh_make_unique<EIM_F>(*this, index);
   }
 
   /**
@@ -69,56 +53,18 @@ public:
    */
   virtual void init_data()
   {
-    Parent::init_data();
+    this->add_variable ("eim_var", libMesh::FIRST);
 
-    set_inner_product_assembly(ip);
+    RBEIMConstruction::init_data();
   }
 
   /**
-   * Initialize the implicit system that is used to perform L2 projections.
+   * Provide an implementation of build_eim_assembly
    */
-  virtual void init_implicit_system()
+  virtual std::unique_ptr<ElemAssembly> build_eim_assembly(unsigned int index)
   {
-    this->add_variable ("L2_proj_var", libMesh::FIRST);
+    return std::make_unique<EIM_F>(get_rb_eim_evaluation(), index);
   }
-
-  /**
-   * Initialize the explicit system that is used to store the basis functions.
-   */
-  virtual void init_explicit_system()
-  {
-    u_var = get_explicit_system().add_variable ("f_EIM", libMesh::FIRST);
-  }
-
-  /**
-   * Pre-request all relevant element data.
-   */
-  virtual void init_context(FEMContext & c)
-  {
-    // For efficiency, we should prerequest all
-    // the data we will need to build the
-    // linear system before doing an element loop.
-    FEBase * elem_fe = nullptr;
-    c.get_element_fe(u_var, elem_fe);
-
-    elem_fe->get_JxW();
-    elem_fe->get_phi();
-    elem_fe->get_dphi();
-
-    FEBase * side_fe = nullptr;
-    c.get_side_fe(u_var, side_fe);
-    side_fe->get_nothing();
-  }
-
-  /**
-   * Variable number for u.
-   */
-  unsigned int u_var;
-
-  /**
-   * Inner product assembly object
-   */
-  EIM_IP_assembly ip;
 };
 
 #endif

--- a/examples/reduced_basis/reduced_basis_ex4/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex4/rb_classes.h
@@ -21,6 +21,7 @@
 #define RB_CLASSES_H
 
 #include "libmesh/rb_construction.h"
+#include "libmesh/rb_evaluation.h"
 #include "assembly.h"
 
 #ifdef LIBMESH_ENABLE_DIRICHLET

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -174,7 +174,6 @@ int main (int argc, char ** argv)
       // Write out the basis functions, if requested
       if (store_basis_functions)
         {
-          // TODO: This needs to be implemented in the new version of RBEIMEvaluation
           eim_rb_eval.write_out_basis_functions("eim_data", /*binary=*/false);
 
           rb_construction.get_rb_evaluation().write_out_basis_functions(rb_construction,
@@ -208,9 +207,7 @@ int main (int argc, char ** argv)
       if (store_basis_functions)
         {
           // read in the data from files
-
-          // FIXME: This needs to be implemented in the new version of RBEIMEvaluation
-          // eim_rb_eval.read_in_basis_functions(eim_construction.get_explicit_system(), "eim_data");
+          eim_rb_eval.read_in_basis_functions("eim_data", /*binary=*/false);
 
           rb_eval.read_in_basis_functions(rb_construction, "rb_data");
 

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -178,7 +178,7 @@ int main (int argc, char ** argv)
 
         RBDataDeserialization::RBEIMEvaluationDeserialization rb_eim_eval_reader(eim_rb_eval);
         rb_eim_eval_reader.read_from_file("rb_eim_eval.bin");
-        eim_rb_eval.read_in_basis_functions("eim_data", /*binary=*/false);
+        eim_rb_eval.read_in_basis_functions(rb_construction, "eim_data", /*binary=*/false);
 
         // Read data from input file and print state
         rb_construction.process_parameters_file(rb_parameters);

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -101,10 +101,13 @@ int main (int argc, char ** argv)
 
   ReplicatedMesh mesh (init.comm(), dim);
   MeshTools::Generation::build_square (mesh,
-                                      n_elem, n_elem,
-                                      -1., 1.,
-                                      -1., 1.,
-                                      QUAD4);
+                                       n_elem, n_elem,
+                                       -1., 1.,
+                                       -1., 1.,
+                                       QUAD4);
+
+  // Set to true the write binary (XDR) files with EIM data, false to write ASCII files.
+  bool eim_binary_io = true;
 
   if (!online_mode)
     {
@@ -144,7 +147,7 @@ int main (int argc, char ** argv)
         rb_eim_eval_writer.write_to_file("rb_eim_eval.bin");
 
         // Write out the EIM basis functions
-        eim_rb_eval.write_out_basis_functions("eim_data", /*binary=*/false);
+        eim_rb_eval.write_out_basis_functions("eim_data", eim_binary_io);
       }
 
       {
@@ -178,7 +181,7 @@ int main (int argc, char ** argv)
 
         RBDataDeserialization::RBEIMEvaluationDeserialization rb_eim_eval_reader(eim_rb_eval);
         rb_eim_eval_reader.read_from_file("rb_eim_eval.bin");
-        eim_rb_eval.read_in_basis_functions(rb_construction, "eim_data", /*binary=*/false);
+        eim_rb_eval.read_in_basis_functions(rb_construction, "eim_data", eim_binary_io);
 
         // Read data from input file and print state
         rb_construction.process_parameters_file(rb_parameters);

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -174,9 +174,8 @@ int main (int argc, char ** argv)
       // Write out the basis functions, if requested
       if (store_basis_functions)
         {
-          // FIXME: This needs to be implemented in the new version of RBEIMEvaluation
-          // eim_construction.get_rb_evaluation().write_out_basis_functions(eim_construction.get_explicit_system(),
-          //                                                                "eim_data");
+          // TODO: This needs to be implemented in the new version of RBEIMEvaluation
+          eim_rb_eval.write_out_basis_functions("eim_data", /*binary=*/false);
 
           rb_construction.get_rb_evaluation().write_out_basis_functions(rb_construction,
                                                                         "rb_data");

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.in
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.in
@@ -1,7 +1,6 @@
 # ========= Main function parameters =========
 
 n_elem = 25
-store_basis_functions = true
 
 parameter_names = 'center_x center_y'
 

--- a/examples/reduced_basis/reduced_basis_ex6/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex6/assembly.h
@@ -35,7 +35,6 @@ using libMesh::RBParametrizedFunction;
 using libMesh::RBTheta;
 using libMesh::RBThetaExpansion;
 using libMesh::RBEIMAssembly;
-using libMesh::RBEIMConstruction;
 using libMesh::RBEIMEvaluation;
 using libMesh::RBEIMTheta;
 using libMesh::Real;
@@ -244,9 +243,9 @@ struct ThetaEIM : RBEIMTheta
 
 struct AssemblyEIM : RBEIMAssembly
 {
-  AssemblyEIM(RBEIMConstruction & rb_eim_con_in,
+  AssemblyEIM(RBEIMEvaluation & rb_eim_eval_in,
               unsigned int basis_function_index_in) :
-    RBEIMAssembly(rb_eim_con_in,
+    RBEIMAssembly(rb_eim_eval_in,
                   basis_function_index_in)
   {}
 
@@ -271,21 +270,18 @@ struct AssemblyEIM : RBEIMAssembly
     const unsigned int n_u_dofs = c.get_dof_indices(u_var).size();
 
     std::vector<Number> eim_values_Gx;
-    evaluate_basis_function(Gx_var,
-                            c.get_elem(),
-                            c.get_element_qrule().get_points(),
+    evaluate_basis_function(c.get_elem().id(),
+                            Gx_var,
                             eim_values_Gx);
 
     std::vector<Number> eim_values_Gy;
-    evaluate_basis_function(Gy_var,
-                            c.get_elem(),
-                            c.get_element_qrule().get_points(),
+    evaluate_basis_function(c.get_elem().id(),
+                            Gy_var,
                             eim_values_Gy);
 
     std::vector<Number> eim_values_Gz;
-    evaluate_basis_function(Gz_var,
-                            c.get_elem(),
-                            c.get_element_qrule().get_points(),
+    evaluate_basis_function(c.get_elem().id(),
+                            Gz_var,
                             eim_values_Gz);
 
     for (unsigned int qp=0; qp != c.get_element_qrule().n_points(); qp++)

--- a/examples/reduced_basis/reduced_basis_ex6/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex6/assembly.h
@@ -54,7 +54,8 @@ struct Gxyz : public RBParametrizedFunction
   virtual Number evaluate(const RBParameters & mu,
                           unsigned int comp,
                           const Point & p,
-                          subdomain_id_type /*subdomain_id*/)
+                          subdomain_id_type /*subdomain_id*/,
+                          const std::vector<Point> & /*p_perturb*/)
   {
     Real curvature = mu.get_value("curvature");
 

--- a/examples/reduced_basis/reduced_basis_ex6/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex6/assembly.h
@@ -35,6 +35,7 @@ using libMesh::RBParametrizedFunction;
 using libMesh::RBTheta;
 using libMesh::RBThetaExpansion;
 using libMesh::RBEIMAssembly;
+using libMesh::RBEIMConstruction;
 using libMesh::RBEIMEvaluation;
 using libMesh::RBEIMTheta;
 using libMesh::Real;
@@ -240,9 +241,9 @@ struct ThetaEIM : RBEIMTheta
 
 struct AssemblyEIM : RBEIMAssembly
 {
-  AssemblyEIM(RBEIMEvaluation & rb_eim_eval_in,
+  AssemblyEIM(RBEIMConstruction & rb_eim_con_in,
               unsigned int basis_function_index_in) :
-    RBEIMAssembly(rb_eim_eval_in,
+    RBEIMAssembly(rb_eim_con_in,
                   basis_function_index_in)
   {}
 

--- a/examples/reduced_basis/reduced_basis_ex6/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex6/assembly.h
@@ -41,45 +41,41 @@ using libMesh::Real;
 using libMesh::RealGradient;
 using libMesh::Elem;
 using libMesh::FEBase;
+using libMesh::subdomain_id_type;
 
-struct ElemAssemblyWithConstruction : ElemAssembly
+// The function we're approximating with EIM
+struct Gxyz : public RBParametrizedFunction
 {
-  RBConstruction * rb_con;
-};
-
-// The "x component" of the function we're approximating with EIM
-struct Gx : public RBParametrizedFunction
-{
-  virtual Number evaluate(const RBParameters & mu,
-                          const Point & p,
-                          const Elem &)
+  unsigned int get_n_components() const
   {
-    Real curvature = mu.get_value("curvature");
-    return 1. + curvature*p(0);
+    return 3;
   }
-};
 
-// The "y component" of the function we're approximating with EIM
-struct Gy : public RBParametrizedFunction
-{
   virtual Number evaluate(const RBParameters & mu,
+                          unsigned int comp,
                           const Point & p,
-                          const Elem &)
+                          subdomain_id_type /*subdomain_id*/)
   {
     Real curvature = mu.get_value("curvature");
-    return 1. + curvature*p(0);
-  }
-};
 
-// The "z component" of the function we're approximating with EIM
-struct Gz : public RBParametrizedFunction
-{
-  virtual Number evaluate(const RBParameters & mu,
-                          const Point & p,
-                          const Elem &)
-  {
-    Real curvature = mu.get_value("curvature");
-    return 1./(1. + curvature*p(0));
+    if(comp == 0)
+    {
+      return 1. + curvature*p(0);
+    }
+    else if(comp == 1)
+    {
+      return 1. + curvature*p(0);
+    }
+    else if(comp == 2)
+    {
+      return 1./(1. + curvature*p(0));
+    }
+    else
+    {
+      libmesh_error_msg("Error: Invalid comp");
+    }
+
+    return 0.;
   }
 };
 
@@ -91,12 +87,12 @@ struct ThetaA0 : RBTheta
   }
 };
 
-struct AssemblyA0 : ElemAssemblyWithConstruction
+struct AssemblyA0 : ElemAssembly
 {
   virtual void boundary_assembly(FEMContext & c)
   {
     std::vector<boundary_id_type> bc_ids;
-    rb_con->get_mesh().get_boundary_info().boundary_ids (&c.get_elem(), c.side, bc_ids);
+    c.get_system().get_mesh().get_boundary_info().boundary_ids (&c.get_elem(), c.side, bc_ids);
     for (std::vector<boundary_id_type>::const_iterator b =
            bc_ids.begin(); b != bc_ids.end(); ++b)
       if (*b == 1 || *b == 2 || *b == 3 || *b == 4)
@@ -134,12 +130,12 @@ struct ThetaA1 : RBTheta
   }
 };
 
-struct AssemblyA1 : ElemAssemblyWithConstruction
+struct AssemblyA1 : ElemAssembly
 {
   virtual void boundary_assembly(FEMContext & c)
   {
     std::vector<boundary_id_type> bc_ids;
-    rb_con->get_mesh().get_boundary_info().boundary_ids (&c.get_elem(), c.side, bc_ids);
+    c.get_system().get_mesh().get_boundary_info().boundary_ids (&c.get_elem(), c.side, bc_ids);
     for (std::vector<boundary_id_type>::const_iterator b =
            bc_ids.begin(); b != bc_ids.end(); ++b)
       if (*b == 1 || *b == 3) // y == -0.2, y == 0.2
@@ -181,12 +177,12 @@ struct ThetaA2 : RBTheta {
     return 0.2*mu.get_value("kappa") * mu.get_value("Bi") * mu.get_value("curvature");
   }
 };
-struct AssemblyA2 : ElemAssemblyWithConstruction
+struct AssemblyA2 : ElemAssembly
 {
   virtual void boundary_assembly(FEMContext & c)
   {
     std::vector<boundary_id_type> bc_ids;
-    rb_con->get_mesh().get_boundary_info().boundary_ids (&c.get_elem(), c.side, bc_ids);
+    c.get_system().get_mesh().get_boundary_info().boundary_ids (&c.get_elem(), c.side, bc_ids);
     for (std::vector<boundary_id_type>::const_iterator b =
            bc_ids.begin(); b != bc_ids.end(); ++b)
       if (*b == 2 || *b == 4) // x == 0.2, x == -0.2
@@ -392,31 +388,6 @@ struct Ex6InnerProduct : ElemAssembly
   }
 };
 
-struct Ex6EIMInnerProduct : ElemAssembly
-{
-  // Use the L2 inner product to find the best fit
-  virtual void interior_assembly(FEMContext & c)
-  {
-    FEBase * elem_fe = nullptr;
-    c.get_element_fe(0, elem_fe);
-
-    const std::vector<Real> & JxW = elem_fe->get_JxW();
-
-    const std::vector<std::vector<Real>> & phi = elem_fe->get_phi();
-
-    const unsigned int n_dofs = c.get_dof_indices().size();
-
-    unsigned int n_qpoints = c.get_element_qrule().n_points();
-
-    for (unsigned int qp=0; qp != n_qpoints; qp++)
-      for (unsigned int i=0; i != n_dofs; i++)
-        for (unsigned int j=0; j != n_dofs; j++)
-          {
-            c.get_elem_jacobian()(i,j) += JxW[qp] * phi[j][qp]*phi[i][qp];
-          }
-  }
-};
-
 // Define an RBThetaExpansion class for this PDE
 // The A terms depend on EIM, so we deal with them later
 struct Ex6ThetaExpansion : RBThetaExpansion
@@ -450,13 +421,8 @@ struct Ex6AssemblyExpansion : RBAssemblyExpansion
   /**
    * Constructor.
    */
-  Ex6AssemblyExpansion(RBConstruction & rb_con)
+  Ex6AssemblyExpansion()
   {
-    // Point to the RBConstruction object
-    assembly_a0.rb_con = &rb_con;
-    assembly_a1.rb_con = &rb_con;
-    assembly_a2.rb_con = &rb_con;
-
     attach_A_assembly(&assembly_a0);
     attach_A_assembly(&assembly_a1);
     attach_A_assembly(&assembly_a2);

--- a/examples/reduced_basis/reduced_basis_ex6/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex6/assembly.h
@@ -52,15 +52,15 @@ struct Gxyz : public RBParametrizedFunction
     return 3;
   }
 
-  virtual std::vector<Number> evaluate(const RBParameters & mu,
-                                       const Point & p,
-                                       subdomain_id_type /*subdomain_id*/,
-                                       const std::vector<Point> & /*p_perturb*/)
+  virtual std::vector<Number>
+  evaluate(const RBParameters & mu,
+           const Point & p,
+           subdomain_id_type /*subdomain_id*/,
+           const std::vector<Point> & /*p_perturb*/) override
   {
     Real curvature = mu.get_value("curvature");
 
-    std::vector<Number> values {1. + curvature*p(0), 1. + curvature*p(0), 1./(1. + curvature*p(0))};
-    return values;
+    return {1. + curvature*p(0), 1. + curvature*p(0), 1./(1. + curvature*p(0))};
   }
 };
 
@@ -78,9 +78,8 @@ struct AssemblyA0 : ElemAssembly
   {
     std::vector<boundary_id_type> bc_ids;
     c.get_system().get_mesh().get_boundary_info().boundary_ids (&c.get_elem(), c.side, bc_ids);
-    for (std::vector<boundary_id_type>::const_iterator b =
-           bc_ids.begin(); b != bc_ids.end(); ++b)
-      if (*b == 1 || *b == 2 || *b == 3 || *b == 4)
+    for (const auto & bc_id : bc_ids)
+      if (bc_id == 1 || bc_id == 2 || bc_id == 3 || bc_id == 4)
         {
           const unsigned int u_var = 0;
 
@@ -121,9 +120,8 @@ struct AssemblyA1 : ElemAssembly
   {
     std::vector<boundary_id_type> bc_ids;
     c.get_system().get_mesh().get_boundary_info().boundary_ids (&c.get_elem(), c.side, bc_ids);
-    for (std::vector<boundary_id_type>::const_iterator b =
-           bc_ids.begin(); b != bc_ids.end(); ++b)
-      if (*b == 1 || *b == 3) // y == -0.2, y == 0.2
+    for (const auto & bc_id : bc_ids)
+      if (bc_id == 1 || bc_id == 3) // y == -0.2, y == 0.2
         {
           const unsigned int u_var = 0;
 
@@ -168,9 +166,8 @@ struct AssemblyA2 : ElemAssembly
   {
     std::vector<boundary_id_type> bc_ids;
     c.get_system().get_mesh().get_boundary_info().boundary_ids (&c.get_elem(), c.side, bc_ids);
-    for (std::vector<boundary_id_type>::const_iterator b =
-           bc_ids.begin(); b != bc_ids.end(); ++b)
-      if (*b == 2 || *b == 4) // x == 0.2, x == -0.2
+    for (const auto & bc_id : bc_ids)
+      if (bc_id == 2 || bc_id == 4) // x == 0.2, x == -0.2
         {
           const unsigned int u_var = 0;
 
@@ -187,7 +184,7 @@ struct AssemblyA2 : ElemAssembly
           // Now we will build the affine operator
           unsigned int n_sidepoints = c.get_side_qrule().n_points();
 
-          if (*b==2)
+          if (bc_id == 2)
             {
               for (unsigned int qp=0; qp != n_sidepoints; qp++)
                 {
@@ -197,7 +194,7 @@ struct AssemblyA2 : ElemAssembly
                 }
             }
 
-          if (*b==4)
+          if (bc_id == 4)
             {
               for (unsigned int qp=0; qp != n_sidepoints; qp++)
                 {

--- a/examples/reduced_basis/reduced_basis_ex6/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex6/assembly.h
@@ -52,32 +52,15 @@ struct Gxyz : public RBParametrizedFunction
     return 3;
   }
 
-  virtual Number evaluate(const RBParameters & mu,
-                          unsigned int comp,
-                          const Point & p,
-                          subdomain_id_type /*subdomain_id*/,
-                          const std::vector<Point> & /*p_perturb*/)
+  virtual std::vector<Number> evaluate(const RBParameters & mu,
+                                       const Point & p,
+                                       subdomain_id_type /*subdomain_id*/,
+                                       const std::vector<Point> & /*p_perturb*/)
   {
     Real curvature = mu.get_value("curvature");
 
-    if(comp == 0)
-    {
-      return 1. + curvature*p(0);
-    }
-    else if(comp == 1)
-    {
-      return 1. + curvature*p(0);
-    }
-    else if(comp == 2)
-    {
-      return 1./(1. + curvature*p(0));
-    }
-    else
-    {
-      libmesh_error_msg("Error: Invalid comp");
-    }
-
-    return 0.;
+    std::vector<Number> values {1. + curvature*p(0), 1. + curvature*p(0), 1./(1. + curvature*p(0))};
+    return values;
   }
 };
 

--- a/examples/reduced_basis/reduced_basis_ex6/eim_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex6/eim_classes.h
@@ -57,7 +57,7 @@ public:
    */
   virtual std::unique_ptr<ElemAssembly> build_eim_assembly(unsigned int index)
   {
-    return libmesh_make_unique<AssemblyEIM>(get_rb_eim_evaluation(), index);
+    return libmesh_make_unique<AssemblyEIM>(*this, index);
   }
 
   /**

--- a/examples/reduced_basis/reduced_basis_ex6/eim_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex6/eim_classes.h
@@ -9,6 +9,8 @@
 // Example includes
 #include "assembly.h"
 
+using libMesh::RBEIMConstruction;
+
 #ifndef LIBMESH_HAVE_CXX14_MAKE_UNIQUE
 using libMesh::make_unique;
 #endif
@@ -23,9 +25,12 @@ public:
   SimpleEIMEvaluation(const libMesh::Parallel::Communicator & comm)
     : RBEIMEvaluation(comm)
   {
-    attach_parametrized_function(&g_x);
-    attach_parametrized_function(&g_y);
-    attach_parametrized_function(&g_z);
+    // FIXME: We can only attach a single RBParametrizedFunction by calling
+    // set_parametrized_function(). Each RBParametrizedFunction can have multiple
+    // components, though.
+    // attach_parametrized_function(&g_x);
+    // attach_parametrized_function(&g_y);
+    // attach_parametrized_function(&g_z);
   }
 
   /**
@@ -39,9 +44,9 @@ public:
   /**
    * Parametrized functions that we approximate with EIM
    */
-  Gx g_x;
-  Gy g_y;
-  Gz g_z;
+  // Gx g_x;
+  // Gy g_y;
+  // Gz g_z;
 };
 
 // A simple subclass of RBEIMConstruction.

--- a/examples/reduced_basis/reduced_basis_ex6/eim_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex6/eim_classes.h
@@ -11,10 +11,6 @@
 
 using libMesh::RBEIMConstruction;
 
-#ifndef LIBMESH_HAVE_CXX14_MAKE_UNIQUE
-using libMesh::make_unique;
-#endif
-
 // A simple subclass of RBEIMEvaluation. Overload
 // evaluate_parametrized_function to define the
 // function that we "empirically" interpolate.
@@ -25,7 +21,7 @@ public:
   SimpleEIMEvaluation(const libMesh::Parallel::Communicator & comm)
     : RBEIMEvaluation(comm)
   {
-    set_parametrized_function(std::make_unique<Gxyz>());
+    set_parametrized_function(libmesh_make_unique<Gxyz>());
   }
 
   /**

--- a/examples/reduced_basis/reduced_basis_ex6/eim_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex6/eim_classes.h
@@ -25,12 +25,7 @@ public:
   SimpleEIMEvaluation(const libMesh::Parallel::Communicator & comm)
     : RBEIMEvaluation(comm)
   {
-    // FIXME: We can only attach a single RBParametrizedFunction by calling
-    // set_parametrized_function(). Each RBParametrizedFunction can have multiple
-    // components, though.
-    // attach_parametrized_function(&g_x);
-    // attach_parametrized_function(&g_y);
-    // attach_parametrized_function(&g_z);
+    set_parametrized_function(std::make_unique<Gxyz>());
   }
 
   /**
@@ -40,13 +35,6 @@ public:
   {
     return libmesh_make_unique<ThetaEIM>(*this, index);
   }
-
-  /**
-   * Parametrized functions that we approximate with EIM
-   */
-  // Gx g_x;
-  // Gy g_y;
-  // Gz g_z;
 };
 
 // A simple subclass of RBEIMConstruction.
@@ -60,21 +48,16 @@ public:
   SimpleEIMConstruction (EquationSystems & es,
                          const std::string & name_in,
                          const unsigned int number_in)
-    : Parent(es, name_in, number_in)
+    : RBEIMConstruction(es, name_in, number_in)
   {
   }
-
-  /**
-   * The type of the parent.
-   */
-  typedef RBEIMConstruction Parent;
 
   /**
    * Provide an implementation of build_eim_assembly
    */
   virtual std::unique_ptr<ElemAssembly> build_eim_assembly(unsigned int index)
   {
-    return libmesh_make_unique<AssemblyEIM>(*this, index);
+    return libmesh_make_unique<AssemblyEIM>(get_rb_eim_evaluation(), index);
   }
 
   /**
@@ -82,64 +65,11 @@ public:
    */
   virtual void init_data()
   {
-    Parent::init_data();
+    this->add_variable ("eim_var", libMesh::FIRST);
 
-    set_inner_product_assembly(eim_ip);
+    RBEIMConstruction::init_data();
   }
 
-  /**
-   * Initialize the implicit system that is used to perform L2 projections.
-   */
-  virtual void init_implicit_system()
-  {
-    this->add_variable ("L2_proj_var", libMesh::FIRST);
-  }
-
-  /**
-   * Initialize the explicit system that is used to store the basis functions.
-   */
-  virtual void init_explicit_system()
-  {
-    Gx_var = get_explicit_system().add_variable ("x_comp_of_G", libMesh::FIRST);
-    Gy_var = get_explicit_system().add_variable ("y_comp_of_G", libMesh::FIRST);
-    Gz_var = get_explicit_system().add_variable ("z_comp_of_G", libMesh::FIRST);
-  }
-
-  /**
-   * Pre-request all relevant element data.
-   */
-  virtual void init_context(FEMContext & c)
-  {
-    // For efficiency, we should prerequest all
-    // the data we will need to build the
-    // linear system before doing an element loop.
-    //
-    // With equal variable types in x/y/z we only have the one elem_fe
-    // to prerequest from.
-    FEBase * elem_fe = nullptr;
-    c.get_element_fe(Gx_var, elem_fe);
-
-    elem_fe->get_JxW();
-    elem_fe->get_phi();
-    elem_fe->get_dphi();
-
-    FEBase * side_fe = nullptr;
-    c.get_side_fe(Gx_var, side_fe);
-    side_fe->get_nothing();
-  }
-
-
-  /**
-   * Variable numbers.
-   */
-  unsigned int Gx_var;
-  unsigned int Gy_var;
-  unsigned int Gz_var;
-
-  /**
-   * Inner product assembly object
-   */
-  Ex6EIMInnerProduct eim_ip;
 };
 
 #endif

--- a/examples/reduced_basis/reduced_basis_ex6/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex6/rb_classes.h
@@ -79,7 +79,6 @@ public:
                         const std::string & name_in,
                         const unsigned int number_in)
     : Parent(es, name_in, number_in),
-      ex6_assembly_expansion(*this),
       dirichlet_bc(std::unique_ptr<DirichletBoundary>())
   {}
 

--- a/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
+++ b/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
@@ -135,8 +135,10 @@ int main (int argc, char ** argv)
   // This is a 3D example
   libmesh_example_requires(3 == LIBMESH_DIM, "3D support");
 
-#ifndef LIBMESH_ENABLE_DIRICHLET
-  libmesh_example_requires(false, "--enable-dirichlet");
+  // This example requires libmesh to be configured with both
+  // DirichletBoundary and Cap'n Proto support.
+#if !defined(LIBMESH_ENABLE_DIRICHLET) || !defined(LIBMESH_HAVE_CAPNPROTO)
+  libmesh_example_requires(false, "--enable-dirichlet --enable-capnp");
 #else
 
   // Parse the input file using GetPot

--- a/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
+++ b/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
@@ -194,7 +194,7 @@ int main (int argc, char ** argv)
   SimpleEIMEvaluation eim_rb_eval(mesh.comm());
 
   // Set the rb_eval objects for the RBConstructions
-  eim_construction.set_rb_evaluation(eim_rb_eval);
+  eim_construction.set_rb_eim_evaluation(eim_rb_eval);
   rb_construction.set_rb_evaluation(rb_eval);
 
   if (!online_mode) // Perform the Offline stage of the RB method
@@ -204,9 +204,8 @@ int main (int argc, char ** argv)
       eim_construction.print_info();
 
       // Perform the EIM Greedy and write out the data
-      eim_construction.initialize_rb_construction();
-
-      eim_construction.train_reduced_basis();
+      eim_construction.initialize_eim_construction();
+      eim_construction.train_eim_approximation();
 
 #if defined(LIBMESH_HAVE_CAPNPROTO)
       RBDataSerialization::RBEIMEvaluationSerialization rb_eim_eval_writer(eim_rb_eval);
@@ -245,8 +244,6 @@ int main (int argc, char ** argv)
       if (store_basis_functions)
         {
           // Write out the basis functions
-          eim_construction.get_rb_evaluation().write_out_basis_functions(eim_construction.get_explicit_system(),
-                                                                         "eim_data");
           rb_construction.get_rb_evaluation().write_out_basis_functions(rb_construction,
                                                                         "rb_data");
         }
@@ -288,11 +285,8 @@ int main (int argc, char ** argv)
       if (store_basis_functions)
         {
           // read in the data from files
-          eim_rb_eval.read_in_basis_functions(
-                                              eim_construction.get_explicit_system(), "eim_data");
           rb_eval.read_in_basis_functions(rb_construction, "rb_data");
 
-          eim_construction.load_rb_solution();
           rb_construction.load_rb_solution();
 
           transform_mesh_and_plot(equation_systems, online_curvature, "RB_sol.e");

--- a/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
+++ b/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
@@ -240,7 +240,7 @@ int main (int argc, char ** argv)
 
         RBDataDeserialization::RBEIMEvaluationDeserialization rb_eim_eval_reader(eim_rb_eval);
         rb_eim_eval_reader.read_from_file("rb_eim_eval.bin");
-        eim_rb_eval.read_in_basis_functions("eim_data", /*binary=*/false);
+        eim_rb_eval.read_in_basis_functions(rb_construction, "eim_data", /*binary=*/false);
 
         // Read data from input file and print state
         rb_construction.process_parameters_file(rb_parameters);

--- a/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
+++ b/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
@@ -150,9 +150,6 @@ int main (int argc, char ** argv)
   unsigned int n_elem_xy = infile("n_elem_xy", 1);
   unsigned int n_elem_z  = infile("n_elem_z", 1);
 
-  // Do we write the RB basis functions to disk?
-  bool store_basis_functions = infile("store_basis_functions", true);
-
   // Read the "online_mode" flag from the command line
   GetPot command_line (argc, argv);
   int online_mode = 0;
@@ -172,102 +169,120 @@ int main (int argc, char ** argv)
                                      0., 3.,
                                      HEX8);
 
-  // Create an equation systems object.
-  EquationSystems equation_systems (mesh);
-
-  SimpleEIMConstruction & eim_construction =
-    equation_systems.add_system<SimpleEIMConstruction> ("EIM");
-  SimpleRBConstruction & rb_construction =
-    equation_systems.add_system<SimpleRBConstruction> ("RB");
-
-  // Initialize the data structures for the equation system.
-  equation_systems.init ();
-
-  // Print out some information about the "truth" discretization
-  equation_systems.print_info();
-  mesh.print_info();
-
-  // Initialize the standard RBEvaluation object
-  SimpleRBEvaluation rb_eval(mesh.comm());
-
-  // Initialize the EIM RBEvaluation object
-  SimpleEIMEvaluation eim_rb_eval(mesh.comm());
-
-  // Set the rb_eval objects for the RBConstructions
-  eim_construction.set_rb_eim_evaluation(eim_rb_eval);
-  rb_construction.set_rb_evaluation(rb_eval);
-
-  if (!online_mode) // Perform the Offline stage of the RB method
+  if (!online_mode)
     {
-      // Read data from input file and print state
-      eim_construction.process_parameters_file(eim_parameters);
-      eim_construction.print_info();
+      // First run the Offline stage for the EIM approximation.
+      {
+        libMesh::out << "Perform EIM training" << std::endl << std::endl;
 
-      // Perform the EIM Greedy and write out the data
-      eim_construction.initialize_eim_construction();
-      eim_construction.train_eim_approximation();
+        // Initialize the EquationSystems object for this mesh and attach
+        // the EIM and RB Construction objects
+        EquationSystems equation_systems (mesh);
 
-#if defined(LIBMESH_HAVE_CAPNPROTO)
-      RBDataSerialization::RBEIMEvaluationSerialization rb_eim_eval_writer(eim_rb_eval);
-      rb_eim_eval_writer.write_to_file("rb_eim_eval.bin");
-#else
-      eim_construction.get_rb_evaluation().legacy_write_offline_data_to_files("eim_data");
-#endif
+        SimpleEIMConstruction & eim_construction =
+          equation_systems.add_system<SimpleEIMConstruction> ("EIM");
 
-      // Read data from input file and print state
-      rb_construction.process_parameters_file(rb_parameters);
+        // Initialize the data structures for the equation system.
+        equation_systems.init ();
 
-      // attach the EIM theta objects to the RBEvaluation
-      eim_rb_eval.initialize_eim_theta_objects();
-      rb_eval.get_rb_theta_expansion().attach_multiple_A_theta(eim_rb_eval.get_eim_theta_objects());
+        // Print out some information about the "truth" discretization
+        mesh.print_info();
+        equation_systems.print_info();
 
-      // attach the EIM assembly objects to the RBConstruction
-      eim_construction.initialize_eim_assembly_objects();
-      rb_construction.get_rb_assembly_expansion().attach_multiple_A_assembly(eim_construction.get_eim_assembly_objects());
+        // Initialize the EIM RBEvaluation object
+        SimpleEIMEvaluation eim_rb_eval(mesh.comm());
 
-      // Print out the state of rb_construction now that the EIM objects have been attached
-      rb_construction.print_info();
+        // Set the rb_eval objects for the RBConstructions
+        eim_construction.set_rb_eim_evaluation(eim_rb_eval);
 
-      // Need to initialize _after_ EIM greedy so that
-      // the system knows how many affine terms there are
-      rb_construction.initialize_rb_construction();
-      rb_construction.train_reduced_basis();
+        // Read data from input file and print state
+        eim_construction.process_parameters_file(eim_parameters);
+        eim_construction.print_info();
 
-#if defined(LIBMESH_HAVE_CAPNPROTO)
-      RBDataSerialization::RBEvaluationSerialization rb_eval_writer(rb_construction.get_rb_evaluation());
-      rb_eval_writer.write_to_file("rb_eval.bin");
-#else
-      rb_construction.get_rb_evaluation().legacy_write_offline_data_to_files("rb_data");
-#endif
+        // Perform the EIM Greedy and write out the data
+        eim_construction.initialize_eim_construction();
+        eim_construction.train_eim_approximation();
 
-      // Write out the basis functions, if requested
-      if (store_basis_functions)
-        {
-          // Write out the basis functions
-          rb_construction.get_rb_evaluation().write_out_basis_functions(rb_construction,
-                                                                        "rb_data");
-        }
+        RBDataSerialization::RBEIMEvaluationSerialization rb_eim_eval_writer(eim_rb_eval);
+        rb_eim_eval_writer.write_to_file("rb_eim_eval.bin");
+
+        // Write out the EIM basis functions
+        eim_rb_eval.write_out_basis_functions("eim_data", /*binary=*/false);
+      }
+
+      {
+        libMesh::out << std::endl << "Perform RB training" << std::endl << std::endl;
+
+        // Create an equation systems object.
+        EquationSystems equation_systems (mesh);
+
+        SimpleEIMConstruction & eim_construction =
+          equation_systems.add_system<SimpleEIMConstruction> ("EIM");
+        SimpleRBConstruction & rb_construction =
+          equation_systems.add_system<SimpleRBConstruction> ("RB");
+
+        // Initialize the data structures for the equation system.
+        equation_systems.init ();
+
+        // Print out some information about the "truth" discretization
+        equation_systems.print_info();
+        mesh.print_info();
+
+        // Initialize the standard RBEvaluation object
+        SimpleRBEvaluation rb_eval(mesh.comm());
+
+        // Initialize the EIM RBEvaluation object
+        SimpleEIMEvaluation eim_rb_eval(mesh.comm());
+
+        // Set the rb_eval objects for the RBConstructions
+        eim_construction.set_rb_eim_evaluation(eim_rb_eval);
+        rb_construction.set_rb_evaluation(rb_eval);
+
+        RBDataDeserialization::RBEIMEvaluationDeserialization rb_eim_eval_reader(eim_rb_eval);
+        rb_eim_eval_reader.read_from_file("rb_eim_eval.bin");
+        eim_rb_eval.read_in_basis_functions("eim_data", /*binary=*/false);
+
+        // Read data from input file and print state
+        rb_construction.process_parameters_file(rb_parameters);
+
+        // attach the EIM theta objects to the RBEvaluation
+        eim_rb_eval.initialize_eim_theta_objects();
+        rb_eval.get_rb_theta_expansion().attach_multiple_A_theta(eim_rb_eval.get_eim_theta_objects());
+
+        // attach the EIM assembly objects to the RBConstruction
+        eim_construction.initialize_eim_assembly_objects();
+        rb_construction.get_rb_assembly_expansion().attach_multiple_A_assembly(eim_construction.get_eim_assembly_objects());
+
+        // Print out the state of rb_construction now that the EIM objects have been attached
+        rb_construction.print_info();
+
+        // Need to initialize _after_ EIM greedy so that
+        // the system knows how many affine terms there are
+        rb_construction.initialize_rb_construction();
+        rb_construction.train_reduced_basis();
+
+        RBDataSerialization::RBEvaluationSerialization rb_eval_writer(rb_construction.get_rb_evaluation());
+        rb_eval_writer.write_to_file("rb_eval.bin");
+
+        // Write out the basis functions
+        rb_construction.get_rb_evaluation().write_out_basis_functions(rb_construction,
+                                                                      "rb_data");
+      }
     }
-  else // Perform the Online stage of the RB method
+  else
     {
-#if defined(LIBMESH_HAVE_CAPNPROTO)
+      SimpleEIMEvaluation eim_rb_eval(mesh.comm());
+      SimpleRBEvaluation rb_eval(mesh.comm());
+
       RBDataDeserialization::RBEIMEvaluationDeserialization rb_eim_eval_reader(eim_rb_eval);
       rb_eim_eval_reader.read_from_file("rb_eim_eval.bin");
-#else
-      eim_rb_eval.legacy_read_offline_data_from_files("eim_data");
-#endif
 
       // attach the EIM theta objects to rb_eval objects
       eim_rb_eval.initialize_eim_theta_objects();
       rb_eval.get_rb_theta_expansion().attach_multiple_A_theta(eim_rb_eval.get_eim_theta_objects());
 
-      // Read in the offline data for rb_eval
-#if defined(LIBMESH_HAVE_CAPNPROTO)
       RBDataDeserialization::RBEvaluationDeserialization rb_eval_reader(rb_eval);
       rb_eval_reader.read_from_file("rb_eval.bin", /*read_error_bound_data*/ true);
-#else
-      rb_eval.legacy_read_offline_data_from_files("rb_data");
-#endif
 
       // Get the parameters at which we will do a reduced basis solve
       Real online_curvature = infile("online_curvature", 0.);
@@ -281,16 +296,20 @@ int main (int argc, char ** argv)
       rb_eval.print_parameters();
       rb_eval.rb_solve(rb_eval.get_n_basis_functions());
 
-      // plot the solution, if requested
-      if (store_basis_functions)
-        {
-          // read in the data from files
-          rb_eval.read_in_basis_functions(rb_construction, "rb_data");
+      EquationSystems equation_systems (mesh);
 
-          rb_construction.load_rb_solution();
+      SimpleRBConstruction & rb_construction =
+        equation_systems.add_system<SimpleRBConstruction> ("RB");
 
-          transform_mesh_and_plot(equation_systems, online_curvature, "RB_sol.e");
-        }
+      equation_systems.init ();
+
+      rb_construction.set_rb_evaluation(rb_eval);
+
+      // read in the data from files
+      rb_eval.read_in_basis_functions(rb_construction, "rb_data");
+      rb_construction.load_rb_solution();
+
+      transform_mesh_and_plot(equation_systems, online_curvature, "RB_sol.e");
     }
 
 #endif // LIBMESH_ENABLE_DIRICHLET

--- a/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.in
+++ b/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.in
@@ -3,7 +3,6 @@
 n_elem_xy = 8
 n_elem_z  = 40
 
-store_basis_functions = true
 online_N = 20
 
 online_curvature = 1.0472 # pi/3

--- a/include/reduced_basis/rb_data_deserialization.h
+++ b/include/reduced_basis/rb_data_deserialization.h
@@ -220,9 +220,8 @@ void load_transient_rb_evaluation_data(TransientRBEvaluation & trans_rb_eval,
  * Load an EIM RB evaluation from a corresponding reader structure in the buffer.
  * Templated to deal with both Real and Complex numbers.
  */
-template <typename RBEvaluationReaderNumber, typename RBEIMEvaluationReaderNumber>
+template <typename RBEIMEvaluationReaderNumber>
 void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_eval,
-                                 RBEvaluationReaderNumber & rb_evaluation_reader,
                                  RBEIMEvaluationReaderNumber & rb_eim_eval_reader);
 
 #if defined(LIBMESH_HAVE_SLEPC) && (LIBMESH_HAVE_GLPK)
@@ -241,13 +240,6 @@ void load_rb_scm_evaluation_data(RBSCMEvaluation & rb_scm_eval,
  * Helper function that loads point data.
  */
 void load_point(RBData::Point3D::Reader point_reader, Point & point);
-
-/**
- * Helper function that loads element data.
- */
-void load_elem_into_mesh(RBData::MeshElem::Reader mesh_elem_reader,
-                         libMesh::Elem * elem,
-                         libMesh::ReplicatedMesh & mesh);
 
 } // namespace RBDataDeserialization
 

--- a/include/reduced_basis/rb_data_deserialization.h
+++ b/include/reduced_basis/rb_data_deserialization.h
@@ -68,8 +68,15 @@ public:
   RBEvaluationDeserialization(RBEvaluation & rb_eval);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class contains a reference, so it can't be default
+   *   copy/move-assigned.
+   * - The destructor is defaulted out of line.
    */
+  RBEvaluationDeserialization (RBEvaluationDeserialization &&) = default;
+  RBEvaluationDeserialization (const RBEvaluationDeserialization &) = default;
+  RBEvaluationDeserialization & operator= (const RBEvaluationDeserialization &) = delete;
+  RBEvaluationDeserialization & operator= (RBEvaluationDeserialization &&) = delete;
   virtual ~RBEvaluationDeserialization();
 
   /**
@@ -83,8 +90,9 @@ private:
    * The RBEvaluation object that we will read into.
    */
   RBEvaluation & _rb_eval;
-
 };
+
+
 
 /**
  * This class de-serializes a TransientRBEvaluation object
@@ -101,8 +109,15 @@ public:
   TransientRBEvaluationDeserialization(TransientRBEvaluation & trans_rb_eval);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class contains a reference, so it can't be default
+   *   copy/move-assigned.
+   * - The destructor is defaulted out of line.
    */
+  TransientRBEvaluationDeserialization (TransientRBEvaluationDeserialization &&) = default;
+  TransientRBEvaluationDeserialization (const TransientRBEvaluationDeserialization &) = default;
+  TransientRBEvaluationDeserialization & operator= (const TransientRBEvaluationDeserialization &) = delete;
+  TransientRBEvaluationDeserialization & operator= (TransientRBEvaluationDeserialization &&) = delete;
   virtual ~TransientRBEvaluationDeserialization();
 
   /**
@@ -116,8 +131,9 @@ private:
    * The TransientRBEvaluation object that we will read into.
    */
   TransientRBEvaluation & _trans_rb_eval;
-
 };
+
+
 
 /**
  * This class de-serializes a RBEIMEvaluation object
@@ -134,8 +150,15 @@ public:
   RBEIMEvaluationDeserialization(RBEIMEvaluation & trans_rb_eval);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class contains a reference, so it can't be default
+   *   copy/move-assigned.
+   * - The destructor is defaulted out of line.
    */
+  RBEIMEvaluationDeserialization (RBEIMEvaluationDeserialization &&) = default;
+  RBEIMEvaluationDeserialization (const RBEIMEvaluationDeserialization &) = default;
+  RBEIMEvaluationDeserialization & operator= (const RBEIMEvaluationDeserialization &) = delete;
+  RBEIMEvaluationDeserialization & operator= (RBEIMEvaluationDeserialization &&) = delete;
   virtual ~RBEIMEvaluationDeserialization();
 
   /**
@@ -149,8 +172,9 @@ private:
    * The RBEIMEvaluation object we will read into.
    */
   RBEIMEvaluation & _rb_eim_eval;
-
 };
+
+
 
 // RBSCMEvaluation should only be available
 // if SLEPc and GLPK support is enabled.
@@ -171,8 +195,15 @@ public:
   RBSCMEvaluationDeserialization(RBSCMEvaluation & trans_rb_eval);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class contains a reference, so it can't be default
+   *   copy/move-assigned.
+   * - The destructor is defaulted out of line.
    */
+  RBSCMEvaluationDeserialization (RBSCMEvaluationDeserialization &&) = default;
+  RBSCMEvaluationDeserialization (const RBSCMEvaluationDeserialization &) = default;
+  RBSCMEvaluationDeserialization & operator= (const RBSCMEvaluationDeserialization &) = delete;
+  RBSCMEvaluationDeserialization & operator= (RBSCMEvaluationDeserialization &&) = delete;
   virtual ~RBSCMEvaluationDeserialization();
 
   /**
@@ -186,8 +217,8 @@ private:
    * The RBSCMEvaluation object we will read into.
    */
   RBSCMEvaluation & _rb_scm_eval;
-
 };
+
 #endif // LIBMESH_HAVE_SLEPC && LIBMESH_HAVE_GLPK
 
 /**

--- a/include/reduced_basis/rb_data_serialization.h
+++ b/include/reduced_basis/rb_data_serialization.h
@@ -215,9 +215,8 @@ void add_transient_rb_evaluation_data_to_builder(TransientRBEvaluation & trans_r
  * Add data for an RBEIMEvaluation to the builder.
  * Templated to deal with both Real and Complex numbers.
  */
-template <typename RBEvaluationBuilderNumber, typename RBEIMEvaluationBuilderNumber>
+template <typename RBEIMEvaluationBuilderNumber>
 void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_eval,
-                                           RBEvaluationBuilderNumber & rb_eval_builder,
                                            RBEIMEvaluationBuilderNumber & rb_eim_eval_builder);
 
 #if defined(LIBMESH_HAVE_SLEPC) && (LIBMESH_HAVE_GLPK)
@@ -237,12 +236,6 @@ void add_rb_scm_evaluation_data_to_builder(RBSCMEvaluation & rb_scm_eval,
  */
 void add_point_to_builder(const Point & point,
                           RBData::Point3D::Builder point_builder);
-
-/**
- * Helper function that adds element data.
- */
-void add_elem_to_builder(const Elem & elem,
-                         RBData::MeshElem::Builder mesh_elem_builder);
 
 } // namespace RBDataSerialization
 

--- a/include/reduced_basis/rb_data_serialization.h
+++ b/include/reduced_basis/rb_data_serialization.h
@@ -66,8 +66,15 @@ public:
   RBEvaluationSerialization(RBEvaluation & rb_eval);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class contains a reference, so it can't be default
+   *   copy/move-assigned.
+   * - The destructor is defaulted out of line.
    */
+  RBEvaluationSerialization (RBEvaluationSerialization &&) = default;
+  RBEvaluationSerialization (const RBEvaluationSerialization &) = default;
+  RBEvaluationSerialization & operator= (const RBEvaluationSerialization &) = delete;
+  RBEvaluationSerialization & operator= (RBEvaluationSerialization &&) = delete;
   virtual ~RBEvaluationSerialization();
 
   /**
@@ -81,8 +88,9 @@ private:
    * The RBEvaluation object that will be written to disk.
    */
   RBEvaluation & _rb_eval;
-
 };
+
+
 
 /**
  * This class serializes a TransientRBEvaluation object
@@ -99,8 +107,15 @@ public:
   TransientRBEvaluationSerialization(TransientRBEvaluation & rb_eval);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class contains a reference, so it can't be default
+   *   copy/move-assigned.
+   * - The destructor is defaulted out of line.
    */
+  TransientRBEvaluationSerialization (TransientRBEvaluationSerialization &&) = default;
+  TransientRBEvaluationSerialization (const TransientRBEvaluationSerialization &) = default;
+  TransientRBEvaluationSerialization & operator= (const TransientRBEvaluationSerialization &) = delete;
+  TransientRBEvaluationSerialization & operator= (TransientRBEvaluationSerialization &&) = delete;
   virtual ~TransientRBEvaluationSerialization();
 
   /**
@@ -114,8 +129,9 @@ private:
    * The RBEvaluation object that will be written to disk.
    */
   TransientRBEvaluation & _trans_rb_eval;
-
 };
+
+
 
 /**
  * This class serializes an RBEIMEvaluation object
@@ -132,8 +148,15 @@ public:
   RBEIMEvaluationSerialization(RBEIMEvaluation & rb_eval);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class contains a reference, so it can't be default
+   *   copy/move-assigned.
+   * - The destructor is defaulted out of line.
    */
+  RBEIMEvaluationSerialization (RBEIMEvaluationSerialization &&) = default;
+  RBEIMEvaluationSerialization (const RBEIMEvaluationSerialization &) = default;
+  RBEIMEvaluationSerialization & operator= (const RBEIMEvaluationSerialization &) = delete;
+  RBEIMEvaluationSerialization & operator= (RBEIMEvaluationSerialization &&) = delete;
   virtual ~RBEIMEvaluationSerialization();
 
   /**
@@ -147,8 +170,9 @@ private:
    * The RBEvaluation object that will be written to disk.
    */
   RBEIMEvaluation & _rb_eim_eval;
-
 };
+
+
 
 // RBSCMEvaluation should only be available
 // if SLEPc and GLPK support is enabled.
@@ -169,8 +193,15 @@ public:
   RBSCMEvaluationSerialization(RBSCMEvaluation & rb_eval);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class contains a reference, so it can't be default
+   *   copy/move-assigned.
+   * - The destructor is defaulted out of line.
    */
+  RBSCMEvaluationSerialization (RBSCMEvaluationSerialization &&) = default;
+  RBSCMEvaluationSerialization (const RBSCMEvaluationSerialization &) = default;
+  RBSCMEvaluationSerialization & operator= (const RBSCMEvaluationSerialization &) = delete;
+  RBSCMEvaluationSerialization & operator= (RBSCMEvaluationSerialization &&) = delete;
   virtual ~RBSCMEvaluationSerialization();
 
   /**
@@ -184,9 +215,12 @@ private:
    * The RBEvaluation object that will be written to disk.
    */
   RBSCMEvaluation & _rb_scm_eval;
-
 };
+
 #endif // LIBMESH_HAVE_SLEPC && LIBMESH_HAVE_GLPK
+
+
+
 
 /**
  * Add parameter ranges for continuous and discrete parameters.

--- a/include/reduced_basis/rb_eim_assembly.h
+++ b/include/reduced_basis/rb_eim_assembly.h
@@ -35,7 +35,7 @@ namespace libMesh
 {
 
 class RBParameters;
-class RBEIMEvaluation;
+class RBEIMConstruction;
 
 /**
  * This class provides functionality required to define an assembly
@@ -52,7 +52,7 @@ public:
   /**
    * Constructor.
    */
-  RBEIMAssembly(RBEIMEvaluation & rb_eim_eval_in,
+  RBEIMAssembly(RBEIMConstruction & rb_eim_eval_in,
                 unsigned int basis_function_index_in);
 
   /**
@@ -71,18 +71,17 @@ public:
   /**
    * Get a reference to the RBEIMEvaluation object.
    */
-  RBEIMEvaluation & get_rb_eim_evaluation();
+  RBEIMConstruction & get_rb_eim_construction();
 
 private:
 
   /**
-   * The RBEIMEvaluation that stores the EIM basis functions that we use
-   * in evaluate_basis_function().
+   * The RBEIMConstruction that the assembly data comes from.
    */
-  RBEIMEvaluation & _rb_eim_eval;
+  RBEIMConstruction & _rb_eim_con;
 
   /**
-   * The EIM basis function index (from rb_eim_eval) for this assembly object.
+   * The EIM basis function index (from _rb_eim_con's RBEIMEvaluation) for this assembly object.
    */
   unsigned int _basis_function_index;
 

--- a/include/reduced_basis/rb_eim_assembly.h
+++ b/include/reduced_basis/rb_eim_assembly.h
@@ -34,9 +34,8 @@
 namespace libMesh
 {
 
-class Elem;
 class RBParameters;
-class RBEIMConstruction;
+class RBEIMEvaluation;
 
 /**
  * This class provides functionality required to define an assembly
@@ -53,7 +52,7 @@ public:
   /**
    * Constructor.
    */
-  RBEIMAssembly(RBEIMConstruction & rb_eim_con_in,
+  RBEIMAssembly(RBEIMEvaluation & rb_eim_eval_in,
                 unsigned int basis_function_index_in);
 
   /**
@@ -62,58 +61,30 @@ public:
   virtual ~RBEIMAssembly();
 
   /**
-   * Evaluate variable \p var_number of this object's EIM basis function
-   * at the points \p points, where the points are in reference coordinates.
-   * Fill \p values with the basis function values.
+   * Return the basis function values for all quadrature points for variable \p var
+   * on element \p elem_id.
    */
-  virtual void evaluate_basis_function(unsigned int var,
-                                       const Elem & element,
-                                       const std::vector<Point> & points,
-                                       std::vector<Number> & values);
+  void evaluate_basis_function(dof_id_type elem_id,
+                               unsigned int var,
+                               std::vector<Number> & values);
 
   /**
-   * Get a reference to the RBEIMConstruction object.
+   * Get a reference to the RBEIMEvaluation object.
    */
-  RBEIMConstruction & get_rb_eim_construction();
-
-  /**
-   * Get a reference to the ghosted_basis_function.
-   */
-  NumericVector<Number> & get_ghosted_basis_function();
-
-  /**
-   * Retrieve the FE object.
-   */
-  FEBase & get_fe();
+  RBEIMEvaluation & get_rb_eim_evaluation();
 
 private:
 
   /**
-   * Initialize the FE object.
+   * The RBEIMEvaluation that stores the EIM basis functions that we use
+   * in evaluate_basis_function().
    */
-  void initialize_fe();
-
-  /**
-   * The RBEIMConstruction object that this RBEIMAssembly is based on.
-   */
-  RBEIMConstruction & _rb_eim_con;
+  RBEIMEvaluation & _rb_eim_eval;
 
   /**
    * The EIM basis function index (from rb_eim_eval) for this assembly object.
    */
   unsigned int _basis_function_index;
-
-  /**
-   * The basis function that we sample to evaluate the
-   * empirical interpolation approximation. This will be a GHOSTED
-   * vector to facilitate interpolation in the case of multiple processors.
-   */
-  std::unique_ptr<NumericVector<Number>> _ghosted_basis_function;
-
-  /**
-   * We store an FE object so we can easily reinit in evaluate_basis_function.
-   */
-  std::unique_ptr<FEBase> _fe;
 
 };
 

--- a/include/reduced_basis/rb_eim_assembly.h
+++ b/include/reduced_basis/rb_eim_assembly.h
@@ -56,8 +56,15 @@ public:
                 unsigned int basis_function_index_in);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class contains a reference, so it can't be default
+   *   copy/move-assigned.
+   * - The destructor is defaulted out of line.
    */
+  RBEIMAssembly (RBEIMAssembly &&) = default;
+  RBEIMAssembly (const RBEIMAssembly &) = default;
+  RBEIMAssembly & operator= (const RBEIMAssembly &) = delete;
+  RBEIMAssembly & operator= (RBEIMAssembly &&) = delete;
   virtual ~RBEIMAssembly();
 
   /**
@@ -84,7 +91,6 @@ private:
    * The EIM basis function index (from _rb_eim_con's RBEIMEvaluation) for this assembly object.
    */
   unsigned int _basis_function_index;
-
 };
 
 }

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -168,6 +168,12 @@ public:
   virtual void set_Nmax(unsigned int Nmax);
 
   /**
+   * Get/set the perturbation size used in finite difference calculations.
+   */
+  void set_perturbation_size(Real perturb_size);
+  Real get_perturbation_size() const;
+
+  /**
    * Enum that indicates which type of "best fit" algorithm
    * we should use.
    * a) projection: Find the best fit in the inner product
@@ -301,6 +307,20 @@ private:
   std::unordered_map<dof_id_type, std::vector<Point> > _local_quad_point_locations;
   std::unordered_map<dof_id_type, std::vector<Real> > _local_quad_point_JxW;
   std::unordered_map<dof_id_type, subdomain_id_type > _local_quad_point_subdomain_ids;
+
+  /**
+   * EIM approximations often arise when applying a geometric mapping to a Reduced Basis
+   * formulation. In this context, we often need to approximate derivates of the mapping
+   * function via EIM. In order to enable this, we also optionally store perturbations
+   * about each point in _local_quad_point_locations to enable finite difference approximation
+   * to the mapping function derivatives.
+   */
+  std::unordered_map<dof_id_type, std::vector<std::vector<Point>> > _local_quad_point_locations_perturbations;
+
+  /**
+   * Perturbation size used in computation of perturbations of quad point locations.
+   */
+  Real _perturb_size;
 
 };
 

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -24,6 +24,7 @@
 #include "libmesh/rb_construction.h"
 #include "libmesh/rb_assembly_expansion.h"
 #include "libmesh/rb_eim_assembly.h"
+#include "libmesh/rb_eim_evaluation.h"
 
 // libMesh includes
 #include "libmesh/mesh_function.h"

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -169,12 +169,6 @@ public:
   virtual void set_Nmax(unsigned int Nmax);
 
   /**
-   * Get/set the perturbation size used in finite difference calculations.
-   */
-  void set_perturbation_size(Real perturb_size);
-  Real get_perturbation_size() const;
-
-  /**
    * Enum that indicates which type of "best fit" algorithm
    * we should use.
    * a) projection: Find the best fit in the inner product
@@ -317,11 +311,6 @@ private:
    * to the mapping function derivatives.
    */
   std::unordered_map<dof_id_type, std::vector<std::vector<Point>> > _local_quad_point_locations_perturbations;
-
-  /**
-   * Perturbation size used in computation of perturbations of quad point locations.
-   */
-  Real _perturb_size;
 
 };
 

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -119,8 +119,9 @@ public:
 
   /**
    * Generate the EIM approximation for the specified parametrized function.
+   * Return the final tolerance from the training algorithm.
    */
-  void train_eim_approximation();
+  Real train_eim_approximation();
 
   /**
    * Build a vector of ElemAssembly objects that accesses the basis

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -31,6 +31,7 @@
 #include "libmesh/coupling_matrix.h"
 
 // C++ includes
+#include <map>
 
 namespace libMesh
 {
@@ -63,6 +64,11 @@ public:
    * Destructor.
    */
   virtual ~RBEIMConstruction ();
+
+  /**
+   * Type of the data structure used to map from (elem id) -> [n_vars][n_qp] data.
+   */
+  typedef RBEIMEvaluation::QpDataMap QpDataMap;
 
   /**
    * Clear this object.
@@ -211,15 +217,13 @@ private:
    * stored in _local_quad_point_JxW, so that this is equivalent to
    * computing w^t M v, where M is the mass matrix.
    */
-  Number inner_product(
-    const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & v,
-    const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & w);
+  Number inner_product(const QpDataMap & v, const QpDataMap & w);
 
   /**
    * Get the maximum absolute value from a vector stored in the format that we use
    * for basis functions.
    */
-  Real get_max_abs_value(const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & v) const;
+  Real get_max_abs_value(const QpDataMap & v) const;
 
   /**
    * Add a new basis function to the EIM approximation.
@@ -244,7 +248,7 @@ private:
    * Scale all values in \p pf by \p scaling_factor
    */
   static void scale_parametrized_function(
-    std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & local_pf,
+    QpDataMap & local_pf,
     Number scaling_factor);
 
   /**
@@ -286,8 +290,7 @@ private:
    * We use a map to index the element ID, since the IDs on this processor in
    * generally will not start at zero.
    */
-  std::vector<std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> >
-    _local_parametrized_functions_for_training;
+  std::vector<QpDataMap> _local_parametrized_functions_for_training;
 
   /**
    * The quadrature point locations, quadrature point weights (JxW), and subdomain IDs
@@ -312,7 +315,6 @@ private:
    * to the mapping function derivatives.
    */
   std::unordered_map<dof_id_type, std::vector<std::vector<Point>> > _local_quad_point_locations_perturbations;
-
 };
 
 } // namespace libMesh

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -39,13 +39,12 @@ namespace libMesh
  *
  * RBEIMConstruction implements the Construction stage of the
  * Empirical Interpolation Method (EIM). This can be used to
- * generate an affine approximation to non-affine
- * operators.
- *
- * \author David J. Knezevic
- * \date 2010
+ * create an approximation to parametrized functions. In the context
+ * of the reduced basis (RB) method, the EIM approximation is typically
+ * used to create an affine approximation to non-affine operators,
+ * so that the standard RB method can be applied in that case.
  */
-class RBEIMConstruction : public RBConstruction
+class RBEIMConstruction : public RBConstructionBase<System>
 {
 public:
 
@@ -65,25 +64,47 @@ public:
   virtual ~RBEIMConstruction ();
 
   /**
-   * The type of system.
-   */
-  typedef RBEIMConstruction sys_type;
-
-  /**
-   * The type of the parent.
-   */
-  typedef RBConstruction Parent;
-
-  /**
    * Clear this object.
    */
   virtual void clear() override;
 
   /**
+   * Set the RBEIMEvaluation object.
+   */
+  void set_rb_eim_evaluation(RBEIMEvaluation & rb_eim_eval_in);
+
+  /**
+   * Get a reference to the RBEvaluation object.
+   */
+  RBEIMEvaluation & get_rb_eim_evaluation();
+
+  /**
+   * Perform initialization of this object to prepare for running
+   * train_eim_approximation().
+   */
+  void initialize_eim_construction();
+
+  /**
    * Read parameters in from file and set up this system
    * accordingly.
    */
-  virtual void process_parameters_file (const std::string & parameters_filename) override;
+  virtual void process_parameters_file (const std::string & parameters_filename);
+
+  /**
+   * Set the state of this RBConstruction object based on the arguments
+   * to this function.
+   */
+  void set_rb_construction_parameters(unsigned int n_training_samples_in,
+                                      bool deterministic_training_in,
+                                      unsigned int training_parameters_random_seed_in,
+                                      bool quiet_mode_in,
+                                      unsigned int Nmax_in,
+                                      Real rel_training_tolerance_in,
+                                      Real abs_training_tolerance_in,
+                                      RBParameters mu_min_in,
+                                      RBParameters mu_max_in,
+                                      std::map<std::string, std::vector<Real>> discrete_parameter_values_in,
+                                      std::map<std::string,bool> log_scaling);
 
   /**
    * Specify which type of "best fit" we use to guide the EIM
@@ -94,72 +115,12 @@ public:
   /**
    * Print out info that describes the current setup of this RBConstruction.
    */
-  virtual void print_info() override;
+  virtual void print_info();
 
   /**
-   * Initialize this system so that we can perform
-   * the Construction stage of the RB method.
+   * Generate the EIM approximation for the specified parametrized function.
    */
-  virtual void initialize_rb_construction(bool skip_matrix_assembly=false,
-                                          bool skip_vector_assembly=false) override;
-
-  /**
-   * Override train_reduced_basis to first initialize _parametrized_functions_in_training_set.
-   */
-  virtual Real train_reduced_basis(const bool resize_rb_eval_data=true) override;
-
-  /**
-   * Load the truth representation of the parametrized function
-   * at the current parameters into the solution vector.
-   * The truth representation is the projection of
-   * parametrized_function into the finite element space.
-   * If \p plot_solution > 0 the solution will be plotted
-   * to an output file.
-   */
-  virtual Real truth_solve(int plot_solution) override;
-
-  /**
-   * We compute the best fit of parametrized_function
-   * into the EIM space and then evaluate the error
-   * in the norm defined by inner_product_matrix.
-   *
-   * \returns The error in the best fit
-   */
-  virtual Real compute_best_fit_error();
-
-  /**
-   * Initialize \p c based on \p sys.
-   */
-  virtual void init_context_with_sys(FEMContext & c, System & sys);
-
-  /**
-   * Add variables to the ExplicitSystem that is used to store
-   * the basis functions.
-   */
-  virtual void init_explicit_system() = 0;
-
-  /**
-   * Add one variable to the ImplicitSystem (i.e. this system) that is
-   * used to perform L2 project solves.
-   */
-  virtual void init_implicit_system() = 0;
-
-  /**
-   * Evaluate the mesh function at the specified point and for the specified variable.
-   */
-  Number evaluate_mesh_function(unsigned int var_number,
-                                Point p);
-
-  /**
-   * Set a point locator tolerance to be used in this class's MeshFunction, and
-   * other operations that require a PointLocator.
-   */
-  void set_point_locator_tol(Real point_locator_tol);
-
-  /**
-   * \returns The point locator tolerance.
-   */
-  Real get_point_locator_tol() const;
+  void train_eim_approximation();
 
   /**
    * Build a vector of ElemAssembly objects that accesses the basis
@@ -183,143 +144,128 @@ public:
   virtual std::unique_ptr<ElemAssembly> build_eim_assembly(unsigned int bf_index) = 0;
 
   /**
-   * Get the ExplicitSystem associated with this system.
+   * Pre-request FE data needed for calculations.
    */
-  ExplicitSystem & get_explicit_system();
+  virtual void init_context(FEMContext &);
 
   /**
-   * Load the i^th RB function into the RBConstruction
-   * solution vector.
-   * Override to load the basis function into the ExplicitSystem.
+   * Get/set the relative tolerance for the basis training.
    */
-  virtual void load_basis_function(unsigned int i) override;
+  void set_rel_training_tolerance(Real new_training_tolerance);
+  Real get_rel_training_tolerance();
 
   /**
-   * Load the RB solution from the most recent solve with rb_eval
-   * into this system's solution vector.
-   * Override to load the solution into the ExplicitSystem.
+   * Get/set the absolute tolerance for the basis training.
    */
-  virtual void load_rb_solution() override;
+  void set_abs_training_tolerance(Real new_training_tolerance);
+  Real get_abs_training_tolerance();
 
   /**
-   * Load \p source into the subvector of \p dest corresponding
-   * to var \p var.
+   * Get/set Nmax, the maximum number of RB
+   * functions we are willing to compute.
    */
-  void set_explicit_sys_subvector(NumericVector<Number>& dest,
-                                  unsigned int var,
-                                  NumericVector<Number>& source);
-
-  /**
-   * Load the subvector of \p localized_source corresponding to variable \p var into
-   * \p dest. We require localized_source to be localized before we call this method.
-   */
-  void get_explicit_sys_subvector(NumericVector<Number>& dest,
-                                  unsigned int var,
-                                  NumericVector<Number>& localized_source);
-
-  /**
-   * Set up the index map between the implicit and explicit systems.
-   */
-  void init_dof_map_between_systems();
-
-  /**
-   * Plot all the parameterized functions that we are storing
-   * in _parametrized_functions_in_training_set. \p pathname
-   * provides the path to where the plot data will be saved.
-   */
-  void plot_parametrized_functions_in_training_set(const std::string & pathname);
-
-  /**
-   * @return true if the most recent truth solve gave a zero solution.
-   */
-  bool check_if_zero_truth_solve() override;
-
-  //----------- PUBLIC DATA MEMBERS -----------//
+  unsigned int get_Nmax() const;
+  virtual void set_Nmax(unsigned int Nmax);
 
   /**
    * Enum that indicates which type of "best fit" algorithm
    * we should use.
    * a) projection: Find the best fit in the inner product
    * b) eim: Use empirical interpolation to find a "best fit"
-   *
-   * \returns The error associated with the "best fit" in the
-   * norm induced by inner_product_matrix.
    */
   BEST_FIT_TYPE best_fit_type_flag;
-
-protected:
-
-  /**
-   * Override to initialize the coupling matrix to decouple variables in this system.
-   */
-  virtual void init_data() override;
-
-  /**
-   * Add a new basis function to the RB space. Override
-   * to enrich with the EIM basis functions.
-   */
-  virtual void enrich_RB_space() override;
-
-  /**
-   * Update the system after enriching the RB space; this calls
-   * a series of functions to update the system properly.
-   */
-  virtual void update_system() override;
-
-  /**
-   * Compute the reduced basis matrices for the current basis.
-   * Override to update the inner product matrix that
-   * is used to compute the best fit to parametrized_function.
-   */
-  virtual void update_RB_system_matrices() override;
-
-  /**
-   * Override to return the best fit error. This function is used in
-   * the Greedy algorithm to select the next parameter.
-   */
-  virtual Real get_RB_error_bound() override;
-
-  /**
-   * Pre-request FE data needed for calculations.
-   */
-  virtual void init_context(FEMContext &) override;
-
-  /**
-   * Loop over the training set and compute the parametrized function for each
-   * training index.
-   */
-  void initialize_parametrized_functions_in_training_set();
-
-  /**
-   * Boolean flag to indicate whether or not we have called
-   * compute_parametrized_functions_in_training_set() yet.
-   */
-  bool _parametrized_functions_in_training_set_initialized;
-
-  /**
-   * The libMesh vectors storing the finite element coefficients
-   * of the RB basis functions.
-   */
-  std::vector<std::unique_ptr<NumericVector<Number>>> _parametrized_functions_in_training_set;
 
 private:
 
   /**
-   * A mesh function to interpolate on the mesh.
+   * Find the training sample that has the largest EIM approximation error
+   * based on the current EIM approximation. Return the maximum error, and
+   * the training sample index at which it occured.
    */
-  std::unique_ptr<MeshFunction> _mesh_function;
+  std::pair<Real, unsigned int> compute_max_eim_error();
 
   /**
-   * We also need an extra vector in which we can store a ghosted
-   * copy of the vector that we wish to use MeshFunction on.
+   * Compute the maximum (i.e. l-infinity norm) error of the best fit
+   * of the parametrized function at training index \p training_index
+   * into the EIM approximation space.
    */
-  std::unique_ptr<NumericVector<Number>> _ghosted_meshfunction_vector;
+  Real compute_best_fit_error(unsigned int training_index);
 
   /**
-   * We initialize RBEIMConstruction so that it has an "empty" RBAssemblyExpansion,
-   * because this isn't used at all in the EIM.
+   * Compute and store the parametrized function for each
+   * parameter in the training set at all the stored qp locations.
    */
-  RBAssemblyExpansion _empty_rb_assembly_expansion;
+  void initialize_parametrized_functions_in_training_set();
+
+  /**
+   * Initialize the data associated with each quad point (location, JxW, etc.)
+   * so that we can use this in evaluation of the parametrized functions.
+   */
+  void initialize_qp_data();
+
+  /**
+   * Evaluate the inner product of vec1 and vec2 which specify values at
+   * quadrature points. The inner product includes the JxW contributions
+   * stored in _local_quad_point_JxW, so that this is equivalent to
+   * computing w^t M v, where M is the mass matrix.
+   */
+  Number inner_product(
+    const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & v,
+    const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & w);
+
+  /**
+   * Get the maximum absolute value from a vector stored in the format that we use
+   * for basis functions.
+   */
+  Real get_max_abs_value(const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & v) const;
+
+  /**
+   * Add a new basis function to the EIM approximation.
+   */
+  void enrich_eim_approximation(unsigned int training_index);
+
+  /**
+   * Update the matrices used in training the EIM approximation.
+   */
+  void update_eim_matrices();
+
+  /**
+   * We compute the best fit of parametrized_function
+   * into the EIM space and then evaluate the error
+   * in the norm defined by inner_product_matrix.
+   *
+   * \returns The error in the best fit
+   */
+  Real compute_best_fit_error();
+
+  /**
+   * Scale all values in \p pf by \p scaling_factor
+   */
+  static void scale_parametrized_function(
+    std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & local_pf,
+    Number scaling_factor);
+
+  /**
+   * Maximum number of EIM basis functions we are willing to use.
+   */
+  unsigned int _Nmax;
+
+  /**
+   * Relative and absolute tolerances for training the EIM approximation.
+   */
+  Real _rel_training_tolerance;
+  Real _abs_training_tolerance;
+
+  /**
+   * The matrix we use in order to perform L2 projections of
+   * parametrized functions as part of EIM training.
+   */
+  DenseMatrix<Number> _eim_projection_matrix;
+
+  /**
+   * The RBEIMEvaluation object that we use to perform the EIM training.
+   */
+  RBEIMEvaluation * _rb_eim_eval;
 
   /**
    * The vector of assembly objects that are created to point to
@@ -328,29 +274,34 @@ private:
   std::vector<std::unique_ptr<ElemAssembly>> _rb_eim_assembly_objects;
 
   /**
-   * We use an ExplicitSystem to store the EIM basis functions.
-   * This is because if we have an EIM system with many variables
-   * we need to allocate a large matrix. Better to avoid this
-   * and use an ExplicitSystem instead, and only use the ImplicitSystem
-   * to deal with the per-variable L2 projections.
+   * The parametrized functions that are used for training. We pre-compute and
+   * store all of these functions, rather than recompute them at each iteration
+   * of the training.
+   *
+   * We store values at quadrature points on elements that are local to this processor.
+   * The indexing is as follows:
+   *   basis function index --> element ID --> variable --> quadrature point --> value
+   * We use a map to index the element ID, since the IDs on this processor in
+   * generally will not start at zero.
    */
-  std::string _explicit_system_name;
+  std::vector<std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> >
+    _local_parametrized_functions_for_training;
 
   /**
-   * The index map between the explicit system and the implicit system.
+   * The quadrature point locations, quadrature point weights (JxW), and subdomain IDs
+   * on every element local to this processor.
+   *
+   * The indexing is as follows:
+   *   element ID --> quadrature point --> xyz
+   *   element ID --> quadrature point --> JxW
+   *   element ID --> subdomain_id
+   * We use a map to index the element ID, since the IDs on this processor in
+   * generally will not start at zero.
    */
-  std::vector<std::vector<dof_id_type>> _dof_map_between_systems;
+  std::unordered_map<dof_id_type, std::vector<Point> > _local_quad_point_locations;
+  std::unordered_map<dof_id_type, std::vector<Real> > _local_quad_point_JxW;
+  std::unordered_map<dof_id_type, subdomain_id_type > _local_quad_point_subdomain_ids;
 
-  /**
-   * This vector is used to store inner_product_matrix * basis_function[i] for each i,
-   * since we frequently use this data.
-   */
-  std::vector<std::unique_ptr<NumericVector<Number>>> _matrix_times_bfs;
-
-  /**
-   * The point locator tolerance.
-   */
-  Real _point_locator_tol;
 };
 
 } // namespace libMesh

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -31,7 +31,11 @@
 #include "libmesh/coupling_matrix.h"
 
 // C++ includes
+#include <unordered_map>
 #include <map>
+#include <string>
+#include <memory>
+#include <vector>
 
 namespace libMesh
 {
@@ -61,8 +65,15 @@ public:
                      const unsigned int number);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class contains unique_ptrs, so it can't be default copy
+       constructed/assigned.
+   * - The destructor is defaulted out of line.
    */
+  RBEIMConstruction (RBEIMConstruction &&) = default;
+  RBEIMConstruction (const RBEIMConstruction &) = delete;
+  RBEIMConstruction & operator= (const RBEIMConstruction &) = delete;
+  RBEIMConstruction & operator= (RBEIMConstruction &&) = default;
   virtual ~RBEIMConstruction ();
 
   /**

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -155,7 +155,6 @@ public:
     unsigned int comp,
     unsigned int qp);
 
-
   /**
    * Fill up \p values with the basis function values for basis function
    * \p basis_function_index and variable \p var, at all quadrature points

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -249,6 +249,19 @@ public:
   void write_out_basis_functions(const std::string & directory_name = "offline_data",
                                  bool write_binary_basis_functions = true);
 
+  /**
+   * Read in all the basis functions from file.
+   *
+   * \param sys Used for file IO.
+   * \param directory_name Specifies which directory to write files to.
+   * \param read_binary_basis_functions Indicates whether to expect binary or ASCII data.
+   *
+   * Note: this is not currently a virtual function and is not related
+   * to the RBEvaluation function of the same name.
+   */
+  void read_in_basis_functions(const std::string & directory_name = "offline_data",
+                               const bool read_binary_basis_functions = true);
+
 private:
 
   /**

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -233,6 +233,19 @@ public:
    */
   bool evaluate_eim_error_bound;
 
+  /**
+   * Write out all the basis functions to file.
+   * \p sys is used for file IO
+   * \p directory_name specifies which directory to write files to
+   * \p read_binary_basis_functions indicates whether to write
+   * binary or ASCII data
+   *
+   * Note: this is not currently a virtual function and is not related
+   * to the RBEvaluation function of the same name.
+   */
+  void write_out_basis_functions(const std::string & directory_name = "offline_data",
+                                 bool write_binary_basis_functions = true);
+
 private:
 
   /**

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -194,6 +194,7 @@ public:
   void add_interpolation_points_xyz(Point p);
   void add_interpolation_points_comp(unsigned int comp);
   void add_interpolation_points_subdomain_id(subdomain_id_type sbd_id);
+  void add_interpolation_points_xyz_perturbations(const std::vector<Point> & perturbs);
   void add_interpolation_points_elem_id(dof_id_type elem_id);
   void add_interpolation_points_qp(unsigned int qp);
 
@@ -203,6 +204,7 @@ public:
   Point get_interpolation_points_xyz(unsigned int index) const;
   unsigned int get_interpolation_points_comp(unsigned int index) const;
   subdomain_id_type get_interpolation_points_subdomain_id(unsigned int index) const;
+  const std::vector<Point> & get_interpolation_points_xyz_perturbations(unsigned int index) const;
   dof_id_type get_interpolation_points_elem_id(unsigned int index) const;
   unsigned int get_interpolation_points_qp(unsigned int index) const;
 
@@ -225,7 +227,8 @@ public:
     unsigned int comp,
     dof_id_type elem_id,
     subdomain_id_type subdomain_id,
-    unsigned int qp);
+    unsigned int qp,
+    const std::vector<Point> & perturbs);
 
   /**
    * Boolean to indicate whether we evaluate a posteriori error bounds
@@ -268,6 +271,12 @@ private:
   std::vector<Point> _interpolation_points_xyz;
   std::vector<unsigned int> _interpolation_points_comp;
   std::vector<subdomain_id_type> _interpolation_points_subdomain_id;
+
+  /**
+   * We also store perturbations of the xyz locations that may be
+   * needed to evaluate finite difference approximations to derivatives.
+   */
+    std::vector<std::vector<Point>> _interpolation_points_xyz_perturbations;
 
   /**
    * We also store the element ID and qp index of each interpolation

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -31,6 +31,8 @@
 // C++ includes
 #include <memory>
 #include <map>
+#include <vector>
+#include <string>
 
 namespace libMesh
 {
@@ -57,8 +59,15 @@ public:
   RBEIMEvaluation(const Parallel::Communicator & comm);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class contains unique_ptrs, so it can't be default copy
+       constructed/assigned.
+   * - The destructor is defaulted out of line.
    */
+  RBEIMEvaluation (RBEIMEvaluation &&) = default;
+  RBEIMEvaluation (const RBEIMEvaluation &) = delete;
+  RBEIMEvaluation & operator= (const RBEIMEvaluation &) = delete;
+  RBEIMEvaluation & operator= (RBEIMEvaluation &&) = default;
   virtual ~RBEIMEvaluation ();
 
   /**
@@ -264,7 +273,7 @@ public:
    * Note: this is not a virtual function and is not related to the
    * RBEvaluation function of the same name.
    */
-  void read_in_basis_functions(System & rb_construction,
+  void read_in_basis_functions(const System & sys,
                                const std::string & directory_name = "offline_data",
                                bool read_binary_basis_functions = true);
 

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -333,6 +333,13 @@ private:
    * Helper function mainly useful for debugging.
    */
   void print_local_eim_basis_functions() const;
+
+  /**
+   * Helper function that gathers the contents of
+   * _local_eim_basis_functions to processor 0 in preparation for
+   * printing to file.
+   */
+  void gather_bfs();
 };
 
 }

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -30,7 +30,7 @@
 
 // C++ includes
 #include <memory>
-#include <unordered_map>
+#include <map>
 
 namespace libMesh
 {
@@ -59,6 +59,11 @@ public:
    * Destructor.
    */
   virtual ~RBEIMEvaluation ();
+
+  /**
+   * Type of the data structure used to map from (elem id) -> [n_vars][n_qp] data.
+   */
+  typedef std::map<dof_id_type, std::vector<std::vector<Number>>> QpDataMap;
 
   /**
    * Clear this object.
@@ -112,7 +117,7 @@ public:
   /**
    * Subtract coeffs[i]*basis_function[i] from \p v.
    */
-  void decrement_vector(std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & v,
+  void decrement_vector(QpDataMap & v,
                         const DenseVector<Number> & coeffs);
 
   /**
@@ -139,7 +144,7 @@ public:
    * points on element \p elem_id and component \p comp.
    */
   static void get_parametrized_function_values_at_qps(
-    const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & pf,
+    const QpDataMap & pf,
     dof_id_type elem_id,
     unsigned int comp,
     std::vector<Number> & values);
@@ -150,7 +155,7 @@ public:
    */
   static Number get_parametrized_function_value(
     const Parallel::Communicator & comm,
-    const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & pf,
+    const QpDataMap & pf,
     dof_id_type elem_id,
     unsigned int comp,
     unsigned int qp);
@@ -179,8 +184,7 @@ public:
   /**
    * Get a reference to the i^th basis function.
    */
-  const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> &
-    get_basis_function(unsigned int i) const;
+  const QpDataMap & get_basis_function(unsigned int i) const;
 
   /**
    * Return a const reference to the EIM solution coefficients from the most
@@ -222,7 +226,7 @@ public:
    * Add \p bf to our EIM basis.
    */
   void add_basis_function_and_interpolation_data(
-    const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & bf,
+    const QpDataMap & bf,
     Point p,
     unsigned int comp,
     dof_id_type elem_id,
@@ -260,7 +264,7 @@ public:
    * to the RBEvaluation function of the same name.
    */
   void read_in_basis_functions(const std::string & directory_name = "offline_data",
-                               const bool read_binary_basis_functions = true);
+                               bool read_binary_basis_functions = true);
 
 private:
 
@@ -322,8 +326,13 @@ private:
    * We use a map to index the element ID, since the IDs on this processor in
    * generally will not start at zero.
    */
-  std::vector<std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> > _local_eim_basis_functions;
+  std::vector<QpDataMap> _local_eim_basis_functions;
 
+  /**
+   * Print the contents of _local_eim_basis_functions to libMesh::out.
+   * Helper function mainly useful for debugging.
+   */
+  void print_local_eim_basis_functions() const;
 };
 
 }

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -22,12 +22,15 @@
 
 // libMesh includes
 #include "libmesh/point.h"
-#include "libmesh/rb_evaluation.h"
-#include "libmesh/replicated_mesh.h"
 #include "libmesh/rb_theta_expansion.h"
+#include "libmesh/rb_parametrized.h"
+#include "libmesh/parallel_object.h"
+#include "libmesh/dense_matrix.h"
+#include "libmesh/dense_vector.h"
 
 // C++ includes
 #include <memory>
+#include <unordered_map>
 
 namespace libMesh
 {
@@ -38,34 +41,24 @@ class Elem;
 class RBTheta;
 
 /**
- * This class is part of the rbOOmit framework.
- *
- * RBEIMEvaluation extends RBEvaluation to
- * encapsulate the code and data required
- * to perform "online" evaluations for
- * EIM approximations.
- *
- * \author David J. Knezevic
- * \date 2011
+ * This class enables evaluation of an Empirical Interpolation Method (EIM)
+ * approximation. RBEvaluation plays an analogous role in the context of
+ * the regular reduced basis method.
  */
-class RBEIMEvaluation : public RBEvaluation
+class RBEIMEvaluation : public RBParametrized,
+                        public ParallelObject
 {
 public:
 
   /**
    * Constructor.
    */
-  RBEIMEvaluation (const libMesh::Parallel::Communicator & comm_in);
+  RBEIMEvaluation(const Parallel::Communicator & comm);
 
   /**
    * Destructor.
    */
   virtual ~RBEIMEvaluation ();
-
-  /**
-   * The type of the parent.
-   */
-  typedef RBEvaluation Parent;
 
   /**
    * Clear this object.
@@ -76,59 +69,51 @@ public:
    * Resize the data structures for storing data associated
    * with this object.
    */
-  virtual void resize_data_structures(const unsigned int Nmax,
-                                      bool resize_error_bound_data=true) override;
+  void resize_data_structures(const unsigned int Nmax);
 
   /**
-   * Attach the parametrized function that we will approximate
-   * using the Empirical Interpolation Method.
+   * Set the parametrized function that we will approximate
+   * using the Empirical Interpolation Method. This object
+   * will take ownership of the unique pointer.
    */
-  void attach_parametrized_function(RBParametrizedFunction * pf);
-
-
-  /**
-   * Get the number of parametrized functions that have
-   * been attached to this system.
-   */
-  unsigned int get_n_parametrized_functions() const;
+  void set_parametrized_function(std::unique_ptr<RBParametrizedFunction> pf);
 
   /**
-   * Get a writable reference to the interpolation points mesh.
+   * Get a const reference to the parametrized function.
    */
-  ReplicatedMesh & get_interpolation_points_mesh();
-
-  /**
-   * \returns The value of the parametrized function that is being
-   * approximated at the point \p p.
-   * \p var_index specifies the
-   * variable (i.e. the parametrized function index) to be evaluated.
-   * \p elem specifies the element of the mesh that contains p.
-   */
-  Number evaluate_parametrized_function(unsigned int var_index,
-                                        const Point & p,
-                                        const Elem & elem);
+  RBParametrizedFunction & get_parametrized_function();
 
   /**
    * Calculate the EIM approximation to parametrized_function
    * using the first \p N EIM basis functions. Store the
-   * solution coefficients in the member RB_solution.
+   * solution coefficients in the member _eim_solution.
    * \returns The EIM a posteriori error bound.
    */
-  using RBEvaluation::rb_solve;
-  virtual Real rb_solve(unsigned int N) override;
+  virtual Real rb_eim_solve(unsigned int N);
 
   /**
    * Calculate the EIM approximation for the given
    * right-hand side vector \p EIM_rhs. Store the
-   * solution coefficients in the member RB_solution.
+   * solution coefficients in the member _eim_solution.
    */
-  void rb_solve(DenseVector<Number> & EIM_rhs);
+  void rb_eim_solve(DenseVector<Number> & EIM_rhs);
 
   /**
-   * \returns A scaling factor that we can use to provide a consistent
-   * scaling of the RB error bound across different parameter values.
+   * Return the current number of EIM basis functions.
    */
-  virtual Real get_error_bound_normalization() override;
+  unsigned int get_n_basis_functions() const;
+
+  /**
+   * Set the number of basis functions. Useful when reading in
+   * stored data.
+   */
+  void set_n_basis_functions(unsigned int n_bfs);
+
+  /**
+   * Subtract coeffs[i]*basis_function[i] from \p v.
+   */
+  void decrement_vector(std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & v,
+                        const DenseVector<Number> & coeffs);
 
   /**
    * Build a vector of RBTheta objects that accesses the components
@@ -150,68 +135,144 @@ public:
   virtual std::unique_ptr<RBTheta> build_eim_theta(unsigned int index);
 
   /**
-   * Write out all the data to text files in order to segregate the
-   * Offline stage from the Online stage.
-   *
-   * \note This is a legacy method, use RBDataSerialization instead.
+   * Fill up values by evaluating the parametrized function \p pf for all quadrature
+   * points on element \p elem_id and component \p comp.
    */
-  virtual void legacy_write_offline_data_to_files(const std::string & directory_name = "offline_data",
-                                                  const bool write_binary_data=true) override;
+  static void get_parametrized_function_values_at_qps(
+    const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & pf,
+    dof_id_type elem_id,
+    unsigned int comp,
+    std::vector<Number> & values);
 
   /**
-   * Read in the saved Offline reduced basis data
-   * to initialize the system for Online solves.
-   *
-   * \note This is a legacy method, use RBDataSerialization instead.
+   * Same as above, except that we just return the value at the qp^th
+   * quadrature point.
    */
-  virtual void legacy_read_offline_data_from_files(const std::string & directory_name = "offline_data",
-                                                   bool read_error_bound_data=true,
-                                                   const bool read_binary_data=true) override;
+  static Number get_parametrized_function_value(
+    const Parallel::Communicator & comm,
+    const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & pf,
+    dof_id_type elem_id,
+    unsigned int comp,
+    unsigned int qp);
 
-  //----------- PUBLIC DATA MEMBERS -----------//
+
+  /**
+   * Fill up \p values with the basis function values for basis function
+   * \p basis_function_index and variable \p var, at all quadrature points
+   * on element \p elem_id. Each processor stores data for only the
+   * elements local to that processor, so if elem_id is not on this processor
+   * then \p values will be empty.
+   */
+  void get_eim_basis_function_values_at_qps(unsigned int basis_function_index,
+                                            dof_id_type elem_id,
+                                            unsigned int var,
+                                            std::vector<Number> & values) const;
+
+  /**
+   * Same as above, except that we just return the value at the qp^th
+   * quadrature point.
+   */
+  Number get_eim_basis_function_value(unsigned int basis_function_index,
+                                      dof_id_type elem_id,
+                                      unsigned int comp,
+                                      unsigned int qp) const;
+
+  /**
+   * Get a reference to the i^th basis function.
+   */
+  const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> &
+    get_basis_function(unsigned int i) const;
+
+  /**
+   * Return a const reference to the EIM solution coefficients from the most
+   * recent solve.
+   */
+  const DenseVector<Number> & get_rb_eim_solution() const;
+
+  /**
+   * Set the data associated with EIM interpolation points.
+   */
+  void add_interpolation_points_xyz(Point p);
+  void add_interpolation_points_comp(unsigned int comp);
+  void add_interpolation_points_subdomain_id(subdomain_id_type sbd_id);
+  void add_interpolation_points_elem_id(dof_id_type elem_id);
+  void add_interpolation_points_qp(unsigned int qp);
+
+  /**
+   * Get the data associated with EIM interpolation points.
+   */
+  Point get_interpolation_points_xyz(unsigned int index) const;
+  unsigned int get_interpolation_points_comp(unsigned int index) const;
+  subdomain_id_type get_interpolation_points_subdomain_id(unsigned int index) const;
+  dof_id_type get_interpolation_points_elem_id(unsigned int index) const;
+  unsigned int get_interpolation_points_qp(unsigned int index) const;
+
+  /**
+   * Set entry of the EIM interpolation matrix.
+   */
+  void set_interpolation_matrix_entry(unsigned int i, unsigned int j, Number value);
+
+  /**
+   * Get the EIM interpolation matrix.
+   */
+  const DenseMatrix<Number> & get_interpolation_matrix() const;
+
+  /**
+   * Add \p bf to our EIM basis.
+   */
+  void add_basis_function_and_interpolation_data(
+    const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & bf,
+    Point p,
+    unsigned int comp,
+    dof_id_type elem_id,
+    subdomain_id_type subdomain_id,
+    unsigned int qp);
+
+  /**
+   * Boolean to indicate whether we evaluate a posteriori error bounds
+   * when eim_solve is called.
+   */
+  bool evaluate_eim_error_bound;
+
+private:
+
+  /**
+   * The EIM solution coefficients from the most recent eim_solve().
+   */
+  DenseVector<Number> _rb_eim_solution;
 
   /**
    * Dense matrix that stores the lower triangular
    * interpolation matrix that can be used
    */
-  DenseMatrix<Number> interpolation_matrix;
+  DenseMatrix<Number> _interpolation_matrix;
 
   /**
-   * The list of interpolation points, i.e. locations at
-   * which the basis functions are maximized.
+   * We need to store interpolation point data in order to
+   * evaluate parametrized functions at the interpolation points.
+   * This requires the xyz locations, the components to evaluate,
+   * and the subdomain IDs.
    */
-  std::vector<Point> interpolation_points;
+  std::vector<Point> _interpolation_points_xyz;
+  std::vector<unsigned int> _interpolation_points_comp;
+  std::vector<subdomain_id_type> _interpolation_points_subdomain_id;
 
   /**
-   * The corresponding list of variables indices at which
-   * the interpolation points were identified.
+   * We also store the element ID and qp index of each interpolation
+   * point so that we can evaluate our basis functions at these
+   * points by simply looking up the appropriate stored values.
+   * This data is only needed during the EIM training.
    */
-  std::vector<unsigned int> interpolation_points_var;
+  std::vector<dof_id_type> _interpolation_points_elem_id;
+  std::vector<unsigned int> _interpolation_points_qp;
 
   /**
-   * The corresponding list of elements at which
-   * the interpolation points were identified.
+   * Store the parametrized function that will be approximated
+   * by this EIM system. Note that the parametrized function
+   * may have more than one component, and each component is
+   * approximated by a separate variable in the EIM system.
    */
-  std::vector<Elem *> interpolation_points_elem;
-
-private:
-
-  /**
-   * Write out interpolation_points_elem by putting the elements into
-   * a mesh and writing out the mesh.
-   */
-  void legacy_write_out_interpolation_points_elem(const std::string & directory_name);
-
-  /**
-   * Read int interpolation_points_elem from a mesh.
-   */
-  void legacy_read_in_interpolation_points_elem(const std::string & directory_name);
-
-  /**
-   * This vector stores the parametrized functions
-   * that will be approximated in this EIM system.
-   */
-  std::vector<RBParametrizedFunction *> _parametrized_functions;
+  std::unique_ptr<RBParametrizedFunction> _parametrized_function;
 
   /**
    * The vector of RBTheta objects that are created to point to
@@ -220,34 +281,14 @@ private:
   std::vector<std::unique_ptr<RBTheta>> _rb_eim_theta_objects;
 
   /**
-   * We initialize RBEIMEvaluation so that it has an "empty" RBThetaExpansion, because
-   * this isn't used at all in the EIM.
+   * The EIM basis functions. We store values at quadrature points
+   * on elements that are local to this processor. The indexing
+   * is as follows:
+   *   basis function index --> element ID --> variable --> quadrature point --> value
+   * We use a map to index the element ID, since the IDs on this processor in
+   * generally will not start at zero.
    */
-  RBThetaExpansion _empty_rb_theta_expansion;
-
-  /**
-   * Store the parameters at which the previous solve was performed (so we can avoid
-   * an unnecessary repeat solve).
-   */
-  RBParameters _previous_parameters;
-
-  /**
-   * Store the number of basis functions used for the previous solve (so we can avoid
-   * an unnecessary repeat solve).
-   */
-  unsigned int _previous_N;
-
-  /**
-   * Store the previous error bound returned by rb_solve (so we can return it if we
-   * are avoiding an unnecessary repeat solve).
-   */
-  Real _previous_error_bound;
-
-  /**
-   * Mesh object that we use to store copies of the elements associated with
-   * interpolation points.
-   */
-  ReplicatedMesh _interpolation_points_mesh;
+  std::vector<std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> > _local_eim_basis_functions;
 
 };
 

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -37,8 +37,9 @@ namespace libMesh
 
 class RBParameters;
 class RBParametrizedFunction;
-class Elem;
 class RBTheta;
+class System;
+class Elem;
 
 /**
  * This class enables evaluation of an Empirical Interpolation Method (EIM)
@@ -256,14 +257,15 @@ public:
   /**
    * Read in all the basis functions from file.
    *
-   * \param sys Used for file IO.
+   * \param sys The Mesh in this System determines the parallel distribution of the basis functions.
    * \param directory_name Specifies which directory to write files to.
    * \param read_binary_basis_functions Indicates whether to expect binary or ASCII data.
    *
-   * Note: this is not currently a virtual function and is not related
-   * to the RBEvaluation function of the same name.
+   * Note: this is not a virtual function and is not related to the
+   * RBEvaluation function of the same name.
    */
-  void read_in_basis_functions(const std::string & directory_name = "offline_data",
+  void read_in_basis_functions(System & rb_construction,
+                               const std::string & directory_name = "offline_data",
                                bool read_binary_basis_functions = true);
 
 private:
@@ -293,7 +295,7 @@ private:
    * We also store perturbations of the xyz locations that may be
    * needed to evaluate finite difference approximations to derivatives.
    */
-    std::vector<std::vector<Point>> _interpolation_points_xyz_perturbations;
+  std::vector<std::vector<Point>> _interpolation_points_xyz_perturbations;
 
   /**
    * We also store the element ID and qp index of each interpolation
@@ -340,6 +342,13 @@ private:
    * printing to file.
    */
   void gather_bfs();
+
+  /**
+   * Helper function that distributes the entries of
+   * _local_eim_basis_functions to their respective processors after
+   * they are read in on processor 0.
+   */
+  void distribute_bfs(const System & sys);
 };
 
 }

--- a/include/reduced_basis/rb_eim_theta.h
+++ b/include/reduced_basis/rb_eim_theta.h
@@ -49,6 +49,17 @@ public:
   RBEIMTheta(RBEIMEvaluation & rb_eim_eval_in, unsigned int index_in);
 
   /**
+   * Special functions.
+   * This class contains a reference, so it can't be default
+   * copy/move-assigned.
+   */
+  RBEIMTheta (RBEIMTheta &&) = default;
+  RBEIMTheta (const RBEIMTheta &) = default;
+  RBEIMTheta & operator= (const RBEIMTheta &) = delete;
+  RBEIMTheta & operator= (RBEIMTheta &&) = delete;
+  ~RBEIMTheta() = default;
+
+  /**
    * Evaluate this RBEIMTheta object at the parameter \p mu.
    * This entails solving the RB EIM approximation and picking
    * out the appropriate coefficient.

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -45,6 +45,11 @@ class RBParametrizedFunction
 public:
 
   /**
+   * Constructor.
+   */
+  RBParametrizedFunction();
+
+  /**
    * Virtual evaluate() gives us a vtable, so there's no cost in adding a
    * virtual destructor for safety's sake.
    */
@@ -59,29 +64,33 @@ public:
 
   /**
    * Evaluate the parametrized function at the specified point for
-   * parameter \p mu.
+   * parameter \p mu.  If requires_xyz_perturbations==false, then
+   * xyz_perturb will not be used.
    */
   virtual Number evaluate(const RBParameters & mu,
                           unsigned int comp,
                           const Point & xyz,
-                          subdomain_id_type subdomain_id) = 0;
+                          subdomain_id_type subdomain_id,
+                          const std::vector<Point> & xyz_perturb) = 0;
 
   /**
-   * Vectorized version of evaluate.
+   * Vectorized version of evaluate. If requires_xyz_perturbations==false, then all_xyz_perturb will not be used.
    */
   virtual void vectorized_evaluate(const RBParameters & mu,
                                    const std::unordered_map<dof_id_type, std::vector<Point>> & all_xyz,
                                    const std::unordered_map<dof_id_type, subdomain_id_type> & sbd_ids,
+                                   const std::unordered_map<dof_id_type, std::vector<std::vector<Point>> > & all_xyz_perturb,
                                    std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & output);
 
   /**
    * Store the result of vectorized_evaluate. This is helpful during EIM training,
    * since we can pre-evaluate and store the parameterized function for each training
-   * sample.
+   * sample. If requires_xyz_perturbations==false, then all_xyz_perturb will not be used.
    */
   virtual void preevaluate_parametrized_function(const RBParameters & mu,
                                                  const std::unordered_map<dof_id_type, std::vector<Point>> & all_xyz,
-                                                 const std::unordered_map<dof_id_type, subdomain_id_type> & sbd_ids);
+                                                 const std::unordered_map<dof_id_type, subdomain_id_type> & sbd_ids,
+                                                 const std::unordered_map<dof_id_type, std::vector<std::vector<Point>> > & all_xyz_perturb);
 
   /**
    * Look up the preevaluate values of the parametrized function for
@@ -96,6 +105,14 @@ public:
    *   elem_id --> comp --> qp --> value
    */
   std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> preevaluated_values;
+
+  /**
+   * Boolean to indicate whether this parametrized function requires xyz perturbations
+   * in order to evaluate function values. An example of where perturbations are
+   * required is when the parametrized function is based on finite difference
+   * approximations to derivatives.
+   */
+  bool requires_xyz_perturbations;
 };
 
 }

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -63,7 +63,7 @@ public:
    */
   virtual Number evaluate(const RBParameters & mu,
                           unsigned int comp,
-                          Point xyz,
+                          const Point & xyz,
                           subdomain_id_type subdomain_id) = 0;
 
   /**

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -113,6 +113,12 @@ public:
    * approximations to derivatives.
    */
   bool requires_xyz_perturbations;
+
+  /**
+   * The finite difference step size in the case that this function in the case
+   * that this function uses finite differencing.
+   */
+  Real fd_delta;
 };
 
 }

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -20,8 +20,12 @@
 #ifndef LIBMESH_RB_PARAMETRIZED_FUNCTION_H
 #define LIBMESH_RB_PARAMETRIZED_FUNCTION_H
 
+// libMesh includes
 #include "libmesh/libmesh_common.h"
 
+// C++ includes
+#include <unordered_map>
+#include <vector>
 
 namespace libMesh
 {
@@ -67,7 +71,7 @@ public:
    */
   virtual void vectorized_evaluate(const RBParameters & mu,
                                    const std::unordered_map<dof_id_type, std::vector<Point>> & all_xyz,
-                                   std::unordered_map<dof_id_type, subdomain_id_type> sbd_ids,
+                                   const std::unordered_map<dof_id_type, subdomain_id_type> & sbd_ids,
                                    std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & output);
 
   /**
@@ -77,7 +81,7 @@ public:
    */
   virtual void preevaluate_parametrized_function(const RBParameters & mu,
                                                  const std::unordered_map<dof_id_type, std::vector<Point>> & all_xyz,
-                                                 std::unordered_map<dof_id_type, subdomain_id_type> sbd_ids);
+                                                 const std::unordered_map<dof_id_type, subdomain_id_type> & sbd_ids);
 
   /**
    * Look up the preevaluate values of the parametrized function for

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -44,7 +44,7 @@ public:
    * Virtual evaluate() gives us a vtable, so there's no cost in adding a
    * virtual destructor for safety's sake.
    */
-  virtual ~RBParametrizedFunction() {}
+  virtual ~RBParametrizedFunction();
 
   /**
    * Specify the number of components in this parametrized function.
@@ -68,32 +68,7 @@ public:
   virtual void vectorized_evaluate(const RBParameters & mu,
                                    const std::unordered_map<dof_id_type, std::vector<Point>> & all_xyz,
                                    std::unordered_map<dof_id_type, subdomain_id_type> sbd_ids,
-                                   std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & output)
-  {
-    output.clear();
-
-    for (auto it : all_xyz)
-      {
-        dof_id_type elem_id = it.first;
-        const std::vector<Point> & xyz_vec = it.second;
-
-        auto sbd_it = sbd_ids.find(elem_id);
-        if (sbd_it == sbd_ids.end())
-          libmesh_error_msg("Error: elem_id not found");
-        subdomain_id_type subdomain_id = sbd_it->second;
-
-        std::vector<std::vector<Number>> values(get_n_components());
-        for (unsigned int comp=0; comp<get_n_components(); comp++)
-          {
-            values[comp].resize(xyz_vec.size());
-            for (unsigned int qp : index_range(xyz_vec))
-              {
-                values[comp][qp] = evaluate(mu, comp, xyz_vec[qp], subdomain_id);
-              }
-          }
-        output[elem_id] = values;
-      }
-  }
+                                   std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & output);
 
   /**
    * Store the result of vectorized_evaluate. This is helpful during EIM training,
@@ -102,10 +77,7 @@ public:
    */
   virtual void preevaluate_parametrized_function(const RBParameters & mu,
                                                  const std::unordered_map<dof_id_type, std::vector<Point>> & all_xyz,
-                                                 std::unordered_map<dof_id_type, subdomain_id_type> sbd_ids)
-  {
-    vectorized_evaluate(mu, all_xyz, sbd_ids, preevaluated_values);
-  }
+                                                 std::unordered_map<dof_id_type, subdomain_id_type> sbd_ids);
 
   /**
    * Look up the preevaluate values of the parametrized function for
@@ -113,22 +85,7 @@ public:
    */
   virtual Number lookup_preevaluated_value(unsigned int comp,
                                            dof_id_type elem_id,
-                                           unsigned int qp) const
-  {
-    const auto elem_it = preevaluated_values.find(elem_id);
-    if (elem_it == preevaluated_values.end())
-      libmesh_error_msg("Error: elem_id not found");
-
-    const std::vector<std::vector<Number>> & values = elem_it->second;
-
-    if (comp >= values.size())
-      libmesh_error_msg("Error: invalid comp");
-
-    if (qp >= values[comp].size())
-      libmesh_error_msg("Error: invalid qp");
-
-    return values[comp][qp];
-  }
+                                           unsigned int qp) const;
 
   /**
    * Storage for pre-evaluated values. The indexing here is:

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -66,12 +66,26 @@ public:
    * Evaluate the parametrized function at the specified point for
    * parameter \p mu.  If requires_xyz_perturbations==false, then
    * xyz_perturb will not be used.
+   *
+   * In this case we return the value for component \p comp only.
    */
   virtual Number evaluate(const RBParameters & mu,
                           unsigned int comp,
                           const Point & xyz,
                           subdomain_id_type subdomain_id,
-                          const std::vector<Point> & xyz_perturb) = 0;
+                          const std::vector<Point> & xyz_perturb);
+
+  /**
+   * Evaluate the parametrized function at the specified point for
+   * parameter \p mu.  If requires_xyz_perturbations==false, then
+   * xyz_perturb will not be used.
+   *
+   * In this case we evaluate for all components.
+   */
+  virtual std::vector<Number> evaluate(const RBParameters & mu,
+                                       const Point & xyz,
+                                       subdomain_id_type subdomain_id,
+                                       const std::vector<Point> & xyz_perturb) = 0;
 
   /**
    * Vectorized version of evaluate. If requires_xyz_perturbations==false, then all_xyz_perturb will not be used.

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -50,9 +50,14 @@ public:
   RBParametrizedFunction();
 
   /**
-   * Virtual evaluate() gives us a vtable, so there's no cost in adding a
-   * virtual destructor for safety's sake.
+   * Special functions.
+   * - This class can be default copy/move assigned/constructed.
+   * - The destructor is defaulted out-of-line.
    */
+  RBParametrizedFunction (RBParametrizedFunction &&) = default;
+  RBParametrizedFunction (const RBParametrizedFunction &) = default;
+  RBParametrizedFunction & operator= (const RBParametrizedFunction &) = default;
+  RBParametrizedFunction & operator= (RBParametrizedFunction &&) = default;
   virtual ~RBParametrizedFunction();
 
   /**
@@ -67,13 +72,17 @@ public:
    * parameter \p mu.  If requires_xyz_perturbations==false, then
    * xyz_perturb will not be used.
    *
-   * In this case we return the value for component \p comp only.
+   * In this case we return the value for component \p comp only, but
+   * the base class implementation simply calls the vector-returning
+   * evaluate() function below and returns the comp'th component, so
+   * derived classes should provide a more efficient routine or just call
+   * the vector-returning function instead.
    */
-  virtual Number evaluate(const RBParameters & mu,
-                          unsigned int comp,
-                          const Point & xyz,
-                          subdomain_id_type subdomain_id,
-                          const std::vector<Point> & xyz_perturb);
+  virtual Number evaluate_comp(const RBParameters & mu,
+                               unsigned int comp,
+                               const Point & xyz,
+                               subdomain_id_type subdomain_id,
+                               const std::vector<Point> & xyz_perturb);
 
   /**
    * Evaluate the parametrized function at the specified point for

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -333,6 +333,7 @@ libmesh_SOURCES =  \
         src/reduced_basis/rb_evaluation.C \
         src/reduced_basis/rb_parameters.C \
         src/reduced_basis/rb_parametrized.C \
+        src/reduced_basis/rb_parametrized_function.C \
         src/reduced_basis/rb_scm_construction.C \
         src/reduced_basis/rb_scm_evaluation.C \
         src/reduced_basis/rb_temporal_discretization.C \

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -638,5 +638,6 @@ template class RBConstructionBase<CondensedEigenSystem>;
 #endif
 
 template class RBConstructionBase<LinearImplicitSystem>;
+template class RBConstructionBase<System>;
 
 } // namespace libMesh

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -110,7 +110,7 @@ numeric_index_type RBConstructionBase<Base>::get_local_n_training_samples() cons
 {
   libmesh_assert(training_parameters_initialized);
 
-  if(training_parameters.empty())
+  if (training_parameters.empty())
     return 0;
 
   return training_parameters.begin()->second->local_size();
@@ -121,7 +121,7 @@ numeric_index_type RBConstructionBase<Base>::get_first_local_training_index() co
 {
   libmesh_assert(training_parameters_initialized);
 
-  if(training_parameters.empty())
+  if (training_parameters.empty())
     return 0;
 
   return training_parameters.begin()->second->first_local_index();
@@ -132,7 +132,7 @@ numeric_index_type RBConstructionBase<Base>::get_last_local_training_index() con
 {
   libmesh_assert(training_parameters_initialized);
 
-  if(training_parameters.empty())
+  if (training_parameters.empty())
     return 0;
 
   return training_parameters.begin()->second->last_local_index();
@@ -196,7 +196,7 @@ void RBConstructionBase<Base>::initialize_training_parameters(const RBParameters
                                                               std::map<std::string,bool> log_param_scale,
                                                               bool deterministic)
 {
-  if(!is_quiet())
+  if (!is_quiet())
     {
       // Print out some info about the training set initialization
       libMesh::out << "Initializing training parameters with "
@@ -481,17 +481,17 @@ void RBConstructionBase<Base>::generate_training_parameters_deterministic(const 
   // than 0) so that we don't skip the inner part of the triply-nested loop over
   // n_training_samples_per_param below.
   std::vector<unsigned int> n_training_samples_per_param(3);
-  for(unsigned int param=0; param<3; param++)
+  for (unsigned int param=0; param<3; param++)
     {
-      if(param < num_params)
-          {
-            n_training_samples_per_param[param] =
-              static_cast<unsigned int>( std::round(std::pow(static_cast<Real>(n_training_samples_in), 1./num_params)) );
-          }
-        else
-          {
-            n_training_samples_per_param[param] = 1;
-          }
+      if (param < num_params)
+        {
+          n_training_samples_per_param[param] =
+            static_cast<unsigned int>( std::round(std::pow(static_cast<Real>(n_training_samples_in), 1./num_params)) );
+        }
+      else
+        {
+          n_training_samples_per_param[param] = 1;
+        }
     }
 
   {

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -769,7 +769,28 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
 
     for (unsigned int i=0; i<n_bfs; ++i)
       {
-        rb_eim_evaluation.add_interpolation_points_elem_id(interpolation_points_qp_list[i]);
+        rb_eim_evaluation.add_interpolation_points_qp(interpolation_points_qp_list[i]);
+      }
+  }
+
+  // Interpolation points perturbations
+  {
+    auto interpolation_points_list_outer =
+      rb_eim_evaluation_reader.getInterpolationXyzPerturb();
+
+    if (interpolation_points_list_outer.size() != n_bfs)
+      libmesh_error_msg("Size error while reading the eim interpolation points.");
+
+    for (unsigned int i=0; i<n_bfs; ++i)
+      {
+        auto interpolation_points_list_inner = interpolation_points_list_outer[i];
+
+        std::vector<Point> perturbs(interpolation_points_list_inner.size());
+        for (unsigned int j=0; j<perturbs.size(); j++)
+          {
+            load_point(interpolation_points_list_inner[j], perturbs[j]);
+          }
+        rb_eim_evaluation.add_interpolation_points_xyz_perturbations(perturbs);
       }
   }
 }

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -72,8 +72,7 @@ RBEvaluationDeserialization::RBEvaluationDeserialization(RBEvaluation & rb_eval)
   _rb_eval(rb_eval)
 {}
 
-RBEvaluationDeserialization::~RBEvaluationDeserialization()
-{}
+RBEvaluationDeserialization::~RBEvaluationDeserialization() = default;
 
 void RBEvaluationDeserialization::read_from_file(const std::string & path,
                                                  bool read_error_bound_data)
@@ -123,8 +122,7 @@ TransientRBEvaluationDeserialization(TransientRBEvaluation & trans_rb_eval) :
   _trans_rb_eval(trans_rb_eval)
 {}
 
-TransientRBEvaluationDeserialization::~TransientRBEvaluationDeserialization()
-{}
+TransientRBEvaluationDeserialization::~TransientRBEvaluationDeserialization() = default;
 
 void TransientRBEvaluationDeserialization::read_from_file(const std::string & path,
                                                           bool read_error_bound_data)
@@ -181,8 +179,7 @@ RBEIMEvaluationDeserialization(RBEIMEvaluation & rb_eim_eval) :
   _rb_eim_eval(rb_eim_eval)
 {}
 
-RBEIMEvaluationDeserialization::~RBEIMEvaluationDeserialization()
-{}
+RBEIMEvaluationDeserialization::~RBEIMEvaluationDeserialization() = default;
 
 void RBEIMEvaluationDeserialization::read_from_file(const std::string & path)
 {
@@ -236,8 +233,7 @@ RBSCMEvaluationDeserialization(RBSCMEvaluation & rb_scm_eval) :
   _rb_scm_eval(rb_scm_eval)
 {}
 
-RBSCMEvaluationDeserialization::~RBSCMEvaluationDeserialization()
-{}
+RBSCMEvaluationDeserialization::~RBSCMEvaluationDeserialization() = default;
 
 void RBSCMEvaluationDeserialization::read_from_file(const std::string & path)
 {

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -186,17 +186,12 @@ void RBEIMEvaluationSerialization::write_to_file(const std::string & path)
 #ifndef LIBMESH_USE_COMPLEX_NUMBERS
       RBData::RBEIMEvaluationReal::Builder rb_eim_eval_builder =
         message.initRoot<RBData::RBEIMEvaluationReal>();
-      RBData::RBEvaluationReal::Builder rb_eval_builder =
-        rb_eim_eval_builder.initRbEvaluation();
 #else
       RBData::RBEIMEvaluationComplex::Builder rb_eim_eval_builder =
         message.initRoot<RBData::RBEIMEvaluationComplex>();
-      RBData::RBEvaluationComplex::Builder rb_eval_builder =
-        rb_eim_eval_builder.initRbEvaluation();
 #endif
 
       add_rb_eim_evaluation_data_to_builder(_rb_eim_eval,
-                                            rb_eval_builder,
                                             rb_eim_eval_builder);
 
       int fd = open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0664);
@@ -598,14 +593,21 @@ void add_transient_rb_evaluation_data_to_builder(TransientRBEvaluation & trans_r
 
 }
 
-template <typename RBEvaluationBuilderNumber, typename RBEIMEvaluationBuilderNumber>
+template <typename RBEIMEvaluationBuilderNumber>
 void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
-                                           RBEvaluationBuilderNumber & rb_evaluation_builder,
                                            RBEIMEvaluationBuilderNumber & rb_eim_evaluation_builder)
 {
-  add_rb_evaluation_data_to_builder(rb_eim_evaluation, rb_evaluation_builder);
+  // Number of basis functions
+    unsigned int n_bfs = rb_eim_evaluation.get_n_basis_functions();
+  rb_eim_evaluation_builder.setNBfs(n_bfs);
 
-  unsigned int n_bfs = rb_eim_evaluation.get_n_basis_functions();
+  auto parameter_ranges_list =
+    rb_eim_evaluation_builder.initParameterRanges();
+  auto discrete_parameters_list =
+    rb_eim_evaluation_builder.initDiscreteParameters();
+  add_parameter_ranges_to_builder(rb_eim_evaluation,
+                                  parameter_ranges_list,
+                                  discrete_parameters_list);
 
   // EIM interpolation matrix
   {
@@ -621,44 +623,53 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
           unsigned int offset = i*(i+1)/2 + j;
           set_scalar_in_list(interpolation_matrix_list,
                              offset,
-                             rb_eim_evaluation.interpolation_matrix(i,j));
+                             rb_eim_evaluation.get_interpolation_matrix()(i,j));
         }
   }
 
   // Interpolation points
   {
     auto interpolation_points_list =
-      rb_eim_evaluation_builder.initInterpolationPoints(n_bfs);
+      rb_eim_evaluation_builder.initInterpolationXyz(n_bfs);
     for (unsigned int i=0; i < n_bfs; ++i)
-      add_point_to_builder(rb_eim_evaluation.interpolation_points[i],
+      add_point_to_builder(rb_eim_evaluation.get_interpolation_points_xyz(i),
                            interpolation_points_list[i]);
   }
 
-  // Interpolation points variables
+  // Interpolation points comps
   {
-    auto interpolation_points_var_list =
-      rb_eim_evaluation_builder.initInterpolationPointsVar(n_bfs);
+    auto interpolation_points_comp_list =
+      rb_eim_evaluation_builder.initInterpolationComp(n_bfs);
     for (unsigned int i=0; i<n_bfs; ++i)
-      interpolation_points_var_list.set(i,
-                                        rb_eim_evaluation.interpolation_points_var[i]);
+      interpolation_points_comp_list.set(i,
+                                         rb_eim_evaluation.get_interpolation_points_comp(i));
   }
 
-  // Interpolation elements
+  // Interpolation points subdomain IDs
   {
-    unsigned int n_interpolation_elems =
-      rb_eim_evaluation.interpolation_points_elem.size();
-    auto interpolation_points_elem_list =
-      rb_eim_evaluation_builder.initInterpolationPointsElems(n_interpolation_elems);
+    auto interpolation_points_subdomain_id_list =
+      rb_eim_evaluation_builder.initInterpolationSubdomainId(n_bfs);
+    for (unsigned int i=0; i<n_bfs; ++i)
+      interpolation_points_subdomain_id_list.set(i,
+                                                 rb_eim_evaluation.get_interpolation_points_subdomain_id(i));
+  }
 
-    if (n_interpolation_elems != n_bfs)
-      libmesh_error_msg("The number of elements should match the number of basis functions");
+  // Interpolation points element IDs
+  {
+    auto interpolation_points_elem_id_list =
+      rb_eim_evaluation_builder.initInterpolationElemId(n_bfs);
+    for (unsigned int i=0; i<n_bfs; ++i)
+      interpolation_points_elem_id_list.set(i,
+                                            rb_eim_evaluation.get_interpolation_points_elem_id(i));
+  }
 
-    for (unsigned int i=0; i<n_interpolation_elems; ++i)
-      {
-        const libMesh::Elem & elem = *rb_eim_evaluation.interpolation_points_elem[i];
-        auto mesh_elem_builder = interpolation_points_elem_list[i];
-        add_elem_to_builder(elem, mesh_elem_builder);
-      }
+  // Interpolation points quadrature point indices
+  {
+    auto interpolation_points_qp_list =
+      rb_eim_evaluation_builder.initInterpolationQp(n_bfs);
+    for (unsigned int i=0; i<n_bfs; ++i)
+      interpolation_points_qp_list.set(i,
+                                       rb_eim_evaluation.get_interpolation_points_qp(i));
   }
 }
 
@@ -744,22 +755,6 @@ void add_point_to_builder(const Point & point, RBData::Point3D::Builder point_bu
 
   if (LIBMESH_DIM >= 3)
     point_builder.setZ(point(2));
-}
-
-void add_elem_to_builder(const libMesh::Elem & elem, RBData::MeshElem::Builder mesh_elem_builder)
-{
-  std::string elem_type_string = libMesh::Utility::enum_to_string(elem.type());
-
-  mesh_elem_builder.setType(elem_type_string.c_str());
-  mesh_elem_builder.setSubdomainId(elem.subdomain_id());
-
-  unsigned int n_points = elem.n_nodes();
-  auto mesh_elem_point_list = mesh_elem_builder.initPoints(n_points);
-
-  for (unsigned int j=0; j < n_points; ++j)
-    {
-      add_point_to_builder(elem.node_ref(j), mesh_elem_point_list[j]);
-    }
 }
 
 // ---- Helper functions for adding data to capnp Builders (END) ----

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -671,6 +671,22 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
       interpolation_points_qp_list.set(i,
                                        rb_eim_evaluation.get_interpolation_points_qp(i));
   }
+
+  // Interpolation points perturbations
+  {
+    auto interpolation_points_list_outer =
+      rb_eim_evaluation_builder.initInterpolationXyzPerturb(n_bfs);
+    for (unsigned int i=0; i < n_bfs; ++i)
+      {
+        const std::vector<Point> & perturbs = rb_eim_evaluation.get_interpolation_points_xyz_perturbations(i);
+        auto interpolation_points_list_inner = interpolation_points_list_outer.init(i, perturbs.size());
+
+        for (unsigned int j : index_range(perturbs))
+          {
+            add_point_to_builder(perturbs[j], interpolation_points_list_inner[j]);
+          }
+      }
+  }
 }
 
 #if defined(LIBMESH_HAVE_SLEPC) && (LIBMESH_HAVE_GLPK)

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -75,9 +75,7 @@ RBEvaluationSerialization::RBEvaluationSerialization(RBEvaluation & rb_eval)
 {
 }
 
-RBEvaluationSerialization::~RBEvaluationSerialization()
-{
-}
+RBEvaluationSerialization::~RBEvaluationSerialization() = default;
 
 void RBEvaluationSerialization::write_to_file(const std::string & path)
 {
@@ -120,9 +118,7 @@ TransientRBEvaluationSerialization(TransientRBEvaluation & trans_rb_eval) :
 {
 }
 
-TransientRBEvaluationSerialization::~TransientRBEvaluationSerialization()
-{
-}
+TransientRBEvaluationSerialization::~TransientRBEvaluationSerialization() = default;
 
 void TransientRBEvaluationSerialization::write_to_file(const std::string & path)
 {
@@ -171,9 +167,7 @@ RBEIMEvaluationSerialization::RBEIMEvaluationSerialization(RBEIMEvaluation & rb_
 {
 }
 
-RBEIMEvaluationSerialization::~RBEIMEvaluationSerialization()
-{
-}
+RBEIMEvaluationSerialization::~RBEIMEvaluationSerialization() = default;
 
 void RBEIMEvaluationSerialization::write_to_file(const std::string & path)
 {
@@ -219,9 +213,7 @@ RBSCMEvaluationSerialization::RBSCMEvaluationSerialization(RBSCMEvaluation & rb_
 {
 }
 
-RBSCMEvaluationSerialization::~RBSCMEvaluationSerialization()
-{
-}
+RBSCMEvaluationSerialization::~RBSCMEvaluationSerialization() = default;
 
 void RBSCMEvaluationSerialization::write_to_file(const std::string & path)
 {

--- a/src/reduced_basis/rb_eim_assembly.C
+++ b/src/reduced_basis/rb_eim_assembly.C
@@ -19,7 +19,7 @@
 
 // rbOOmit includes
 #include "libmesh/rb_eim_assembly.h"
-#include "libmesh/rb_eim_evaluation.h"
+#include "libmesh/rb_eim_construction.h"
 
 // libMesh includes
 #include "libmesh/fem_context.h"
@@ -31,10 +31,10 @@
 namespace libMesh
 {
 
-RBEIMAssembly::RBEIMAssembly(RBEIMEvaluation & rb_eim_eval,
+RBEIMAssembly::RBEIMAssembly(RBEIMConstruction & rb_eim_con,
                              unsigned int basis_function_index_in)
   :
-  _rb_eim_eval(rb_eim_eval),
+  _rb_eim_con(rb_eim_con),
   _basis_function_index(basis_function_index_in)
 {
 }
@@ -47,13 +47,13 @@ void RBEIMAssembly::evaluate_basis_function(dof_id_type elem_id,
                                             unsigned int comp,
                                             std::vector<Number> & values)
 {
-  get_rb_eim_evaluation().get_eim_basis_function_values_at_qps(
+  get_rb_eim_construction().get_rb_eim_evaluation().get_eim_basis_function_values_at_qps(
     _basis_function_index, elem_id, comp, values);
 }
 
-RBEIMEvaluation & RBEIMAssembly::get_rb_eim_evaluation()
+RBEIMConstruction & RBEIMAssembly::get_rb_eim_construction()
 {
-  return _rb_eim_eval;
+  return _rb_eim_con;
 }
 
 }

--- a/src/reduced_basis/rb_eim_assembly.C
+++ b/src/reduced_basis/rb_eim_assembly.C
@@ -39,9 +39,7 @@ RBEIMAssembly::RBEIMAssembly(RBEIMConstruction & rb_eim_con,
 {
 }
 
-RBEIMAssembly::~RBEIMAssembly()
-{
-}
+RBEIMAssembly::~RBEIMAssembly() = default;
 
 void RBEIMAssembly::evaluate_basis_function(dof_id_type elem_id,
                                             unsigned int comp,
@@ -50,7 +48,7 @@ void RBEIMAssembly::evaluate_basis_function(dof_id_type elem_id,
   get_rb_eim_construction().get_rb_eim_evaluation().get_eim_basis_function_values_at_qps(
     _basis_function_index, elem_id, comp, values);
 
-  if(values.empty())
+  if (values.empty())
     libmesh_error_msg("Error: EIM basis function has no entries on this element for this processor");
 }
 

--- a/src/reduced_basis/rb_eim_assembly.C
+++ b/src/reduced_basis/rb_eim_assembly.C
@@ -19,8 +19,7 @@
 
 // rbOOmit includes
 #include "libmesh/rb_eim_assembly.h"
-#include "libmesh/rb_eim_construction.h"
-#include "libmesh/rb_evaluation.h"
+#include "libmesh/rb_eim_evaluation.h"
 
 // libMesh includes
 #include "libmesh/fem_context.h"
@@ -32,94 +31,29 @@
 namespace libMesh
 {
 
-RBEIMAssembly::RBEIMAssembly(RBEIMConstruction & rb_eim_con_in,
+RBEIMAssembly::RBEIMAssembly(RBEIMEvaluation & rb_eim_eval,
                              unsigned int basis_function_index_in)
-  : _rb_eim_con(rb_eim_con_in),
-    _basis_function_index(basis_function_index_in),
-    _ghosted_basis_function(NumericVector<Number>::build(rb_eim_con_in.get_explicit_system().comm()))
+  :
+  _rb_eim_eval(rb_eim_eval),
+  _basis_function_index(basis_function_index_in)
 {
-  // localize the vector that stores the basis function for this assembly object,
-  // i.e. the vector that is used in evaluate_basis_function_at_quad_pts
-#ifdef LIBMESH_ENABLE_GHOSTED
-  _ghosted_basis_function->init (_rb_eim_con.get_explicit_system().n_dofs(),
-                                 _rb_eim_con.get_explicit_system().n_local_dofs(),
-                                 _rb_eim_con.get_explicit_system().get_dof_map().get_send_list(),
-                                 false,
-                                 GHOSTED);
-  _rb_eim_con.get_rb_evaluation().get_basis_function(_basis_function_index).
-    localize(*_ghosted_basis_function,
-             _rb_eim_con.get_explicit_system().get_dof_map().get_send_list());
-#else
-  _ghosted_basis_function->init (_rb_eim_con.get_explicit_system().n_dofs(), false, SERIAL);
-  _rb_eim_con.get_rb_evaluation().get_basis_function(_basis_function_index).
-    localize(*_ghosted_basis_function);
-#endif
-
-  initialize_fe();
 }
 
 RBEIMAssembly::~RBEIMAssembly()
 {
 }
 
-void RBEIMAssembly::evaluate_basis_function(unsigned int var,
-                                            const Elem & element,
-                                            const std::vector<Point> & points,
+void RBEIMAssembly::evaluate_basis_function(dof_id_type elem_id,
+                                            unsigned int comp,
                                             std::vector<Number> & values)
 {
-  LOG_SCOPE("evaluate_basis_function", "RBEIMAssembly");
-
-  const std::vector<std::vector<Real>> & phi = get_fe().get_phi();
-
-  // The FE object caches data, hence we recompute as little as
-  // possible on the call to reinit.
-  get_fe().reinit (&element, &points);
-
-  std::vector<dof_id_type> dof_indices_var;
-
-  DofMap & dof_map = get_rb_eim_construction().get_explicit_system().get_dof_map();
-  dof_map.dof_indices (&element, dof_indices_var, var);
-
-  libmesh_assert(dof_indices_var.size() == phi.size());
-
-  unsigned int n_points = points.size();
-  values.resize(n_points);
-
-  for (unsigned int pt_index=0; pt_index<n_points; pt_index++)
-    {
-      values[pt_index] = 0.;
-      for (auto i : index_range(dof_indices_var))
-        values[pt_index] += (*_ghosted_basis_function)(dof_indices_var[i]) * phi[i][pt_index];
-    }
+  get_rb_eim_evaluation().get_eim_basis_function_values_at_qps(
+    _basis_function_index, elem_id, comp, values);
 }
 
-RBEIMConstruction & RBEIMAssembly::get_rb_eim_construction()
+RBEIMEvaluation & RBEIMAssembly::get_rb_eim_evaluation()
 {
-  return _rb_eim_con;
-}
-
-NumericVector<Number> & RBEIMAssembly::get_ghosted_basis_function()
-{
-  return *_ghosted_basis_function;
-}
-
-FEBase & RBEIMAssembly::get_fe()
-{
-  return *_fe;
-}
-
-void RBEIMAssembly::initialize_fe()
-{
-  DofMap & dof_map = get_rb_eim_construction().get_explicit_system().get_dof_map();
-
-  const unsigned int dim =
-    get_rb_eim_construction().get_mesh().mesh_dimension();
-
-  FEType fe_type = dof_map.variable_type(0);
-  _fe = FEBase::build(dim, fe_type);
-
-  // Pre-request the shape function for efficieny's sake
-  _fe->get_phi();
+  return _rb_eim_eval;
 }
 
 }

--- a/src/reduced_basis/rb_eim_assembly.C
+++ b/src/reduced_basis/rb_eim_assembly.C
@@ -49,6 +49,9 @@ void RBEIMAssembly::evaluate_basis_function(dof_id_type elem_id,
 {
   get_rb_eim_construction().get_rb_eim_evaluation().get_eim_basis_function_values_at_qps(
     _basis_function_index, elem_id, comp, values);
+
+  if(values.empty())
+    libmesh_error_msg("Error: EIM basis function has no entries on this element for this processor");
 }
 
 RBEIMConstruction & RBEIMAssembly::get_rb_eim_construction()

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -264,7 +264,7 @@ void RBEIMConstruction::set_rb_construction_parameters(unsigned int n_training_s
                                  deterministic_training_in);
 }
 
-void RBEIMConstruction::train_eim_approximation()
+Real RBEIMConstruction::train_eim_approximation()
 {
   LOG_SCOPE("train_eim_approximation()", "RBConstruction");
 
@@ -283,6 +283,7 @@ void RBEIMConstruction::train_eim_approximation()
     }
 
   libMesh::out << std::endl << "---- Performing Greedy EIM basis enrichment ----" << std::endl;
+  Real abs_greedy_error = 0.;
   Real initial_greedy_error = 0.;
   bool initial_greedy_error_initialized = false;
   std::vector<RBParameters> greedy_param_list;
@@ -304,7 +305,7 @@ void RBEIMConstruction::train_eim_approximation()
 
       libMesh::out << "Computing EIM error on training set" << std::endl;
       std::pair<Real,unsigned int> max_error_pair = compute_max_eim_error();
-      Real abs_greedy_error = max_error_pair.first;
+      abs_greedy_error = max_error_pair.first;
       current_training_index = max_error_pair.second;
       set_params_from_training_set(current_training_index);
 
@@ -355,6 +356,8 @@ void RBEIMConstruction::train_eim_approximation()
             }
       }
     }
+
+  return abs_greedy_error;
 }
 
 void RBEIMConstruction::initialize_eim_assembly_objects()

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -60,6 +60,9 @@ RBEIMConstruction::RBEIMConstruction (EquationSystems & es,
     _rel_training_tolerance(1.e-4),
     _abs_training_tolerance(1.e-12)
 {
+  // The training set should be the same on all processors in the
+  // case of EIM training.
+  serial_training_set = true;
 }
 
 RBEIMConstruction::~RBEIMConstruction ()

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -633,9 +633,8 @@ void RBEIMConstruction::initialize_qp_data()
     }
 }
 
-Number RBEIMConstruction::inner_product(
-  const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & v,
-  const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & w)
+Number
+RBEIMConstruction::inner_product(const QpDataMap & v, const QpDataMap & w)
 {
   LOG_SCOPE("inner_product()", "RBEIMConstruction");
 
@@ -670,7 +669,7 @@ Number RBEIMConstruction::inner_product(
   return val;
 }
 
-Real RBEIMConstruction::get_max_abs_value(const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & v) const
+Real RBEIMConstruction::get_max_abs_value(const QpDataMap & v) const
 {
   LOG_SCOPE("get_max_abs_value()", "RBEIMConstruction");
 
@@ -871,8 +870,7 @@ Real RBEIMConstruction::compute_best_fit_error(unsigned int training_index)
 
   // Make a copy of the pre-computed solution for the specified training sample
   // since we will modify it below to compute the best fit error.
-  std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> solution =
-    _local_parametrized_functions_for_training[training_index];
+  QpDataMap solution = _local_parametrized_functions_for_training[training_index];
 
   const unsigned int RB_size = get_rb_eim_evaluation().get_n_basis_functions();
   DenseVector<Number> best_fit_coeffs;
@@ -921,7 +919,7 @@ Real RBEIMConstruction::compute_best_fit_error(unsigned int training_index)
 }
 
 void RBEIMConstruction::scale_parametrized_function(
-    std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & local_pf,
+    QpDataMap & local_pf,
     Number scaling_factor)
 {
   LOG_SCOPE("scale_parametrized_function()", "RBEIMConstruction");

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -131,7 +131,6 @@ void RBEIMConstruction::print_info()
   print_discrete_parameter_values();
   libMesh::out << "n_training_samples: " << get_n_training_samples() << std::endl;
   libMesh::out << "quiet mode? " << is_quiet() << std::endl;
-  libMesh::out << std::endl;
 
   if (best_fit_type_flag == PROJECTION_BEST_FIT)
     {

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -552,10 +552,11 @@ void RBEIMConstruction::initialize_qp_data()
         {
           Real fd_delta = get_rb_eim_evaluation().get_parametrized_function().fd_delta;
 
-          std::vector<Point> xyz_perturb_vec;
+          std::vector<std::vector<Point>> xyz_perturb_vec_at_qps;
 
           for (const Point & xyz_qp : xyz)
             {
+              std::vector<Point> xyz_perturb_vec;
               if(elem->dim() == 3)
                 {
                   Point xyz_perturb = xyz_qp;
@@ -625,9 +626,11 @@ void RBEIMConstruction::initialize_qp_data()
                   // Support for this case could be added if it is
                   // needed.
                 }
+
+              xyz_perturb_vec_at_qps.emplace_back(xyz_perturb_vec);
             }
 
-          _local_quad_point_locations[elem_id] = xyz_perturb_vec;
+          _local_quad_point_locations_perturbations[elem_id] = xyz_perturb_vec_at_qps;
         }
     }
 }

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -871,7 +871,7 @@ Real RBEIMConstruction::compute_best_fit_error(unsigned int training_index)
 
   // Make a copy of the pre-computed solution for the specified training sample
   // since we will modify it below to compute the best fit error.
-  QpDataMap solution = _local_parametrized_functions_for_training[training_index];
+  QpDataMap solution_copy = _local_parametrized_functions_for_training[training_index];
 
   const unsigned int RB_size = get_rb_eim_evaluation().get_n_basis_functions();
   DenseVector<Number> best_fit_coeffs;
@@ -885,7 +885,7 @@ Real RBEIMConstruction::compute_best_fit_error(unsigned int training_index)
         DenseVector<Number> best_fit_rhs(RB_size);
         for (unsigned int i=0; i<RB_size; i++)
           {
-            best_fit_rhs(i) = inner_product(solution, get_rb_eim_evaluation().get_basis_function(i));
+            best_fit_rhs(i) = inner_product(solution_copy, get_rb_eim_evaluation().get_basis_function(i));
           }
 
         // Now compute the best fit by an LU solve
@@ -913,9 +913,9 @@ Real RBEIMConstruction::compute_best_fit_error(unsigned int training_index)
       libmesh_error_msg("Should not reach here");
     }
 
-  get_rb_eim_evaluation().decrement_vector(solution, best_fit_coeffs);
+  get_rb_eim_evaluation().decrement_vector(solution_copy, best_fit_coeffs);
 
-  Real best_fit_error = get_max_abs_value(solution);
+  Real best_fit_error = get_max_abs_value(solution_copy);
   return best_fit_error;
 }
 

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -46,6 +46,7 @@
 // rbOOmit includes
 #include "libmesh/rb_eim_construction.h"
 #include "libmesh/rb_eim_evaluation.h"
+#include "libmesh/rb_parametrized_function.h"
 
 namespace libMesh
 {
@@ -53,70 +54,43 @@ namespace libMesh
 RBEIMConstruction::RBEIMConstruction (EquationSystems & es,
                                       const std::string & name_in,
                                       const unsigned int number_in)
-  : Parent(es, name_in, number_in),
+  : RBConstructionBase(es, name_in, number_in),
     best_fit_type_flag(PROJECTION_BEST_FIT),
-    _parametrized_functions_in_training_set_initialized(false),
-    _point_locator_tol(TOLERANCE)
+    _Nmax(0),
+    _rel_training_tolerance(1.e-4),
+    _abs_training_tolerance(1.e-12)
 {
-  _explicit_system_name = name_in + "_explicit_sys";
-
-  // We cannot do rb_solve with an empty
-  // "rb space" with EIM
-  use_empty_rb_solve_in_greedy = false;
-
-  // Indicate that we need to compute the RB
-  // inner product matrix in this case
-  compute_RB_inner_product = true;
-
-  // Indicate that we need the training set
-  // for the Greedy to be the same on all
-  // processors
-  serial_training_set = true;
-
-  // attach empty RBAssemblyExpansion object
-  set_rb_assembly_expansion(_empty_rb_assembly_expansion);
-
-  // We set implicit_neighbor_dofs = false. This is important when we use
-  // DISCONTINUOUS basis functions, since by default libMesh sets
-  // implicit_neighbor_dofs = true for "all discontinuous" systems, which
-  // results in a larger sparsity: dofs on neighboring elements are added
-  // to the sparsity pattern since this is typically required for DG or FV
-  // discretizations. Since we're only doing L2 projects here, we do not
-  // need extra dofs in the sparsity pattern, so we set implicit neighbor
-  // dofs to false.
-  get_dof_map().set_implicit_neighbor_dofs(false);
 }
 
 RBEIMConstruction::~RBEIMConstruction ()
 {
-  this->clear();
 }
 
 void RBEIMConstruction::clear()
 {
-  Parent::clear();
+  RBConstructionBase::clear();
 
-  // clear the mesh function
-  _mesh_function.reset();
-
-  // clear the eim assembly vector
   _rb_eim_assembly_objects.clear();
 
-  // clear the parametrized functions from the training set
-  _parametrized_functions_in_training_set.clear();
-  _parametrized_functions_in_training_set_initialized = false;
+  _local_parametrized_functions_for_training.clear();
+  _local_quad_point_locations.clear();
+  _local_quad_point_JxW.clear();
+  _local_quad_point_subdomain_ids.clear();
 
-  _matrix_times_bfs.clear();
+  _eim_projection_matrix.resize(0,0);
 }
 
-void RBEIMConstruction::process_parameters_file (const std::string & parameters_filename)
+void RBEIMConstruction::set_rb_eim_evaluation(RBEIMEvaluation & rb_eim_eval_in)
 {
-  Parent::process_parameters_file(parameters_filename);
+  _rb_eim_eval = &rb_eim_eval_in;
+}
 
-  GetPot infile(parameters_filename);
+RBEIMEvaluation & RBEIMConstruction::get_rb_eim_evaluation()
+{
+  if (!_rb_eim_eval)
+    libmesh_error_msg("Error: RBEIMEvaluation object hasn't been initialized yet");
 
-  std::string best_fit_type_string = infile("best_fit_type","projection");
-  set_best_fit_type_flag(best_fit_type_string);
+  return *_rb_eim_eval;
 }
 
 void RBEIMConstruction::set_best_fit_type_flag (const std::string & best_fit_type_string)
@@ -136,682 +110,259 @@ void RBEIMConstruction::set_best_fit_type_flag (const std::string & best_fit_typ
 
 void RBEIMConstruction::print_info()
 {
-  Parent::print_info();
-
-  // Print out setup info
+  // Print out info that describes the current setup
   libMesh::out << std::endl << "RBEIMConstruction parameters:" << std::endl;
+  libMesh::out << "system name: " << this->name() << std::endl;
+  libMesh::out << "Nmax: " << get_Nmax() << std::endl;
+  libMesh::out << "Greedy relative error tolerance: " << get_rel_training_tolerance() << std::endl;
+  libMesh::out << "Greedy absolute error tolerance: " << get_abs_training_tolerance() << std::endl;
+  libMesh::out << "Number of parameters: " << get_n_params() << std::endl;
+  for (const auto & pr : get_parameters())
+    if (!is_discrete_parameter(pr.first))
+      {
+        libMesh::out <<   "Parameter " << pr.first
+                     << ": Min = " << get_parameter_min(pr.first)
+                     << ", Max = " << get_parameter_max(pr.first) << std::endl;
+      }
+
+  print_discrete_parameter_values();
+  libMesh::out << "n_training_samples: " << get_n_training_samples() << std::endl;
+  libMesh::out << "quiet mode? " << is_quiet() << std::endl;
+  libMesh::out << std::endl;
+
   if (best_fit_type_flag == PROJECTION_BEST_FIT)
     {
-      libMesh::out << "best fit type: projection" << std::endl;
+      libMesh::out << "EIM best fit type: projection" << std::endl;
     }
   else
     if (best_fit_type_flag == EIM_BEST_FIT)
       {
-        libMesh::out << "best fit type: eim" << std::endl;
+        libMesh::out << "EIM best fit type: eim" << std::endl;
       }
   libMesh::out << std::endl;
 }
 
-void RBEIMConstruction::init_data()
+void RBEIMConstruction::initialize_eim_construction()
 {
-  // Add the ExplicitSystem that we use to store the EIM basis functions
-  get_equation_systems().add_system<ExplicitSystem>(_explicit_system_name);
-
-  init_implicit_system();
-  init_explicit_system();
-
-  Parent::init_data();
-}
-
-void RBEIMConstruction::initialize_rb_construction(bool skip_matrix_assembly,
-                                                   bool skip_vector_assembly)
-{
-  Parent::initialize_rb_construction(skip_matrix_assembly, skip_vector_assembly);
-
-  // initialize a serial vector that we will use for MeshFunction evaluations
-  _ghosted_meshfunction_vector = NumericVector<Number>::build(this->comm());
-  _ghosted_meshfunction_vector->init (get_explicit_system().n_dofs(), get_explicit_system().n_local_dofs(),
-                                      get_explicit_system().get_dof_map().get_send_list(), false,
-                                      GHOSTED);
-
-  // Initialize the MeshFunction for interpolating the
-  // solution vector at quadrature points
-  std::vector<unsigned int> vars;
-  get_explicit_system().get_all_variable_numbers(vars);
-  _mesh_function = libmesh_make_unique<MeshFunction>
-    (get_equation_systems(),
-     *_ghosted_meshfunction_vector,
-     get_explicit_system().get_dof_map(),
-     vars);
-  _mesh_function->init();
-
-  // inner_product_solver performs solves with the same matrix every time
-  // hence we can set reuse_preconditioner(true).
-  inner_product_solver->reuse_preconditioner(true);
-
-  init_dof_map_between_systems();
-}
-
-Real RBEIMConstruction::train_reduced_basis(const bool resize_rb_eval_data)
-{
-  // precompute all the parametrized functions that we'll use in the greedy
   initialize_parametrized_functions_in_training_set();
-
-  return Parent::train_reduced_basis(resize_rb_eval_data);
 }
 
-Number RBEIMConstruction::evaluate_mesh_function(unsigned int var_number,
-                                                 Point p)
+void RBEIMConstruction::process_parameters_file (const std::string & parameters_filename)
 {
-  // Set default values to be an empty vector so that we can use it
-  // below
-  // to check if this processor returned valid data.
-  DenseVector<Number> default_values;
-  _mesh_function->enable_out_of_mesh_mode(default_values);
+  // First read in data from input_filename
+  GetPot infile(parameters_filename);
 
-  _mesh_function->set_point_locator_tolerance( get_point_locator_tol() );
+  std::string best_fit_type_string = infile("best_fit_type","projection");
+  set_best_fit_type_flag(best_fit_type_string);
 
-  DenseVector<Number> values;
-  (*_mesh_function)(p,
-                    /*time*/ 0.,
-                    values);
+  const unsigned int n_training_samples = infile("n_training_samples",0);
+  const bool deterministic_training = infile("deterministic_training",false);
+  unsigned int training_parameters_random_seed_in =
+    static_cast<unsigned int>(-1);
+  training_parameters_random_seed_in = infile("training_parameters_random_seed",
+                                              training_parameters_random_seed_in);
+  const bool quiet_mode_in = infile("quiet_mode", quiet_mode);
+  const unsigned int Nmax_in = infile("Nmax", _Nmax);
+  const Real rel_training_tolerance_in = infile("rel_training_tolerance",
+                                                _rel_training_tolerance);
+  const Real abs_training_tolerance_in = infile("abs_training_tolerance",
+                                                _abs_training_tolerance);
 
-  // We evaluated the mesh function, but it will only return a valid set of values on one processor
-  // (values will be empty on all other processors) so we need to broadcast those valid values
-  // to all processors.
-  Number value = 0;
-  unsigned int root_id=0;
-  unsigned int check_for_valid_value = 0;
-  if (values.size() != 0)
+  // Read in the parameters from the input file too
+  unsigned int n_continuous_parameters = infile.vector_variable_size("parameter_names");
+  RBParameters mu_min_in;
+  RBParameters mu_max_in;
+  for (unsigned int i=0; i<n_continuous_parameters; i++)
     {
-      root_id = this->processor_id();
-      value = values(var_number);
-      check_for_valid_value = 1;
+      // Read in the parameter names
+      std::string param_name = infile("parameter_names", "NONE", i);
+
+      {
+        Real min_val = infile(param_name, 0., 0);
+        mu_min_in.set_value(param_name, min_val);
+      }
+
+      {
+        Real max_val = infile(param_name, 0., 1);
+        mu_max_in.set_value(param_name, max_val);
+      }
     }
 
-  // If this sum is zero, then we didn't enter the if block above on any processor. In that
-  // case we should throw an error.
-  this->comm().sum(check_for_valid_value);
-  if (check_for_valid_value == 0)
+  std::map<std::string, std::vector<Real>> discrete_parameter_values_in;
+
+  unsigned int n_discrete_parameters = infile.vector_variable_size("discrete_parameter_names");
+  for (unsigned int i=0; i<n_discrete_parameters; i++)
     {
-      libmesh_error_msg("MeshFunction evaluation failed on all processors");
+      std::string param_name = infile("discrete_parameter_names", "NONE", i);
+
+      unsigned int n_vals_for_param = infile.vector_variable_size(param_name);
+      std::vector<Real> vals_for_param(n_vals_for_param);
+      for (auto j : make_range(vals_for_param.size()))
+        vals_for_param[j] = infile(param_name, 0., j);
+
+      discrete_parameter_values_in[param_name] = vals_for_param;
     }
 
-  // root_id may be non-zero on more than one processor due to ghost elements
-  // so use this->comm().max to get just one proc id
-  this->comm().max(root_id);
+  std::map<std::string,bool> log_scaling_in;
+  // For now, just set all entries to false.
+  // TODO: Implement a decent way to specify log-scaling true/false
+  // in the input text file
+  for (const auto & pr : mu_min_in)
+    log_scaling_in[pr.first] = false;
 
-  // Then broadcast the result
-  this->comm().broadcast(value, root_id);
-
-  return value;
+  // Set the parameters that have been read in
+  set_rb_construction_parameters(n_training_samples,
+                                 deterministic_training,
+                                 training_parameters_random_seed_in,
+                                 quiet_mode_in,
+                                 Nmax_in,
+                                 rel_training_tolerance_in,
+                                 abs_training_tolerance_in,
+                                 mu_min_in,
+                                 mu_max_in,
+                                 discrete_parameter_values_in,
+                                 log_scaling_in);
 }
 
-void RBEIMConstruction::set_point_locator_tol(Real point_locator_tol)
+void RBEIMConstruction::set_rb_construction_parameters(unsigned int n_training_samples_in,
+                                                       bool deterministic_training_in,
+                                                       unsigned int training_parameters_random_seed_in,
+                                                       bool quiet_mode_in,
+                                                       unsigned int Nmax_in,
+                                                       Real rel_training_tolerance_in,
+                                                       Real abs_training_tolerance_in,
+                                                       RBParameters mu_min_in,
+                                                       RBParameters mu_max_in,
+                                                       std::map<std::string, std::vector<Real>> discrete_parameter_values_in,
+                                                       std::map<std::string,bool> log_scaling_in)
 {
-  _point_locator_tol = point_locator_tol;
+  // Read in training_parameters_random_seed value.  This is used to
+  // seed the RNG when picking the training parameters.  By default the
+  // value is -1, which means use std::time to seed the RNG.
+  set_training_random_seed(training_parameters_random_seed_in);
+
+  // Set quiet mode
+  set_quiet_mode(quiet_mode_in);
+
+  // Initialize RB parameters
+  set_Nmax(Nmax_in);
+
+  set_rel_training_tolerance(rel_training_tolerance_in);
+  set_abs_training_tolerance(abs_training_tolerance_in);
+
+  // Initialize the parameter ranges and the parameters themselves
+  initialize_parameters(mu_min_in, mu_max_in, discrete_parameter_values_in);
+
+  initialize_training_parameters(this->get_parameters_min(),
+                                 this->get_parameters_max(),
+                                 n_training_samples_in,
+                                 log_scaling_in,
+                                 deterministic_training_in);
 }
 
-Real RBEIMConstruction::get_point_locator_tol() const
+void RBEIMConstruction::train_eim_approximation()
 {
-  return _point_locator_tol;
+  LOG_SCOPE("train_eim_approximation()", "RBConstruction");
+
+  _eim_projection_matrix.resize(get_Nmax(),get_Nmax());
+
+  RBEIMEvaluation & rbe = get_rb_eim_evaluation();
+  rbe.initialize_parameters(*this);
+  rbe.resize_data_structures(get_Nmax());    
+
+  // If we are continuing from a previous training run,
+  // we might already be at the max number of basis functions.
+  // If so, we can just return.
+  if (rbe.get_n_basis_functions() > 0)
+    {
+      libmesh_error_msg("Error: We currently only support EIM training starting from an empty basis");
+    }
+
+  libMesh::out << std::endl << "---- Performing Greedy EIM basis enrichment ----" << std::endl;
+  Real initial_greedy_error = 0.;
+  bool initial_greedy_error_initialized = false;
+  std::vector<RBParameters> greedy_param_list;
+  greedy_param_list.emplace_back();
+  unsigned int current_training_index = 0;
+  set_params_from_training_set(current_training_index);
+  while (true)
+    {
+      libMesh::out << "Greedily selected parameter vector:" << std::endl;
+      print_parameters();
+      greedy_param_list.emplace_back(get_parameters());
+
+      libMesh::out << "Enriching the EIM approximation" << std::endl;
+      enrich_eim_approximation(current_training_index);
+      update_eim_matrices();
+
+      libMesh::out << std::endl << "---- Basis dimension: "
+                   << rbe.get_n_basis_functions() << " ----" << std::endl;
+
+      libMesh::out << "Computing EIM error on training set" << std::endl;
+      std::pair<Real,unsigned int> max_error_pair = compute_max_eim_error();
+      Real abs_greedy_error = max_error_pair.first;
+      current_training_index = max_error_pair.second;
+      set_params_from_training_set(current_training_index);
+
+      libMesh::out << "Maximum EIM error is " << abs_greedy_error << std::endl << std::endl;
+
+      // record the initial error
+      if (!initial_greedy_error_initialized)
+        {
+          initial_greedy_error = abs_greedy_error;
+          initial_greedy_error_initialized = true;
+        }
+
+      // Convergence and/or termination tests
+      {
+        if (rbe.get_n_basis_functions() >= this->get_Nmax())
+          {
+            libMesh::out << "Maximum number of basis functions reached: Nmax = "
+                          << get_Nmax() << std::endl;
+            break;
+          }
+
+        if (abs_greedy_error < get_abs_training_tolerance())
+          {
+            libMesh::out << "Absolute error tolerance reached." << std::endl;
+            break;
+          }
+
+        Real rel_greedy_error = abs_greedy_error/initial_greedy_error;
+        if (rel_greedy_error < get_rel_training_tolerance())
+          {
+            libMesh::out << "Relative error tolerance reached." << std::endl;
+            break;
+          }
+
+        if (rbe.get_n_basis_functions() >= this->get_Nmax())
+          {
+            libMesh::out << "Maximum number of basis functions reached: Nmax = "
+                         << get_Nmax() << std::endl;
+            break;
+          }
+
+        for (auto & param : greedy_param_list)
+          if (param == get_parameters())
+            {
+              libMesh::out << "Exiting greedy because the same parameters were selected twice"
+                           << std::endl;
+              break;
+            }
+      }
+    }
 }
 
 void RBEIMConstruction::initialize_eim_assembly_objects()
 {
   _rb_eim_assembly_objects.clear();
-  for (unsigned int i=0; i<get_rb_evaluation().get_n_basis_functions(); i++)
+  for (unsigned int i=0; i<get_rb_eim_evaluation().get_n_basis_functions(); i++)
     _rb_eim_assembly_objects.push_back(build_eim_assembly(i));
-}
-
-ExplicitSystem & RBEIMConstruction::get_explicit_system()
-{
-  return get_equation_systems().get_system<ExplicitSystem>(_explicit_system_name);
-}
-
-void RBEIMConstruction::load_basis_function(unsigned int i)
-{
-  LOG_SCOPE("load_basis_function()", "RBEIMConstruction");
-
-  libmesh_assert_less (i, get_rb_evaluation().get_n_basis_functions());
-
-  *get_explicit_system().solution = get_rb_evaluation().get_basis_function(i);
-
-  get_explicit_system().update();
-}
-
-void RBEIMConstruction::load_rb_solution()
-{
-  LOG_SCOPE("load_rb_solution()", "RBEIMConstruction");
-
-  solution->zero();
-
-  if (get_rb_evaluation().RB_solution.size() > get_rb_evaluation().get_n_basis_functions())
-    libmesh_error_msg("ERROR: System contains " << get_rb_evaluation().get_n_basis_functions() << " basis functions." \
-                      << " RB_solution vector constains " << get_rb_evaluation().RB_solution.size() << " entries." \
-                      << " RB_solution in RBConstruction::load_rb_solution is too long!");
-
-  RBEvaluation & rbe = get_rb_evaluation();
-  for (auto i : make_range(rbe.RB_solution.size()))
-    get_explicit_system().solution->add(rbe.RB_solution(i),
-                                        rbe.get_basis_function(i));
-
-  get_explicit_system().update();
 }
 
 std::vector<std::unique_ptr<ElemAssembly>> & RBEIMConstruction::get_eim_assembly_objects()
 {
   return _rb_eim_assembly_objects;
-}
-
-void RBEIMConstruction::enrich_RB_space()
-{
-  LOG_SCOPE("enrich_RB_space()", "RBEIMConstruction");
-
-  // put solution in _ghosted_meshfunction_vector so we can access it from the mesh function
-  // this allows us to compute EIM_rhs appropriately
-  get_explicit_system().solution->localize(*_ghosted_meshfunction_vector,
-                                           get_explicit_system().get_dof_map().get_send_list());
-
-  RBEIMEvaluation & eim_eval = cast_ref<RBEIMEvaluation &>(get_rb_evaluation());
-
-  // If we have at least one basis function we need to use
-  // rb_solve to find the EIM interpolation error, otherwise just use solution as is
-  if (get_rb_evaluation().get_n_basis_functions() > 0)
-    {
-      // get the right-hand side vector for the EIM approximation
-      // by sampling the parametrized function (stored in solution)
-      // at the interpolation points
-      unsigned int RB_size = get_rb_evaluation().get_n_basis_functions();
-      DenseVector<Number> EIM_rhs(RB_size);
-      for (unsigned int i=0; i<RB_size; i++)
-        {
-          EIM_rhs(i) = evaluate_mesh_function( eim_eval.interpolation_points_var[i],
-                                               eim_eval.interpolation_points[i] );
-        }
-
-      eim_eval.set_parameters( get_parameters() );
-      eim_eval.rb_solve(EIM_rhs);
-
-      // Load the "EIM residual" into solution by subtracting
-      // the EIM approximation
-      for (unsigned int i=0; i<get_rb_evaluation().get_n_basis_functions(); i++)
-        {
-          get_explicit_system().solution->add(-eim_eval.RB_solution(i), get_rb_evaluation().get_basis_function(i));
-        }
-    }
-
-  // need to update since context uses current_local_solution
-  get_explicit_system().update();
-
-  // Find the quadrature point at which solution (which now stores
-  // the "EIM residual") has maximum absolute value
-  // by looping over the mesh
-  Point optimal_point;
-  Number optimal_value = 0.;
-  unsigned int optimal_var = 0;
-  dof_id_type optimal_elem_id = DofObject::invalid_id;
-
-  // Initialize largest_abs_value to be negative so that it definitely gets updated.
-  Real largest_abs_value = -1.;
-
-  // Compute truth representation via projection
-  MeshBase & mesh = this->get_mesh();
-
-  std::unique_ptr<DGFEMContext> explicit_c = libmesh_make_unique<DGFEMContext>(get_explicit_system());
-  DGFEMContext & explicit_context = cast_ref<DGFEMContext &>(*explicit_c);
-
-  // Pre-request required data
-  init_context_with_sys(explicit_context, get_explicit_system());
-
-  // Get local reference to xyz data for variable 0. This is needed in
-  // the loop below, but we cannot call elem_fe->get_xyz() once
-  // calculations have already started. Note: We don't need a separate
-  // "xyz" for each var, since all vars should be using the same
-  // quadrature rule.
-  FEBase * elem_fe = nullptr;
-  explicit_context.get_element_fe( 0, elem_fe );
-  const std::vector<Point> & xyz = elem_fe->get_xyz();
-
-  for (const auto & elem : mesh.active_local_element_ptr_range())
-    {
-      explicit_context.pre_fe_reinit(get_explicit_system(), elem);
-      explicit_context.elem_fe_reinit();
-
-      for (unsigned int var=0; var<get_explicit_system().n_vars(); var++)
-        {
-          unsigned int n_qpoints = explicit_context.get_element_qrule().n_points();
-
-          for (unsigned int qp=0; qp<n_qpoints; qp++)
-            {
-              Number value = explicit_context.interior_value(var, qp);
-              Real abs_value = std::abs(value);
-
-              if (abs_value > largest_abs_value)
-                {
-                  optimal_value = value;
-                  largest_abs_value = abs_value;
-                  optimal_var = var;
-                  optimal_elem_id = elem->id();
-                  optimal_point = xyz[qp];
-                }
-            }
-        }
-    }
-
-  // Find out which processor has the largest of the abs values
-  unsigned int proc_ID_index;
-  this->comm().maxloc(largest_abs_value, proc_ID_index);
-
-  // Broadcast the optimal point from proc_ID_index
-  this->comm().broadcast(optimal_point, proc_ID_index);
-
-  // Also broadcast the corresponding optimal_var, optimal_value, and optimal_elem_id
-  this->comm().broadcast(optimal_var, proc_ID_index);
-  this->comm().broadcast(optimal_value, proc_ID_index);
-  this->comm().broadcast(optimal_elem_id, proc_ID_index);
-
-  // In debug mode, assert that we found an optimal_elem_id
-  libmesh_assert_not_equal_to(optimal_elem_id, DofObject::invalid_id);
-
-  // Scale the solution
-  get_explicit_system().solution->scale(1./optimal_value);
-
-  // Store optimal point in interpolation_points
-  eim_eval.interpolation_points.push_back(optimal_point);
-  eim_eval.interpolation_points_var.push_back(optimal_var);
-  Elem * elem_ptr = mesh.elem_ptr(optimal_elem_id);
-  eim_eval.interpolation_points_elem.push_back( elem_ptr );
-
-  {
-    auto new_bf = NumericVector<Number>::build(this->comm());
-    new_bf->init (get_explicit_system().n_dofs(), get_explicit_system().n_local_dofs(), false, PARALLEL);
-    *new_bf = *get_explicit_system().solution;
-    get_rb_evaluation().basis_functions.emplace_back( std::move(new_bf) );
-  }
-
-  if (best_fit_type_flag == PROJECTION_BEST_FIT)
-    {
-      // In order to speed up dot products, we store the product
-      // of the basis function and the inner product matrix
-
-      std::unique_ptr<NumericVector<Number>> implicit_sys_temp1 = this->solution->zero_clone();
-      std::unique_ptr<NumericVector<Number>> implicit_sys_temp2 = this->solution->zero_clone();
-      auto matrix_times_new_bf = get_explicit_system().solution->zero_clone();
-
-      // We must localize new_bf before calling get_explicit_sys_subvector
-      std::unique_ptr<NumericVector<Number>> localized_new_bf =
-        NumericVector<Number>::build(this->comm());
-      localized_new_bf->init(get_explicit_system().n_dofs(), false, SERIAL);
-      get_rb_evaluation().basis_functions.back()->localize(*localized_new_bf);
-
-      for (unsigned int var=0; var<get_explicit_system().n_vars(); var++)
-        {
-          get_explicit_sys_subvector(*implicit_sys_temp1,
-                                     var,
-                                     *localized_new_bf);
-
-          inner_product_matrix->vector_mult(*implicit_sys_temp2, *implicit_sys_temp1);
-
-          set_explicit_sys_subvector(*matrix_times_new_bf,
-                                     var,
-                                     *implicit_sys_temp2);
-        }
-
-      _matrix_times_bfs.emplace_back(std::move(matrix_times_new_bf));
-    }
-}
-
-void RBEIMConstruction::initialize_parametrized_functions_in_training_set()
-{
-  if (!serial_training_set)
-    libmesh_error_msg("Error: We must have serial_training_set==true in " \
-                      << "RBEIMConstruction::initialize_parametrized_functions_in_training_set");
-
-  libMesh::out << "Initializing parametrized functions in training set..." << std::endl;
-  // initialize rb_eval's parameters
-  get_rb_evaluation().initialize_parameters(*this);
-
-  _parametrized_functions_in_training_set.resize( get_n_training_samples() );
-  for (unsigned int i=0; i<get_n_training_samples(); i++)
-    {
-      set_params_from_training_set(i);
-      truth_solve(-1);
-
-      _parametrized_functions_in_training_set[i] = get_explicit_system().solution->clone();
-
-      libMesh::out << "Completed solve for training sample " << (i+1) << " of " << get_n_training_samples() << std::endl;
-    }
-
-  _parametrized_functions_in_training_set_initialized = true;
-
-  libMesh::out << "Parametrized functions in training set initialized" << std::endl << std::endl;
-}
-
-void RBEIMConstruction::plot_parametrized_functions_in_training_set(const std::string & pathname)
-{
-  // Ignore unused parameter warnings when Exodus is not available.
-  libmesh_ignore(pathname);
-
-  libmesh_assert(_parametrized_functions_in_training_set_initialized);
-
-  for (auto i : index_range(_parametrized_functions_in_training_set))
-    {
-#ifdef LIBMESH_HAVE_EXODUS_API
-      *get_explicit_system().solution = *_parametrized_functions_in_training_set[i];
-
-      std::stringstream pathname_i;
-      pathname_i << pathname << "_" << i << ".exo";
-
-      std::set<std::string> system_names;
-      system_names.insert(get_explicit_system().name());
-      ExodusII_IO(get_mesh()).write_equation_systems (pathname_i.str(),
-                                                      this->get_equation_systems(),
-                                                      &system_names);
-      libMesh::out << "Plotted parameterized function " << i << std::endl;
-#endif
-    }
-}
-
-bool RBEIMConstruction::check_if_zero_truth_solve()
-{
-  return (get_explicit_system().solution->l2_norm() == 0.);
-}
-
-Real RBEIMConstruction::compute_best_fit_error()
-{
-  LOG_SCOPE("compute_best_fit_error()", "RBEIMConstruction");
-
-  const unsigned int RB_size = get_rb_evaluation().get_n_basis_functions();
-
-  // load up the parametrized function for the current parameters
-  truth_solve(-1);
-
-  switch(best_fit_type_flag)
-    {
-      // Perform an L2 projection in order to find an approximation to solution (from truth_solve above)
-    case(PROJECTION_BEST_FIT):
-      {
-        // We have pre-stored inner_product_matrix * basis_function[i] for each i
-        // so we can just evaluate the dot product here.
-        DenseVector<Number> best_fit_rhs(RB_size);
-        for (unsigned int i=0; i<RB_size; i++)
-          {
-            best_fit_rhs(i) = get_explicit_system().solution->dot(*_matrix_times_bfs[i]);
-          }
-
-        // Now compute the best fit by an LU solve
-        get_rb_evaluation().RB_solution.resize(RB_size);
-        DenseMatrix<Number> RB_inner_product_matrix_N(RB_size);
-        get_rb_evaluation().RB_inner_product_matrix.get_principal_submatrix(RB_size, RB_inner_product_matrix_N);
-
-        RB_inner_product_matrix_N.lu_solve(best_fit_rhs, get_rb_evaluation().RB_solution);
-        break;
-      }
-      // Perform EIM solve in order to find the approximation to solution
-      // (rb_solve provides the EIM basis function coefficients used below)
-    case(EIM_BEST_FIT):
-      {
-        // Turn off error estimation for this rb_solve, we use the linfty norm instead
-        get_rb_evaluation().evaluate_RB_error_bound = false;
-        get_rb_evaluation().set_parameters( get_parameters() );
-        get_rb_evaluation().rb_solve(RB_size);
-        get_rb_evaluation().evaluate_RB_error_bound = true;
-        break;
-      }
-    default:
-      libmesh_error_msg("Should not reach here");
-    }
-
-  // load the error into solution
-  for (unsigned int i=0; i<get_rb_evaluation().get_n_basis_functions(); i++)
-    get_explicit_system().solution->add(-get_rb_evaluation().RB_solution(i),
-                                        get_rb_evaluation().get_basis_function(i));
-
-  Real best_fit_error = get_explicit_system().solution->linfty_norm();
-
-  return best_fit_error;
-}
-
-Real RBEIMConstruction::truth_solve(int plot_solution)
-{
-  LOG_SCOPE("truth_solve()", "RBEIMConstruction");
-
-  int training_parameters_found_index = -1;
-  if (_parametrized_functions_in_training_set_initialized)
-    {
-      // Check if parameters are in the training set. If so, we can just load the
-      // solution from _parametrized_functions_in_training_set
-
-      for (unsigned int i=0; i<get_n_training_samples(); i++)
-        {
-          if (get_parameters() == get_params_from_training_set(i))
-            {
-              training_parameters_found_index = i;
-              break;
-            }
-        }
-    }
-
-  // If the parameters are in the training set, just copy the solution vector
-  if (training_parameters_found_index >= 0)
-    {
-      *get_explicit_system().solution =
-        *_parametrized_functions_in_training_set[training_parameters_found_index];
-      get_explicit_system().update(); // put the solution into current_local_solution as well
-    }
-  // Otherwise, we have to compute the projection
-  else
-    {
-      if (this->n_vars() != 1)
-        {
-          libmesh_error_msg("The system that we use to perform EIM L2 solves should have one variable");
-        }
-
-      RBEIMEvaluation & eim_eval = cast_ref<RBEIMEvaluation &>(get_rb_evaluation());
-      eim_eval.set_parameters( get_parameters() );
-
-      // Compute truth representation via L2 projection
-      const MeshBase & mesh = this->get_mesh();
-
-      std::unique_ptr<DGFEMContext> c = libmesh_make_unique<DGFEMContext>(*this);
-      DGFEMContext & context = cast_ref<DGFEMContext &>(*c);
-
-      // Pre-request required data
-      init_context_with_sys(context, *this);
-
-      // Get local references to context data (will be updated each
-      // time elem_fe_reinit() is called).
-      FEBase * elem_fe = nullptr;
-      context.get_element_fe( 0, elem_fe );
-      const std::vector<Real> & JxW = elem_fe->get_JxW();
-      const std::vector<std::vector<Real>> & phi = elem_fe->get_phi();
-      const std::vector<Point> & xyz = elem_fe->get_xyz();
-
-      // First cache all the element data
-      std::vector<std::vector<std::vector<Number>>> parametrized_fn_vals(mesh.n_elem());
-      std::vector<std::vector<Real>> JxW_values(mesh.n_elem());
-      std::vector<std::vector<std::vector<Real>>> phi_values(mesh.n_elem());
-
-      for (const auto & elem : mesh.active_local_element_ptr_range())
-        {
-          dof_id_type elem_id = elem->id();
-
-          // Recompute values for current Elem
-          context.pre_fe_reinit(*this, elem);
-          context.elem_fe_reinit();
-
-          // Loop over qp before var because parametrized functions often use
-          // some caching based on qp.
-          unsigned int n_qpoints = context.get_element_qrule().n_points();
-          parametrized_fn_vals[elem_id].resize(n_qpoints);
-          JxW_values[elem_id].resize(n_qpoints);
-          phi_values[elem_id].resize(n_qpoints);
-          for (unsigned int qp=0; qp<n_qpoints; qp++)
-            {
-              JxW_values[elem_id][qp] = JxW[qp];
-
-              unsigned int n_var_dofs = cast_int<unsigned int>(context.get_dof_indices().size());
-              phi_values[elem_id][qp].resize(n_var_dofs);
-              for (unsigned int i=0; i != n_var_dofs; i++)
-                {
-                  phi_values[elem_id][qp][i] = phi[i][qp];
-                }
-
-              parametrized_fn_vals[elem_id][qp].resize(get_explicit_system().n_vars());
-              for (unsigned int var=0; var<get_explicit_system().n_vars(); var++)
-                {
-                  Number eval_result = eim_eval.evaluate_parametrized_function(var, xyz[qp], *elem);
-                  parametrized_fn_vals[elem_id][qp][var] = eval_result;
-                }
-            }
-        }
-
-      // We do a distinct solve for each variable in the ExplicitSystem
-      for (unsigned int var=0; var<get_explicit_system().n_vars(); var++)
-        {
-          rhs->zero();
-
-          for (const auto & elem : mesh.active_local_element_ptr_range())
-            {
-              dof_id_type elem_id = elem->id();
-
-              context.pre_fe_reinit(*this, elem);
-              //context.elem_fe_reinit(); <--- skip this because we cached all the FE data
-
-              // Loop over qp before var because parametrized functions often use
-              // some caching based on qp.
-              for (auto qp : index_range(JxW_values[elem_id]))
-                {
-                  const unsigned int n_var_dofs =
-                    cast_int<unsigned int>(phi_values[elem_id][qp].size());
-
-                  Number eval_result = parametrized_fn_vals[elem_id][qp][var];
-                  for (unsigned int i=0; i != n_var_dofs; i++)
-                    {
-                      context.get_elem_residual()(i) +=
-                        JxW_values[elem_id][qp] * eval_result * phi_values[elem_id][qp][i];
-                    }
-                }
-
-              // Apply constraints, e.g. periodic constraints
-              this->get_dof_map().constrain_element_vector(context.get_elem_residual(), context.get_dof_indices() );
-
-              // Add element vector to global vector
-              rhs->add_vector(context.get_elem_residual(), context.get_dof_indices() );
-            }
-
-          // Solve to find the best fit, then solution stores the truth representation
-          // of the function to be approximated
-          solve_for_matrix_and_rhs(*inner_product_solver, *inner_product_matrix, *rhs);
-
-          if (assert_convergence)
-            check_convergence(*inner_product_solver);
-
-          // Now copy the solution to the explicit system's solution.
-          set_explicit_sys_subvector(*get_explicit_system().solution, var, *solution);
-        }
-      get_explicit_system().update();
-    }
-
-  if (plot_solution > 0)
-    {
-#ifdef LIBMESH_HAVE_EXODUS_API
-      ExodusII_IO(get_mesh()).write_equation_systems ("truth.exo",
-                                                      this->get_equation_systems());
-#endif
-    }
-
-  return 0.;
-}
-
-void RBEIMConstruction::init_context_with_sys(FEMContext & c, System & sys)
-{
-  // default implementation of init_context for compute_best_fit. We
-  // pre-request FE data for all element dimensions present in the
-  // mesh.
-  for (int dim=1; dim<=3; ++dim)
-    if (sys.get_mesh().elem_dimensions().count(dim))
-      for (unsigned int var=0; var<sys.n_vars(); var++)
-        {
-          auto elem_fe = c.get_element_fe(var, dim);
-          elem_fe->get_JxW();
-          elem_fe->get_phi();
-          elem_fe->get_xyz();
-
-          // Explicitly request nothing to be computed for sides.
-          auto side_fe = c.get_side_fe(var, dim);
-          side_fe->get_nothing();
-        }
-}
-
-void RBEIMConstruction::update_RB_system_matrices()
-{
-  LOG_SCOPE("update_RB_system_matrices()", "RBEIMConstruction");
-
-  // First, update the inner product matrix
-  {
-    unsigned int RB_size = get_rb_evaluation().get_n_basis_functions();
-
-    std::unique_ptr<NumericVector<Number>> explicit_sys_temp =
-      get_explicit_system().solution->zero_clone();
-
-    std::unique_ptr<NumericVector<Number>> temp1 = this->solution->zero_clone();
-    std::unique_ptr<NumericVector<Number>> temp2 = this->solution->zero_clone();
-
-    for (unsigned int i=(RB_size-1); i<RB_size; i++)
-      {
-        for (unsigned int j=0; j<RB_size; j++)
-          {
-            // We must localize get_rb_evaluation().get_basis_function(j) before calling
-            // get_explicit_sys_subvector
-            std::unique_ptr<NumericVector<Number>> localized_basis_function =
-              NumericVector<Number>::build(this->comm());
-            localized_basis_function->init(get_explicit_system().n_dofs(), false, SERIAL);
-            get_rb_evaluation().get_basis_function(j).localize(*localized_basis_function);
-
-            // Compute reduced inner_product_matrix via a series of matvecs
-            for (unsigned int var=0; var<get_explicit_system().n_vars(); var++)
-              {
-                get_explicit_sys_subvector(*temp1, var, *localized_basis_function);
-                inner_product_matrix->vector_mult(*temp2, *temp1);
-                set_explicit_sys_subvector(*explicit_sys_temp, var, *temp2);
-              }
-
-            Number value = explicit_sys_temp->dot( get_rb_evaluation().get_basis_function(i) );
-            get_rb_evaluation().RB_inner_product_matrix(i,j) = value;
-            if (i!=j)
-              {
-                // The inner product matrix is assumed
-                // to be hermitian
-                get_rb_evaluation().RB_inner_product_matrix(j,i) = libmesh_conj(value);
-              }
-          }
-      }
-  }
-
-  unsigned int RB_size = get_rb_evaluation().get_n_basis_functions();
-
-  RBEIMEvaluation & eim_eval = cast_ref<RBEIMEvaluation &>(get_rb_evaluation());
-
-  // update the EIM interpolation matrix
-  for (unsigned int j=0; j<RB_size; j++)
-    {
-      // Sample the basis functions at the
-      // new interpolation point
-      get_rb_evaluation().get_basis_function(j).localize(*_ghosted_meshfunction_vector,
-                                                         get_explicit_system().get_dof_map().get_send_list());
-
-      eim_eval.interpolation_matrix(RB_size-1,j) =
-        evaluate_mesh_function( eim_eval.interpolation_points_var[RB_size-1],
-                                eim_eval.interpolation_points[RB_size-1] );
-    }
-}
-
-Real RBEIMConstruction::get_RB_error_bound()
-{
-  Real best_fit_error = compute_best_fit_error();
-  return best_fit_error;
 }
 
 void RBEIMConstruction::init_context(FEMContext & c)
@@ -829,104 +380,449 @@ void RBEIMConstruction::init_context(FEMContext & c)
       {
         auto fe = c.get_element_fe(var, dim);
         fe->get_JxW();
-        fe->get_phi();
         fe->get_xyz();
 
         auto side_fe = c.get_side_fe(var, dim);
         side_fe->get_JxW();
-        side_fe->get_phi();
         side_fe->get_xyz();
       }
 }
 
-void RBEIMConstruction::update_system()
+void RBEIMConstruction::set_rel_training_tolerance(Real new_training_tolerance)
 {
-  libMesh::out << "Updating RB matrices" << std::endl;
-  update_RB_system_matrices();
+  _rel_training_tolerance = new_training_tolerance;
 }
 
-void RBEIMConstruction::set_explicit_sys_subvector(NumericVector<Number> & dest,
-                                                   unsigned int var,
-                                                   NumericVector<Number> & source)
+Real RBEIMConstruction::get_rel_training_tolerance()
 {
-  LOG_SCOPE("set_explicit_sys_subvector()", "RBEIMConstruction");
-
-  // For convenience we localize the source vector first to make it easier to
-  // copy over (no need to do distinct send/receives).
-  std::unique_ptr<NumericVector<Number>> localized_source =
-    NumericVector<Number>::build(this->comm());
-  localized_source->init(this->n_dofs(), false, SERIAL);
-  source.localize(*localized_source);
-
-  for (auto i : make_range(_dof_map_between_systems[var].size()))
-    {
-      dof_id_type implicit_sys_dof_index = i;
-      dof_id_type explicit_sys_dof_index = _dof_map_between_systems[var][i];
-
-      if ((dest.first_local_index() <= explicit_sys_dof_index) &&
-          (explicit_sys_dof_index < dest.last_local_index()))
-        dest.set(explicit_sys_dof_index,
-                 (*localized_source)(implicit_sys_dof_index));
-    }
-
-  dest.close();
+  return _rel_training_tolerance;
 }
 
-void RBEIMConstruction::get_explicit_sys_subvector(NumericVector<Number> & dest,
-                                                   unsigned int var,
-                                                   NumericVector<Number> & localized_source)
+void RBEIMConstruction::set_abs_training_tolerance(Real new_training_tolerance)
 {
-  LOG_SCOPE("get_explicit_sys_subvector()", "RBEIMConstruction");
-
-  for (auto i : make_range(_dof_map_between_systems[var].size()))
-    {
-      dof_id_type implicit_sys_dof_index = i;
-      dof_id_type explicit_sys_dof_index = _dof_map_between_systems[var][i];
-
-      if ((dest.first_local_index() <= implicit_sys_dof_index) &&
-          (implicit_sys_dof_index < dest.last_local_index()))
-        dest.set(implicit_sys_dof_index,
-                 localized_source(explicit_sys_dof_index));
-    }
-
-  dest.close();
+  _abs_training_tolerance = new_training_tolerance;
 }
 
-void RBEIMConstruction::init_dof_map_between_systems()
+Real RBEIMConstruction::get_abs_training_tolerance()
 {
-  LOG_SCOPE("init_dof_map_between_systems()", "RBEIMConstruction");
+  return _abs_training_tolerance;
+}
 
-  unsigned int n_vars = get_explicit_system().n_vars();
-  unsigned int n_sys_dofs = this->n_dofs();
+unsigned int RBEIMConstruction::get_Nmax() const
+{
+  return _Nmax;
+}
 
-  _dof_map_between_systems.resize(n_vars);
-  for (unsigned int var=0; var<n_vars; var++)
+void RBEIMConstruction::set_Nmax(unsigned int Nmax)
+{
+  _Nmax = Nmax;
+}
+
+std::pair<Real,unsigned int> RBEIMConstruction::compute_max_eim_error()
+{
+  LOG_SCOPE("compute_max_eim_error()", "RBEIMConstruction");
+
+  if (get_n_params() == 0)
     {
-      _dof_map_between_systems[var].resize(n_sys_dofs);
+      // Just return 0 if we have no parameters.
+      return std::make_pair(0.,0);
     }
 
-  std::vector<dof_id_type> implicit_sys_dof_indices;
-  std::vector<dof_id_type> explicit_sys_dof_indices;
+  // keep track of the maximum error
+  unsigned int max_err_index = 0;
+  Real max_err = 0.;
 
-  for (const auto & elem : get_mesh().active_element_ptr_range())
+  if (get_n_training_samples() != get_local_n_training_samples())
+    libmesh_error_msg("Error: Training samples should be the same on all procs");
+
+  for (unsigned int i=0; i<get_n_training_samples(); i++)
     {
-      this->get_dof_map().dof_indices (elem, implicit_sys_dof_indices);
+      Real best_fit_error = compute_best_fit_error(i);
 
-      const std::size_t n_dofs = implicit_sys_dof_indices.size();
-
-      for (unsigned int var=0; var<n_vars; var++)
+      if (best_fit_error > max_err)
         {
-          get_explicit_system().get_dof_map().dof_indices (elem, explicit_sys_dof_indices, var);
+          max_err_index = i;
+          max_err = best_fit_error;
+        }
+    }
 
-          libmesh_assert(explicit_sys_dof_indices.size() == n_dofs);
+  return std::make_pair(max_err,max_err_index);
+}
 
-          for (std::size_t i=0; i<n_dofs; i++)
+void RBEIMConstruction::initialize_parametrized_functions_in_training_set()
+{
+  LOG_SCOPE("initialize_parametrized_functions_in_training_set()", "RBEIMConstruction");
+
+  if (!serial_training_set)
+    libmesh_error_msg("Error: We must have serial_training_set==true in " \
+                      << "RBEIMConstruction::initialize_parametrized_functions_in_training_set");
+
+  libMesh::out << "Initializing parametrized functions in training set..." << std::endl;
+
+  // Store the locations of all quadrature points
+  initialize_qp_data();
+
+  RBEIMEvaluation & eim_eval = get_rb_eim_evaluation();
+
+  _local_parametrized_functions_for_training.resize( get_n_training_samples() );
+  for (unsigned int i=0; i<get_n_training_samples(); i++)
+    {
+      libMesh::out << "Initializing parametrized function for training sample "
+        << (i+1) << " of " << get_n_training_samples() << std::endl;
+
+      set_params_from_training_set(i);
+      eim_eval.get_parametrized_function().preevaluate_parametrized_function(get_parameters(),
+                                                                             _local_quad_point_locations,
+                                                                             _local_quad_point_subdomain_ids);
+
+      unsigned int n_comps = eim_eval.get_parametrized_function().get_n_components();
+
+      for (const auto local_quad_point_locations_it : _local_quad_point_locations)
+      {
+        dof_id_type elem_id = local_quad_point_locations_it.first;
+        const auto & xyz_vector = local_quad_point_locations_it.second;
+
+        std::vector<std::vector<Number>> comps_and_qps(n_comps);
+        for (unsigned int comp=0; comp<n_comps; comp++)
+          {
+            comps_and_qps[comp].resize(xyz_vector.size());
+            for (unsigned int qp : index_range(xyz_vector))
+              {
+                comps_and_qps[comp][qp] =
+                  eim_eval.get_parametrized_function().lookup_preevaluated_value(comp, elem_id, qp);
+              }
+          }
+
+        _local_parametrized_functions_for_training[i][elem_id] = comps_and_qps;
+      }
+    }
+
+  libMesh::out << "Parametrized functions in training set initialized" << std::endl << std::endl;
+}
+
+void RBEIMConstruction::initialize_qp_data()
+{
+  LOG_SCOPE("initialize_qp_data()", "RBEIMConstruction");
+
+  // Compute truth representation via L2 projection
+  const MeshBase & mesh = this->get_mesh();
+
+  FEMContext context(*this);
+  init_context(context);
+
+  FEBase * elem_fe = nullptr;
+  context.get_element_fe( 0, elem_fe );
+  const std::vector<Real> & JxW = elem_fe->get_JxW();
+  const std::vector<Point> & xyz = elem_fe->get_xyz();
+
+  _local_quad_point_locations.clear();
+  _local_quad_point_subdomain_ids.clear();
+  _local_quad_point_JxW.clear();
+
+  for (const auto & elem : mesh.active_local_element_ptr_range())
+    {
+      dof_id_type elem_id = elem->id();
+
+      context.pre_fe_reinit(*this, elem);
+      context.elem_fe_reinit();
+
+      _local_quad_point_locations[elem_id] = xyz;
+      _local_quad_point_JxW[elem_id] = JxW;
+      _local_quad_point_subdomain_ids[elem_id] = elem->subdomain_id();
+    }
+}
+
+Number RBEIMConstruction::inner_product(
+  const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & v,
+  const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & w)
+{
+  LOG_SCOPE("inner_product()", "RBEIMConstruction");
+
+  Number val = 0.;
+
+  for (const auto v_it : v)
+    {
+      dof_id_type elem_id = v_it.first;
+      const auto & v_comp_and_qp = v_it.second;
+
+      auto w_comp_and_qp_it = w.find(elem_id);
+      if(w_comp_and_qp_it == w.end())
+        libmesh_error_msg("Error: elem_id not found");
+      const auto & w_comp_and_qp = w_comp_and_qp_it->second;
+
+      auto _local_quad_point_JxW_it = _local_quad_point_JxW.find(elem_id);
+      if(w_comp_and_qp_it == w.end())
+        libmesh_error_msg("Error: elem_id not found");
+      const auto & JxW = _local_quad_point_JxW_it->second;
+
+      for (const auto & comp : index_range(v_comp_and_qp))
+        {
+          const std::vector<Number> & v_qp = v_comp_and_qp[comp];
+          const std::vector<Number> & w_qp = w_comp_and_qp[comp];
+
+          for (unsigned int qp : index_range(JxW))
+            val += JxW[qp] * v_qp[qp] * w_qp[qp];
+        }
+    }
+
+  comm().sum(val);
+  return val;
+}
+
+Real RBEIMConstruction::get_max_abs_value(const std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & v) const
+{
+  LOG_SCOPE("get_max_abs_value()", "RBEIMConstruction");
+
+  Real max_value = 0.;
+
+  for (const auto v_it : v)
+    {
+      const auto & v_comp_and_qp = v_it.second;
+
+      for (const auto & comp : index_range(v_comp_and_qp))
+        {
+          const std::vector<Number> & v_qp = v_comp_and_qp[comp];
+          for (Number value : v_qp)
+            max_value = std::max(max_value, std::abs(value));
+        }
+    }
+
+  comm().max(max_value);
+  return max_value;
+}
+
+void RBEIMConstruction::enrich_eim_approximation(unsigned int training_index)
+{
+  LOG_SCOPE("enrich_eim_approximation()", "RBEIMConstruction");
+
+  RBEIMEvaluation & eim_eval = get_rb_eim_evaluation();
+
+  set_params_from_training_set(training_index);
+
+  // Make a copy of the parametrized function for training index, since we
+  // will modify this below to give us a new basis function.
+  auto local_pf = _local_parametrized_functions_for_training[training_index];
+
+  // If we have at least one basis function, then we need to use
+  // rb_eim_solve() to find the EIM interpolation error. Otherwise,
+  // just use solution as is.
+  if (get_rb_eim_evaluation().get_n_basis_functions() > 0)
+    {
+      // Get the right-hand side vector for the EIM approximation
+      // by sampling the parametrized function (stored in solution)
+      // at the interpolation points.
+      unsigned int RB_size = get_rb_eim_evaluation().get_n_basis_functions();
+      DenseVector<Number> EIM_rhs(RB_size);
+      for (unsigned int i=0; i<RB_size; i++)
+        {
+          EIM_rhs(i) =
+            RBEIMEvaluation::get_parametrized_function_value(comm(),
+                                                             local_pf,
+                                                             eim_eval.get_interpolation_points_elem_id(i),
+                                                             eim_eval.get_interpolation_points_comp(i),
+                                                             eim_eval.get_interpolation_points_qp(i));
+        }
+
+      eim_eval.set_parameters( get_parameters() );
+      eim_eval.rb_eim_solve(EIM_rhs);
+
+      // Load the "EIM residual" into solution by subtracting
+      // the EIM approximation
+      get_rb_eim_evaluation().decrement_vector(local_pf, eim_eval.get_rb_eim_solution());
+    }
+
+  // Find the quadrature point at which local_pf (which now stores
+  // the "EIM residual") has maximum absolute value
+  Number optimal_value = 0.;
+  Point optimal_point;
+  unsigned int optimal_comp = 0;
+  dof_id_type optimal_elem_id = DofObject::invalid_id;
+  subdomain_id_type optimal_subdomain_id = 0;
+  unsigned int optimal_qp = 0;
+
+  // Initialize largest_abs_value to be negative so that it definitely gets updated.
+  Real largest_abs_value = -1.;
+
+  for (const auto local_pf_it : local_pf)
+    {
+      dof_id_type elem_id = local_pf_it.first;
+      const auto & comp_and_qp = local_pf_it.second;
+
+      for (const auto & comp : index_range(comp_and_qp))
+        {
+          const std::vector<Number> & qp_values = comp_and_qp[comp];
+
+          for (unsigned int qp : index_range(qp_values))
             {
-              dof_id_type implicit_sys_dof_index = implicit_sys_dof_indices[i];
-              dof_id_type explicit_sys_dof_index = explicit_sys_dof_indices[i];
+              Number value = qp_values[qp];
+              Real abs_value = std::abs(value);
 
-              _dof_map_between_systems[var][implicit_sys_dof_index] =
-                explicit_sys_dof_index;
+              if (abs_value > largest_abs_value)
+                {
+                  largest_abs_value = abs_value;
+                  optimal_value = value;
+                  optimal_comp = comp;
+                  optimal_elem_id = elem_id;
+                  optimal_qp = qp;
+
+                  auto point_it = _local_quad_point_locations.find(elem_id);
+                  if(point_it == _local_quad_point_locations.end())
+                    libmesh_error_msg("Error: Invalid element ID");
+                  if(qp >= point_it->second.size())
+                    libmesh_error_msg("Error: Invalid qp");
+                  optimal_point = point_it->second[qp];
+
+                  auto subdomain_it = _local_quad_point_subdomain_ids.find(elem_id);
+                  if(subdomain_it == _local_quad_point_subdomain_ids.end())
+                    libmesh_error_msg("Error: Invalid element ID");
+                  optimal_subdomain_id = subdomain_it->second;
+                }
+            }
+        }
+    }
+
+  // Find out which processor has the largest of the abs values
+  // and broadcast from that processor.
+  unsigned int proc_ID_index;
+  this->comm().maxloc(largest_abs_value, proc_ID_index);
+
+  this->comm().broadcast(optimal_value, proc_ID_index);
+  this->comm().broadcast(optimal_point, proc_ID_index);
+  this->comm().broadcast(optimal_comp, proc_ID_index);
+  this->comm().broadcast(optimal_elem_id, proc_ID_index);
+  this->comm().broadcast(optimal_subdomain_id, proc_ID_index);
+  this->comm().broadcast(optimal_qp, proc_ID_index);
+
+  if (optimal_elem_id == DofObject::invalid_id)
+    libmesh_error_msg("Error: Invalid element ID");
+
+  // Scale local_pf so that its largest value is 1.0
+  scale_parametrized_function(local_pf, 1./optimal_value);
+
+  // Add local_pf as the new basis function and store data
+  // associated with the interpolation point.
+  eim_eval.add_basis_function_and_interpolation_data(local_pf,
+                                                     optimal_point,
+                                                     optimal_comp,
+                                                     optimal_elem_id,
+                                                     optimal_subdomain_id,
+                                                     optimal_qp);
+}
+
+void RBEIMConstruction::update_eim_matrices()
+{
+  LOG_SCOPE("update_eim_matrices()", "RBEIMConstruction");
+
+  RBEIMEvaluation & eim_eval = get_rb_eim_evaluation();
+  unsigned int RB_size = eim_eval.get_n_basis_functions();
+
+  // update the matrix that is used to evaluate L2 projections
+  // into the EIM approximation space
+  for (unsigned int i=(RB_size-1); i<RB_size; i++)
+    {
+      for (unsigned int j=0; j<RB_size; j++)
+        {
+          Number value = inner_product(eim_eval.get_basis_function(i),
+                                       eim_eval.get_basis_function(j));
+
+          _eim_projection_matrix(i,j) = value;
+          if (i!=j)
+            {
+              // The inner product matrix is assumed to be hermitian
+              _eim_projection_matrix(j,i) = libmesh_conj(value);
+            }
+        }
+    }
+
+  // update the EIM interpolation matrix
+  for (unsigned int j=0; j<RB_size; j++)
+    {
+      // Evaluate the basis functions at the new interpolation point in order
+      // to update the interpolation matrix
+      Number value =
+        eim_eval.get_eim_basis_function_value(j,
+                                              eim_eval.get_interpolation_points_elem_id(RB_size-1),
+                                              eim_eval.get_interpolation_points_comp(RB_size-1),
+                                              eim_eval.get_interpolation_points_qp(RB_size-1));
+      eim_eval.set_interpolation_matrix_entry(RB_size-1, j, value);
+
+    }
+}
+
+Real RBEIMConstruction::compute_best_fit_error(unsigned int training_index)
+{
+  LOG_SCOPE("compute_best_fit_error()", "RBEIMConstruction");
+
+  set_params_from_training_set(training_index);
+
+  // Make a copy of the pre-computed solution for the specified training sample
+  // since we will modify it below to compute the best fit error.
+  std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> solution =
+    _local_parametrized_functions_for_training[training_index];
+
+  const unsigned int RB_size = get_rb_eim_evaluation().get_n_basis_functions();
+  DenseVector<Number> best_fit_coeffs;
+
+  switch(best_fit_type_flag)
+    {
+    case(PROJECTION_BEST_FIT):
+      {
+        // Perform an L2 projection in order to find the best approximation to
+        // the parametrized function from the current EIM space.
+        DenseVector<Number> best_fit_rhs(RB_size);
+        for (unsigned int i=0; i<RB_size; i++)
+          {
+            best_fit_rhs(i) = inner_product(solution, get_rb_eim_evaluation().get_basis_function(i));
+          }
+
+        // Now compute the best fit by an LU solve
+        DenseMatrix<Number> RB_inner_product_matrix_N(RB_size);
+        _eim_projection_matrix.get_principal_submatrix(RB_size, RB_inner_product_matrix_N);
+
+        RB_inner_product_matrix_N.lu_solve(best_fit_rhs, best_fit_coeffs);
+        break;
+      }
+    case(EIM_BEST_FIT):
+      {
+        // Perform EIM solve in order to find the approximation to solution
+        // (rb_eim_solve provides the EIM basis function coefficients used below)
+
+        // Turn off error estimation for this rb_eim_solve, we use the linfty norm instead
+        get_rb_eim_evaluation().evaluate_eim_error_bound = false;
+        get_rb_eim_evaluation().set_parameters( get_parameters() );
+        get_rb_eim_evaluation().rb_eim_solve(RB_size);
+        get_rb_eim_evaluation().evaluate_eim_error_bound = true;
+
+        best_fit_coeffs = get_rb_eim_evaluation().get_rb_eim_solution();
+        break;
+      }
+    default:
+      libmesh_error_msg("Should not reach here");
+    }
+
+  get_rb_eim_evaluation().decrement_vector(solution, best_fit_coeffs);
+
+  Real best_fit_error = get_max_abs_value(solution);
+  return best_fit_error;
+}
+
+void RBEIMConstruction::scale_parametrized_function(
+    std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & local_pf,
+    Number scaling_factor)
+{
+  LOG_SCOPE("scale_parametrized_function()", "RBEIMConstruction");
+
+  for (auto local_pf_it : local_pf)
+    {
+      auto & comp_and_qp = local_pf_it.second;
+
+      for (unsigned int comp : index_range(comp_and_qp))
+        {
+          std::vector<Number> & qp_values = comp_and_qp[comp];
+
+          for (unsigned int qp : index_range(qp_values))
+            {
+              qp_values[qp] *= scaling_factor;
             }
         }
     }

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -52,6 +52,7 @@ void RBEIMEvaluation::clear()
   _interpolation_points_xyz.clear();
   _interpolation_points_comp.clear();
   _interpolation_points_subdomain_id.clear();
+  _interpolation_points_xyz_perturbations.clear();
   _interpolation_points_elem_id.clear();
   _interpolation_points_qp.clear();
 
@@ -67,6 +68,7 @@ void RBEIMEvaluation::resize_data_structures(const unsigned int Nmax)
   _interpolation_points_xyz.clear();
   _interpolation_points_comp.clear();
   _interpolation_points_subdomain_id.clear();
+  _interpolation_points_xyz_perturbations.clear();
   _interpolation_points_elem_id.clear();
   _interpolation_points_qp.clear();
 
@@ -104,7 +106,8 @@ Real RBEIMEvaluation::rb_eim_solve(unsigned int N)
       EIM_rhs(i) = get_parametrized_function().evaluate(get_parameters(),
                                                         _interpolation_points_comp[i],
                                                         _interpolation_points_xyz[i],
-                                                        _interpolation_points_subdomain_id[i]);
+                                                        _interpolation_points_subdomain_id[i],
+                                                        _interpolation_points_xyz_perturbations[i]);
     }
 
   DenseMatrix<Number> interpolation_matrix_N;
@@ -122,7 +125,8 @@ Real RBEIMEvaluation::rb_eim_solve(unsigned int N)
       Number g_at_next_x = get_parametrized_function().evaluate(get_parameters(),
                                                         _interpolation_points_comp[N],
                                                         _interpolation_points_xyz[N],
-                                                        _interpolation_points_subdomain_id[N]);
+                                                        _interpolation_points_subdomain_id[N],
+                                                        _interpolation_points_xyz_perturbations[N]);
 
       // Next, evaluate the EIM approximation at x_{N+1}
       Number EIM_approx_at_next_x = 0.;
@@ -326,6 +330,12 @@ void RBEIMEvaluation::add_interpolation_points_subdomain_id(subdomain_id_type sb
   _interpolation_points_subdomain_id.emplace_back(sbd_id);
 }
 
+void RBEIMEvaluation::add_interpolation_points_xyz_perturbations(const std::vector<Point> & perturbs)
+{
+  _interpolation_points_xyz_perturbations.emplace_back(perturbs);
+}
+
+
 void RBEIMEvaluation::add_interpolation_points_elem_id(dof_id_type elem_id)
 {
   _interpolation_points_elem_id.emplace_back(elem_id);
@@ -358,6 +368,14 @@ subdomain_id_type RBEIMEvaluation::get_interpolation_points_subdomain_id(unsigne
     libmesh_error_msg("Error: Invalid index");
 
   return _interpolation_points_subdomain_id[index];
+}
+
+const std::vector<Point> & RBEIMEvaluation::get_interpolation_points_xyz_perturbations(unsigned int index) const
+{
+  if(index >= _interpolation_points_xyz_perturbations.size())
+    libmesh_error_msg("Error: Invalid index");
+
+  return _interpolation_points_xyz_perturbations[index];
 }
 
 dof_id_type RBEIMEvaluation::get_interpolation_points_elem_id(unsigned int index) const
@@ -395,7 +413,8 @@ void RBEIMEvaluation::add_basis_function_and_interpolation_data(
   unsigned int comp,
   dof_id_type elem_id,
   subdomain_id_type subdomain_id,
-  unsigned int qp)
+  unsigned int qp,
+  const std::vector<Point> & perturbs)
 {
   _local_eim_basis_functions.emplace_back(bf);
 
@@ -404,6 +423,7 @@ void RBEIMEvaluation::add_basis_function_and_interpolation_data(
   _interpolation_points_elem_id.emplace_back(elem_id);
   _interpolation_points_subdomain_id.emplace_back(subdomain_id);
   _interpolation_points_qp.emplace_back(qp);
+  _interpolation_points_xyz_perturbations.emplace_back(perturbs);
 }
 
 void RBEIMEvaluation::

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -194,7 +194,7 @@ void RBEIMEvaluation::decrement_vector(std::unordered_map<dof_id_type, std::vect
               if(qp >= basis_comp_and_qp[comp].size())
                 libmesh_error_msg("Error: Invalid qp");
 
-              v[elem_id][comp][qp] -= get_rb_eim_solution()(i) * basis_comp_and_qp[comp][qp];
+              v[elem_id][comp][qp] -= coeffs(i) * basis_comp_and_qp[comp][qp];
             }
     }
 

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -562,4 +562,12 @@ write_out_basis_functions(const std::string & directory_name,
     }
 }
 
+void RBEIMEvaluation::
+read_in_basis_functions(const std::string & /*directory_name*/,
+                        const bool /*read_binary_basis_functions*/)
+{
+  // not implemented yet
+  libmesh_not_implemented();
+}
+
 } // namespace libMesh

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -431,6 +431,8 @@ void RBEIMEvaluation::
 write_out_basis_functions(const std::string & directory_name,
                           bool write_binary_basis_functions)
 {
+  LOG_SCOPE("write_out_basis_functions()", "RBEIMEvaluation");
+
   libMesh::out << "Called RBEIMEvaluation::write_out_basis_functions()" << std::endl;
   libMesh::out << "Writing to directory: " << directory_name << std::endl;
   libMesh::out << "write_binary_basis_functions = " << write_binary_basis_functions << std::endl;
@@ -565,6 +567,8 @@ void RBEIMEvaluation::
 read_in_basis_functions(const std::string & directory_name,
                         bool read_binary_basis_functions)
 {
+  LOG_SCOPE("read_in_basis_functions()", "RBEIMEvaluation");
+
   // Read values on processor 0 only.
   if (this->processor_id() == 0)
     {

--- a/src/reduced_basis/rb_eim_theta.C
+++ b/src/reduced_basis/rb_eim_theta.C
@@ -51,9 +51,15 @@ Number RBEIMTheta::evaluate(const RBParameters & mu)
       rb_eim_eval.set_parameters(mu);
     }
 
-  rb_eim_eval.rb_solve(rb_eim_eval.get_n_basis_functions());
+  rb_eim_eval.rb_eim_solve(rb_eim_eval.get_n_basis_functions());
 
-  return rb_eim_eval.RB_solution(index);
+  const DenseVector<Number> & eim_solution = rb_eim_eval.get_rb_eim_solution();
+  if(index >= eim_solution.size())
+  {
+    libmesh_error_msg("Error: Invalid EIM solution index, " + std::to_string(index));
+  }
+
+  return eim_solution(index);
 }
 
 }

--- a/src/reduced_basis/rb_eim_theta.C
+++ b/src/reduced_basis/rb_eim_theta.C
@@ -54,7 +54,7 @@ Number RBEIMTheta::evaluate(const RBParameters & mu)
   rb_eim_eval.rb_eim_solve(rb_eim_eval.get_n_basis_functions());
 
   const DenseVector<Number> & eim_solution = rb_eim_eval.get_rb_eim_solution();
-  if(index >= eim_solution.size())
+  if (index >= eim_solution.size())
   {
     libmesh_error_msg("Error: Invalid EIM solution index, " + std::to_string(index));
   }

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -26,7 +26,8 @@ namespace libMesh
 
 RBParametrizedFunction::RBParametrizedFunction()
 :
-requires_xyz_perturbations(false)
+requires_xyz_perturbations(false),
+fd_delta(1.e-6)
 {}
 
 RBParametrizedFunction::~RBParametrizedFunction() {}

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -32,6 +32,20 @@ fd_delta(1.e-6)
 
 RBParametrizedFunction::~RBParametrizedFunction() {}
 
+Number RBParametrizedFunction::evaluate(const RBParameters & mu,
+                                        unsigned int comp,
+                                        const Point & xyz,
+                                        subdomain_id_type subdomain_id,
+                                        const std::vector<Point> & xyz_perturb)
+{
+  std::vector<Number> values = evaluate(mu, xyz, subdomain_id, xyz_perturb);
+
+  if (comp >= values.size())
+    libmesh_error_msg("Error: Invalid value of comp");
+
+  return values[comp];
+}
+
 void RBParametrizedFunction::vectorized_evaluate(const RBParameters & mu,
                                                  const std::unordered_map<dof_id_type, std::vector<Point>> & all_xyz,
                                                  const std::unordered_map<dof_id_type, subdomain_id_type> & sbd_ids,
@@ -40,10 +54,10 @@ void RBParametrizedFunction::vectorized_evaluate(const RBParameters & mu,
 {
   output.clear();
 
-  for (auto it : all_xyz)
+  for (const auto & xyz_pair : all_xyz)
     {
-      dof_id_type elem_id = it.first;
-      const std::vector<Point> & xyz_vec = it.second;
+      dof_id_type elem_id = xyz_pair.first;
+      const std::vector<Point> & xyz_vec = xyz_pair.second;
 
       auto sbd_it = sbd_ids.find(elem_id);
       if (sbd_it == sbd_ids.end())

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -1,0 +1,85 @@
+// rbOOmit: An implementation of the Certified Reduced Basis method.
+// Copyright (C) 2009, 2010 David J. Knezevic
+
+// This file is part of rbOOmit.
+
+// rbOOmit is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// rbOOmit is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#include "libmesh/rb_parametrized_function.h"
+#include "libmesh/int_range.h"
+#include "libmesh/point.h"
+
+namespace libMesh
+{
+
+RBParametrizedFunction::~RBParametrizedFunction() {}
+
+void RBParametrizedFunction::vectorized_evaluate(const RBParameters & mu,
+                                                 const std::unordered_map<dof_id_type, std::vector<Point>> & all_xyz,
+                                                 const std::unordered_map<dof_id_type, subdomain_id_type> & sbd_ids,
+                                                 std::unordered_map<dof_id_type, std::vector<std::vector<Number>>> & output)
+{
+  output.clear();
+
+  for (auto it : all_xyz)
+    {
+      dof_id_type elem_id = it.first;
+      const std::vector<Point> & xyz_vec = it.second;
+
+      auto sbd_it = sbd_ids.find(elem_id);
+      if (sbd_it == sbd_ids.end())
+        libmesh_error_msg("Error: elem_id not found");
+      subdomain_id_type subdomain_id = sbd_it->second;
+
+      std::vector<std::vector<Number>> values(get_n_components());
+      for (unsigned int comp=0; comp<get_n_components(); comp++)
+        {
+          values[comp].resize(xyz_vec.size());
+          for (unsigned int qp : index_range(xyz_vec))
+            {
+              values[comp][qp] = evaluate(mu, comp, xyz_vec[qp], subdomain_id);
+            }
+        }
+      output[elem_id] = values;
+    }
+}
+
+void RBParametrizedFunction::preevaluate_parametrized_function(const RBParameters & mu,
+                                                               const std::unordered_map<dof_id_type, std::vector<Point>> & all_xyz,
+                                                               const std::unordered_map<dof_id_type, subdomain_id_type> & sbd_ids)
+{
+  vectorized_evaluate(mu, all_xyz, sbd_ids, preevaluated_values);
+}
+
+Number RBParametrizedFunction::lookup_preevaluated_value(unsigned int comp,
+                                                         dof_id_type elem_id,
+                                                         unsigned int qp) const
+{
+  const auto elem_it = preevaluated_values.find(elem_id);
+  if (elem_it == preevaluated_values.end())
+    libmesh_error_msg("Error: elem_id not found");
+
+  const std::vector<std::vector<Number>> & values = elem_it->second;
+
+  if (comp >= values.size())
+    libmesh_error_msg("Error: invalid comp");
+
+  if (qp >= values[comp].size())
+    libmesh_error_msg("Error: invalid qp");
+
+  return values[comp][qp];
+}
+
+}


### PR DESCRIPTION
Mainly this change reorders how we store EIM basis functions so that it's easier to return values for all quad points on an element and the code overall runs faster. This change is not backwards-compatible but it's unlikely there are many external codes using these APIs. We've updated the relevant libmesh examples, so people can also use those to update their codes if required. Finally, if required, once this is merged I can always retroactively start a 1.6.0 release branch from the commit just before the merge in order to have one more release with the old API.
