### PR TITLE
Add some vector CompareTypes

### DIFF
--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -1131,6 +1131,18 @@ TypeVector<T> TypeVector<T>::unit() const
 #endif
 
 }
+
+template <typename T>
+struct CompareTypes<TypeTensor<T>, TypeTensor<T>>
+{
+  typedef TypeTensor<T> supertype;
+};
+
+template <typename T, typename T2>
+struct CompareTypes<TypeTensor<T>, TypeTensor<T2>>
+{
+  typedef TypeTensor<typename CompareTypes<T,T2>::supertype> supertype;
+};
 } // namespace libMesh
 
 namespace std

--- a/include/numerics/vector_value.h
+++ b/include/numerics/vector_value.h
@@ -22,6 +22,7 @@
 
 // Local includes
 #include "libmesh/type_vector.h"
+#include "libmesh/compare_types.h"
 
 #ifdef LIBMESH_HAVE_METAPHYSICL
 #include "metaphysicl/raw_type.h"
@@ -220,6 +221,29 @@ VectorValue<T>::VectorValue (const TypeVector<Real> & p_re,
 }
 #endif
 
+template <typename T>
+struct CompareTypes<VectorValue<T>, VectorValue<T>>
+{
+  typedef VectorValue<T> supertype;
+};
+
+template <typename T, typename T2>
+struct CompareTypes<VectorValue<T>, VectorValue<T2>>
+{
+  typedef VectorValue<typename CompareTypes<T,T2>::supertype> supertype;
+};
+
+template <typename T, typename T2>
+struct CompareTypes<VectorValue<T>, TypeVector<T2>>
+{
+  typedef VectorValue<typename CompareTypes<T,T2>::supertype> supertype;
+};
+
+template <typename T, typename T2>
+struct CompareTypes<TypeVector<T>, VectorValue<T2>>
+{
+  typedef VectorValue<typename CompareTypes<T,T2>::supertype> supertype;
+};
 
 } // namespace libMesh
 


### PR DESCRIPTION
Documentation for `CompareTypes` is:
```
// Operators using different but compatible types need a return value
// based on whichever type the other can be upconverted into.  For
// instance, the proper return type for
// TypeVector<float>::operator*(double) is TypeVector<double>.  In
// general, an operation using types S and T should return a value
// based on CompareTypes<S,T>::supertype
```
So what I've implemented here wouldn't be valid for all elementary binary operations, e.g. for multiplication, but I think this holds true to the "upconverted" concept, and obviously would hold true for + and - operations (which is what motivated this PR).