### PR TITLE
NemesisIO input

### DIFF
--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -818,14 +818,17 @@ protected:
   };
 
 
-private:
+protected:
 
   /**
-   * read_var_names() dispatches to this function.
+   * read_var_names() dispatches to this function.  We need to
+   * override it slightly for Nemesis.
    */
-  void read_var_names_impl(const char * var_type,
-                           int & count,
-                           std::vector<std::string> & result);
+  virtual void read_var_names_impl(const char * var_type,
+                                   int & count,
+                                   std::vector<std::string> & result);
+
+private:
 
   /**
    * write_var_names() dispatches to this function.

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -638,12 +638,12 @@ public:
 
   // Maps libMesh element numbers to Exodus element numbers
   // gets filled in when write_elements gets called
-  std::map<int, int> libmesh_elem_num_to_exodus;
+  std::map<dof_id_type, dof_id_type> libmesh_elem_num_to_exodus;
   std::vector<int> exodus_elem_num_to_libmesh;
 
   // Map of all node numbers connected to local node numbers to their exodus numbering.
   // The exodus numbers are stored in here starting with 1
-  std::map<int, int> libmesh_node_num_to_exodus;
+  std::map<dof_id_type, dof_id_type> libmesh_node_num_to_exodus;
   std::vector<int> exodus_node_num_to_libmesh;
 
   // The number of timesteps in the file, as returned by ex_inquire

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -658,8 +658,10 @@ public:
   // The names of the nodal variables stored in the Exodus file
   std::vector<std::string> nodal_var_names;
 
-  // Holds the nodal variable values for a given variable, one value per node
-  std::vector<Real> nodal_var_values;
+  // Holds the nodal variable values for a given variable, one value
+  // per node, indexed by libMesh node id.
+  // This is a map so it can handle Nemesis files as well.
+  std::map<dof_id_type, Real> nodal_var_values;
 
   // The number of elemental variables in the Exodus file
   int num_elem_vars;

--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -122,7 +122,7 @@ public:
    * case of \p root_id equal to \p DofObject::invalid_processor_id
    * this function performs an allgather.
    */
-  void gather (const processor_id_type root_id, DistributedMesh &) const;
+  void gather (const processor_id_type root_id, MeshBase &) const;
 
   /**
    * This method takes an input \p DistributedMesh which may be
@@ -132,7 +132,7 @@ public:
    * will be serialized on each processor.  Since this method is
    * collective it must be called by all processors.
    */
-  void allgather (DistributedMesh & mesh) const
+  void allgather (MeshBase & mesh) const
   { MeshCommunication::gather(DofObject::invalid_processor_id, mesh); }
 
   /**

--- a/include/mesh/mesh_input.h
+++ b/include/mesh/mesh_input.h
@@ -72,9 +72,19 @@ public:
 
   /**
    * This method implements reading a mesh from a specified file.
+   *
+   * This should typically be called in parallel if
+   * is_parallel_format(), but should be called only on processor 0
+   * (after which a mesh broadcast() is called) otherwise.
    */
   virtual void read (const std::string &) = 0;
 
+  /**
+   * Returns true iff this mesh file format and input class are
+   * parallelized, so that all processors can read their share of the
+   * data at once.
+   */
+  bool is_parallel_format () const { return this->_is_parallel_format; }
 
 protected:
 
@@ -102,7 +112,6 @@ protected:
    */
   void skip_comment_lines (std::istream & in,
                            const char comment_start);
-
 
 private:
 

--- a/include/mesh/nemesis_io.h
+++ b/include/mesh/nemesis_io.h
@@ -135,6 +135,13 @@ public:
   void verbose (bool set_verbosity);
 
   /**
+   * Set the flag indicating whether the complex modulus should be
+   * written when complex numbers are enabled. By default this flag
+   * is set to true.
+   */
+  void write_complex_magnitude (bool val);
+
+  /**
    * Write out global variables.
    */
   void write_global_data (const std::vector<Number> &,

--- a/include/mesh/nemesis_io.h
+++ b/include/mesh/nemesis_io.h
@@ -166,6 +166,35 @@ public:
                            std::string exodus_var_name,
                            unsigned int timestep=1);
 
+  /**
+   * If we read in a elemental solution while reading in a mesh, we can attempt
+   * to copy that elemental solution into an EquationSystems object.
+   */
+  void copy_elemental_solution(System & system,
+                               std::string system_var_name,
+                               std::string exodus_var_name,
+                               unsigned int timestep=1);
+
+  /**
+   * Copy global variables into scalar variables of a System object.
+   */
+  void copy_scalar_solution(System & system,
+                            std::vector<std::string> system_var_names,
+                            std::vector<std::string> exodus_var_names,
+                            unsigned int timestep=1);
+
+  /**
+   * Given a vector of global variables and a time step, returns the values
+   * of the global variable at the corresponding time step index.
+   * \param global_var_names Vector of names of global variables
+   * \param timestep The corresponding time step index
+   * \param global_values The vector to be filled
+   */
+  void read_global_variable(std::vector<std::string> global_var_names,
+                            unsigned int timestep,
+                            std::vector<Real> & global_values);
+
+
 private:
 
   /*

--- a/include/mesh/nemesis_io.h
+++ b/include/mesh/nemesis_io.h
@@ -34,6 +34,7 @@ namespace libMesh
 
 // Forward declarations
 class Nemesis_IO_Helper;
+class System;
 
 /**
  * The \p Nemesis_IO class implements reading parallel meshes in the
@@ -155,6 +156,15 @@ public:
    * Return list of the nodal variable names
    */
   const std::vector<std::string> & get_nodal_var_names();
+
+  /**
+   * If we read in a nodal solution while reading in a mesh, we can attempt
+   * to copy that nodal solution into an EquationSystems object.
+   */
+  void copy_nodal_solution(System & system,
+                           std::string system_var_name,
+                           std::string exodus_var_name,
+                           unsigned int timestep=1);
 
 private:
 

--- a/include/mesh/nemesis_io.h
+++ b/include/mesh/nemesis_io.h
@@ -152,6 +152,15 @@ public:
   void append(bool val);
 
 private:
+
+  /*
+   * A helper function for use in debug and devel modes, for asserting
+   * that we get symmetric communication maps from a file we read
+   * and/or that we're writing them out in a symmetric fashion
+   * ourselves.
+   */
+  void assert_symmetric_cmaps();
+
 #if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
   std::unique_ptr<Nemesis_IO_Helper> nemhelper;
 

--- a/include/mesh/nemesis_io.h
+++ b/include/mesh/nemesis_io.h
@@ -151,6 +151,11 @@ public:
    */
   void append(bool val);
 
