### PR TITLE
Add const get_periodic_boundaries API in DofMap

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1296,6 +1296,11 @@ public:
     return _periodic_boundaries.get();
   }
 
+  const PeriodicBoundaries * get_periodic_boundaries() const
+  {
+    return _periodic_boundaries.get();
+  }
+
 #endif // LIBMESH_ENABLE_PERIODIC
 
 


### PR DESCRIPTION
I have a `const DofMap *` data member in a class and I want to retrieve
its periodic boundaries for setting periodic boundaries in a ghosting
functor I am initializing, but I currently can't do it because we just
have the non-const API