### PR TITLE
Make our disambiguating constructor explicit

### DIFF
--- a/include/geom/node.h
+++ b/include/geom/node.h
@@ -91,7 +91,7 @@ public:
   template <typename T,
             typename = typename
               boostcopy::enable_if_c<ScalarTraits<T>::value,void>::type>
-  Node (const T x) :
+  explicit Node (const T x) :
     Point (x,0,0)
   { this->set_id() = invalid_id; }
 


### PR DESCRIPTION
Not sure how we forgot this, but without it a function with an argument
intended to take const Node & can compile when passed dof_id_type
instead, because libMesh will sadistically construct a temporary node
whose x coordinate is the specified id.

Thanks to @rwcarlsen for his finding this and apologies to @rwcarlsen
for our enabling this.