+  /**
+   * Return list of the nodal variable names
+   */
+  const std::vector<std::string> & get_nodal_var_names();
+
 private:
 
   /*

--- a/include/mesh/nemesis_io_helper.h
+++ b/include/mesh/nemesis_io_helper.h
@@ -285,12 +285,6 @@ public:
   virtual void write_nodesets(const MeshBase & mesh) override;
 
   /**
-   * This function is specialized from ExodusII_IO_Helper to create the
-   * nodal coordinates stored on the local piece of the Mesh.
-   */
-  virtual void create(std::string filename) override;
-
-  /**
    * Specialization of the initialize function from ExodusII_IO_Helper that
    * also writes global initial data to file.
    */

--- a/include/mesh/nemesis_io_helper.h
+++ b/include/mesh/nemesis_io_helper.h
@@ -80,6 +80,13 @@ public:
   virtual ~Nemesis_IO_Helper();
 
   /**
+   * Set the flag indicating whether the complex modulus should be
+   * written when complex numbers are enabled. By default this flag
+   * is set to true.
+   */
+  void write_complex_magnitude (bool val);
+
+  /**
    * Reading functions.  These just allocate memory for you and call the Nemesis
    * routines of the same name.  They also handle error checking for the Nemesis
    * return value.  Be careful calling these at random, some depend on others
@@ -564,6 +571,17 @@ public:
   std::vector<std::vector<int>> elem_cmap_elem_ids;
   std::vector<std::vector<int>> elem_cmap_side_ids;
   std::vector<std::vector<int>> elem_cmap_proc_ids;
+
+  /**
+   * By default, when complex numbers are enabled, for each variable
+   * we write out three values: the real part, "r_u" the imaginary
+   * part, "i_u", and the complex modulus, a_u := sqrt(r_u*r_u +
+   * i_u*i_u), which is also the value returned by
+   * std::abs(std::complex).  Since the modulus is not an independent
+   * quantity, we can set this flag to false and save some file space
+   * by not writing out.
+   */
+  bool write_complex_abs;
 
 protected:
   /**

--- a/include/mesh/nemesis_io_helper.h
+++ b/include/mesh/nemesis_io_helper.h
@@ -253,17 +253,6 @@ public:
                     std::vector<int> & elem_mapb);
 
   /**
-   * Writes the specified number of coordinate values starting at the specified
-   * index.
-   */
-  void put_n_coord(unsigned start_node_num,
-                   unsigned num_nodes,
-                   std::vector<Real> & x_coor,
-                   std::vector<Real> & y_coor,
-                   std::vector<Real> & z_coor);
-
-
-  /**
    * This function is specialized from ExodusII_IO_Helper to write only the
    * nodal coordinates stored on the local piece of the Mesh.
    */

