### PR TITLE
Remove non-unique DOF ids in Build::sorted_connected_dofs()

### DIFF
--- a/src/base/sparsity_pattern.C
+++ b/src/base/sparsity_pattern.C
@@ -95,6 +95,10 @@ void Build::sorted_connected_dofs(const Elem * elem,
   // We can be more efficient if we sort the element DOFs into
   // increasing order
   std::sort(dofs_vi.begin(), dofs_vi.end());
+
+  // Handle cases where duplicate nodes are intentionally assigned to
+  // a single element.
+  dofs_vi.erase(std::unique(dofs_vi.begin(), dofs_vi.end()), dofs_vi.end());
 }
 
 


### PR DESCRIPTION
This avoids an assert when building the sparsity pattern for "degenerate" elements. These are elements where a single Node is repeated twice in the connectivity array, allowing us to solve on e.g. a Quad4 that has a zero length side, effectively making it a Tri3. Surprisingly, this basically works in libmesh with a few minor exceptions such as avoiding `reinit()` calls on the degenerate Node and degenerate side, which would otherwise result in zero Jacobian errors. 

The degenerate element approach is useful since in cases where you would need to have a hybrid Quad/Tri mesh, you can instead get away with having all elements in a single Quad4 subdomain, some of which are degenerate. This approach is apparently used in some of the standard FE software like Abaqus, so it is quite common to see it in practice as well.

To check whether this extra `std::unique` call had a noticeable impact on the `build_sparsity()` routine, I ran five trials of: `./example-opt -d 3 -n 20` both before and after my change, but there seemed to be almost no difference.

BEFORE
```
 ---------------------------------------------------------------------------------------------------------------------
| Event                                  nCalls     Total Time  Avg Time    Total Time  Avg Time    % of Active Time  |
|                                                   w/o Sub     w/o Sub     With Sub    With Sub    w/o S    With S   |
|---------------------------------------------------------------------------------------------------------------------|
|   build_sparsity()                     1          0.0710      0.071034    0.0810      0.080977    4.02     4.58     |
|   build_sparsity()                     1          0.0670      0.066968    0.0761      0.076067    4.17     4.73     |
|   build_sparsity()                     1          0.0675      0.067546    0.0766      0.076556    4.25     4.81     |
|   build_sparsity()                     1          0.0674      0.067374    0.0767      0.076652    4.20     4.78     |
|   build_sparsity()                     1          0.0669      0.066921    0.0760      0.075967    4.06     4.61     |
```

AFTER
```
 ---------------------------------------------------------------------------------------------------------------------
| Event                                  nCalls     Total Time  Avg Time    Total Time  Avg Time    % of Active Time  |
|                                                   w/o Sub     w/o Sub     With Sub    With Sub    w/o S    With S   |
|---------------------------------------------------------------------------------------------------------------------|
|   build_sparsity()                     1          0.0678      0.067799    0.0764      0.076432    4.08     4.60     |
|   build_sparsity()                     1          0.0685      0.068457    0.0773      0.077341    4.24     4.79     |
|   build_sparsity()                     1          0.0681      0.068125    0.0771      0.077086    4.27     4.83     |
|   build_sparsity()                     1          0.0696      0.069612    0.0787      0.078668    4.37     4.94     |
|   build_sparsity()                     1          0.0678      0.067840    0.0768      0.076799    4.19     4.74     |
```
Average over trials BEFORE: 0.0772438
Average over trials AFTER:  0.0772652
