### PR TITLE
GhostPointNeighbors optimization

### DIFF
--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -403,10 +403,26 @@ public:
    * now be \p n_integers associated; this *replaces*, not augments,
    * any previous count.
    *
+   * Any newly-added values will initially be DofObject::invalid_id
+   *
    * If non-integer data is in the set, each datum of type T should be
    * counted sizeof(T)/sizeof(dof_id_type) times in \p n_integers.
    */
   void add_extra_integers (const unsigned int n_integers);
+
+  /**
+   * Assigns a set of extra integers to this \p DofObject.  There will
+   * now be \p n_integers associated; this *replaces*, not augments,
+   * any previous count.
+   *
+   * Any newly-added values will be copied from \p default_values.
+   *
+   * If non-integer data is in the set, each datum of type T should be
+   * counted sizeof(T)/sizeof(dof_id_type) times in \p n_integers, and
+   * its data should be expressed in \p default_values as per memcpy.
+   */
+  void add_extra_integers (const unsigned int n_integers,
+                           const std::vector<dof_id_type> & default_values);
 
   /**
    * Returns how many extra integers are associated to the \p DofObject

--- a/include/base/ghost_point_neighbors.h
+++ b/include/base/ghost_point_neighbors.h
@@ -28,8 +28,9 @@ namespace libMesh
 {
 
 /**
- * This class implements the default geometry ghosting in libMesh:
- * point neighbors and interior_parent elements are ghosted.
+ * This class implements the original default geometry ghosting
+ * requirements in libMesh: point neighbors on the same manifold, and
+ * interior_parent elements.
  *
  * \author Roy H. Stogner
  * \date 2016

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -750,11 +750,15 @@ public:
    * manual call to \p size_elem_extra_integers() will need to be done
    * before the new space is usable.
    *
+   * Newly allocated values for the new datum will be initialized to
+   * \p default_value
+   *
    * \returns The index number for the new datum, or for the existing
    * datum if one by the same name has already been added.
    */
   unsigned int add_elem_integer(const std::string & name,
-                                bool allocate_data = true);
+                                bool allocate_data = true,
+                                dof_id_type default_value = DofObject::invalid_id);
 
   /**
    * Register integer data (of type dof_id_type) to be added to
@@ -763,11 +767,16 @@ public:
    * If the mesh already has elements, data by default is allocated in
    * each of them.
    *
+   * Newly allocated values for the new datum with name \p names[i]
+   * will be initialized to \p default_values[i], or to
+   * DofObject::invalid_id if \p default_values is null.
+   *
    * \returns The index numbers for the new data, and/or for existing
    * data if data by some of the same names has already been added.
    */
   std::vector<unsigned int> add_elem_integers(const std::vector<std::string> & names,
-                                              bool allocate_data = true);
+                                              bool allocate_data = true,
+                                              const std::vector<dof_id_type> * default_values = nullptr);
 
   /*
    * \returns The index number for the named extra element integer
@@ -808,6 +817,10 @@ public:
    * manual call to \p size_elem_extra_integers() will need to be done
    * before the new space is usable.
    *
+   * Newly allocated values for the new datum will be initialized to
+   * \p *default_value if \p default_value is not null, or to
+   * meaningless memcpy output otherwise.
+   *
    * \returns The index numbers for the new data, and/or for existing
    * data if data by some of the same names has already been added.
    *
@@ -820,13 +833,18 @@ public:
    */
   template <typename T>
   unsigned int add_elem_datum(const std::string & name,
-                              bool allocate_data = true);
+                              bool allocate_data = true,
+                              const T * default_value = nullptr);
 
   /**
    * Register data (of type T) to be added to each element in the
    * mesh.
    *
    * If the mesh already has elements, data is allocated in each.
+   *
+   * Newly allocated values for the new datum with name \p names[i]
+   * will be initialized to \p default_values[i], or to
+   * meaningless memcpy output if \p default_values is null.
    *
    * \returns The starting index number for the new data, or for the
    * existing data if one by the same name has already been added.
@@ -840,7 +858,8 @@ public:
    */
   template <typename T>
   std::vector<unsigned int> add_elem_data(const std::vector<std::string> & names,
-                                          bool allocate_data = true);
+                                          bool allocate_data = true,
+                                          const std::vector<T> * default_values = nullptr);
 
   /**
    * Register an integer datum (of type dof_id_type) to be added to
@@ -853,11 +872,15 @@ public:
    * manual call to \p size_node_extra_integers() will need to be done
    * before the new space is usable.
    *
+   * Newly allocated values for the new datum will be initialized to
+   * \p default_value
+   *
    * \returns The index number for the new datum, or for the existing
    * datum if one by the same name has already been added.
    */
   unsigned int add_node_integer(const std::string & name,
-                                bool allocate_data = true);
+                                bool allocate_data = true,
+                                dof_id_type default_value = DofObject::invalid_id);
 
   /**
    * Register integer data (of type dof_id_type) to be added to
@@ -866,11 +889,16 @@ public:
    * If the mesh already has nodes, data by default is allocated in
    * each.
    *
+   * Newly allocated values for the new datum with name \p names[i]
+   * will be initialized to \p default_values[i], or to
+   * DofObject::invalid_id if \p default_values is null.
+   *
    * \returns The index numbers for the new data, and/or for existing
    * data if data by some of the same names has already been added.
    */
   std::vector<unsigned int> add_node_integers(const std::vector<std::string> & names,
-                                              bool allocate_data = true);
+                                              bool allocate_data = true,
+                                              const std::vector<dof_id_type> * default_values = nullptr);
 
   /*
    * \returns The index number for the named extra node integer
@@ -911,6 +939,10 @@ public:
    * manual call to \p size_node_extra_integers() will need to be done
    * before the new space is usable.
    *
+   * Newly allocated values for the new datum will be initialized to
+   * \p *default_value if \p default_value is not null, or to
+   * meaningless memcpy output otherwise.
+   *
    * \returns The starting index number for the new datum, or for the
    * existing datum if one by the same name has already been added.
    *
@@ -923,13 +955,18 @@ public:
    */
   template <typename T>
   unsigned int add_node_datum(const std::string & name,
-                              bool allocate_data = true);
+                              bool allocate_data = true,
+                              const T * default_value = nullptr);
 
   /**
    * Register data (of type T) to be added to each node in the
    * mesh.
    *
    * If the mesh already has nodes, data by default is allocated in each.
+   *
+   * Newly allocated values for the new datum with name \p names[i]
+   * will be initialized to \p default_values[i], or to
+   * meaningless memcpy output if \p default_values is null.
    *
    * \returns The starting index number for the new data, or for the
    * existing data if one by the same name has already been added.
@@ -943,7 +980,8 @@ public:
    */
   template <typename T>
   std::vector<unsigned int> add_node_data(const std::vector<std::string> & name,
-                                          bool allocate_data = true);
+                                          bool allocate_data = true,
+                                          const std::vector<T> * default_values = nullptr);
 
   /**
    * Prepare a newly ecreated (or read) mesh for use.
@@ -1764,10 +1802,22 @@ protected:
   std::vector<std::string> _elem_integer_names;
 
   /**
+   * The array of default initialization values for integer data
+   * associated with each element in the mesh
+   */
+  std::vector<dof_id_type> _elem_integer_default_values;
+
+  /**
    * The array of names for integer data associated with each node
    * in the mesh
    */
   std::vector<std::string> _node_integer_names;
