### PR TITLE
Add some TypeTensor<T> helper functions

### DIFF
--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -382,6 +382,28 @@ public:
   left_multiply (const TypeVector<T2> & p) const;
 
   /**
+   * Computes the vector z = A*x + y without creating an intermediate
+   * temporary. This makes sense as a static function since it does
+   * not require an object.
+   */
+  static
+  TypeVector<T>
+  axpy(const TypeTensor<T> & A,
+       const TypeVector<T> & x,
+       const TypeVector<T> & y)
+  {
+    TypeVector<T> ret;
+    for (int i=0; i<LIBMESH_DIM; i++)
+      {
+        for (int j=0; j<LIBMESH_DIM; j++)
+          ret(i) += A._coords[i*LIBMESH_DIM + j] * x(j);
+
+        ret(i) += y(i);
+      }
+    return ret;
+  }
+
+  /**
    * \returns The transpose of this tensor (with complex numbers not conjugated).
    */
   TypeTensor<T> transpose() const;

--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -324,8 +324,7 @@ public:
    * Computes the matrix-matrix-matrix product, D = A * B * C, or
    * D_ij = A_ik * B_kl * C_lj
    * without creating a temporary. This makes sense as a static function
-   * since it does not require an object but needs to access the _coords
-   * member of the passed-in objects for efficient indexing operations.
+   * since it does not require an object.
    */
   static
   TypeTensor<T>
@@ -333,19 +332,16 @@ public:
             const TypeTensor<T> & B,
             const TypeTensor<T> & C)
   {
-    // Macro for readability
-#define IDX(i,j) i*LIBMESH_DIM + j
-
-    TypeTensor<T> ret;
+    TypeTensor<T> D;
     for (int i=0; i<LIBMESH_DIM; i++)
       for (int j=0; j<LIBMESH_DIM; j++)
         for (int k=0; k<LIBMESH_DIM; k++)
           {
-            T Aik = A._coords[IDX(i,k)];
+            T Aik = A(i,k);
             for (int l=0; l<LIBMESH_DIM; l++)
-              ret._coords[IDX(i,j)] += Aik * B._coords[IDX(k,l)] * C._coords[IDX(l,j)];
+              D(i,j) += Aik * B(k,l) * C(l,j);
           }
-    return ret;
+    return D;
   }
 
   /**
@@ -392,15 +388,15 @@ public:
        const TypeVector<T> & x,
        const TypeVector<T> & y)
   {
-    TypeVector<T> ret;
+    TypeVector<T> z;
     for (int i=0; i<LIBMESH_DIM; i++)
       {
         for (int j=0; j<LIBMESH_DIM; j++)
-          ret(i) += A._coords[i*LIBMESH_DIM + j] * x(j);
+          z(i) += A(i,j) * x(j);
 
-        ret(i) += y(i);
+        z(i) += y(i);
       }
-    return ret;
+    return z;
   }
 
   /**

--- a/tests/numerics/type_tensor_test.C
+++ b/tests/numerics/type_tensor_test.C
@@ -21,10 +21,10 @@ public:
 #if LIBMESH_DIM > 2
   CPPUNIT_TEST(testInverse);
   CPPUNIT_TEST(testLeftMultiply);
-#endif
-  CPPUNIT_TEST(testIsZero);
   CPPUNIT_TEST(matMult3);
   CPPUNIT_TEST(axpy);
+#endif
+  CPPUNIT_TEST(testIsZero);
 
   CPPUNIT_TEST_SUITE_END();
 

--- a/tests/numerics/type_tensor_test.C
+++ b/tests/numerics/type_tensor_test.C
@@ -24,6 +24,7 @@ public:
 #endif
   CPPUNIT_TEST(testIsZero);
   CPPUNIT_TEST(matMult3);
+  CPPUNIT_TEST(axpy);
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -87,6 +88,25 @@ private:
 
     LIBMESH_ASSERT_FP_EQUAL(0, D12, TOLERANCE * TOLERANCE);
     LIBMESH_ASSERT_FP_EQUAL(0, D23, TOLERANCE * TOLERANCE);
+  }
+
+  void axpy()
+  {
+    // Test that the operations
+    // .) A * x + y;
+    // .) axpy(A, x, y);
+    // all give the same result.
+    auto r = [](){ return static_cast<Real>(std::rand()) / static_cast<Real>(RAND_MAX); };
+
+    RealTensorValue A(r(), r(), r(), r(), r(), r(), r(), r(), r());
+    RealVectorValue x(r(), r(), r());
+    RealVectorValue y(r(), r(), r());
+
+    RealVectorValue z1 = A * x + y;
+    RealVectorValue z2 = RealTensorValue::axpy(A, x, y);
+
+    Real z12 = (z1 - z2).norm();
+    LIBMESH_ASSERT_FP_EQUAL(0, z12, TOLERANCE * TOLERANCE);
   }
 
   void testOuterProduct()

--- a/tests/numerics/type_tensor_test.C
+++ b/tests/numerics/type_tensor_test.C
@@ -2,8 +2,10 @@
 #include <libmesh/tensor_value.h>
 #include <libmesh/vector_value.h>
 
-#include "libmesh_cppunit.h"
+// C++ includes
+#include <cstdlib> // std::rand
 
+#include "libmesh_cppunit.h"
 
 using namespace libMesh;
 
@@ -21,6 +23,7 @@ public:
   CPPUNIT_TEST(testLeftMultiply);
 #endif
   CPPUNIT_TEST(testIsZero);
+  CPPUNIT_TEST(matMult3);
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -60,6 +63,30 @@ private:
     LIBMESH_ASSERT_FP_EQUAL(34, left_mult(1), 1e-12);
     LIBMESH_ASSERT_FP_EQUAL(17, right_mult(0), 1e-12);
     LIBMESH_ASSERT_FP_EQUAL(39, right_mult(1), 1e-12);
+  }
+
+  void matMult3()
+  {
+    // Test that the operations
+    // .) A * B * C;
+    // .) A *= B; A *= C;
+    // .) mat_mult3(A, B, C);
+    // all give the same result.
+    auto r = [](){ return static_cast<Real>(std::rand()) / static_cast<Real>(RAND_MAX); };
+
+    RealTensorValue A(r(), r(), r(), r(), r(), r(), r(), r(), r());
+    RealTensorValue B(r(), r(), r(), r(), r(), r(), r(), r(), r());
+    RealTensorValue C(r(), r(), r(), r(), r(), r(), r(), r(), r());
+
+    RealTensorValue D1 = A * B * C;
+    RealTensorValue D2 = A; D2 *= B; D2 *= C;
+    RealTensorValue D3 = RealTensorValue::mat_mult3(A, B, C);
+
+    Real D12 = (D1 - D2).norm();
+    Real D23 = (D2 - D3).norm();
+
+    LIBMESH_ASSERT_FP_EQUAL(0, D12, TOLERANCE * TOLERANCE);
+    LIBMESH_ASSERT_FP_EQUAL(0, D23, TOLERANCE * TOLERANCE);
   }
 
   void testOuterProduct()


### PR DESCRIPTION
I have a few places in applications where these would be useful and hopefully more performant than the alternatives using operators. Note that I did not attempt to introduce all the fancy `CompareTypes<T,T2>::supertype` stuff yet, but I might add that in the future. Also, I decided to make these static member functions of `TypeTensor` rather than free functions as I think it is a good fit for static member functions, but this is a bit different from the approach currently used for e.g. `outer_product()`, so it might be worth making all that consistent as well at some point.
