### PR TITLE
Add/update special functions in RB classes.

### DIFF
--- a/include/reduced_basis/rb_construction_base.h
+++ b/include/reduced_basis/rb_construction_base.h
@@ -64,8 +64,14 @@ public:
                       const unsigned int number);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class contains a unique_ptr so it can't be copy assigned/constructed.
+   * - Destructor is defaulted out-of-line.
    */
+  RBConstructionBase (RBConstructionBase &&) = default;
+  RBConstructionBase & operator= (RBConstructionBase &&) = default;
+  RBConstructionBase (const RBConstructionBase &) = delete;
+  RBConstructionBase & operator= (const RBConstructionBase &) = delete;
   virtual ~RBConstructionBase ();
 
   /**
@@ -280,7 +286,6 @@ private:
    * number generator seed.
    */
   int training_parameters_random_seed;
-
 };
 
 } // namespace libMesh

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -68,16 +68,12 @@ public:
    * Special functions.
    * - This class contains unique_ptrs, so it can't be default copy
    *   constructed/assigned.
-   * - The base class (RBConstructionBase) move constructor and move
-   *   assignment operators are (implicitly?) deleted according to
-   *   clang-9.0, therefore it is an error to try and default them
-   *   here.
    * - The destructor is defaulted out of line.
    */
-  RBEIMConstruction (RBEIMConstruction &&) = delete;
+  RBEIMConstruction (RBEIMConstruction &&) = default;
   RBEIMConstruction (const RBEIMConstruction &) = delete;
   RBEIMConstruction & operator= (const RBEIMConstruction &) = delete;
-  RBEIMConstruction & operator= (RBEIMConstruction &&) = delete;
+  RBEIMConstruction & operator= (RBEIMConstruction &&) = default;
   virtual ~RBEIMConstruction ();
 
   /**

--- a/include/reduced_basis/rb_parametrized.h
+++ b/include/reduced_basis/rb_parametrized.h
@@ -51,8 +51,14 @@ public:
   RBParametrized ();
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This simple class can be default copy/move constructed/assigned.
+   * - Destructor is defaulted out-of-line.
    */
+  RBParametrized (RBParametrized &&) = default;
+  RBParametrized & operator= (RBParametrized &&) = default;
+  RBParametrized (const RBParametrized &) = default;
+  RBParametrized & operator= (const RBParametrized &) = default;
   virtual ~RBParametrized ();
 
   /**
@@ -238,7 +244,6 @@ private:
    * Map that defines the allowable values of any discrete parameters.
    */
   std::map<std::string, std::vector<Real>> _discrete_parameter_values;
-
 };
 
 } // namespace libMesh

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -53,14 +53,10 @@ RBConstructionBase<Base>::RBConstructionBase (EquationSystems & es,
     training_parameters_initialized(false),
     training_parameters_random_seed(-1) // by default, use std::time to seed RNG
 {
-  training_parameters.clear();
 }
 
 template <class Base>
-RBConstructionBase<Base>::~RBConstructionBase ()
-{
-  this->clear();
-}
+RBConstructionBase<Base>::~RBConstructionBase () = default;
 
 template <class Base>
 void RBConstructionBase<Base>::clear ()

--- a/src/reduced_basis/rb_parametrized.C
+++ b/src/reduced_basis/rb_parametrized.C
@@ -31,23 +31,14 @@
 namespace libMesh
 {
 
-// ------------------------------------------------------------
-// RBParameters implementation
-
 RBParametrized::RBParametrized()
   :
   verbose_mode(false),
   parameters_initialized(false)
 {
-  parameters.clear();
-  parameters_min.clear();
-  parameters_max.clear();
 }
 
-RBParametrized::~RBParametrized()
-{
-  this->clear();
-}
+RBParametrized::~RBParametrized() = default;
 
 void RBParametrized::clear()
 {


### PR DESCRIPTION
* RBConstructionBase
* RBParametrized
* RBEIMConstruction

In general we should not call clear() in any class destructor unless
we need to manually clean up memory managed by that class. Instead, we
should just let the member destructors do their thing.

Refs #2710