### PR TITLE
allgather() before falling back on Metis

### DIFF
--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -127,6 +127,10 @@ void ParmetisPartitioner::_do_repartition (MeshBase & mesh,
 
   MetisPartitioner mp;
 
+  // Metis and other fallbacks only work in serial, and need to get
+  // handed element ranges from an already-serialized mesh.
+  mesh.allgather();
+
   // Don't just call partition() here; that would end up calling
   // post-element-partitioning work redundantly (and at the moment
   // incorrectly)


### PR DESCRIPTION
I ran across this in a --enable-parmesh --disable-parmetis configuration
while testing #2665 fixes.  Which, admittedly, is an awful configuration
that nobody should use right now, but if we find ourselves there we
should scream and give slow-but-correct results, not produce a corrupt
mesh.