### PR TITLE
Share global-to-local map among numeric vectors

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -74,7 +74,7 @@ template <typename T> class DenseMatrix;
 template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 
-
+typedef std::unordered_map<numeric_index_type,numeric_index_type> GlobalToLocalMap;
 
 // ------------------------------------------------------------
 // Do we need constraints for anything?
@@ -473,6 +473,10 @@ public:
   void clear_send_list ()
   {
     _send_list.clear();
+
+    // _global_to_local_map needs to match _send_list
+    if (_global_to_local_map)
+      _global_to_local_map->clear();
   }
 
   /**
@@ -497,6 +501,8 @@ public:
    * computation.
    */
   const std::vector<dof_id_type> & get_send_list() const { return _send_list; }
+
+  const std::shared_ptr<GlobalToLocalMap> get_global_to_local_map() const { return _global_to_local_map; }
 
   /**
    * \returns A constant reference to the \p _n_nz list for this processor.
@@ -1686,6 +1692,12 @@ private:
    * solution on my processor.
    */
   std::vector<dof_id_type> _send_list;
+
+  /**
+   * Map that maps global to local ghost cells (will be empty if not
+   * in ghost cell mode).
+   */
+  std::shared_ptr<GlobalToLocalMap> _global_to_local_map;
 
   /**
    * Function object to call to add extra entries to the sparsity pattern

--- a/include/numerics/distributed_vector.h
+++ b/include/numerics/distributed_vector.h
@@ -132,6 +132,12 @@ public:
                      const bool fast = false,
                      const ParallelType = AUTOMATIC) override;
 
+  virtual void init (const numeric_index_type N,
+                     const numeric_index_type n_local,
+                     const std::shared_ptr<GlobalToLocalMap> ghost_map,
+                     const bool fast = false,
+                     const ParallelType = AUTOMATIC) override;
+
   virtual void init (const NumericVector<T> & other,
                      const bool fast = false) override;
 
@@ -409,6 +415,17 @@ void DistributedVector<T>::init (const numeric_index_type n,
   this->init(n, n_local, fast, ptype);
 }
 
+template <typename T>
+inline
+void DistributedVector<T>::init (const numeric_index_type n,
+                                 const numeric_index_type n_local,
+                                 const std::shared_ptr<GlobalToLocalMap> /*ghost_map*/,
+                                 const bool fast,
+                                 const ParallelType ptype)
+{
+  // TODO: we shouldn't ignore the ghost sparsity pattern
+  this->init(n, n_local, fast, ptype);
+}
 
 
 /* Default implementation for solver packages for which ghosted

--- a/include/numerics/eigen_sparse_vector.h
+++ b/include/numerics/eigen_sparse_vector.h
@@ -90,6 +90,18 @@ public:
                      const std::vector<numeric_index_type> & ghost,
                      const ParallelType = AUTOMATIC);
 
+   /**
+    * Constructor. Set local dimension to \p n_local, the global
+    * dimension to \p n, but additionally reserve memory for the
+    * indices specified by the \p ghost_map argument.
+    * \p ghost_map is a global-to-local map.
+    */
+   EigenSparseVector (const Parallel::Communicator & comm_in,
+                      const numeric_index_type N,
+                      const numeric_index_type n_local,
+                      const std::shared_ptr<GlobalToLocalMap> ghost_map,
+                      const ParallelType = AUTOMATIC);
+
   /**
    * Copy assignment operator. Does some state checks before copying
    * the underlying Eigen data type.
@@ -133,6 +145,12 @@ public:
   virtual void init (const numeric_index_type N,
                      const numeric_index_type n_local,
                      const std::vector<numeric_index_type> & ghost,
+                     const bool fast = false,
+                     const ParallelType = AUTOMATIC) override;
+
+  virtual void init (const numeric_index_type N,
+                     const numeric_index_type n_local,
+                     const std::shared_ptr<GlobalToLocalMap> ghost_map,
                      const bool fast = false,
                      const ParallelType = AUTOMATIC) override;
 
@@ -305,7 +323,17 @@ EigenSparseVector<T>::EigenSparseVector (const Parallel::Communicator & comm_in,
   this->init(N, n_local, ghost, false, ptype);
 }
 
-
+template <typename T>
+inline
+EigenSparseVector<T>::EigenSparseVector (const Parallel::Communicator & comm_in,
+                                         const numeric_index_type N,
+                                         const numeric_index_type n_local,
+                                         const std::shared_ptr<GlobalToLocalMap> ghost_map,
+                                         const ParallelType ptype)
+  : NumericVector<T>(comm_in, ptype)
+{
+  this->init(N, n_local, ghost_map, false, ptype);
+}
 
 template <typename T>
 inline
@@ -357,6 +385,18 @@ void EigenSparseVector<T>::init (const numeric_index_type n,
                                  const ParallelType ptype)
 {
   libmesh_assert(ghost.empty());
+  this->init(n,n_local,fast,ptype);
+}
+
+template <typename T>
+inline
+void EigenSparseVector<T>::init (const numeric_index_type n,
+                                 const numeric_index_type n_local,
+                                 std::shared_ptr<GlobalToLocalMap> libmesh_dbg_var(ghost_map),
+                                 const bool fast,
+                                 const ParallelType ptype)
+{
+  libmesh_assert(ghost_map->empty());
   this->init(n,n_local,fast,ptype);
 }
 

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -58,6 +58,11 @@ template <typename T> class SparseMatrix;
 template <typename T> class ShellMatrix;
 
 /**
+ * Type for map that maps global to local ghost cells.
+ */
+typedef std::unordered_map<numeric_index_type,numeric_index_type> GlobalToLocalMap;
+
+/**
  * \brief Provides a uniform interface to vector storage schemes for different
  * linear algebra libraries.
  *
@@ -111,6 +116,18 @@ public:
                  const numeric_index_type n_local,
                  const std::vector<numeric_index_type> & ghost,
                  const ParallelType ptype = AUTOMATIC);
+
+   /**
+    * Constructor. Set local dimension to \p n_local, the global
+    * dimension to \p n, but additionally reserve memory for the
+    * indices specified by the \p ghost_map argument.
+    * \p ghost_map is global-to-local map for ghosting elements.
+    */
+   NumericVector (const Parallel::Communicator & comm_in,
+                  const numeric_index_type N,
+                  const numeric_index_type n_local,
+                  const std::shared_ptr<GlobalToLocalMap> ghost_map,
+                  const ParallelType ptype = AUTOMATIC);
 
   /**
    * This _looks_ like a copy assignment operator, but note that,
@@ -233,6 +250,17 @@ public:
                      const std::vector<numeric_index_type> & ghost,
                      const bool fast = false,
                      const ParallelType ptype = AUTOMATIC) = 0;
+
+   /**
+    * Create a vector that holds tha local indices plus those specified
+    * in the \p ghost_map argument. \p ghost_map is a global-to-local map
+    * for ghosting elements.
+    */
+   virtual void init (const numeric_index_type n,
+                      const numeric_index_type n_local,
+                      const std::shared_ptr<GlobalToLocalMap> ghost_map,
+                      const bool fast = false,
+                      const ParallelType ptype = AUTOMATIC) = 0;
 
   /**
    * Creates a vector that has the same dimension and storage type as
@@ -807,6 +835,22 @@ NumericVector<T>::NumericVector (const Parallel::Communicator & comm_in,
                                  const numeric_index_type /*n*/,
                                  const numeric_index_type /*n_local*/,
                                  const std::vector<numeric_index_type> & /*ghost*/,
