### PR TITLE
Add ExodusII_IO::write_nodeset_data() API

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -313,6 +313,26 @@ public:
                      std::vector<std::map<BoundaryInfo::BCTuple, Real>> & bc_vals);
 
   /**
+   * The Exodus format can also store values on nodesets. This can be
+   * thought of as an alternative to defining a nodal variable
+   * field on lower-dimensional elements making up a part of the
+   * boundary. The inputs to the function are:
+   * .) var_names[i] is the name of the ith sideset variable to be written to file.
+   * .) node_boundary_ids[i] is a set of node_ids where var_names[i] is active.
+   * .) bc_vals[i] is a map from (node-id, boundary-id) NodeBCTuple objects to the
+   *    corresponding real-valued data.
+   *
+   * \note You must have already written the mesh by calling
+   * e.g. write() before calling this function, because it uses the
+   * existing ordering of the Exodus nodesets.
+   */
+  void
+  write_nodeset_data (int timestep,
+                      const std::vector<std::string> & var_names,
+                      std::vector<std::set<boundary_id_type>> & node_boundary_ids,
+                      std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> & bc_vals);
+
+  /**
    * Read all the nodeset data at a particular timestep. TODO:
    * currently _all_ the nodeset variables are read, but we might want
    * to change this to only read the requested ones.

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -356,6 +356,15 @@ public:
                      std::vector<std::map<BoundaryInfo::BCTuple, Real>> & bc_vals);
 
   /**
+   * Write nodeset data for the requested timestep.
+   */
+  void
+  write_nodeset_data (int timestep,
+                      const std::vector<std::string> & var_names,
+                      const std::vector<std::set<boundary_id_type>> & node_boundary_ids,
+                      std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> & bc_vals);
+
+  /**
    * Read nodeset variables, if any, into the provided data structures.
    */
   void

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1535,6 +1535,22 @@ read_sideset_data(int timestep,
 
 void
 ExodusII_IO::
+write_nodeset_data (int timestep,
+                    const std::vector<std::string> & var_names,
+                    std::vector<std::set<boundary_id_type>> & node_boundary_ids,
+                    std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> & bc_vals)
+{
+  libmesh_error_msg_if(!exio_helper->opened_for_writing,
+                       "ERROR, ExodusII file must be opened for writing "
+                       "before calling ExodusII_IO::write_nodeset_data()!");
+
+  exio_helper->write_nodeset_data(timestep, var_names, node_boundary_ids, bc_vals);
+}
+
+
+
+void
+ExodusII_IO::
 read_nodeset_data (int timestep,
                    std::vector<std::string> & var_names,
                    std::vector<std::set<boundary_id_type>> & node_boundary_ids,

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -2602,9 +2602,6 @@ write_sideset_data(const MeshBase & mesh,
   // .) ss_ids
   this->read_sideset_info();
 
-  // Debugging:
-  // libMesh::out << "File has " << num_side_sets << " side sets." << std::endl;
-
   // Write "truth" table for sideset variables.  The function
   // exII::ex_put_var_param() must be called before
   // exII::ex_put_sset_var_tab(). For us, this happens during the call
@@ -2624,12 +2621,6 @@ write_sideset_data(const MeshBase & mesh,
       // this class.
       offset += (ss > 0 ? num_sides_per_set[ss-1] : 0);
       this->read_sideset(ss, offset);
-
-      // Debugging:
-      // libMesh::out << "Sideset " << ss_ids[ss]
-      //              << " has " << num_sides_per_set[ss]
-      //              << " entries."
-      //              << std::endl;
 
       // For each variable in var_names, write the values for the
       // current sideset, if any.
@@ -2679,11 +2670,6 @@ write_sideset_data(const MeshBase & mesh,
 
               // Map from Exodus side ids to libmesh side ids.
               unsigned int converted_side_id = conv.get_side_map(side_id);
-
-              // Debugging:
-              // libMesh::out << "side_id=" << side_id
-              //              << ", converted_side_id=" << converted_side_id
-              //              << std::endl;
 
               // Construct a key so we can quickly see whether there is any
               // data for this variable in the map.
@@ -2791,14 +2777,6 @@ read_sideset_data(const MeshBase & mesh,
                      MappedInputVector(sset_var_vals, _single_precision).data());
                   EX_CHECK_ERR(ex_err, "Error reading sideset variable.");
 
-                  // Debugging:
-                  // libMesh::out << "Variable " << sideset_var_names[var]
-                  //              << " is defined on side set " << ss_ids[ss]
-                  //              << " and has values: " << std::endl;
-                  // for (int i=0; i<num_sides_per_set[ss]; ++i)
-                  //   libMesh::out << sset_var_vals[i] << " ";
-                  // libMesh::out << std::endl;
-
                   for (int i=0; i<num_sides_per_set[ss]; ++i)
                     {
                       dof_id_type exodus_elem_id = elem_list[i + offset];
@@ -2817,16 +2795,6 @@ read_sideset_data(const MeshBase & mesh,
                       // Note: the mapping is defined on 0-based indices, so subtract
                       // 1 before doing the mapping.
                       unsigned int converted_side_id = conv.get_side_map(exodus_side_id - 1);
-
-                      // Debugging:
-                      // libMesh::out << "exodus_elem_id = " << exodus_elem_id
-                      //              << "\n"
-                      //              << "converted_elem_id = " << converted_elem_id
-                      //              << "\n\n"
-                      //              << "exodus_side_id = " << exodus_side_id
-                      //              << "\n"
-                      //              << "converted_side_id = " << converted_side_id
-                      //              << std::endl;
 
                       // Make a BCTuple key from the converted information.
                       BoundaryInfo::BCTuple key = std::make_tuple
@@ -2869,13 +2837,6 @@ write_nodeset_data (int timestep,
   // Note: we need these arrays so that we know what data to write
   this->read_all_nodesets();
 
-  // Debugging
-  // libMesh::out << "num_node_sets = " << this->num_node_sets << std::endl;
-  // libMesh::out << "nodset_ids = ";
-  // for (const auto & id : nodeset_ids)
-  //   libMesh::out << id << " ";
-  // libMesh::out << std::endl;
-
   // The "truth" table for nodeset variables. nset_var_tab is a
   // logically (num_node_sets x num_nset_var) integer array of 0s and
   // 1s indicating which nodesets a given nodeset variable is defined
@@ -2884,9 +2845,6 @@ write_nodeset_data (int timestep,
 
   for (int ns=0; ns<num_node_sets; ++ns)
   {
-    // Debugging:
-    // libMesh::out << "Writing data for nodeset " << ns << std::endl;
-
     // The offset into the node_sets_node_list for the current nodeset
     int offset = node_sets_node_index[ns];
 
@@ -2916,9 +2874,6 @@ write_nodeset_data (int timestep,
             // I don't think it is set up at the time when
             // write_nodeset_data() would normally be called.
             dof_id_type libmesh_node_id = node_sets_node_list[i + offset] - 1;
-
-            // Debugging
-            // libMesh::out << "libmesh_node_id=" << libmesh_node_id << std::endl;
 
             // Construct a key to look up values in data_map.
             BoundaryInfo::NodeBCTuple key =

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -2316,15 +2316,18 @@ void ExodusII_IO_Helper::write_nodesets(const MeshBase & mesh)
   // build_node_list() builds a sorted list of (node-id, bc-id) tuples
   // that is sorted by node-id, but we actually want it to be sorted
   // by bc-id, i.e. the second argument of the tuple.
-  typedef std::tuple<dof_id_type, boundary_id_type> tuple_t;
-  std::vector<tuple_t> bc_tuples =
+  auto bc_tuples =
     mesh.get_boundary_info().build_node_list();
 
-  // We use std::stable_sort so that the entries within a single
-  // nodeset remain in whatever order they were previously in.
+  // We use std::stable_sort() here so that the entries within a
+  // single nodeset remain sorted in node-id order, but now the
+  // smallest boundary id's nodes appear first in the list, followed
+  // by the second smallest, etc. That is, we are purposely doing two
+  // different sorts here, with the first one being within the
+  // build_node_list() call itself.
   std::stable_sort(bc_tuples.begin(), bc_tuples.end(),
-                   [](const tuple_t & t1,
-                      const tuple_t & t2)
+                   [](const BoundaryInfo::NodeBCTuple & t1,
+                      const BoundaryInfo::NodeBCTuple & t2)
                    { return std::get<1>(t1) < std::get<1>(t2); });
 
   std::vector<boundary_id_type> node_boundary_ids;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -69,6 +69,7 @@ unit_tests_sources = \
   mesh/mapped_subdomain_partitioner_test.C \
   mesh/mesh_function_dfem.C \
   mesh/write_sideset_data.C \
+  mesh/write_nodeset_data.C \
   mesh/write_edgeset_data.C \
   mesh/write_vec_and_scalar.C \
   mesh/all_second_order.C \
@@ -252,6 +253,7 @@ CLEANFILES = cube_mesh.xda \
 	     mesh_with_soln.e \
 	     elemental_from_nodal.e \
              write_sideset_data.e \
+             write_nodeset_data.e \
              write_edgeset_data.e \
              read_header_test.e \
              output.dat \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -210,8 +210,9 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C mesh/write_sideset_data.C \
-	mesh/write_edgeset_data.C mesh/write_vec_and_scalar.C \
-	mesh/all_second_order.C numerics/composite_function_test.C \
+	mesh/write_nodeset_data.C mesh/write_edgeset_data.C \
+	mesh/write_vec_and_scalar.C mesh/all_second_order.C \
+	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -291,6 +292,7 @@ am__objects_3 = unit_tests_dbg-driver.$(OBJEXT) \
 	mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_function_dfem.$(OBJEXT) \
 	mesh/unit_tests_dbg-write_sideset_data.$(OBJEXT) \
+	mesh/unit_tests_dbg-write_nodeset_data.$(OBJEXT) \
 	mesh/unit_tests_dbg-write_edgeset_data.$(OBJEXT) \
 	mesh/unit_tests_dbg-write_vec_and_scalar.$(OBJEXT) \
 	mesh/unit_tests_dbg-all_second_order.$(OBJEXT) \
@@ -368,8 +370,9 @@ am__unit_tests_devel_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C mesh/write_sideset_data.C \
-	mesh/write_edgeset_data.C mesh/write_vec_and_scalar.C \
-	mesh/all_second_order.C numerics/composite_function_test.C \
+	mesh/write_nodeset_data.C mesh/write_edgeset_data.C \
+	mesh/write_vec_and_scalar.C mesh/all_second_order.C \
+	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -447,6 +450,7 @@ am__objects_5 = unit_tests_devel-driver.$(OBJEXT) \
 	mesh/unit_tests_devel-mapped_subdomain_partitioner_test.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_function_dfem.$(OBJEXT) \
 	mesh/unit_tests_devel-write_sideset_data.$(OBJEXT) \
+	mesh/unit_tests_devel-write_nodeset_data.$(OBJEXT) \
 	mesh/unit_tests_devel-write_edgeset_data.$(OBJEXT) \
 	mesh/unit_tests_devel-write_vec_and_scalar.$(OBJEXT) \
 	mesh/unit_tests_devel-all_second_order.$(OBJEXT) \
@@ -520,8 +524,9 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C mesh/write_sideset_data.C \
-	mesh/write_edgeset_data.C mesh/write_vec_and_scalar.C \
-	mesh/all_second_order.C numerics/composite_function_test.C \
+	mesh/write_nodeset_data.C mesh/write_edgeset_data.C \
+	mesh/write_vec_and_scalar.C mesh/all_second_order.C \
+	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -599,6 +604,7 @@ am__objects_7 = unit_tests_oprof-driver.$(OBJEXT) \
 	mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_function_dfem.$(OBJEXT) \
 	mesh/unit_tests_oprof-write_sideset_data.$(OBJEXT) \
+	mesh/unit_tests_oprof-write_nodeset_data.$(OBJEXT) \
 	mesh/unit_tests_oprof-write_edgeset_data.$(OBJEXT) \
 	mesh/unit_tests_oprof-write_vec_and_scalar.$(OBJEXT) \
 	mesh/unit_tests_oprof-all_second_order.$(OBJEXT) \
@@ -672,8 +678,9 @@ am__unit_tests_opt_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C mesh/write_sideset_data.C \
-	mesh/write_edgeset_data.C mesh/write_vec_and_scalar.C \
-	mesh/all_second_order.C numerics/composite_function_test.C \
+	mesh/write_nodeset_data.C mesh/write_edgeset_data.C \
+	mesh/write_vec_and_scalar.C mesh/all_second_order.C \
+	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -751,6 +758,7 @@ am__objects_9 = unit_tests_opt-driver.$(OBJEXT) \
 	mesh/unit_tests_opt-mapped_subdomain_partitioner_test.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_function_dfem.$(OBJEXT) \
 	mesh/unit_tests_opt-write_sideset_data.$(OBJEXT) \
+	mesh/unit_tests_opt-write_nodeset_data.$(OBJEXT) \
 	mesh/unit_tests_opt-write_edgeset_data.$(OBJEXT) \
 	mesh/unit_tests_opt-write_vec_and_scalar.$(OBJEXT) \
 	mesh/unit_tests_opt-all_second_order.$(OBJEXT) \
@@ -824,8 +832,9 @@ am__unit_tests_prof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C mesh/write_sideset_data.C \
-	mesh/write_edgeset_data.C mesh/write_vec_and_scalar.C \
-	mesh/all_second_order.C numerics/composite_function_test.C \
+	mesh/write_nodeset_data.C mesh/write_edgeset_data.C \
+	mesh/write_vec_and_scalar.C mesh/all_second_order.C \
+	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -903,6 +912,7 @@ am__objects_11 = unit_tests_prof-driver.$(OBJEXT) \
 	mesh/unit_tests_prof-mapped_subdomain_partitioner_test.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_function_dfem.$(OBJEXT) \
 	mesh/unit_tests_prof-write_sideset_data.$(OBJEXT) \
+	mesh/unit_tests_prof-write_nodeset_data.$(OBJEXT) \
 	mesh/unit_tests_prof-write_edgeset_data.$(OBJEXT) \
 	mesh/unit_tests_prof-write_vec_and_scalar.$(OBJEXT) \
 	mesh/unit_tests_prof-all_second_order.$(OBJEXT) \
@@ -959,7 +969,7 @@ am__v_P_1 = :
 AM_V_GEN = $(am__v_GEN_@AM_V@)
 am__v_GEN_ = $(am__v_GEN_@AM_DEFAULT_V@)
 am__v_GEN_0 = @echo "  GEN     " $@;
-am__v_GEN_1 = 
+am__v_GEN_1 =
 AM_V_at = $(am__v_at_@AM_V@)
 am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
 am__v_at_0 = @
@@ -1128,6 +1138,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-spatial_dimension_test.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-write_edgeset_data.Po \
+	mesh/$(DEPDIR)/unit_tests_dbg-write_nodeset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-write_vec_and_scalar.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-all_second_order.Po \
@@ -1151,6 +1162,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-spatial_dimension_test.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-write_edgeset_data.Po \
+	mesh/$(DEPDIR)/unit_tests_devel-write_nodeset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-write_vec_and_scalar.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-all_second_order.Po \
@@ -1174,6 +1186,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-spatial_dimension_test.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-write_edgeset_data.Po \
+	mesh/$(DEPDIR)/unit_tests_oprof-write_nodeset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-write_vec_and_scalar.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-all_second_order.Po \
@@ -1197,6 +1210,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-spatial_dimension_test.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-write_edgeset_data.Po \
+	mesh/$(DEPDIR)/unit_tests_opt-write_nodeset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-write_vec_and_scalar.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-all_second_order.Po \
@@ -1220,6 +1234,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-spatial_dimension_test.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-write_edgeset_data.Po \
+	mesh/$(DEPDIR)/unit_tests_prof-write_nodeset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-write_vec_and_scalar.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Po \
@@ -1886,8 +1901,9 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C mesh/write_sideset_data.C \
-	mesh/write_edgeset_data.C mesh/write_vec_and_scalar.C \
-	mesh/all_second_order.C numerics/composite_function_test.C \
+	mesh/write_nodeset_data.C mesh/write_edgeset_data.C \
+	mesh/write_vec_and_scalar.C mesh/all_second_order.C \
+	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -1953,8 +1969,8 @@ data = meshes/1_quad.bxt.gz \
 @LIBMESH_ENABLE_CPPUNIT_TRUE@TESTS = run_unit_tests.sh
 CLEANFILES = cube_mesh.xda slit_mesh.xda slit_solution.xda out.e \
 	mesh_with_soln.e elemental_from_nodal.e write_sideset_data.e \
-	write_edgeset_data.e read_header_test.e output.dat periodic.e \
-	$(am__append_12) $(am__append_13)
+	write_nodeset_data.e write_edgeset_data.e read_header_test.e \
+	output.dat periodic.e $(am__append_12) $(am__append_13)
 
 # need to link any data files for VPATH builds
 @LIBMESH_VPATH_BUILD_TRUE@BUILT_SOURCES = .linkstamp
@@ -2127,6 +2143,8 @@ mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.$(OBJEXT):  \
 mesh/unit_tests_dbg-mesh_function_dfem.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-write_sideset_data.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_dbg-write_nodeset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-write_edgeset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -2364,6 +2382,8 @@ mesh/unit_tests_devel-mesh_function_dfem.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-write_sideset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_devel-write_nodeset_data.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-write_edgeset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-write_vec_and_scalar.$(OBJEXT):  \
@@ -2551,6 +2571,8 @@ mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.$(OBJEXT):  \
 mesh/unit_tests_oprof-mesh_function_dfem.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-write_sideset_data.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_oprof-write_nodeset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-write_edgeset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -2740,6 +2762,8 @@ mesh/unit_tests_opt-mesh_function_dfem.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-write_sideset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_opt-write_nodeset_data.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-write_edgeset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-write_vec_and_scalar.$(OBJEXT):  \
@@ -2927,6 +2951,8 @@ mesh/unit_tests_prof-mapped_subdomain_partitioner_test.$(OBJEXT):  \
 mesh/unit_tests_prof-mesh_function_dfem.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-write_sideset_data.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_prof-write_nodeset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-write_edgeset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -3204,6 +3230,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-spatial_dimension_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-write_edgeset_data.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-write_nodeset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-write_vec_and_scalar.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-all_second_order.Po@am__quote@ # am--include-marker
@@ -3227,6 +3254,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-spatial_dimension_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-write_edgeset_data.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-write_nodeset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-write_vec_and_scalar.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-all_second_order.Po@am__quote@ # am--include-marker
@@ -3250,6 +3278,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-spatial_dimension_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-write_edgeset_data.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-write_nodeset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-write_vec_and_scalar.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-all_second_order.Po@am__quote@ # am--include-marker
@@ -3273,6 +3302,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-spatial_dimension_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-write_edgeset_data.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-write_nodeset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-write_vec_and_scalar.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-all_second_order.Po@am__quote@ # am--include-marker
@@ -3296,6 +3326,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-spatial_dimension_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-write_edgeset_data.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-write_nodeset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-write_vec_and_scalar.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Po@am__quote@ # am--include-marker
@@ -4176,6 +4207,20 @@ mesh/unit_tests_dbg-write_sideset_data.obj: mesh/write_sideset_data.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_sideset_data.C' object='mesh/unit_tests_dbg-write_sideset_data.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-write_sideset_data.obj `if test -f 'mesh/write_sideset_data.C'; then $(CYGPATH_W) 'mesh/write_sideset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_sideset_data.C'; fi`
+
+mesh/unit_tests_dbg-write_nodeset_data.o: mesh/write_nodeset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-write_nodeset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-write_nodeset_data.Tpo -c -o mesh/unit_tests_dbg-write_nodeset_data.o `test -f 'mesh/write_nodeset_data.C' || echo '$(srcdir)/'`mesh/write_nodeset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-write_nodeset_data.Tpo mesh/$(DEPDIR)/unit_tests_dbg-write_nodeset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_nodeset_data.C' object='mesh/unit_tests_dbg-write_nodeset_data.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-write_nodeset_data.o `test -f 'mesh/write_nodeset_data.C' || echo '$(srcdir)/'`mesh/write_nodeset_data.C
+
+mesh/unit_tests_dbg-write_nodeset_data.obj: mesh/write_nodeset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-write_nodeset_data.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-write_nodeset_data.Tpo -c -o mesh/unit_tests_dbg-write_nodeset_data.obj `if test -f 'mesh/write_nodeset_data.C'; then $(CYGPATH_W) 'mesh/write_nodeset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_nodeset_data.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-write_nodeset_data.Tpo mesh/$(DEPDIR)/unit_tests_dbg-write_nodeset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_nodeset_data.C' object='mesh/unit_tests_dbg-write_nodeset_data.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-write_nodeset_data.obj `if test -f 'mesh/write_nodeset_data.C'; then $(CYGPATH_W) 'mesh/write_nodeset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_nodeset_data.C'; fi`
 
 mesh/unit_tests_dbg-write_edgeset_data.o: mesh/write_edgeset_data.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-write_edgeset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-write_edgeset_data.Tpo -c -o mesh/unit_tests_dbg-write_edgeset_data.o `test -f 'mesh/write_edgeset_data.C' || echo '$(srcdir)/'`mesh/write_edgeset_data.C
@@ -5423,6 +5468,20 @@ mesh/unit_tests_devel-write_sideset_data.obj: mesh/write_sideset_data.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-write_sideset_data.obj `if test -f 'mesh/write_sideset_data.C'; then $(CYGPATH_W) 'mesh/write_sideset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_sideset_data.C'; fi`
 
+mesh/unit_tests_devel-write_nodeset_data.o: mesh/write_nodeset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-write_nodeset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-write_nodeset_data.Tpo -c -o mesh/unit_tests_devel-write_nodeset_data.o `test -f 'mesh/write_nodeset_data.C' || echo '$(srcdir)/'`mesh/write_nodeset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-write_nodeset_data.Tpo mesh/$(DEPDIR)/unit_tests_devel-write_nodeset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_nodeset_data.C' object='mesh/unit_tests_devel-write_nodeset_data.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-write_nodeset_data.o `test -f 'mesh/write_nodeset_data.C' || echo '$(srcdir)/'`mesh/write_nodeset_data.C
+
+mesh/unit_tests_devel-write_nodeset_data.obj: mesh/write_nodeset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-write_nodeset_data.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-write_nodeset_data.Tpo -c -o mesh/unit_tests_devel-write_nodeset_data.obj `if test -f 'mesh/write_nodeset_data.C'; then $(CYGPATH_W) 'mesh/write_nodeset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_nodeset_data.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-write_nodeset_data.Tpo mesh/$(DEPDIR)/unit_tests_devel-write_nodeset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_nodeset_data.C' object='mesh/unit_tests_devel-write_nodeset_data.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-write_nodeset_data.obj `if test -f 'mesh/write_nodeset_data.C'; then $(CYGPATH_W) 'mesh/write_nodeset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_nodeset_data.C'; fi`
+
 mesh/unit_tests_devel-write_edgeset_data.o: mesh/write_edgeset_data.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-write_edgeset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-write_edgeset_data.Tpo -c -o mesh/unit_tests_devel-write_edgeset_data.o `test -f 'mesh/write_edgeset_data.C' || echo '$(srcdir)/'`mesh/write_edgeset_data.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-write_edgeset_data.Tpo mesh/$(DEPDIR)/unit_tests_devel-write_edgeset_data.Po
@@ -6668,6 +6727,20 @@ mesh/unit_tests_oprof-write_sideset_data.obj: mesh/write_sideset_data.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_sideset_data.C' object='mesh/unit_tests_oprof-write_sideset_data.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-write_sideset_data.obj `if test -f 'mesh/write_sideset_data.C'; then $(CYGPATH_W) 'mesh/write_sideset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_sideset_data.C'; fi`
+
+mesh/unit_tests_oprof-write_nodeset_data.o: mesh/write_nodeset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-write_nodeset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-write_nodeset_data.Tpo -c -o mesh/unit_tests_oprof-write_nodeset_data.o `test -f 'mesh/write_nodeset_data.C' || echo '$(srcdir)/'`mesh/write_nodeset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-write_nodeset_data.Tpo mesh/$(DEPDIR)/unit_tests_oprof-write_nodeset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_nodeset_data.C' object='mesh/unit_tests_oprof-write_nodeset_data.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-write_nodeset_data.o `test -f 'mesh/write_nodeset_data.C' || echo '$(srcdir)/'`mesh/write_nodeset_data.C
+
+mesh/unit_tests_oprof-write_nodeset_data.obj: mesh/write_nodeset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-write_nodeset_data.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-write_nodeset_data.Tpo -c -o mesh/unit_tests_oprof-write_nodeset_data.obj `if test -f 'mesh/write_nodeset_data.C'; then $(CYGPATH_W) 'mesh/write_nodeset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_nodeset_data.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-write_nodeset_data.Tpo mesh/$(DEPDIR)/unit_tests_oprof-write_nodeset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_nodeset_data.C' object='mesh/unit_tests_oprof-write_nodeset_data.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-write_nodeset_data.obj `if test -f 'mesh/write_nodeset_data.C'; then $(CYGPATH_W) 'mesh/write_nodeset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_nodeset_data.C'; fi`
 
 mesh/unit_tests_oprof-write_edgeset_data.o: mesh/write_edgeset_data.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-write_edgeset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-write_edgeset_data.Tpo -c -o mesh/unit_tests_oprof-write_edgeset_data.o `test -f 'mesh/write_edgeset_data.C' || echo '$(srcdir)/'`mesh/write_edgeset_data.C
@@ -7915,6 +7988,20 @@ mesh/unit_tests_opt-write_sideset_data.obj: mesh/write_sideset_data.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-write_sideset_data.obj `if test -f 'mesh/write_sideset_data.C'; then $(CYGPATH_W) 'mesh/write_sideset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_sideset_data.C'; fi`
 
+mesh/unit_tests_opt-write_nodeset_data.o: mesh/write_nodeset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-write_nodeset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-write_nodeset_data.Tpo -c -o mesh/unit_tests_opt-write_nodeset_data.o `test -f 'mesh/write_nodeset_data.C' || echo '$(srcdir)/'`mesh/write_nodeset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-write_nodeset_data.Tpo mesh/$(DEPDIR)/unit_tests_opt-write_nodeset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_nodeset_data.C' object='mesh/unit_tests_opt-write_nodeset_data.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-write_nodeset_data.o `test -f 'mesh/write_nodeset_data.C' || echo '$(srcdir)/'`mesh/write_nodeset_data.C
+
+mesh/unit_tests_opt-write_nodeset_data.obj: mesh/write_nodeset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-write_nodeset_data.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-write_nodeset_data.Tpo -c -o mesh/unit_tests_opt-write_nodeset_data.obj `if test -f 'mesh/write_nodeset_data.C'; then $(CYGPATH_W) 'mesh/write_nodeset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_nodeset_data.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-write_nodeset_data.Tpo mesh/$(DEPDIR)/unit_tests_opt-write_nodeset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_nodeset_data.C' object='mesh/unit_tests_opt-write_nodeset_data.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-write_nodeset_data.obj `if test -f 'mesh/write_nodeset_data.C'; then $(CYGPATH_W) 'mesh/write_nodeset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_nodeset_data.C'; fi`
+
 mesh/unit_tests_opt-write_edgeset_data.o: mesh/write_edgeset_data.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-write_edgeset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-write_edgeset_data.Tpo -c -o mesh/unit_tests_opt-write_edgeset_data.o `test -f 'mesh/write_edgeset_data.C' || echo '$(srcdir)/'`mesh/write_edgeset_data.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-write_edgeset_data.Tpo mesh/$(DEPDIR)/unit_tests_opt-write_edgeset_data.Po
@@ -9161,6 +9248,20 @@ mesh/unit_tests_prof-write_sideset_data.obj: mesh/write_sideset_data.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-write_sideset_data.obj `if test -f 'mesh/write_sideset_data.C'; then $(CYGPATH_W) 'mesh/write_sideset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_sideset_data.C'; fi`
 
+mesh/unit_tests_prof-write_nodeset_data.o: mesh/write_nodeset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-write_nodeset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-write_nodeset_data.Tpo -c -o mesh/unit_tests_prof-write_nodeset_data.o `test -f 'mesh/write_nodeset_data.C' || echo '$(srcdir)/'`mesh/write_nodeset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-write_nodeset_data.Tpo mesh/$(DEPDIR)/unit_tests_prof-write_nodeset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_nodeset_data.C' object='mesh/unit_tests_prof-write_nodeset_data.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-write_nodeset_data.o `test -f 'mesh/write_nodeset_data.C' || echo '$(srcdir)/'`mesh/write_nodeset_data.C
+
+mesh/unit_tests_prof-write_nodeset_data.obj: mesh/write_nodeset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-write_nodeset_data.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-write_nodeset_data.Tpo -c -o mesh/unit_tests_prof-write_nodeset_data.obj `if test -f 'mesh/write_nodeset_data.C'; then $(CYGPATH_W) 'mesh/write_nodeset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_nodeset_data.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-write_nodeset_data.Tpo mesh/$(DEPDIR)/unit_tests_prof-write_nodeset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_nodeset_data.C' object='mesh/unit_tests_prof-write_nodeset_data.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-write_nodeset_data.obj `if test -f 'mesh/write_nodeset_data.C'; then $(CYGPATH_W) 'mesh/write_nodeset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_nodeset_data.C'; fi`
+
 mesh/unit_tests_prof-write_edgeset_data.o: mesh/write_edgeset_data.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-write_edgeset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-write_edgeset_data.Tpo -c -o mesh/unit_tests_prof-write_edgeset_data.o `test -f 'mesh/write_edgeset_data.C' || echo '$(srcdir)/'`mesh/write_edgeset_data.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-write_edgeset_data.Tpo mesh/$(DEPDIR)/unit_tests_prof-write_edgeset_data.Po
@@ -10272,6 +10373,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_vec_and_scalar.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-all_second_order.Po
@@ -10295,6 +10397,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_vec_and_scalar.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-all_second_order.Po
@@ -10318,6 +10421,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_vec_and_scalar.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-all_second_order.Po
@@ -10341,6 +10445,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_vec_and_scalar.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-all_second_order.Po
@@ -10364,6 +10469,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_vec_and_scalar.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Po
@@ -10764,6 +10870,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_vec_and_scalar.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-all_second_order.Po
@@ -10787,6 +10894,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_vec_and_scalar.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-all_second_order.Po
@@ -10810,6 +10918,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_vec_and_scalar.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-all_second_order.Po
@@ -10833,6 +10942,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_vec_and_scalar.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-all_second_order.Po
@@ -10856,6 +10966,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_vec_and_scalar.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Po

--- a/tests/mesh/write_nodeset_data.C
+++ b/tests/mesh/write_nodeset_data.C
@@ -1,0 +1,123 @@
+// Basic include files
+#include "libmesh/equation_systems.h"
+#include "libmesh/exodusII_io.h"
+#include "libmesh/mesh.h"
+#include "libmesh/mesh_generation.h"
+#include "libmesh/parallel.h" // set_union
+#include "libmesh/string_to_enum.h"
+#include "libmesh/boundary_info.h"
+
+#include "test_comm.h"
+#include "libmesh_cppunit.h"
+
+
+// Bring in everything from the libMesh namespace
+using namespace libMesh;
+
+class WriteNodesetData : public CppUnit::TestCase
+{
+public:
+  CPPUNIT_TEST_SUITE(WriteNodesetData);
+
+#if LIBMESH_DIM > 1
+  CPPUNIT_TEST(testWrite);
+#endif
+
+  CPPUNIT_TEST_SUITE_END();
+
+  void testWrite()
+  {
+    Mesh mesh(*TestCommWorld);
+    mesh.allow_renumbering(false);
+    MeshTools::Generation::build_square(mesh,
+                                        /*nx=*/5, /*ny=*/5,
+                                        -1., 1.,
+                                        -1., 1.,
+                                        QUAD4);
+
+    BoundaryInfo & bi = mesh.get_boundary_info();
+
+    // Meshes created via build_square() don't have any nodesets
+    // defined on them by default, so let's create some now. Note that
+    // this function handles the synchronization of ghost element and
+    // node ids in parallel internally.
+    bi.build_node_list_from_side_list();
+
+    // Get list of all (node, id) tuples
+    std::vector<BoundaryInfo::NodeBCTuple> all_bc_tuples = bi.build_node_list();
+
+    // Data structures to be passed to ExodusII_IO::write_nodeset_data()
+    std::vector<std::string> var_names = {"var1", "var2"};
+    std::vector<std::set<boundary_id_type>> node_boundary_ids =
+      {
+        {0, 2}, // var1 is defined on nodesets 0 and 2
+        {1, 3}  // var2 is defined on nodesets 1 and 3
+      };
+
+    // Data structure mapping (node, id) tuples to Real values that
+    // will be passed to Exodus.
+    std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> bc_vals(var_names.size());
+
+    // For each var_names[i], construct bc_vals[i]
+    for (unsigned int i=0; i<var_names.size(); ++i)
+      {
+        // const auto & var_name = var_names[i];
+        auto & vals = bc_vals[i];
+
+        for (const auto & t : all_bc_tuples)
+          {
+            boundary_id_type b_id = std::get<1>(t);
+
+            if (node_boundary_ids[i].count(b_id))
+              {
+                // Compute a value. This could in theory depend on
+                // var_name, node_id, and/or b_id.
+                Real val = static_cast<Real>(b_id);
+
+                // Insert into the vals map.
+                vals.emplace(t, val);
+              }
+          }
+
+        // If we have a distributed mesh, the ExodusII writer
+        // serializes it before writing, so we need to serialize our
+        // nodeset data as well so that it can all be written from
+        // processor 0.
+        if (!mesh.is_serial())
+          TestCommWorld->set_union(vals);
+
+      } // done constructing bc_vals
+
+#ifdef LIBMESH_HAVE_EXODUS_API
+
+    // We write the file in the ExodusII format.
+    {
+      ExodusII_IO writer(mesh);
+      writer.write("write_nodeset_data.e");
+      writer.write_nodeset_data (/*timestep=*/1, var_names, node_boundary_ids, bc_vals);
+    }
+
+    // Make sure that the writing is done before the reading starts.
+    TestCommWorld->barrier();
+
+    // Now read it back in
+    Mesh read_mesh(*TestCommWorld);
+    ExodusII_IO reader(read_mesh);
+    reader.read("write_nodeset_data.e");
+
+    std::vector<std::string> read_in_var_names;
+    std::vector<std::set<boundary_id_type>> read_in_node_boundary_ids;
+    std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> read_in_bc_vals;
+    reader.read_nodeset_data
+      (/*timestep=*/1, read_in_var_names, read_in_node_boundary_ids, read_in_bc_vals);
+
+    // Assert that we got back out what we put in.
+    CPPUNIT_ASSERT(read_in_var_names == var_names);
+    CPPUNIT_ASSERT(read_in_node_boundary_ids == node_boundary_ids);
+    CPPUNIT_ASSERT(read_in_bc_vals == bc_vals);
+
+#endif // #ifdef LIBMESH_HAVE_EXODUS_API
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(WriteNodesetData);


### PR DESCRIPTION
Also add a new unit test for this. We are now able to read and write variables on node, edge, and sidesets in the Exodus format.