### PR TITLE
Fix scatter for node constraints

### DIFF
--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -4416,11 +4416,6 @@ void DofMap::scatter_constraints(MeshBase & mesh)
       libmesh_assert_equal_to
         (ids_offsets.size(), keys_vals.size());
 
-      if (!mesh.is_serial())
-        this->comm().receive_packed_range
-          (pid, &mesh, mesh_inserter_iterator<Node>(mesh),
-           (Node**)nullptr, range_tag);
-
       // Add the node constraints that I've been sent
       for (auto i : index_range(ids_offsets))
         {


### PR DESCRIPTION
I'm not sure how this got left in #2558 but it was made redundant by the
upgrade there and it's a horrible deadlock to leave it in.