### PR TITLE
Ubuntu 20.10 (gcc 10.2) fixes

### DIFF
--- a/include/utils/xdr_cxx.h
+++ b/include/utils/xdr_cxx.h
@@ -29,8 +29,11 @@
 #include <memory>
 #include <cstdio> // FILE
 #ifdef LIBMESH_HAVE_XDR
+// I see a redundant declaration warning here on Ubuntu 20.10
+#include "libmesh/ignore_warnings.h"
 # include <rpc/rpc.h>
 # include <rpc/xdr.h>
+#include "libmesh/restore_warnings.h"
 #endif
 
 #include <iosfwd>

--- a/src/numerics/type_vector.C
+++ b/src/numerics/type_vector.C
@@ -65,8 +65,6 @@ template <typename T>
 void TypeVector<T>::write_unformatted (std::ostream & os,
                                        const bool newline) const
 {
-  libmesh_assert (os);
-
   os << std::setiosflags(std::ios::showpoint)
      << (*this)(0) << " "
      << (*this)(1) << " "


### PR DESCRIPTION
These fix a couple errors that gcc 10.2.0-13ubuntu1 gives me when trying to build a --enable-paranoid-warnings --enable-werror configuration on a beta of Ubuntu 20.10.