### PR TITLE
Enable counting the total dofs of a node

### DIFF
--- a/include/geom/node.h
+++ b/include/geom/node.h
@@ -196,6 +196,11 @@ public:
    */
   processor_id_type choose_processor_id(processor_id_type pid1, processor_id_type pid2) const;
 
+  /**
+   * Return the total number of DOFs associated with this node.
+   */
+   unsigned int total_dofs();
+
 private:
 
   /**

--- a/src/geom/node.C
+++ b/src/geom/node.C
@@ -102,5 +102,14 @@ Node::choose_processor_id(processor_id_type pid1, processor_id_type pid2) const
   return std::min(pid1, pid2);
 }
 
+unsigned int
+Node::total_dofs()
+{
+  unsigned int dof_count=0;
+  for (auto s : make_range(this->n_systems()))
+    for (auto v : make_range(this->n_vars(s)))
+      dof_count += this->n_comp(s,v);
+  return dof_count;
+}
 
 } // namespace libMesh


### PR DESCRIPTION
Sometimes we would like to check how many DOFs are associated with one node. 