### PR TITLE
Use -> to get a member from a pointer

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -2032,7 +2032,7 @@ std::vector<unsigned int> MeshBase::add_elem_data(const std::vector<std::string>
                                                   bool allocate_data,
                                                   const std::vector<T> * default_values)
 {
-  libmesh_assert(!default_values || default_values.size() == names.size());
+  libmesh_assert(!default_values || default_values->size() == names.size());
 
   std::vector<unsigned int> returnval(names.size());
 
@@ -2081,7 +2081,7 @@ std::vector<unsigned int> MeshBase::add_node_data(const std::vector<std::string>
                                                   bool allocate_data,
                                                   const std::vector<T> * default_values)
 {
-  libmesh_assert(!default_values || default_values.size() == names.size());
+  libmesh_assert(!default_values || default_values->size() == names.size());
 
   std::vector<unsigned int> returnval(names.size());
 


### PR DESCRIPTION
This regressed in #2677

This method is templated and not being instantiated, so I guess my
compiler and our CI compilers didn't bother to check the code's validity
when seeing vector<T> with an indeterminate T, rather than realizing
that a pointer to *any* object can't have a size() method.

This will need to be backported to the release branch, for the sake of
users who want to use this method or who have smarter compilers than
mine.  Thanks to @dschwen for reporting this.