### PR TITLE
Subdomain expansion projection fixes

### DIFF
--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -819,9 +819,27 @@ public:
 
     libmesh_assert_equal_to (old_indices.size(), indices.size());
 
-    values.resize(old_indices.size());
+    // We may have invalid_id in cases where no old DoF existed, e.g.
+    // due to expansion of a subdomain-restricted variable's subdomain
+    bool invalid_old_index = false;
+    for (const auto & di : old_indices)
+      if (di == DofObject::invalid_id)
+        invalid_old_index = true;
 
-    old_solution.get(old_indices, values);
+    values.resize(old_indices.size());
+    if (invalid_old_index)
+      {
+        for (auto i : index_range(old_indices))
+          {
+            const dof_id_type di = old_indices[i];
+            if (di == DofObject::invalid_id)
+              values[i] = 0;
+            else
+              values[i] = old_solution(di);
+          }
+      }
+    else
+      old_solution.get(old_indices, values);
   }
 
 

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -1361,6 +1361,11 @@ void
 GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::SubFunctor::insert_id(
     dof_id_type id, const InsertInput & val, processor_id_type pid)
 {
+  // We may see invalid ids when expanding a subdomain with a
+  // restricted variable
+  if (id == DofObject::invalid_id)
+    return;
+
   auto iter = new_ids_to_push.find(id);
   if (iter == new_ids_to_push.end())
     action.insert(id, val);
@@ -1406,6 +1411,12 @@ GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::SubFunctor::inse
   for (auto i : index_range(ids))
     {
       const dof_id_type id = ids[i];
+
+      // We may see invalid ids when expanding a subdomain with a
+      // restricted variable
+      if (id == DofObject::invalid_id)
+        continue;
+
       const InsertInput & val = vals[i];
 
       auto iter = new_ids_to_push.find(id);

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1683,6 +1683,9 @@ void DofMap::prepare_send_list ()
   // Remove the end of the send_list.  Use the "swap trick"
   // from Effective STL
   std::vector<dof_id_type> (_send_list.begin(), new_end).swap (_send_list);
+
+  // Make sure the send list has nothing invalid in it.
+  libmesh_assert(_send_list.empty() || _send_list.back() < this->n_dofs());
 }
 
 void DofMap::reinit_send_list (MeshBase & mesh)

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1589,8 +1589,12 @@ void DofMap::add_neighbors_to_send_list(MeshBase & mesh)
 
               // Insert the remote DOF indices into the send list
               for (auto d : di)
-                if (!this->local_index(d))
-                  _send_list.push_back(d);
+                if (d != DofObject::invalid_id &&
+                    !this->local_index(d))
+                  {
+                    libmesh_assert_less(d, this->n_dofs());
+                    _send_list.push_back(d);
+                  }
             }
         }
       else
@@ -1600,8 +1604,12 @@ void DofMap::add_neighbors_to_send_list(MeshBase & mesh)
 
           // Insert the remote DOF indices into the send list
           for (const auto & dof : di)
-            if (!this->local_index(dof))
-              _send_list.push_back(dof);
+            if (dof != DofObject::invalid_id &&
+                !this->local_index(dof))
+              {
+                libmesh_assert_less(dof, this->n_dofs());
+                _send_list.push_back(dof);
+              }
         }
 
     }
@@ -1627,8 +1635,12 @@ void DofMap::add_neighbors_to_send_list(MeshBase & mesh)
 
       // Insert the remote DOF indices into the send list
       for (const auto & dof : di)
-        if (!this->local_index(dof))
-          _send_list.push_back(dof);
+        if (dof != DofObject::invalid_id &&
+            !this->local_index(dof))
+          {
+            libmesh_assert_less(dof, this->n_dofs());
+            _send_list.push_back(dof);
+          }
     }
 }
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2316,15 +2316,23 @@ void DofMap::_node_dof_indices (const Elem & elem,
     }
   // If this is a vertex or an element without extra hanging
   // dofs, our dofs come in forward order coming from the
-  // beginning
+  // beginning.  But we still might not have all those dofs, in cases
+  // where a subdomain-restricted variable just had its subdomain
+  // expanded.
   else