--- a/include/mesh/nemesis_io_helper.h
+++ b/include/mesh/nemesis_io_helper.h
@@ -60,7 +60,9 @@ extern "C" {
  * the same file format.
  *
  * \author John W. Peterson
+ * \author Roy Stogner
  * \date 2008
+ * \date 2020
  */
 class Nemesis_IO_Helper : public ExodusII_IO_Helper
 {
@@ -563,6 +565,14 @@ public:
   std::vector<std::vector<int>> elem_cmap_side_ids;
   std::vector<std::vector<int>> elem_cmap_proc_ids;
 
+protected:
+  /**
+   * read_var_names() dispatches to this function.  We need to
+   * override it slightly for Nemesis.
+   */
+  virtual void read_var_names_impl(const char * var_type,
+                                   int & count,
+                                   std::vector<std::string> & result);
 
 private:
   /**

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -557,11 +557,10 @@ void ExodusII_IO::copy_nodal_solution(System & system,
 
   const unsigned int var_num = system.variable_number(system_var_name);
 
-  for (dof_id_type i=0,
-       n_nodal = cast_int<dof_id_type>(exio_helper->nodal_var_values.size());
-       i != n_nodal; ++i)
+  for (auto p : exio_helper->nodal_var_values)
     {
-      const Node * node = MeshInput<MeshBase>::mesh().query_node_ptr(i);
+      dof_id_type i = p.first;
+      const Node * node = MeshInput<MeshBase>::mesh().node_ptr(i);
 
       if (node && node->n_comp(system.number(), var_num) > 0)
         {
@@ -569,7 +568,7 @@ void ExodusII_IO::copy_nodal_solution(System & system,
 
           // If the dof_index is local to this processor, set the value
           if ((dof_index >= system.solution->first_local_index()) && (dof_index < system.solution->last_local_index()))
-            system.solution->set (dof_index, exio_helper->nodal_var_values[i]);
+            system.solution->set (dof_index, p.second);
         }
     }
 

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -2691,7 +2691,8 @@ write_sideset_data(const MeshBase & mesh,
               // Sanity check: make sure that the "off by one"
               // assumption we used above to set 'elem_id' is valid.
               libmesh_error_msg_if
-                (libmesh_map_find(libmesh_elem_num_to_exodus, cast_int<int>(elem_id)) != elem_list[i + offset],
+                (libmesh_map_find(libmesh_elem_num_to_exodus, cast_int<int>(elem_id)) !=
+                 cast_int<dof_id_type>(elem_list[i + offset]),
                  "Error mapping Exodus elem id to libmesh elem id.");
 
               // Map from Exodus side ids to libmesh side ids.

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1620,7 +1620,7 @@ void ExodusII_IO_Helper::create(std::string filename)
 
       ex_id = exII::ex_create(filename.c_str(), mode, &comp_ws, &io_ws);
 
-      EX_CHECK_ERR(ex_id, "Error creating ExodusII mesh file.");
+      EX_CHECK_ERR(ex_id, "Error creating ExodusII/Nemesis mesh file.");
 
       if (verbose)
         libMesh::out << "File created successfully." << std::endl;

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1470,6 +1470,11 @@ ExodusII_IO_Helper::write_var_names_impl(const char * var_type,
   ex_err = exII::ex_put_var_param(ex_id, var_type, count);
   EX_CHECK_ERR(ex_err, "Error setting number of vars.");
 
+  // Nemesis doesn't like trying to write nodal variable names in
+  // files with no nodes.
+  if (!this->num_nodes)
+    return;
+
   if (count > 0)
     {
       NamesData names_table(count, MAX_STR_LENGTH);

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1338,8 +1338,8 @@ void ExodusII_IO_Helper::read_nodal_var_values(std::string nodal_var_name, int t
       libmesh_error_msg("Unable to locate variable named: " << nodal_var_name);
     }
 
-  // Allocate enough space to store the nodal variable values
-  nodal_var_values.resize(num_nodes);
+  // Clear out any previously read nodal variable values
+  nodal_var_values.clear();
 
   std::vector<Real> unmapped_nodal_var_values(num_nodes);
 
@@ -1354,9 +1354,13 @@ void ExodusII_IO_Helper::read_nodal_var_values(std::string nodal_var_name, int t
 
   for (unsigned i=0; i<static_cast<unsigned>(num_nodes); i++)
     {
+      libmesh_assert_less(i, this->node_num_map.size());
+
       // Use the node_num_map to obtain the ID of this node in the Exodus file,
       // and remember to subtract 1 since libmesh is zero-based and Exodus is 1-based.
-      unsigned mapped_node_id = this->node_num_map[i] - 1;
+      const unsigned mapped_node_id = this->node_num_map[i] - 1;
+
+      libmesh_assert_less(i, unmapped_nodal_var_values.size());
 
       // Store the nodal value in the map.
       nodal_var_values[mapped_node_id] = unmapped_nodal_var_values[i];

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1165,14 +1165,14 @@ void MeshCommunication::broadcast (MeshBase & mesh) const
 
 #ifndef LIBMESH_HAVE_MPI // avoid spurious gcc warnings
 // ------------------------------------------------------------
-void MeshCommunication::gather (const processor_id_type, DistributedMesh &) const
+void MeshCommunication::gather (const processor_id_type, MeshBase &) const
 {
   // no MPI == one processor, no need for this method...
   return;
 }
 #else
 // ------------------------------------------------------------
-void MeshCommunication::gather (const processor_id_type root_id, DistributedMesh & mesh) const
+void MeshCommunication::gather (const processor_id_type root_id, MeshBase & mesh) const
 {
   // Check for quick return
   if (mesh.n_processors() == 1)

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -960,7 +960,7 @@ void Nemesis_IO::read (const std::string & base_filename)
 
   // Read *local* sideset info the same way it is done in
   // exodusII_io_helper.  May be called any time after
-  // nem_helper->read_and_store_header_info(); This sets num_side_sets and resizes
+  // nemhelper->read_and_store_header_info(); This sets num_side_sets and resizes
   // elem_list, side_list, and id_list to num_elem_all_sidesets.  Note
   // that there appears to be the same number of sidesets in each file
   // but they all have different numbers of entries (some are empty).

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -1159,7 +1159,7 @@ void Nemesis_IO::read (const std::string & base_filename)
   // And if that didn't work, then we're actually reading into a
   // ReplicatedMesh, so forget about gathering neighboring elements
   if (mesh.is_serial())
-    return;
+    libmesh_not_implemented();
 
   // Gather neighboring elements so that the mesh has the proper "ghost" neighbor information.
   MeshCommunication().gather_neighboring_elements(cast_ref<DistributedMesh &>(mesh));

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -157,8 +157,9 @@ void Nemesis_IO::read (const std::string & base_filename)
       // object, it will no longer be set... thus no extra print-outs for serial runs.
       // ExodusII_IO(this->mesh()).read (base_filename); // ambiguous when Nemesis_IO is multiply-inherited
 
+      std::string nemesis_filename = nemhelper->construct_nemesis_filename(base_filename);
       MeshBase & mesh = MeshInput<MeshBase>::mesh();
-      ExodusII_IO(mesh).read (base_filename);
+      ExodusII_IO(mesh).read (nemesis_filename);
       return;
     }
 

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -1643,25 +1643,6 @@ void Nemesis_IO::write_information_records ( const std::vector<std::string> & )
 const std::vector<std::string> & Nemesis_IO::get_nodal_var_names()
 {
   nemhelper->read_var_names(ExodusII_IO_Helper::NODAL);
-
-  // With tests where we have more processors than
-  // elements, Nemesis doesn't let us put variable names in files
-  // written by processors owning no nodes, but we may still *need*
-  // those variable names on every processor, so let's sync them up...
-  processor_id_type pid_broadcasting_names = this->processor_id();
-  const std::size_t n_names = nemhelper->nodal_var_names.size();
-  if (!n_names)
-    pid_broadcasting_names = DofObject::invalid_processor_id;
-
-  libmesh_assert(this->comm().semiverify
-                 (n_names ? nullptr : &n_names));
-
-  this->comm().min(pid_broadcasting_names);
-
-  if (pid_broadcasting_names != DofObject::invalid_processor_id)
-    this->comm().broadcast(nemhelper->nodal_var_names,
-                           pid_broadcasting_names);
-
   return nemhelper->nodal_var_names;
 }
 

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -1636,8 +1636,6 @@ void Nemesis_IO::write_information_records ( const std::vector<std::string> & )
   libmesh_error_msg("ERROR, Nemesis API is not defined.");
 }
 
-#endif // #if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
-
 
 
 const std::vector<std::string> & Nemesis_IO::get_nodal_var_names()
@@ -1680,6 +1678,8 @@ void Nemesis_IO::copy_nodal_solution(System & system,
 }
 
 
+
+#endif // #if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
 
 
 

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -481,9 +481,8 @@ void Nemesis_IO::read (const std::string & base_filename)
                        << ", but we wanted ID " << my_next_node << std::endl;
         }
 
-      // update the local->global index map, when we are done
-      // it will be 0-based.
-      nemhelper->node_num_map[local_node_idx] = my_next_node++;
+      // update the local->global index map, keeping it 1-based
+      nemhelper->node_num_map[local_node_idx] = my_next_node++ + 1;
     }
 
   // Now, for the boundary nodes...  We may very well own some of them,
@@ -530,9 +529,8 @@ void Nemesis_IO::read (const std::string & base_filename)
                            << ", but we wanted ID " << my_next_node << std::endl;
             }
 
-          // update the local->global index map, when we are done
-          // it will be 0-based.
-          nemhelper->node_num_map[local_node_idx] = my_next_node++;
+          // update the local->global index map, keeping it 1-based
+          nemhelper->node_num_map[local_node_idx] = my_next_node++ + 1;
         }
     }
   // That should cover numbering all the nodes which belong to us...
@@ -678,9 +676,8 @@ void Nemesis_IO::read (const std::string & base_filename)
                                    << ", but we wanted ID " << global_node_idx << std::endl;
                     }
 
-                  // update the local->global index map, when we are done
-                  // it will be 0-based.
-                  nemhelper->node_num_map[local_node_idx] = global_node_idx;
+                  // update the local->global index map, keeping it 1-based
+                  nemhelper->node_num_map[local_node_idx] = global_node_idx + 1;
 
                   // we are not really going to use my_next_node again, but we can
                   // keep incrementing it to track how many nodes we have added
@@ -694,8 +691,8 @@ void Nemesis_IO::read (const std::string & base_filename)
   // we had better have added all the nodes we need to!
   libmesh_assert_equal_to ((my_next_node - my_node_offset), to_uint(nemhelper->num_nodes));
 
-  // After all that, we should be done with all node-related arrays *except* the
-  // node_num_map, which we have transformed to use our new numbering...
+  // After all that, we should be done with all node-related arrays
+  // *except* the node_num_map.
   // So let's clean up the arrays we are done with.
   {
     Utility::deallocate (nemhelper->node_mapi);
@@ -889,7 +886,7 @@ void Nemesis_IO::read (const std::string & base_filename)
                 gi              = (j*nemhelper->num_nodes_per_elem +       // index into connectivity array
                                    conv.get_node_map(k)),
                 local_node_idx  = nemhelper->connect[gi]-1,                // local node index
-                global_node_idx = nemhelper->node_num_map[local_node_idx]; // new global node index
+                global_node_idx = nemhelper->node_num_map[local_node_idx]-1; // new global node index
 
               // Set node number
               elem->set_node(k) = mesh.node_ptr(global_node_idx);
@@ -1127,7 +1124,7 @@ void Nemesis_IO::read (const std::string & base_filename)
 
           // We should be able to use the node_num_map data structure set up previously to determine
           // the proper global node index.
-          unsigned global_node_id = nemhelper->node_num_map[ nemhelper->node_list[node]-1 /*Exodus is 1-based!*/ ];
+          unsigned global_node_id = nemhelper->node_num_map[ nemhelper->node_list[node]-1 /*Exodus is 1-based!*/ ]-1;
 
           if (_verbose)
             {

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -1627,4 +1627,33 @@ void Nemesis_IO::write_information_records ( const std::vector<std::string> & )
 
 #endif // #if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
 
+
+
+const std::vector<std::string> & Nemesis_IO::get_nodal_var_names()
+{
+  nemhelper->read_var_names(ExodusII_IO_Helper::NODAL);
+
+  // With tests where we have more processors than
+  // elements, Nemesis doesn't let us put variable names in files
+  // written by processors owning no nodes, but we may still *need*
+  // those variable names on every processor, so let's sync them up...
+  processor_id_type pid_broadcasting_names = this->processor_id();
+  const std::size_t n_names = nemhelper->nodal_var_names.size();
+  if (!n_names)
+    pid_broadcasting_names = DofObject::invalid_processor_id;
+
+  libmesh_assert(this->comm().semiverify
+                 (n_names ? nullptr : &n_names));
+
+  this->comm().min(pid_broadcasting_names);
+
+  if (pid_broadcasting_names != DofObject::invalid_processor_id)
+    this->comm().broadcast(nemhelper->nodal_var_names,
+                           pid_broadcasting_names);
+
+  return nemhelper->nodal_var_names;
+}
+
+
+
 } // namespace libMesh

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -183,20 +183,6 @@ void Nemesis_IO::assert_symmetric_cmaps()
 #if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
 void Nemesis_IO::read (const std::string & base_filename)
 {
-  // On one processor, Nemesis and ExodusII should be equivalent, so
-  // let's cowardly defer to that implementation...
-  if (this->n_processors() == 1)
-    {
-      // We can do this in one line but if the verbose flag was set in this
-      // object, it will no longer be set... thus no extra print-outs for serial runs.
-      // ExodusII_IO(this->mesh()).read (base_filename); // ambiguous when Nemesis_IO is multiply-inherited
-
-      std::string nemesis_filename = nemhelper->construct_nemesis_filename(base_filename);
-      MeshBase & mesh = MeshInput<MeshBase>::mesh();
-      ExodusII_IO(mesh).read (nemesis_filename);
-      return;
-    }
-
   LOG_SCOPE ("read()","Nemesis_IO");
 
   // This function must be run on all processors at once

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -694,31 +694,6 @@ void Nemesis_IO_Helper::put_elem_map(std::vector<int> & elem_mapi_in,
 
 
 
-
-
-
-void Nemesis_IO_Helper::put_n_coord(unsigned start_node_num,
-                                    unsigned num_nodes_in,
-                                    std::vector<Real> & x_coor,
-                                    std::vector<Real> & y_coor,
-                                    std::vector<Real> & z_coor)
-{
-  if (num_nodes_in)
-    {
-      nemesis_err_flag =
-        Nemesis::ne_put_n_coord(ex_id,
-                                start_node_num,
-                                num_nodes_in,
-                                x_coor.empty() ? nullptr : x_coor.data(),
-                                y_coor.empty() ? nullptr : y_coor.data(),
-                                z_coor.empty() ? nullptr : z_coor.data());
-
-      EX_CHECK_ERR(nemesis_err_flag, "Error writing coords to file!");
-    }
-}
-
-
-
 void Nemesis_IO_Helper::initialize(std::string title_in, const MeshBase & mesh, bool /*use_discontinuous*/)
 {
   // Make sure that the reference passed in is really a DistributedMesh

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -719,50 +719,6 @@ void Nemesis_IO_Helper::put_n_coord(unsigned start_node_num,
 
 
 
-
-
-
-
-
-// Note: we can't reuse the ExodusII_IO_Helper code directly, since it only runs
-// on processor 0.  TODO: We could have the body of this function as a separate
-// function and then ExodusII_IO_Helper would only call it if on processor 0...
-void Nemesis_IO_Helper::create(std::string filename)
-{
-  // Fall back on double precision when necessary since ExodusII
-  // doesn't seem to support long double
-  int
-    comp_ws = 0,
-    io_ws = 0;
-
-  if (_single_precision)
-    {
-      comp_ws = sizeof(float);
-      io_ws = sizeof(float);
-    }
-  else
-    {
-      comp_ws = cast_int<int>(std::min(sizeof(Real), sizeof(double)));
-      io_ws = cast_int<int>(std::min(sizeof(Real), sizeof(double)));
-    }
-
-  this->ex_id = exII::ex_create(filename.c_str(), EX_CLOBBER, &comp_ws, &io_ws);
-
-  EX_CHECK_ERR(ex_id, "Error creating Nemesis mesh file.");
-
-  if (verbose)
-    libMesh::out << "File created successfully." << std::endl;
-
-  this->opened_for_writing = true;
-}
-
-
-
-
-
-
-
-
 void Nemesis_IO_Helper::initialize(std::string title_in, const MeshBase & mesh, bool /*use_discontinuous*/)
 {
   // Make sure that the reference passed in is really a DistributedMesh

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -580,17 +580,12 @@ void Nemesis_IO_Helper::put_cmap_params(std::vector<int> & node_cmap_ids_in,
                                         std::vector<int> & elem_cmap_ids_in,
                                         std::vector<int> & elem_cmap_elem_cnts_in)
 {
-  libmesh_assert(!node_cmap_ids_in.empty());
-  libmesh_assert(!node_cmap_node_cnts_in.empty());
-  libmesh_assert(!elem_cmap_ids_in.empty());
-  libmesh_assert(!elem_cmap_elem_cnts_in.empty());
-
   nemesis_err_flag =
     Nemesis::ne_put_cmap_params(ex_id,
-                                node_cmap_ids_in.data(),
-                                node_cmap_node_cnts_in.data(),
-                                elem_cmap_ids_in.data(),
-                                elem_cmap_elem_cnts_in.data(),
+                                node_cmap_ids_in.empty() ? nullptr : node_cmap_ids_in.data(),
+                                node_cmap_node_cnts_in.empty() ? nullptr : node_cmap_node_cnts_in.data(),
+                                elem_cmap_ids_in.empty() ? nullptr : elem_cmap_ids_in.data(),
+                                elem_cmap_elem_cnts_in.empty() ? nullptr : elem_cmap_elem_cnts_in.data(),
                                 this->processor_id());
 
   EX_CHECK_ERR(nemesis_err_flag, "Error writing cmap parameters!");
@@ -802,49 +797,39 @@ void Nemesis_IO_Helper::initialize(std::string title_in, const MeshBase & mesh, 
   // when the mesh file is read back in.
   this->compute_communication_map_parameters();
 
-  // Do we have communication maps to write?  Note that
-  // ne_put_cmap_params expects us to have either *both* node and elem
-  // cmaps or *neither*
-  if (!this->node_cmap_ids.empty() &&
-      !this->node_cmap_node_cnts.empty() &&
-      !this->elem_cmap_ids.empty() &&
-      !this->elem_cmap_elem_cnts.empty())
-    {
-      // Write communication map parameters to file.
-      this->put_cmap_params(this->node_cmap_ids,
-                            this->node_cmap_node_cnts,
-                            this->elem_cmap_ids,
-                            this->elem_cmap_elem_cnts);
+  // Write communication map parameters to file.
+  this->put_cmap_params(this->node_cmap_ids,
+                        this->node_cmap_node_cnts,
+                        this->elem_cmap_ids,
+                        this->elem_cmap_elem_cnts);
 
-      // Ready the node communication maps.  The node IDs which
-      // are communicated are the ones currently stored in
-      // proc_nodes_touched_intersections.
-      this->compute_node_communication_maps();
+  // Ready the node communication maps.  The node IDs which
+  // are communicated are the ones currently stored in
+  // proc_nodes_touched_intersections.
+  this->compute_node_communication_maps();
 
-      // Write the packed node communication vectors to file.
-      this->put_node_cmap(this->node_cmap_node_ids,
-                          this->node_cmap_proc_ids);
+  // Write the packed node communication vectors to file.
+  this->put_node_cmap(this->node_cmap_node_ids,
+                      this->node_cmap_proc_ids);
 
-      // Ready the node maps.  These have nothing to do with communication, they map
-      // the nodes to internal, border, and external nodes in the file.
-      this->compute_node_maps();
+  // Ready the node maps.  These have nothing to do with communication, they map
+  // the nodes to internal, border, and external nodes in the file.
+  this->compute_node_maps();
 
-      // Call the Nemesis API to write the node maps to file.
-      this->put_node_map(this->node_mapi,
-                         this->node_mapb,
-                         this->node_mape);
+  // Call the Nemesis API to write the node maps to file.
+  this->put_node_map(this->node_mapi,
+                     this->node_mapb,
+                     this->node_mape);
 
-      // Ready the element communication maps.  This includes border
-      // element IDs, sides which are on the border, and the processors to which
-      // they are to be communicated...
-      this->compute_elem_communication_maps();
+  // Ready the element communication maps.  This includes border
+  // element IDs, sides which are on the border, and the processors to which
+  // they are to be communicated...
+  this->compute_elem_communication_maps();
 
-      // Call the Nemesis API to write the packed element communication maps vectors to file
-      this->put_elem_cmap(this->elem_cmap_elem_ids,
-                          this->elem_cmap_side_ids,
-                          this->elem_cmap_proc_ids);
-    }
-
+  // Call the Nemesis API to write the packed element communication maps vectors to file
+  this->put_elem_cmap(this->elem_cmap_elem_ids,
+                      this->elem_cmap_side_ids,
+                      this->elem_cmap_proc_ids);
 
   // Ready the Nemesis element maps (internal and border) for writing to file.
   this->compute_element_maps();

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -2669,10 +2669,11 @@ void Nemesis_IO_Helper::read_var_names_impl(const char * var_type,
 
   // But with tests where we have more processors than elements,
   // Nemesis doesn't let us put variable names in files written by
-  // processors owning no nodes, but we may still *need* those
+  // processors owning nothing, but we may still *need* those
   // variable names on every processor, so let's sync them up...
+
   processor_id_type pid_broadcasting_names = this->processor_id();
-  const std::size_t n_names = this->nodal_var_names.size();
+  const std::size_t n_names = result.size();
   if (!n_names)
     pid_broadcasting_names = DofObject::invalid_processor_id;
 
@@ -2682,8 +2683,7 @@ void Nemesis_IO_Helper::read_var_names_impl(const char * var_type,
   this->comm().min(pid_broadcasting_names);
 
   if (pid_broadcasting_names != DofObject::invalid_processor_id)
-    this->comm().broadcast(this->nodal_var_names,
-                           pid_broadcasting_names);
+    this->comm().broadcast(result, pid_broadcasting_names);
 }
 
 

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -1693,7 +1693,7 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
       // libmesh_node_num_to_exodus[ libmesh_node_id ] returns the *Exodus* ID for that node.
       // Unlike the exodus_node_num_to_libmesh vector above, this one is a std::map
       this->libmesh_node_num_to_exodus[id] =
-        cast_int<int>(this->exodus_node_num_to_libmesh.size()); // should never be zero...
+        this->exodus_node_num_to_libmesh.size(); // should never be zero...
     }
 
   // Now we're going to loop over the subdomain map and build a few things right
@@ -1739,7 +1739,7 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
           // Set the number map for elements
           this->exodus_elem_num_to_libmesh.push_back(elem_id);
           this->libmesh_elem_num_to_exodus[elem_id] =
-            cast_int<int>(this->exodus_elem_num_to_libmesh.size());
+            this->exodus_elem_num_to_libmesh.size();
 
           const Elem & elem = pmesh.elem_ref(elem_id);
 
@@ -1921,7 +1921,7 @@ void Nemesis_IO_Helper::write_nodesets(const MeshBase & mesh)
     {
       // Don't try to grab a reference to the vector unless the current node is attached
       // to a local element.  Otherwise, another processor will be responsible for writing it in its nodeset.
-      std::map<int, int>::iterator it = this->libmesh_node_num_to_exodus.find(std::get<0>(t));
+      const auto it = this->libmesh_node_num_to_exodus.find(std::get<0>(t));
 
       if (it != this->libmesh_node_num_to_exodus.end())
         {

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -305,6 +305,12 @@ Elem * ReplicatedMesh::add_elem (Elem * e)
 
   if (id < _elements.size())
     {
+      // This should *almost* never happen, but we rely on it when
+      // using allgather to replicate a not-yet-actually-replicated
+      // ReplicatedMesh under construction in parallel.
+      if (e == _elements[id])
+        return e;
+
       // Overwriting existing elements is still probably a mistake.
       libmesh_assert(!_elements[id]);
     }

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -543,14 +543,16 @@ Node * ReplicatedMesh::insert_node(Node * n)
 
   if (n->id() < _nodes.size())
     {
-      // Don't allow inserting on top of an existing Node.
+      // Trying to add an existing node is a no-op.  This lets us use
+      // a straightforward MeshCommunication::allgather() to fix a
+      // not-actually-replicated-yet ReplicatedMesh, as occurs when
+      // reading Nemesis files.
+      if (n->valid_id() && _nodes[n->id()] == n)
+        return n;
 
-      // Doing so doesn't have to be *error*, in the case where a
-      // redundant insert is done, but when that happens we ought to
-      // always be able to make the code more efficient by avoiding
-      // the redundant insert, so let's keep screaming "Error" here.
+      // Don't allow anything else to replace an existing Node.
       libmesh_error_msg_if(_nodes[ n->id() ] != nullptr,
-                           "Error, cannot insert node on top of existing node.");
+                           "Error, cannot insert new node on top of existing node.");
     }
   else
     {

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -55,6 +55,8 @@ public:
 
   CPPUNIT_TEST( testNemesisCopyNodalSolutionDistributed );
   CPPUNIT_TEST( testNemesisCopyNodalSolutionReplicated );
+  CPPUNIT_TEST( testNemesisCopyElementSolutionDistributed );
+  CPPUNIT_TEST( testNemesisCopyElementSolutionReplicated );
 #endif
 
   CPPUNIT_TEST( testDynaReadElem );
@@ -276,6 +278,14 @@ public:
 
   void testExodusCopyElementSolutionDistributed ()
   { testCopyElementSolutionImpl<DistributedMesh,ExodusII_IO>("dist_with_elem_soln.e"); }
+
+#if defined(LIBMESH_HAVE_NEMESIS_API)
+  void testNemesisCopyElementSolutionReplicated ()
+  { testCopyElementSolutionImpl<ReplicatedMesh,Nemesis_IO>("repl_with_elem_soln.nem"); }
+
+  void testNemesisCopyElementSolutionDistributed ()
+  { testCopyElementSolutionImpl<DistributedMesh,Nemesis_IO>("dist_with_elem_soln.nem"); }
+#endif
 
 
 #ifndef LIBMESH_USE_COMPLEX_NUMBERS

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -135,15 +135,18 @@ public:
 
     {
       MeshType mesh(*TestCommWorld);
+      IOType meshinput(mesh);
 
       // Avoid getting Nemesis solution values mixed up
-      mesh.allow_renumbering(false);
+      if (meshinput.is_parallel_format())
+        {
+          mesh.allow_renumbering(false);
+          mesh.skip_noncritical_partitioning(true);
+        }
 
       EquationSystems es(mesh);
       System &sys = es.add_system<System> ("SimpleSystem");
       sys.add_variable("testn", FIRST, LAGRANGE);
-
-      IOType meshinput(mesh);
 
       if (mesh.processor_id() == 0 || meshinput.is_parallel_format())
         meshinput.read(filename);
@@ -222,12 +225,18 @@ public:
 
     {
       MeshType mesh(*TestCommWorld);
+      IOType meshinput(mesh);
+
+      // Avoid getting Nemesis solution values mixed up
+      if (meshinput.is_parallel_format())
+        {
+          mesh.allow_renumbering(false);
+          mesh.skip_noncritical_partitioning(true);
+        }
 
       EquationSystems es(mesh);
       System &sys = es.add_system<System> ("SimpleSystem");
       sys.add_variable("teste", CONSTANT, MONOMIAL);
-
-      IOType meshinput(mesh);
 
       if (mesh.processor_id() == 0 || meshinput.is_parallel_format())
         meshinput.read(filename);

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -46,7 +46,7 @@ public:
 #endif // LIBMESH_HAVE_EXODUS_API
 
 #if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
-  // CPPUNIT_TEST( testNemesisReadReplicated ); // Not yet implemented
+  CPPUNIT_TEST( testNemesisReadReplicated ); // Not yet implemented
   CPPUNIT_TEST( testNemesisReadDistributed );
 #endif
 

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -19,15 +19,15 @@
 using namespace libMesh;
 
 
-Number x_plus_y (const Point& p,
-                 const Parameters&,
-                 const std::string&,
-                 const std::string&)
+Number six_x_plus_sixty_y (const Point& p,
+                           const Parameters&,
+                           const std::string&,
+                           const std::string&)
 {
   const Real & x = p(0);
   const Real & y = p(1);
 
-  return x + y;
+  return 6*x + 60*y;
 }
 
 
@@ -126,7 +126,7 @@ public:
                                            0., 1., 0., 1.);
 
       es.init();
-      sys.project_solution(x_plus_y, nullptr, es.parameters);
+      sys.project_solution(six_x_plus_sixty_y, nullptr, es.parameters);
 
       IOType meshoutput(mesh);
 
@@ -171,7 +171,7 @@ public:
           {
             Point p(x,y);
             LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(0,p)),
-                                    libmesh_real(x+y),
+                                    libmesh_real(6*x+60*y),
                                     exotol);
           }
     }
@@ -208,7 +208,7 @@ public:
                                            0., 1., 0., 1.);
 
       es.init();
-      sys.project_solution(x_plus_y, nullptr, es.parameters);
+      sys.project_solution(six_x_plus_sixty_y, nullptr, es.parameters);
 
       IOType meshinput(mesh);
 
@@ -255,7 +255,7 @@ public:
           {
             Point p(x,y);
             LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(0,p)),
-                                    libmesh_real(x+y),
+                                    libmesh_real(6*x+60*y),
                                     exotol);
           }
     }

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -46,7 +46,7 @@ public:
 #endif // LIBMESH_HAVE_EXODUS_API
 
 #if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
-  CPPUNIT_TEST( testNemesisReadReplicated ); // Not yet implemented
+  CPPUNIT_TEST( testNemesisReadReplicated );
   CPPUNIT_TEST( testNemesisReadDistributed );
 #endif
 

--- a/tests/mesh/write_vec_and_scalar.C
+++ b/tests/mesh/write_vec_and_scalar.C
@@ -1,13 +1,13 @@
 // Basic include files
 #include "libmesh/equation_systems.h"
 #include "libmesh/exodusII_io.h"
+#include "libmesh/explicit_system.h"
 #include "libmesh/mesh.h"
 #include "libmesh/mesh_generation.h"
+#include "libmesh/nemesis_io.h"
 #include "libmesh/node.h"
-#include "libmesh/string_to_enum.h"
-#include "libmesh/exodusII_io.h"
-#include "libmesh/explicit_system.h"
 #include "libmesh/numeric_vector.h"
+#include "libmesh/string_to_enum.h"
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"
@@ -79,6 +79,7 @@ public:
     sys_solution.close();
 
 #ifdef LIBMESH_HAVE_EXODUS_API
+    {
 
     // We write the file in the ExodusII format.
     ExodusII_IO(mesh).write_equation_systems("out.e", equation_systems);
@@ -167,7 +168,105 @@ public:
                                 std::abs(gold_vector[gold_i_v]), tol);
 #endif
       }
+    }
+
+
+#ifdef LIBMESH_HAVE_NEMESIS_API
+
+    {
+    // We write the file in the ExodusII format.
+    Nemesis_IO(mesh).write_equation_systems("out.nem", equation_systems);
+
+    // Make sure that the writing is done before the reading starts.
+    TestCommWorld->barrier();
+
+    // Now read it back in
+    Mesh read_mesh(*TestCommWorld);
+    Nemesis_IO nemio(read_mesh);
+    nemio.read("out.nem");
+
+    read_mesh.prepare_for_use();
+    EquationSystems es2(read_mesh);
+    /*
+    ExplicitSystem & sys2 = es2.add_system<ExplicitSystem>("Test");
+
+    const std::vector<std::string> & nodal_vars(nemio.get_nodal_var_names());
+
+    for (const auto & var_name : nodal_vars)
+      sys2.add_variable(var_name, SECOND, LAGRANGE);
+
+    es2.init();
+
+    for (const auto & var_name : nodal_vars)
+      nemio.copy_nodal_solution(sys2, var_name, var_name, 1);
+
+    // VariableGroup optimization means that DoFs iterate over each of
+    // the 3 variables on each node before proceeding to the next
+    // node.
+    //                                     u_x, u_y, v
+    const std::vector<Real> gold_vector = {-1,  3,   10,
+                                           0,   1,   12,
+                                           2,   0,   14,
+                                           0,   1.5, 11,
+                                           0.5, 1,   13,
+                                           0.5, 1.5, 12,
+                                           3,   4,   16,
+                                           3,   1.5, 15,
+                                           0.5, 4,   13};
+
+    // Translation from node id to dof indexing order as gets done in
+    // serial
+    const std::vector<dof_id_type>
+      node_reordering({0, 3, 1, 8, 5, 4, 6, 7, 2});
+
+    Real tol = 1e-12;
+    NumericVector<Number> & sys2_soln(*sys2.solution);
+    for (const auto & node : read_mesh.node_ptr_range())
+      {
+        if (node->processor_id() != mesh.processor_id())
+          continue;
+
+        // We write out real, imaginary, and magnitude for complex
+        // numbers
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+        const unsigned int v2 = 3;
+#else
+        const unsigned int v2 = 1;
+#endif
+        CPPUNIT_ASSERT_EQUAL(node->n_vars(0), 3*v2);
+
+        const dof_id_type gold_i_ux = node_reordering[node->id()] * 3;
+        const dof_id_type gold_i_uy = gold_i_ux + 1;
+        const dof_id_type gold_i_v  = gold_i_uy + 1;
+
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,0,0))),
+                                gold_vector[gold_i_ux], tol);
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,v2,0))),
+                                gold_vector[gold_i_uy], tol);
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,2*v2,0))),
+                                gold_vector[gold_i_v], tol);
+
+        // Let's check imaginary parts and magnitude for good measure
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,1,0))),
+                                0.0, tol);
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,2,0))),
+                                std::abs(gold_vector[gold_i_ux]), tol);
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,4,0))),
+                                0.0, tol);
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,5,0))),
+                                std::abs(gold_vector[gold_i_uy]), tol);
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,7,0))),
+                                0.0, tol);
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,8,0))),
+                                std::abs(gold_vector[gold_i_v]), tol);
+#endif
+      }
+    */
+#endif // #ifdef LIBMESH_HAVE_NEMESIS_API
+    }
 #endif // #ifdef LIBMESH_HAVE_EXODUS_API
+
   }
 };
 

