### PR TITLE
Add warnings arising from clang 11 to ignore_warnings

### DIFF
--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -46,6 +46,13 @@
 // This was introduced in 3.6
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"
 #endif // clang > 3.5
+// These were introduced in clang 10
+#if (__clang_major__ > 9)
+// Ignore warnings from code that does "if (foo) bar();"
+#pragma clang diagnostic ignored "-Wmisleading-indentation"
+#pragma clang diagnostic ignored "-Wint-in-bool-context"
+#pragma clang diagnostic ignored "-Wdeprecated-copy"
+#endif // clang > 9
 #endif
 
 #if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__)


### PR DESCRIPTION
I am updating the MOOSE package to clang 11, to allow support for XCode 12 and Big Sur (see idaholab/moose#16295). This has uncovered a few new warnings when building.

The following three were already present in newer GCC version diagnostic flags (and were new in clang 10), so I've added them in directly:
- `-Wint-in-bool-context`
- `-Wmisleading-indentation`
- `-Wdeprecated-copy`

I have a few more that are brand new (comparing my clang 9 build output to clang 11). @roystgnr since all of these are related to contribs, what do you recommend I do with these? I am providing an example warning output for each in a dropdown.

- `-Wimplicit-const-int-float-conversion` related to netcdf3
<details>
  <summary>Click to see example output</summary>

```
  CC       libnetcdf3_la-ncx.lo
/Users/icenct/projects/moose/scripts/../libmesh/contrib/netcdf/v4/libsrc/ncx.m4:1655:12: warning: implicit conversion from 'long long' to 'float' changes value from 9223372036854775807 to 9223372036854775808 [-Wimplicit-const-int-float-conversion]
        if (xx == LONGLONG_MAX)      *ip = LONGLONG_MAX;
               ~~ ^~~~~~~~~~~~
/Users/icenct/projects/moose/scripts/../libmesh/contrib/netcdf/v4/libsrc/ncx.m4:144:22: note: expanded from macro 'LONGLONG_MAX'
#define LONGLONG_MAX LONG_LONG_MAX
                     ^~~~~~~~~~~~~
/Users/icenct/opt/miniconda3/envs/testing/lib/clang/11.0.0/include/limits.h:97:24: note: expanded from macro 'LONG_LONG_MAX'
#define LONG_LONG_MAX  __LONG_LONG_MAX__
                       ^~~~~~~~~~~~~~~~~
<built-in>:41:27: note: expanded from here
#define __LONG_LONG_MAX__ 9223372036854775807LL
                          ^~~~~~~~~~~~~~~~~~~~~
```

</details>

- `-Wpointer-compare` related to ExodusII (ex-utils)
<details>
  <summary>Click to see example output</summary>

```
  CC       cbind/src/libdevel_la-ex_copy.lo
/Users/icenct/projects/moose/scripts/../libmesh/contrib/exodusii/v5.22/exodus/cbind/src/ex_utils.c:182:21: warning: comparing a pointer to a null character constant; did you mean to compare to NULL? [-Wpointer-compare]
    if (names[i] != '\0') {
                    ^~~~
                    (void *)0
```

</details>

- `-Wvariadic-macros` doesn't appear to be honored, even though it's already in `ignore_warnings.h`. This is related to tecplot / tecio and X11.
<details>
  <summary>Click to see example output</summary>

```
  CXX      tecsrc/libdbg_la-dataset0.lo
In file included from /Users/icenct/projects/moose/scripts/../libmesh/contrib/tecplot/tecio/tecsrc/auxdata.cpp:2:
In file included from /Users/icenct/projects/moose/scripts/../libmesh/contrib/tecplot/tecio/tecsrc/MASTER.h:508:
In file included from /opt/X11/include/X11/Intrinsic.h:53:
In file included from /opt/X11/include/X11/Xlib.h:47:
/opt/X11/include/X11/Xfuncproto.h:174:24: warning: named variadic macros are a GNU extension [-Wvariadic-macros]
#define _X_NONNULL(args...)  __attribute__((nonnull(args)))
                       ^
```

</details>

- Related to the above, tecplot / tecio / X11 also throws `-Wunused-parameter` and `-Wunused-variable`, but I would imagine we'd want to keep these around :) 
<details>
  <summary>Click to see example output</summary>

```
/Users/icenct/projects/moose/scripts/../libmesh/contrib/tecplot/tecio/tecsrc/dataset0.cpp:872:72: warning: unused parameter 'IsFragmented' [-Wunused-parameter]
                                                       Boolean_t       IsFragmented)
                                                                       ^
/Users/icenct/projects/moose/scripts/../libmesh/contrib/tecplot/tecio/tecsrc/dataio.cpp:300:23: warning: unused variable 'NumGeoms' [-Wunused-variable]
            LgIndex_t NumGeoms = 0;
                      ^
```

</details>

- `-Wreturn-stack-address` related to qhull

<details>
  <summary>Click to see example output</summary>

```
  CXX      src/libqhullcpp/libdbg_la-QhullHyperplane.lo
In file included from /Users/icenct/projects/moose/scripts/../libmesh/contrib/qhull/qhull/src/libqhullcpp/PointCoordinates.cpp:9:
In file included from /Users/icenct/projects/moose/scripts/../libmesh/contrib/qhull/qhull/src/libqhullcpp/QhullError.h:12:
/Users/icenct/projects/moose/scripts/../libmesh/contrib/qhull/qhull/src/libqhullcpp/RoadError.h:65:52: warning: returning address of local temporary object [-Wreturn-stack-address]
    static const char  *stringGlobalLog() { return global_log.str().c_str(); }
                                                   ^~~~~~~~~~~~~~~~
```
</details>

All other warnings I see are consistent with those from clang 9.0.1. 