### PR TITLE
PeriodicBoundaries should store unique_ptrs instead of dumb ptrs

### DIFF
--- a/include/base/periodic_boundaries.h
+++ b/include/base/periodic_boundaries.h
@@ -28,6 +28,7 @@
 
 // C++ Includes
 #include <map>
+#include <memory>
 
 namespace libMesh
 {
@@ -41,21 +42,18 @@ class PointLocatorBase;
  * We're using a class instead of a typedef to allow forward
  * declarations and future flexibility.
  *
- * \note \p std::map has no virtual destructor, so downcasting here
- * would be dangerous.
- *
  * \author Roy Stogner
  * \date 2010
  * \brief Maps between boundary ids and PeriodicBoundaryBase objects.
  */
-class PeriodicBoundaries : public std::map<boundary_id_type, PeriodicBoundaryBase *>
+class PeriodicBoundaries : public std::map<boundary_id_type, std::unique_ptr<PeriodicBoundaryBase>>
 {
 public:
   PeriodicBoundaryBase * boundary(boundary_id_type id);
 
   const PeriodicBoundaryBase * boundary(boundary_id_type id) const;
 
-  PeriodicBoundaries() {}
+  PeriodicBoundaries() = default;
 
   ~PeriodicBoundaries();
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -38,6 +38,7 @@
 #include "libmesh/mesh_subdivision_support.h"
 #include "libmesh/mesh_tools.h"
 #include "libmesh/numeric_vector.h"
+#include "libmesh/periodic_boundary_base.h"
 #include "libmesh/periodic_boundaries.h"
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/sparsity_pattern.h"

--- a/src/base/periodic_boundaries.C
+++ b/src/base/periodic_boundaries.C
@@ -21,7 +21,6 @@
 #ifdef LIBMESH_ENABLE_PERIODIC
 
 #include "libmesh/periodic_boundaries.h"
-
 #include "libmesh/boundary_info.h"
 #include "libmesh/elem.h"
 #include "libmesh/mesh_base.h"
@@ -32,11 +31,7 @@
 namespace libMesh
 {
 
-PeriodicBoundaries::~PeriodicBoundaries()
-{
-  for (auto & pr : *this)
-    delete pr.second;
-}
+PeriodicBoundaries::~PeriodicBoundaries() = default;
 
 
 
@@ -45,7 +40,7 @@ PeriodicBoundaryBase * PeriodicBoundaries::boundary(boundary_id_type id)
   iterator i = this->find(id);
   if (i == this->end())
     return nullptr;
-  return i->second;
+  return i->second.get();
 }
 
 
@@ -55,7 +50,7 @@ const PeriodicBoundaryBase * PeriodicBoundaries::boundary(boundary_id_type id) c
   const_iterator i = this->find(id);
   if (i == this->end())
     return nullptr;
-  return i->second;
+  return i->second.get();
 }
 
 


### PR DESCRIPTION
This allows the PeriodicBoundaries destructor to be defaulted and simplifies some of the code which uses this class.