--- a/tests/mesh/write_vec_and_scalar.C
+++ b/tests/mesh/write_vec_and_scalar.C
@@ -25,15 +25,14 @@ public:
   CPPUNIT_TEST_SUITE(WriteVecAndScalar);
 
 #if LIBMESH_DIM > 1
-  CPPUNIT_TEST(testWrite);
+  CPPUNIT_TEST(testWriteExodus);
+  CPPUNIT_TEST(testWriteNemesis);
 #endif
 
   CPPUNIT_TEST_SUITE_END();
 
-  void testWrite()
+  void setupTests(Mesh & mesh, EquationSystems & equation_systems)
   {
-    Mesh mesh(*TestCommWorld);
-
     // We set our initial conditions based on build_square node ids
     mesh.allow_renumbering(false);
 
@@ -42,9 +41,6 @@ public:
                                         -1., 1.,
                                         -1., 1.,
                                         Utility::string_to_enum<ElemType>("TRI6"));
-
-    // Create an equation systems object.
-    EquationSystems equation_systems(mesh);
 
     ExplicitSystem & system = equation_systems.add_system<ExplicitSystem>("Tester");
     system.add_variable("u", FIRST, NEDELEC_ONE);
@@ -77,10 +73,84 @@ public:
           CPPUNIT_ASSERT_EQUAL(initial_vector[node->id()], dof_id*Real(2));
       }
     sys_solution.close();
