### PR TITLE
Updates to InfFEBase::build_elem()

### DIFF
--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -784,7 +784,6 @@ unsigned int DofObject::n_dofs (const unsigned int s,
 inline
 dof_id_type DofObject::id () const
 {
-  libmesh_assert (this->valid_id());
   return _id;
 }
 

--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -160,11 +160,12 @@ private:
 public:
 
   /**
-   * Build the base element of an infinite element.  Be careful,
-   * this method allocates memory!  So be sure to delete the
-   * new element afterward.
+   * Build the base element of an infinite element. Here "base" refers
+   * to the non-infinite/traditional geometric element face which is
+   * associated with this infinite element. A const base Elem is built
+   * from a const input InfElem.
    */
-  static Elem * build_elem (const Elem * inf_elem);
+  static std::unique_ptr<const Elem> build_elem (const Elem * inf_elem);
 
   /**
    * \returns The base element associated to
@@ -1091,10 +1092,11 @@ protected:
   std::unique_ptr<QBase> radial_qrule;
 
   /**
-   * The base element associated with the
-   * current infinite element
+   * The "base" (aka non-infinite) element associated with the current
+   * infinite element. We treat is as const since the InfFE should not
+   * have to modify the geometric Elem in order to do its calculations.
    */
-  std::unique_ptr<Elem> base_elem;
+  std::unique_ptr<const Elem> base_elem;
 
   /**
    * Have a \p FE<Dim-1,T_base> handy for base approximation.

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -117,7 +117,7 @@ void InfFE<Dim,T_radial,T_map>::attach_quadrature_rule (QBase * q)
 template <unsigned int Dim, FEFamily T_radial, InfMapType T_base>
 void InfFE<Dim,T_radial,T_base>::update_base_elem (const Elem * inf_elem)
 {
-  base_elem.reset(InfFEBase::build_elem(inf_elem));
+  base_elem = InfFEBase::build_elem(inf_elem);
 }
 
 

--- a/src/fe/inf_fe_base_radial.C
+++ b/src/fe/inf_fe_base_radial.C
@@ -32,17 +32,10 @@ namespace libMesh
 
 // ------------------------------------------------------------
 // InfFEBase class members
-Elem * InfFEBase::build_elem (const Elem * inf_elem)
+std::unique_ptr<const Elem> InfFEBase::build_elem (const Elem * inf_elem)
 {
-  std::unique_ptr<const Elem> ape(inf_elem->build_side_ptr(0));
-
-  // The incoming inf_elem is const, but this function is required to
-  // return a non-const Elem * so that it can be used by
-  // update_base_elem().  Therefore a const_cast seems to be
-  // unavoidable here.
-  return const_cast<Elem *>(ape.release());
+  return inf_elem->build_side_ptr(0);
 }
-
 
 
 

--- a/src/fe/inf_fe_map.C
+++ b/src/fe/inf_fe_map.C
@@ -250,20 +250,6 @@ Point InfFEMap::inverse_map (const unsigned int dim,
       libmesh_error_msg("Invalid dim = " << dim);
     }
 
-#ifndef NDEBUG
-  // FIXME: In debug mode, the base_elem must have a valid id(), since
-  // inverse_map() may call elem->id() in some code paths, and
-  // DofObject::id() asserts if the id is not valid.  Thus, we should
-  // set base_elem's id to something valid, but this is tricky to do
-  // since base_elem is otherwise treated as const, as it is
-  // originally built from a const InfElem.  It would be nice if there
-  // was some workaround for this, such as build_side_ptr() actually
-  // setting a valid id (anything other than libMesh::invalid_uint
-  // would probably work).
-  auto settable_elem = const_cast<Elem *>(base_elem.get());
-  settable_elem->set_id(inf_elem->id());
-#endif
-
   // 3.)
   // Now we have the intersection-point (projection of physical point onto base-element).
   // Lets compute its internal coordinates (being p(0) and p(1)):

--- a/tests/fe/inf_fe_radial_test.C
+++ b/tests/fe/inf_fe_radial_test.C
@@ -77,7 +77,7 @@ public:
 
     // 1.)
     // build a base element to do the map inversion in the base face
-    std::unique_ptr<Elem> base_elem (InfFEBase::build_elem (inf_elem));
+    std::unique_ptr<const Elem> base_elem = InfFEBase::build_elem (inf_elem);
 
     // the origin of the infinite element
     const Point o = inf_elem->origin();


### PR DESCRIPTION
* Preserve const-ness of input in the output
* Don't hand back allocated dumb pointer to the user
* InfFE::base_elem should be treated as const
* Update docs including the need for a const_cast workaround in debug mode.