### PR TITLE
Add methods to synchronize side boundary ids on the fly

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -699,17 +699,13 @@ public:
   build_shellface_list() const;
 
   /**
-   * Push the boundary element change to the processors that own the element
+   * Synchronize the boundary element side across processors.
+   * This function is needed when boundary info is changed by adding or removing
+   * sides on the fly.
+   * Note: if the side of a ghost element is changed, then you would need to do
+   * do parallel push (see e.g., timpi/parallel_sync.h) and then sync.
    */
-  void sync_push_remove_boundary_side_id(
-    std::unordered_map<processor_id_type, std::vector<std::pair<dof_id_type, unsigned int>>>
-    & elems_to_push
-  );
-
-  /**
-   * Synchronize the boundary element side across processors
-   */
-  void sync_pull_boundary_side_id();
+  void sync_boundary_side_ids();
 
   /**
    * \returns A set of the boundary ids which exist on semilocal parts

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -699,13 +699,14 @@ public:
   build_shellface_list() const;
 
   /**
-   * Synchronize the boundary element side across processors.
+   * Synchronize the boundary element side and node across processors.
    * This function is needed when boundary info is changed by adding or removing
    * sides on the fly.
    * Note: if the side of a ghost element is changed, then you would need to do
    * do parallel push (see e.g., timpi/parallel_sync.h) and then sync.
    */
-  void sync_boundary_side_ids();
+  void parallel_sync_side_ids();
+  void parallel_sync_node_ids();
 
   /**
    * \returns A set of the boundary ids which exist on semilocal parts

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -699,6 +699,19 @@ public:
   build_shellface_list() const;
 
   /**
+   * Push the boundary element change to the processors that own the element
+   */
+  void sync_push_remove_boundary_side_id(
+    std::unordered_map<processor_id_type, std::vector<std::pair<dof_id_type, unsigned int>>>
+    & elems_to_push
+  );
+
+  /**
+   * Synchronize the boundary element side across processors
+   */
+  void sync_pull_boundary_side_id();
+
+  /**
    * \returns A set of the boundary ids which exist on semilocal parts
    * of the mesh.
    *

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1806,24 +1806,7 @@ BoundaryInfo::build_node_list_from_side_list()
      node_bcid_action_functor, datum_type_ex);
 }
 
-void BoundaryInfo::sync_push_remove_boundary_side_id(
-  std::unordered_map<processor_id_type, std::vector<std::pair<dof_id_type, unsigned int>>>
-  & elems_to_push)
-{
-  auto elem_action_functor =
-    [this]
-    (processor_id_type,
-     const std::vector<std::pair<dof_id_type, unsigned int>> & received_elem)
-    {
-      for (const auto & pr : received_elem)
-        this->remove_side(_mesh.elem_ptr(pr.first), pr.second);
-    };
-
-  Parallel::push_parallel_vector_data
-    (this->comm(), elems_to_push, elem_action_functor);
-}
-
-void BoundaryInfo::sync_pull_boundary_side_id()
+void BoundaryInfo::sync_boundary_side_ids()
 {
   // we need BCs for ghost elements.
   std::unordered_map<processor_id_type, std::vector<dof_id_type>>

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1806,6 +1806,78 @@ BoundaryInfo::build_node_list_from_side_list()
      node_bcid_action_functor, datum_type_ex);
 }
 
+void BoundaryInfo::sync_push_remove_boundary_side_id(
+  std::unordered_map<processor_id_type, std::vector<std::pair<dof_id_type, unsigned int>>>
+  & elems_to_push)
+{
+  auto elem_action_functor =
+    [this]
+    (processor_id_type,
+     const std::vector<std::pair<dof_id_type, unsigned int>> & received_elem)
+    {
+      for (const auto & pr : received_elem)
+        this->remove_side(_mesh.elem_ptr(pr.first), pr.second);
+    };
+
+  Parallel::push_parallel_vector_data
+    (this->comm(), elems_to_push, elem_action_functor);
+}
+
+void BoundaryInfo::sync_pull_boundary_side_id()
+{
+  // we need BCs for ghost elements.
+  std::unordered_map<processor_id_type, std::vector<dof_id_type>>
+    elem_ids_requested;
+
+  // Determine what elements we need to request
+  for (const auto & elem : _mesh.element_ptr_range())
+  {
+    const processor_id_type pid = elem->processor_id();
+    if (pid != this->processor_id())
+      elem_ids_requested[pid].push_back(elem->id());
+  }
+
+  typedef std::vector<std::pair<unsigned short int, boundary_id_type>> datum_type;
+
+  // gather the element ID, side, and boundary_id_type for the ghost elements
+  auto elem_id_gather_functor =
+    [this]
+    (processor_id_type,
+     const std::vector<dof_id_type> & ids,
+     std::vector<datum_type> & data)
+  {
+    data.resize(ids.size());
+    for (auto i : index_range(ids))
+    {
+      Elem * elem = _mesh.elem_ptr(ids[i]);
+      for (const auto & pr : as_range(_boundary_side_id.equal_range(elem)))
+        data[i].push_back(std::make_pair(pr.second.first, pr.second.second));
+    }
+  };
+  // update the _boundary_side_id on this processor
+  auto elem_id_action_functor =
+    [this]
+    (processor_id_type,
+     const std::vector<dof_id_type> & ids,
+     std::vector<datum_type> & data)
+  {
+      for (auto i : index_range(ids))
+      {
+        Elem * elem = _mesh.elem_ptr(ids[i]);
+        //clear boundary sides for this element
+        _boundary_side_id.erase(elem);
+        // update boundary sides for it
+        for (const auto & pr : data[i])
+          _boundary_side_id.insert(std::make_pair(elem, std::make_pair(pr.first, pr.second)));
+      }
+  };
+
+
+  datum_type * datum_type_ex = nullptr;
+  Parallel::pull_parallel_vector_data
+    (this->comm(), elem_ids_requested, elem_id_gather_functor,
+     elem_id_action_functor, datum_type_ex);
+}
 
 
 


### PR DESCRIPTION
This PR adds the capability to synchronize boundary side changes across processors. This capability is realized via `sync_pull_boundary_side_id()`. In the case when boundary sides of a ghost element is removed, the `sync_push_remove_boundary_side_id()` method is utilized to communicate with the processor that owns this element.

This is an initial implementation of this method that is just enough to fulfill my use case. @fdkong @roystgnr I would really appreciate it if you would provide some suggestions for making it mergeable :)