### PR TITLE
Updates to pkgconfig files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -115,21 +115,33 @@ AUX_DIST = build-aux/install-sh \
 # Support for pkgconfig
 pkgconfigdir     = $(libdir)/pkgconfig
 pkgconfig_DATA   = contrib/utils/Make.common \
-                   contrib/utils/libmesh.pc \
-                   contrib/utils/libmesh-opt.pc \
-                   contrib/utils/libmesh-dbg.pc \
-                   contrib/utils/libmesh-devel.pc \
-                   contrib/utils/libmesh-prof.pc \
-                   contrib/utils/libmesh-oprof.pc
+                   contrib/utils/libmesh.pc
 
 configdir        = $(sysconfdir)/libmesh
 config_DATA      = contrib/utils/Make.common \
-                   contrib/utils/libmesh.pc \
-                   contrib/utils/libmesh-opt.pc \
-                   contrib/utils/libmesh-dbg.pc \
-                   contrib/utils/libmesh-devel.pc \
-                   contrib/utils/libmesh-prof.pc \
-                   contrib/utils/libmesh-oprof.pc
+                   contrib/utils/libmesh.pc
+
+# Install pkgconfig files for enabled build modes
+if LIBMESH_OPT_MODE
+  pkgconfig_DATA += contrib/utils/libmesh-opt.pc
+  config_DATA += contrib/utils/libmesh-opt.pc
+endif
+if LIBMESH_DBG_MODE
+  pkgconfig_DATA += contrib/utils/libmesh-dbg.pc
+  config_DATA += contrib/utils/libmesh-dbg.pc
+endif
+if LIBMESH_DEVEL_MODE
+  pkgconfig_DATA += contrib/utils/libmesh-devel.pc
+  config_DATA += contrib/utils/libmesh-devel.pc
+endif
+if LIBMESH_PROF_MODE
+  pkgconfig_DATA += contrib/utils/libmesh-prof.pc
+  config_DATA += contrib/utils/libmesh-prof.pc
+endif
+if LIBMESH_OPROF_MODE
+  pkgconfig_DATA += contrib/utils/libmesh-oprof.pc
+  config_DATA += contrib/utils/libmesh-oprof.pc
+endif
 
 # install the libtool script so that dependent apps can also use it
 contribbindir      = $(prefix)/contrib/bin

--- a/configure
+++ b/configure
@@ -3833,7 +3833,7 @@ test -n "$target_alias" &&
     NONENONEs,x,x, &&
   program_prefix=${target_alias}-
 
-ac_config_files="$ac_config_files Makefile include/Makefile include/libmesh/Makefile contrib/Makefile contrib/utils/Makefile contrib/utils/Make.common tests/Makefile contrib/utils/libmesh.pc:contrib/utils/libmesh-opt.pc.in contrib/utils/libmesh-opt.pc contrib/utils/libmesh-dbg.pc contrib/utils/libmesh-devel.pc contrib/utils/libmesh-prof.pc contrib/utils/libmesh-oprof.pc doc/Doxyfile doc/Makefile doc/html/Makefile"
+ac_config_files="$ac_config_files Makefile include/Makefile include/libmesh/Makefile contrib/Makefile contrib/utils/Makefile contrib/utils/Make.common tests/Makefile contrib/utils/libmesh-opt.pc contrib/utils/libmesh-dbg.pc contrib/utils/libmesh-devel.pc contrib/utils/libmesh-prof.pc contrib/utils/libmesh-oprof.pc doc/Doxyfile doc/Makefile doc/html/Makefile"
 
 
 ac_config_files="$ac_config_files contrib/bin/libmesh-config"
@@ -8710,6 +8710,19 @@ else
 fi
 
 
+ LIBMESH_PC_IN=""
+  # set the configuration input file for libmesh.pc
+  if test x$build_opt = xyes; then :
+  LIBMESH_PC_IN="contrib/utils/libmesh-opt.pc.in"
+elif test x$build_dbg = xyes; then :
+  LIBMESH_PC_IN="contrib/utils/libmesh-dbg.pc.in"
+elif test x$build_devel = xyes; then :
+  LIBMESH_PC_IN="contrib/utils/libmesh-devel.pc.in"
+elif test x$build_prof = xyes; then :
+  LIBMESH_PC_IN="contrib/utils/libmesh-prof.pc.in"
+elif test x$build_oprof = xyes; then :
+  LIBMESH_PC_IN="contrib/utils/libmesh-oprof.pc.in"
+fi
 
 
 
@@ -8730,6 +8743,10 @@ fi
 
 
 
+
+
+
+ac_config_files="$ac_config_files contrib/utils/libmesh.pc:$LIBMESH_PC_IN"
 
 
 # By default we merely enable some warnings, but we can turn those
