### PR TITLE
Move LinearSolver to ImplicitSystem

### DIFF
--- a/include/systems/continuation_system.h
+++ b/include/systems/continuation_system.h
@@ -370,13 +370,6 @@ private:
   NumericVector<Number> * delta_u;
 
   /**
-   * We maintain our own linear solver interface, for solving
-   * custom systems of equations and/or things which do not require
-   * a full-blown NewtonSolver.
-   */
-  std::unique_ptr<LinearSolver<Number>> linear_solver;
-
-  /**
    * False until initialize_tangent() is called
    */
   bool tangent_initialized;

--- a/include/systems/diff_system.h
+++ b/include/systems/diff_system.h
@@ -118,12 +118,6 @@ public:
   get_linear_solve_parameters() const override;
 
   /**
-   * Releases a pointer to a linear solver acquired by
-   * \p this->get_linear_solver()
-   */
-  virtual void release_linear_solver(LinearSolver<Number> *) const override;
-
-  /**
    * Assembles a residual in \p rhs and/or a jacobian in \p matrix,
    * as requested.
    * Note that in some cases only

--- a/include/systems/implicit_system.h
+++ b/include/systems/implicit_system.h
@@ -114,15 +114,9 @@ public:
    * \returns A pointer to a linear solver appropriate for use in
    * adjoint and/or sensitivity solves
    *
-   * This function must be overridden in derived classes, since this
-   * base class does not have a valid LinearSolver to hand back a
-   * pointer to.
-   *
-   * \deprecated This function's current behavior, i.e. allocating a
-   * LinearSolver and handing it back to the user, makes it very easy
-   * to leak memory, and probably won't have the intended effect,
-   * i.e. of setting some parameters on a LinearSolver that the System
-   * would later use internally.
+   * This function must be overridden in derived classes. Since this
+   * class does not have a valid LinearSolver to hand back a pointer
+   * to, it is implemented as an error here.
    */
   virtual LinearSolver<Number> * get_linear_solver() const;
 

--- a/include/systems/implicit_system.h
+++ b/include/systems/implicit_system.h
@@ -111,12 +111,19 @@ public:
   virtual std::string system_type () const override { return "Implicit"; }
 
   /**
-   * \returns A pointer to a linear solver appropriate for use in
-   * adjoint and/or sensitivity solves
+   * \returns A dumb pointer to a local std::unique_ptr<LinearSolver>
+   * member which can be used in adjoint and/or sensitivity solves.
    *
-   * This function must be overridden in derived classes. Since this
-   * class does not have a valid LinearSolver to hand back a pointer
-   * to, it is implemented as an error here.
+   * To mimic the previous behavior of this function, if the
+   * linear_solver member is already initialized when this function is
+   * called, this function first clears it. That is, no attempt is
+   * made to reuse an existing LinearSolver object. The user MUST NOT
+   * attempt to clean up this pointer, otherwise the std::unique_ptr
+   * held by this class will likely become corrupted.
+   *
+   * This function is virtual so it can be overridden in derived
+   * classes if necessary, however most will probably just want to use
+   * the base class behavior.
    */
   virtual LinearSolver<Number> * get_linear_solver() const;
 
@@ -129,12 +136,11 @@ public:
   get_linear_solve_parameters() const;
 
   /**
-   * Releases a pointer to a linear solver acquired by
-   * \p this->get_linear_solver()
+   * Currently a no-op.
    *
-   * \deprecated This function is designed to work with the deprecated
-   * get_linear_solver() function, so its use is now deprecated as
-   * well.
+   * \deprecated This function no longer needs to be called, since
+   * get_linear_solver() no longer returns a heap-allocated dumb
+   * pointer.
    */
   virtual void release_linear_solver(LinearSolver<Number> *) const;
 
@@ -313,6 +319,16 @@ public:
    * to take care of setting these to zero before assembly begins
    */
   bool zero_out_matrix_and_rhs;
+
+  /**
+   * This class handles all the details of interfacing with various
+   * linear algebra packages like PETSc or LASPACK.  This is a public
+   * member for backwards compatibility reasons, but in general it's
+   * better to use get_linear_solver() to access this member, since
+   * that function will also handle initialization if it hasn't
+   * already been taken care of.
+   */
+  mutable std::unique_ptr<LinearSolver<Number>> linear_solver;
 
 protected:
   /**

--- a/include/systems/linear_implicit_system.h
+++ b/include/systems/linear_implicit_system.h
@@ -129,12 +129,6 @@ public:
   virtual LinearSolver<Number> * get_linear_solver() const override;
 
   /**
-   * Releases a pointer to a linear solver acquired by
-   * \p this->get_linear_solver()
-   */
-  virtual void release_linear_solver(LinearSolver<Number> *) const override;
-
-  /**
    * Assembles a residual in \p rhs and/or a jacobian in \p matrix,
    * as requested.
    */
