### PR TITLE
Eliminate leak in merge_ghost_functor_outputs

### DIFF
--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1501,7 +1501,10 @@ merge_ghost_functor_outputs(GhostingFunctor::map_type & elements_to_ghost,
                       std::set<CouplingMatrix *>::iterator temp_it =
                         temporary_coupling_matrices.find(const_cast<CouplingMatrix *>(existing_it->second));
                       if (temp_it != temporary_coupling_matrices.end())
+                      {
+                        delete *temp_it;
                         temporary_coupling_matrices.erase(temp_it);
+                      }
 
                       existing_it->second = nullptr;
                     }


### PR DESCRIPTION
We appear to have a leak from this code as shown [here](https://civet.inl.gov/job/653571/). This patch appears to fix the issue as shown [here](https://civet.inl.gov/job/654071/).