### PR TITLE
Always skip remote neighbors in DefaultCoupling

### DIFF
--- a/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
+++ b/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
@@ -36,7 +36,7 @@
 
 // libMesh includes
 #include "libmesh/libmesh.h"
-#include "libmesh/replicated_mesh.h"
+#include "libmesh/mesh.h"
 #include "libmesh/mesh_refinement.h"
 #include "libmesh/gmv_io.h"
 #include "libmesh/exodusII_io.h"
@@ -225,9 +225,7 @@ int main (int argc, char ** argv)
   libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");
 
   // Create a new mesh on the default MPI communicator.
-  // DistributedMesh currently has a bug which is triggered by this
-  // example.
-  ReplicatedMesh mesh(init.comm());
+  Mesh mesh(init.comm());
 
   // Create an equation systems object.
   EquationSystems equation_systems (mesh);

--- a/src/base/default_coupling.C
+++ b/src/base/default_coupling.C
@@ -132,19 +132,9 @@ void DefaultCoupling::operator()
             {
               const Elem * neigh = elem->neighbor_ptr(s);
 
-              // If we have a neighbor here
-              if (neigh)
-                {
-                  // Mesh ghosting might ask us about what we want to
-                  // distribute along with non-local elements, and those
-                  // non-local elements might have remote neighbors, and
-                  // if they do then we can't say anything about them.
-                  if (neigh == remote_elem)
-                    continue;
-                }
 #ifdef LIBMESH_ENABLE_PERIODIC
               // We might still have a periodic neighbor here
-              else if (check_periodic_bcs)
+              if (!neigh && check_periodic_bcs)
                 {
                   libmesh_assert(_mesh);
 
@@ -154,8 +144,11 @@ void DefaultCoupling::operator()
 #endif
 
               // With no regular *or* periodic neighbors we have nothing
-              // to do.
-              if (!neigh)
+              // to do. *Or* Mesh ghosting might ask us about what we want to
+              // distribute along with non-local elements, and those
+              // non-local elements might have remote neighbors, and
+              // if they do then we can't say anything about them.
+              if (!neigh || neigh == remote_elem)
                 continue;
 
               // With any kind of neighbor, we need to couple to all the


### PR DESCRIPTION
Previously we only skipped over remote neighbors if they were a side neighbor. Now we skip whether they are a side neighbor or a periodic boundary neighbor.