### PR TITLE
Add libmesh_error_msg_if(cond, msg) macro

### DIFF
--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -430,6 +430,12 @@ struct casting_compare {
 
 #define libmesh_error() libmesh_error_msg("")
 
+#define libmesh_error_msg_if(cond, msg)         \
+  do {                                          \
+    if (cond)                                   \
+      libmesh_error_msg(msg);                   \
+  } while (0)
+
 #define libmesh_exceptionless_error_msg(msg)                            \
   do {                                                                  \
     libMesh::err << msg << std::endl;                                   \

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -358,8 +358,7 @@ void BoundaryInfo::get_side_and_node_maps (UnstructuredMesh & boundary_mesh,
             }
         }
 
-      if (!found_matching_sides)
-        libmesh_error_msg("No matching side found within the specified tolerance");
+      libmesh_error_msg_if(!found_matching_sides, "No matching side found within the specified tolerance");
 
       side_id_map[boundary_elem->id()] = interior_parent_side_index;
 
@@ -647,8 +646,10 @@ void BoundaryInfo::add_node(const dof_id_type node_id,
 
   // The user could easily ask for an invalid node id, so let's throw
   // an easy-to-understand error message when this happens.
-  if (!node_ptr)
-    libmesh_error_msg("BoundaryInfo::add_node(): Could not retrieve pointer for node " << node_id << ", no boundary id was added.");
+  libmesh_error_msg_if(!node_ptr,
+                       "BoundaryInfo::add_node(): Could not retrieve pointer for node "
+                       << node_id
+                       << ", no boundary id was added.");
 
   this->add_node (node_ptr, id);
 }
@@ -658,10 +659,10 @@ void BoundaryInfo::add_node(const dof_id_type node_id,
 void BoundaryInfo::add_node(const Node * node,
                             const boundary_id_type id)
 {
-  if (id == invalid_id)
-    libmesh_error_msg("ERROR: You may not set a boundary ID of "   \
-                      << invalid_id                                \
-                      << "\n That is reserved for internal use.");
+  libmesh_error_msg_if(id == invalid_id,
+                       "ERROR: You may not set a boundary ID of "
+                       << invalid_id
+                       << "\n That is reserved for internal use.");
 
   // Don't add the same ID twice
   for (const auto & pr : as_range(_boundary_node_id.equal_range(node)))
@@ -698,10 +699,10 @@ void BoundaryInfo::add_node(const Node * node,
 
   for (auto & id : as_range(unique_ids.begin(), new_end))
     {
-      if (id == invalid_id)
-        libmesh_error_msg("ERROR: You may not set a boundary ID of "    \
-                          << invalid_id                                 \
-                          << "\n That is reserved for internal use.");
+      libmesh_error_msg_if(id == invalid_id,
+                           "ERROR: You may not set a boundary ID of "
+                           << invalid_id
+                           << "\n That is reserved for internal use.");
 
       bool already_inserted = false;
       for (const auto & pr : as_range(bounds))
@@ -744,10 +745,10 @@ void BoundaryInfo::add_edge(const Elem * elem,
   // Only add BCs for level-0 elements.
   libmesh_assert_equal_to (elem->level(), 0);
 
-  if (id == invalid_id)
-    libmesh_error_msg("ERROR: You may not set a boundary ID of "        \
-                      << invalid_id                                     \
-                      << "\n That is reserved for internal use.");
+  libmesh_error_msg_if(id == invalid_id,
+                       "ERROR: You may not set a boundary ID of "
+                       << invalid_id
+                       << "\n That is reserved for internal use.");
 
   // Don't add the same ID twice
   for (const auto & pr : as_range(_boundary_edge_id.equal_range(elem)))
@@ -789,10 +790,10 @@ void BoundaryInfo::add_edge(const Elem * elem,
 
   for (auto & id : as_range(unique_ids.begin(), new_end))
     {
-      if (id == invalid_id)
-        libmesh_error_msg("ERROR: You may not set a boundary ID of "   \
-                          << invalid_id                                \
-                          << "\n That is reserved for internal use.");
+      libmesh_error_msg_if(id == invalid_id,
+                           "ERROR: You may not set a boundary ID of "
+                           << invalid_id
+                           << "\n That is reserved for internal use.");
 
       bool already_inserted = false;
       for (const auto & pr : as_range(bounds))
@@ -834,10 +835,10 @@ void BoundaryInfo::add_shellface(const Elem * elem,
   // Shells only have 2 faces
   libmesh_assert_less(shellface, 2);
 
-  if (id == invalid_id)
-    libmesh_error_msg("ERROR: You may not set a boundary ID of "        \
-                      << invalid_id                                     \
-                      << "\n That is reserved for internal use.");
+  libmesh_error_msg_if(id == invalid_id,
+                       "ERROR: You may not set a boundary ID of "
+                       << invalid_id
+                       << "\n That is reserved for internal use.");
 
   // Don't add the same ID twice
   for (const auto & pr : as_range(_boundary_shellface_id.equal_range(elem)))
@@ -882,10 +883,10 @@ void BoundaryInfo::add_shellface(const Elem * elem,
 
   for (auto & id : as_range(unique_ids.begin(), new_end))
     {
-      if (id == invalid_id)
-        libmesh_error_msg("ERROR: You may not set a boundary ID of "   \
-                          << invalid_id                                \
-                          << "\n That is reserved for internal use.");
+      libmesh_error_msg_if(id == invalid_id,
+                           "ERROR: You may not set a boundary ID of "
+                           << invalid_id
+                           << "\n That is reserved for internal use.");
 
       bool already_inserted = false;
       for (const auto & pr : as_range(bounds))
@@ -923,10 +924,9 @@ void BoundaryInfo::add_side(const Elem * elem,
   // Only add BCs for level-0 elements.
   libmesh_assert_equal_to (elem->level(), 0);
 
-  if (id == invalid_id)
-    libmesh_error_msg("ERROR: You may not set a boundary ID of "        \
-                      << invalid_id                                     \
-                      << "\n That is reserved for internal use.");
+  libmesh_error_msg_if(id == invalid_id, "ERROR: You may not set a boundary ID of "
+                       << invalid_id
+                       << "\n That is reserved for internal use.");
 
   // Don't add the same ID twice
   for (const auto & pr : as_range(_boundary_side_id.equal_range(elem)))
@@ -968,10 +968,10 @@ void BoundaryInfo::add_side(const Elem * elem,
 
   for (auto & id : as_range(unique_ids.begin(), new_end))
     {
-      if (id == invalid_id)
-        libmesh_error_msg("ERROR: You may not set a boundary ID of "    \
-                          << invalid_id                                 \
-                          << "\n That is reserved for internal use.");
+      libmesh_error_msg_if(id == invalid_id,
+                           "ERROR: You may not set a boundary ID of "
+                           << invalid_id
+                           << "\n That is reserved for internal use.");
 
       bool already_inserted = false;
       for (const auto & pr : as_range(bounds))

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -15,9 +15,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-#include "libmesh/checkpoint_io.h"
-
 // Local includes
+#include "libmesh/checkpoint_io.h"
 #include "libmesh/boundary_info.h"
 #include "libmesh/distributed_mesh.h"
 #include "libmesh/elem.h"
@@ -112,18 +111,18 @@ void make_dir(const std::string & input_name, libMesh::processor_id_type n_procs
 {
   auto ret = libMesh::Utility::mkdir(input_name.c_str());
   // error only if we failed to create dir - don't care if it was already there
-  if (ret != 0 && ret != -1)
-    libmesh_error_msg(
-        "Failed to create mesh split directory '" << input_name << "': " << std::strerror(ret));
+  libmesh_error_msg_if
+    (ret != 0 && ret != -1,
+     "Failed to create mesh split directory '" << input_name << "': " << std::strerror(ret));
 
   auto dir_name = split_dir(input_name, n_procs);
   ret = libMesh::Utility::mkdir(dir_name.c_str());
   if (ret == -1)
     libmesh_warning("In CheckpointIO::write, directory '"
                     << dir_name << "' already exists, overwriting contents.");
-  else if (ret != 0)
-    libmesh_error_msg(
-        "Failed to create mesh split directory '" << dir_name << "': " << std::strerror(ret));
+  else
+    libmesh_error_msg_if
+      (ret != 0, "Failed to create mesh split directory '" << dir_name << "': " << std::strerror(ret));
 }
 
 } // namespace
@@ -201,15 +200,13 @@ processor_id_type CheckpointIO::select_split_config(const std::string & input_na
             auto orig_header_name = header_name;
             header_name = header_file(input_name, 1);
             std::ifstream in2 (header_name.c_str());
-            if (!in2.good())
-              {
-                libmesh_error_msg("ERROR: Neither one of the following files can be located:\n\t'"
-                                  << orig_header_name << "' nor\n\t'" << input_name << "'\n"
-                                  << "If you are running a parallel job, double check that you've "
-                                  << "created a split for " << _my_n_processors << " ranks.\n"
-                                  << "Note: One of paths above may refer to a valid directory on your "
-                                  << "system, however we are attempting to read a valid header file.");
-              }
+            libmesh_error_msg_if(!in2.good(),
+                                 "ERROR: Neither one of the following files can be located:\n\t'"
+                                 << orig_header_name << "' nor\n\t'" << input_name << "'\n"
+                                 << "If you are running a parallel job, double check that you've "
+                                 << "created a split for " << _my_n_processors << " ranks.\n"
+                                 << "Note: One of paths above may refer to a valid directory on your "
+                                 << "system, however we are attempting to read a valid header file.");
           }
       }
 
@@ -838,8 +835,7 @@ void CheckpointIO::read (const std::string & input_name)
           {
             std::ifstream in (file_name.c_str());
 
-            if (!in.good())
-              libmesh_error_msg("ERROR: cannot locate specified file:\n\t" << file_name);
+            libmesh_error_msg_if(!in.good(), "ERROR: cannot locate specified file:\n\t" << file_name);
           }
 
           // Do we expect all our files' remote_elem entries to really

--- a/src/mesh/dyna_io.C
+++ b/src/mesh/dyna_io.C
@@ -142,8 +142,7 @@ void DynaIO::read_mesh(std::istream & in)
   // broadcast later
   libmesh_assert_equal_to (MeshInput<MeshBase>::mesh().processor_id(), 0);
 
-  if (!in.good())
-    libmesh_error_msg("Can't read input stream");
+  libmesh_error_msg_if(!in.good(), "Can't read input stream");
 
   // clear any data in the mesh
   MeshBase & mesh = MeshInput<MeshBase>::mesh();
@@ -236,8 +235,8 @@ void DynaIO::read_mesh(std::istream & in)
 
           if (s.find("B E X T 2.0") == static_cast<std::string::size_type>(0))
           {
-            if (section != FILE_HEADER)
-              libmesh_error_msg("Found 'B E X T 2.0' outside file header?");
+            libmesh_error_msg_if(section != FILE_HEADER,
+                                 "Found 'B E X T 2.0' outside file header?");
 
             section = PATCH_HEADER;
             continue;
@@ -260,8 +259,7 @@ void DynaIO::read_mesh(std::istream & in)
             stream >> n_elem;
             stream >> n_coef_vec;
             stream >> weight_control_flag;
-            if (stream.fail())
-              libmesh_error_msg("Failure to parse patch header\n");
+            libmesh_error_msg_if(stream.fail(), "Failure to parse patch header\n");
 
             spline_node_ptrs.resize(n_spline_nodes);
             spline_weights.resize(n_spline_nodes);
@@ -298,16 +296,14 @@ void DynaIO::read_mesh(std::istream & in)
             }
             ++n_nodes_read;
 
-            if (stream.fail())
-              libmesh_error_msg("Failure to parse node line\n");
+            libmesh_error_msg_if(stream.fail(), "Failure to parse node line\n");
 
             if (n_nodes_read >= n_spline_nodes)
               section = N_ELEM_SUBBLOCKS;
             break;
           case N_ELEM_SUBBLOCKS:
             stream >> n_elem_blocks;
-            if (stream.fail())
-              libmesh_error_msg("Failure to parse n_elem_blocks\n");
+            libmesh_error_msg_if(stream.fail(), "Failure to parse n_elem_blocks\n");
 
             block_elem_type.resize(n_elem_blocks);
             block_n_elem.resize(n_elem_blocks);
@@ -329,8 +325,7 @@ void DynaIO::read_mesh(std::istream & in)
             stream >> block_n_coef_vec[n_elem_blocks_read];
             stream >> block_p[n_elem_blocks_read];
 
-            if (stream.fail())
-              libmesh_error_msg("Failure to parse elem block\n");
+            libmesh_error_msg_if(stream.fail(), "Failure to parse elem block\n");
 
             block_dim[n_elem_blocks_read] = 1; // All blocks here are at least 1D
 
@@ -389,8 +384,7 @@ void DynaIO::read_mesh(std::istream & in)
                   // Let's assume that our *only* mid-line breaks are
                   // due to the max_ints_per_line limit.  This should be
                   // less flexible but better for error detection.
-                  if (stream.fail())
-                    libmesh_error_msg("Failure to parse elem nodes\n");
+                  libmesh_error_msg_if(stream.fail(), "Failure to parse elem nodes\n");
                 }
 
               if (n_elem_nodes_read == block_n_nodes[n_elem_blocks_read])
@@ -415,8 +409,7 @@ void DynaIO::read_mesh(std::istream & in)
                   // Let's assume that our *only* mid-line breaks are
                   // due to the max_ints_per_line limit.  This should be
                   // less flexible but better for error detection.
-                  if (stream.fail())
-                    libmesh_error_msg("Failure to parse elem cvids\n");
+                  libmesh_error_msg_if(stream.fail(), "Failure to parse elem cvids\n");
                 }
               if (n_elem_cvids_read == block_n_nodes[n_elem_blocks_read])
                 {
@@ -439,8 +432,7 @@ void DynaIO::read_mesh(std::istream & in)
               dyna_int_type n_sparse_coef_vec_blocks;
               stream >> n_sparse_coef_vec_blocks;
 
-              if (stream.fail())
-                libmesh_error_msg("Failure to parse n_*_coef_vec_blocks\n");
+              libmesh_error_msg_if(stream.fail(), "Failure to parse n_*_coef_vec_blocks\n");
 
               if (n_sparse_coef_vec_blocks != 0)
                 libmesh_not_implemented();
@@ -456,8 +448,7 @@ void DynaIO::read_mesh(std::istream & in)
             stream >> n_coef_vecs_in_subblock[n_coef_headers_read];
             stream >> n_coef_comp[n_coef_headers_read];
 
-            if (stream.fail())
-              libmesh_error_msg("Failure to parse dense coef subblock header\n");
+            libmesh_error_msg_if(stream.fail(), "Failure to parse dense coef subblock header\n");
 
             dense_constraint_vecs[n_coef_headers_read].resize
               (n_coef_vecs_in_subblock[n_coef_headers_read]);
@@ -490,8 +481,7 @@ void DynaIO::read_mesh(std::istream & in)
                   // Let's assume that our *only* mid-line breaks are
                   // due to the max_fps_per_line limit.  This should be
                   // less flexible but better for error detection.
-                  if (stream.fail())
-                    libmesh_error_msg("Failure to parse coefficients\n");
+                  libmesh_error_msg_if(stream.fail(), "Failure to parse coefficients\n");
                 }
               if (n_coef_comp_read == n_coef_comp[n_coef_blocks_read])
                 {
@@ -557,17 +547,17 @@ void DynaIO::read_mesh(std::istream & in)
                                                   block_p[block_num]));
 
           // Make sure we actually found something
-          if (eletypes_it == _element_maps.in.end())
-            libmesh_error_msg
-              ("Element of type " << block_elem_type[block_num] <<
-               " dim " << block_dim[block_num] <<
-               " degree " << block_p[block_num] << " not found!");
+          libmesh_error_msg_if
+            (eletypes_it == _element_maps.in.end(),
+             "Element of type " << block_elem_type[block_num] <<
+             " dim " << block_dim[block_num] <<
+             " degree " << block_p[block_num] << " not found!");
 
           const ElementDefinition * elem_defn = &(eletypes_it->second);
           auto elem = Elem::build(elem_defn->type);
-          if (elem->dim() != block_dim[block_num])
-            libmesh_error_msg("Elem dim " << elem->dim() <<
-                              " != block_dim " << block_dim[block_num]);
+          libmesh_error_msg_if(elem->dim() != block_dim[block_num],
+                               "Elem dim " << elem->dim() <<
+                               " != block_dim " << block_dim[block_num]);
 
           auto & my_constraint_rows = elem_constraint_rows[block_num][elem_num];
           auto & my_global_nodes    = elem_global_nodes[block_num][elem_num];
@@ -594,18 +584,17 @@ void DynaIO::read_mesh(std::istream & in)
                 }
 
               // Make sure we did find a valid coef block
-              if (coef_block_num == n_dense_coef_vec_blocks &&
-                  first_block_coef_vec <= elem_coef_vec_index)
-                libmesh_error_msg("Can't find valid constraint coef vector");
+              libmesh_error_msg_if(coef_block_num == n_dense_coef_vec_blocks &&
+                                   first_block_coef_vec <= elem_coef_vec_index,
+                                   "Can't find valid constraint coef vector");
 
               coef_block_num--;
 
-              if (dyna_int_type(elem->n_nodes()) !=
-                  n_coef_comp[coef_block_num])
-                libmesh_error_msg("Found " <<
-                                  n_coef_comp[coef_block_num] <<
-                                  " constraint coef vectors for " <<
-                                  elem->n_nodes() << " nodes");
+              libmesh_error_msg_if
+                (dyna_int_type(elem->n_nodes()) != n_coef_comp[coef_block_num],
+                 "Found " << n_coef_comp[coef_block_num] <<
+                 " constraint coef vectors for " <<
+                 elem->n_nodes() << " nodes");
 
               for (auto elem_node_index :
                    make_range(elem->n_nodes()))
@@ -635,8 +624,8 @@ void DynaIO::read_mesh(std::istream & in)
 
                   // Global nodes are supposed to be in sorted order
                   if (global_node_idx != DofObject::invalid_id)
-                    if (my_global_nodes[spline_node_index] <= global_node_idx)
-                      libmesh_error_msg("Found unsorted global node");
+                    libmesh_error_msg_if(my_global_nodes[spline_node_index] <= global_node_idx,
+                                         "Found unsorted global node");
 
                   global_node_idx = my_global_nodes[spline_node_index];
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -16,12 +16,6 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-#include <fstream>
-#include <cstring>
-#include <sstream>
-#include <map>
-
 // Local includes
 #include "libmesh/exodusII_io.h"
 #include "libmesh/boundary_info.h"
@@ -40,6 +34,12 @@
 #include "libmesh/parallel.h"
 #include "libmesh/utility.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+
+// C++ includes
+#include <fstream>
+#include <cstring>
+#include <sstream>
+#include <map>
 
 namespace libMesh
 {
@@ -184,12 +184,12 @@ void ExodusII_IO::read (const std::string & fname)
 
       // If the Mesh assigned an ID different from what is in the
       // Exodus file, we should probably error.
-      if (added_node->id() != static_cast<unsigned>(exodus_id-1))
-        libmesh_error_msg("Error!  Mesh assigned node ID "    \
-                          << added_node->id()                         \
-                          << " which is different from the (zero-based) Exodus ID " \
-                          << exodus_id-1                              \
-                          << "!");
+      libmesh_error_msg_if(added_node->id() != static_cast<unsigned>(exodus_id-1),
+                           "Error!  Mesh assigned node ID "
+                           << added_node->id()
+                           << " which is different from the (zero-based) Exodus ID "
+                           << exodus_id-1
+                           << "!");
     }
 
   // This assert is no longer valid if the nodes are not numbered
@@ -260,12 +260,12 @@ void ExodusII_IO::read (const std::string & fname)
 
           // If the Mesh assigned an ID different from what is in the
           // Exodus file, we should probably error.
-          if (elem->id() != static_cast<unsigned>(exodus_id-1))
-            libmesh_error_msg("Error!  Mesh assigned ID "       \
-                              << elem->id()                             \
-                              << " which is different from the (zero-based) Exodus ID " \
-                              << exodus_id-1                            \
-                              << "!");
+          libmesh_error_msg_if(elem->id() != static_cast<unsigned>(exodus_id-1),
+                               "Error!  Mesh assigned ID "
+                               << elem->id()
+                               << " which is different from the (zero-based) Exodus ID "
+                               << exodus_id-1
+                               << "!");
 
           // Assign extra integer IDs
           for (auto & id : extra_ids)
@@ -350,11 +350,11 @@ void ExodusII_IO::read (const std::string & fname)
             int mapped_shellface = raw_side_index;
 
             // Check for errors
-            if (mapped_shellface == ExodusII_IO_Helper::Conversion::invalid_id)
-              libmesh_error_msg("Invalid 1-based side id: "                 \
-                                << mapped_shellface                         \
-                                << " detected for "                         \
-                                << Utility::enum_to_string(elem.type()));
+            libmesh_error_msg_if(mapped_shellface == ExodusII_IO_Helper::Conversion::invalid_id,
+                                 "Invalid 1-based side id: "
+                                 << mapped_shellface
+                                 << " detected for "
+                                 << Utility::enum_to_string(elem.type()));
 
             // Add this (elem,shellface,id) triplet to the BoundaryInfo object.
             mesh.get_boundary_info().add_shellface (libmesh_elem_id,
@@ -367,11 +367,11 @@ void ExodusII_IO::read (const std::string & fname)
             int mapped_side = conv.get_side_map(side_index);
 
             // Check for errors
-            if (mapped_side == ExodusII_IO_Helper::Conversion::invalid_id)
-              libmesh_error_msg("Invalid 1-based side id: "                 \
-                                << side_index                               \
-                                << " detected for "                         \
-                                << Utility::enum_to_string(elem.type()));
+            libmesh_error_msg_if(mapped_side == ExodusII_IO_Helper::Conversion::invalid_id,
+                                 "Invalid 1-based side id: "
+                                 << side_index
+                                 << " detected for "
+                                 << Utility::enum_to_string(elem.type()));
 
             // Add this (elem,side,id) triplet to the BoundaryInfo object.
             mesh.get_boundary_info().add_side (libmesh_elem_id,
@@ -413,9 +413,9 @@ void ExodusII_IO::read (const std::string & fname)
             // by accident.  Instead of possibly accessing past the
             // end of node_num_map, let's make sure we have that many
             // entries.
-            if (static_cast<std::size_t>(exodus_id - 1) >= exio_helper->node_num_map.size())
-              libmesh_error_msg("Invalid Exodus node id " << exodus_id
-                                << " found in nodeset " << nodeset_id);
+            libmesh_error_msg_if(static_cast<std::size_t>(exodus_id - 1) >= exio_helper->node_num_map.size(),
+                                 "Invalid Exodus node id " << exodus_id
+                                 << " found in nodeset " << nodeset_id);
 
             // As before, the entries in 'node_list' are 1-based
             // indices into the node_num_map array, so we have to map
@@ -428,12 +428,12 @@ void ExodusII_IO::read (const std::string & fname)
   }
 
 #if LIBMESH_DIM < 3
-  if (mesh.mesh_dimension() > LIBMESH_DIM)
-    libmesh_error_msg("Cannot open dimension "        \
-                      << mesh.mesh_dimension()            \
-                      << " mesh file when configured without "        \
-                      << mesh.mesh_dimension()                        \
-                      << "D support.");
+  libmesh_error_msg_if(mesh.mesh_dimension() > LIBMESH_DIM,
+                       "Cannot open dimension "
+                       << mesh.mesh_dimension()
+                       << " mesh file when configured without "
+                       << mesh.mesh_dimension()
+                       << "D support.");
 #endif
 }
 
@@ -524,8 +524,9 @@ void ExodusII_IO::append(bool val)
 
 const std::vector<Real> & ExodusII_IO::get_time_steps()
 {
-  if (!exio_helper->opened_for_reading)
-    libmesh_error_msg("ERROR, ExodusII file must be opened for reading before calling ExodusII_IO::get_time_steps()!");
+  libmesh_error_msg_if
+    (!exio_helper->opened_for_reading,
+     "ERROR, ExodusII file must be opened for reading before calling ExodusII_IO::get_time_steps()!");
 
   exio_helper->read_time_steps();
   return exio_helper->time_steps;
@@ -535,8 +536,8 @@ const std::vector<Real> & ExodusII_IO::get_time_steps()
 
 int ExodusII_IO::get_num_time_steps()
 {
-  if (!exio_helper->opened_for_reading && !exio_helper->opened_for_writing)
-    libmesh_error_msg("ERROR, ExodusII file must be opened for reading or writing before calling ExodusII_IO::get_num_time_steps()!");
+  libmesh_error_msg_if(!exio_helper->opened_for_reading && !exio_helper->opened_for_writing,
+                       "ERROR, ExodusII file must be opened for reading or writing before calling ExodusII_IO::get_num_time_steps()!");
 
   exio_helper->read_num_time_steps();
   return exio_helper->num_time_steps;
@@ -549,8 +550,8 @@ void ExodusII_IO::copy_nodal_solution(System & system,
                                       std::string exodus_var_name,
                                       unsigned int timestep)
 {
-  if (!exio_helper->opened_for_reading)
-    libmesh_error_msg("ERROR, ExodusII file must be opened for reading before copying a nodal solution!");
+  libmesh_error_msg_if(!exio_helper->opened_for_reading,
+                       "ERROR, ExodusII file must be opened for reading before copying a nodal solution!");
 
   exio_helper->read_nodal_var_values(exodus_var_name, timestep);
 
@@ -585,8 +586,8 @@ void ExodusII_IO::copy_elemental_solution(System & system,
 {
   if (system.comm().rank() == 0)
     {
-      if (!exio_helper->opened_for_reading)
-        libmesh_error_msg("ERROR, ExodusII file must be opened for reading before copying an elemental solution!");
+      libmesh_error_msg_if(!exio_helper->opened_for_reading,
+                           "ERROR, ExodusII file must be opened for reading before copying an elemental solution!");
 
       // Map from element ID to elemental variable value.  We need to use
       // a map here rather than a vector (e.g. elem_var_values) since the
@@ -597,8 +598,8 @@ void ExodusII_IO::copy_elemental_solution(System & system,
       exio_helper->read_elemental_var_values(exodus_var_name, timestep, elem_var_value_map);
 
       const unsigned int var_num = system.variable_number(system_var_name);
-      if (system.variable_type(var_num) != FEType(CONSTANT, MONOMIAL))
-        libmesh_error_msg("Error! Trying to copy elemental solution into a variable that is not of CONSTANT MONOMIAL type.");
+      libmesh_error_msg_if(system.variable_type(var_num) != FEType(CONSTANT, MONOMIAL),
+                           "Error! Trying to copy elemental solution into a variable that is not of CONSTANT MONOMIAL type.");
 
       std::map<dof_id_type, Real>::iterator
         it = elem_var_value_map.begin(),
@@ -625,11 +626,11 @@ void ExodusII_IO::copy_scalar_solution(System & system,
                                        std::vector<std::string> exodus_var_names,
                                        unsigned int timestep)
 {
-  if (!exio_helper->opened_for_reading)
-    libmesh_error_msg("ERROR, ExodusII file must be opened for reading before copying a scalar solution!");
+  libmesh_error_msg_if(!exio_helper->opened_for_reading,
+                       "ERROR, ExodusII file must be opened for reading before copying a scalar solution!");
 
-  if (system_var_names.size() != exodus_var_names.size())
-    libmesh_error_msg("ERROR, the number of system_var_names must match exodus_var_names.");
+  libmesh_error_msg_if(system_var_names.size() != exodus_var_names.size(),
+                       "ERROR, the number of system_var_names must match exodus_var_names.");
 
   std::vector<Real> values_from_exodus;
   read_global_variable(exodus_var_names, timestep, values_from_exodus);
@@ -684,8 +685,7 @@ void ExodusII_IO::read_global_variable(std::vector<std::string> global_var_names
                                        std::vector<Real> & global_values)
 {
   std::size_t size = global_var_names.size();
-  if (size == 0)
-    libmesh_error_msg("ERROR, empty list of global variables to read from the Exodus file.");
+  libmesh_error_msg_if(size == 0, "ERROR, empty list of global variables to read from the Exodus file.");
 
   // read the values for all global variables
   std::vector<Real> values_from_exodus;
@@ -714,8 +714,8 @@ void ExodusII_IO::read_global_variable(std::vector<std::string> global_var_names
 void ExodusII_IO::write_element_data (const EquationSystems & es)
 {
   // Be sure the file has been opened for writing!
-  if (MeshOutput<MeshBase>::mesh().processor_id() == 0 && !exio_helper->opened_for_writing)
-    libmesh_error_msg("ERROR, ExodusII file must be initialized before outputting element variables.");
+  libmesh_error_msg_if(MeshOutput<MeshBase>::mesh().processor_id() == 0 && !exio_helper->opened_for_writing,
+                       "ERROR, ExodusII file must be initialized before outputting element variables.");
 
   // This function currently only works on serialized meshes. We rely
   // on having a reference to a non-const MeshBase object from our
@@ -828,8 +828,8 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
   // Be sure that some other function has already opened the file and prepared it
   // for writing. This is the same behavior as the write_element_data() function
   // which we are trying to mimic.
-  if (MeshOutput<MeshBase>::mesh().processor_id() == 0 && !exio_helper->opened_for_writing)
-    libmesh_error_msg("ERROR, ExodusII file must be initialized before outputting element variables.");
+  libmesh_error_msg_if(MeshOutput<MeshBase>::mesh().processor_id() == 0 && !exio_helper->opened_for_writing,
+                       "ERROR, ExodusII file must be initialized before outputting element variables.");
 
   // This function currently only works on serialized meshes.  The
   // "true" flag specifies that we only need the mesh serialized to
@@ -905,8 +905,8 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
       // failed) but it doesn't hurt to be on the safe side.
       auto pr2 = subdomain_id_to_vertices_per_elem.emplace
         (elem->subdomain_id(), elem->n_vertices());
-      if (!pr2.second && pr2.first->second != elem->n_vertices())
-        libmesh_error_msg("Elem with different number of vertices found.");
+      libmesh_error_msg_if(!pr2.second && pr2.first->second != elem->n_vertices(),
+                           "Elem with different number of vertices found.");
     }
 
   // Determine "derived" variable names. These names are created by
@@ -1009,8 +1009,8 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
           // location of orig_name in the var_names vector matches its
           // index in the vars_active_subdomains container.
           auto var_loc = std::find(var_names.begin(), var_names.end(), orig_name);
-          if (var_loc == var_names.end())
-            libmesh_error_msg("Variable " << orig_name << " somehow not found in var_names array.");
+          libmesh_error_msg_if(var_loc == var_names.end(),
+                               "Variable " << orig_name << " somehow not found in var_names array.");
           auto var_id = std::distance(var_names.begin(), var_loc);
 
           // The derived_var will only be active if this subdomain has
@@ -1292,8 +1292,8 @@ void ExodusII_IO::write_information_records (const std::vector<std::string> & re
   if (MeshOutput<MeshBase>::mesh().processor_id())
     return;
 
-  if (!exio_helper->opened_for_writing)
-    libmesh_error_msg("ERROR, ExodusII file must be initialized before outputting information records.");
+  libmesh_error_msg_if(!exio_helper->opened_for_writing,
+                       "ERROR, ExodusII file must be initialized before outputting information records.");
 
   exio_helper->write_information_records(records);
 }
@@ -1306,8 +1306,8 @@ void ExodusII_IO::write_global_data (const std::vector<Number> & soln,
   if (MeshOutput<MeshBase>::mesh().processor_id())
     return;
 
-  if (!exio_helper->opened_for_writing)
-    libmesh_error_msg("ERROR, ExodusII file must be initialized before outputting global variables.");
+  libmesh_error_msg_if(!exio_helper->opened_for_writing,
+                       "ERROR, ExodusII file must be initialized before outputting global variables.");
 
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS
 
@@ -1383,9 +1383,9 @@ write_sideset_data(int timestep,
                    const std::vector<std::set<boundary_id_type>> & side_ids,
                    const std::vector<std::map<BoundaryInfo::BCTuple, Real>> & bc_vals)
 {
-  if (!exio_helper->opened_for_writing)
-    libmesh_error_msg("ERROR, ExodusII file must be opened for writing "
-                      "before calling ExodusII_IO::write_sideset_data()!");
+  libmesh_error_msg_if(!exio_helper->opened_for_writing,
+                       "ERROR, ExodusII file must be opened for writing "
+                       "before calling ExodusII_IO::write_sideset_data()!");
 
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
   exio_helper->write_sideset_data(mesh, timestep, var_names, side_ids, bc_vals);
@@ -1400,9 +1400,9 @@ read_sideset_data(int timestep,
                   std::vector<std::set<boundary_id_type>> & side_ids,
                   std::vector<std::map<BoundaryInfo::BCTuple, Real>> & bc_vals)
 {
-  if (!exio_helper->opened_for_reading)
-    libmesh_error_msg("ERROR, ExodusII file must be opened for reading "
-                      "before calling ExodusII_IO::read_sideset_data()!");
+  libmesh_error_msg_if(!exio_helper->opened_for_reading,
+                       "ERROR, ExodusII file must be opened for reading "
+                       "before calling ExodusII_IO::read_sideset_data()!");
 
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
   exio_helper->read_sideset_data(mesh, timestep, var_names, side_ids, bc_vals);
@@ -1556,11 +1556,11 @@ void ExodusII_IO::write_nodal_data_common(std::string fname,
       // We are already open for writing, so check that the filename
       // passed to this function matches the filename currently in use
       // by the helper.
-      if (fname != exio_helper->current_filename)
-        libmesh_error_msg("Error! This ExodusII_IO object is already associated with file: " \
-                          << exio_helper->current_filename              \
-                          << ", cannot use it with requested file: "    \
-                          << fname);
+      libmesh_error_msg_if(fname != exio_helper->current_filename,
+                           "Error! This ExodusII_IO object is already associated with file: "
+                           << exio_helper->current_filename
+                           << ", cannot use it with requested file: "
+                           << fname);
     }
 }
 

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -21,11 +21,7 @@
 
 #ifdef LIBMESH_HAVE_EXODUS_API
 
-#include <algorithm>
-#include <sstream>
-#include <cstdlib> // std::strtol
-#include <unordered_map>
-
+// libMesh includes
 #include "libmesh/boundary_info.h"
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/elem.h"
@@ -39,6 +35,12 @@
 #ifdef DEBUG
 #include "libmesh/mesh_tools.h"  // for elem_types warning
 #endif
+
+// C++ includes
+#include <algorithm>
+#include <sstream>
+#include <cstdlib> // std::strtol
+#include <unordered_map>
 
 // Anonymous namespace for file local data
 namespace
@@ -1978,8 +1980,8 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
         {
           // Make sure the existing data is consistent
           auto & val_pair = check_it->second;
-          if (val_pair.first != edge->type() || val_pair.second != edge->n_nodes())
-            libmesh_error_msg("All edges in a block must have same geometric type.");
+          libmesh_error_msg_if(val_pair.first != edge->type() || val_pair.second != edge->n_nodes(),
+                               "All edges in a block must have same geometric type.");
         }
 
       // Get reference to the connectivity array for this block
@@ -2124,14 +2126,13 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
           // This needs to be more than an assert so we don't fail
           // with a mysterious segfault while trying to write mixed
           // element meshes in optimized mode.
-          if (elem.type() != conv.libmesh_elem_type())
-            libmesh_error_msg("Error: Exodus requires all elements with a given subdomain ID to be the same type.\n" \
-                              << "Can't write both "                  \
-                              << Utility::enum_to_string(elem.type()) \
-                              << " and "                              \
-                              << Utility::enum_to_string(conv.libmesh_elem_type()) \
-                              << " in the same block!");
-
+          libmesh_error_msg_if(elem.type() != conv.libmesh_elem_type(),
+                               "Error: Exodus requires all elements with a given subdomain ID to be the same type.\n"
+                               << "Can't write both "
+                               << Utility::enum_to_string(elem.type())
+                               << " and "
+                               << Utility::enum_to_string(conv.libmesh_elem_type())
+                               << " in the same block!");
 
           for (unsigned int j=0; j<static_cast<unsigned int>(num_nodes_per_elem); ++j)
             {
@@ -2454,8 +2455,8 @@ void ExodusII_IO_Helper::initialize_element_variables(std::vector<std::string> n
       for (auto block_id : current_set)
         {
           auto it = std::find(block_ids.begin(), block_ids.end(), block_id);
-          if (it == block_ids.end())
-            libmesh_error_msg("ExodusII_IO_Helper: block id " << block_id << " not found in block_ids.");
+          libmesh_error_msg_if(it == block_ids.end(),
+                               "ExodusII_IO_Helper: block id " << block_id << " not found in block_ids.");
 
           std::size_t block_index =
             std::distance(block_ids.begin(), it);
@@ -2684,9 +2685,9 @@ write_sideset_data(const MeshBase & mesh,
 
               // Sanity check: make sure that the "off by one"
               // assumption we used above to set 'elem_id' is valid.
-              if (libmesh_map_find(libmesh_elem_num_to_exodus, cast_int<int>(elem_id))
-                  != elem_list[i + offset])
-                libmesh_error_msg("Error mapping Exodus elem id to libmesh elem id.");
+              libmesh_error_msg_if
+                (libmesh_map_find(libmesh_elem_num_to_exodus, cast_int<int>(elem_id)) != elem_list[i + offset],
+                 "Error mapping Exodus elem id to libmesh elem id.");
 
               // Map from Exodus side ids to libmesh side ids.
               const auto & conv = get_conversion(mesh.elem_ptr(elem_id)->type());
@@ -3039,8 +3040,8 @@ void ExodusII_IO_Helper::write_element_values_element_major
                             var_names_this_sbd.end(),
                             derived_var_names[var_id]);
 
-                if (pos == var_names_this_sbd.end())
-                  libmesh_error_msg("Derived name " << derived_var_names[var_id] << " not found!");
+                libmesh_error_msg_if(pos == var_names_this_sbd.end(),
+                                     "Derived name " << derived_var_names[var_id] << " not found!");
 
                 // Find the current variable's location in the list of all variable
                 // names on the current Elem's subdomain.
@@ -3417,11 +3418,10 @@ char ** ExodusII_IO_Helper::NamesData::get_char_star_star()
 
 char * ExodusII_IO_Helper::NamesData::get_char_star(int i)
 {
-  if (static_cast<unsigned>(i) >= table_size)
-    libmesh_error_msg("Requested char * " << i << " but only have " << table_size << "!");
+  libmesh_error_msg_if(static_cast<unsigned>(i) >= table_size,
+                       "Requested char * " << i << " but only have " << table_size << "!");
 
-  else
-    return data_table[i].data();
+  return data_table[i].data();
 }
 
 

--- a/src/mesh/fro_io.C
+++ b/src/mesh/fro_io.C
@@ -77,9 +77,9 @@ void FroIO::write (const std::string & fname)
       for (const auto & elem : the_mesh.active_element_ptr_range())
         {
           // .fro likes TRI3's
-          if (elem->type() != TRI3)
-            libmesh_error_msg("ERROR:  .fro format only valid for triangles!\n" \
-                              << "  writing of " << fname << " aborted.");
+          libmesh_error_msg_if(elem->type() != TRI3,
+                               "ERROR:  .fro format only valid for triangles!\n"
+                               << "  writing of " << fname << " aborted.");
 
           out_stream << ++e << " \t";
 

--- a/src/mesh/gnuplot_io.C
+++ b/src/mesh/gnuplot_io.C
@@ -162,8 +162,7 @@ void GnuPlotIO::write_solution(const std::string & fname,
       // Create an output stream for data file
       std::ofstream data(data_file_name.c_str());
 
-      if (!data.good())
-        libmesh_error_msg("ERROR: opening output data file " << data_file_name);
+      libmesh_error_msg_if(!data.good(), "ERROR: opening output data file " << data_file_name);
 
       // get ordered nodal data using a map
       std::map<Real, std::vector<Number>> node_map;

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -710,9 +710,9 @@ const Elem * MeshFunction::find_element(const Point & p,
     {
       const MeshFunction * master =
         cast_ptr<const MeshFunction *>(this->_master);
-      if (_out_of_mesh_mode!=master->_out_of_mesh_mode)
-        libmesh_error_msg("ERROR: If you use out-of-mesh-mode in connection with master mesh " \
-                          << "functions, you must enable out-of-mesh mode for both the master and the slave mesh function.");
+      libmesh_error_msg_if(_out_of_mesh_mode!=master->_out_of_mesh_mode,
+                           "ERROR: If you use out-of-mesh-mode in connection with master mesh "
+                           "functions, you must enable out-of-mesh mode for both the master and the slave mesh function.");
     }
 #endif
 
@@ -754,9 +754,9 @@ std::set<const Elem *> MeshFunction::find_elements(const Point & p,
     {
       const MeshFunction * master =
         cast_ptr<const MeshFunction *>(this->_master);
-      if (_out_of_mesh_mode!=master->_out_of_mesh_mode)
-        libmesh_error_msg("ERROR: If you use out-of-mesh-mode in connection with master mesh " \
-                          << "functions, you must enable out-of-mesh mode for both the master and the slave mesh function.");
+      libmesh_error_msg_if(_out_of_mesh_mode!=master->_out_of_mesh_mode,
+                           "ERROR: If you use out-of-mesh-mode in connection with master mesh "
+                           "functions, you must enable out-of-mesh mode for both the master and the slave mesh function.");
     }
 #endif
 

--- a/src/mesh/mesh_smoother_laplace.C
+++ b/src/mesh/mesh_smoother_laplace.C
@@ -68,8 +68,8 @@ void LaplaceMeshSmoother::smooth(unsigned int n_iterations)
 
       for (auto & node : _mesh.local_node_ptr_range())
         {
-          if (node == nullptr)
-            libmesh_error_msg("[" << _mesh.processor_id() << "]: Node iterator returned nullptr.");
+          libmesh_error_msg_if(node == nullptr,
+                               "[" << _mesh.processor_id() << "]: Node iterator returned nullptr.");
 
           // leave the boundary intact
           // Only relocate the nodes which are vertices of an element

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -4009,8 +4009,7 @@ void VariationalMeshSmoother::metr_data_gen(std::string grid,
 
   // generate metric file
   std::ofstream metric_file(metr.c_str());
-  if (!metric_file.good())
-    libmesh_error_msg("Error opening metric output file.");
+  libmesh_error_msg_if(!metric_file.good(), "Error opening metric output file.");
 
   // Use scientific notation with 6 digits
   metric_file << std::scientific << std::setprecision(6);
@@ -4313,8 +4312,7 @@ void VariationalMeshSmoother::metr_data_gen(std::string grid,
   metric_file.close();
 
   std::ofstream grid_file(grid.c_str());
-  if (!grid_file.good())
-    libmesh_error_msg("Error opening file: " << grid);
+  libmesh_error_msg_if(!grid_file.good(), "Error opening file: " << grid);
 
   grid_file << _dim << "\n" << _n_nodes << "\n" << Ncells << "\n0" << std::endl;
 

--- a/src/mesh/mesh_tetgen_interface.C
+++ b/src/mesh/mesh_tetgen_interface.C
@@ -223,8 +223,8 @@ void TetGenMeshInterface::triangulate_conformingDelaunayMesh_carvehole  (const s
 
             // Check to see if not found: this could also indicate the sequential
             // node map is not sorted...
-            if (node_iter == _sequential_to_libmesh_node_map.end())
-              libmesh_error_msg("Global node " << libmesh_node_id << " not found in sequential node map!");
+            libmesh_error_msg_if(node_iter == _sequential_to_libmesh_node_map.end(),
+                                 "Global node " << libmesh_node_id << " not found in sequential node map!");
 
             int sequential_index = cast_int<int>
               (std::distance(_sequential_to_libmesh_node_map.begin(),

--- a/src/mesh/mesh_tetgen_wrapper.C
+++ b/src/mesh/mesh_tetgen_wrapper.C
@@ -76,12 +76,12 @@ void TetGenWrapper::set_numberofpoints(int i)
 void TetGenWrapper::get_output_node(unsigned i, REAL & x, REAL & y, REAL & z)
 {
   // Bounds checking...
-  if (i >= static_cast<unsigned>(tetgen_output->numberofpoints))
-    libmesh_error_msg("Error, requested point "        \
-                      << i                             \
-                      << ", but there are only "       \
-                      << tetgen_output->numberofpoints \
-                      << " points available.");
+  libmesh_error_msg_if(i >= static_cast<unsigned>(tetgen_output->numberofpoints),
+                       "Error, requested point "
+                       << i
+                       << ", but there are only "
+                       << tetgen_output->numberofpoints
+                       << " points available.");
 
   x = tetgen_output->pointlist[3*i];
   y = tetgen_output->pointlist[3*i+1];
@@ -142,8 +142,8 @@ void TetGenWrapper::allocate_pointlist(int numofpoints)
   if (this->tetgen_data.numberofpoints > 0)
     {
       // Is there previously-allocated memory here?
-      if (this->tetgen_data.pointlist != nullptr)
-        libmesh_error_msg("Cannot allocate on top of previously allocated memory!");
+      libmesh_error_msg_if(this->tetgen_data.pointlist != nullptr,
+                           "Cannot allocate on top of previously allocated memory!");
 
       // We allocate memory here, the tetgenio destructor will delete it.
       this->tetgen_data.pointlist = new REAL[this->tetgen_data.numberofpoints * 3];
@@ -159,10 +159,10 @@ void TetGenWrapper::set_switches(const std::string & s)
   char buffer[256];
 
   // Make sure char buffer has enough room
-  if (s.size() >= sizeof(buffer)-1)
-    libmesh_error_msg("Fixed size buffer of length "                  \
-                      << sizeof(buffer)                               \
-                      << " not large enough to hold TetGen switches.");
+  libmesh_error_msg_if(s.size() >= sizeof(buffer)-1,
+                       "Fixed size buffer of length "
+                       << sizeof(buffer)
+                       << " not large enough to hold TetGen switches.");
 
   // Copy the string, don't forget to terminate!
   buffer[ s.copy( buffer , sizeof( buffer ) - 1 ) ] = '\0' ;
@@ -215,8 +215,8 @@ void TetGenWrapper::allocate_facetlist(int numoffacets, int numofholes)
   if (this->tetgen_data.numberoffacets > 0)
     {
       // Is there previously-allocated memory here?
-      if (this->tetgen_data.facetlist != nullptr)
-        libmesh_error_msg("Cannot allocate on top of previously allocated memory!");
+      libmesh_error_msg_if(this->tetgen_data.facetlist != nullptr,
+                           "Cannot allocate on top of previously allocated memory!");
 
       // We allocate memory here, the tetgenio destructor cleans it up.
       this->tetgen_data.facetlist = new tetgenio::facet[this->tetgen_data.numberoffacets];
@@ -230,8 +230,8 @@ void TetGenWrapper::allocate_facetlist(int numoffacets, int numofholes)
   if (this->tetgen_data.numberofholes > 0)
     {
       // Is there previously-allocated memory here?
-      if (this->tetgen_data.holelist != nullptr)
-        libmesh_error_msg("Cannot allocate on top of previously allocated memory!");
+      libmesh_error_msg_if(this->tetgen_data.holelist != nullptr,
+                           "Cannot allocate on top of previously allocated memory!");
 
       this->tetgen_data.holelist = new REAL[this->tetgen_data.numberofholes * 3];
     }
@@ -247,8 +247,8 @@ void TetGenWrapper::allocate_regionlist(int numofregions)
   if (this->tetgen_data.numberofregions > 0)
     {
       // Is there previously-allocated memory here?
-      if (this->tetgen_data.regionlist != nullptr)
-        libmesh_error_msg("Cannot allocate on top of previously allocated memory!");
+      libmesh_error_msg_if(this->tetgen_data.regionlist != nullptr,
+                           "Cannot allocate on top of previously allocated memory!");
 
       // We allocate memory here, the tetgenio destructor cleans it up.
       this->tetgen_data.regionlist = new REAL[this->tetgen_data.numberofregions * 5];
@@ -283,8 +283,8 @@ void TetGenWrapper::allocate_facet_polygonlist(unsigned i, int numofpolygons)
   if (numofpolygons > 0)
     {
       // Is there previously-allocated memory here?
-      if (this->tetgen_data.facetlist[i].polygonlist != nullptr)
-        libmesh_error_msg("Cannot allocate on top of previously allocated memory!");
+      libmesh_error_msg_if(this->tetgen_data.facetlist[i].polygonlist != nullptr,
+                           "Cannot allocate on top of previously allocated memory!");
 
       // We allocate memory here, the tetgenio destructor cleans it up.
       this->tetgen_data.facetlist[i].polygonlist = new tetgenio::polygon[numofpolygons];
@@ -312,8 +312,8 @@ void TetGenWrapper::allocate_polygon_vertexlist(unsigned i, unsigned j, int numo
   if (numofvertices > 0)
     {
       // Is there previously-allocated memory here?
-      if (this->tetgen_data.facetlist[i].polygonlist[j].vertexlist != nullptr)
-        libmesh_error_msg("Cannot allocate on top of previously allocated memory!");
+      libmesh_error_msg_if(this->tetgen_data.facetlist[i].polygonlist[j].vertexlist != nullptr,
+                           "Cannot allocate on top of previously allocated memory!");
 
       // We allocate memory here, the tetgenio destructor cleans it up.
       this->tetgen_data.facetlist[i].polygonlist[j].vertexlist = new int[numofvertices];

--- a/src/mesh/namebased_io.C
+++ b/src/mesh/namebased_io.C
@@ -16,14 +16,6 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-#include <iomanip>
-#include <fstream>
-#include <vector>
-
-#include <sys/types.h> // getpid
-#include <unistd.h>
-
 // Local includes
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_base.h"
@@ -48,8 +40,14 @@
 #include "libmesh/checkpoint_io.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/enum_xdr_mode.h"
-
 #include "libmesh/parallel.h" // broadcast
+
+// C++ includes
+#include <iomanip>
+#include <fstream>
+#include <vector>
+#include <sys/types.h> // getpid
+#include <unistd.h>
 
 
 namespace libMesh
@@ -87,17 +85,13 @@ void NameBasedIO::read (const std::string & name)
                 << '.' << std::setfill('0') << std::setw(field_width) << mymesh.processor_id();
 
       std::ifstream in (full_name.str().c_str());
-
-      if (!in.good())
-        libmesh_error_msg("ERROR: cannot locate specified file:\n\t" << full_name.str());
+      libmesh_error_msg_if(!in.good(), "ERROR: cannot locate specified file:\n\t" << full_name.str());
     }
   else if (name.rfind(".cp")) {} // Do error checking in the reader
   else
     {
       std::ifstream in (name.c_str());
-
-      if (!in.good())
-        libmesh_error_msg("ERROR: cannot locate specified file:\n\t" << name);
+      libmesh_error_msg_if(!in.good(), "ERROR: cannot locate specified file:\n\t" << name);
     }
 
   // Look for parallel formats first

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -211,8 +211,8 @@ void Nemesis_IO::read (const std::string & base_filename)
   nemhelper->get_loadbal_param();
 
   // Do some error checking
-  if (nemhelper->num_external_nodes)
-    libmesh_error_msg("ERROR: there should be no external nodes in an element-based partitioning!");
+  libmesh_error_msg_if(nemhelper->num_external_nodes,
+                       "ERROR: there should be no external nodes in an element-based partitioning!");
 
   libmesh_assert_equal_to (nemhelper->num_nodes,
                            (nemhelper->num_internal_nodes +
@@ -863,12 +863,12 @@ void Nemesis_IO::read (const std::string & base_filename)
           // We are expecting the element "thrown back" by libmesh to have the ID we specified for it...
           // Check to see that really is the case.  Note that my_next_elem was post-incremented, so
           // subtract 1 when performing the check.
-          if (elem->id() != my_next_elem-1)
-            libmesh_error_msg("Unexpected ID "  \
-                              << elem->id()                             \
-                              << " set by parallel mesh. (expecting "   \
-                              << my_next_elem-1                         \
-                              << ").");
+          libmesh_error_msg_if(elem->id() != my_next_elem-1,
+                               "Unexpected ID "
+                               << elem->id()
+                               << " set by parallel mesh. (expecting "
+                               << my_next_elem-1
+                               << ").");
 
           // Set all the nodes for this element
           if (_verbose)
@@ -921,12 +921,12 @@ void Nemesis_IO::read (const std::string & base_filename)
   mesh.set_mesh_dimension(max_dim_seen);
 
 #if LIBMESH_DIM < 3
-  if (mesh.mesh_dimension() > LIBMESH_DIM)
-    libmesh_error_msg("Cannot open dimension "   \
-                      << mesh.mesh_dimension()                          \
-                      << " mesh file when configured without "          \
-                      << mesh.mesh_dimension()                          \
-                      << "D support." );
+  libmesh_error_msg_if(mesh.mesh_dimension() > LIBMESH_DIM,
+                       "Cannot open dimension "
+                       << mesh.mesh_dimension()
+                       << " mesh file when configured without "
+                       << mesh.mesh_dimension()
+                       << "D support." );
 #endif
 
 
@@ -985,9 +985,9 @@ void Nemesis_IO::read (const std::string & base_filename)
     int sum_num_elem_all_sidesets = nemhelper->num_elem_all_sidesets;
     this->comm().sum(sum_num_elem_all_sidesets);
 
-    if (sum_num_global_side_counts != sum_num_elem_all_sidesets)
-      libmesh_error_msg("Error! global side count reported by Nemesis does not " \
-                        << "match the side count reported by the individual files!");
+    libmesh_error_msg_if(sum_num_global_side_counts != sum_num_elem_all_sidesets,
+                         "Error! global side count reported by Nemesis does not "
+                         "match the side count reported by the individual files!");
   }
 #endif
 
@@ -1059,12 +1059,12 @@ void Nemesis_IO::read (const std::string & base_filename)
   // which should match nemhelper->elem_list.size().
   {
     std::size_t nbcs = mesh.get_boundary_info().n_boundary_conds();
-    if (nbcs != nemhelper->elem_list.size())
-      libmesh_error_msg("[" << this->processor_id() << "] "   \
-                        << "BoundaryInfo contains "                     \
-                        << nbcs                                         \
-                        << " boundary conditions, while the Exodus file had " \
-                        << nemhelper->elem_list.size());
+    libmesh_error_msg_if(nbcs != nemhelper->elem_list.size(),
+                         "[" << this->processor_id() << "] "
+                         << "BoundaryInfo contains "
+                         << nbcs
+                         << " boundary conditions, while the Exodus file had "
+                         << nemhelper->elem_list.size());
   }
 
   // Read global nodeset parameters?  We might be able to use this to verify
@@ -1114,8 +1114,8 @@ void Nemesis_IO::read (const std::string & base_filename)
       for (auto node : index_range(nemhelper->node_list))
         {
           // Don't run past the end of our node map!
-          if (to_uint(nemhelper->node_list[node]-1) >= nemhelper->node_num_map.size())
-            libmesh_error_msg("Error, index is past the end of node_num_map array!");
+          libmesh_error_msg_if(to_uint(nemhelper->node_list[node]-1) >= nemhelper->node_num_map.size(),
+                               "Error, index is past the end of node_num_map array!");
 
           // We should be able to use the node_num_map data structure set up previously to determine
           // the proper global node index.
@@ -1410,8 +1410,8 @@ void Nemesis_IO::write_nodal_data (const std::string &,
 
 void Nemesis_IO::write_element_data (const EquationSystems & es)
 {
-  if (!nemhelper->opened_for_writing)
-    libmesh_error_msg("ERROR, Nemesis file must be initialized before outputting elemental variables.");
+  libmesh_error_msg_if(!nemhelper->opened_for_writing,
+                       "ERROR, Nemesis file must be initialized before outputting elemental variables.");
 
   // To be (possibly) filled with a filtered list of variable names to output.
   std::vector<std::string> names;
@@ -1520,8 +1520,8 @@ void Nemesis_IO::write_nodal_data (const std::string &,
 void Nemesis_IO::write_global_data (const std::vector<Number> & soln,
                                     const std::vector<std::string> & names)
 {
-  if (!nemhelper->opened_for_writing)
-    libmesh_error_msg("ERROR, Nemesis file must be initialized before outputting global variables.");
+  libmesh_error_msg_if(!nemhelper->opened_for_writing,
+                       "ERROR, Nemesis file must be initialized before outputting global variables.");
 
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS
 
@@ -1589,8 +1589,8 @@ void Nemesis_IO::write_global_data (const std::vector<Number> &,
 
 void Nemesis_IO::write_information_records (const std::vector<std::string> & records)
 {
-  if (!nemhelper->opened_for_writing)
-    libmesh_error_msg("ERROR, Nemesis file must be initialized before outputting information records.");
+  libmesh_error_msg_if(!nemhelper->opened_for_writing,
+                       "ERROR, Nemesis file must be initialized before outputting information records.");
 
   // Call the Exodus writer implementation
   nemhelper->write_information_records( records );

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -538,11 +538,8 @@ Node * ReplicatedMesh::add_node (std::unique_ptr<Node> n)
 
 Node * ReplicatedMesh::insert_node(Node * n)
 {
-  if (!n)
-    libmesh_error_msg("Error, attempting to insert nullptr node.");
-
-  if (n->id() == DofObject::invalid_id)
-    libmesh_error_msg("Error, cannot insert node with invalid id.");
+  libmesh_error_msg_if(!n, "Error, attempting to insert nullptr node.");
+  libmesh_error_msg_if(n->id() == DofObject::invalid_id, "Error, cannot insert node with invalid id.");
 
   if (n->id() < _nodes.size())
     {
@@ -552,8 +549,8 @@ Node * ReplicatedMesh::insert_node(Node * n)
       // redundant insert is done, but when that happens we ought to
       // always be able to make the code more efficient by avoiding
       // the redundant insert, so let's keep screaming "Error" here.
-      if (_nodes[ n->id() ] != nullptr)
-        libmesh_error_msg("Error, cannot insert node on top of existing node.");
+      libmesh_error_msg_if(_nodes[ n->id() ] != nullptr,
+                           "Error, cannot insert node on top of existing node.");
     }
   else
     {
@@ -1096,9 +1093,9 @@ void ReplicatedMesh::stitching_helper (const ReplicatedMesh * other_mesh,
       // nodes on the surfaces being stitched, and we don't currently support that case.
       // (It might be possible to support, but getting it exactly right would be tricky
       // and probably not worth the extra complications to the "normal" case.)
-      if (h_min < std::numeric_limits<Real>::epsilon())
-        libmesh_error_msg("Coincident nodes detected on source and/or target "
-                          "surface, stitching meshes is not possible.");
+      libmesh_error_msg_if(h_min < std::numeric_limits<Real>::epsilon(),
+                           "Coincident nodes detected on source and/or target "
+                           "surface, stitching meshes is not possible.");
 
       // We require nanoflann for the "binary search" (really kd-tree)
       // option to work. If it's not available, turn that option off,
@@ -1154,8 +1151,8 @@ void ReplicatedMesh::stitching_helper (const ReplicatedMesh * other_mesh,
           // If the 2 maps don't have the same size, it means we have overwritten a value in node_to_node_map
           // It means one node in this mesh is the nearest neighbor of several nodes in other mesh.
           // Not possible !
-          if (node_to_node_map.size() != other_to_this_node_map.size())
-            libmesh_error_msg("Error: Found multiple matching nodes in stitch_meshes");
+          libmesh_error_msg_if(node_to_node_map.size() != other_to_this_node_map.size(),
+                               "Error: Found multiple matching nodes in stitch_meshes");
 #endif
         }
         else
@@ -1191,8 +1188,8 @@ void ReplicatedMesh::stitching_helper (const ReplicatedMesh * other_mesh,
               if (node_distance < tol*h_min)
               {
                 // Make sure we didn't already find a matching node!
-                if (found_matching_nodes)
-                  libmesh_error_msg("Error: Found multiple matching nodes in stitch_meshes");
+                libmesh_error_msg_if(found_matching_nodes,
+                                     "Error: Found multiple matching nodes in stitch_meshes");
 
                 node_to_node_map[this_node_id] = other_node_id;
                 other_to_this_node_map[other_node_id] = this_node_id;
@@ -1239,8 +1236,8 @@ void ReplicatedMesh::stitching_helper (const ReplicatedMesh * other_mesh,
           std::size_t n_matching_nodes = node_to_node_map.size();
           std::size_t this_mesh_n_nodes = this_boundary_node_ids.size();
           std::size_t other_mesh_n_nodes = other_boundary_node_ids.size();
-          if ((n_matching_nodes != this_mesh_n_nodes) || (n_matching_nodes != other_mesh_n_nodes))
-            libmesh_error_msg("Error: We expected the number of nodes to match.");
+          libmesh_error_msg_if((n_matching_nodes != this_mesh_n_nodes) || (n_matching_nodes != other_mesh_n_nodes),
+                               "Error: We expected the number of nodes to match.");
         }
     }
   else
@@ -1575,8 +1572,8 @@ ReplicatedMesh::get_disconnected_subdomains(std::vector<subdomain_id_type> * sub
 std::unordered_map<dof_id_type, std::vector<std::vector<Point>>>
 ReplicatedMesh::get_boundary_points() const
 {
-  if (mesh_dimension() != 2)
-    libmesh_error_msg("Error: get_boundary_points only works for 2D now");
+  libmesh_error_msg_if(mesh_dimension() != 2,
+                       "Error: get_boundary_points only works for 2D now");
 
   // find number of disconnected subdomains
   // subdomains will hold the IDs of disconnected subdomains for all elements.
@@ -1675,8 +1672,8 @@ ReplicatedMesh::get_boundary_points() const
         if (found)
           break;
       }
-      if (!found)
-        libmesh_error_msg("ERROR: mesh topology error on visiting boundary sides");
+
+      libmesh_error_msg_if(!found, "ERROR: mesh topology error on visiting boundary sides");
 
       // exit if we reach the starting point
       if (elem == eseed && s == sseed)

--- a/src/mesh/tecplot_io.C
+++ b/src/mesh/tecplot_io.C
@@ -17,11 +17,6 @@
 
 
 
-// C++ includes
-#include <fstream>
-#include <iomanip>
-#include <sstream>
-
 // Local includes
 #include "libmesh/libmesh_config.h"
 #include "libmesh/libmesh_logging.h"
@@ -37,6 +32,10 @@ extern "C" {
 }
 #endif
 
+// C++ includes
+#include <fstream>
+#include <iomanip>
+#include <sstream>
 
 namespace libMesh
 {
@@ -215,8 +214,8 @@ unsigned TecplotIO::elem_dimension()
     elem_dims[elem->dim() - 1] = 1;
 
   // Detect and disallow (for now) the writing of mixed dimension meshes.
-  if (std::count(elem_dims.begin(), elem_dims.end(), 1) > 1)
-    libmesh_error_msg("Error, cannot write Mesh with mixed element dimensions to Tecplot file!");
+  libmesh_error_msg_if(std::count(elem_dims.begin(), elem_dims.end(), 1) > 1,
+                       "Error, cannot write Mesh with mixed element dimensions to Tecplot file!");
 
   if (elem_dims[0])
     return 1;

--- a/src/mesh/tetgen_io.C
+++ b/src/mesh/tetgen_io.C
@@ -73,11 +73,11 @@ void TetGenIO::read (const std::string & name)
   std::ifstream node_stream (name_node.c_str());
   std::ifstream ele_stream  (name_ele.c_str());
 
-  if (!node_stream.good() || !ele_stream.good())
-    libmesh_error_msg("Error while opening either "     \
-                      << name_node                      \
-                      << " or "                         \
-                      << name_ele);
+  libmesh_error_msg_if(!node_stream.good() || !ele_stream.good(),
+                       "Error while opening either "
+                       << name_node
+                       << " or "
+                       << name_ele);
 
   libMesh::out<< "TetGenIO found the tetgen files to read " <<std::endl;
 
@@ -203,8 +203,8 @@ void TetGenIO::element_in (std::istream & ele_stream)
   // region it belongs to. Normally, this id matches a value in a
   // corresponding .poly or .smesh file, but here we simply use it to
   // set the subdomain_id of the element in question.
-  if (region_attribute > 1)
-    libmesh_error_msg("Invalid region_attribute " << region_attribute << " specified in .ele file.");
+  libmesh_error_msg_if(region_attribute > 1,
+                       "Invalid region_attribute " << region_attribute << " specified in .ele file.");
 
   // Vector that assigns element nodes to their correct position.
   // TetGen is normally 0-based
@@ -272,8 +272,8 @@ void TetGenIO::write (const std::string & fname)
   // libmesh_assert three dimensions (should be extended later)
   libmesh_assert_equal_to (MeshOutput<MeshBase>::mesh().mesh_dimension(), 3);
 
-  if (!(fname.rfind(".poly") < fname.size()))
-    libmesh_error_msg("ERROR: Unrecognized file name: " << fname);
+  libmesh_error_msg_if(!(fname.rfind(".poly") < fname.size()),
+                       "ERROR: Unrecognized file name: " << fname);
 
   // Open the output file stream
   std::ofstream out_stream (fname.c_str());

--- a/src/mesh/ucd_io.C
+++ b/src/mesh/ucd_io.C
@@ -236,12 +236,12 @@ void UCDIO::read_implementation (std::istream & in)
         mesh.set_mesh_dimension(i);
 
 #if LIBMESH_DIM < 3
-    if (mesh.mesh_dimension() > LIBMESH_DIM)
-      libmesh_error_msg("Cannot open dimension " \
-                        << mesh.mesh_dimension() \
-                        << " mesh file when configured without " \
-                        << mesh.mesh_dimension() \
-                        << "D support.");
+    libmesh_error_msg_if(mesh.mesh_dimension() > LIBMESH_DIM,
+                         "Cannot open dimension "
+                         << mesh.mesh_dimension()
+                         << " mesh file when configured without "
+                         << mesh.mesh_dimension()
+                         << "D support.");
 #endif
   }
 }
@@ -255,9 +255,9 @@ void UCDIO::write_implementation (std::ostream & out_stream)
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
 
   // UCD doesn't work any dimension except 3?
-  if (mesh.mesh_dimension() != 3)
-    libmesh_error_msg("Error: Can't write boundary elements for meshes of dimension less than 3. " \
-                      << "Mesh dimension = " << mesh.mesh_dimension());
+  libmesh_error_msg_if(mesh.mesh_dimension() != 3,
+                       "Error: Can't write boundary elements for meshes of dimension less than 3. "
+                       "Mesh dimension = " << mesh.mesh_dimension());
 
   // Write header
   this->write_header(out_stream, mesh, mesh.n_elem(), 0);

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -17,16 +17,6 @@
 
 
 
-// C++ includes
-#include <fstream>
-#include <sstream>
-#include <iomanip>
-#include <unordered_map>
-
-// C includes
-#include <sys/types.h> // for pid_t
-#include <unistd.h>    // for getpid(), unlink()
-
 // Local includes
 #include "libmesh/boundary_info.h"
 #include "libmesh/ghosting_functor.h"
@@ -41,7 +31,15 @@
 #include "libmesh/enum_order.h"
 #include "libmesh/mesh_communication.h"
 
+// C++ includes
+#include <fstream>
+#include <sstream>
+#include <iomanip>
+#include <unordered_map>
 
+// C includes
+#include <sys/types.h> // for pid_t
+#include <unistd.h>    // for getpid(), unlink()
 
 namespace libMesh
 {
@@ -1137,8 +1135,8 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
   for (auto & lo_elem : element_ptr_range())
     {
       // make sure it is linear order
-      if (lo_elem->default_order() != FIRST)
-        libmesh_error_msg("ERROR: This is not a linear element: type=" << lo_elem->type());
+      libmesh_error_msg_if(lo_elem->default_order() != FIRST,
+                           "ERROR: This is not a linear element: type=" << lo_elem->type());
 
       // this does _not_ work for refined elements
       libmesh_assert_equal_to (lo_elem->level (), 0);

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -129,8 +129,7 @@ void UNVIO::read_implementation (std::istream & in_stream)
   elems_of_dimension.resize(4, false);
 
   {
-    if (!in_stream.good())
-      libmesh_error_msg("ERROR: Input file not good.");
+    libmesh_error_msg_if(!in_stream.good(), "ERROR: Input file not good.");
 
     // Flags to be set when certain sections are encountered
     bool
@@ -176,8 +175,8 @@ void UNVIO::read_implementation (std::istream & in_stream)
                 // The current implementation requires the nodes to
                 // have been read before reaching the elements
                 // section.
-                if (!found_node)
-                  libmesh_error_msg("ERROR: The Nodes section must come before the Elements section of the UNV file!");
+                libmesh_error_msg_if(!found_node,
+                                     "ERROR: The Nodes section must come before the Elements section of the UNV file!");
 
                 found_elem = true;
                 this->elements_in(in_stream);
@@ -190,8 +189,8 @@ void UNVIO::read_implementation (std::istream & in_stream)
                 // The current implementation requires the nodes and
                 // elements to have already been read before reaching
                 // the groups section.
-                if (!found_node || !found_elem)
-                  libmesh_error_msg("ERROR: The Nodes and Elements sections must come before the Groups section of the UNV file!");
+                libmesh_error_msg_if(!found_node || !found_elem,
+                                     "ERROR: The Nodes and Elements sections must come before the Groups section of the UNV file!");
 
                 found_group = true;
                 this->groups_in(in_stream);
@@ -216,11 +215,8 @@ void UNVIO::read_implementation (std::istream & in_stream)
 
     // By now we better have found the datasets for nodes and elements,
     // otherwise the unv file is bad!
-    if (!found_node)
-      libmesh_error_msg("ERROR: Could not find nodes!");
-
-    if (!found_elem)
-      libmesh_error_msg("ERROR: Could not find elements!");
+    libmesh_error_msg_if(!found_node, "ERROR: Could not find nodes!");
+    libmesh_error_msg_if(!found_elem, "ERROR: Could not find elements!");
   }
 
 
@@ -230,12 +226,12 @@ void UNVIO::read_implementation (std::istream & in_stream)
     MeshInput<MeshBase>::mesh().set_mesh_dimension(max_elem_dimension_seen());
 
 #if LIBMESH_DIM < 3
-    if (MeshInput<MeshBase>::mesh().mesh_dimension() > LIBMESH_DIM)
-      libmesh_error_msg("Cannot open dimension "                        \
-                        << MeshInput<MeshBase>::mesh().mesh_dimension() \
-                        << " mesh file when configured without "        \
-                        << MeshInput<MeshBase>::mesh().mesh_dimension() \
-                        << "D support." );
+    libmesh_error_msg_if(MeshInput<MeshBase>::mesh().mesh_dimension() > LIBMESH_DIM,
+                         "Cannot open dimension "
+                         << MeshInput<MeshBase>::mesh().mesh_dimension()
+                         << " mesh file when configured without "
+                         << MeshInput<MeshBase>::mesh().mesh_dimension()
+                         << "D support." );
 #endif
 
     // Delete any lower-dimensional elements that might have been
@@ -291,8 +287,7 @@ void UNVIO::write (const std::string & file_name)
 
 void UNVIO::write_implementation (std::ostream & out_file)
 {
-  if (!out_file.good())
-    libmesh_error_msg("ERROR: Output file not good.");
+  libmesh_error_msg_if(!out_file.good(), "ERROR: Output file not good.");
 
   // write the nodes, then the elements
   this->nodes_out    (out_file);
@@ -519,9 +514,9 @@ void UNVIO::groups_in (std::istream & in_file)
                     // one dimension lower than the max element
                     // dimension.  Not sure if "edge" BCs in 3D
                     // actually make sense/are required...
-                    if (group_elem->dim()+1 != max_dim)
-                      libmesh_error_msg("ERROR: Expected boundary element of dimension " \
-                                        << max_dim-1 << " but got " << group_elem->dim());
+                    libmesh_error_msg_if(group_elem->dim()+1 != max_dim,
+                                         "ERROR: Expected boundary element of dimension "
+                                         << max_dim-1 << " but got " << group_elem->dim());
 
                     // Set the current group number as the lower-dimensional element's subdomain ID.
                     // We will use this later to set a boundary ID.
@@ -1169,8 +1164,7 @@ void UNVIO::read_dataset(std::string file_name)
 {
   std::ifstream in_stream(file_name.c_str());
 
-  if (!in_stream.good())
-    libmesh_error_msg("Error opening UNV data file.");
+  libmesh_error_msg_if(!in_stream.good(), "Error opening UNV data file.");
 
   std::string olds, news, dummy;
 
@@ -1204,8 +1198,7 @@ void UNVIO::read_dataset(std::string file_name)
           in_stream >> dataset_location;
 
           // Currently only nodal datasets are supported.
-          if (dataset_location != 1)
-            libmesh_error_msg("ERROR: Currently only Data at nodes is supported.");
+          libmesh_error_msg_if(dataset_location != 1, "ERROR: Currently only Data at nodes is supported.");
 
           // Ignore the rest of this line and the next five records.
           for (unsigned int i=0; i<6; i++)

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -16,9 +16,6 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-#include <fstream>
-
 // Local includes
 #include "libmesh/libmesh_config.h"
 #include "libmesh/vtk_io.h"
@@ -57,6 +54,10 @@
 #endif
 
 #include "libmesh/restore_warnings.h"
+
+// C++ includes
+#include <fstream>
+
 
 // A convenient macro for comparing VTK versions.  Returns 1 if the
 // current VTK version is < major.minor.subminor and zero otherwise.
@@ -237,12 +238,12 @@ void VTKIO::read (const std::string & name)
       mesh.set_mesh_dimension(i);
 
 #if LIBMESH_DIM < 3
-  if (mesh.mesh_dimension() > LIBMESH_DIM)
-    libmesh_error_msg("Cannot open dimension "  \
-                      << mesh.mesh_dimension()              \
-                      << " mesh file when configured without "  \
-                      << mesh.mesh_dimension()                  \
-                      << "D support.");
+  libmesh_error_msg_if(mesh.mesh_dimension() > LIBMESH_DIM,
+                       "Cannot open dimension "
+                       << mesh.mesh_dimension()
+                       << " mesh file when configured without "
+                       << mesh.mesh_dimension()
+                       << "D support.");
 #endif // LIBMESH_DIM < 3
 }
 
@@ -262,8 +263,8 @@ void VTKIO::write_nodal_data (const std::string & fname,
   // should not be empty, it should have been broadcast to all
   // processors by the MeshOutput base class, since VTK is a parallel
   // format.  Verify this before going further.
-  if (!names.empty() && soln.empty())
-    libmesh_error_msg("Empty soln vector in VTKIO::write_nodal_data().");
+  libmesh_error_msg_if(!names.empty() && soln.empty(),
+                       "Empty soln vector in VTKIO::write_nodal_data().");
 
   // Get a reference to the mesh
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -17,10 +17,8 @@
 
 
 
-// Local includes
-#include "libmesh/xdr_io.h"
-
 // libMesh includes
+#include "libmesh/xdr_io.h"
 #include "libmesh/boundary_info.h"
 #include "libmesh/elem.h"
 #include "libmesh/enum_xdr_mode.h"
@@ -114,8 +112,7 @@ XdrIO::~XdrIO ()
 
 void XdrIO::write (const std::string & name)
 {
-  if (this->legacy())
-    libmesh_error_msg("We don't support writing parallel files in the legacy format.");
+  libmesh_error_msg_if(this->legacy(), "We don't support writing parallel files in the legacy format.");
 
   Xdr io ((this->processor_id() == 0) ? name : "", this->binary() ? ENCODE : WRITE);
 
@@ -1229,8 +1226,7 @@ void XdrIO::read (const std::string & name)
   this->legacy() = !(this->version().find("libMesh") < this->version().size());
 
   // Check for a legacy version format.
-  if (this->legacy())
-    libmesh_error_msg("We no longer support reading files in the legacy format.");
+  libmesh_error_msg_if(this->legacy(), "We no longer support reading files in the legacy format.");
 
   // Read headers with the old id type if they're pre-1.3.0, or with
   // the new id type if they're post-1.3.0
@@ -1648,12 +1644,12 @@ void XdrIO::read_serialized_connectivity (Xdr & io, const dof_id_type n_elem, st
       mesh.set_mesh_dimension(i);
 
 #if LIBMESH_DIM < 3
-  if (mesh.mesh_dimension() > LIBMESH_DIM)
-    libmesh_error_msg("Cannot open dimension "              \
-                      << mesh.mesh_dimension()                          \
-                      << " mesh file when configured without "          \
-                      << mesh.mesh_dimension()                          \
-                      << "D support.");
+  libmesh_error_msg_if(mesh.mesh_dimension() > LIBMESH_DIM,
+                       "Cannot open dimension "
+                       << mesh.mesh_dimension()
+                       << " mesh file when configured without "
+                       << mesh.mesh_dimension()
+                       << "D support.");
 #endif
 }
 


### PR DESCRIPTION
The idea here is to make error checking more self-contained while also allowing for the possibility of later adding a configure option which disables _all_ error checking.
    
Another option would have been to add:
```
libmesh_always_assert_msg(asserted, msg)
```    
but in that case in order to use the new macro we'd have to reverse the logic of all the checks that are already present in the code, and that seemed too error prone to me.

So far I have updated the files in src/mesh to use the new macro. If all goes well, I will eventually update the rest of the code.
