### PR TITLE
The residual history vector pointer for the PETSc linear solver should…

### DIFF
--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -1262,7 +1262,7 @@ void PetscLinearSolver<T>::get_residual_history(std::vector<double> & hist)
   // methods, the number of residuals returned in the history
   // vector may be different from what you are expecting.  For
   // example, TFQMR returns two residual values per iteration step.
-  PetscReal * p;
+  const PetscReal * p;
   ierr = KSPGetResidualHistory(_ksp, &p, &its);
   LIBMESH_CHKERR(ierr);
 
@@ -1295,7 +1295,7 @@ Real PetscLinearSolver<T>::get_initial_residual()
   // methods, the number of residuals returned in the history
   // vector may be different from what you are expecting.  For
   // example, TFQMR returns two residual values per iteration step.
-  PetscReal * p;
+  const PetscReal * p;
   ierr = KSPGetResidualHistory(_ksp, &p, &its);
   LIBMESH_CHKERR(ierr);
 

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -1263,12 +1263,12 @@ void PetscLinearSolver<T>::get_residual_history(std::vector<double> & hist)
   // vector may be different from what you are expecting.  For
   // example, TFQMR returns two residual values per iteration step.
 
-  // Recent development versions of PETSc require the residual
-  // history vector pointer to be declared as const
-#if PETSC_VERSION_RELEASE == 0
-  const PetscReal * p;
-#else
+  // Recent versions of PETSc require the residual
+  // history vector pointer to be declared as const.
+#if PETSC_VERSION_LESS_THAN(3,14,4) && PETSC_VERSION_RELEASE
   PetscReal * p;
+#else
+  const PetscReal * p;
 #endif
 
   ierr = KSPGetResidualHistory(_ksp, &p, &its);
@@ -1304,13 +1304,14 @@ Real PetscLinearSolver<T>::get_initial_residual()
   // vector may be different from what you are expecting.  For
   // example, TFQMR returns two residual values per iteration step.
 
-  // Recent development versions of PETSc require the residual
-  // history vector pointer to be declared as const
-#if PETSC_VERSION_RELEASE == 0
-  const PetscReal * p;
-#else
+  // Recent versions of PETSc require the residual
+  // history vector pointer to be declared as const.
+#if PETSC_VERSION_LESS_THAN(3,14,4) && PETSC_VERSION_RELEASE
   PetscReal * p;
+#else
+  const PetscReal * p;
 #endif
+
 
   ierr = KSPGetResidualHistory(_ksp, &p, &its);
   LIBMESH_CHKERR(ierr);

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -1263,7 +1263,7 @@ void PetscLinearSolver<T>::get_residual_history(std::vector<double> & hist)
   // vector may be different from what you are expecting.  For
   // example, TFQMR returns two residual values per iteration step.
 
-  // Recent development versions of PETSc require the residual 
+  // Recent development versions of PETSc require the residual
   // history vector pointer to be declared as const
 #if PETSC_VERSION_RELEASE == 0
   const PetscReal * p;
@@ -1303,8 +1303,8 @@ Real PetscLinearSolver<T>::get_initial_residual()
   // methods, the number of residuals returned in the history
   // vector may be different from what you are expecting.  For
   // example, TFQMR returns two residual values per iteration step.
- 
-  // Recent development versions of PETSc require the residual 
+
+  // Recent development versions of PETSc require the residual
   // history vector pointer to be declared as const
 #if PETSC_VERSION_RELEASE == 0
   const PetscReal * p;

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -1262,7 +1262,15 @@ void PetscLinearSolver<T>::get_residual_history(std::vector<double> & hist)
   // methods, the number of residuals returned in the history
   // vector may be different from what you are expecting.  For
   // example, TFQMR returns two residual values per iteration step.
+
+  // Recent development versions of PETSc require the residual 
+  // history vector pointer to be declared as const
+#if PETSC_VERSION_RELEASE == 0
   const PetscReal * p;
+#else
+  PetscReal * p;
+#endif
+
   ierr = KSPGetResidualHistory(_ksp, &p, &its);
   LIBMESH_CHKERR(ierr);
 
@@ -1295,7 +1303,15 @@ Real PetscLinearSolver<T>::get_initial_residual()
   // methods, the number of residuals returned in the history
   // vector may be different from what you are expecting.  For
   // example, TFQMR returns two residual values per iteration step.
+ 
+  // Recent development versions of PETSc require the residual 
+  // history vector pointer to be declared as const
+#if PETSC_VERSION_RELEASE == 0
   const PetscReal * p;
+#else
+  PetscReal * p;
+#endif
+
   ierr = KSPGetResidualHistory(_ksp, &p, &its);
   LIBMESH_CHKERR(ierr);
 


### PR DESCRIPTION
… be declared as const, otherwise the compilation will fail with recent (git master branch) PETSc versions