### PR TITLE
Add variadic template VecScatterBeginEnd() helper function

### DIFF
--- a/include/numerics/petsc_solver_exception.h
+++ b/include/numerics/petsc_solver_exception.h
@@ -22,7 +22,7 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 
-#include "libmesh_exceptions.h"
+#include "libmesh/libmesh_exceptions.h"
 
 #ifdef I
 # define LIBMESH_SAW_I
@@ -38,6 +38,12 @@
 
 namespace libMesh
 {
+
+// Forward declarations
+namespace Parallel
+{
+class Communicator;
+}
 
 // The SolverException class is only defined when exceptions are enabled.
 #ifdef LIBMESH_ENABLE_EXCEPTIONS
@@ -78,9 +84,13 @@ public:
 
 // Two-argument CHKERR macro that takes both a comm and an error
 // code. When exceptions are enabled, the comm is not used for
-// anything.  This is helpful when you need to call LIBMESH_CHKERR but
-// you're not in a ParallelObject.
-#define LIBMESH_CHKERR2(comm, ierr) LIBMESH_CHKERR(ierr);
+// anything, so we libmesh_ignore() it.  This macro is useful when you
+// need to call LIBMESH_CHKERR but you're not in a ParallelObject.
+#define LIBMESH_CHKERR2(comm, ierr)             \
+  do {                                          \
+    libmesh_ignore(comm);                       \
+    LIBMESH_CHKERR(ierr);                       \
+  } while (0)
 
 #else
 
@@ -96,6 +106,21 @@ public:
 #define LIBMESH_CHKERRABORT(ierr) LIBMESH_CHKERR(ierr)
 
 #endif
+
+/**
+ * Saves a few lines of code by calling both VecScatterBegin() and
+ * VecScatterEnd(), checking errors after each.
+ */
+template<class ...Args>
+inline
+void VecScatterBeginEnd(const Parallel::Communicator & comm, const Args&... args)
+{
+  PetscErrorCode ierr = 0;
+  ierr = VecScatterBegin(args...);
+  LIBMESH_CHKERR2(comm, ierr);
+  ierr = VecScatterEnd(args...);
+  LIBMESH_CHKERR2(comm, ierr);
+}
 
 } // namespace libMesh
 

--- a/include/numerics/petsc_solver_exception.h
+++ b/include/numerics/petsc_solver_exception.h
@@ -107,20 +107,22 @@ public:
 
 #endif
 
-/**
- * Saves a few lines of code by calling both VecScatterBegin() and
- * VecScatterEnd(), checking errors after each.
- */
-template<class ...Args>
-inline
-void VecScatterBeginEnd(const Parallel::Communicator & comm, const Args&... args)
-{
-  PetscErrorCode ierr = 0;
-  ierr = VecScatterBegin(args...);
-  LIBMESH_CHKERR2(comm, ierr);
-  ierr = VecScatterEnd(args...);
-  LIBMESH_CHKERR2(comm, ierr);
-}
+#define PETSC_BEGIN_END(Function)                                       \
+  template<class ...Args>                                               \
+  inline                                                                \
+  void Function ## BeginEnd(const Parallel::Communicator & comm, const Args&... args) \
+  {                                                                     \
+    PetscErrorCode ierr = 0;                                            \
+    ierr = Function ## Begin(args...);                                  \
+    LIBMESH_CHKERR2(comm, ierr);                                        \
+    ierr = Function ## End(args...);                                    \
+    LIBMESH_CHKERR2(comm, ierr);                                        \
+  }
+
+PETSC_BEGIN_END(VecScatter) // VecScatterBeginEnd
+PETSC_BEGIN_END(MatAssembly) // MatAssemblyBeginEnd
+PETSC_BEGIN_END(VecAssembly) // VecAssemblyBeginEnd
+PETSC_BEGIN_END(VecGhostUpdate) // VecGhostUpdateBeginEnd
 
 } // namespace libMesh
 

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -816,20 +816,10 @@ void PetscVector<T>::close ()
 
   this->_restore_array();
 
