### PR TITLE
Fix leak introduced in 25cecd701

### DIFF
--- a/src/numerics/petsc_preconditioner.C
+++ b/src/numerics/petsc_preconditioner.C
@@ -61,6 +61,10 @@ void PetscPreconditioner<T>::init ()
   // Clear the preconditioner in case it has been created in the past
   if (!this->_is_initialized)
     {
+      // Should probably use PCReset(), but it's not working at the moment so we'll destroy instead
+      if (_pc)
+        _pc.destroy();
+
       PetscErrorCode ierr = PCCreate(this->comm().get(), _pc.get());
       LIBMESH_CHKERR(ierr);
 


### PR DESCRIPTION
Notes:
* This was only discovered by running Valgrind, which is something we
  don't normally do on libMesh PRs
* I think it's unnecessary to check if (_pc) here as it is never
  explicitly set to nullptr in the code, but I left it in to mimic the
  previous behavior for now.