### PR TITLE
Make overzealous PBC error into careful assertion

### DIFF
--- a/src/base/periodic_boundaries.C
+++ b/src/base/periodic_boundaries.C
@@ -21,11 +21,13 @@
 #ifdef LIBMESH_ENABLE_PERIODIC
 
 #include "libmesh/periodic_boundaries.h"
-#include "libmesh/point_locator_base.h"
-#include "libmesh/elem.h"
-#include "libmesh/periodic_boundary.h"
-#include "libmesh/mesh_base.h"
+
 #include "libmesh/boundary_info.h"
+#include "libmesh/elem.h"
+#include "libmesh/mesh_base.h"
+#include "libmesh/periodic_boundary.h"
+#include "libmesh/point_locator_base.h"
+#include "libmesh/remote_elem.h"
 
 namespace libMesh
 {
@@ -92,8 +94,13 @@ const Elem * PeriodicBoundaries::neighbor(boundary_id_type boundary_id,
         }
     }
 
-  libmesh_error_msg("Periodic boundary neighbor not found");
-  return nullptr;
+  // If we should have found a periodic neighbor but didn't then
+  // either we're on a ghosted element with a remote periodic neighbor
+  // or we're on a mesh with an inconsistent periodic boundary.
+  libmesh_assert_msg(!mesh.is_serial() &&
+                     (e->processor_id() != mesh.processor_id()),
+                     "Periodic boundary neighbor not found");
+  return remote_elem;
 }
 
 } // namespace libMesh


### PR DESCRIPTION
If we're on a distributed mesh, it's possible for our ghost elements to
have periodic boundary conditions with remote periodic neighbors.  If
we're in such a state and we try to query those neighbors (as can happen
in our adaptive refinement code), we want to get remote_elem back, not
throw an error.

Thanks to @fdkong for catching this.

Neither of us have figured out why none of the libMesh (or GRINS! or MOOSE!) tests have managed to trigger it, though.  It appears to have been a regression created when @dknez and I were fixing the overlapping-boundaries case in 2018, but I've been regularly running distributed libMesh tests (and sporadically running distributed GRINS and MOOSE tests), including PBC tests, since then.

I'm still compiling this proposed fix, and Fande's only barely started trying out the simpler "just delete the overzealous error message" fix that came to mind first; we'll hammer on this more before we merge even if I'm lucky enough that it passes CI on the first try.