-    for (unsigned int i=0; i<nc; i++)
-      {
-        const dof_id_type d =
-          obj.dof_number(sys_num, vg, vig, i, n_comp);
-        libmesh_assert_not_equal_to (d, DofObject::invalid_id);
-        di.push_back(d);
-      }
+    {
+      const unsigned int good_nc =
+        std::min(static_cast<unsigned int>(n_comp), nc);
+      for (unsigned int i=0; i != good_nc; ++i)
+        {
+          const dof_id_type d =
+            obj.dof_number(sys_num, vg, vig, i, n_comp);
+          libmesh_assert_not_equal_to (d, DofObject::invalid_id);
+          di.push_back(d);
+        }
+      for (unsigned int i=good_nc; i != nc; ++i)
+        di.push_back(DofObject::invalid_id);
+    }
 }
 
 
@@ -2703,30 +2711,32 @@ void DofMap::old_dof_indices (const Elem * const elem,
                           }
                         // If this is a vertex or an element without extra hanging
                         // dofs, our dofs come in forward order coming from the
-                        // beginning
+                        // beginning.  But we still might not have all
+                        // those dofs on the old_dof_obj, in cases
+                        // where a subdomain-restricted variable just
+                        // had its subdomain expanded.
                         else
-                          for (unsigned int i=0; i<nc; i++)
-                            {
-                              const dof_id_type d =
-                                old_dof_obj->dof_number(sys_num, vg, vig, i, n_comp);
+                          {
+                            const unsigned int old_nc =
+                              std::min(static_cast<unsigned int>(n_comp), nc);
+                            for (unsigned int i=0; i != old_nc; ++i)
+                              {
+                                const dof_id_type d =
+                                  old_dof_obj->dof_number(sys_num, vg, vig, i, n_comp);
 
-                              // On a newly-expanded subdomain, we
-                              // may have some DoFs that didn't
-                              // exist in the old system, in which
-                              // case we can't assert this:
-                              // libmesh_assert_not_equal_to (d, DofObject::invalid_id);
+                                libmesh_assert_not_equal_to (d, DofObject::invalid_id);
 
-                              di.push_back(d);
-                            }
+                                di.push_back(d);
+                              }
+                            for (unsigned int i=old_nc; i != nc; ++i)
+                              di.push_back(DofObject::invalid_id);
+                          }
                       }
 
                     // If there are any element-based DOF numbers, get them
                     const unsigned int nc =
                       FEInterface::n_dofs_per_elem(fe_type, extra_order, elem);
 
-                    // We should never have fewer dofs than necessary on an
-                    // element unless we're getting indices on a parent element
-                    // or a just-coarsened element
                     if (nc != 0)
                       {
                         const DofObject * old_dof_obj = elem->old_dof_object;

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2749,8 +2749,14 @@ void DofMap::old_dof_indices (const Elem * const elem,
                           }
                         else
                           {
-                            libmesh_assert(!elem->active() || fe_type.family == LAGRANGE ||
-                                           elem->refinement_flag() == Elem::JUST_COARSENED);
+                            // We should never have fewer dofs than
+                            // necessary on an element unless we're
+                            // getting indices on a parent element, a
+                            // just-coarsened element ... or a
+                            // subdomain-restricted variable with a
+                            // just-expanded subdomain
+                            // libmesh_assert(!elem->active() || fe_type.family == LAGRANGE ||
+                            //                 elem->refinement_flag() == Elem::JUST_COARSENED);
                             di.resize(di.size() + nc, DofObject::invalid_id);
                           }
                       }

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2691,7 +2691,13 @@ void DofMap::old_dof_indices (const Elem * const elem,
                                 {
                                   const dof_id_type d =
                                     old_dof_obj->dof_number(sys_num, vg, vig, i, n_comp);
-                                  libmesh_assert_not_equal_to (d, DofObject::invalid_id);
+
+                                  // On a newly-expanded subdomain, we
+                                  // may have some DoFs that didn't
+                                  // exist in the old system, in which
+                                  // case we can't assert this:
+                                  // libmesh_assert_not_equal_to (d, DofObject::invalid_id);
+
                                   di.push_back(d);
                                 }
                           }
