### PR TITLE
Support IsoGeometric Analysis meshes in System::project_vector()

### DIFF
--- a/include/base/sparsity_pattern.h
+++ b/include/base/sparsity_pattern.h
@@ -221,7 +221,9 @@ private:
                              std::vector<dof_id_type> & dofs_vi,
                              unsigned int vi);
 
-public:
+#ifndef LIBMESH_ENABLE_DEPRECATED
+private:
+#endif
 
   SparsityPattern::Graph sparsity_pattern;
 

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -1200,7 +1200,6 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::project
 
   done_saving_ids = sort_work.edges.empty() &&
     sort_work.sides.empty() && sort_work.interiors.empty();
-  system.comm().max(done_saving_ids);
 
   {
     ProjectVertices project_vertices(*this);
@@ -1212,7 +1211,6 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::project
   }
 
   done_saving_ids = sort_work.sides.empty() && sort_work.interiors.empty();
-  system.comm().max(done_saving_ids);
 
   this->send_and_insert_dof_values(ids_to_push, action);
 
@@ -1227,7 +1225,6 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::project
   }
 
   done_saving_ids = sort_work.interiors.empty();
-  system.comm().max(done_saving_ids);
 
   this->send_and_insert_dof_values(ids_to_push, action);
 

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -1589,6 +1589,15 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::SortAndCopy
             continue;
           FEType fe_type = var.type();
 
+          // If we're trying to do projections on an isogeometric
+          // analysis mesh, only the finite element nodes constrained
+          // by those spline nodes truly have delta function degrees
+          // of freedom.  We'll have to back out the spline degrees of
+          // freedom indirectly later.
+          if (fe_type.family == RATIONAL_BERNSTEIN &&
+              elem->type() == NODEELEM)
+            continue;
+
           if (FEInterface::n_dofs_at_node(fe_type, elem, 0))
             vertex_vars.insert(vertex_vars.end(), v_num);
 

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1888,6 +1888,17 @@ protected:
                        NumericVector<Number> &,
                        int is_adjoint = -1) const;
 
