### PR TITLE
Default/delete special functions for System classes.

### DIFF
--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -64,12 +64,10 @@ public:
 
   /**
    * Special functions.
-   * - This class contains unique_ptrs so it can't be default copy assigned/constructed
-   * - This class inherits from System so it can't be default move assigned/constructed
-   *   (to be defaulted later, after we make the System tree move-compatible)
+   * - This class has the same restrictions/defaults as its base class.
    * - Destructor is defaulted out-of-line
    */
-  RBConstruction (RBConstruction &&) = delete;
+  RBConstruction (RBConstruction &&) = default;
   RBConstruction (const RBConstruction &) = delete;
   RBConstruction & operator= (const RBConstruction &) = delete;
   RBConstruction & operator= (RBConstruction &&) = delete;

--- a/include/reduced_basis/rb_construction_base.h
+++ b/include/reduced_basis/rb_construction_base.h
@@ -56,8 +56,7 @@ class RBConstructionBase : public Base, public RBParametrized
 public:
 
   /**
-   * Constructor.  Initializes required
-   * data structures.
+   * Constructor.
    */
   RBConstructionBase (EquationSystems & es,
                       const std::string & name,
@@ -65,11 +64,13 @@ public:
 
   /**
    * Special functions.
-   * - This class contains a unique_ptr so it can't be copy assigned/constructed.
+   * - This class has the same restrictions as the union of its
+   *   potential base classes (currently LinearImplicitSystem and
+   *   EigenSystem).
    * - Destructor is defaulted out-of-line.
    */
   RBConstructionBase (RBConstructionBase &&) = default;
-  RBConstructionBase & operator= (RBConstructionBase &&) = default;
+  RBConstructionBase & operator= (RBConstructionBase &&) = delete;
   RBConstructionBase (const RBConstructionBase &) = delete;
   RBConstructionBase & operator= (const RBConstructionBase &) = delete;
   virtual ~RBConstructionBase ();

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -66,14 +66,10 @@ public:
 
   /**
    * Special functions.
-   * - This class contains unique_ptrs, so it can't be default copy
-   *   constructed/assigned.
-   * - The move constructor and assignment operator are deleted since
-   *   otherwise clang 9 warns that they are implicitly deleted via
-   *   the base class.
-   * - The destructor is defaulted out of line.
+   * - This class has the same restrictions/defaults as its base class.
+   * - Destructor is defaulted out-of-line
    */
-  RBEIMConstruction (RBEIMConstruction &&) = delete;
+  RBEIMConstruction (RBEIMConstruction &&) = default;
   RBEIMConstruction (const RBEIMConstruction &) = delete;
   RBEIMConstruction & operator= (const RBEIMConstruction &) = delete;
   RBEIMConstruction & operator= (RBEIMConstruction &&) = delete;

--- a/include/reduced_basis/rb_scm_construction.h
+++ b/include/reduced_basis/rb_scm_construction.h
@@ -63,8 +63,14 @@ public:
                      const unsigned int number_in);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class has the same restrictions/defaults as its base class.
+   * - Destructor is defaulted out-of-line
    */
+  RBSCMConstruction (RBSCMConstruction &&) = default;
+  RBSCMConstruction (const RBSCMConstruction &) = delete;
+  RBSCMConstruction & operator= (const RBSCMConstruction &) = delete;
+  RBSCMConstruction & operator= (RBSCMConstruction &&) = delete;
   virtual ~RBSCMConstruction ();
 
   /**

--- a/include/systems/condensed_eigen_system.h
+++ b/include/systems/condensed_eigen_system.h
@@ -48,12 +48,22 @@ class CondensedEigenSystem : public EigenSystem
 public:
 
   /**
-   * Constructor.  Optionally initializes required
-   * data structures.
+   * Constructor.
    */
   CondensedEigenSystem (EquationSystems & es,
                         const std::string & name_in,
                         const unsigned int number_in);
