### PR TITLE
Simplify unique_ptr return statements

### DIFF
--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -128,7 +128,7 @@ DofMap::build_sparsity (const MeshBase & mesh) const
     _augment_sparsity_pattern->augment_sparsity_pattern
       (sp->sparsity_pattern, sp->n_nz, sp->n_oz);
 
-  return std::unique_ptr<SparsityPattern::Build>(sp.release());
+  return sp;
 }
 
 

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -801,7 +801,7 @@ EquationSystems::build_parallel_solution_vector(const std::set<std::string> * sy
   // Divide to get the average value at the nodes
   parallel_soln /= repeat_count;
 
-  return std::unique_ptr<NumericVector<Number>>(parallel_soln_ptr.release());
+  return parallel_soln_ptr;
 }
 
 
@@ -1033,7 +1033,7 @@ EquationSystems::build_parallel_elemental_solution_vector (std::vector<std::stri
     } // end loop over var_nums
 
   parallel_soln.close();
-  return std::unique_ptr<NumericVector<Number>>(parallel_soln_ptr.release());
+  return parallel_soln_ptr;
 }
 
 


### PR DESCRIPTION
If there's no issue with `std::unique_ptr<Derived>` vs. `std::unique_ptr<Base>`, we should be able to simply return the object we've created without any additional `release()` gymnastics.

It's possible that this was just a workaround required on older compilers, so if this works with our current "min" gcc and clang, I think we should be safe to merge.
