### PR TITLE
Use parallel_sync for SparsityPattern

### DIFF
--- a/src/base/sparsity_pattern.C
+++ b/src/base/sparsity_pattern.C
@@ -537,6 +537,8 @@ void Build::parallel_sync ()
       for (auto i : IntRange<std::size_t>(0, n_rows))
         {
           const auto r = received_ids[i];
+          libmesh_assert(dof_map.local_index(r));
+
           const auto my_r = r - local_first_dof;
 
           auto & their_row = received_rows[i];

--- a/src/base/sparsity_pattern.C
+++ b/src/base/sparsity_pattern.C
@@ -28,6 +28,8 @@
 #include "libmesh/hashword.h"
 #include "libmesh/parallel_algebra.h"
 #include "libmesh/parallel.h"
+#include "libmesh/parallel_sync.h"
+#include "libmesh/utility.h"
 
 // TIMPI includes
 #include "timpi/communicator.h"
@@ -472,24 +474,16 @@ void Build::parallel_sync ()
   libmesh_assert(this->comm().verify(need_full_sparsity_pattern));
 
   auto & comm = this->comm();
-  auto pid = comm.rank();
-  auto num_procs = comm.size();
-
-  auto dof_tag = comm.get_unique_tag();
-  auto row_tag = comm.get_unique_tag();
+  auto my_pid = comm.rank();
 
   const auto n_global_dofs   = dof_map.n_dofs();
-  const auto n_dofs_on_proc  = dof_map.n_dofs_on_processor(pid);
+  const auto n_dofs_on_proc  = dof_map.n_dofs_on_processor(my_pid);
   const auto local_first_dof = dof_map.first_dof();
   const auto local_end_dof   = dof_map.end_dof();
 
   // The data to send
-  std::map<processor_id_type, std::pair<std::vector<dof_id_type>, std::vector<Row>>> data_to_send;
-
-  // True/false if we're sending to that processor
-  std::vector<char> will_send_to(num_procs);
-
-  processor_id_type num_sends = 0;
+  std::map<processor_id_type, std::vector<dof_id_type>> ids_to_send;
+  std::map<processor_id_type, std::vector<Row>> rows_to_send;
 
   // Loop over the nonlocal rows and transform them into the new datastructure
   NonlocalGraph::iterator it = nonlocal_pattern.begin();
@@ -502,139 +496,107 @@ void Build::parallel_sync ()
     while (dof_id >= dof_map.end_dof(proc_id))
       proc_id++;
 
-    // Count the unique sends
-    if (!will_send_to[proc_id])
-      num_sends++;
-
-    will_send_to[proc_id] = true;
-
-    // rhs [] on purpose
-    auto & proc_data = data_to_send[proc_id];
-
-    proc_data.first.push_back(dof_id);
+    ids_to_send[proc_id].push_back(dof_id);
 
     // Note this invalidates the data in nonlocal_pattern
-    proc_data.second.emplace_back(std::move(row));
+    rows_to_send[proc_id].push_back(std::move(row));
 
     // Might as well remove it since it's invalidated anyway
     it = nonlocal_pattern.erase(it);
   }
 
-  // Tell everyone about where everyone will send to
-  comm.alltoall(will_send_to);
+  std::map<processor_id_type, std::vector<dof_id_type>> received_ids_map;
 
-  // will_send_to now represents who we'll receive from
-  // give it a good name
-  auto & will_receive_from = will_send_to;
-
-  std::vector<Parallel::Request> dof_sends(num_sends);
-  std::vector<Parallel::Request> row_sends(num_sends);
-
-  // Post all of the sends
-  processor_id_type current_send = 0;
-  for (auto & proc_data : data_to_send)
-  {
-    auto proc_id = proc_data.first;
-
-    auto & dofs = proc_data.second.first;
-    auto & rows = proc_data.second.second;
-
-    comm.send(proc_id, dofs, dof_sends[current_send], dof_tag);
-    comm.send(proc_id, rows, row_sends[current_send], row_tag);
-
-    current_send++;
-  }
-
-  // Figure out how many receives we're going to have and make a
-  // quick list of who's sending
-  processor_id_type num_receives = 0;
-  std::vector<processor_id_type> receiving_from;
-  for (processor_id_type proc_id = 0; proc_id < num_procs; proc_id++)
-  {
-    auto will = will_receive_from[proc_id];
-
-    if (will)
+  auto ids_action_functor =
+    [this,
+     & received_ids_map]
+    (processor_id_type pid,
+     const std::vector<dof_id_type> & received_ids)
     {
-      num_receives++;
-      receiving_from.push_back(proc_id);
-    }
-  }
+      received_ids_map.emplace(pid, received_ids);
+    };
 