-  PetscErrorCode ierr=0;
-
-  ierr = VecAssemblyBegin(_vec);
-  LIBMESH_CHKERR(ierr);
-  ierr = VecAssemblyEnd(_vec);
-  LIBMESH_CHKERR(ierr);
+  VecAssemblyBeginEnd(this->comm(), _vec);
 
   if (this->type() == GHOSTED)
-    {
-      ierr = VecGhostUpdateBegin(_vec,INSERT_VALUES,SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
-      ierr = VecGhostUpdateEnd(_vec,INSERT_VALUES,SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
-    }
+    VecGhostUpdateBeginEnd(this->comm(), _vec, INSERT_VALUES, SCATTER_FORWARD);
 
   this->_is_closed = true;
 }

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -985,12 +985,7 @@ void PetscMatrix<T>::close ()
   //   if (this->closed())
   //     return;
 
-  PetscErrorCode ierr=0;
-
-  ierr = MatAssemblyBegin (_mat, MAT_FINAL_ASSEMBLY);
-  LIBMESH_CHKERR(ierr);
-  ierr = MatAssemblyEnd   (_mat, MAT_FINAL_ASSEMBLY);
-  LIBMESH_CHKERR(ierr);
+  MatAssemblyBeginEnd(this->comm(), _mat, MAT_FINAL_ASSEMBLY);
 }
 
 template <typename T>
@@ -998,12 +993,7 @@ void PetscMatrix<T>::flush ()
 {
   semiparallel_only();
 
-  PetscErrorCode ierr=0;
-
-  ierr = MatAssemblyBegin (_mat, MAT_FLUSH_ASSEMBLY);
-  LIBMESH_CHKERR(ierr);
-  ierr = MatAssemblyEnd   (_mat, MAT_FLUSH_ASSEMBLY);
-  LIBMESH_CHKERR(ierr);
+  MatAssemblyBeginEnd(this->comm(), _mat, MAT_FLUSH_ASSEMBLY);
 }
 
 

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -651,10 +651,7 @@ void PetscVector<T>::localize (NumericVector<T> & v_local_in) const
     WrappedPetsc<VecScatter> scatter;
     ierr = VecScatterCreateToAll(_vec, scatter.get(), nullptr);
     LIBMESH_CHKERR(ierr);
-    ierr = VecScatterBegin(scatter, _vec, v_local->_vec, INSERT_VALUES, SCATTER_FORWARD);
-    LIBMESH_CHKERR(ierr);
-    ierr = VecScatterEnd(scatter, _vec, v_local->_vec, INSERT_VALUES, SCATTER_FORWARD);
-    LIBMESH_CHKERR(ierr);
+    VecScatterBeginEnd(this->comm(), scatter, _vec, v_local->_vec, INSERT_VALUES, SCATTER_FORWARD);
   }
   // Two vectors have the same size, and we should just do a simple copy.
   // v_local could be either a parallel or ghosted vector