+  /*
+   * If we have e.g. a element space constrained by spline values, we
+   * can directly project only on the constrained basis; to get
+   * consistent constraining values we have to solve for them.
+   *
+   * Constrain the new vector using the requested adjoint rather than
+   * primal constraints if is_adjoint is non-negative.
+   */
+  void solve_for_unconstrained_dofs (NumericVector<Number> &,
+                                     int is_adjoint = -1) const;
+
 private:
   /**
    * Helper function to keep DofMap forward declarable in system.h

--- a/src/mesh/dyna_io.C
+++ b/src/mesh/dyna_io.C
@@ -730,7 +730,7 @@ void DynaIO::add_spline_constraints(DofMap & dof_map,
                                     unsigned int var_num)
 {
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
-  const MeshBase & mesh = this->mesh();
+  MeshBase & mesh = this->mesh();
 
   // We have some strict compatibility requirements here still
   if (mesh.allow_renumbering() ||
@@ -766,6 +766,9 @@ void DynaIO::add_spline_constraints(DofMap & dof_map,
       // conflict with *any* other constraints.
       dof_map.add_constraint_row(constrained_id, dc_row, false);
     }
+
+  dof_map.process_constraints(mesh);
+  dof_map.prepare_send_list();
 #else
   libmesh_ignore(dof_map, sys_num, var_num);
   libmesh_not_implemented();

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -87,7 +87,7 @@ System::System (EquationSystems & es,
   _sys_name                         (name_in),
   _sys_number                       (number_in),
   _active                           (true),
-  _can_add_matrices                 (true),
+  _matrices_initialized             (false),
   _solution_projection              (true),
   _basic_system_only                (false),
   _is_initialized                   (false),
@@ -180,7 +180,7 @@ void System::clear ()
 
   // clear any user-added matrices
   _matrices.clear();
-  _can_add_matrices = true;
+  _matrices_initialized = false;
 }
 
 
@@ -291,18 +291,26 @@ void System::init_data ()
 
 void System::init_matrices ()
 {
-  // no chance to add other matrices
-  _can_add_matrices = false;
-
   // No matrices to init
   if (_matrices.empty())
-    return;
+    {
+      // any future matrices to be added will need their own
+      // initialization
+      _matrices_initialized = true;
+
+      return;
+    }
 
   // Check for quick return in case the first matrix
   // (and by extension all the matrices) has already
   // been initialized
   if (_matrices.begin()->second->initialized())
-    return;
+    {
+      libmesh_assert(_matrices_initialized);
+      return;
+    }
+
+  _matrices_initialized = true;
 
   // Tell the matrices about the dof map, and vice versa
   for (auto & pr : _matrices)
@@ -867,16 +875,11 @@ SparseMatrix<Number> & System::add_matrix (const std::string & mat_name,
                                            const ParallelType type,
                                            const MatrixBuildType mat_build_type)
 {
-  // only add matrices before initializing...
-  if (!_can_add_matrices)
-    libmesh_error_msg("ERROR: Too late.  Cannot add matrices to the system after initialization"
-                      << "\n any more.  You should have done this earlier.");
-
   // Return the matrix if it is already there.
   if (this->have_matrix(mat_name))
     return *(_matrices[mat_name]);
 
-  // Otherwise build the matrix and return a reference to it.
+  // Otherwise build the matrix to return.
   auto pr = _matrices.emplace
     (mat_name,
      SparseMatrix<Number>::build(this->comm(),
@@ -885,8 +888,26 @@ SparseMatrix<Number> & System::add_matrix (const std::string & mat_name,
 
   _matrix_types.emplace(mat_name, type);
 
-  return *(pr.first->second);
+  SparseMatrix<Number> & mat = *(pr.first->second);
+
+  // Initialize it first if we've already initialized the others.
+  this->late_matrix_init(mat, type);
+
+  return mat;
 }
+
+
+
+void System::late_matrix_init(SparseMatrix<Number> & mat,
+                              ParallelType type)
+{
+  if (_matrices_initialized)
+    {
+      this->get_dof_map().attach_matrix(mat);
+      mat.init(type);
+    }
+}
+
 
 
 

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -39,6 +39,7 @@
 
 #include "libmesh/compare_types.h"
 #include "libmesh/int_range.h"
+#include "libmesh/linear_solver.h"
 
 using MetaPhysicL::DynamicSparseNumberArray;
 
@@ -1989,6 +1990,62 @@ void BoundaryProjectSolution::operator()(const ConstElemRange & range) const
           }
         }  // end elem loop
     } // end variables loop
+}
+
+
+void System::solve_for_unconstrained_dofs(NumericVector<Number> & vec,
+                                          int is_adjoint) const
+{
+  const DofMap & dof_map = this->get_dof_map();
+
+  std::unique_ptr<SparseMatrix<Number>> mat =
+    SparseMatrix<Number>::build(this->comm());
+
+  std::unique_ptr<SparsityPattern::Build> sp;
+
+  if (dof_map.computed_sparsity_already())
+    dof_map.update_sparsity_pattern(*mat);
+  else
+    {
+      mat->attach_dof_map(dof_map);
+      sp = dof_map.build_sparsity(this->get_mesh());
+      mat->attach_sparsity_pattern(*sp);
+    }
+
+  mat->init();
+
+  libmesh_assert_equal_to(vec.size(), dof_map.n_dofs());
+  libmesh_assert_equal_to(vec.local_size(), dof_map.n_local_dofs());
+
+  std::unique_ptr<NumericVector<Number>> rhs =
+    NumericVector<Number>::build(this->comm());
+
+  rhs->init(dof_map.n_dofs(), dof_map.n_local_dofs(), false,
+            PARALLEL);
+
+  for (dof_id_type d : IntRange<dof_id_type>(dof_map.first_dof(),
+                                             dof_map.end_dof()))
+    {
+      if (dof_map.is_constrained_dof(d))
+        {
+          DenseMatrix<Number> K(1,1);
+          DenseVector<Number> F(1);
+          std::vector<dof_id_type> dof_indices(1, d);
+          K(0,0) = 1;
+          F(0) = (*this->solution)(d);
+          dof_map.heterogenously_constrain_element_matrix_and_vector
+            (K, F, dof_indices, false, is_adjoint);
+          mat->add_matrix(K, dof_indices);
+          rhs->add_vector(F, dof_indices);
+        }
+    }
+
+  std::unique_ptr<LinearSolver<Number>> linear_solver =
+    LinearSolver<Number>::build(this->comm());
+
+  linear_solver->solve(*mat, vec, *rhs,
+                       double(this->get_equation_systems().parameters.get<Real>("linear solver tolerance")),
+                       this->get_equation_systems().parameters.get<unsigned int>("linear solver maximum iterations"));
 }
 
 


### PR DESCRIPTION
This was way trickier than I was expecting.  We can't project constraining DoFs and then just do a forward application of constraint equations to get the constrained DoFs consistent; we have to project constrained DoFs and then do a constrained solve to get the constraining DoFs consistent.