### PR TITLE
Simplify DiagonalMatrix::zero_clone() slightly

### DIFF
--- a/include/numerics/diagonal_matrix.h
+++ b/include/numerics/diagonal_matrix.h
@@ -84,14 +84,18 @@ public:
 
   /**
    * Initialize with a NumericVector \p other, e.g. duplicate the storage
-   * allocation of \p other. This in general DOES NOT copy the vector entires
+   * allocation of \p other. This function DOES NOT copy the vector entries.
+   * If you set fast = false, the initialized entries are explicitly zeroed,
+   * otherwise their values are indeterminate.
    */
   virtual void init(const NumericVector<T> & other, const bool fast = false);
 
   /**
    * Initialize with DiagonalMatrix \p other, e.g. duplicate the storage
-   * allocation of the underlying NumericVector in \p other. This in general
-   * DOES NOT copy the vector entires
+   * allocation of the underlying NumericVector in \p other. This function
+   * DOES NOT copy the vector entries. If you set fast = false, the
+   * initialized entries are explicitly zeroed, otherwise their values
+   * are indeterminate.
    */
   virtual void init(const DiagonalMatrix<T> & other, const bool fast = false);
 

--- a/src/numerics/diagonal_matrix.C
+++ b/src/numerics/diagonal_matrix.C
@@ -110,11 +110,9 @@ std::unique_ptr<SparseMatrix<T>> DiagonalMatrix<T>::zero_clone () const
   // Make empty copy with matching comm
   auto mat_copy = libmesh_make_unique<DiagonalMatrix<T>>(this->comm());
 
-  // Make zero copy of our diagonal
-  auto diag_copy = _diagonal->zero_clone();
-
-  // Swap diag_copy with diagonal in mat_copy
-  *mat_copy = std::move(*diag_copy);
+  // Initialize copy with our same nonzero structure, and explicitly
+  // zero values using fast == false.
+  mat_copy->init(*this, /*fast=*/false);
 
   // Work around an issue on older compilers.  We are able to simply
   // "return mat_copy;" on newer compilers


### PR DESCRIPTION
@lindsayad what do you think about this? I think it's a bit clearer to reuse `init()` here, while otherwise being the same amount of work overall. Calling `init()` doesn't really work as nicely in the non-zero `clone()` case since it doesn't actually copy values... so I left that one alone.