+  }
+
+
+  void testSolution (const MeshBase & read_mesh, const System & sys2)
+  {
+    // VariableGroup optimization means that DoFs iterate over each of
+    // the 3 variables on each node before proceeding to the next
+    // node.
+    //                                     u_x, u_y, v
+    const std::vector<Real> gold_vector = {-1,  3,   10,
+                                           0,   1,   12,
+                                           2,   0,   14,
+                                           0,   1.5, 11,
+                                           0.5, 1,   13,
+                                           0.5, 1.5, 12,
+                                           3,   4,   16,
+                                           3,   1.5, 15,
+                                           0.5, 4,   13};
+
+    // Translation from node id to dof indexing order as gets done in
+    // serial
+    const std::vector<dof_id_type>
+      node_reordering({0, 3, 1, 8, 5, 4, 6, 7, 2});
+
+    Real tol = 1e-12;
+    NumericVector<Number> & sys2_soln(*sys2.solution);
+    for (const auto & node : read_mesh.node_ptr_range())
+      {
+        if (node->processor_id() != read_mesh.processor_id())
+          continue;
+
+        // We write out real, imaginary, and magnitude for complex
+        // numbers
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+        const unsigned int v2 = 3;
+#else
+        const unsigned int v2 = 1;
+#endif
+        CPPUNIT_ASSERT_EQUAL(node->n_vars(0), 3*v2);
+
+        const dof_id_type gold_i_ux = node_reordering[node->id()] * 3;
+        const dof_id_type gold_i_uy = gold_i_ux + 1;
+        const dof_id_type gold_i_v  = gold_i_uy + 1;
+
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,0,0))),
+                                gold_vector[gold_i_ux], tol);
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,v2,0))),
+                                gold_vector[gold_i_uy], tol);
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,2*v2,0))),
+                                gold_vector[gold_i_v], tol);
+
+        // Let's check imaginary parts and magnitude for good measure
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,1,0))),
+                                0.0, tol);
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,2,0))),
+                                std::abs(gold_vector[gold_i_ux]), tol);
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,4,0))),
+                                0.0, tol);
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,5,0))),
+                                std::abs(gold_vector[gold_i_uy]), tol);
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,7,0))),
+                                0.0, tol);
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,8,0))),
+                                std::abs(gold_vector[gold_i_v]), tol);
+#endif
+      }
+  }
+
+
+  void testWriteExodus()
+  {
+    Mesh mesh(*TestCommWorld);
+    EquationSystems equation_systems(mesh);
+
+    setupTests(mesh, equation_systems);
 
 #ifdef LIBMESH_HAVE_EXODUS_API
-    {
-
     // We write the file in the ExodusII format.
     ExodusII_IO(mesh).write_equation_systems("out.e", equation_systems);
 
@@ -106,75 +176,20 @@ public:
     for (const auto & var_name : nodal_vars)
       exio.copy_nodal_solution(sys2, var_name, var_name, 1);
 
-    // VariableGroup optimization means that DoFs iterate over each of
-    // the 3 variables on each node before proceeding to the next
-    // node.
-    //                                     u_x, u_y, v
-    const std::vector<Real> gold_vector = {-1,  3,   10,
-                                           0,   1,   12,
-                                           2,   0,   14,
-                                           0,   1.5, 11,
-                                           0.5, 1,   13,
-                                           0.5, 1.5, 12,
-                                           3,   4,   16,
-                                           3,   1.5, 15,
-                                           0.5, 4,   13};
+    testSolution(read_mesh, sys2);
+#endif // #ifdef LIBMESH_HAVE_EXODUS_API
+  }
 
-    // Translation from node id to dof indexing order as gets done in
-    // serial
-    const std::vector<dof_id_type>
-      node_reordering({0, 3, 1, 8, 5, 4, 6, 7, 2});
 
-    Real tol = 1e-12;
-    NumericVector<Number> & sys2_soln(*sys2.solution);
-    for (const auto & node : read_mesh.node_ptr_range())
-      {
-        if (node->processor_id() != mesh.processor_id())
-          continue;
+  void testWriteNemesis()
+  {
+    Mesh mesh(*TestCommWorld);
+    EquationSystems equation_systems(mesh);
 
-        // We write out real, imaginary, and magnitude for complex
-        // numbers
-#ifdef LIBMESH_USE_COMPLEX_NUMBERS
-        const unsigned int v2 = 3;
-#else
-        const unsigned int v2 = 1;
-#endif
-        CPPUNIT_ASSERT_EQUAL(node->n_vars(0), 3*v2);
-
-        const dof_id_type gold_i_ux = node_reordering[node->id()] * 3;
-        const dof_id_type gold_i_uy = gold_i_ux + 1;
-        const dof_id_type gold_i_v  = gold_i_uy + 1;
-
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,0,0))),
-                                gold_vector[gold_i_ux], tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,v2,0))),
-                                gold_vector[gold_i_uy], tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,2*v2,0))),
-                                gold_vector[gold_i_v], tol);
-
-        // Let's check imaginary parts and magnitude for good measure
-#ifdef LIBMESH_USE_COMPLEX_NUMBERS
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,1,0))),
-                                0.0, tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,2,0))),
-                                std::abs(gold_vector[gold_i_ux]), tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,4,0))),
-                                0.0, tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,5,0))),
-                                std::abs(gold_vector[gold_i_uy]), tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,7,0))),
-                                0.0, tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,8,0))),
-                                std::abs(gold_vector[gold_i_v]), tol);
-#endif
-      }
-    }
-
+    setupTests(mesh, equation_systems);
 
 #ifdef LIBMESH_HAVE_NEMESIS_API
