### PR TITLE
TypeVector overloads for std::norm and friends for Eigen::Matrix

### DIFF
--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -30,6 +30,12 @@
 #include <cmath>
 #include <complex>
 
+#ifdef LIBMESH_HAVE_EIGEN
+#include "libmesh/ignore_warnings.h"
+#include "Eigen/Core"
+#include "libmesh/restore_warnings.h"
+#endif
+
 #ifdef LIBMESH_HAVE_METAPHYSICL
 #include "metaphysicl/dualnumber_forward.h"
 
@@ -47,6 +53,24 @@ template <typename T, typename D, bool asd>
 MetaPhysicL::DualNumber<T, D, asd> abs(const MetaPhysicL::DualNumber<T, D, asd> & in);
 template <typename T, typename D, bool asd>
 MetaPhysicL::DualNumber<T, D, asd> abs(MetaPhysicL::DualNumber<T, D, asd> && in);
+
+#ifdef LIBMESH_HAVE_EIGEN
+template <typename T, typename D, bool asd>
+using ADRealEigenVector = Eigen::Matrix<MetaPhysicL::DualNumber<T, D, asd>, Eigen::Dynamic, 1>;
+
+template <typename T, typename D, bool asd>
+ADRealEigenVector<T, D, asd> norm(const ADRealEigenVector<T, D, asd> &) {throw std::runtime_error("unimplemented");}
+template <typename T, typename D, bool asd>
+ADRealEigenVector<T, D, asd> norm(ADRealEigenVector<T, D, asd> &&) {throw std::runtime_error("unimplemented");}
+template <typename T, typename D, bool asd>
+ADRealEigenVector<T, D, asd> sqrt(const ADRealEigenVector<T, D, asd> &) {throw std::runtime_error("unimplemented");}
+template <typename T, typename D, bool asd>
+ADRealEigenVector<T, D, asd> sqrt(ADRealEigenVector<T, D, asd> &&) {throw std::runtime_error("unimplemented");}
+template <typename T, typename D, bool asd>
+ADRealEigenVector<T, D, asd> abs(const ADRealEigenVector<T, D, asd> &) {throw std::runtime_error("unimplemented");}
+template <typename T, typename D, bool asd>
+ADRealEigenVector<T, D, asd> abs(ADRealEigenVector<T, D, asd> &&) {throw std::runtime_error("unimplemented");}
+#endif
 }
 #endif
 


### PR DESCRIPTION
This is needed in MOOSE.  I know this really seems like a moose-specific
hack finding its way into libmesh, but the way moose does unity builds,
we can't guarantee the order of appearance of the declarations of these
overloads.  The compiler keeps finding the wrong ones and ignores the
correct one if we put the overloads anywhere in MOOSE.  We can definitely
mod it a bit to try to generalize it a bit more, stick it in a separate include
file, etc. - but we're going to need something ~like this.