@@ -148,14 +142,6 @@ public:
    * the system type in an equation system file.
    */
   virtual std::string system_type () const override { return "LinearImplicit"; }
-
-  /**
-   * The \p LinearSolver defines the interface used to
-   * solve the linear_implicit system.  This class handles all the
-   * details of interfacing with various linear algebra packages
-   * like PETSc or LASPACK.
-   */
-  std::unique_ptr<LinearSolver<Number>> linear_solver;
 
   /**
    * \returns The number of iterations

--- a/src/systems/continuation_system.C
+++ b/src/systems/continuation_system.C
@@ -48,7 +48,6 @@ ContinuationSystem::ContinuationSystem (EquationSystems & es,
   newton_stepgrowth_aggressiveness(1.),
   newton_progress_check(true),
   rhs_mode(Residual),
-  linear_solver(LinearSolver<Number>::build(es.comm())),
   tangent_initialized(false),
   newton_solver(nullptr),
   dlambda_ds(0.707),
@@ -61,6 +60,11 @@ ContinuationSystem::ContinuationSystem (EquationSystems & es,
   // Warn about using untested code
   libmesh_experimental();
 
+  // linear_solver is now in the ImplicitSystem base class, but we are
+  // going to keep using it basically the way we did before it was
+  // moved.
+  linear_solver = LinearSolver<Number>::build(es.comm());
+
   if (libMesh::on_command_line("--solver-system-names"))
     linear_solver->init((this->name()+"_").c_str());
   else
@@ -70,18 +74,12 @@ ContinuationSystem::ContinuationSystem (EquationSystems & es,
 
 
 
-ContinuationSystem::~ContinuationSystem ()
-{
-  this->clear();
-}
-
+ContinuationSystem::~ContinuationSystem () = default;
 
 
 
 void ContinuationSystem::clear()
 {
-  // FIXME: Do anything here, e.g. zero vectors, etc?
-
   // Call the Parent's clear function
   Parent::clear();
 }

--- a/src/systems/diff_system.C
+++ b/src/systems/diff_system.C
@@ -193,10 +193,6 @@ std::pair<unsigned int, Real> DifferentiableSystem::get_linear_solve_parameters(
 
 
 
-void DifferentiableSystem::release_linear_solver(LinearSolver<Number> *) const
-{
-}
-
 void DifferentiableSystem::add_second_order_dot_vars()
 {
   const std::set<unsigned int> & second_order_vars = this->get_second_order_vars();

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -135,7 +135,7 @@ ImplicitSystem::sensitivity_solve (const ParameterVector & parameters)
     }
 
   // The sensitivity problem is linear
-  LinearSolver<Number> * linear_solver = this->get_linear_solver();
+  LinearSolver<Number> * solver = this->get_linear_solver();
 
   // Our iteration counts and residuals will be sums of the individual
   // results
@@ -148,11 +148,11 @@ ImplicitSystem::sensitivity_solve (const ParameterVector & parameters)
   for (auto p : make_range(parameters.size()))
     {
       std::pair<unsigned int, Real> rval =
-        linear_solver->solve (*matrix, pc,
-                              this->add_sensitivity_solution(p),
-                              this->get_sensitivity_rhs(p),
-                              double(solver_params.second),
-                              solver_params.first);
+        solver->solve (*matrix, pc,
+                       this->add_sensitivity_solution(p),
+                       this->get_sensitivity_rhs(p),
+                       double(solver_params.second),
+                       solver_params.first);
 
       totalrval.first  += rval.first;
       totalrval.second += rval.second;
@@ -183,7 +183,7 @@ ImplicitSystem::adjoint_solve (const QoISet & qoi_indices)
                     /* get_jacobian = */ true);
 
   // The adjoint problem is linear
