### PR TITLE
Exodus copy fixes

### DIFF
--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -569,7 +569,7 @@ void ExodusII_IO::copy_nodal_solution(System & system,
 
   auto & node_var_value_map = exio_helper->nodal_var_values;
 
-  const bool serial_on_zero = !mesh.is_serial_on_zero();
+  const bool serial_on_zero = mesh.is_serial_on_zero();
 
   // If our mesh isn't serial, then non-root processors need to
   // request the data for their parts of the mesh and insert it
@@ -672,7 +672,7 @@ void ExodusII_IO::copy_elemental_solution(System & system,
       exio_helper->read_elemental_var_values(exodus_var_name, timestep, elem_var_value_map);
     }
 
-  const bool serial_on_zero = !mesh.is_serial_on_zero();
+  const bool serial_on_zero = mesh.is_serial_on_zero();
 
   // If our mesh isn't serial, then non-root processors need to
   // request the data for their parts of the mesh and insert it

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -595,9 +595,13 @@ void ExodusII_IO::copy_nodal_solution(System & system,
           for (std::size_t i=0; i != query_size; ++i)
             {
               const auto it = node_var_value_map.find(ids[i]);
-              libmesh_assert(it != node_var_value_map.end());
-              values[i] = it->second;
-              node_var_value_map.erase(it);
+              if (it != node_var_value_map.end())
+                {
+                  values[i] = it->second;
+                  node_var_value_map.erase(it);
+                }
+              else
+                values[i] = std::numeric_limits<Real>::quiet_NaN();
             }
         };
 
@@ -609,7 +613,8 @@ void ExodusII_IO::copy_nodal_solution(System & system,
         {
           const std::size_t query_size = ids.size();
           for (std::size_t i=0; i != query_size; ++i)
-            node_var_value_map[ids[i]] = values[i];
+            if (!libmesh_isnan(values[i]))
+              node_var_value_map[ids[i]] = values[i];
         };
 
       Real * value_ex = nullptr;
@@ -698,9 +703,13 @@ void ExodusII_IO::copy_elemental_solution(System & system,
           for (std::size_t i=0; i != query_size; ++i)
             {
               const auto it = elem_var_value_map.find(ids[i]);
-              libmesh_assert(it != elem_var_value_map.end());
-              values[i] = it->second;
-              elem_var_value_map.erase(it);
+              if (it != elem_var_value_map.end())
+                {
+                  values[i] = it->second;
+                  elem_var_value_map.erase(it);
+                }
+              else
+                values[i] = std::numeric_limits<Real>::quiet_NaN();
             }
         };
 
@@ -712,7 +721,8 @@ void ExodusII_IO::copy_elemental_solution(System & system,
         {
           const std::size_t query_size = ids.size();
           for (std::size_t i=0; i != query_size; ++i)
-            elem_var_value_map[ids[i]] = values[i];
+            if (!libmesh_isnan(values[i]))
+              elem_var_value_map[ids[i]] = values[i];
         };
 
       Real * value_ex = nullptr;

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -37,9 +37,8 @@ public:
 
 #if LIBMESH_DIM > 1
 #ifdef LIBMESH_HAVE_EXODUS_API
-  // Still not yet working?
-  // CPPUNIT_TEST( testExodusCopyNodalSolutionDistributed );
-  // CPPUNIT_TEST( testExodusCopyElementSolutionDistributed );
+  CPPUNIT_TEST( testExodusCopyNodalSolutionDistributed );
+  CPPUNIT_TEST( testExodusCopyElementSolutionDistributed );
   CPPUNIT_TEST( testExodusCopyNodalSolutionReplicated );
   CPPUNIT_TEST( testExodusCopyElementSolutionReplicated );
   CPPUNIT_TEST( testExodusReadHeader );


### PR DESCRIPTION
Fixes and newly-enabled unit tests for DistributedMesh bugs in the new ExodusII_IO code in #2681, one of which had doubled up to become a ReplicatedMesh-with-subdomain-restricted-variable regression too.