### PR TITLE
Enable synchronizing ghost element subdomain ID

### DIFF
--- a/include/parallel/parallel_ghost_sync.h
+++ b/include/parallel/parallel_ghost_sync.h
@@ -826,6 +826,31 @@ struct SyncNodalPositions
   MeshBase & mesh;
 };
 
+// This struct can be created and passed to the
+// Parallel::sync_dofobject_data_by_id() function.
+struct SyncSubdomainIds
+{
+  // The constructor.  You need a reference to the mesh where you will
+  // be setting/getting element subdomain IDs.
+  explicit
+  SyncSubdomainIds(MeshBase & m);
+
+  // The datum typedef is required of this functor, so that the
+  // Parallel::sync_dofobject_data_by_id() function can create e.g.
+  // std::vector<datum>.
+  typedef subdomain_id_type datum;
+
+  // First required interface.  This function must fill up the data vector for the
+  // ids specified in the ids vector.
+  void gather_data (const std::vector<dof_id_type> & ids, std::vector<datum> & data) const;
+
+  // Second required interface.  This function must do something with the data in
+  // the data vector for the ids in the ids vector.
+  void act_on_data (const std::vector<dof_id_type> & ids, const std::vector<datum> & data) const;
+
+  MeshBase & mesh;
+};
+
 
 } // namespace libMesh
 

--- a/src/parallel/parallel_ghost_sync.C
+++ b/src/parallel/parallel_ghost_sync.C
@@ -61,4 +61,31 @@ void SyncNodalPositions::act_on_data (const std::vector<dof_id_type> & ids,
     } // end for
 } // act_on_data()
 
+
+SyncSubdomainIds::SyncSubdomainIds(MeshBase & m)
+  : mesh(m)
+{}
+
+void SyncSubdomainIds::gather_data (const std::vector<dof_id_type> & ids,
+                                        std::vector<datum> & ids_out) const
+{
+  ids_out.reserve(ids.size());
+
+  for (const auto & id : ids)
+    {
+      Elem & elem = mesh.elem_ref(id);
+      ids_out.push_back(elem.subdomain_id());
+    }
+}
+
+void SyncSubdomainIds::act_on_data (const std::vector<dof_id_type> & ids,
+                              const std::vector<datum> & subdomain_ids) const
+{
+  for (auto i : index_range(ids))
+    {
+      Elem & elem = mesh.elem_ref(ids[i]);
+      elem.subdomain_id()=subdomain_ids[i];
+    }
+}
+
 } // namespace


### PR DESCRIPTION
While expanding a subdomain, we need to ensure that the subdomain ID is updated for the corresponding ghost element as well.