### PR TITLE
Link to libvtkCommonExecutionModel

### DIFF
--- a/configure
+++ b/configure
@@ -38464,12 +38464,14 @@ else
                                                    VTK_LIBRARY_WITH_VERSION="-L$VTK_LIB -lvtkIOCore-$vtkmajorminor -lvtkCommonCore-$vtkmajorminor -lvtkCommonDataModel-$vtkmajorminor \
                                            -lvtkFiltersCore-$vtkmajorminor -lvtkIOXML-$vtkmajorminor -lvtkImagingCore-$vtkmajorminor \
                                            -lvtkIOImage-$vtkmajorminor -lvtkImagingMath-$vtkmajorminor -lvtkIOParallelXML-$vtkmajorminor \
-                                           -lvtkParallelMPI-$vtkmajorminor -lvtkParallelCore-$vtkmajorminor"
+                                           -lvtkParallelMPI-$vtkmajorminor -lvtkParallelCore-$vtkmajorminor \
+                                           -lvtkCommonExecutionModel-$vtkmajorminor"
 
                                                                     VTK_LIBRARY_NO_VERSION="-L$VTK_LIB -lvtkIOCore -lvtkCommonCore -lvtkCommonDataModel \
                                          -lvtkFiltersCore -lvtkIOXML -lvtkImagingCore \
                                          -lvtkIOImage -lvtkImagingMath -lvtkIOParallelXML \
-                                         -lvtkParallelMPI -lvtkParallelCore"
+                                         -lvtkParallelMPI -lvtkParallelCore \
+                                         -lvtkCommonExecutionModel"
 
 fi
 

--- a/m4/vtk.m4
+++ b/m4/vtk.m4
@@ -176,7 +176,8 @@ AC_DEFUN([CONFIGURE_VTK],
                  VTK_LIBRARY_WITH_VERSION="-L$VTK_LIB -lvtkIOCore-$vtkmajorminor -lvtkCommonCore-$vtkmajorminor -lvtkCommonDataModel-$vtkmajorminor \
                                            -lvtkFiltersCore-$vtkmajorminor -lvtkIOXML-$vtkmajorminor -lvtkImagingCore-$vtkmajorminor \
                                            -lvtkIOImage-$vtkmajorminor -lvtkImagingMath-$vtkmajorminor -lvtkIOParallelXML-$vtkmajorminor \
-                                           -lvtkParallelMPI-$vtkmajorminor -lvtkParallelCore-$vtkmajorminor"
+                                           -lvtkParallelMPI-$vtkmajorminor -lvtkParallelCore-$vtkmajorminor \
+                                           -lvtkCommonExecutionModel-$vtkmajorminor"
 
                  dnl Some Linux distributions (Arch) install VTK without the
                  dnl "libfoo-6.x.so" naming scheme, so we try to handle that
@@ -184,7 +185,8 @@ AC_DEFUN([CONFIGURE_VTK],
                  VTK_LIBRARY_NO_VERSION="-L$VTK_LIB -lvtkIOCore -lvtkCommonCore -lvtkCommonDataModel \
                                          -lvtkFiltersCore -lvtkIOXML -lvtkImagingCore \
                                          -lvtkIOImage -lvtkImagingMath -lvtkIOParallelXML \
-                                         -lvtkParallelMPI -lvtkParallelCore"
+                                         -lvtkParallelMPI -lvtkParallelCore \
+                                         -lvtkCommonExecutionModel"
                ])
 
          dnl Try to compile test prog to check for existence of VTK libraries.


### PR DESCRIPTION
This is the solution suggested by Charles Taylor to VTK linking problems people have occasionally encountered:

https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/moose-users/B-MoFSnFCKg/ipRdBmwnBAAJ

https://groups.google.com/g/moose-users/c/7lDXjHVnRgQ

I'm not sure what code is *selectively* trying to request those particular symbols; it might be internal to certain VTK configurations.  But this does seem to be the right library to add to fix them.

I'm just starting to build this myself, so hopefully there's no embarrassing mistakes, but I wanted it to upload it ASAP so someone who can reproduce the original problem can make sure this fixes it.