### PR TITLE
RB: Deprecate some get_parameter_names() functions

### DIFF
--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -106,11 +106,21 @@ public:
 
   /**
    * Fill \p param_names with the names of the parameters.
+   *
+   * \deprecated to avoid making it too easy to create copies that in
+   * most circumstances aren't needed.  If this functionality really
+   * is required, call get_parameters_map() and loop over the keys
+   * directly.
    */
   void get_parameter_names(std::set<std::string> & param_names) const;
 
   /**
    * Fill \p param_names with the names of the extra parameters.
+   *
+   * \deprecated to avoid making it too easy to create copies that in
+   * most circumstances aren't needed.  If this functionality really
+   * is required, call get_parameters_map() and loop over the keys
+   * directly.
    */
   void get_extra_parameter_names(std::set<std::string> & param_names) const;
 

--- a/include/reduced_basis/rb_parametrized.h
+++ b/include/reduced_basis/rb_parametrized.h
@@ -90,6 +90,11 @@ public:
 
   /**
    * Get a set that stores the parameter names.
+   *
+   * \deprecated to avoid making it too easy to create copies that in
+   * most circumstances aren't needed.  If this functionality really
+   * is required, call get_parameters_min().get_parameters_map() and
+   * loop over the keys directly.
    */
   std::set<std::string> get_parameter_names() const;
 

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -251,22 +251,19 @@ void add_parameter_ranges_to_builder(const RBParametrized & rb_evaluation,
     auto mins = parameter_ranges_list.initMinValues(n_continuous_parameters);
     auto maxs = parameter_ranges_list.initMaxValues(n_continuous_parameters);
 
-    std::set<std::string> parameter_names = rb_evaluation.get_parameter_names();
     const RBParameters & parameters_min = rb_evaluation.get_parameters_min();
     const RBParameters & parameters_max = rb_evaluation.get_parameters_max();
 
+    // We could loop over either parameters_min or parameters_max, they should have the same keys.
     unsigned int count = 0;
-    for (const auto & parameter_name : parameter_names)
-      {
-        if (!rb_evaluation.is_discrete_parameter(parameter_name))
-          {
-            names.set(count, parameter_name);
-            mins.set(count, parameters_min.get_value(parameter_name));
-            maxs.set(count, parameters_max.get_value(parameter_name));
-
-            ++count;
-          }
-      }
+    for (const auto & pr : parameters_min.get_parameters_map())
+      if (!rb_evaluation.is_discrete_parameter(pr.first))
+        {
+          names.set(count, pr.first);
+          mins.set(count, pr.second);
+          maxs.set(count, parameters_max.get_value(pr.first));
+          ++count;
+        }
 
     libmesh_error_msg_if(count != n_continuous_parameters, "Mismatch in number of continuous parameters");
   }

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -78,20 +78,18 @@ unsigned int RBParameters::n_parameters() const
 
 void RBParameters::get_parameter_names(std::set<std::string> & param_names) const
 {
-  param_names.clear();
+  libmesh_deprecated();
 
-  const_iterator it     = _parameters.begin();
-  const_iterator it_end = _parameters.end();
-  for ( ; it != it_end; ++it)
-    {
-      param_names.insert( it->first );
-    }
+  param_names.clear();
+  for (const auto & pr : _parameters)
+    param_names.insert(pr.first);
 }
 
 void RBParameters::get_extra_parameter_names(std::set<std::string> & param_names) const
 {
-  param_names.clear();
+  libmesh_deprecated();
 
+  param_names.clear();
   for (const auto & pr : _extra_parameters)
     param_names.insert(pr.first);
 }

--- a/src/reduced_basis/rb_parametrized.C
+++ b/src/reduced_basis/rb_parametrized.C
@@ -131,8 +131,12 @@ std::set<std::string> RBParametrized::get_parameter_names() const
 {
   libmesh_error_msg_if(!parameters_initialized, "Error: parameters not initialized in RBParametrized::get_parameter_names");
 
+  // TODO: We may also want to deprecate this funtion since there is
+  // already a public accessor for the parameters_min member.
   std::set<std::string> parameter_names;
-  parameters_min.get_parameter_names(parameter_names);
+  const auto & params_map = parameters_min.get_parameters_map();
+  for (const auto & pr : params_map)
+    parameter_names.insert(pr.first);
 
   return parameter_names;
 }

--- a/src/reduced_basis/rb_parametrized.C
+++ b/src/reduced_basis/rb_parametrized.C
@@ -129,10 +129,9 @@ unsigned int RBParametrized::get_n_discrete_params() const
 
 std::set<std::string> RBParametrized::get_parameter_names() const
 {
+  libmesh_deprecated();
   libmesh_error_msg_if(!parameters_initialized, "Error: parameters not initialized in RBParametrized::get_parameter_names");
 
-  // TODO: We may also want to deprecate this funtion since there is
-  // already a public accessor for the parameters_min member.
   std::set<std::string> parameter_names;
   const auto & params_map = parameters_min.get_parameters_map();
   for (const auto & pr : params_map)


### PR DESCRIPTION
Now that we have the `get_parameters_map()` accessor, I found that this function is basically never needed, and if you are using it, you can do whatever you're doing more efficiently by just looping over the map directly.