### PR TITLE
Test whether we need to call build_constraint_matrix() recursively

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1586,11 +1586,9 @@ private:
    * Build the constraint matrix C and the forcing vector H
    * associated with the element degree of freedom indices elem_dofs.
    * The optional parameter \p called_recursively should be left at
-   * the default value \p false.  This is used to handle the special
-   * case of an element's degrees of freedom being constrained in
-   * terms of other, local degrees of freedom.  The usual case is for
-   * an elements DOFs to be constrained by some other, external DOFs
-   * and/or Dirichlet conditions.
+   * the default value \p false. It used to be necessary to call this function
+   * recursively to handle "unexpanded" constraints, but we now
+   * expand all the constraints before calling this function.
    *
    * The forcing vector will depend on which solution's heterogenous
    * constraints are being applied.  For the default \p qoi_index this

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1574,11 +1574,9 @@ private:
    * Build the constraint matrix C associated with the element
    * degree of freedom indices elem_dofs. The optional parameter
    * \p called_recursively should be left at the default value
-   * \p false.  This is used to handle the special case of
-   * an element's degrees of freedom being constrained in terms
-   * of other, local degrees of freedom.  The usual case is
-   * for an elements DOFs to be constrained by some other,
-   * external DOFs.
+   * \p false. It used to be necessary to call this function
+   * recursively to handle "unexpanded" constraints, but we now
+   * expand all the constraints before calling this function.
    */
   void build_constraint_matrix (DenseMatrix<Number> & C,
                                 std::vector<dof_id_type> & elem_dofs,

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -3100,23 +3100,21 @@ void DofMap::build_constraint_matrix_and_vector (DenseMatrix<Number> & C,
           dof_set.insert (item.first);
       }
 
-  // May be safe to return at this point
-  // (but remember to stop the perflog)
+  // We can return now if there aren't any constraints
   if (!we_have_constraints)
     return;
 
   for (const auto & dof : elem_dofs)
     dof_set.erase (dof);
 
-  // If we added any DOFS then we need to do this recursively.
-  // It is possible that we just added a DOF that is also
-  // constrained!
-  //
-  // Also, we need to handle the special case of an element having DOFs
-  // constrained in terms of other, local DOFs
-  if (!dof_set.empty() ||  // case 1: constrained in terms of other DOFs
-      !called_recursively) // case 2: constrained in terms of our own DOFs
-    {
+  // libMesh now expands all constraints before calling build_constraint_matrix(),
+  // so there should be no DOFs left in dof_set to handle, and no need to call
+  // this function recursively.
+  libmesh_error_msg_if(called_recursively, "DofMap::build_constraint_matrix() should no longer be called recursively.");
+  libmesh_error_msg_if(!dof_set.empty(),
+                       "All constraints should have been expanded before calling DofMap::build_constraint_matrix(), "
+                       "but dof_set still contains " << dof_set.size() << " entries.");
+
       const DofConstraintValueMap * rhs_values = nullptr;
       if (qoi_index < 0)
         rhs_values = &_primal_constraint_values;
@@ -3176,27 +3174,7 @@ void DofMap::build_constraint_matrix_and_vector (DenseMatrix<Number> & C,
             C(i,i) = 1.;
           }
 
-      // May need to do this recursively.  It is possible
-      // that we just replaced a constrained DOF with another
-      // constrained DOF.
-      DenseMatrix<Number> Cnew;
-      DenseVector<Number> Hnew;
-
-      this->build_constraint_matrix_and_vector (Cnew, Hnew, elem_dofs,
-                                                qoi_index, true);
-
-      if ((C.n() == Cnew.m()) &&          // If the constraint matrix
-          (Cnew.n() == elem_dofs.size())) // is constrained...
-        {
-          // If x = Cy + h and y = Dz + g
-          // Then x = (CD)z + (Cg + h)
-          C.vector_mult_add(H, 1, Hnew);
-
-          C.right_multiply(Cnew);
-        }
-
       libmesh_assert_equal_to (C.n(), elem_dofs.size());
-    }
 }
 
 


### PR DESCRIPTION
The hypothesis is that libmesh now expands all "recursive" constraints before calling this function, and therefore it should not need to be called recursively. This PR tests whether that is the case.