+
+  /**
+   * Special functions.
+   * - This class has the same restrictions/defaults as its base class.
+   * - The destructor is defaulted out-of-line.
+   */
+  CondensedEigenSystem (const CondensedEigenSystem &) = delete;
+  CondensedEigenSystem & operator= (const CondensedEigenSystem &) = delete;
+  CondensedEigenSystem (CondensedEigenSystem &&) = default;
+  CondensedEigenSystem & operator= (CondensedEigenSystem &&) = delete;
+  virtual ~CondensedEigenSystem ();
 
   /**
    * The type of system.

--- a/include/systems/continuation_system.h
+++ b/include/systems/continuation_system.h
@@ -23,8 +23,6 @@
 // Local Includes
 #include "libmesh/fem_system.h"
 
-// C++ includes
-
 namespace libMesh
 {
 
@@ -64,8 +62,14 @@ public:
                       const unsigned int number);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class has the same restrictions as its base class.
+   * - The destructor is defaulted out-of-line.
    */
+  ContinuationSystem (const ContinuationSystem &) = delete;
+  ContinuationSystem & operator= (const ContinuationSystem &) = delete;
+  ContinuationSystem (ContinuationSystem &&) = delete;
+  ContinuationSystem & operator= (ContinuationSystem &&) = delete;
   virtual ~ContinuationSystem ();
 
   /**

--- a/include/systems/diff_system.h
+++ b/include/systems/diff_system.h
@@ -57,16 +57,25 @@ class DifferentiableSystem : public ImplicitSystem,
 public:
 
   /**
-   * Constructor.  Optionally initializes required
-   * data structures.
+   * Constructor.
    */
   DifferentiableSystem (EquationSystems & es,
                         const std::string & name,
                         const unsigned int number);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class has the same restrictions as its base class.
+   * - This class also can't be default move constructed because it
+   *   manually manages the memory of the _diff_physics and diff_qoi
+   *   objects.
+   * - The destructor potentially cleans up the _diff_physics and
+   *   diff_qoi objects.
    */
+  DifferentiableSystem (const DifferentiableSystem &) = delete;
+  DifferentiableSystem & operator= (const DifferentiableSystem &) = delete;
+  DifferentiableSystem (DifferentiableSystem &&) = delete;
+  DifferentiableSystem & operator= (DifferentiableSystem &&) = delete;
   virtual ~DifferentiableSystem ();
 
   /**

--- a/include/systems/eigen_system.h
+++ b/include/systems/eigen_system.h
@@ -57,16 +57,21 @@ class EigenSystem : public System
 public:
 
   /**
-   * Constructor.  Optionally initializes required
-   * data structures.
+   * Constructor.
    */
   EigenSystem (EquationSystems & es,
                const std::string & name_in,
                const unsigned int number_in);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class has the same restrictions/defaults as its base class.
+   * - Destructor is defaulted out-of-line
    */
+  EigenSystem (const EigenSystem &) = delete;
+  EigenSystem & operator= (const EigenSystem &) = delete;
+  EigenSystem (EigenSystem &&) = default;
+  EigenSystem & operator= (EigenSystem &&) = delete;
   virtual ~EigenSystem ();
 
   /**

--- a/include/systems/explicit_system.h
+++ b/include/systems/explicit_system.h
@@ -50,12 +50,22 @@ class ExplicitSystem : public System
 public:
 
   /**
-   * Constructor.  Optionally initializes required
-   * data structures.
+   * Constructor.
    */
   ExplicitSystem (EquationSystems & es,
                   const std::string & name,
                   const unsigned int number);
+
+  /**
+   * Special functions.
+   * - This class has the same restrictions/defaults as its base class.
+   * - The destructor is defaulted out-of-line.
+   */
+  ExplicitSystem (const ExplicitSystem &) = delete;
+  ExplicitSystem & operator= (const ExplicitSystem &) = delete;
+  ExplicitSystem (ExplicitSystem &&) = default;
+  ExplicitSystem & operator= (ExplicitSystem &&) = delete;
+  virtual ~ExplicitSystem ();
 
   /**
    * The type of system.
@@ -112,7 +122,6 @@ public:
    * right-hand-side vector b.
    */
   NumericVector<Number> * rhs;
