### PR TITLE
MeshBase move constructor can't be safely defaulted

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -93,10 +93,11 @@ public:
   MeshBase (const MeshBase & other_mesh);
 
   /**
-   * Move-constructor - this function is defaulted out-of-line (in the
-   * C file) to play nicely with our forward declarations.
+   * Move-constructor - deleted because after a theoretical move-construction
+   * and then destruction of the moved-from object, the moved \p BoundaryInfo
+   * would hold an invalid reference to the moved-from mesh
    */
-  MeshBase(MeshBase &&);
+  MeshBase(MeshBase &&) = delete;
 
   /**
    * Copy and move assignment are not allowed because MeshBase

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -139,43 +139,6 @@ MeshBase::MeshBase (const MeshBase & other_mesh) :
     _partitioner = other_mesh._partitioner->clone();
 }
 
-
-
-MeshBase::MeshBase(MeshBase && other_mesh) :
-    ParallelObject (other_mesh),
-    boundary_info (new BoundaryInfo(*this)),
-    _n_parts       (other_mesh._n_parts),
-    _default_mapping_type(other_mesh._default_mapping_type),
-    _default_mapping_data(other_mesh._default_mapping_data),
-    _is_prepared   (other_mesh._is_prepared),
-    _point_locator (std::move(other_mesh._point_locator)),
-    _count_lower_dim_elems_in_point_locator(other_mesh._count_lower_dim_elems_in_point_locator),
-    _partitioner   (std::move(other_mesh._partitioner)),
-#ifdef LIBMESH_ENABLE_UNIQUE_ID
-    _next_unique_id(other_mesh._next_unique_id),
-#endif
-    _skip_noncritical_partitioning(other_mesh._skip_noncritical_partitioning),
-    _skip_all_partitioning(other_mesh._skip_all_partitioning),
-    _skip_renumber_nodes_and_elements(other_mesh._skip_renumber_nodes_and_elements),
-    _skip_find_neighbors(other_mesh._skip_find_neighbors),
-    _allow_remote_element_removal(other_mesh._allow_remote_element_removal),
-    _block_id_to_name(std::move(other_mesh._block_id_to_name)),
-    _elem_dims(std::move(other_mesh._elem_dims)),
-    _spatial_dimension(other_mesh._spatial_dimension),
-    _elem_integer_names(std::move(other_mesh._elem_integer_names)),
-    _elem_integer_default_values(std::move(other_mesh._elem_integer_default_values)),
-    _node_integer_names(std::move(other_mesh._node_integer_names)),
-    _node_integer_default_values(std::move(other_mesh._node_integer_default_values)),
-    _default_ghosting(std::move(other_mesh._default_ghosting)),
-    _ghosting_functors(std::move(other_mesh._ghosting_functors)),
-    _shared_functors(std::move(other_mesh._shared_functors)),
-    _point_locator_close_to_point_tol(other_mesh._point_locator_close_to_point_tol)
-{
-}
-
-
-
-
 MeshBase::~MeshBase()
 {
   this->clear();

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -141,7 +141,38 @@ MeshBase::MeshBase (const MeshBase & other_mesh) :
 
 
 
-MeshBase::MeshBase(MeshBase &&) = default;
+MeshBase::MeshBase(MeshBase && other_mesh) :
+    ParallelObject (other_mesh),
+    boundary_info (new BoundaryInfo(*this)),
+    _n_parts       (other_mesh._n_parts),
+    _default_mapping_type(other_mesh._default_mapping_type),
+    _default_mapping_data(other_mesh._default_mapping_data),
+    _is_prepared   (other_mesh._is_prepared),
+    _point_locator (std::move(other_mesh._point_locator)),
+    _count_lower_dim_elems_in_point_locator(other_mesh._count_lower_dim_elems_in_point_locator),
+    _partitioner   (std::move(other_mesh._partitioner)),
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+    _next_unique_id(other_mesh._next_unique_id),
+#endif
+    _skip_noncritical_partitioning(other_mesh._skip_noncritical_partitioning),
+    _skip_all_partitioning(other_mesh._skip_all_partitioning),
+    _skip_renumber_nodes_and_elements(other_mesh._skip_renumber_nodes_and_elements),
+    _skip_find_neighbors(other_mesh._skip_find_neighbors),
+    _allow_remote_element_removal(other_mesh._allow_remote_element_removal),
+    _block_id_to_name(std::move(other_mesh._block_id_to_name)),
+    _elem_dims(std::move(other_mesh._elem_dims)),
+    _spatial_dimension(other_mesh._spatial_dimension),
+    _elem_integer_names(std::move(other_mesh._elem_integer_names)),
+    _elem_integer_default_values(std::move(other_mesh._elem_integer_default_values)),
+    _node_integer_names(std::move(other_mesh._node_integer_names)),
+    _node_integer_default_values(std::move(other_mesh._node_integer_default_values)),
+    _default_ghosting(std::move(other_mesh._default_ghosting)),
+    _ghosting_functors(std::move(other_mesh._ghosting_functors)),
+    _shared_functors(std::move(other_mesh._shared_functors)),
+    _point_locator_close_to_point_tol(other_mesh._point_locator_close_to_point_tol)
+{
+}
+
 
 
 

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -619,13 +619,12 @@ public:
     CPPUNIT_ASSERT_EQUAL(mesh2.n_elem(),
                          static_cast<dof_id_type>(9));
 
-    // Verify that the moved-from mesh's Partitioner and BoundaryInfo
-    // objects were successfully stolen.  Note: moved-from unique_ptrs
+    // Verify that the moved-from mesh's Partitioner
+    // object was successfully stolen.  Note: moved-from unique_ptrs
     // are guaranteed to compare equal to nullptr, see e.g. Section
     // 20.8.1/4 of the standard.
     // https://stackoverflow.com/questions/24061767/is-unique-ptr-guaranteed-to-store-nullptr-after-move
     CPPUNIT_ASSERT(!mesh.partitioner());
-    CPPUNIT_ASSERT(!mesh.boundary_info);
   }
 };
 

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -62,8 +62,6 @@ public:
   CPPUNIT_TEST( testDynaReadElem );
   CPPUNIT_TEST( testDynaReadPatch );
   CPPUNIT_TEST( testDynaFileMappingsFEMEx5);
-
-  CPPUNIT_TEST( testMeshMoveConstructor );
 #endif // LIBMESH_DIM > 1
 
   CPPUNIT_TEST_SUITE_END();
@@ -602,29 +600,6 @@ public:
   void testDynaFileMappingsFEMEx5 ()
   {
     testDynaFileMappings("meshes/PressurizedCyl_Patch6_256Elem.bxt.gz");
-  }
-
-
-  void testMeshMoveConstructor ()
-  {
-    Mesh mesh(*TestCommWorld);
-    MeshTools::Generation::build_square (mesh,
-                                         3, 3,
-                                         0., 1., 0., 1.);
-
-    // Construct mesh2, stealing the resources of the original.
-    Mesh mesh2(std::move(mesh));
-
-    // Make sure mesh2 now has the 9 elements.
-    CPPUNIT_ASSERT_EQUAL(mesh2.n_elem(),
-                         static_cast<dof_id_type>(9));
-
-    // Verify that the moved-from mesh's Partitioner
-    // object was successfully stolen.  Note: moved-from unique_ptrs
-    // are guaranteed to compare equal to nullptr, see e.g. Section
-    // 20.8.1/4 of the standard.
-    // https://stackoverflow.com/questions/24061767/is-unique-ptr-guaranteed-to-store-nullptr-after-move
-    CPPUNIT_ASSERT(!mesh.partitioner());
   }
 };
 


### PR DESCRIPTION
This is because of the way we construct the `BoundaryInfo` member. Using
the default move constructor, our `BoundaryInfo` in the move-constructed
object will have an invalid reference to its `_mesh` member after the `other_mesh` 
is destructed.