+
+  /**
+   * The array of default initialization values for integer data
+   * associated with each node in the mesh
+   */
+  std::vector<dof_id_type> _node_integer_default_values;
 
   /**
    * Size extra-integer arrays of all elements in the mesh
@@ -1955,14 +2005,19 @@ MeshBase::const_node_iterator : variant_filter_iterator<MeshBase::Predicate,
 template <typename T>
 inline
 unsigned int MeshBase::add_elem_datum(const std::string & name,
-                                      bool allocate_data)
+                                      bool allocate_data,
+                                      const T * default_value)
 {
   const std::size_t old_size = _elem_integer_names.size();
 
-  unsigned int start_idx = this->add_elem_integer(name, false);
   unsigned int n_more_integers = (sizeof(T)-1)/sizeof(dof_id_type);
+  std::vector<dof_id_type> int_data(n_more_integers+1, DofObject::invalid_id);
+  if (default_value)
+    std::memcpy(int_data.data(), default_value, sizeof(T));
+
+  unsigned int start_idx = this->add_elem_integer(name, false, int_data[0]);
   for (unsigned int i=0; i != n_more_integers; ++i)
-    this->add_elem_integer(name+"__"+std::to_string(i));
+    this->add_elem_integer(name+"__"+std::to_string(i), false, int_data[i+1]);
 
   if (allocate_data && old_size != _elem_integer_names.size())
     this->size_elem_extra_integers();
@@ -1974,14 +2029,20 @@ unsigned int MeshBase::add_elem_datum(const std::string & name,
 template <typename T>
 inline
 std::vector<unsigned int> MeshBase::add_elem_data(const std::vector<std::string> & names,
-                                                  bool allocate_data)
+                                                  bool allocate_data,
+                                                  const std::vector<T> * default_values)
 {
+  libmesh_assert(!default_values || default_values.size() == names.size());
+
   std::vector<unsigned int> returnval(names.size());
 
   const std::size_t old_size = _elem_integer_names.size();
 
   for (auto i : index_range(names))
-    returnval[i] = this->add_elem_datum<T>(names[i], false);
+    returnval[i] =
+      this->add_elem_datum<T>(names[i], false,
+                              default_values ?
+                              (*default_values)[i] : nullptr);
 
   if (allocate_data && old_size != _elem_integer_names.size())
     this->size_elem_extra_integers();
@@ -1993,14 +2054,19 @@ std::vector<unsigned int> MeshBase::add_elem_data(const std::vector<std::string>
 template <typename T>
 inline
 unsigned int MeshBase::add_node_datum(const std::string & name,
-                                      bool allocate_data)
+                                      bool allocate_data,
+                                      const T * default_value)
 {
   const std::size_t old_size = _node_integer_names.size();
 
-  unsigned int start_idx = this->add_node_integer(name, false);
   unsigned int n_more_integers = (sizeof(T)-1)/sizeof(dof_id_type);
+  std::vector<dof_id_type> int_data(n_more_integers+1, DofObject::invalid_id);
+  if (default_value)
+    std::memcpy(int_data.data(), default_value, sizeof(T));
+
+  unsigned int start_idx = this->add_node_integer(name, false, int_data[0]);
   for (unsigned int i=0; i != n_more_integers; ++i)
-    this->add_node_integer(name+"__"+std::to_string(i), false);
+    this->add_node_integer(name+"__"+std::to_string(i), false, int_data[i+1]);
 
   if (allocate_data && old_size != _node_integer_names.size())
     this->size_node_extra_integers();
@@ -2012,14 +2078,20 @@ unsigned int MeshBase::add_node_datum(const std::string & name,
 template <typename T>
 inline
 std::vector<unsigned int> MeshBase::add_node_data(const std::vector<std::string> & names,
-                                                  bool allocate_data)
+                                                  bool allocate_data,
+                                                  const std::vector<T> * default_values)
 {
+  libmesh_assert(!default_values || default_values.size() == names.size());
+
   std::vector<unsigned int> returnval(names.size());
 
   const std::size_t old_size = _node_integer_names.size();
 
   for (auto i : index_range(names))
-    returnval[i] = this->add_node_datum<T>(names[i], false);
+    returnval[i] =
+      this->add_node_datum<T>(names[i], false,
+                              default_values ?
+                              (*default_values)[i] : nullptr);
 
   if (allocate_data && old_size != _node_integer_names.size())
     this->size_node_extra_integers();

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -745,7 +745,10 @@ public:
    *
    * If the mesh already has elements, data by default is allocated in
    * each of them.  This may be expensive to do repeatedly; use
-   * add_elem_integers instead.
+   * add_elem_integers instead.  Alternatively, the \p allocate_data
+   * option can be manually set to false, but if this is done then a
+   * manual call to \p size_elem_extra_integers() will need to be done
+   * before the new space is usable.
    *
    * \returns The index number for the new datum, or for the existing
    * datum if one by the same name has already been added.
@@ -800,7 +803,10 @@ public:
    *
    * If the mesh already has elements, data by default is allocated in
    * each of them.  This may be expensive to do repeatedly; use
-   * add_elem_data instead.
+   * add_elem_data instead.  Alternatively, the \p allocate_data
+   * option can be manually set to false, but if this is done then a
+   * manual call to \p size_elem_extra_integers() will need to be done
+   * before the new space is usable.
    *
    * \returns The index numbers for the new data, and/or for existing
    * data if data by some of the same names has already been added.
@@ -842,7 +848,10 @@ public:
    *
    * If the mesh already has nodes, data by default is allocated in
    * each of them.  This may be expensive to do repeatedly; use
-   * add_node_integers instead.
+   * add_node_integers instead.  Alternatively, the \p allocate_data
+   * option can be manually set to false, but if this is done then a
+   * manual call to \p size_node_extra_integers() will need to be done
+   * before the new space is usable.
    *
    * \returns The index number for the new datum, or for the existing
    * datum if one by the same name has already been added.
@@ -897,7 +906,10 @@ public:
    *
    * If the mesh already has nodes, data by default is allocated in
    * each of them.  This may be expensive to do repeatedly; use
-   * add_node_data instead.
+   * add_node_data instead.  Alternatively, the \p allocate_data
+   * option can be manually set to false, but if this is done then a
+   * manual call to \p size_node_extra_integers() will need to be done
+   * before the new space is usable.
    *
    * \returns The starting index number for the new datum, or for the
    * existing datum if one by the same name has already been added.

--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -551,6 +551,25 @@ DofObject::add_extra_integers (const unsigned int n_integers)
 
 
 
+void
+DofObject::add_extra_integers (const unsigned int n_integers,
+                               const std::vector<dof_id_type> & default_values)
+{
+  libmesh_assert_equal_to(n_integers, default_values.size());
+
+  const unsigned int n_old_integers = this->n_extra_integers();
+  this->add_extra_integers(n_integers);
+  if (n_integers > n_old_integers)
+    {
+      const unsigned int n_more_integers = n_integers - n_old_integers;
+      std::copy(default_values.begin()+n_old_integers,
+                default_values.end(),
+                _idx_buf.end()-n_more_integers);
+    }
+}
+
+
+
 unsigned int DofObject::packed_indexing_size() const
 {
   return

--- a/src/base/ghost_point_neighbors.C
+++ b/src/base/ghost_point_neighbors.C
@@ -106,19 +106,9 @@ void GhostPointNeighbors::operator()
     }
 
   // Connect any interior_parents who are really in our mesh
-  for (const auto & elem : _mesh->element_ptr_range())
-    {
-      std::unordered_set<const Elem *>::iterator ip_it =
-        interior_parents.find(elem);
-
-      if (ip_it != interior_parents.end())
-        {
-          coupled_elements.emplace(elem, nullcm);
-
-          // Shrink the set ASAP to speed up subsequent searches
-          interior_parents.erase(ip_it);
-        }
-    }
+  for (const auto & elem : interior_parents)
+    if (_mesh->query_elem_ptr(elem->id()) == elem)
+      coupled_elements.emplace(elem, nullcm);
 
   // Connect any active elements which are connected to our range's
   // elements' nodes by addin elements connected to nodes on active

--- a/src/base/ghost_point_neighbors.C
+++ b/src/base/ghost_point_neighbors.C
@@ -35,11 +35,18 @@ void GhostPointNeighbors::operator()
    GhostPointNeighbors::map_type & coupled_elements)
 {
   libmesh_assert(_mesh);
-  // Using the connected_nodes set rather than point_neighbors() gives
-  // us correct results even in corner cases, such as where two
-  // elements meet only at a corner.  ;-)
 
-  std::unordered_set<const Node *> connected_nodes;
+  // Using a connected_nodes set rather than point_neighbors() would
+  // give us correct results even in corner cases, such as where two
+  // elements meet only at a corner.  ;-)
+  //
+  // std::unordered_set<const Node *> connected_nodes;
+  //
+  // Unfortunately, it's not a *fast* enough test to use on a
+  // ReplicatedMesh (where it's O(Nprocs) times slower), or as a
+  // coupling functor (where it's O(Nelem/Nprocs) times slower), or as
+  // a coupling functor on a ReplicatedMesh (where you might as well
+  // just give up now)
 
   // Links between boundary and interior elements on mixed
   // dimensional meshes also give us correct ghosting in this way.
@@ -66,58 +73,24 @@ void GhostPointNeighbors::operator()
       if (elem->processor_id() != p)
         coupled_elements.emplace(elem, nullcm);
 
-      for (auto neigh : elem->neighbor_ptr_range())
-        {
-          if (neigh && neigh != remote_elem)
-            {
-#ifdef LIBMESH_ENABLE_AMR
-              if (!neigh->active())
-                {
-                  std::vector<const Elem*> family;
-                  neigh->active_family_tree_by_neighbor(family, elem);
+      std::set<const Elem *> elem_point_neighbors;
+      elem->find_point_neighbors(elem_point_neighbors);
 
-                  for (const Elem * f : family)
-                    if (f->processor_id() != p)
-                      coupled_elements.emplace(f, nullcm);
-                }
-              else
-#endif
-                if (neigh->processor_id() != p)
-                  coupled_elements.emplace(neigh, nullcm);
-            }
-        }
+      for (const auto & neigh : elem_point_neighbors)
+        coupled_elements.emplace(neigh, nullcm);
 
-      // It is possible that a refined boundary element will not
-      // touch any nodes of its interior_parent, in TRI3/TET4 and in
-      // non-level-one rule cases.  So we can't just rely on node
-      // connections to preserve interior_parent().  However, trying
-      // to preserve interior_parent() manually only works if it's on
+      // An interior_parent isn't on the same manifold so won't be
+      // found as a point neighbor, and it may not share nodes so we
+      // can't use a connected_nodes test.
+      //
+      // Trying to preserve interior_parent() only works if it's on
       // the same Mesh, which is *not* guaranteed!  So we'll
-      // double-check later to make sure our interior parents are in
-      // the mesh before we connect them.
-      if (elem->dim() < LIBMESH_DIM &&
-          elem->interior_parent() &&
-          elem->interior_parent()->processor_id() != p)
-        interior_parents.insert (elem->interior_parent());
-
-      // Add nodes connected to active local elements
-      for (auto n : elem->node_index_range())
-        connected_nodes.insert (elem->node_ptr(n));
+      // double-check.
+      const Elem * ip = elem->interior_parent();
+      if (ip && ip->processor_id() != p &&
+          _mesh->query_elem_ptr(ip->id()) == ip)
+        coupled_elements.emplace(ip, nullcm);
     }
-
-  // Connect any interior_parents who are really in our mesh
-  for (const auto & elem : interior_parents)
-    if (_mesh->query_elem_ptr(elem->id()) == elem)
-      coupled_elements.emplace(elem, nullcm);
-
-  // Connect any active elements which are connected to our range's
-  // elements' nodes by addin elements connected to nodes on active
-  // local elements.
-  for (const auto & elem : _mesh->active_element_ptr_range())
-    if (elem->processor_id() != p)
-      for (auto & n : elem->node_ref_range())
-        if (connected_nodes.count(&n))
-          coupled_elements.emplace(elem, nullcm);
 }
 
 } // namespace libMesh

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -547,7 +547,8 @@ Elem * DistributedMesh::add_elem (Elem * e)
 
   // Make sure any new element is given space for any extra integers
   // we've requested
-  e->add_extra_integers(_elem_integer_names.size());
+  e->add_extra_integers(_elem_integer_names.size(),
+                        _elem_integer_default_values);
 
   // And set mapping type and data on any new element
   e->set_mapping_type(this->default_mapping_type());
@@ -606,7 +607,8 @@ Elem * DistributedMesh::insert_elem (Elem * e)
 
   // Make sure any new element is given space for any extra integers
   // we've requested
-  e->add_extra_integers(_elem_integer_names.size());
+  e->add_extra_integers(_elem_integer_names.size(),
+                        _elem_integer_default_values);
 
   // And set mapping type and data on any new element
   e->set_mapping_type(this->default_mapping_type());
@@ -790,7 +792,8 @@ Node * DistributedMesh::add_node (Node * n)
     }
 #endif
 
-  n->add_extra_integers(_node_integer_names.size());
+  n->add_extra_integers(_node_integer_names.size(),
+                        _node_integer_default_values);
 
   // Unpartitioned nodes should be added on every processor
   // And shouldn't be added in the same batch as ghost nodes

--- a/src/mesh/dyna_io.C
+++ b/src/mesh/dyna_io.C
@@ -266,8 +266,13 @@ void DynaIO::read_mesh(std::istream & in)
 
             if (weight_control_flag)
               {
+                // If we ever add more nodes that aren't in this file,
+                // merge this mesh with a non-spline mesh, etc., 1.0
+                // is a good default weight
+                const Real default_weight = 1.0;
                 weight_index = cast_int<unsigned char>
-                  (mesh.add_node_datum<Real>("rational_weight"));
+                  (mesh.add_node_datum<Real>("rational_weight", true,
+                                             &default_weight));
                 mesh.set_default_mapping_type(RATIONAL_BERNSTEIN_MAP);
                 mesh.set_default_mapping_data(weight_index);
               }

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1106,7 +1106,9 @@ void MeshCommunication::broadcast (MeshBase & mesh) const
 
   // We may have set extra data only on processor 0 in a read()
   mesh.comm().broadcast(mesh._node_integer_names);
+  mesh.comm().broadcast(mesh._node_integer_default_values);
   mesh.comm().broadcast(mesh._elem_integer_names);
+  mesh.comm().broadcast(mesh._elem_integer_default_values);
 
   // We may have set mapping data only on processor 0 in a read()
   unsigned char map_type = mesh.default_mapping_type();

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -318,7 +318,8 @@ Elem * ReplicatedMesh::add_elem (Elem * e)
 
   // Make sure any new element is given space for any extra integers
   // we've requested
-  e->add_extra_integers(_elem_integer_names.size());
+  e->add_extra_integers(_elem_integer_names.size(),
+                        _elem_integer_default_values);
 
   // And set mapping type and data on any new element
   e->set_mapping_type(this->default_mapping_type());
@@ -361,7 +362,8 @@ Elem * ReplicatedMesh::insert_elem (Elem * e)
 
   // Make sure any new element is given space for any extra integers
   // we've requested
-  e->add_extra_integers(_elem_integer_names.size());
+  e->add_extra_integers(_elem_integer_names.size(),
+                        _elem_integer_default_values);
 
   // And set mapping type and data on any new element
   e->set_mapping_type(this->default_mapping_type());
@@ -466,7 +468,8 @@ Node * ReplicatedMesh::add_point (const Point & p,
                       cast_int<dof_id_type>(_nodes.size()-1) : id).release();
       n->processor_id() = proc_id;
 
-      n->add_extra_integers(_node_integer_names.size());
+      n->add_extra_integers(_node_integer_names.size(),
+                            _node_integer_default_values);
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
       if (!n->valid_unique_id())
@@ -521,7 +524,8 @@ Node * ReplicatedMesh::add_node (Node * n)
    _next_unique_id = std::max(_next_unique_id, n->unique_id()+1);
 #endif
 
-  n->add_extra_integers(_node_integer_names.size());
+  n->add_extra_integers(_node_integer_names.size(),
+                        _node_integer_default_values);
 
   return n;
 }
@@ -567,7 +571,8 @@ Node * ReplicatedMesh::insert_node(Node * n)
    _next_unique_id = std::max(_next_unique_id, n->unique_id()+1);
 #endif
 
-  n->add_extra_integers(_node_integer_names.size());
+  n->add_extra_integers(_node_integer_names.size(),
+                        _node_integer_default_values);
 
   // We have enough space and this spot isn't already occupied by
   // another node, so go ahead and add it.

--- a/tests/fe/fe_rational_map.C
+++ b/tests/fe/fe_rational_map.C
@@ -42,8 +42,14 @@ public:
     // Make sure we can handle non-zero weight indices
     _mesh->add_node_integer("buffer integer1");
     _mesh->add_node_integer("buffer integer2");
+
+    // Default weight to 1.0 so we don't get NaN from contains_point
+    // checks with a default GhostPointNeighbors ghosting
+    const Real default_weight = 1.0;
     unsigned char weight_index = cast_int<unsigned char>
-      (_mesh->add_node_datum<Real>("rational_weight"));
+      (_mesh->add_node_datum<Real>("rational_weight", true,
+                                   &default_weight));
+
     libmesh_assert_not_equal_to(weight_index, 0);
 
     _mesh->set_default_mapping_type(RATIONAL_BERNSTEIN_MAP);

--- a/tests/fe/fe_test.h
+++ b/tests/fe/fe_test.h
@@ -184,8 +184,13 @@ public:
       {
         // Make sure we can handle non-zero weight indices
         _mesh->add_node_integer("buffer integer");
+
+        // Default weight to 1.0 so we don't get NaN from contains_point
+        // checks with a default GhostPointNeighbors ghosting
+        const Real default_weight = 1.0;
         weight_index = cast_int<unsigned char>
-          (_mesh->add_node_datum<Real>("rational_weight"));
+          (_mesh->add_node_datum<Real>("rational_weight", true,
+                                       &default_weight));
         libmesh_assert_not_equal_to(weight_index, 0);
 
         // Set mapping data but not type, since here we're testing


### PR DESCRIPTION
In theory this should give *much* faster results when doing mesh splitting, and slightly faster results for distributed mesh redistribution.

In practice, we should try some performance testing on common distributed mesh applications to make sure performance really is improved or unchanged there.

This change removes support for meshes where point_neighbors searches don't work because two sections of a 2D or 3D manifold only meet at a single node.  Such configurations haven't been supported for many years, and probably already break in other code paths, yet it turns out we had a mesh like that in our own unit tests.  That I wrote.  Embarrassing.

To make the new code (and other code) work more robustly on IGA meshes, I added the ability to default IGA node weights to values other than 0.0 on newly created elements, which incidentally means we also have the ability to set default values for any other extra elem or node data as well.  So that's nice.

This is passing my tests, but these changes are invasive enough and low-priority enough that we definitely should not merge this until Civet says it's okay, probably after tacking on a distributed mesh debug sweep too.