### PR TITLE
PetscMatrix functions change for static condensation

### DIFF
--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -301,6 +301,18 @@ public:
   void get_row(numeric_index_type i,
                std::vector<numeric_index_type> & indices,
                std::vector<T> & values) const override;
+
+  /**
+   * Similar to the `create_submatrix` function, this function creates a \p
+   * submatrix which is defined by the indices given in the \p rows
+   * and \p cols vectors.
+   * Note: Both \p rows and \p cols can be unsorted;
+   *       Use the above function for better efficiency if your indices are sorted;
+   *       \p rows and \p cols can contain indices that are owned by other processors.
+   */
+   virtual void create_submatrix_nosort(SparseMatrix<T> & submatrix,
+                                        const std::vector<numeric_index_type> & rows,
+                                        const std::vector<numeric_index_type> & cols) const override;
 protected:
 
   /**
@@ -317,7 +329,6 @@ protected:
                               const std::vector<numeric_index_type> & rows,
                               const std::vector<numeric_index_type> & cols,
                               const bool reuse_submatrix) const override;
-
 private:
 
   /**

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -404,6 +404,9 @@ public:
    * This function creates a matrix called "submatrix" which is defined
    * by the row and column indices given in the "rows" and "cols" entries.
    * Currently this operation is only defined for the PetscMatrix type.
+   * Note: The \p rows and \p cols vectors need to be sorted;
+   *       Use the nosort version below if \p rows and \p cols vectors are not sorted;
+   *       The \p rows and \p cols only contain indices that are owned by this processor.
    */
   virtual void create_submatrix(SparseMatrix<T> & submatrix,
                                 const std::vector<numeric_index_type> & rows,
@@ -413,6 +416,21 @@ public:
                          rows,
                          cols,
                          false); // false means DO NOT REUSE submatrix
+  }
+
+  /**
+   * Similar to the above function, this function creates a \p
+   * submatrix which is defined by the indices given in the \p rows
+   * and \p cols vectors.
+   * Note: Both \p rows and \p cols can be unsorted;
+   *       Use the above function for better efficiency if your indices are sorted;
+   *       \p rows and \p cols can contain indices that are owned by other processors.
+   */
+  virtual void create_submatrix_nosort(SparseMatrix<T> & /*submatrix*/,
+                                         const std::vector<numeric_index_type> & /*rows*/,
+                                         const std::vector<numeric_index_type> & /*cols*/) const
+  {
+    libmesh_not_implemented();
   }
 
   /**


### PR DESCRIPTION
Several changes are made in the PetscMatrix class to enable static condensation in this [PR](https://github.com/idaholab/moose/pull/16017)

- Add an unsorted version for `create_submatrix`, which ensures that no zero diagonal entry appears in the Jacobian matrix
- Make sure `matrix_matrix_mult` initializes and closes the product matrix 
- Make sure that `add_sparse_matrix` works properly in parallel