-  LinearSolver<Number> * linear_solver = this->get_linear_solver();
+  LinearSolver<Number> * solver = this->get_linear_solver();
 
   // Reset and build the RHS from the QOI derivative
   this->assemble_qoi_derivative(qoi_indices,
@@ -200,10 +200,10 @@ ImplicitSystem::adjoint_solve (const QoISet & qoi_indices)
     if (qoi_indices.has_index(i))
       {
         const std::pair<unsigned int, Real> rval =
-          linear_solver->adjoint_solve (*matrix, this->add_adjoint_solution(i),
-                                        this->get_adjoint_rhs(i),
-                                        double(solver_params.second),
-                                        solver_params.first);
+          solver->adjoint_solve (*matrix, this->add_adjoint_solution(i),
+                                 this->get_adjoint_rhs(i),
+                                 double(solver_params.second),
+                                 solver_params.first);
 
         totalrval.first  += rval.first;
         totalrval.second += rval.second;
@@ -333,7 +333,7 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
   }
 
   // The weighted adjoint-adjoint problem is linear
-  LinearSolver<Number> * linear_solver = this->get_linear_solver();
+  LinearSolver<Number> * solver = this->get_linear_solver();
 
   // Our iteration counts and residuals will be sums of the individual
   // results
@@ -345,10 +345,10 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
     if (qoi_indices.has_index(i))
       {
         const std::pair<unsigned int, Real> rval =
-          linear_solver->solve (*matrix, this->add_weighted_sensitivity_adjoint_solution(i),
-                                *(temprhs[i]),
-                                double(solver_params.second),
-                                solver_params.first);
+          solver->solve (*matrix, this->add_weighted_sensitivity_adjoint_solution(i),
+                         *(temprhs[i]),
+                         double(solver_params.second),
+                         solver_params.first);
 
         totalrval.first  += rval.first;
         totalrval.second += rval.second;
@@ -427,16 +427,16 @@ ImplicitSystem::weighted_sensitivity_solve (const ParameterVector & parameters_i
   this->matrix->close();
 
   // The weighted sensitivity problem is linear
-  LinearSolver<Number> * linear_solver = this->get_linear_solver();
+  LinearSolver<Number> * solver = this->get_linear_solver();
 
   std::pair<unsigned int, Real> solver_params =
     this->get_linear_solve_parameters();
 
   const std::pair<unsigned int, Real> rval =
-    linear_solver->solve (*matrix, this->add_weighted_sensitivity_solution(),
-                          *temprhs,
-                          double(solver_params.second),
-                          solver_params.first);
+    solver->solve (*matrix, this->add_weighted_sensitivity_solution(),
+                   *temprhs,
+                   double(solver_params.second),
+                   solver_params.first);
 
   // The linear solver may not have fit our constraints exactly
 #ifdef LIBMESH_ENABLE_CONSTRAINTS

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -1201,26 +1201,11 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
 
 LinearSolver<Number> * ImplicitSystem::get_linear_solver() const
 {
-  // This function allocates memory and hands it back to the user as a
-  // naked pointer.  This makes it too easy to leak memory, and
-  // therefore this function is deprecated.  After a period of
-  // deprecation, this function will eventually be marked with a
-  // libmesh_error_msg().
-  libmesh_deprecated();
-  // libmesh_error_msg("This function should be overridden by derived classes. "
-  //                   "It does not contain a valid LinearSolver to hand back to "
-  //                   "the user, so it creates one, opening up the possibility "
-  //                   "of a memory leak.");
+  libmesh_error_msg("get_linear_solver() should be overridden by derived classes, "
+                    "the base ImplicitSystem class does not contain a valid LinearSolver.");
 
-  LinearSolver<Number> * new_solver =
-    LinearSolver<Number>::build(this->comm()).release();
-
-  if (libMesh::on_command_line("--solver-system-names"))
-    new_solver->init((this->name()+"_").c_str());
-  else
-    new_solver->init();
-
-  return new_solver;
+  // Avoid compiler warnings
+  return nullptr;
 }
 
 

--- a/src/systems/linear_implicit_system.C
+++ b/src/systems/linear_implicit_system.C
@@ -39,22 +39,21 @@ LinearImplicitSystem::LinearImplicitSystem (EquationSystems & es,
                                             const unsigned int number_in) :
 
   Parent                 (es, name_in, number_in),
-  linear_solver          (LinearSolver<Number>::build(es.comm())),
   _n_linear_iterations   (0),
   _final_linear_residual (1.e20),
   _shell_matrix(nullptr),
   _subset(nullptr),
   _subset_solve_mode(SUBSET_ZERO)
 {
+  // linear_solver is now in the ImplicitSystem base class, but we are
+  // going to keep using it basically the way we did before it was
+  // moved.
+  linear_solver = LinearSolver<Number>::build(es.comm());
 }
 
 
 
-LinearImplicitSystem::~LinearImplicitSystem ()
-{
-  // Clear data
-  this->clear();
-}
+LinearImplicitSystem::~LinearImplicitSystem () = default;
 
 
 
@@ -353,12 +352,6 @@ void LinearImplicitSystem::attach_shell_matrix (ShellMatrix<Number> * shell_matr
 LinearSolver<Number> * LinearImplicitSystem::get_linear_solver() const
 {
   return linear_solver.get();
-}
-
-
-
-void LinearImplicitSystem::release_linear_solver(LinearSolver<Number> *) const
-{
 }
 
 


### PR DESCRIPTION
~~This function has been deprecated since the 1.1.x series of releases (2016), so now's a good time to finally make it an error to call it.~~

In order to maintain the const-ness of `ImplicitSystem::get_linear_solver()`, I had to make the `linear_solver` member mutable. I think it's a reasonable compromise to maintain backwards compatibility while avoiding manual memory management.