-
 
 private:
 

--- a/include/systems/fem_system.h
+++ b/include/systems/fem_system.h
@@ -64,8 +64,14 @@ public:
              const unsigned int number);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class has the same restrictions as its base class.
+   * - The destructor is defaulted out-of-line.
    */
+  FEMSystem (const FEMSystem &) = delete;
+  FEMSystem & operator= (const FEMSystem &) = delete;
+  FEMSystem (FEMSystem &&) = delete;
+  FEMSystem & operator= (FEMSystem &&) = delete;
   virtual ~FEMSystem ();
 
   /**

--- a/include/systems/frequency_system.h
+++ b/include/systems/frequency_system.h
@@ -65,16 +65,21 @@ class FrequencySystem : public LinearImplicitSystem
 public:
 
   /**
-   * Constructor.  Optionally initializes required
-   * data structures.
+   * Constructor.
    */
   FrequencySystem (EquationSystems & es,
                    const std::string & name_in,
                    const unsigned int number_in);
   /**
-   * Destructor.
+   * Special functions.
+   * - This class has the same restrictions/defaults as its base class.
+   * - The destructor is defaulted out-of-line.
    */
-  ~FrequencySystem ();
+  FrequencySystem (const FrequencySystem &) = delete;
+  FrequencySystem & operator= (const FrequencySystem &) = delete;
+  FrequencySystem (FrequencySystem &&) = default;
+  FrequencySystem & operator= (FrequencySystem &&) = delete;
+  virtual ~FrequencySystem ();
 
   /**
    * Clear all the data structures associated with

--- a/include/systems/implicit_system.h
+++ b/include/systems/implicit_system.h
@@ -58,16 +58,21 @@ class ImplicitSystem : public ExplicitSystem
 public:
 
   /**
-   * Constructor.  Optionally initializes required
-   * data structures.
+   * Constructor.
    */
   ImplicitSystem (EquationSystems & es,
                   const std::string & name,
                   const unsigned int number);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class has the same restrictions/defaults as its base class.
+   * - The destructor is defaulted out-of-line.
    */
+  ImplicitSystem (const ImplicitSystem &) = delete;
+  ImplicitSystem & operator= (const ImplicitSystem &) = delete;
+  ImplicitSystem (ImplicitSystem &&) = default;
+  ImplicitSystem & operator= (ImplicitSystem &&) = delete;
   virtual ~ImplicitSystem ();
 
   /**

--- a/include/systems/linear_implicit_system.h
+++ b/include/systems/linear_implicit_system.h
@@ -57,16 +57,21 @@ class LinearImplicitSystem : public ImplicitSystem
 public:
 
   /**
-   * Constructor.  Optionally initializes required
-   * data structures.
+   * Constructor.
    */
   LinearImplicitSystem (EquationSystems & es,
                         const std::string & name,
                         const unsigned int number);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class has the same restrictions/defaults as its base class.
+   * - The destructor is defaulted out-of-line.
    */
+  LinearImplicitSystem (const LinearImplicitSystem &) = delete;
+  LinearImplicitSystem & operator= (const LinearImplicitSystem &) = delete;
+  LinearImplicitSystem (LinearImplicitSystem &&) = default;
+  LinearImplicitSystem & operator= (LinearImplicitSystem &&) = delete;
   virtual ~LinearImplicitSystem ();
 
   /**

--- a/include/systems/newmark_system.h
+++ b/include/systems/newmark_system.h
@@ -53,17 +53,22 @@ class NewmarkSystem : public LinearImplicitSystem
 public:
 
   /**
-   * Constructor.  Optionally initializes required
-   * data structures.
+   * Constructor.
    */
   NewmarkSystem (EquationSystems & es,
                  const std::string & name,
                  const unsigned int number);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class has the same restrictions/defaults as its base class.
+   * - The destructor is defaulted out-of-line.
    */