-
-    {
-    // We write the file in the ExodusII format.
+    // We write the file in the Nemesis format.
     Nemesis_IO(mesh).write_equation_systems("out.nem", equation_systems);
 
     // Make sure that the writing is done before the reading starts.
@@ -187,7 +202,6 @@ public:
 
     read_mesh.prepare_for_use();
     EquationSystems es2(read_mesh);
-    /*
     ExplicitSystem & sys2 = es2.add_system<ExplicitSystem>("Test");
 
     const std::vector<std::string> & nodal_vars(nemio.get_nodal_var_names());
@@ -200,73 +214,9 @@ public:
     for (const auto & var_name : nodal_vars)
       nemio.copy_nodal_solution(sys2, var_name, var_name, 1);
 
-    // VariableGroup optimization means that DoFs iterate over each of
-    // the 3 variables on each node before proceeding to the next
-    // node.
-    //                                     u_x, u_y, v
-    const std::vector<Real> gold_vector = {-1,  3,   10,
-                                           0,   1,   12,
-                                           2,   0,   14,
-                                           0,   1.5, 11,
-                                           0.5, 1,   13,
-                                           0.5, 1.5, 12,
-                                           3,   4,   16,
-                                           3,   1.5, 15,
-                                           0.5, 4,   13};
-
-    // Translation from node id to dof indexing order as gets done in
-    // serial
-    const std::vector<dof_id_type>
-      node_reordering({0, 3, 1, 8, 5, 4, 6, 7, 2});
-
-    Real tol = 1e-12;
-    NumericVector<Number> & sys2_soln(*sys2.solution);
-    for (const auto & node : read_mesh.node_ptr_range())
-      {
-        if (node->processor_id() != mesh.processor_id())
-          continue;
-
-        // We write out real, imaginary, and magnitude for complex
-        // numbers
-#ifdef LIBMESH_USE_COMPLEX_NUMBERS
-        const unsigned int v2 = 3;
-#else
-        const unsigned int v2 = 1;
-#endif
-        CPPUNIT_ASSERT_EQUAL(node->n_vars(0), 3*v2);
-
-        const dof_id_type gold_i_ux = node_reordering[node->id()] * 3;
-        const dof_id_type gold_i_uy = gold_i_ux + 1;
-        const dof_id_type gold_i_v  = gold_i_uy + 1;
-
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,0,0))),
-                                gold_vector[gold_i_ux], tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,v2,0))),
-                                gold_vector[gold_i_uy], tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,2*v2,0))),
-                                gold_vector[gold_i_v], tol);
-
-        // Let's check imaginary parts and magnitude for good measure
-#ifdef LIBMESH_USE_COMPLEX_NUMBERS
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,1,0))),
-                                0.0, tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,2,0))),
-                                std::abs(gold_vector[gold_i_ux]), tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,4,0))),
-                                0.0, tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,5,0))),
-                                std::abs(gold_vector[gold_i_uy]), tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,7,0))),
-                                0.0, tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,8,0))),
-                                std::abs(gold_vector[gold_i_v]), tol);
-#endif
-      }
-    */
+    // FIXME - Nemesis still needs work for vector-valued variables
+    // testSolution(read_mesh, sys2);
 #endif // #ifdef LIBMESH_HAVE_NEMESIS_API
-    }
-#endif // #ifdef LIBMESH_HAVE_EXODUS_API
-
   }
 };
 


### PR DESCRIPTION
This adds a basic NemesisIO(DistributedMesh) read() unit test, followed by enough fixes to get that read() working.

I'll be adding more serious testing (and realistically more fixes) in subsequent PRs but this should hopefully be a straightforward improvement already.

However, this shouldn't be merged until we have Civet up and running again - I think the Nemesis CI tests in MOOSE are going to be robust enough to not be fazed by the numbering issue I fixed here without us having to re-gold first, but I won't swear to that.