### PR TITLE
Ubuntu 20.10 clang 11 warning fixes

### DIFF
--- a/examples/adjoints/adjoints_ex7/adjoints_ex7.C
+++ b/examples/adjoints/adjoints_ex7/adjoints_ex7.C
@@ -451,8 +451,6 @@ int main (int argc, char ** argv)
 
   // To keep the number of vectors consistent between the primal and adjoint
   // loops, we will also pre-add the adjoint rhs vector
-  const std::string & adjoint_rhs_name0 = "adjoint_rhs0";
-  const std::string & adjoint_rhs_name1 = "adjoint_rhs1";
   system.add_vector("adjoint_rhs0", false, GHOSTED);
   system.add_vector("adjoint_rhs1", false, GHOSTED);
 

--- a/include/mesh/nemesis_io_helper.h
+++ b/include/mesh/nemesis_io_helper.h
@@ -603,7 +603,7 @@ protected:
    */
   virtual void read_var_names_impl(const char * var_type,
                                    int & count,
-                                   std::vector<std::string> & result);
+                                   std::vector<std::string> & result) override;
 
 private:
   /**

--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -65,12 +65,14 @@ public:
   /**
    * Special functions.
    * - This class contains unique_ptrs so it can't be default copy assigned/constructed
+   * - This class inherits from System so it can't be default move assigned/constructed
+   *   (to be defaulted later, after we make the System tree move-compatible)
    * - Destructor is defaulted out-of-line
    */
-  RBConstruction (RBConstruction &&) = default;
+  RBConstruction (RBConstruction &&) = delete;
   RBConstruction (const RBConstruction &) = delete;
   RBConstruction & operator= (const RBConstruction &) = delete;
-  RBConstruction & operator= (RBConstruction &&) = default;
+  RBConstruction & operator= (RBConstruction &&) = delete;
   virtual ~RBConstruction ();
 
   /**

--- a/include/solvers/steady_solver.h
+++ b/include/solvers/steady_solver.h
@@ -129,7 +129,7 @@ public:
    * Fills in an ErrorVector that contains the weighted sum of errors from all the QoIs and can be used to guide AMR.
    * CURRENTLY ONLY SUPPORTED for Backward Euler.
    */
-  virtual void integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error);
+  virtual void integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error) override;
 
 protected:
 

--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -33,6 +33,7 @@
 #pragma clang diagnostic ignored "-Wunused-private-field"
 #pragma clang diagnostic ignored "-Wextra"
 #pragma clang diagnostic ignored "-Wredundant-decls"
+#pragma clang diagnostic ignored "-Wcast-align"
 #pragma clang diagnostic ignored "-Wcast-qual"
 #pragma clang diagnostic ignored "-Wswitch-default"
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/src/apps/meshtool.C
+++ b/src/apps/meshtool.C
@@ -120,7 +120,7 @@ int main (int argc, char ** argv)
   // Number of refinements
   if (command_line.search(1, "-r"))
     {
-      int tmp;
+      int tmp = 0;
       tmp = command_line.next(tmp);
       n_rsteps = cast_int<unsigned int>(tmp);
     }
@@ -128,7 +128,7 @@ int main (int argc, char ** argv)
   // Number of subdomains for partitioning
   if (command_line.search(1, "-p"))
     {
-      int tmp;
+      int tmp = 0;
       tmp = command_line.next(tmp);
       n_subdomains = cast_int<unsigned int>(tmp);
     }

--- a/src/fe/inf_fe_map.C
+++ b/src/fe/inf_fe_map.C
@@ -46,7 +46,6 @@ Point InfFEMap::map (const unsigned int dim,
 
   std::unique_ptr<Elem>      base_elem (InfFEBase::build_elem (inf_elem));
 
-  const Order        radial_mapping_order (InfFERadial::mapping_order());
   const Real         v                    (reference_point(dim-1));
 
   // map in the base face
@@ -75,6 +74,9 @@ Point InfFEMap::map (const unsigned int dim,
   // used e.g. for \p inverse_map() and \p reinit() explicitly.
   return (base_point-inf_elem->origin())*2./(1.-v)+inf_elem->origin();
 
+#if 0 // Leave this documented, but w/o unreachable-code warnings
+  const Order radial_mapping_order (InfFERadial::mapping_order());
+
   // map in the outer node face not necessary. Simply
   // compute the outer_point = base_point + (base_point-origin)
   const Point outer_point (base_point * 2. - inf_elem->origin());
@@ -86,6 +88,7 @@ Point InfFEMap::map (const unsigned int dim,
   p.add_scaled (outer_point, eval (v, radial_mapping_order, 1));
 
   return p;
+#endif
 }
 
 


### PR DESCRIPTION
This isn't as complete as #2760 was (we'll need a TIMPI ignore_warnings.h update too, and that's too much hassle to be worth it just so we can turn on --enable-werror --enable-paranoid-warnings on one specific compiler), but it's everything that I could get to trigger outside of a submodule.