### PR TITLE
Add sanity check to System::init_data() 

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -238,8 +238,9 @@ public:
    * Distribute dofs on the current mesh.  Also builds the send list for
    * processor \p proc_id, which defaults to 0 for ease of use in serial
    * applications.
+   * \returns The total number of DOFs for the System, summed across all procs.
    */
-  void distribute_dofs (MeshBase &);
+  std::size_t distribute_dofs (MeshBase &);
 
   /**
    * Computes the sparsity pattern for the matrices corresponding to

--- a/include/numerics/distributed_vector.h
+++ b/include/numerics/distributed_vector.h
@@ -227,6 +227,8 @@ public:
 
   virtual void swap (NumericVector<T> & v) override;
 
+  virtual std::size_t max_allowed_id() const override;
+
 private:
 
   /**
@@ -657,6 +659,14 @@ void DistributedVector<T>::swap (NumericVector<T> & other)
 
   // This should be O(1) with any reasonable STL implementation
   std::swap(_values, v._values);
+}
+
+template <typename T>
+inline
+std::size_t DistributedVector<T>::max_allowed_id () const
+{
+  // Uses a std:vector<T>, so our indexing matches that
+  return std::numeric_limits<typename std::vector<T>::size_type>::max();
 }
 
 } // namespace libMesh

--- a/include/numerics/eigen_sparse_vector.h
+++ b/include/numerics/eigen_sparse_vector.h
@@ -31,6 +31,9 @@
 #include "libmesh/eigen_core_support.h"
 #include "libmesh/numeric_vector.h"
 
+// C++ includes
+#include <limits>
+
 namespace libMesh
 {
 
@@ -225,6 +228,8 @@ public:
                                const NumericVector<T> & vec2) override;
 
   virtual void swap (NumericVector<T> & v) override;
+
+  virtual std::size_t max_allowed_id() const override;
 
   /**
    * References to the underlying Eigen data types.
@@ -523,6 +528,16 @@ void EigenSparseVector<T>::swap (NumericVector<T> & other)
   std::swap (this->_type,           v._type);
 }
 
+
+
+template <typename T>
+inline
+std::size_t EigenSparseVector<T>::max_allowed_id () const
+{
+  // We use the Eigen::Matrix type which appears to be templated on
+  // int for its sizes, see e.g. https://eigen.tuxfamily.org/dox/classEigen_1_1Matrix.html
+  return std::numeric_limits<int>::max();
+}
 
 } // namespace libMesh
 

--- a/include/numerics/laspack_vector.h
+++ b/include/numerics/laspack_vector.h
@@ -30,12 +30,13 @@
 // Local includes
 #include "libmesh/numeric_vector.h"
 
-// C++ includes
-#include <cstdio> // for std::sprintf
-
 // Laspack includes
 #include <operats.h>
 #include <qvector.h>
+
+// C++ includes
+#include <cstdio> // for std::sprintf
+#include <limits>
 
 namespace libMesh
 {
@@ -226,6 +227,8 @@ public:
                                const NumericVector<T> & vec2) override;
 
   virtual void swap (NumericVector<T> & v) override;
+
+  virtual std::size_t max_allowed_id() const override;
 
 private:
 
@@ -556,6 +559,16 @@ void LaspackVector<T>::swap (NumericVector<T> & other)
   // data on the heap
 
   std::swap(_vec.Cmp, v._vec.Cmp);
+}
+
+
+
+template <typename T>
+inline
+std::size_t LaspackVector<T>::max_allowed_id () const
+{
+  // The QVector type declares a "size_t Dim;"
+  return std::numeric_limits<std::size_t>::max();
 }
 
 

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -717,6 +717,19 @@ public:
    */
   virtual void swap (NumericVector<T> & v);
 
