### PR TITLE
Fix print_personal

### DIFF
--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -725,7 +725,7 @@ void PetscMatrix<T>::print_personal(std::ostream & os) const
   // Print to screen if ostream is stdout
   if (os.rdbuf() == std::cout.rdbuf())
     {
-      ierr = MatView(_mat, PETSC_VIEWER_STDOUT_SELF);
+      ierr = MatView(_mat, NULL);
       LIBMESH_CHKERR(ierr);
     }
 


### PR DESCRIPTION
- Fix the communicator in PetscMatrix<T>::print_personal() in order to avoid PETSc error
- Make sure that the output matrix is initialized in PetscMatrix<T>::matrix_matrix_mult() (see this fix in PR #2838 instead )