-  ~NewmarkSystem ();
+  NewmarkSystem (const NewmarkSystem &) = delete;
+  NewmarkSystem & operator= (const NewmarkSystem &) = delete;
+  NewmarkSystem (NewmarkSystem &&) = default;
+  NewmarkSystem & operator= (NewmarkSystem &&) = delete;
+  virtual ~NewmarkSystem ();
 
   /**
    * The type of system.

--- a/include/systems/nonlinear_implicit_system.h
+++ b/include/systems/nonlinear_implicit_system.h
@@ -56,16 +56,21 @@ class NonlinearImplicitSystem : public ImplicitSystem
 public:
 
   /**
-   * Constructor.  Optionally initializes required
-   * data structures.
+   * Constructor.
    */
   NonlinearImplicitSystem (EquationSystems & es,
                            const std::string & name,
                            const unsigned int number);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class has the same restrictions/defaults as its base class.
+   * - The destructor is defaulted out-of-line.
    */
+  NonlinearImplicitSystem (const NonlinearImplicitSystem &) = delete;
+  NonlinearImplicitSystem & operator= (const NonlinearImplicitSystem &) = delete;
+  NonlinearImplicitSystem (NonlinearImplicitSystem &&) = default;
+  NonlinearImplicitSystem & operator= (NonlinearImplicitSystem &&) = delete;
   virtual ~NonlinearImplicitSystem ();
 
   /**

--- a/include/systems/optimization_system.h
+++ b/include/systems/optimization_system.h
@@ -45,16 +45,21 @@ class OptimizationSystem : public ImplicitSystem
 public:
 
   /**
-   * Constructor.  Optionally initializes required
-   * data structures.
+   * Constructor.
    */
   OptimizationSystem (EquationSystems & es,
                       const std::string & name,
                       const unsigned int number);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class has the same restrictions/defaults as its base class.
+   * - The destructor is defaulted out-of-line.
    */
+  OptimizationSystem (const OptimizationSystem &) = delete;
+  OptimizationSystem & operator= (const OptimizationSystem &) = delete;
+  OptimizationSystem (OptimizationSystem &&) = default;
+  OptimizationSystem & operator= (OptimizationSystem &&) = delete;
   virtual ~OptimizationSystem ();
 
   /**

--- a/src/systems/condensed_eigen_system.C
+++ b/src/systems/condensed_eigen_system.C
@@ -43,6 +43,8 @@ CondensedEigenSystem::CondensedEigenSystem (EquationSystems & es,
 {
 }
 
+CondensedEigenSystem::~CondensedEigenSystem() = default;
+
 void
 CondensedEigenSystem::initialize_condensed_dofs(const std::set<dof_id_type> & global_dirichlet_dofs_set)
 {

--- a/src/systems/diff_system.C
+++ b/src/systems/diff_system.C
@@ -16,6 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
+// libMesh includes
 #include "libmesh/diff_solver.h"
 #include "libmesh/diff_system.h"
 #include "libmesh/time_solver.h"
@@ -24,6 +25,7 @@
 #include "libmesh/dof_map.h"
 #include "libmesh/zero_function.h"
 
+// C++ includes
 #include <utility> // std::swap
 
 namespace libMesh

--- a/src/systems/eigen_system.C
+++ b/src/systems/eigen_system.C
@@ -36,8 +36,6 @@ namespace libMesh
 {
 
 
-// ------------------------------------------------------------
-// EigenSystem implementation
 EigenSystem::EigenSystem (EquationSystems & es,
                           const std::string & name_in,
                           const unsigned int number_in
@@ -57,11 +55,7 @@ EigenSystem::EigenSystem (EquationSystems & es,
 
 
 
-EigenSystem::~EigenSystem ()
-{
-  // clear data
-  this->clear();
-}
+EigenSystem::~EigenSystem () = default;
 
 
 

--- a/src/systems/explicit_system.C
+++ b/src/systems/explicit_system.C
@@ -17,8 +17,6 @@
 
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/explicit_system.h"
 #include "libmesh/numeric_vector.h"
@@ -27,8 +25,8 @@ namespace libMesh
 {
 
 
-// ------------------------------------------------------------
-// ExplicitSystem implementation
+ExplicitSystem::~ExplicitSystem() = default;
+
 ExplicitSystem::ExplicitSystem (EquationSystems & es,
                                 const std::string & name_in,
                                 const unsigned int number_in) :

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-
+// libMesh includes
 #include "libmesh/dof_map.h"
 #include "libmesh/elem.h"
 #include "libmesh/equation_systems.h"
@@ -834,9 +834,7 @@ FEMSystem::FEMSystem (EquationSystems & es,
 }
 
 
-FEMSystem::~FEMSystem ()
-{
-}
+FEMSystem::~FEMSystem () = default;
 
 
 

--- a/src/systems/frequency_system.C
+++ b/src/systems/frequency_system.C
@@ -20,14 +20,8 @@
 // Local includes
 #include "libmesh/libmesh_config.h"
 
-/*
- * Require complex arithmetic
- */
+// This class is only enabled in complex numbers builds
 #if defined(LIBMESH_USE_COMPLEX_NUMBERS)