+  /**
+   * \returns the max number of entries (across all procs) that the
+   * NumericVector can have.
+   *
+   * Although we define numeric_index_type, and it is typically
+   * required that the NumericVector's underlying implementation's
+   * indices have _size_ equal to sizeof(numeric_index_type), these
+   * two types can still have different _signedness_, which affects
+   * the maximum number of values which can be stored in the
+   * NumericVector.
+   */
+  virtual std::size_t max_allowed_id() const = 0;
+
 protected:
 
   /**

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -48,6 +48,7 @@
 #include <cstring>
 #include <vector>
 #include <unordered_map>
+#include <limits>
 
 #ifdef LIBMESH_HAVE_CXX11_THREAD
 #include <atomic>
@@ -323,6 +324,8 @@ public:
                                 const std::vector<numeric_index_type> & rows) const override;
 
   virtual void swap (NumericVector<T> & v) override;
+
+  virtual std::size_t max_allowed_id() const override;
 
   /**
    * \returns The raw PETSc Vec pointer.
@@ -1204,6 +1207,15 @@ void PetscVector<T>::swap (NumericVector<T> & other)
 }
 
 
+
+template <typename T>
+inline
+std::size_t PetscVector<T>::max_allowed_id () const
+{
+  // The PetscInt type is used for indexing, it may be either a signed
+  // 4-byte or 8-byte integer depending on how PETSc is configured.
+  return std::numeric_limits<PetscInt>::max();
+}
 
 
 

--- a/include/numerics/trilinos_epetra_vector.h
+++ b/include/numerics/trilinos_epetra_vector.h
@@ -40,6 +40,7 @@
 // C++ includes
 #include <cstddef>
 #include <vector>
+#include <limits>
 
 // Forward declarations
 class Epetra_IntSerialDenseVector;
@@ -252,6 +253,8 @@ public:
                                  const std::vector<numeric_index_type> & rows) const override;
 
   virtual void swap (NumericVector<T> & v) override;
+
+  virtual std::size_t max_allowed_id() const override;
 
   /**
    * \returns The raw Epetra_Vector pointer.
@@ -829,6 +832,17 @@ void EpetraVector<T>::swap (NumericVector<T> & other)
   std::swap(last_edit, v.last_edit);
   std::swap(ignoreNonLocalEntries_, v.ignoreNonLocalEntries_);
 }
+
+
+
+template <typename T>
+inline
+std::size_t EpetraVector<T>::max_allowed_id () const
+{
+  // Epetra_Vector seems to use hard-coded ints in its various indexing routines.
+  return std::numeric_limits<int>::max();
+}
+
 
 
 // Trilinos only got serious about const in version 10.4

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1081,7 +1081,12 @@ std::size_t DofMap::distribute_dofs (MeshBase & mesh)
   // dependencies to the send_list too.
   // this->sort_send_list ();
 
-  // Return total number of DOFs across all procs.
+  // Return total number of DOFs across all procs. We compute and
+  // return this as a std::size_t so that we can detect situations in
+  // which the total number of DOFs across all procs would exceed the
+  // capability of the underlying NumericVector representation to
+  // index into it correctly (std::size_t is the largest unsigned
+  // type, so no NumericVector representation can exceed it).
   return std::accumulate(dofs_on_proc.begin(), dofs_on_proc.end(), static_cast<std::size_t>(0));
 }
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -909,7 +909,7 @@ void DofMap::clear()
 
 
 
-void DofMap::distribute_dofs (MeshBase & mesh)
+std::size_t DofMap::distribute_dofs (MeshBase & mesh)
 {
   // This function must be run on all processors at once
   parallel_object_only();
@@ -1080,6 +1080,9 @@ void DofMap::distribute_dofs (MeshBase & mesh)
   // EquationSystems call that for us, after we've added constraint
   // dependencies to the send_list too.
   // this->sort_send_list ();
+
+  // Return total number of DOFs across all procs.
+  return std::accumulate(dofs_on_proc.begin(), dofs_on_proc.end(), static_cast<std::size_t>(0));
 }
 
 

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -219,7 +219,14 @@ void System::init_data ()
     _dof_map->add_variable_group(this->variable_group(vg));
 
   // Distribute the degrees of freedom on the mesh
-  _dof_map->distribute_dofs (mesh);
+  auto total_dofs = _dof_map->distribute_dofs (mesh);
+
+  // Throw an error if the total number of DOFs is not capable of
+  // being indexed by our solution vector.
+  auto max_allowed_id = solution->max_allowed_id();
+  libmesh_error_msg_if(total_dofs > max_allowed_id,
+                       "Cannot allocate a NumericVector with " << total_dofs << " degrees of freedom. "
+                       "The vector can only index up to " << max_allowed_id << " entries.");
 
   // Recreate any user or internal constraints
   this->reinit_constraints();


### PR DESCRIPTION
Avoid trying to `init()` `System` solution vectors which are larger than the underlying NumericVector representation's index type allows. An example of this is with PETSc, which uses the `PetscInt` type that can be either a signed 4 or signed 8 byte type depending on how PETSc is configured. The idea/hope is that this will be an easier exception to recover from than an error which has to propagate up from the underlying NumericVector representation's library.
