### PR TITLE
ParsedFEMFunction: change "parsers" to a vector of unique_ptrs

### DIFF
--- a/include/numerics/parsed_fem_function.h
+++ b/include/numerics/parsed_fem_function.h
@@ -40,6 +40,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace libMesh
 {
@@ -68,21 +69,13 @@ public:
                      const std::vector<Output> * initial_vals=nullptr);
 
   /**
-   * This class contains a const reference so it can't be copy or move-assigned.
+   * Special functions
+   * - This class contains a const reference so it can't be copy or move-assigned.
+   * - This class contains unique_ptrs so it can't be default copy constructed.
    */
   ParsedFEMFunction & operator= (const ParsedFEMFunction &) = delete;
   ParsedFEMFunction & operator= (ParsedFEMFunction &&) = delete;
-
-  /**
-   * The remaining 5 special functions can be safely defaulted.
-   *
-   * \note The underlying FunctionParserBase class has a copy
-   * constructor, so this class should be default-constructible.  And,
-   * although FunctionParserBase's move constructor is deleted, _this_
-   * class should still be move-constructible because
-   * FunctionParserBase only appears in a vector.
-   */
-  ParsedFEMFunction (const ParsedFEMFunction &) = default;
+  ParsedFEMFunction (const ParsedFEMFunction &) = delete;
   ParsedFEMFunction (ParsedFEMFunction &&) = default;
   virtual ~ParsedFEMFunction () = default;
 
@@ -168,9 +161,9 @@ private:
     _n_requested_hess_components;
   bool _requested_normals;
 #ifdef LIBMESH_HAVE_FPARSER
-  std::vector<FunctionParserBase<Output>> parsers;
+  std::vector<std::unique_ptr<FunctionParserBase<Output>>> parsers;
 #else
-  std::vector<char> parsers;
+  std::vector<char*> parsers;
 #endif
   std::vector<Output> _spacetime;
 
@@ -401,7 +394,7 @@ ParsedFEMFunction<Output>::operator() (const FEMContext & c,
 {
   eval_args(c, p, time);
 
-  return eval(parsers[0], "f", 0);
+  return eval(*parsers[0], "f", 0);
 }
 
 
@@ -421,7 +414,7 @@ ParsedFEMFunction<Output>::operator() (const FEMContext & c,
   libmesh_assert_equal_to (size, parsers.size());
 
   for (unsigned int i=0; i != size; ++i)
-    output(i) = eval(parsers[i], "f", i);
+    output(i) = eval(*parsers[i], "f", i);
 }
 
 
@@ -436,7 +429,7 @@ ParsedFEMFunction<Output>::component (const FEMContext & c,
   eval_args(c, p, time);
 
   libmesh_assert_less (i, parsers.size());
-  return eval(parsers[i], "f", i);
+  return eval(*parsers[i], "f", i);
 }
 
 template <typename Output>
@@ -479,16 +472,16 @@ ParsedFEMFunction<Output>::get_inline_value(const std::string & inline_var_name)
 #ifdef LIBMESH_HAVE_FPARSER
       // Parse and evaluate the new subexpression.
       // Add the same constants as we used originally.
-      FunctionParserBase<Output> fp;
-      fp.AddConstant("NaN", std::numeric_limits<Real>::quiet_NaN());
-      fp.AddConstant("pi", std::acos(Real(-1)));
-      fp.AddConstant("e", std::exp(Real(1)));
+      auto fp = libmesh_make_unique<FunctionParserBase<Output>>();
+      fp->AddConstant("NaN", std::numeric_limits<Real>::quiet_NaN());
+      fp->AddConstant("pi", std::acos(Real(-1)));
+      fp->AddConstant("e", std::exp(Real(1)));
       libmesh_error_msg_if
-        (fp.Parse(new_subexpression, variables) != -1, // -1 for success
+        (fp->Parse(new_subexpression, variables) != -1, // -1 for success
          "ERROR: FunctionParser is unable to parse modified expression: "
-         << new_subexpression << '\n' << fp.ErrorMsg());
+         << new_subexpression << '\n' << fp->ErrorMsg());
 
-      Output new_var_value = this->eval(fp, new_subexpression, 0);
+      Output new_var_value = this->eval(*fp, new_subexpression, 0);
 #ifdef NDEBUG
       return new_var_value;
 #else
@@ -621,16 +614,16 @@ ParsedFEMFunction<Output>::partial_reparse (const std::string & expression)
 #ifdef LIBMESH_HAVE_FPARSER
       // Parse (and optimize if possible) the subexpression.
       // Add some basic constants, to Real precision.
-      FunctionParserBase<Output> fp;
-      fp.AddConstant("NaN", std::numeric_limits<Real>::quiet_NaN());
-      fp.AddConstant("pi", std::acos(Real(-1)));
-      fp.AddConstant("e", std::exp(Real(1)));
+      auto fp = libmesh_make_unique<FunctionParserBase<Output>>();
+      fp->AddConstant("NaN", std::numeric_limits<Real>::quiet_NaN());
+      fp->AddConstant("pi", std::acos(Real(-1)));
+      fp->AddConstant("e", std::exp(Real(1)));
       libmesh_error_msg_if
-        (fp.Parse(_subexpressions.back(), variables) != -1, // -1 for success
+        (fp->Parse(_subexpressions.back(), variables) != -1, // -1 for success
          "ERROR: FunctionParser is unable to parse expression: "
-         << _subexpressions.back() << '\n' << fp.ErrorMsg());
-      fp.Optimize();
-      parsers.push_back(fp);
+         << _subexpressions.back() << '\n' << fp->ErrorMsg());
+      fp->Optimize();
+      parsers.push_back(std::move(fp));
 #else
       libmesh_error_msg("ERROR: This functionality requires fparser!");
 #endif

--- a/tests/numerics/parsed_fem_function_test.C
+++ b/tests/numerics/parsed_fem_function_test.C
@@ -142,13 +142,6 @@ private:
         c->get_elem().processor_id() == TestCommWorld->rank())
       {
         ParsedFEMFunction<Number> x2(*sys, "x2");
-
-        // Test that copy constructor works
-        ParsedFEMFunction<Number> x2_copy(x2);
-
-        LIBMESH_ASSERT_FP_EQUAL
-          (1.0, libmesh_real(x2_copy(*c,Point(0.5,0.5,0.5))), TOLERANCE*TOLERANCE);
-
         ParsedFEMFunction<Number> xy8(*sys, "x2*y4");
 
         // Test that move constructor works


### PR DESCRIPTION
This is an attempt to fix the issue raised in #2710. Since
FunctionParserBase has a deleted move constructor, it is not
considered to be MoveInsertable, which means it cannot be passed to
std::vector::push_back() by value.