### PR TITLE
Fix unit test bugs, including with TIMPI 1.2 update

### DIFF
--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -27,6 +27,16 @@
 #include "libmesh/tensor_value.h"
 #include "libmesh/enum_elem_type.h"
 
+namespace {
+  // Put this outside a templated class, so we only get 1 warning
+  // during our unit tests, not 1 warning for each of the zillion FE
+  // specializations we test.
+  void nonlagrange_dual_warning () {
+    libmesh_warning("dual calculations have only been verified for the LAGRANGE family");
+  }
+}
+
+
 namespace libMesh
 {
 
@@ -286,7 +296,7 @@ void FE<Dim,T>::reinit(const Elem * elem,
       if (this->calculate_dual)
       {
         if (T != LAGRANGE)
-          libmesh_warning("dual calculations have only been verified for the LAGRANGE family");
+          nonlagrange_dual_warning();
 
         // In order for the matrices for the biorthogonality condition to be
         // non-singular, the dual basis coefficients must be computed when the

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -29,6 +29,19 @@
 #include "libmesh/int_range.h"
 #include "libmesh/auto_ptr.h"
 
+
+namespace {
+  // Put this outside a templated class, so we only get 1 warning
+  // during our unit tests, not 1 warning for each of the zillion FE
+  // specializations we test.
+  void inffe_hessian_warning () {
+    libmesh_warning("Warning: Second derivatives for Infinite elements"
+                    << " are not yet implemented!"
+                    << std::endl);
+  }
+}
+
+
 namespace libMesh
 {
 
@@ -552,9 +565,7 @@ void InfFE<Dim,T_radial,T_map>::init_shape_functions(const std::vector<Point> & 
     dphidz.resize  (n_total_approx_shape_functions);
     dphidxi.resize (n_total_approx_shape_functions);
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
-    libmesh_warning("Warning: Second derivatives for Infinite elements"
-                    << " are not yet implemented!"
-                    << std::endl);
+    inffe_hessian_warning();
 
     d2phi.resize     (n_total_approx_shape_functions);
     d2phidx2.resize  (n_total_approx_shape_functions);

--- a/tests/fe/fe_test.h
+++ b/tests/fe/fe_test.h
@@ -252,30 +252,6 @@ public:
 
     FEType fe_type = _sys->variable_type(0);
     _fe = FEBase::build(_dim, fe_type).release();
-    _fe->get_phi();
-    _fe->get_dphi();
-    _fe->get_dphidx();
-#if LIBMESH_DIM > 1
-    _fe->get_dphidy();
-#endif
-#if LIBMESH_DIM > 2
-    _fe->get_dphidz();
-#endif
-
-#if LIBMESH_ENABLE_SECOND_DERIVATIVES
-    _fe->get_d2phi();
-    _fe->get_d2phidx2();
-#if LIBMESH_DIM > 1
-    _fe->get_d2phidxdy();
-    _fe->get_d2phidy2();
-#endif
-#if LIBMESH_DIM > 2
-    _fe->get_d2phidxdz();
-    _fe->get_d2phidydz();
-    _fe->get_d2phidz2();
-#endif
-
-#endif
 
     // Create quadrature rule for use in computing dual shape coefficients
     _qrule = new QGauss(_dim, fe_type.default_quadrature_order());
@@ -297,6 +273,41 @@ public:
     grad_tol = 2 * TOLERANCE * sqrt(TOLERANCE);
 
     hess_tol = sqrt(TOLERANCE); // FIXME: we see some ~1e-5 errors?!?
+
+    // Prerequest everything we'll want to calculate later.
+    _fe->get_phi();
+    _fe->get_dphi();
+    _fe->get_dphidx();
+#if LIBMESH_DIM > 1
+    _fe->get_dphidy();
+#endif
+#if LIBMESH_DIM > 2
+    _fe->get_dphidz();
+#endif
+
+#if LIBMESH_ENABLE_SECOND_DERIVATIVES
+
+    // Clough-Tocher elements still don't work multithreaded
+    if (family == CLOUGH && libMesh::n_threads() > 1)
+      return;
+
+    // Szabab elements don't have second derivatives yet
+    if (family == SZABAB)
+      return;
+
+    _fe->get_d2phi();
+    _fe->get_d2phidx2();
+#if LIBMESH_DIM > 1
+    _fe->get_d2phidxdy();
+    _fe->get_d2phidy2();
+#endif
+#if LIBMESH_DIM > 2
+    _fe->get_d2phidxdz();
+    _fe->get_d2phidydz();
+    _fe->get_d2phidz2();
+#endif
+
+#endif
   }
 
   void tearDown()

--- a/tests/parallel/message_tag.C
+++ b/tests/parallel/message_tag.C
@@ -33,12 +33,12 @@ public:
 
   void testGetUniqueTagAuto()
   {
-    // We need to duplicate the communicator first, because the
-    // original might already have tags used by other unit tests
+    // We need to explicitly duplicate the communicator first, because
+    // the original might already have tags used by other unit tests
 
     Parallel::Communicator newcomm;
 
-    TestCommWorld->duplicate(newcomm);
+    newcomm.duplicate(*TestCommWorld);
 
     const int n_vals = 5;
     const int n_vals_in_scope = 3;

--- a/tests/parallel/parallel_sync_test.C
+++ b/tests/parallel/parallel_sync_test.C
@@ -169,7 +169,7 @@ public:
     // Test the received results, for each processor id p we're in
     // charge of.
     std::vector<std::size_t> checked_sizes(size, 0);
-    for (int p=rank; p != M; p += size)
+    for (int p=rank; p < M; p += size)
       for (int srcp=0; srcp != size; ++srcp)
         {
           int diffsize = std::abs(srcp-p);
@@ -295,7 +295,7 @@ public:
     // Test the received results, for each processor id p we're in
     // charge of.
     std::vector<std::size_t> checked_sizes(size, 0);
-    for (int p=rank; p != M; p += size)
+    for (int p=rank; p < M; p += size)
       for (int srcp=0; srcp != size; ++srcp)
         {
           int diffsize = std::abs(srcp-p);
@@ -433,7 +433,7 @@ public:
     // Test the received results, for each processor id p we're in
     // charge of.
     std::vector<std::size_t> checked_sizes(size, 0);
-    for (int p=rank; p != M; p += size)
+    for (int p=rank; p < M; p += size)
       for (int srcp=0; srcp != size; ++srcp)
         {
           int diffsize = std::abs(srcp-p);
@@ -512,7 +512,7 @@ public:
     // Test the received results, for each processor id p we're in
     // charge of.
     std::vector<std::size_t> checked_sizes(size, 0);
-    for (int p=rank; p != M; p += size)
+    for (int p=rank; p < M; p += size)
       for (int srcp=0; srcp != size; ++srcp)
         {
           int diffsize = std::abs(srcp-p);

--- a/tests/run_unit_tests.sh.in
+++ b/tests/run_unit_tests.sh.in
@@ -6,8 +6,18 @@ set -e
 # there's a failure we get the most informative death possible
 ORDERED_METHODS="dbg debug devel profiling pro prof oprofile oprof optimized opt"
 
+# when run outside of the automake envionment make sure we get METHODS set
+# to something useful
+if (test "x${METHODS}" = "x"); then
+    if (test "x${METHOD}" = "x"); then
+        METHODS="@METHODS@"
+    else
+        METHODS="$METHOD"
+    fi
+fi
+
 for method in ${ORDERED_METHODS}; do
-    for mymethod in @METHODS@; do
+    for mymethod in ${METHODS}; do
         if (test "x${mymethod}" = "x${method}"); then
             MY_METHODS="${MY_METHODS} ${mymethod}"
         fi

--- a/tests/utils/xdr_test.C
+++ b/tests/utils/xdr_test.C
@@ -35,6 +35,12 @@ public:
   {
     std::vector<Real> vec = {libMesh::pi, 2*libMesh::pi, 3*libMesh::pi};
 
+    // There was once a weird bug mutating our TestCommWorld in
+    // a previous unit test, which turned *this* test into a race
+    // condition.  Let's make sure that never happens again.
+    CPPUNIT_ASSERT_EQUAL(TestCommWorld->rank(),
+                         libMesh::global_processor_id());
+
     // Test reading/writing on 1 processor
     if (TestCommWorld->rank() == 0)
       {


### PR DESCRIPTION
This was a maddening rabbit hole, but I think I reached bottom.  A race condition in a new unit test, that almost never triggered, turned out to be entirely caused by a bug in a different unit test, which turned out to be covering up a bug in a third unit test, which was covering up a bug in TIMPI code.

While I was hunting down the Xdr and parallel_sync test bugs here I tried to do a little cleanup and make our unit test framework a little more flexible too.