### PR TITLE
Generalize default constructors for TypeTensor and TypeVector

### DIFF
--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -519,20 +519,20 @@ template <typename T>
 inline
 TypeTensor<T>::TypeTensor ()
 {
-  _coords[0] = 0;
+  _coords[0] = {};
 
 #if LIBMESH_DIM > 1
-  _coords[1] = 0;
-  _coords[2] = 0;
-  _coords[3] = 0;
+  _coords[1] = {};
+  _coords[2] = {};
+  _coords[3] = {};
 #endif
 
 #if LIBMESH_DIM > 2
-  _coords[4] = 0;
-  _coords[5] = 0;
-  _coords[6] = 0;
-  _coords[7] = 0;
-  _coords[8] = 0;
+  _coords[4] = {};
+  _coords[5] = {};
+  _coords[6] = {};
+  _coords[7] = {};
+  _coords[8] = {};
 #endif
 }
 

--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -433,14 +433,14 @@ template <typename T>
 inline
 TypeVector<T>::TypeVector ()
 {
-  _coords[0] = 0;
+  _coords[0] = {};
 
 #if LIBMESH_DIM > 1
-  _coords[1] = 0;
+  _coords[1] = {};
 #endif
 
 #if LIBMESH_DIM > 2
-  _coords[2] = 0;
+  _coords[2] = {};
 #endif
 }
 


### PR DESCRIPTION
Assigning to the (template typed) values in these data structures with
the (integer) zero doesn't work when the template type is not POD nor
has an overloaded assignment operator taking an int/number.  Assigning
"{}" instead works for a larger set of types, while still giving zero
values to POD.  This issue was run into when I tried to use an
eigen::Matrix<DualNumber<...>> in TypeVector.