### PR TITLE
Avoid manual memory management in System class

### DIFF
--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -63,8 +63,14 @@ public:
                   const unsigned int number);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class contains unique_ptrs so it can't be default copy assigned/constructed
+   * - Destructor is defaulted out-of-line
    */
+  RBConstruction (RBConstruction &&) = default;
+  RBConstruction (const RBConstruction &) = delete;
+  RBConstruction & operator= (const RBConstruction &) = delete;
+  RBConstruction & operator= (RBConstruction &&) = default;
   virtual ~RBConstruction ();
 
   /**

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -114,6 +114,23 @@ public:
           const unsigned int number);
 
   /**
+   * Special functions.
+   * - The copy constructor and assignment operator were previously
+   *   declared as private libmesh_not_implemented() functions, this
+   *   is the C++11 way of achieving the same effect.
+   * - The System holds references to Mesh and EquationSystems
+   *   objects, therefore it can't be default move-assigned.
+   * - This class manages memory in the _vectors member, so we can't
+   *   default the move constructor.
+   * - The destructor is responsible for cleaning up the _vectors member.
+   */
+  System (const System &) = delete;
+  System & operator= (const System &) = delete;
+  System (System &&) = delete;
+  System & operator= (System &&) = delete;
+  virtual ~System ();
+
+  /**
    * Abstract base class to be used for system initialization.
    * A user class derived from this class may be used to
    * initialize the system values by attaching an object
@@ -232,13 +249,6 @@ public:
                                  bool include_liftfunc,
                                  bool apply_constraints) = 0;
   };
-
-
-
-  /**
-   * Destructor.
-   */
-  virtual ~System ();
 
   /**
    * The type of system.
@@ -1871,22 +1881,6 @@ protected:
                        int is_adjoint = -1) const;
 
 private:
-  /**
-   * This isn't a copyable object, so let's make sure nobody tries.
-   *
-   * We won't even bother implementing this; we'll just make sure that
-   * the compiler doesn't implement a default.
-   */
-  System (const System &);
-
-  /**
-   * This isn't a copyable object, so let's make sure nobody tries.
-   *
-   * We won't even bother implementing this; we'll just make sure that
-   * the compiler doesn't implement a default.
-   */
-  System & operator=(const System &);
-
   /**
    * Finds the discrete norm for the entries in the vector
    * corresponding to Dofs associated with var.

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -53,10 +53,7 @@ RBEvaluation::RBEvaluation (const Parallel::Communicator & comm_in)
 {
 }
 
-RBEvaluation::~RBEvaluation()
-{
-  this->clear();
-}
+RBEvaluation::~RBEvaluation() = default;
 
 void RBEvaluation::clear()
 {

--- a/src/reduced_basis/rb_scm_construction.C
+++ b/src/reduced_basis/rb_scm_construction.C
@@ -62,11 +62,7 @@ RBSCMConstruction::RBSCMConstruction (EquationSystems & es,
 
 }
 
-RBSCMConstruction::~RBSCMConstruction ()
-{
-  this->clear();
-}
-
+RBSCMConstruction::~RBSCMConstruction () = default;
 
 void RBSCMConstruction::clear()
 {

--- a/src/reduced_basis/rb_scm_evaluation.C
+++ b/src/reduced_basis/rb_scm_evaluation.C
@@ -60,9 +60,7 @@ RBSCMEvaluation::RBSCMEvaluation (const Parallel::Communicator & comm_in) :
   SCM_UB_vectors.clear();
 }
 
-RBSCMEvaluation::~RBSCMEvaluation ()
-{
-}
+RBSCMEvaluation::~RBSCMEvaluation () = default;
 
 void RBSCMEvaluation::set_rb_theta_expansion(RBThetaExpansion & rb_theta_expansion_in)
 {

--- a/src/reduced_basis/transient_rb_construction.C
+++ b/src/reduced_basis/transient_rb_construction.C
@@ -80,13 +80,7 @@ TransientRBConstruction::TransientRBConstruction (EquationSystems & es,
   exit_on_repeated_greedy_parameters = false;
 }
 
-
-
-TransientRBConstruction::~TransientRBConstruction ()
-{
-  this->clear();
-}
-
+TransientRBConstruction::~TransientRBConstruction () = default;
 
 void TransientRBConstruction::clear()
 {

--- a/src/reduced_basis/transient_rb_evaluation.C
+++ b/src/reduced_basis/transient_rb_evaluation.C
@@ -45,10 +45,7 @@ TransientRBEvaluation::TransientRBEvaluation(const Parallel::Communicator & comm
   compute_RB_inner_product = true;
 }
 
-TransientRBEvaluation::~TransientRBEvaluation ()
-{
-  clear();
-}
+TransientRBEvaluation::~TransientRBEvaluation () = default;
 
 void TransientRBEvaluation::clear()
 {

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -895,8 +895,7 @@ void System::remove_matrix (const std::string & mat_name)
   if (pos == _matrices.end())
     return;
 
-  pos->second.reset();
-  _matrices.erase(pos);
+  _matrices.erase(pos); // erase()'d entries are destroyed
 }
 
 

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -841,21 +841,16 @@ const std::string & System::vector_name (const unsigned int vec_num) const
 
 const std::string & System::vector_name (const NumericVector<Number> & vec_reference) const
 {
-  const_vectors_iterator v = vectors_begin();
-  const_vectors_iterator v_end = vectors_end();
-
-  for (; v != v_end; ++v)
-    {
-      // Compare pointers to see if the current vector is the one whose name we want
-      if (&vec_reference == v->second.get())
-        break; // exit loop if it is
-    }
+  // Linear search for a vector whose pointer matches vec_reference
+  auto it = std::find_if(vectors_begin(), vectors_end(),
+                         [&vec_reference](const decltype(_vectors)::value_type & pr)
+                         { return &vec_reference == pr.second.get(); });
 
   // Before returning, make sure we didnt loop till the end and not find any match
-  libmesh_assert (v != v_end);
+  libmesh_assert (it != vectors_end());
 
   // Return the string associated with the current vector
-  return v->first;
+  return it->first;
 }
 
 

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -100,49 +100,11 @@ System::System (EquationSystems & es,
 
 
 
-// No copy construction of System objects!
-System::System (const System & other) :
-  ReferenceCountedObject<System>(),
-  ParallelObject(other),
-  _equation_systems(other._equation_systems),
-  _mesh(other._mesh),
-  _sys_number(other._sys_number)
-{
-  libmesh_not_implemented();
-}
-
-
-
-System & System::operator= (const System &)
-{
-  libmesh_not_implemented();
-}
-
-
 System::~System ()
 {
-  // Null-out the function pointers.  Since this
-  // class is getting destructed it is pointless,
-  // but a good habit.
-  _init_system_function =
-    _assemble_system_function =
-    _constrain_system_function = nullptr;
-
-  _qoi_evaluate_function = nullptr;
-  _qoi_evaluate_derivative_function =  nullptr;
-
-  // nullptr-out user-provided objects.
-  _init_system_object             = nullptr;
-  _assemble_system_object         = nullptr;
-  _constrain_system_object        = nullptr;
-  _qoi_evaluate_object            = nullptr;
-  _qoi_evaluate_derivative_object = nullptr;
-
-  // Clear data
-  // Note: although clear() is virtual, C++ only calls
-  // the clear() of the base class in the destructor.
-  // Thus we add System namespace to make it clear.
-  System::clear ();
+  // This class does manual memory management of the _vectors map, so
+  // we need to be sure and free that in the destructor.
+  System::clear();
 
   libmesh_exceptionless_assert (!libMesh::closed());
 }

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1908,9 +1908,7 @@ void System::attach_init_function (void fptr(EquationSystems & es,
 
   if (_init_system_object != nullptr)
     {
-      libmesh_here();
-      libMesh::out << "WARNING:  Cannot specify both initialization function and object!"
-                   << std::endl;
+      libmesh_warning("WARNING:  Cannot specify both initialization function and object!");
 
       _init_system_object = nullptr;
     }
@@ -1924,9 +1922,7 @@ void System::attach_init_object (System::Initialization & init_in)
 {
   if (_init_system_function != nullptr)
     {
-      libmesh_here();
-      libMesh::out << "WARNING:  Cannot specify both initialization object and function!"
-                   << std::endl;
+      libmesh_warning("WARNING:  Cannot specify both initialization object and function!");
 
       _init_system_function = nullptr;
     }
@@ -1943,9 +1939,7 @@ void System::attach_assemble_function (void fptr(EquationSystems & es,
 
   if (_assemble_system_object != nullptr)
     {
-      libmesh_here();
-      libMesh::out << "WARNING:  Cannot specify both assembly function and object!"
-                   << std::endl;
+      libmesh_warning("WARNING:  Cannot specify both assembly function and object!");
 
       _assemble_system_object = nullptr;
     }
@@ -1959,9 +1953,7 @@ void System::attach_assemble_object (System::Assembly & assemble_in)
 {
   if (_assemble_system_function != nullptr)
     {
-      libmesh_here();
-      libMesh::out << "WARNING:  Cannot specify both assembly object and function!"
-                   << std::endl;
+      libmesh_warning("WARNING:  Cannot specify both assembly object and function!");
 
       _assemble_system_function = nullptr;
     }
@@ -1978,9 +1970,7 @@ void System::attach_constraint_function(void fptr(EquationSystems & es,
 
   if (_constrain_system_object != nullptr)
     {
-      libmesh_here();
-      libMesh::out << "WARNING:  Cannot specify both constraint function and object!"
-                   << std::endl;
+      libmesh_warning("WARNING:  Cannot specify both constraint function and object!");
 
       _constrain_system_object = nullptr;
     }
@@ -1994,9 +1984,7 @@ void System::attach_constraint_object (System::Constraint & constrain)
 {
   if (_constrain_system_function != nullptr)
     {
-      libmesh_here();
-      libMesh::out << "WARNING:  Cannot specify both constraint object and function!"
-                   << std::endl;
+      libmesh_warning("WARNING:  Cannot specify both constraint object and function!");
 
       _constrain_system_function = nullptr;
     }
@@ -2014,9 +2002,7 @@ void System::attach_QOI_function(void fptr(EquationSystems &,
 
   if (_qoi_evaluate_object != nullptr)
     {
-      libmesh_here();
-      libMesh::out << "WARNING:  Cannot specify both QOI function and object!"
-                   << std::endl;
+      libmesh_warning("WARNING:  Cannot specify both QOI function and object!");
 
       _qoi_evaluate_object = nullptr;
     }
@@ -2030,9 +2016,7 @@ void System::attach_QOI_object (QOI & qoi_in)
 {
   if (_qoi_evaluate_function != nullptr)
     {
-      libmesh_here();
-      libMesh::out << "WARNING:  Cannot specify both QOI object and function!"
-                   << std::endl;
+      libmesh_warning("WARNING:  Cannot specify both QOI object and function!");
 
       _qoi_evaluate_function = nullptr;
     }
@@ -2049,9 +2033,7 @@ void System::attach_QOI_derivative(void fptr(EquationSystems &, const std::strin
 
   if (_qoi_evaluate_derivative_object != nullptr)
     {
-      libmesh_here();
-      libMesh::out << "WARNING:  Cannot specify both QOI derivative function and object!"
-                   << std::endl;
+      libmesh_warning("WARNING:  Cannot specify both QOI derivative function and object!");
 
       _qoi_evaluate_derivative_object = nullptr;
     }
@@ -2065,9 +2047,7 @@ void System::attach_QOI_derivative_object (QOIDerivative & qoi_derivative)
 {
   if (_qoi_evaluate_derivative_function != nullptr)
     {
-      libmesh_here();
-      libMesh::out << "WARNING:  Cannot specify both QOI derivative object and function!"
-                   << std::endl;
+      libmesh_warning("WARNING:  Cannot specify both QOI derivative object and function!");
 
       _qoi_evaluate_derivative_function = nullptr;
     }

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -762,34 +762,28 @@ NumericVector<Number> * System::request_vector (const std::string & vec_name)
 
 const NumericVector<Number> * System::request_vector (const unsigned int vec_num) const
 {
-  const_vectors_iterator v = vectors_begin();
-  const_vectors_iterator v_end = vectors_end();
-  unsigned int num = 0;
-  while ((num<vec_num) && (v!=v_end))
-    {
-      num++;
-      ++v;
-    }
-  if (v==v_end)
+  // If we don't have that many vectors, return nullptr
+  if (vec_num >= _vectors.size())
     return nullptr;
-  return v->second.get();
+
+  // Otherwise return a pointer to the vec_num'th vector
+  auto it = vectors_begin();
+  std::advance(it, vec_num);
+  return it->second.get();
 }
 
 
 
 NumericVector<Number> * System::request_vector (const unsigned int vec_num)
 {
-  vectors_iterator v = vectors_begin();
-  vectors_iterator v_end = vectors_end();
-  unsigned int num = 0;
-  while ((num<vec_num) && (v!=v_end))
-    {
-      num++;
-      ++v;
-    }
-  if (v==v_end)
+  // If we don't have that many vectors, return nullptr
+  if (vec_num >= _vectors.size())
     return nullptr;
-  return v->second.get();
+
+  // Otherwise return a pointer to the vec_num'th vector
+  auto it = vectors_begin();
+  std::advance(it, vec_num);
+  return it->second.get();
 }
 
 
@@ -810,48 +804,39 @@ NumericVector<Number> & System::get_vector (const std::string & vec_name)
 
 const NumericVector<Number> & System::get_vector (const unsigned int vec_num) const
 {
-  const_vectors_iterator v = vectors_begin();
-  const_vectors_iterator v_end = vectors_end();
-  unsigned int num = 0;
-  while ((num<vec_num) && (v!=v_end))
-    {
-      num++;
-      ++v;
-    }
-  libmesh_assert (v != v_end);
-  return *(v->second);
+  // If we don't have that many vectors, throw an error
+  libmesh_assert_less(vec_num, _vectors.size());
+
+  // Otherwise return a reference to the vec_num'th vector
+  auto it = vectors_begin();
+  std::advance(it, vec_num);
+  return *(it->second);
 }
 
 
 
 NumericVector<Number> & System::get_vector (const unsigned int vec_num)
 {
-  vectors_iterator v = vectors_begin();
-  vectors_iterator v_end = vectors_end();
-  unsigned int num = 0;
-  while ((num<vec_num) && (v!=v_end))
-    {
-      num++;
-      ++v;
-    }
-  libmesh_assert (v != v_end);
-  return *(v->second);
+  // If we don't have that many vectors, throw an error
+  libmesh_assert_less(vec_num, _vectors.size());
+
+  // Otherwise return a reference to the vec_num'th vector
+  auto it = vectors_begin();
+  std::advance(it, vec_num);
+  return *(it->second);
 }
 
 
 
 const std::string & System::vector_name (const unsigned int vec_num) const
 {
-  const_vectors_iterator v = vectors_begin();
-  const_vectors_iterator v_end = vectors_end();
-  unsigned int num = 0;
-  while ((num<vec_num) && (v!=v_end))
-    {
-      num++;
-      ++v;
-    }
-  libmesh_assert (v != v_end);
-  return v->first;
+  // If we don't have that many vectors, throw an error
+  libmesh_assert_less(vec_num, _vectors.size());
+
+  // Otherwise return a reference to the vec_num'th vector name
+  auto it = vectors_begin();
+  std::advance(it, vec_num);
+  return it->first;
 }
 
 const std::string & System::vector_name (const NumericVector<Number> & vec_reference) const

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -403,8 +403,7 @@ void System::read_legacy_data (Xdr & io,
         libmesh_error_msg
           ("Additional vectors in file do not match system");
 
-      std::map<std::string, NumericVector<Number> *>::iterator
-        pos = this->_vectors.begin();
+      auto pos = this->_vectors.begin();
 
       for (std::size_t i = 0; i != this->_additional_data_written; ++i)
         {
@@ -630,8 +629,7 @@ void System::read_parallel_data (Xdr & io,
         libmesh_error_msg
           ("Additional vectors in file do not match system");
 
-      std::map<std::string, NumericVector<Number> *>::const_iterator
-        pos = _vectors.begin();
+      auto pos = _vectors.begin();
 
       for (std::size_t i = 0; i != this->_additional_data_written; ++i)
         {
@@ -769,8 +767,7 @@ void System::read_serialized_data (Xdr & io,
         libmesh_error_msg
           ("Additional vectors in file do not match system");
 
-      std::map<std::string, NumericVector<Number> *>::const_iterator
-        pos = _vectors.begin();
+      auto pos = _vectors.begin();
 
       for (std::size_t i = 0; i != this->_additional_data_written; ++i)
         {
@@ -779,7 +776,7 @@ void System::read_serialized_data (Xdr & io,
 
           // total_read_size +=
           this->read_serialized_vector<InValType>
-            (io, (read_additional_data && nvecs) ? pos->second : nullptr);
+            (io, (read_additional_data && nvecs) ? pos->second.get() : nullptr);
 
           // get the comment
           if (this->processor_id() == 0)


### PR DESCRIPTION
The `System::_vectors` data structure now more closely matches what we do with the `_matrices`. This makes it possible to default the move constructor for `System`. Also updated a few other things for C++11 that I came across.