-  // Post the receives and handle the data
-  for (auto proc_id : receiving_from)
-  {
-    std::vector<dof_id_type> in_dofs;
-    std::vector<Row> in_rows;
+  Parallel::push_parallel_vector_data(this->comm(), ids_to_send,
+                                      ids_action_functor);
 
-    // Receive dofs
-    comm.receive(proc_id, in_dofs, dof_tag);
-    comm.receive(proc_id, in_rows, row_tag);
-
-    const std::size_t n_rows = in_dofs.size();
-    for (std::size_t i = 0; i != n_rows; ++i)
+  auto rows_action_functor =
+    [this,
+     & received_ids_map,
+     n_global_dofs,
+     n_dofs_on_proc,
+     local_first_dof,
+     local_end_dof]
+    (processor_id_type pid,
+     const std::vector<Row> & received_rows)
     {
-      const auto r = in_dofs[i];
-      const auto my_r = r - local_first_dof;
+      const std::vector<dof_id_type> & received_ids = libmesh_map_find(received_ids_map, pid);
 
-      auto & their_row = in_rows[i];
+      std::size_t n_rows = received_rows.size();
+      libmesh_assert_equal_to(n_rows, received_ids.size());
 
-      if (need_full_sparsity_pattern)
-      {
-        auto & my_row = sparsity_pattern[my_r];
-
-        // They wouldn't have sent an empty row
-        libmesh_assert(!their_row.empty());
-
-        // We can end up with an empty row on a dof that touches our
-        // inactive elements but not our active ones
-        if (my_row.empty())
+      for (auto i : IntRange<std::size_t>(0, n_rows))
         {
-          my_row.assign (their_row.begin(), their_row.end());
-        }
-        else
-        {
-          my_row.insert (my_row.end(),
-                         their_row.begin(),
-                         their_row.end());
+          const auto r = received_ids[i];
+          const auto my_r = r - local_first_dof;
 
-          // We cannot use SparsityPattern::sort_row() here because it expects
-          // the [begin,middle) [middle,end) to be non-overlapping.  This is not
-          // necessarily the case here, so use std::sort()
-          std::sort (my_row.begin(), my_row.end());
+          auto & their_row = received_rows[i];
 
-          my_row.erase(std::unique (my_row.begin(), my_row.end()), my_row.end());
-        }
+          if (need_full_sparsity_pattern)
+            {
+              auto & my_row = sparsity_pattern[my_r];
 
-        // fix the number of on and off-processor nonzeros in this row
-        n_nz[my_r] = n_oz[my_r] = 0;
+              // They wouldn't have sent an empty row
+              libmesh_assert(!their_row.empty());
 
-        for (const auto & df : my_row)
-          if ((df < local_first_dof) || (df >= local_end_dof))
-            n_oz[my_r]++;
+              // We can end up with an empty row on a dof that touches our
+              // inactive elements but not our active ones
+              if (my_row.empty())
+              {
+                my_row.assign (their_row.begin(), their_row.end());
+              }
+              else
+              {
+                my_row.insert (my_row.end(),
+                               their_row.begin(),
+                               their_row.end());
+
+                // We cannot use SparsityPattern::sort_row() here because it expects
+                // the [begin,middle) [middle,end) to be non-overlapping.  This is not
+                // necessarily the case here, so use std::sort()
+                std::sort (my_row.begin(), my_row.end());
+
+                my_row.erase(std::unique (my_row.begin(), my_row.end()), my_row.end());
+              }
+
+              // fix the number of on and off-processor nonzeros in this row
+              n_nz[my_r] = n_oz[my_r] = 0;
+
+              for (const auto & df : my_row)
+                if ((df < local_first_dof) || (df >= local_end_dof))
+                  n_oz[my_r]++;
+                else
+                  n_nz[my_r]++;
+            }
           else
-            n_nz[my_r]++;
-      }
-      else
-      {
-        for (const auto & df : their_row)
-          if ((df < local_first_dof) || (df >= local_end_dof))
-            n_oz[my_r]++;
-          else
-            n_nz[my_r]++;
+            {
+              for (const auto & df : their_row)
+                if ((df < local_first_dof) || (df >= local_end_dof))
+                  n_oz[my_r]++;
+                else
+                  n_nz[my_r]++;
 
-        n_nz[my_r] = std::min(n_nz[my_r], n_dofs_on_proc);
-        n_oz[my_r] = std::min(n_oz[my_r],
-                              static_cast<dof_id_type>(n_global_dofs-n_nz[my_r]));
-      }
-    }
-  }
+              n_nz[my_r] = std::min(n_nz[my_r], n_dofs_on_proc);
+              n_oz[my_r] = std::min(n_oz[my_r],
+                                    static_cast<dof_id_type>(n_global_dofs-n_nz[my_r]));
+            }
+        }
+    };
+
+  Parallel::push_parallel_vector_data(this->comm(), rows_to_send,
+                                      rows_action_functor);
 
   // We should have sent everything at this point.
   libmesh_assert (nonlocal_pattern.empty());
-
-  // Make sure to cleanup requests
-  Parallel::wait(dof_sends);
-  Parallel::wait(row_sends);
 }
 
 


### PR DESCRIPTION
I worked this up while trying to debug sparsity calculation issues for the projection calculation in #2808 - that turned out to be a red herring, but the new code here is a little more readable and ought to scale much better to large processor counts.

This depends on (and includes) a TIMPI submodule update.