+                                 const ParallelType ptype) :
+  ParallelObject(comm_in),
+  _is_closed(false),
+  _is_initialized(false),
+  _type(ptype)
+{
+  libmesh_not_implemented(); // Abstract base class!
+  // init(n, n_local, ghost, false, ptype);
+}
+
+template <typename T>
+inline
+NumericVector<T>::NumericVector (const Parallel::Communicator & comm_in,
+                                 const numeric_index_type /*n*/,
+                                 const numeric_index_type /*n_local*/,
+                                 const std::shared_ptr<GlobalToLocalMap> /*ghost_map*/,
                                  const ParallelType ptype) :
   ParallelObject(comm_in),
   _is_closed(false),

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -145,6 +145,7 @@ DofMap::DofMap(const unsigned int number,
   _end_df(),
   _first_scalar_df(),
   _send_list(),
+  _global_to_local_map(std::make_shared<GlobalToLocalMap>()),
   _augment_sparsity_pattern(nullptr),
   _extra_sparsity_function(nullptr),
   _extra_sparsity_context(nullptr),
@@ -1706,6 +1707,12 @@ void DofMap::prepare_send_list ()
   // Remove the end of the send_list.  Use the "swap trick"
   // from Effective STL
   std::vector<dof_id_type> (_send_list.begin(), new_end).swap (_send_list);
+
+  libmesh_assert(_global_to_local_map);
+
+  /* Make the global-to-local ghost cell map.  */
+  for (auto i : index_range(_send_list))
+    (*_global_to_local_map)[_send_list[i]] = i;
 
   // Make sure the send list has nothing invalid in it.
   libmesh_assert(_send_list.empty() || _send_list.back() < this->n_dofs());

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1710,6 +1710,9 @@ void DofMap::prepare_send_list ()
 
   libmesh_assert(_global_to_local_map);
 
+  //Let us clear up '_global_to_local_map', and build it from scratch
+  _global_to_local_map->clear();
+
   /* Make the global-to-local ghost cell map.  */
   for (auto i : index_range(_send_list))
     (*_global_to_local_map)[_send_list[i]] = i;

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -2643,7 +2643,7 @@ void DofMap::enforce_constraints_exactly (const System & system,
     {
       v_built = NumericVector<Number>::build(this->comm());
       v_built->init (v->size(), v->local_size(),
-                     this->get_send_list(), true,
+                     this->get_global_to_local_map(), true,
                      GHOSTED);
       v->localize(*v_built, this->get_send_list());
       v_built->close();
@@ -2723,7 +2723,7 @@ void DofMap::enforce_constraints_on_residual (const NonlinearImplicitSystem & sy
     {
       solution_built = NumericVector<Number>::build(this->comm());
       solution_built->init (solution->size(), solution->local_size(),
-                            this->get_send_list(), true, GHOSTED);
+                            this->get_global_to_local_map(), true, GHOSTED);
       solution->localize(*solution_built, this->get_send_list());
       solution_built->close();
       solution_local = solution_built.get();
@@ -2820,7 +2820,7 @@ void DofMap::enforce_adjoint_constraints_exactly (NumericVector<Number> & v,
     {
       v_built = NumericVector<Number>::build(this->comm());
       v_built->init (v.size(), v.local_size(),
-                     this->get_send_list(), true, GHOSTED);
+                     this->get_global_to_local_map(), true, GHOSTED);
       v.localize(*v_built, this->get_send_list());
       v_built->close();
       v_local = v_built.get();

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -546,12 +546,12 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
   // local ghosted vector, this ensures each processor has all the dof_indices to compute an error indicator for
   // an element it owns
   std::unique_ptr<NumericVector<Number>> localized_projected_residual = NumericVector<Number>::build(system.comm());
-  localized_projected_residual->init(system.n_dofs(), system.n_local_dofs(), system.get_dof_map().get_send_list(), false, GHOSTED);
+  localized_projected_residual->init(system.n_dofs(), system.n_local_dofs(), system.get_dof_map().get_global_to_local_map(), false, GHOSTED);
   projected_residual.localize(*localized_projected_residual, system.get_dof_map().get_send_list());
 
   // Each adjoint solution will also require ghosting; for efficiency we'll reuse the same memory
   std::unique_ptr<NumericVector<Number>> localized_adjoint_solution = NumericVector<Number>::build(system.comm());
-  localized_adjoint_solution->init(system.n_dofs(), system.n_local_dofs(), system.get_dof_map().get_send_list(), false, GHOSTED);
+  localized_adjoint_solution->init(system.n_dofs(), system.n_local_dofs(), system.get_dof_map().get_global_to_local_map(), false, GHOSTED);
 
   // We will loop over each adjoint solution, localize that adjoint
   // solution and then loop over local elements

--- a/src/error_estimation/uniform_refinement_estimator.C
+++ b/src/error_estimation/uniform_refinement_estimator.C
@@ -308,7 +308,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
       projected_solutions[i] = NumericVector<Number>::build(system.comm());
       projected_solutions[i]->init(system.solution->size(),
                                    system.solution->local_size(),
-                                   system.get_dof_map().get_send_list(),
+                                   system.get_dof_map().get_global_to_local_map(),
                                    true, GHOSTED);
       system.solution->localize(*projected_solutions[i],
                                 system.get_dof_map().get_send_list());

--- a/src/solvers/second_order_unsteady_solver.C
+++ b/src/solvers/second_order_unsteady_solver.C
@@ -46,11 +46,11 @@ void SecondOrderUnsteadySolver::init_data()
 
 #ifdef LIBMESH_ENABLE_GHOSTED
   _old_local_solution_rate->init (_system.n_dofs(), _system.n_local_dofs(),
-                                  _system.get_dof_map().get_send_list(), false,
+                                  _system.get_dof_map().get_global_to_local_map(), false,
                                   GHOSTED);
 
   _old_local_solution_accel->init (_system.n_dofs(), _system.n_local_dofs(),
-                                   _system.get_dof_map().get_send_list(), false,
+                                   _system.get_dof_map().get_global_to_local_map(), false,
                                    GHOSTED);
 #else
   _old_local_solution_rate->init (_system.n_dofs(), false, SERIAL);
@@ -64,11 +64,11 @@ void SecondOrderUnsteadySolver::reinit ()
 
 #ifdef LIBMESH_ENABLE_GHOSTED
   _old_local_solution_rate->init (_system.n_dofs(), _system.n_local_dofs(),
-                                  _system.get_dof_map().get_send_list(), false,
+                                  _system.get_dof_map().get_global_to_local_map(), false,
                                   GHOSTED);
 
   _old_local_solution_accel->init (_system.n_dofs(), _system.n_local_dofs(),
-                                   _system.get_dof_map().get_send_list(), false,
+                                   _system.get_dof_map().get_global_to_local_map(), false,
                                    GHOSTED);
 #else
   _old_local_solution_rate->init (_system.n_dofs(), false, SERIAL);

--- a/src/solvers/unsteady_solver.C
+++ b/src/solvers/unsteady_solver.C
@@ -71,7 +71,7 @@ void UnsteadySolver::init_data()
 
 #ifdef LIBMESH_ENABLE_GHOSTED
   old_local_nonlinear_solution->init (_system.n_dofs(), _system.n_local_dofs(),
-                                      _system.get_dof_map().get_send_list(), false,
+                                      _system.get_dof_map().get_global_to_local_map(), false,
                                       GHOSTED);
 #else
   old_local_nonlinear_solution->init (_system.n_dofs(), false, SERIAL);
@@ -86,7 +86,7 @@ void UnsteadySolver::reinit ()
 
 #ifdef LIBMESH_ENABLE_GHOSTED
   old_local_nonlinear_solution->init (_system.n_dofs(), _system.n_local_dofs(),
-                                      _system.get_dof_map().get_send_list(), false,
+                                      _system.get_dof_map().get_global_to_local_map(), false,
                                       GHOSTED);
 #else
   old_local_nonlinear_solution->init (_system.n_dofs(), false, SERIAL);

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -240,7 +240,7 @@ void System::init_data ()
   // Resize the current_local_solution for the current mesh
 #ifdef LIBMESH_ENABLE_GHOSTED
   current_local_solution->init (this->n_dofs(), this->n_local_dofs(),
-                                _dof_map->get_send_list(), false,
+                                _dof_map->get_global_to_local_map(), false,
                                 GHOSTED);
 #else
   current_local_solution->init (this->n_dofs(), false, SERIAL);
@@ -259,7 +259,7 @@ void System::init_data ()
         {
 #ifdef LIBMESH_ENABLE_GHOSTED
           pr.second->init (this->n_dofs(), this->n_local_dofs(),
-                           _dof_map->get_send_list(), false,
+                           _dof_map->get_global_to_local_map(), false,
                            GHOSTED);
 #else
           libmesh_error_msg("Cannot initialize ghosted vectors when they are not enabled.");
@@ -359,7 +359,7 @@ void System::restrict_vectors ()
             {
 #ifdef LIBMESH_ENABLE_GHOSTED
               pr.second->init (this->n_dofs(), this->n_local_dofs(),
-                               _dof_map->get_send_list(), false,
+                               _dof_map->get_global_to_local_map(), false,
                                GHOSTED);
 #else
               libmesh_error_msg("Cannot initialize ghosted vectors when they are not enabled.");
@@ -381,7 +381,7 @@ void System::restrict_vectors ()
 
 #ifdef LIBMESH_ENABLE_GHOSTED
   current_local_solution->init(this->n_dofs(),
-                               this->n_local_dofs(), send_list,
+                               this->n_local_dofs(), _dof_map->get_global_to_local_map(),
                                false, GHOSTED);
 #else
   current_local_solution->init(this->n_dofs());
@@ -725,7 +725,7 @@ NumericVector<Number> & System::add_vector (const std::string & vec_name,
         {
 #ifdef LIBMESH_ENABLE_GHOSTED
           buf->init (this->n_dofs(), this->n_local_dofs(),
-                     _dof_map->get_send_list(), false,
+                     _dof_map->get_global_to_local_map(), false,
                      GHOSTED);
 #else
           libmesh_error_msg("Cannot initialize ghosted vectors when they are not enabled.");
@@ -1594,7 +1594,7 @@ Real System::calculate_norm(const NumericVector<Number> & v,
 
   // Localize the potentially parallel vector
   std::unique_ptr<NumericVector<Number>> local_v = NumericVector<Number>::build(this->comm());
-  local_v->init(v.size(), v.local_size(), _dof_map->get_send_list(),
+  local_v->init(v.size(), v.local_size(), _dof_map->get_global_to_local_map(),
                 true, GHOSTED);
   v.localize (*local_v, _dof_map->get_send_list());
 

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -323,7 +323,7 @@ void System::project_vector (const NumericVector<Number> & old_v,
       new_vector_ptr = new_vector_built.get();
       local_old_vector = local_old_vector_built.get();
       new_vector_ptr->init(this->n_dofs(), this->n_local_dofs(),
-                           this->get_dof_map().get_send_list(), false,
+                           this->get_dof_map().get_global_to_local_map(), false,
                            GHOSTED);
       local_old_vector->init(old_v.size(), old_v.local_size(),
                              projection_list.send_list, false, GHOSTED);
@@ -342,7 +342,7 @@ void System::project_vector (const NumericVector<Number> & old_v,
       projection_list.unique();
 
       new_v.init (this->n_dofs(), this->n_local_dofs(),
-                  this->get_dof_map().get_send_list(), false, GHOSTED);
+                  this->get_dof_map().get_global_to_local_map(), false, GHOSTED);
 
       local_old_vector_built = NumericVector<Number>::build(this->comm());
       new_vector_ptr = &new_v;

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -604,8 +604,12 @@ public:
     unsigned int n_var =
       sys.add_variable("n", Order(order), RATIONAL_BERNSTEIN);
 
-    es.init();
     dyna.add_spline_constraints(sys.get_dof_map(), sys.number(), n_var);
+    // `add_spline_constraints` secretly changed `send_list` and `global_to_local_map`
+    // by calling `dof_map.prepare_send_list()`
+    // If we initialize system earlier, then PetscVector will be out of sync
+    // We should init system only when everything is ready.
+    es.init();
 
     sys.project_solution(sin_x_plus_cos_y, nullptr, es.parameters);
 


### PR DESCRIPTION
Global-to-local map may uses a lot of memory. One quick way to help that is to share the global-to-local map among vectors.

I need to return code to do comparison, but here is some data.

Before PR:

```
(pprof) list PetscVector::init
Total: 1004.79MB
ROUTINE ======================== libMesh::PetscVector::init in /home/kongf/workhome/sawtooth/moosebm/libmesh/installed/include/libmesh/petsc_vector.h
     0  314.07MB (flat, cum) 31.26% of Total
     .     .  746: this->_type = GHOSTED;
     .     .  747:
     .     .  748: /* Make the global-to-local ghost cell map. */
     .     .  749: for (auto i : index_range(ghost))
     .     .  750:  {
     .  314.07MB  751:   _global_to_local_map[ghost[i]] = i;
     .     .  752:  }
     .     .  753:
     .     .  754: /* Create vector. */
     .     .  755: ierr = VecCreateGhost (this->comm().get(), petsc_n_local, petsc_n,
     .     .  756:             petsc_n_ghost, petsc_ghost,
(pprof)
```

After this PR:

```

(pprof) list PetscVector::init
Total: 191.66MB
```