### PR TITLE
Minor changes to RBConstructionBase and related code

### DIFF
--- a/include/reduced_basis/rb_construction_base.h
+++ b/include/reduced_basis/rb_construction_base.h
@@ -178,14 +178,28 @@ public:
   const std::string & get_deterministic_training_parameter_name() const;
 
   /**
-   * Set the number of times each sample of the deterministic training parameter is repeated.
+   * Static helper function for generating a randomized set of parameters.
    */
-  void set_deterministic_training_parameter_repeats(unsigned int repeats);
+  static void generate_training_parameters_random(const Parallel::Communicator & communicator,
+                                                  std::map<std::string, bool> log_param_scale,
+                                                  std::map<std::string, std::unique_ptr<NumericVector<Number>>> & training_parameters_in,
+                                                  unsigned int n_training_samples_in,
+                                                  const RBParameters & min_parameters,
+                                                  const RBParameters & max_parameters,
+                                                  int training_parameters_random_seed=-1,
+                                                  bool serial_training_set=false);
 
   /**
-   * Get the number of times each sample of the deterministic training parameter is repeated.
+   * Static helper function for generating a deterministic set of parameters. Only works with 1 or 2
+   * parameters (as defined by the lengths of min/max parameters vectors), otherwise throws an error.
    */
-  unsigned int get_deterministic_training_parameter_repeats() const;
+  static void generate_training_parameters_deterministic(const Parallel::Communicator & communicator,
+                                                         std::map<std::string, bool> log_param_scale,
+                                                         std::map<std::string, std::unique_ptr<NumericVector<Number>>> & training_parameters_in,
+                                                         unsigned int n_training_samples_in,
+                                                         const RBParameters & min_parameters,
+                                                         const RBParameters & max_parameters,
+                                                         bool serial_training_set=false);
 
 protected:
 
@@ -217,30 +231,6 @@ protected:
    */
   static void get_global_max_error_pair(const Parallel::Communicator & communicator,
                                         std::pair<numeric_index_type, Real> & error_pair);
-
-  /**
-   * Static helper function for generating a randomized set of parameters.
-   */
-  static void generate_training_parameters_random(const Parallel::Communicator & communicator,
-                                                  std::map<std::string, bool> log_param_scale,
-                                                  std::map<std::string, std::unique_ptr<NumericVector<Number>>> & training_parameters_in,
-                                                  unsigned int n_training_samples_in,
-                                                  const RBParameters & min_parameters,
-                                                  const RBParameters & max_parameters,
-                                                  int training_parameters_random_seed=-1,
-                                                  bool serial_training_set=false);
-
-  /**
-   * Static helper function for generating a deterministic set of parameters. Only works with 1 or 2
-   * parameters (as defined by the lengths of min/max parameters vectors), otherwise throws an error.
-   */
-  static void generate_training_parameters_deterministic(const Parallel::Communicator & communicator,
-                                                         std::map<std::string, bool> log_param_scale,
-                                                         std::map<std::string, std::unique_ptr<NumericVector<Number>>> & training_parameters_in,
-                                                         unsigned int n_training_samples_in,
-                                                         const RBParameters & min_parameters,
-                                                         const RBParameters & max_parameters,
-                                                         bool serial_training_set=false);
 
 
   //----------- PROTECTED DATA MEMBERS -----------//

--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -125,6 +125,18 @@ public:
   void get_extra_parameter_names(std::set<std::string> & param_names) const;
 
   /**
+   * Erase \p param_name  from _parameters. If \p param_name is not present
+   * in _parameters, then do nothing.
+   */
+  void erase_parameter(const std::string & param_name);
+
+  /**
+   * Erase \p param_name  from _extra_parameters. If \p param_name is not present
+   * in _extra_parameters, then do nothing.
+   */
+  void erase_extra_parameter(const std::string & param_name);
+
+  /**
    * Get const_iterator access to the parameters stored in this RBParameters object.
    */
   const_iterator begin() const;

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -486,7 +486,7 @@ void RBConstructionBase<Base>::generate_training_parameters_deterministic(const 
   if (num_params > 3)
     {
       libMesh::out << "ERROR: Deterministic training sample generation "
-                   << " not implemented for more than three parameters." << std::endl;
+                   << "not implemented for more than three parameters." << std::endl;
       libmesh_not_implemented();
     }
 

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -94,6 +94,16 @@ void RBParameters::get_extra_parameter_names(std::set<std::string> & param_names
     param_names.insert(pr.first);
 }
 
+void RBParameters::erase_parameter(const std::string & param_name)
+{
+  _parameters.erase(param_name);
+}
+
+void RBParameters::erase_extra_parameter(const std::string & param_name)
+{
+  _extra_parameters.erase(param_name);
+}
+
 RBParameters::const_iterator RBParameters::begin() const
 {
   return _parameters.begin();


### PR DESCRIPTION
Added RBParameters::erase_parameter() and RBParameters::erase_extra_parameter().
Made RBConstructionBase::generate_training_parameters_random_* public rather than protected.