### PR TITLE
Remove potential deadlock with Singletons and RemoteElem

### DIFF
--- a/src/base/libmesh_singleton.C
+++ b/src/base/libmesh_singleton.C
@@ -73,6 +73,8 @@ Singleton::Singleton ()
 
 Singleton::Setup::Setup ()
 {
+  SingletonMutex::scoped_lock lock(setup_mtx);
+
   get_setup_cache().push_back (this);
 }
 

--- a/src/geom/remote_elem.C
+++ b/src/geom/remote_elem.C
@@ -28,10 +28,6 @@ namespace
 {
 using namespace libMesh;
 
-typedef Threads::spin_mutex RemoteElemMutex;
-RemoteElemMutex remote_elem_mtx;
-
-
 // Class to be dispatched by Singleton::setup()
 // to create the \p RemoteElem singleton.
 // While this actual object has file-level static
@@ -59,8 +55,6 @@ const RemoteElem * remote_elem;
 
 RemoteElem::~RemoteElem()
 {
-  RemoteElemMutex::scoped_lock lock(remote_elem_mtx);
-
   remote_elem = nullptr;
 }
 
@@ -68,13 +62,6 @@ RemoteElem::~RemoteElem()
 
 const Elem & RemoteElem::create ()
 {
-  if (remote_elem != nullptr)
-    return *remote_elem;
-
-  RemoteElemMutex::scoped_lock lock(remote_elem_mtx);
-
-  // check again - object could have been created while waiting
-  // for the lock to acquire!
   if (remote_elem == nullptr)
     remote_elem = new RemoteElem;
 


### PR DESCRIPTION
We had a potential deadlock before as reported by helgrind. We would
acquire the `remote_elem_mtx` first during setup and then
`singleton_mtx`. However during destruction we acquire `singleton_mtx`
first and then `remote_elem_mtx`. This has the potential to deadlock. So
why not let the singleton code handle all the locking? Seems like
singleton code should do that kind of thing and we should leverage it in
`RemoteElem` if we are going to go through the process of inheriting
from `Singleton`. This reports helgrind clean now