### PR TITLE
Nonstandard-configuration fixes

### DIFF
--- a/examples/fem_system/fem_system_ex3/fem_system_ex3.C
+++ b/examples/fem_system/fem_system_ex3/fem_system_ex3.C
@@ -40,6 +40,7 @@
 #include "libmesh/enum_solver_package.h"
 #include "libmesh/enum_solver_type.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/numeric_vector.h"
 
 // The systems and solvers we may use
 #include "elasticity_system.h"

--- a/examples/fem_system/fem_system_ex5/fem_system_ex5.C
+++ b/examples/fem_system/fem_system_ex5/fem_system_ex5.C
@@ -44,6 +44,7 @@
 #include "libmesh/enum_solver_package.h"
 #include "libmesh/enum_solver_type.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/numeric_vector.h"
 
 // The systems and solvers we may use
 #include "elasticity_system.h"

--- a/include/numerics/distributed_vector.h
+++ b/include/numerics/distributed_vector.h
@@ -331,6 +331,9 @@ void DistributedVector<T>::init (const numeric_index_type n,
       else
         this->_type = PARALLEL;
     }
+  else if (ptype == GHOSTED &&
+           n == n_local) // We can support GHOSTED with no ghosts...
+    this->_type = SERIAL;
   else
     this->_type = ptype;
 

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -351,6 +351,7 @@ public:
         CPPUNIT_ASSERT_EQUAL(n_neighbors, n_neighbors_expected);
       }
 
+#ifdef LIBMESH_HAVE_SOLVER
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
     // Now test whether we can assign the desired constraint equations
     EquationSystems es(mesh);
@@ -362,6 +363,7 @@ public:
     // We should have a constraint on every FE dof
     CPPUNIT_ASSERT_EQUAL(sys.get_dof_map().n_constrained_dofs(), dof_id_type(121));
 #endif // LIBMESH_ENABLE_CONSTRAINTS
+#endif // LIBMESH_HAVE_SOLVER
   }
 
 


### PR DESCRIPTION
The second commit here fixes the Dyna unit test failure in the configurations in #2717; the first commit fixes an overzealous assert that was affecting a swath of other tests in dbg/devel modes.