@@ -731,13 +728,7 @@ void PetscVector<T>::localize (NumericVector<T> & v_local_in,
 
 
   // Perform the scatter
-  ierr = VecScatterBegin(scatter, _vec, v_local->_vec,
-                         INSERT_VALUES, SCATTER_FORWARD);
-  LIBMESH_CHKERR(ierr);
-
-  ierr = VecScatterEnd  (scatter, _vec, v_local->_vec,
-                         INSERT_VALUES, SCATTER_FORWARD);
-  LIBMESH_CHKERR(ierr);
+  VecScatterBeginEnd(this->comm(), scatter, _vec, v_local->_vec, INSERT_VALUES, SCATTER_FORWARD);
 
   // Make sure ghost dofs are up to date
   if (v_local->type() == GHOSTED)
@@ -778,11 +769,7 @@ void PetscVector<T>::localize (std::vector<T> & v_local,
   LIBMESH_CHKERR(ierr);
 
   // Do the scatter
-  ierr = VecScatterBegin(scatter, _vec, dest, INSERT_VALUES, SCATTER_FORWARD);
-  LIBMESH_CHKERR(ierr);
-
-  ierr = VecScatterEnd(scatter, _vec, dest, INSERT_VALUES, SCATTER_FORWARD);
-  LIBMESH_CHKERR(ierr);
+  VecScatterBeginEnd(this->comm(), scatter, _vec, dest, INSERT_VALUES, SCATTER_FORWARD);
 
   // Get access to the values stored in dest.
   PetscScalar * values;
@@ -850,13 +837,8 @@ void PetscVector<T>::localize (const numeric_index_type first_local_idx,
                             scatter.get());
     LIBMESH_CHKERR(ierr);
 
-    ierr = VecScatterBegin(scatter, _vec, parallel_vec._vec,
-                           INSERT_VALUES, SCATTER_FORWARD);
-    LIBMESH_CHKERR(ierr);
-
-    ierr = VecScatterEnd  (scatter, _vec, parallel_vec._vec,
-                           INSERT_VALUES, SCATTER_FORWARD);
-    LIBMESH_CHKERR(ierr);
+    // Perform the scatter
+    VecScatterBeginEnd(this->comm(), scatter, _vec, parallel_vec._vec, INSERT_VALUES, SCATTER_FORWARD);
   }
 
   // localize like normal
@@ -940,10 +922,7 @@ void PetscVector<Real>::localize_to_one (std::vector<Real> & v_local,
           ierr = VecScatterCreateToZero(_vec, ctx.get(), vout.get());
           LIBMESH_CHKERR(ierr);
 
-          ierr = VecScatterBegin(ctx, _vec, vout, INSERT_VALUES, SCATTER_FORWARD);
-          LIBMESH_CHKERR(ierr);
-          ierr = VecScatterEnd(ctx, _vec, vout, INSERT_VALUES, SCATTER_FORWARD);
-          LIBMESH_CHKERR(ierr);
+          VecScatterBeginEnd(this->comm(), ctx, _vec, vout, INSERT_VALUES, SCATTER_FORWARD);
 
           if (processor_id() == 0)
             {
@@ -1230,17 +1209,7 @@ void PetscVector<T>::create_subvector(NumericVector<T> & subvector,
                           scatter.get()); LIBMESH_CHKERR(ierr);
 
   // Actually perform the scatter
-  ierr = VecScatterBegin(scatter,
-                         this->_vec,
-                         petsc_subvector->_vec,
-                         INSERT_VALUES,
-                         SCATTER_FORWARD); LIBMESH_CHKERR(ierr);
-
-  ierr = VecScatterEnd(scatter,
-                       this->_vec,
-                       petsc_subvector->_vec,
-                       INSERT_VALUES,
-                       SCATTER_FORWARD); LIBMESH_CHKERR(ierr);
+  VecScatterBeginEnd(this->comm(), scatter, this->_vec, petsc_subvector->_vec, INSERT_VALUES, SCATTER_FORWARD);
 }
 
 

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -666,14 +666,9 @@ void PetscVector<T>::localize (NumericVector<T> & v_local_in) const
   }
 
   // Make sure ghost dofs are up to date
+  // We do not call "close" here to save a global reduction
   if (v_local->type() == GHOSTED)
-  {
-    // We do not call "close" here to save a global reduction
-    ierr = VecGhostUpdateBegin(v_local->_vec,INSERT_VALUES,SCATTER_FORWARD);
-    LIBMESH_CHKERR(ierr);
-    ierr = VecGhostUpdateEnd(v_local->_vec,INSERT_VALUES,SCATTER_FORWARD);
-    LIBMESH_CHKERR(ierr);
-  }
+    VecGhostUpdateBeginEnd(this->comm(), v_local->_vec, INSERT_VALUES, SCATTER_FORWARD);
 }
 
 

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -417,15 +417,8 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
       ierr = VecScatterCreate(rhs->vec(), _restrict_solve_to_is, subrhs, nullptr, scatter.get());
       LIBMESH_CHKERR(ierr);
 