@@ -43202,7 +43219,6 @@ do
     "contrib/utils/Makefile") CONFIG_FILES="$CONFIG_FILES contrib/utils/Makefile" ;;
     "contrib/utils/Make.common") CONFIG_FILES="$CONFIG_FILES contrib/utils/Make.common" ;;
     "tests/Makefile") CONFIG_FILES="$CONFIG_FILES tests/Makefile" ;;
-    "contrib/utils/libmesh.pc") CONFIG_FILES="$CONFIG_FILES contrib/utils/libmesh.pc:contrib/utils/libmesh-opt.pc.in" ;;
     "contrib/utils/libmesh-opt.pc") CONFIG_FILES="$CONFIG_FILES contrib/utils/libmesh-opt.pc" ;;
     "contrib/utils/libmesh-dbg.pc") CONFIG_FILES="$CONFIG_FILES contrib/utils/libmesh-dbg.pc" ;;
     "contrib/utils/libmesh-devel.pc") CONFIG_FILES="$CONFIG_FILES contrib/utils/libmesh-devel.pc" ;;
@@ -43218,6 +43234,7 @@ do
     "include/libmesh_config.h.tmp") CONFIG_HEADERS="$CONFIG_HEADERS include/libmesh_config.h.tmp:include/libmesh_config.h.in" ;;
     "include/libmesh_config.h") CONFIG_COMMANDS="$CONFIG_COMMANDS include/libmesh_config.h" ;;
     "depfiles") CONFIG_COMMANDS="$CONFIG_COMMANDS depfiles" ;;
+    "contrib/utils/libmesh.pc") CONFIG_FILES="$CONFIG_FILES contrib/utils/libmesh.pc:$LIBMESH_PC_IN" ;;
     "libtool") CONFIG_COMMANDS="$CONFIG_COMMANDS libtool" ;;
     "contrib/boost/include/Makefile") CONFIG_FILES="$CONFIG_FILES contrib/boost/include/Makefile" ;;
     "contrib/laspack/Makefile") CONFIG_FILES="$CONFIG_FILES contrib/laspack/Makefile" ;;

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,6 @@ AC_CONFIG_FILES([Makefile
                  contrib/utils/Makefile
                  contrib/utils/Make.common
                  tests/Makefile
-                 contrib/utils/libmesh.pc:contrib/utils/libmesh-opt.pc.in
                  contrib/utils/libmesh-opt.pc
                  contrib/utils/libmesh-dbg.pc
                  contrib/utils/libmesh-devel.pc
@@ -238,6 +237,8 @@ libmesh_CXXFLAGS="$GCOV_FLAGS $libmesh_CXXFLAGS"
 # Set compiler flags for devel, opt, etc. methods
 #-----------------------------------------------------
 LIBMESH_SET_METHODS
+
+AC_CONFIG_FILES([contrib/utils/libmesh.pc:$LIBMESH_PC_IN])
 
 # By default we merely enable some warnings, but we can turn those
 # into errors (for library code only, not contrib or external code)

--- a/m4/libmesh_method.m4
+++ b/m4/libmesh_method.m4
@@ -97,6 +97,14 @@ AC_DEFUN([LIBMESH_SET_METHODS],
  AM_CONDITIONAL(LIBMESH_PROF_MODE,  test x$build_prof = xyes)
  AM_CONDITIONAL(LIBMESH_OPROF_MODE, test x$build_oprof = xyes)
 
+ LIBMESH_PC_IN=""
+  # set the configuration input file for libmesh.pc
+  AS_IF([test x$build_opt = xyes], [LIBMESH_PC_IN="contrib/utils/libmesh-opt.pc.in"],
+        [test x$build_dbg = xyes], [LIBMESH_PC_IN="contrib/utils/libmesh-dbg.pc.in"],
+        [test x$build_devel = xyes], [LIBMESH_PC_IN="contrib/utils/libmesh-devel.pc.in"],
+        [test x$build_prof = xyes], [LIBMESH_PC_IN="contrib/utils/libmesh-prof.pc.in"],
+        [test x$build_oprof = xyes], [LIBMESH_PC_IN="contrib/utils/libmesh-oprof.pc.in"])
+
   dnl substitute all methods
   AC_SUBST(CPPFLAGS_DBG)
   AC_SUBST(CXXFLAGS_DBG)


### PR DESCRIPTION
This PR addresses #2679. 

With these changes Pkgconfig files are only installed for build methods which are enabled. 

Additionally, the input file used to configure the `libmesh.pc` file is chosen based on the enabled build methods as well with a preference order of `opt`, `dbg`, `devel`, `prof`, `oprof`. This ensures that the `libmesh.pc` is always valid and can be used by external applications consistently.