### PR TITLE
Re-enable check_dirichlet_bcid_consistency()

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1340,6 +1340,12 @@ public:
   DirichletBoundaries *
   get_adjoint_dirichlet_boundaries(unsigned int q);
 
+  /**
+   * Check that all the ids in dirichlet_bcids are actually present in the mesh.
+   * If not, this will throw an error.
+   */
+  void check_dirichlet_bcid_consistency (const MeshBase & mesh,
+                                         const DirichletBoundary & boundary) const;
 #endif // LIBMESH_ENABLE_DIRICHLET
 
 
@@ -1832,12 +1838,6 @@ private:
 #endif
 
 #ifdef LIBMESH_ENABLE_DIRICHLET
-  /**
-   * Check that all the ids in dirichlet_bcids are actually present in the mesh.
-   * If not, this will throw an error.
-   */
-  void check_dirichlet_bcid_consistency (const MeshBase & mesh,
-                                         const DirichletBoundary & boundary) const;
   /**
    * Data structure containing Dirichlet functions.  The ith
    * entry is the constraint matrix row for boundaryid i.

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1638,12 +1638,6 @@ public:
             // Get pointer to the DirichletBoundary object
             const auto & dirichlet = db_pair.second;
 
-            // TODO: Add sanity check that the boundary ids associated
-            // with the DirichletBoundary objects are actually present in
-            // the mesh. Currently this is a private function on DofMap so
-            // we can't call it here, but maybe it could be made public.
-            // dof_map.check_dirichlet_bcid_consistency(mesh, *dirichlet);
-
             // Loop over all the variables which this DirichletBoundary object is responsible for
             for (const auto & var : dirichlet->variables)
               {
@@ -1845,6 +1839,12 @@ void DofMap::create_dof_constraints(const MeshBase & mesh, Real time)
 
   if (!_dirichlet_boundaries->empty())
     {
+      // Sanity check that the boundary ids associated with the
+      // DirichletBoundary objects are actually present in the
+      // mesh.
+      for (const auto & dirichlet : *_dirichlet_boundaries)
+        this->check_dirichlet_bcid_consistency(mesh, *dirichlet);
+
       // Threaded loop over local over elems applying all Dirichlet BCs
       Threads::parallel_for
         (range,

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -5043,7 +5043,12 @@ DirichletBoundaries::~DirichletBoundaries()
 void DofMap::check_dirichlet_bcid_consistency (const MeshBase & mesh,
                                                const DirichletBoundary & boundary) const
 {
-  const std::set<boundary_id_type>& mesh_bcids = mesh.get_boundary_info().get_boundary_ids();
+  const std::set<boundary_id_type>& mesh_side_bcids =
+    mesh.get_boundary_info().get_boundary_ids();
+  const std::set<boundary_id_type>& mesh_edge_bcids =
+    mesh.get_boundary_info().get_edge_boundary_ids();
+  const std::set<boundary_id_type>& mesh_node_bcids =
+    mesh.get_boundary_info().get_node_boundary_ids();
   const std::set<boundary_id_type>& dbc_bcids = boundary.b;
 
   // DirichletBoundary id sets should be consistent across all ranks
@@ -5054,7 +5059,9 @@ void DofMap::check_dirichlet_bcid_consistency (const MeshBase & mesh,
       // DirichletBoundary id sets should be consistent across all ranks
       libmesh_assert(mesh.comm().verify(bc_id));
 
-      bool found_bcid = (mesh_bcids.find(bc_id) != mesh_bcids.end());
+      bool found_bcid = (mesh_side_bcids.find(bc_id) != mesh_side_bcids.end() ||
+                         mesh_edge_bcids.find(bc_id) != mesh_edge_bcids.end() ||
+                         mesh_node_bcids.find(bc_id) != mesh_node_bcids.end());
 
       // On a distributed mesh, boundary id sets may *not* be
       // consistent across all ranks, since not all ranks see all


### PR DESCRIPTION
As well as expanding it so we don't get false positives in codes that are only pinning points and/or edges but not sides.