### PR TITLE
UnsteadySolver: old_local_nonlinear_solution should be a std::shared_ptr

### DIFF
--- a/include/solvers/unsteady_solver.h
+++ b/include/solvers/unsteady_solver.h
@@ -164,8 +164,10 @@ public:
 
   /**
    * Serial vector of _system.get_vector("_old_nonlinear_solution")
+   * This is a shared_ptr so that it can be shared between different
+   * derived class instances, as in e.g. AdaptiveTimeSolver.
    */
-  std::unique_ptr<NumericVector<Number>> old_local_nonlinear_solution;
+  std::shared_ptr<NumericVector<Number>> old_local_nonlinear_solution;
 
   /**
    * Computes the size of ||u^{n+1} - u^{n}|| in some norm.

--- a/src/solvers/adaptive_time_solver.C
+++ b/src/solvers/adaptive_time_solver.C
@@ -39,22 +39,11 @@ AdaptiveTimeSolver::AdaptiveTimeSolver (sys_type & s)
 {
   // the child class must populate core_time_solver
   // with whatever actual time solver is to be used
-
-  // As an UnsteadySolver, we have an old_local_nonlinear_solution, but we're
-  // going to drop it and use our core time solver's instead.
-  old_local_nonlinear_solution.reset();
 }
 
 
 
-AdaptiveTimeSolver::~AdaptiveTimeSolver ()
-{
-  // As an UnsteadySolver, we have an old_local_nonlinear_solution, but it
-  // is being managed by our core_time_solver.  Make sure we don't delete
-  // it out from under them, in case the user wants to keep using the core
-  // solver after they're done with us.
-  old_local_nonlinear_solution.release();
-}
+AdaptiveTimeSolver::~AdaptiveTimeSolver () = default;
 
 
 
@@ -78,11 +67,7 @@ void AdaptiveTimeSolver::init()
 
   // As an UnsteadySolver, we have an old_local_nonlinear_solution, but it
   // isn't pointing to the right place - fix it
-  //
-  // This leaves us with two std::unique_ptrs holding the same pointer - dangerous
-  // for future use.  Replace with shared_ptr?
-  old_local_nonlinear_solution =
-    std::unique_ptr<NumericVector<Number>>(core_time_solver->old_local_nonlinear_solution.get());
+  old_local_nonlinear_solution = core_time_solver->old_local_nonlinear_solution;
 }
 
 

--- a/src/solvers/unsteady_solver.C
+++ b/src/solvers/unsteady_solver.C
@@ -35,7 +35,7 @@ namespace libMesh
 
 UnsteadySolver::UnsteadySolver (sys_type & s)
   : TimeSolver(s),
-    old_local_nonlinear_solution (NumericVector<Number>::build(s.comm())),
+    old_local_nonlinear_solution (NumericVector<Number>::build(s.comm()).release()),
     first_solve                  (true),
     first_adjoint_step (true)
 {
@@ -52,9 +52,7 @@ UnsteadySolver::UnsteadySolver (sys_type & s)
 
 
 
-UnsteadySolver::~UnsteadySolver ()
-{
-}
+UnsteadySolver::~UnsteadySolver () = default;
 
 
 


### PR DESCRIPTION
This fixes an issue where two `unique_ptrs` "owned" the same pointer, which we previously worked around by `release()`ing one copy before it could be destroyed. This is a situation that is easier to handle with `std::shared_ptrs`.