-      ierr = VecScatterBegin(scatter, rhs->vec(), subrhs, INSERT_VALUES, SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
-      ierr = VecScatterEnd(scatter, rhs->vec(), subrhs, INSERT_VALUES, SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
-
-      ierr = VecScatterBegin(scatter, solution->vec(), subsolution, INSERT_VALUES, SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
-      ierr = VecScatterEnd(scatter, solution->vec(), subsolution, INSERT_VALUES, SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
+      VecScatterBeginEnd(this->comm(), scatter, rhs->vec(), subrhs, INSERT_VALUES, SCATTER_FORWARD);
+      VecScatterBeginEnd(this->comm(), scatter, solution->vec(), subsolution, INSERT_VALUES, SCATTER_FORWARD);
 
       ierr = LibMeshCreateSubMatrix(matrix->mat(),
                                     _restrict_solve_to_is,
@@ -466,10 +459,7 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
           LIBMESH_CHKERR(ierr);
 
           // Scatter values into subvec1
-          ierr = VecScatterBegin(scatter1, _subset_solve_mode==SUBSET_COPY_RHS ? rhs->vec() : solution->vec(), subvec1, INSERT_VALUES, SCATTER_FORWARD);
-          LIBMESH_CHKERR(ierr);
-          ierr = VecScatterEnd(scatter1, _subset_solve_mode==SUBSET_COPY_RHS ? rhs->vec() : solution->vec(), subvec1, INSERT_VALUES, SCATTER_FORWARD);
-          LIBMESH_CHKERR(ierr);
+          VecScatterBeginEnd(this->comm(), scatter1, _subset_solve_mode==SUBSET_COPY_RHS ? rhs->vec() : solution->vec(), subvec1, INSERT_VALUES, SCATTER_FORWARD);
 
           // Scale: v *= -1
           ierr = VecScale(subvec1, -1.0);
@@ -574,10 +564,8 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
         default:
           libmesh_error_msg("Invalid subset solve mode = " << _subset_solve_mode);
         }
-      ierr = VecScatterBegin(scatter, subsolution, solution->vec(), INSERT_VALUES, SCATTER_REVERSE);
-      LIBMESH_CHKERR(ierr);
-      ierr = VecScatterEnd(scatter, subsolution, solution->vec(), INSERT_VALUES, SCATTER_REVERSE);
-      LIBMESH_CHKERR(ierr);
+
+      VecScatterBeginEnd(this->comm(), scatter, subsolution, solution->vec(), INSERT_VALUES, SCATTER_REVERSE);
 
       if (this->_preconditioner)
         {
@@ -651,15 +639,8 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
       ierr = VecScatterCreate(rhs->vec(), _restrict_solve_to_is, subrhs, nullptr, scatter.get());
       LIBMESH_CHKERR(ierr);
 
-      ierr = VecScatterBegin(scatter, rhs->vec(), subrhs, INSERT_VALUES, SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
-      ierr = VecScatterEnd(scatter, rhs->vec(), subrhs, INSERT_VALUES, SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
-
-      ierr = VecScatterBegin(scatter, solution->vec(), subsolution, INSERT_VALUES, SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
-      ierr = VecScatterEnd(scatter, solution->vec(), subsolution, INSERT_VALUES, SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
+      VecScatterBeginEnd(this->comm(), scatter, rhs->vec(), subrhs, INSERT_VALUES, SCATTER_FORWARD);
+      VecScatterBeginEnd(this->comm(), scatter, solution->vec(), subsolution, INSERT_VALUES, SCATTER_FORWARD);
 
       ierr = LibMeshCreateSubMatrix(matrix->mat(),
                                     _restrict_solve_to_is,
@@ -697,10 +678,7 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
           ierr = VecScatterCreate(rhs->vec(), _restrict_solve_to_is_complement, subvec1, nullptr, scatter1.get());
           LIBMESH_CHKERR(ierr);
 
-          ierr = VecScatterBegin(scatter1, _subset_solve_mode==SUBSET_COPY_RHS ? rhs->vec() : solution->vec(), subvec1, INSERT_VALUES, SCATTER_FORWARD);
-          LIBMESH_CHKERR(ierr);
-          ierr = VecScatterEnd(scatter1, _subset_solve_mode==SUBSET_COPY_RHS ? rhs->vec() : solution->vec(), subvec1, INSERT_VALUES, SCATTER_FORWARD);
-          LIBMESH_CHKERR(ierr);
+          VecScatterBeginEnd(this->comm(), scatter1, _subset_solve_mode==SUBSET_COPY_RHS ? rhs->vec() : solution->vec(), subvec1, INSERT_VALUES, SCATTER_FORWARD);
 
           ierr = VecScale(subvec1, -1.0);
           LIBMESH_CHKERR(ierr);
@@ -795,10 +773,8 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
         default:
           libmesh_error_msg("Invalid subset solve mode = " << _subset_solve_mode);
         }
-      ierr = VecScatterBegin(scatter, subsolution, solution->vec(), INSERT_VALUES, SCATTER_REVERSE);
-      LIBMESH_CHKERR(ierr);
-      ierr = VecScatterEnd(scatter, subsolution, solution->vec(), INSERT_VALUES, SCATTER_REVERSE);
-      LIBMESH_CHKERR(ierr);
+
+      VecScatterBeginEnd(this->comm(), scatter, subsolution, solution->vec(), INSERT_VALUES, SCATTER_REVERSE);
 
       if (this->_preconditioner)
         {
@@ -888,15 +864,8 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
       ierr = VecScatterCreate(rhs->vec(), _restrict_solve_to_is, subrhs, nullptr, scatter.get());
       LIBMESH_CHKERR(ierr);
 
-      ierr = VecScatterBegin(scatter, rhs->vec(), subrhs, INSERT_VALUES, SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
-      ierr = VecScatterEnd(scatter, rhs->vec(), subrhs, INSERT_VALUES, SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
-
-      ierr = VecScatterBegin(scatter, solution->vec(), subsolution, INSERT_VALUES, SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
-      ierr = VecScatterEnd(scatter, solution->vec(), subsolution, INSERT_VALUES, SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
+      VecScatterBeginEnd(this->comm(), scatter, rhs->vec(), subrhs, INSERT_VALUES, SCATTER_FORWARD);
+      VecScatterBeginEnd(this->comm(), scatter, solution->vec(), subsolution, INSERT_VALUES, SCATTER_FORWARD);
 
       ierr = LibMeshCreateSubMatrix(mat,
                                     _restrict_solve_to_is,
@@ -927,10 +896,7 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
           ierr = VecScatterCreate(rhs->vec(), _restrict_solve_to_is_complement, subvec1, nullptr, scatter1.get());
           LIBMESH_CHKERR(ierr);
 
-          ierr = VecScatterBegin(scatter1, _subset_solve_mode==SUBSET_COPY_RHS ? rhs->vec() : solution->vec(), subvec1, INSERT_VALUES, SCATTER_FORWARD);
-          LIBMESH_CHKERR(ierr);
-          ierr = VecScatterEnd(scatter1, _subset_solve_mode==SUBSET_COPY_RHS ? rhs->vec() : solution->vec(), subvec1, INSERT_VALUES, SCATTER_FORWARD);
-          LIBMESH_CHKERR(ierr);
+          VecScatterBeginEnd(this->comm(), scatter1, _subset_solve_mode==SUBSET_COPY_RHS ? rhs->vec() : solution->vec(), subvec1, INSERT_VALUES, SCATTER_FORWARD);
 
           ierr = VecScale(subvec1, -1.0);
           LIBMESH_CHKERR(ierr);
@@ -1024,10 +990,8 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
         default:
           libmesh_error_msg("Invalid subset solve mode = " << _subset_solve_mode);
         }
-      ierr = VecScatterBegin(scatter, subsolution, solution->vec(), INSERT_VALUES, SCATTER_REVERSE);
-      LIBMESH_CHKERR(ierr);
-      ierr = VecScatterEnd(scatter, subsolution, solution->vec(), INSERT_VALUES, SCATTER_REVERSE);
-      LIBMESH_CHKERR(ierr);
+
+      VecScatterBeginEnd(this->comm(), scatter, subsolution, solution->vec(), INSERT_VALUES, SCATTER_REVERSE);
     }
 
   // return the # of its. and the final residual norm.
@@ -1114,15 +1078,8 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
       ierr = VecScatterCreate(rhs->vec(), _restrict_solve_to_is, subrhs, nullptr, scatter.get());
       LIBMESH_CHKERR(ierr);
 
-      ierr = VecScatterBegin(scatter, rhs->vec(), subrhs, INSERT_VALUES, SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
-      ierr = VecScatterEnd(scatter, rhs->vec(), subrhs, INSERT_VALUES, SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
-
-      ierr = VecScatterBegin(scatter, solution->vec(), subsolution, INSERT_VALUES, SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
-      ierr = VecScatterEnd(scatter, solution->vec(), subsolution, INSERT_VALUES, SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
+      VecScatterBeginEnd(this->comm(), scatter, rhs->vec(), subrhs, INSERT_VALUES, SCATTER_FORWARD);
+      VecScatterBeginEnd(this->comm(), scatter, solution->vec(), subsolution, INSERT_VALUES, SCATTER_FORWARD);
 
       ierr = LibMeshCreateSubMatrix(mat,
                                     _restrict_solve_to_is,
@@ -1159,10 +1116,7 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
           ierr = VecScatterCreate(rhs->vec(), _restrict_solve_to_is_complement, subvec1, nullptr, scatter1.get());
           LIBMESH_CHKERR(ierr);
 
-          ierr = VecScatterBegin(scatter1, _subset_solve_mode==SUBSET_COPY_RHS ? rhs->vec() : solution->vec(), subvec1, INSERT_VALUES, SCATTER_FORWARD);
-          LIBMESH_CHKERR(ierr);
-          ierr = VecScatterEnd(scatter1, _subset_solve_mode==SUBSET_COPY_RHS ? rhs->vec() : solution->vec(), subvec1, INSERT_VALUES, SCATTER_FORWARD);
-          LIBMESH_CHKERR(ierr);
+          VecScatterBeginEnd(this->comm(), scatter1, _subset_solve_mode==SUBSET_COPY_RHS ? rhs->vec() : solution->vec(), subvec1, INSERT_VALUES, SCATTER_FORWARD);
 
           ierr = VecScale(subvec1, -1.0);
           LIBMESH_CHKERR(ierr);
@@ -1271,10 +1225,8 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
         default:
           libmesh_error_msg("Invalid subset solve mode = " << _subset_solve_mode);
         }
-      ierr = VecScatterBegin(scatter, subsolution, solution->vec(), INSERT_VALUES, SCATTER_REVERSE);
-      LIBMESH_CHKERR(ierr);
-      ierr = VecScatterEnd(scatter, subsolution, solution->vec(), INSERT_VALUES, SCATTER_REVERSE);
-      LIBMESH_CHKERR(ierr);
+
+      VecScatterBeginEnd(this->comm(), scatter, subsolution, solution->vec(), INSERT_VALUES, SCATTER_REVERSE);
 
       if (this->_preconditioner)
         {


### PR DESCRIPTION
New helper function is in petsc_solver_exceptions.h. I initially tried
to put this in petsc_macro.h, but I got the error:
```
./include/libmesh/petsc_macro.h: In function ‘void libMesh::VecScatterBeginEnd(const libMesh::Parallel::Communicator&, const Args& ...)’:
./include/libmesh/petsc_macro.h:223:3: error: there are no arguments to ‘LIBMESH_CHKERR2’ that depend on a template parameter, so a declaration of ‘LIBMESH_CHKERR2’ must be available [-fpermissive]
   LIBMESH_CHKERR2(comm, ierr);
   ^~~~~~~~~~~~~~~
```
It could instead be in a separate header file that includes petsc_solver_exception.h, if desired.