### PR TITLE
Fix incorrect use of unique_ptrs in TransientSystem

### DIFF
--- a/include/systems/transient_system.h
+++ b/include/systems/transient_system.h
@@ -116,7 +116,7 @@ public:
    * current solution with any ghost values needed from
    * other processors.
    */
-  std::unique_ptr<NumericVector<Number>> old_local_solution;
+  NumericVector<Number> * old_local_solution;
 
   /**
    * All the values I need to compute my contribution
@@ -124,8 +124,7 @@ public:
    * current solution with any ghost values needed from
    * other processors.
    */
-  std::unique_ptr<NumericVector<Number>> older_local_solution;
-
+  NumericVector<Number> * older_local_solution;
 
 protected:
 

--- a/src/systems/transient_system.C
+++ b/src/systems/transient_system.C
@@ -40,7 +40,9 @@ TransientSystem<Base>::TransientSystem (EquationSystems & es,
                                         const std::string & name_in,
                                         const unsigned int number_in) :
 
-  Base(es, name_in, number_in)
+  Base(es, name_in, number_in),
+  old_local_solution(nullptr),
+  older_local_solution(nullptr)
 {
   this->add_old_vectors();
 }
@@ -57,11 +59,6 @@ void TransientSystem<Base>::clear ()
 {
   // clear the parent data
   Base::clear();
-
-  // FIXME: This preserves maximum backwards compatibility,
-  // but is probably grossly unnecessary:
-  old_local_solution.release();
-  older_local_solution.release();
 
   // Restore us to a "basic" state
   this->add_old_vectors();
@@ -131,21 +128,15 @@ Number TransientSystem<Base>::older_solution (const dof_id_type global_dof_numbe
 template <class Base>
 void TransientSystem<Base>::add_old_vectors()
 {
+  ParallelType type =
 #ifdef LIBMESH_ENABLE_GHOSTED
-  old_local_solution =
-    std::unique_ptr<NumericVector<Number>>
-    (&(this->add_vector("_transient_old_local_solution", true, GHOSTED)));
-  older_local_solution =
-    std::unique_ptr<NumericVector<Number>>
-    (&(this->add_vector("_transient_older_local_solution", true, GHOSTED)));
+    GHOSTED;
 #else
-  old_local_solution =
-    std::unique_ptr<NumericVector<Number>>
-    (&(this->add_vector("_transient_old_local_solution", true, SERIAL)));
-  older_local_solution =
-    std::unique_ptr<NumericVector<Number>>
-    (&(this->add_vector("_transient_older_local_solution", true, SERIAL)));
+    SERIAL;
 #endif
+
+  old_local_solution = &(this->add_vector("_transient_old_local_solution", true, type));
+  older_local_solution = &(this->add_vector("_transient_older_local_solution", true, type));
 }
 
 // ------------------------------------------------------------

--- a/src/systems/transient_system.C
+++ b/src/systems/transient_system.C
@@ -40,7 +40,7 @@ TransientSystem<Base>::TransientSystem (EquationSystems & es,
                                         const std::string & name_in,
                                         const unsigned int number_in) :
 
-  Base                 (es, name_in, number_in)
+  Base(es, name_in, number_in)
 {
   this->add_old_vectors();
 }
@@ -48,16 +48,7 @@ TransientSystem<Base>::TransientSystem (EquationSystems & es,
 
 
 template <class Base>
-TransientSystem<Base>::~TransientSystem ()
-{
-  this->clear();
-
-  // We still have std::unique_ptrs for API compatibility, but
-  // now that we're System::add_vector()ing these, we can trust
-  // the base class to handle memory management
-  old_local_solution.release();
-  older_local_solution.release();
-}
+TransientSystem<Base>::~TransientSystem () = default;
 
 
 
@@ -66,11 +57,6 @@ void TransientSystem<Base>::clear ()
 {
   // clear the parent data
   Base::clear();
-
-  // the old & older local solutions
-  // are now deleted by System!
-  // old_local_solution->clear();
-  // older_local_solution->clear();
 
   // FIXME: This preserves maximum backwards compatibility,
   // but is probably grossly unnecessary:

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -501,10 +501,10 @@ private:
                                 libmesh_real(sys.point_value(0,p)),
                                 TOLERANCE*TOLERANCE*10);
         LIBMESH_ASSERT_FP_EQUAL(libmesh_real(cubic_test(p,param,"","") + Number(10)),
-                                libmesh_real(sys.point_value(0,p,sys.old_local_solution.get())),
+                                libmesh_real(sys.point_value(0,p,sys.old_local_solution)),
                                 TOLERANCE*TOLERANCE*100);
         LIBMESH_ASSERT_FP_EQUAL(libmesh_real(cubic_test(p,param,"","") + Number(20)),
-                                libmesh_real(sys.point_value(0,p,sys.older_local_solution.get())),
+                                libmesh_real(sys.point_value(0,p,sys.older_local_solution)),
                                 TOLERANCE*TOLERANCE*100);
       }
     if (v_subdomains.count(sbd_id))
@@ -513,10 +513,10 @@ private:
                                 libmesh_real(sys.point_value(1,p)),
                                 TOLERANCE*TOLERANCE*10);
         LIBMESH_ASSERT_FP_EQUAL(libmesh_real(new_linear_test(p,param,"","") + Number(10)),
-                                libmesh_real(sys.point_value(1,p,sys.old_local_solution.get())),
+                                libmesh_real(sys.point_value(1,p,sys.old_local_solution)),
                                 TOLERANCE*TOLERANCE*100);
         LIBMESH_ASSERT_FP_EQUAL(libmesh_real(new_linear_test(p,param,"","") + Number(20)),
-                                libmesh_real(sys.point_value(1,p,sys.older_local_solution.get())),
+                                libmesh_real(sys.point_value(1,p,sys.older_local_solution)),
                                 TOLERANCE*TOLERANCE*100);
       }
     if (w_subdomains.count(sbd_id))
@@ -525,10 +525,10 @@ private:
                                 libmesh_real(sys.point_value(2,p)),
                                 TOLERANCE*TOLERANCE*10);
         LIBMESH_ASSERT_FP_EQUAL(libmesh_real(disc_thirds_test(p,param,"","") + Number(10)),
-                                libmesh_real(sys.point_value(2,p,sys.old_local_solution.get())),
+                                libmesh_real(sys.point_value(2,p,sys.old_local_solution)),
                                 TOLERANCE*TOLERANCE*100);
         LIBMESH_ASSERT_FP_EQUAL(libmesh_real(disc_thirds_test(p,param,"","") + Number(20)),
-                                libmesh_real(sys.point_value(2,p,sys.older_local_solution.get())),
+                                libmesh_real(sys.point_value(2,p,sys.older_local_solution)),
                                 TOLERANCE*TOLERANCE*100);
       }
   }


### PR DESCRIPTION
Previously we were creating `unique_ptrs` out of references passed back from `System::add_vector()`, but this isn't correct as it creates two `unique_ptrs` to the same underlying data, which results in undefined behavior. Surprisingly, this never seemed to cause any issues for us... This could be because `TransientSystem` is not really a widely-used class in general, and/or because the nature of undefined behavior is that it sometimes "works". 

Unfortunately we can't really fix the problem without breaking backwards compatibility, but hopefully there won't be too much app code (any?) that depends on the original data structures. In libmesh itself there was only one unit test that was affected.
