### PR TITLE
Assert that mesh in query_ghosting_functors has elem

### DIFF
--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -155,6 +155,7 @@ void query_ghosting_functors(const MeshBase & mesh,
         {
           const Elem * elem = pr.first;
           libmesh_assert(elem != remote_elem);
+          libmesh_assert(mesh.elem_ptr(elem->id()) == elem);
           connected_elements.insert(elem);
         }
     }


### PR DESCRIPTION
I was bit by a bad ghosting functor setup in MOOSE that actually
returned displaced mesh elements even though the ghosting functor was
attached to the reference mesh. So I've added an assertion that should
verify that the elements to ghost returned by a ghosting functor
actually exist on the mesh we're determining ghosting for