-
-
-// C++ includes
-#include <cstdio>          // for sprintf
 
 // Local includes
 #include "libmesh/frequency_system.h"
@@ -36,13 +30,12 @@
 #include "libmesh/linear_solver.h"
 #include "libmesh/numeric_vector.h"
 
+// C++ includes
+#include <cstdio>          // for sprintf
+
 namespace libMesh
 {
 
-
-
-// ------------------------------------------------------------
-// FrequencySystem implementation
 FrequencySystem::FrequencySystem (EquationSystems & es,
                                   const std::string & name_in,
                                   const unsigned int number_in) :
@@ -60,13 +53,7 @@ FrequencySystem::FrequencySystem (EquationSystems & es,
 
 
 
-FrequencySystem::~FrequencySystem ()
-{
-  this->clear ();
-
-  // the additional matrices and vectors are cleared and zero'ed in System
-}
-
+FrequencySystem::~FrequencySystem () = default;
 
 
 
@@ -79,17 +66,15 @@ void FrequencySystem::clear ()
   _finished_init            = false;
   _finished_assemble        = false;
 
-  /*
-   * We have to distinguish between the
-   * simple straightforward "clear()"
-   * and the clear that also touches the
-   * EquationSystems parameters "current frequency" etc.
-   * Namely, when reading from file (through equation_systems_io.C
-   * methods), the param's are read in, then the systems.
-   * Prior to reading a system, this system gets cleared...
-   * And there, all the previously loaded frequency parameters
-   * would get lost...
-   */
+  // We have to distinguish between the
+  // simple straightforward "clear()"
+  // and the clear that also touches the
+  // EquationSystems parameters "current frequency" etc.
+  // Namely, when reading from file (through equation_systems_io.C
+  // methods), the param's are read in, then the systems.
+  // Prior to reading a system, this system gets cleared...
+  // And there, all the previously loaded frequency parameters
+  // would get lost...
 }
 
 
@@ -128,11 +113,9 @@ void FrequencySystem::init_data ()
   // make sure we have frequencies to solve for
   if (!_finished_set_frequencies)
     {
-      /*
-       * when this system was read from file, check
-       * if this has a "n_frequencies" parameter,
-       * and initialize us with these.
-       */
+      // when this system was read from file, check
+      // if this has a "n_frequencies" parameter,
+      // and initialize us with these.
       if (es.parameters.have_parameter<unsigned int> ("n_frequencies"))
         {
 #ifndef NDEBUG

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -37,8 +37,6 @@
 namespace libMesh
 {
 
-// ------------------------------------------------------------
-// ImplicitSystem implementation
 ImplicitSystem::ImplicitSystem (EquationSystems & es,
                                 const std::string & name_in,
                                 const unsigned int number_in) :
@@ -51,11 +49,7 @@ ImplicitSystem::ImplicitSystem (EquationSystems & es,
 
 
 
-ImplicitSystem::~ImplicitSystem ()
-{
-  // Clear data
-  this->clear();
-}
+ImplicitSystem::~ImplicitSystem () = default;
 
 
 

--- a/src/systems/linear_implicit_system.C
+++ b/src/systems/linear_implicit_system.C
@@ -32,8 +32,6 @@ namespace libMesh
 {
 
 
-// ------------------------------------------------------------
-// LinearImplicitSystem implementation
 LinearImplicitSystem::LinearImplicitSystem (EquationSystems & es,
                                             const std::string & name_in,
                                             const unsigned int number_in) :

--- a/src/systems/newmark_system.C
+++ b/src/systems/newmark_system.C
@@ -17,8 +17,6 @@
 
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/newmark_system.h"
 #include "libmesh/equation_systems.h"
@@ -29,9 +27,6 @@
 namespace libMesh
 {
 
-
-
-
 // ------------------------------------------------------------
 // NewmarkSystem static members
 const Real NewmarkSystem::_default_alpha    = .25;
@@ -40,8 +35,6 @@ const Real NewmarkSystem::_default_timestep = 1.;
 
 
 
-// ------------------------------------------------------------
-// NewmarkSystem implementation
 NewmarkSystem::NewmarkSystem (EquationSystems & es,
                               const std::string & name_in,
                               const unsigned int number_in) :
@@ -95,10 +88,7 @@ NewmarkSystem::NewmarkSystem (EquationSystems & es,
 
 
 
-NewmarkSystem::~NewmarkSystem ()
-{
-  this->clear();
-}
+NewmarkSystem::~NewmarkSystem () = default;
 
 
 

--- a/src/systems/nonlinear_implicit_system.C
+++ b/src/systems/nonlinear_implicit_system.C
@@ -17,8 +17,6 @@
 
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/nonlinear_implicit_system.h"
 #include "libmesh/diff_solver.h"
@@ -30,8 +28,6 @@
 namespace libMesh
 {
 
-// ------------------------------------------------------------
-// NonlinearImplicitSystem implementation
 NonlinearImplicitSystem::NonlinearImplicitSystem (EquationSystems & es,
                                                   const std::string & name_in,
                                                   const unsigned int number_in) :
@@ -60,11 +56,7 @@ NonlinearImplicitSystem::NonlinearImplicitSystem (EquationSystems & es,
 
 
 
-NonlinearImplicitSystem::~NonlinearImplicitSystem ()
-{
-  // Clear data
-  this->clear();
-}
+NonlinearImplicitSystem::~NonlinearImplicitSystem () = default;
 
 
 

--- a/src/systems/optimization_system.C
+++ b/src/systems/optimization_system.C
@@ -17,8 +17,6 @@
 
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/equation_systems.h"
 #include "libmesh/libmesh_logging.h"
@@ -31,8 +29,6 @@
 namespace libMesh
 {
 
-// ------------------------------------------------------------
-// OptimizationSystem implementation
 OptimizationSystem::OptimizationSystem (EquationSystems & es,
                                         const std::string & name_in,
                                         const unsigned int number_in) :
@@ -50,11 +46,7 @@ OptimizationSystem::OptimizationSystem (EquationSystems & es,
 
 
 
-OptimizationSystem::~OptimizationSystem ()
-{
-  // Clear data
-  this->clear();
-}
+OptimizationSystem::~OptimizationSystem () = default;
 
 
 


### PR DESCRIPTION
* ExplicitSystem
* ImplicitSystem
* CondensedEigenSystem
* DifferentiableSystem
* LinearImplicitSystem
* OptimizationSystem
* FEMSystem
* FrequencySystem
* NewmarkSystem
* ContinuationSystem
* RBConstructionBase
* RBConstruction
* RBEIMConstruction
* RBSCMConstruction
* EigenSystem

The destructors for this class hierarchy can mostly just be default()ed and in general should not call clear().

This change defaults a few move constructors that were previously deleted to avoid new clang compiler warnings... @roystgnr if you still have a clang-11 build laying around, it would be great if you could check whether this branch has any warnings for you. I don't think we have any CI with newer clangs, but I could be wrong about that.