@@ -2703,7 +2709,13 @@ void DofMap::old_dof_indices (const Elem * const elem,
                             {
                               const dof_id_type d =
                                 old_dof_obj->dof_number(sys_num, vg, vig, i, n_comp);
-                              libmesh_assert_not_equal_to (d, DofObject::invalid_id);
+
+                              // On a newly-expanded subdomain, we
+                              // may have some DoFs that didn't
+                              // exist in the old system, in which
+                              // case we can't assert this:
+                              // libmesh_assert_not_equal_to (d, DofObject::invalid_id);
+
                               di.push_back(d);
                             }
                       }

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2450,8 +2450,10 @@ void DofMap::_dof_indices (const Elem & elem,
       const unsigned int nc = FEInterface::n_dofs_per_elem(fe_type, p_level, &elem);
 
       // We should never have fewer dofs than necessary on an
-      // element unless we're getting indices on a parent element,
-      // and we should never need those indices
+      // element unless we're getting indices on a parent element
+      // (and we should never need those indices) or off-domain for a
+      // subdomain-restricted variable (where invalid_id is the
+      // correct thing to return)
       if (nc != 0)
         {
           const unsigned int n_comp = elem.n_comp_group(sys_num,vg);

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2437,13 +2437,19 @@ void DofMap::_dof_indices (const Elem & elem,
           // dofs, our dofs come in forward order coming from the
           // beginning
           else
-            for (unsigned int i=0; i<nc; i++)
-              {
-                const dof_id_type d =
-                  node.dof_number(sys_num, vg, vig, i, n_comp);
-                libmesh_assert_not_equal_to (d, DofObject::invalid_id);
-                di.push_back(d);
-              }
+            {
+              for (unsigned int i=0; i!=n_comp; ++i)
+                {
+                  const dof_id_type d =
+                    node.dof_number(sys_num, vg, vig, i, n_comp);
+                  libmesh_assert_not_equal_to (d, DofObject::invalid_id);
+                  libmesh_assert_less (d, this->n_dofs());
+                  di.push_back(d);
+                }
+
+              for (unsigned int i=n_comp; i!=nc; ++i)
+                di.push_back(DofObject::invalid_id);
+            }
         }
 
       // If there are any element-based DOF numbers, get them

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -1386,8 +1386,18 @@ void BuildProjectionList::operator()(const ConstElemRange & range)
         dof_map.old_dof_indices (elem, di);
 
       for (auto di_i : di)
-        if (di_i < first_old_dof || di_i >= end_old_dof)
-          this->send_list.push_back(di_i);
+        {
+          // If we've just expanded a subdomain for a
+          // subdomain-restricted variable, then we may have an
+          // old_dof_object that doesn't have an old DoF for every
+          // local index.
+          if (di_i == DofObject::invalid_id)
+            continue;
+
+          libmesh_assert_less(di_i, dof_map.n_old_dofs());
+          if (di_i < first_old_dof || di_i >= end_old_dof)
+            this->send_list.push_back(di_i);
+        }
     }  // end elem loop
 }
 

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -1360,8 +1360,18 @@ void BuildProjectionList::operator()(const ConstElemRange & range)
                           const unsigned int n_comp =
                             old_dofs->n_comp_group(sysnum, vg);
                           for (unsigned int c=0; c != n_comp; ++c)
-                            di.push_back
-                              (old_dofs->dof_number(sysnum, vg, vig, c, n_comp));
+                            {
+                              const dof_id_type old_id =
+                                old_dofs->dof_number(sysnum, vg, vig,
+                                                     c, n_comp);
+
+                              // We should either have no old id
+                              // (e.g. on a newly expanded subdomain)
+                              // or an id from the old system.
+                              libmesh_assert(old_id < dof_map.n_old_dofs() ||
+                                             old_id == DofObject::invalid_id);
+                              di.push_back(old_id);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Previously, when reaching System::project_vector() after expanding a subdomain with a subdomain-restricted variable, we were getting segfaults.  We should now be getting correct projections of old DoFs combined with zeroing of new DoFs.

Thanks to @dewenyushu for setting up a test case demonstrating this problem.  And for catching this problem in the first place.  And for listening to me when I recommended trying this because I wasn't expecting any problems ...

I'm not confident that we don't have any more bugs in this use case (either nobody was doing this in parallel before or the regressions here were shockingly old), but at least that first Element_Activation/diffuse_activate_element_mesh2.i claims to be converging for me now.  Once we're more confident this is working we'll definitely need some unit testing, because it looks like it would be easy to inadvertently break this during future performance optimizations, just as happened last time, or during future projection feature additions.