### PR TITLE
Don't potentially throw from 'exceptionless' error macros

### DIFF
--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -439,7 +439,8 @@ struct casting_compare {
 #define libmesh_exceptionless_error_msg(msg)                            \
   do {                                                                  \
     libMesh::err << msg << std::endl;                                   \
-    libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME); \
+    libmesh_try { libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME); } \
+    libmesh_catch (...) {}                                              \
     std::terminate();                                                   \
   } while (0)
 


### PR DESCRIPTION
The `report_error()` function is sufficiently complex that we can't _guarantee_ it won't throw, so for the `libmesh_exceptionless_error_msg()` and `libmesh_exceptionless_assert_msg()` let's catch any exceptions that might be thrown and guarantee we `std::terminate()` immediately.