### PR TITLE
Delete all mesh move constructors

### DIFF
--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -73,9 +73,9 @@ public:
   DistributedMesh (const DistributedMesh & other_mesh);
 
   /**
-   * Move-constructor.
+   * Move-constructor deleted in MeshBase.
    */
-  DistributedMesh(DistributedMesh &&) = default;
+  DistributedMesh(DistributedMesh &&) = delete;
 
   /**
    * Copy and move assignment are not allowed.

--- a/include/mesh/mesh.h
+++ b/include/mesh/mesh.h
@@ -68,11 +68,15 @@ public:
   Mesh (const UnstructuredMesh & other_mesh) : DefaultMesh(other_mesh) {}
 
   /**
-   * Default copy/move constructors and destructor.
+   * Default copy constructors and destructor.
    */
   Mesh(const Mesh &) = default;
-  Mesh(Mesh &&) = default;
   ~Mesh() = default;
+
+  /**
+   * Move-constructor deleted in MeshBase.
+   */
+  Mesh(Mesh &&) = delete;
 
   /**
    * Copy and move assignment are not allowed.

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -69,9 +69,9 @@ public:
   ReplicatedMesh (const ReplicatedMesh & other_mesh);
 
   /**
-   * Move-constructor.
+   * Move-constructor deleted in MeshBase.
    */
-  ReplicatedMesh(ReplicatedMesh &&) = default;
+  ReplicatedMesh(ReplicatedMesh &&) = delete;
 
   /**
    * Copy and move assignment are not allowed.

--- a/include/mesh/unstructured_mesh.h
+++ b/include/mesh/unstructured_mesh.h
@@ -64,9 +64,9 @@ public:
   UnstructuredMesh(const UnstructuredMesh &) = default;
 
   /**
-   * Move-constructor.
+   * Move-constructor deleted in MeshBase.
    */
-  UnstructuredMesh(UnstructuredMesh &&) = default;
+  UnstructuredMesh(UnstructuredMesh &&) = delete;
 
   /**
    * Copy and move assignment are not allowed.


### PR DESCRIPTION
Clang warns of explicitly defaulted, implicitly deleted move
construction in `UnstructuredMesh`, which is definitely true. To remove
those warnings, we explicitly delete all move constructors from
`MeshBase` down