### PR TITLE
Fix possible overflow in PeriodicBoundaries::neighbor

### DIFF
--- a/src/base/periodic_boundaries.C
+++ b/src/base/periodic_boundaries.C
@@ -113,7 +113,7 @@ const Elem * PeriodicBoundaries::neighbor(boundary_id_type boundary_id,
                      (e->processor_id() != mesh.processor_id()),
                      "Periodic boundary neighbor not found");
   if (neigh_side)
-    *neigh_side = DofObject::invalid_id;
+    *neigh_side = libMesh::invalid_uint;
   return remote_elem;
 }
 


### PR DESCRIPTION
When compiling with 64-bit indices, I get the compiler warning:
```
periodic_boundaries.C:116:30: warning: conversion from ‘libMesh::dof_id_type’
{aka ‘long unsigned int’} to ‘unsigned int’ changes value from
‘18446744073709551615’ to ‘4294967295’ [-Woverflow]
```
and rightfully so