### PR TITLE
Use Utility::enum_to_string() to improve some error messages.

### DIFF
--- a/include/fe/fe_interface_macros.h
+++ b/include/fe/fe_interface_macros.h
@@ -1,7 +1,30 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2020 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
 #ifndef LIBMESH_FE_INTERFACE_MACROS_H
 #define LIBMESH_FE_INTERFACE_MACROS_H
 
+#include "libmesh/libmesh_config.h"
+
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+#include "libmesh/enum_to_string.h"
 
 #define inf_fe_switch(func_and_args)                                \
   do {                                                              \
@@ -37,7 +60,7 @@
             case LAGRANGE:                                                  \
               prefix InfFE<dim,LAGRANGE,CARTESIAN>::func_and_args suffix    \
             default:                                                        \
-              libmesh_error_msg("Invalid radial family = " << fe_t.radial_family);\
+              libmesh_error_msg("Invalid radial family = " << Utility::enum_to_string(fe_t.radial_family)); \
             }                                                               \
             suffix                                                          \
          }                                                                  \
@@ -45,7 +68,7 @@
        case ELLIPSOIDAL:                                                    \
          libmesh_not_implemented();                                         \
        default:                                                             \
-         libmesh_error_msg("Invalid radial mapping " << fe_t.inf_map);      \
+         libmesh_error_msg("Invalid radial mapping " << Utility::enum_to_string(fe_t.inf_map)); \
       }                                                                     \
   } while (0)
 

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -33,6 +33,7 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/petsc_solver_exception.h"
 #include "libmesh/parallel_only.h"
+#include "libmesh/enum_to_string.h"
 
 // PETSc include files.
 #ifdef I
@@ -684,7 +685,7 @@ void PetscVector<T>::init (const numeric_index_type n,
       LIBMESH_CHKERR(ierr);
     }
   else
-    libmesh_error_msg("Unsupported type " << this->_type);
+    libmesh_error_msg("Unsupported type " << Utility::enum_to_string(this->_type));
 
   this->_is_initialized = true;
   this->_is_closed = true;

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -15,10 +15,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-// Local includes
-#include "libmesh/dof_map.h"
-
 // libMesh includes
+#include "libmesh/dof_map.h"
 #include "libmesh/boundary_info.h" // needed for dirichlet constraints
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
@@ -50,6 +48,7 @@
 #include "libmesh/system.h" // needed by enforce_constraints_exactly()
 #include "libmesh/tensor_tools.h"
 #include "libmesh/threads.h"
+#include "libmesh/enum_to_string.h"
 
 // TIMPI includes
 #include "timpi/parallel_implementation.h"
@@ -2943,7 +2942,7 @@ void DofMap::enforce_constraints_exactly (const System & system,
       v_global = v;
     }
   else // unknown v->type()
-    libmesh_error_msg("ERROR: Unknown v->type() == " << v->type());
+    libmesh_error_msg("ERROR: Unsupported NumericVector type == " << Utility::enum_to_string(v->type()));
 
   // We should never hit these asserts because we should error-out in
   // else clause above.  Just to be sure we don't try to use v_local
@@ -3015,7 +3014,7 @@ void DofMap::enforce_constraints_on_residual (const NonlinearImplicitSystem & sy
       solution_local = solution_built.get();
     }
   else // unknown solution->type()
-    libmesh_error_msg("ERROR: Unknown solution->type() == " << solution->type());
+    libmesh_error_msg("ERROR: Unsupported NumericVector type == " << Utility::enum_to_string(solution->type()));
 
   // We should never hit these asserts because we should error-out in
   // else clause above.  Just to be sure we don't try to use solution_local

--- a/src/error_estimation/patch_recovery_error_estimator.C
+++ b/src/error_estimation/patch_recovery_error_estimator.C
@@ -16,13 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-#include <algorithm> // for std::fill
-#include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
-#include <cmath>     // for std::sqrt std::pow std::abs
-
-
-// Local Includes
+// libmesh includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/patch_recovery_error_estimator.h"
 #include "libmesh/dof_map.h"
@@ -43,6 +37,12 @@
 #include "libmesh/enum_error_estimator_type.h"
 #include "libmesh/enum_norm_type.h"
 #include "libmesh/int_range.h"
+#include "libmesh/enum_to_string.h"
+
+// C++ includes
+#include <algorithm> // for std::fill
+#include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
+#include <cmath>     // for std::sqrt std::pow std::abs
 
 namespace libMesh
 {
@@ -577,7 +577,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
 #endif
                     }
                   else
-                    libmesh_error_msg("Unsupported error norm type!");
+                    libmesh_error_msg("Unsupported error norm type == " << Utility::enum_to_string(error_estimator.error_norm.type(var)));
                 } // end quadrature loop
             } // end patch loop
 
@@ -913,7 +913,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                        error_estimator.error_norm.type(var) == H2_SEMINORM)
                 new_error_per_cell[e] += error_estimator.error_norm.weight_sq(var) * element_error;
               else
-                libmesh_error_msg("Unsupported error norm type!");
+                libmesh_error_msg("Unsupported error norm type == " << Utility::enum_to_string(error_estimator.error_norm.type(var)));
             }  // End (re) loop over patch elements
 
         } // end variables loop

--- a/src/error_estimation/weighted_patch_recovery_error_estimator.C
+++ b/src/error_estimation/weighted_patch_recovery_error_estimator.C
@@ -16,13 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-#include <algorithm> // for std::fill
-#include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
-#include <cmath>     // for std::sqrt std::pow std::abs
-
-
-// Local Includes
+// libmesh includes
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
 #include "libmesh/dof_map.h"
@@ -41,6 +35,12 @@
 #include "libmesh/enum_error_estimator_type.h"
 #include "libmesh/enum_order.h"
 #include "libmesh/enum_norm_type.h"
+#include "libmesh/enum_to_string.h"
+
+// C++ includes
+#include <algorithm> // for std::fill
+#include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
+#include <cmath>     // for std::sqrt std::pow std::abs
 
 namespace libMesh
 {
@@ -489,7 +489,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
 #endif
                     }
                   else
-                    libmesh_error_msg("Unsupported error norm type!");
+                    libmesh_error_msg("Unsupported error norm type == " << Utility::enum_to_string(error_estimator.error_norm.type(var)));
                 } // end quadrature loop
             } // end patch loop
 
@@ -837,7 +837,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                        error_estimator.error_norm.type(var) == H2_SEMINORM)
                 new_error_per_cell[e] += error_estimator.error_norm.weight_sq(var) * element_error;
               else
-                libmesh_error_msg("Unsupported error norm type!");
+                libmesh_error_msg("Unsupported error norm type == " << Utility::enum_to_string(error_estimator.error_norm.type(var)));
             }  // End (re) loop over patch elements
 
         } // end variables loop

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -15,14 +15,10 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-
-
-// Local includes
+// libmesh includes
 #include "libmesh/fe.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/enum_elem_type.h"
-
-// For projection code:
 #include "libmesh/boundary_info.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/dense_matrix.h"
@@ -39,6 +35,7 @@
 #include "libmesh/tensor_value.h"
 #include "libmesh/threads.h"
 #include "libmesh/enum_elem_type.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {
@@ -126,7 +123,7 @@ std::unique_ptr<FEAbstract> FEAbstract::build(const unsigned int dim,
             return libmesh_make_unique<FEScalar<0>>(fet);
 
           default:
-            libmesh_error_msg("ERROR: Bad FEType.family= " << fet.family);
+            libmesh_error_msg("ERROR: Bad FEType.family= " << Utility::enum_to_string(fet.family));
           }
       }
       // 1D
@@ -179,7 +176,7 @@ std::unique_ptr<FEAbstract> FEAbstract::build(const unsigned int dim,
             return libmesh_make_unique<FEScalar<1>>(fet);
 
           default:
-            libmesh_error_msg("ERROR: Bad FEType.family= " << fet.family);
+            libmesh_error_msg("ERROR: Bad FEType.family= " << Utility::enum_to_string(fet.family));
           }
       }
 
@@ -240,7 +237,7 @@ std::unique_ptr<FEAbstract> FEAbstract::build(const unsigned int dim,
             return libmesh_make_unique<FESubdivision>(fet);
 
           default:
-            libmesh_error_msg("ERROR: Bad FEType.family= " << fet.family);
+            libmesh_error_msg("ERROR: Bad FEType.family= " << Utility::enum_to_string(fet.family));
           }
       }
 
@@ -298,7 +295,7 @@ std::unique_ptr<FEAbstract> FEAbstract::build(const unsigned int dim,
             return libmesh_make_unique<FENedelecOne<3>>(fet);
 
           default:
-            libmesh_error_msg("ERROR: Bad FEType.family= " << fet.family);
+            libmesh_error_msg("ERROR: Bad FEType.family= " << Utility::enum_to_string(fet.family));
           }
       }
 
@@ -616,7 +613,7 @@ void FEAbstract::get_refspace_nodes(const ElemType itemType, std::vector<Point> 
       }
 
     default:
-      libmesh_error_msg("ERROR: Unknown element type " << itemType);
+      libmesh_error_msg("ERROR: Unknown element type " << Utility::enum_to_string(itemType));
     }
 }
 
@@ -808,7 +805,7 @@ bool FEAbstract::on_reference_element(const Point & p, const ElemType t, const R
 #endif
 
     default:
-      libmesh_error_msg("ERROR: Unknown element type " << t);
+      libmesh_error_msg("ERROR: Unknown element type " << Utility::enum_to_string(t));
     }
 
   // If we get here then the point is _not_ in the

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -38,6 +38,7 @@
 #include "libmesh/tensor_value.h"
 #include "libmesh/threads.h"
 #include "libmesh/fe_type.h"
+#include "libmesh/enum_to_string.h"
 
 // Anonymous namespace, for a helper function for periodic boundary
 // constraint calculations
@@ -232,7 +233,7 @@ FEGenericBase<Real>::build (const unsigned int dim,
             return libmesh_make_unique<FEScalar<0>>(fet);
 
           default:
-            libmesh_error_msg("ERROR: Bad FEType.family= " << fet.family);
+            libmesh_error_msg("ERROR: Bad FEType.family == " << Utility::enum_to_string(fet.family));
           }
       }
       // 1D
@@ -279,7 +280,7 @@ FEGenericBase<Real>::build (const unsigned int dim,
             return libmesh_make_unique<FEScalar<1>>(fet);
 
           default:
-            libmesh_error_msg("ERROR: Bad FEType.family= " << fet.family);
+            libmesh_error_msg("ERROR: Bad FEType.family == " << Utility::enum_to_string(fet.family));
           }
       }
 
@@ -331,7 +332,7 @@ FEGenericBase<Real>::build (const unsigned int dim,
             return libmesh_make_unique<FESubdivision>(fet);
 
           default:
-            libmesh_error_msg("ERROR: Bad FEType.family= " << fet.family);
+            libmesh_error_msg("ERROR: Bad FEType.family == " << Utility::enum_to_string(fet.family));
           }
       }
 
@@ -380,7 +381,7 @@ FEGenericBase<Real>::build (const unsigned int dim,
             return libmesh_make_unique<FEScalar<3>>(fet);
 
           default:
-            libmesh_error_msg("ERROR: Bad FEType.family= " << fet.family);
+            libmesh_error_msg("ERROR: Bad FEType.family == " << Utility::enum_to_string(fet.family));
           }
       }
 
@@ -410,7 +411,7 @@ FEGenericBase<RealGradient>::build (const unsigned int dim,
             return libmesh_make_unique<FEMonomialVec<0>>(fet);
 
           default:
-            libmesh_error_msg("ERROR: Bad FEType.family= " << fet.family);
+            libmesh_error_msg("ERROR: Bad FEType.family == " << Utility::enum_to_string(fet.family));
           }
       }
     case 1:
@@ -424,7 +425,7 @@ FEGenericBase<RealGradient>::build (const unsigned int dim,
             return libmesh_make_unique<FEMonomialVec<1>>(fet);
 
           default:
-            libmesh_error_msg("ERROR: Bad FEType.family= " << fet.family);
+            libmesh_error_msg("ERROR: Bad FEType.family == " << Utility::enum_to_string(fet.family));
           }
       }
     case 2:
@@ -441,7 +442,7 @@ FEGenericBase<RealGradient>::build (const unsigned int dim,
             return libmesh_make_unique<FENedelecOne<2>>(fet);
 
           default:
-            libmesh_error_msg("ERROR: Bad FEType.family= " << fet.family);
+            libmesh_error_msg("ERROR: Bad FEType.family == " << Utility::enum_to_string(fet.family));
           }
       }
     case 3:
@@ -458,7 +459,7 @@ FEGenericBase<RealGradient>::build (const unsigned int dim,
             return libmesh_make_unique<FENedelecOne<3>>(fet);
 
           default:
-            libmesh_error_msg("ERROR: Bad FEType.family= " << fet.family);
+            libmesh_error_msg("ERROR: Bad FEType.family == " << Utility::enum_to_string(fet.family));
           }
       }
 
@@ -490,7 +491,7 @@ FEGenericBase<Real>::build_InfFE (const unsigned int dim,
         switch (fet.radial_family)
           {
           case INFINITE_MAP:
-            libmesh_error_msg("ERROR: Can't build an infinite element with FEFamily = " << fet.radial_family);
+            libmesh_error_msg("ERROR: Can't build an infinite element with FEFamily = " << Utility::enum_to_string(fet.radial_family));
 
           case JACOBI_20_00:
             {
@@ -500,7 +501,7 @@ FEGenericBase<Real>::build_InfFE (const unsigned int dim,
                   return libmesh_make_unique<InfFE<1,JACOBI_20_00,CARTESIAN>>(fet);
 
                 default:
-                  libmesh_error_msg("ERROR: Can't build an infinite element with InfMapType = " << fet.inf_map);
+                  libmesh_error_msg("ERROR: Can't build an infinite element with InfMapType = " << Utility::enum_to_string(fet.inf_map));
                 }
             }
 
@@ -512,7 +513,7 @@ FEGenericBase<Real>::build_InfFE (const unsigned int dim,
                   return libmesh_make_unique<InfFE<1,JACOBI_30_00,CARTESIAN>>(fet);
 
                 default:
-                  libmesh_error_msg("ERROR: Can't build an infinite element with InfMapType = " << fet.inf_map);
+                  libmesh_error_msg("ERROR: Can't build an infinite element with InfMapType = " << Utility::enum_to_string(fet.inf_map));
                 }
             }
 
@@ -524,7 +525,7 @@ FEGenericBase<Real>::build_InfFE (const unsigned int dim,
                   return libmesh_make_unique<InfFE<1,LEGENDRE,CARTESIAN>>(fet);
 
                 default:
-                  libmesh_error_msg("ERROR: Can't build an infinite element with InfMapType = " << fet.inf_map);
+                  libmesh_error_msg("ERROR: Can't build an infinite element with InfMapType = " << Utility::enum_to_string(fet.inf_map));
                 }
             }
 
@@ -536,12 +537,12 @@ FEGenericBase<Real>::build_InfFE (const unsigned int dim,
                   return libmesh_make_unique<InfFE<1,LAGRANGE,CARTESIAN>>(fet);
 
                 default:
-                  libmesh_error_msg("ERROR: Can't build an infinite element with InfMapType = " << fet.inf_map);
+                  libmesh_error_msg("ERROR: Can't build an infinite element with InfMapType = " << Utility::enum_to_string(fet.inf_map));
                 }
             }
 
           default:
-            libmesh_error_msg("ERROR: Bad FEType.radial_family= " << fet.radial_family);
+            libmesh_error_msg("ERROR: Bad FEType.radial_family= " << Utility::enum_to_string(fet.radial_family));
           }
       }
 
@@ -554,7 +555,7 @@ FEGenericBase<Real>::build_InfFE (const unsigned int dim,
         switch (fet.radial_family)
           {
           case INFINITE_MAP:
-            libmesh_error_msg("ERROR: Can't build an infinite element with FEFamily = " << fet.radial_family);
+            libmesh_error_msg("ERROR: Can't build an infinite element with FEFamily = " << Utility::enum_to_string(fet.radial_family));
 
           case JACOBI_20_00:
             {
@@ -564,7 +565,7 @@ FEGenericBase<Real>::build_InfFE (const unsigned int dim,
                   return libmesh_make_unique<InfFE<2,JACOBI_20_00,CARTESIAN>>(fet);
 
                 default:
-                  libmesh_error_msg("ERROR: Don't build an infinite element with InfMapType = " << fet.inf_map);
+                  libmesh_error_msg("ERROR: Don't build an infinite element with InfMapType = " << Utility::enum_to_string(fet.inf_map));
                 }
             }
 
@@ -576,7 +577,7 @@ FEGenericBase<Real>::build_InfFE (const unsigned int dim,
                   return libmesh_make_unique<InfFE<2,JACOBI_30_00,CARTESIAN>>(fet);
 
                 default:
-                  libmesh_error_msg("ERROR: Don't build an infinite element with InfMapType = " << fet.inf_map);
+                  libmesh_error_msg("ERROR: Don't build an infinite element with InfMapType = " << Utility::enum_to_string(fet.inf_map));
                 }
             }
 
@@ -588,7 +589,7 @@ FEGenericBase<Real>::build_InfFE (const unsigned int dim,
                   return libmesh_make_unique<InfFE<2,LEGENDRE,CARTESIAN>>(fet);
 
                 default:
-                  libmesh_error_msg("ERROR: Don't build an infinite element with InfMapType = " << fet.inf_map);
+                  libmesh_error_msg("ERROR: Don't build an infinite element with InfMapType = " << Utility::enum_to_string(fet.inf_map));
                 }
             }
 
@@ -600,12 +601,12 @@ FEGenericBase<Real>::build_InfFE (const unsigned int dim,
                   return libmesh_make_unique<InfFE<2,LAGRANGE,CARTESIAN>>(fet);
 
                 default:
-                  libmesh_error_msg("ERROR: Don't build an infinite element with InfMapType = " << fet.inf_map);
+                  libmesh_error_msg("ERROR: Don't build an infinite element with InfMapType = " << Utility::enum_to_string(fet.inf_map));
                 }
             }
 
           default:
-            libmesh_error_msg("ERROR: Bad FEType.radial_family= " << fet.radial_family);
+            libmesh_error_msg("ERROR: Bad FEType.radial_family= " << Utility::enum_to_string(fet.radial_family));
           }
       }
 
@@ -618,7 +619,7 @@ FEGenericBase<Real>::build_InfFE (const unsigned int dim,
         switch (fet.radial_family)
           {
           case INFINITE_MAP:
-            libmesh_error_msg("ERROR: Don't build an infinite element with FEFamily = " << fet.radial_family);
+            libmesh_error_msg("ERROR: Don't build an infinite element with FEFamily = " << Utility::enum_to_string(fet.radial_family));
 
           case JACOBI_20_00:
             {
@@ -628,7 +629,7 @@ FEGenericBase<Real>::build_InfFE (const unsigned int dim,
                   return libmesh_make_unique<InfFE<3,JACOBI_20_00,CARTESIAN>>(fet);
 
                 default:
-                  libmesh_error_msg("ERROR: Don't build an infinite element with InfMapType = " << fet.inf_map);
+                  libmesh_error_msg("ERROR: Don't build an infinite element with InfMapType = " << Utility::enum_to_string(fet.inf_map));
                 }
             }
 
@@ -640,7 +641,7 @@ FEGenericBase<Real>::build_InfFE (const unsigned int dim,
                   return libmesh_make_unique<InfFE<3,JACOBI_30_00,CARTESIAN>>(fet);
 
                 default:
-                  libmesh_error_msg("ERROR: Don't build an infinite element with InfMapType = " << fet.inf_map);
+                  libmesh_error_msg("ERROR: Don't build an infinite element with InfMapType = " << Utility::enum_to_string(fet.inf_map));
                 }
             }
 
@@ -652,7 +653,7 @@ FEGenericBase<Real>::build_InfFE (const unsigned int dim,
                   return libmesh_make_unique<InfFE<3,LEGENDRE,CARTESIAN>>(fet);
 
                 default:
-                  libmesh_error_msg("ERROR: Don't build an infinite element with InfMapType = " << fet.inf_map);
+                  libmesh_error_msg("ERROR: Don't build an infinite element with InfMapType = " << Utility::enum_to_string(fet.inf_map));
                 }
             }
 
@@ -664,12 +665,12 @@ FEGenericBase<Real>::build_InfFE (const unsigned int dim,
                   return libmesh_make_unique<InfFE<3,LAGRANGE,CARTESIAN>>(fet);
 
                 default:
-                  libmesh_error_msg("ERROR: Don't build an infinite element with InfMapType = " << fet.inf_map);
+                  libmesh_error_msg("ERROR: Don't build an infinite element with InfMapType = " << Utility::enum_to_string(fet.inf_map));
                 }
             }
 
           default:
-            libmesh_error_msg("ERROR: Bad FEType.radial_family= " << fet.radial_family);
+            libmesh_error_msg("ERROR: Bad FEType.radial_family= " << Utility::enum_to_string(fet.radial_family));
           }
       }
 

--- a/src/fe/fe_bernstein_shape_2D.C
+++ b/src/fe/fe_bernstein_shape_2D.C
@@ -16,15 +16,16 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// Local includes
 #include "libmesh/libmesh_config.h"
+
 #ifdef LIBMESH_ENABLE_HIGHER_ORDER_SHAPES
 
+// libmesh includes
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 #include "libmesh/number_lookups.h"
 #include "libmesh/utility.h"
-
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {
@@ -369,7 +370,7 @@ Real FE<2,BERNSTEIN>::shape(const Elem * elem,
         } // switch order
 
     default:
-      libmesh_error_msg("ERROR: Unsupported element type = " << type);
+      libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
     } // switch type
 }
 
@@ -557,7 +558,7 @@ Real FE<2,BERNSTEIN>::shape_deriv(const Elem * elem,
       }
 
     default:
-      libmesh_error_msg("ERROR: Unsupported element type = " << type);
+      libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
     }
 }
 
@@ -731,7 +732,7 @@ Real FE<2,BERNSTEIN>::shape_second_deriv(const Elem * elem,
       }
 
     default:
-      libmesh_error_msg("ERROR: Unsupported element type = " << type);
+      libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
     }
 }
 

--- a/src/fe/fe_bernstein_shape_3D.C
+++ b/src/fe/fe_bernstein_shape_3D.C
@@ -16,16 +16,14 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
-
-// Local includes
 #include "libmesh/libmesh_config.h"
+
 #ifdef LIBMESH_ENABLE_HIGHER_ORDER_SHAPES
 
+// libmesh includes
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
-
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {
@@ -109,7 +107,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
 
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
           }
       }
 
@@ -238,7 +236,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
 
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
           }
 
       }
@@ -828,7 +826,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
 
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
           } //case HEX27
 
       }//case THIRD
@@ -1355,7 +1353,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
 
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
           }
       }
 
@@ -1512,7 +1510,7 @@ Real FE<3,BERNSTEIN>::shape_deriv(const Elem * elem,
             }
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
           }
       }
 
@@ -1747,7 +1745,7 @@ Real FE<3,BERNSTEIN>::shape_deriv(const Elem * elem,
 
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
           }
       }
 
@@ -2372,7 +2370,7 @@ Real FE<3,BERNSTEIN>::shape_deriv(const Elem * elem,
 
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
           }
       }
 
@@ -2944,7 +2942,7 @@ Real FE<3,BERNSTEIN>::shape_deriv(const Elem * elem,
 
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
           }
       }
 

--- a/src/fe/fe_clough_shape_1D.C
+++ b/src/fe/fe_clough_shape_1D.C
@@ -16,13 +16,11 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
-// Local includes
+// libmesh includes
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 #include "libmesh/fe_interface.h"
-
+#include "libmesh/enum_to_string.h"
 
 // Anonymous namespace for persistent variables.
 // This allows us to cache the global-to-local mapping transformation
@@ -268,7 +266,7 @@ Real FE<1,CLOUGH>::shape(const Elem * elem,
                 }
             }
           default:
-            libmesh_error_msg("ERROR: Unsupported element type = " << type);
+            libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
           }
       }
       // by default throw an error
@@ -358,7 +356,7 @@ Real FE<1,CLOUGH>::shape_deriv(const Elem * elem,
                 }
             }
           default:
-            libmesh_error_msg("ERROR: Unsupported element type = " << type);
+            libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
           }
       }
       // by default throw an error
@@ -426,7 +424,7 @@ Real FE<1,CLOUGH>::shape_second_deriv(const Elem * elem,
                 }
             }
           default:
-            libmesh_error_msg("ERROR: Unsupported element type = " << type);
+            libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
           }
       }
       // by default throw an error

--- a/src/fe/fe_clough_shape_2D.C
+++ b/src/fe/fe_clough_shape_2D.C
@@ -16,13 +16,11 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
-// Local includes
+// libmesh includes
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 #include "libmesh/fe_interface.h"
-
+#include "libmesh/enum_to_string.h"
 
 // Anonymous namespace for persistent variables.
 // This allows us to cache the global-to-local mapping transformation
@@ -1912,7 +1910,7 @@ Real FE<2,CLOUGH>::shape(const Elem * elem,
                 }
             }
           default:
-            libmesh_error_msg("ERROR: Unsupported element type = " << type);
+            libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
           }
       }
       // 3rd-order Clough-Tocher element
@@ -1986,7 +1984,7 @@ Real FE<2,CLOUGH>::shape(const Elem * elem,
                 }
             }
           default:
-            libmesh_error_msg("ERROR: Unsupported element type = " << type);
+            libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
           }
       }
       // by default throw an error
@@ -2119,7 +2117,7 @@ Real FE<2,CLOUGH>::shape_deriv(const Elem * elem,
                 }
             }
           default:
-            libmesh_error_msg("ERROR: Unsupported element type = " << type);
+            libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
           }
       }
       // 3rd-order Clough-Tocher element
@@ -2193,7 +2191,7 @@ Real FE<2,CLOUGH>::shape_deriv(const Elem * elem,
                 }
             }
           default:
-            libmesh_error_msg("ERROR: Unsupported element type = " << type);
+            libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
           }
       }
       // by default throw an error
@@ -2325,7 +2323,7 @@ Real FE<2,CLOUGH>::shape_second_deriv(const Elem * elem,
                 }
             }
           default:
-            libmesh_error_msg("ERROR: Unsupported element type = " << type);
+            libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
           }
       }
       // 3rd-order Clough-Tocher element
@@ -2399,7 +2397,7 @@ Real FE<2,CLOUGH>::shape_second_deriv(const Elem * elem,
                 }
             }
           default:
-            libmesh_error_msg("ERROR: Unsupported element type = " << type);
+            libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
           }
       }
       // by default throw an error

--- a/src/fe/fe_hermite_shape_1D.C
+++ b/src/fe/fe_hermite_shape_1D.C
@@ -15,15 +15,12 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-
-// C++ includes
-
 // Local includes
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/utility.h"
-
+#include "libmesh/enum_to_string.h"
 
 namespace
 {
@@ -227,7 +224,7 @@ Real FE<1,HERMITE>::shape(const Elem * elem,
           }
       }
     default:
-      libmesh_error_msg("ERROR: Unsupported element type = " << type);
+      libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
     }
 }
 
@@ -302,7 +299,7 @@ Real FE<1,HERMITE>::shape_deriv(const Elem * elem,
           }
       }
     default:
-      libmesh_error_msg("ERROR: Unsupported element type = " << type);
+      libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
     }
 }
 
@@ -379,7 +376,7 @@ Real FE<1,HERMITE>::shape_second_deriv(const Elem * elem,
           }
       }
     default:
-      libmesh_error_msg("ERROR: Unsupported element type = " << type);
+      libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
     }
 }
 

--- a/src/fe/fe_hermite_shape_2D.C
+++ b/src/fe/fe_hermite_shape_2D.C
@@ -16,14 +16,12 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/number_lookups.h"
-
+#include "libmesh/enum_to_string.h"
 
 namespace
 {
@@ -239,7 +237,7 @@ Real FE<2,HERMITE>::shape(const Elem * elem,
           FEHermite<1>::hermite_raw_shape(bases1D[1],p(1));
       }
     default:
-      libmesh_error_msg("ERROR: Unsupported element type = " << type);
+      libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
     }
 }
 
@@ -326,7 +324,7 @@ Real FE<2,HERMITE>::shape_deriv(const Elem * elem,
           }
       }
     default:
-      libmesh_error_msg("ERROR: Unsupported element type = " << type);
+      libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
     }
 }
 
@@ -423,7 +421,7 @@ Real FE<2,HERMITE>::shape_second_deriv(const Elem * elem,
           }
       }
     default:
-      libmesh_error_msg("ERROR: Unsupported element type = " << type);
+      libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
     }
 }
 

--- a/src/fe/fe_hermite_shape_3D.C
+++ b/src/fe/fe_hermite_shape_3D.C
@@ -16,14 +16,12 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/number_lookups.h"
-
+#include "libmesh/enum_to_string.h"
 
 namespace
 {
@@ -431,7 +429,7 @@ Real FE<3,HERMITE>::shape(const Elem * elem,
                 FEHermite<1>::hermite_raw_shape(bases1D[2],p(2));
             }
           default:
-            libmesh_error_msg("ERROR: Unsupported element type " << type);
+            libmesh_error_msg("ERROR: Unsupported element type " << Utility::enum_to_string(type));
           }
       }
       // by default throw an error
@@ -535,7 +533,7 @@ Real FE<3,HERMITE>::shape_deriv(const Elem * elem,
 
             }
           default:
-            libmesh_error_msg("ERROR: Unsupported element type " << type);
+            libmesh_error_msg("ERROR: Unsupported element type " << Utility::enum_to_string(type));
           }
       }
       // by default throw an error
@@ -662,7 +660,7 @@ Real FE<3,HERMITE>::shape_second_deriv(const Elem * elem,
 
             }
           default:
-            libmesh_error_msg("ERROR: Unsupported element type " << type);
+            libmesh_error_msg("ERROR: Unsupported element type " << Utility::enum_to_string(type));
           }
       }
       // by default throw an error

--- a/src/fe/fe_hierarchic_shape_2D.C
+++ b/src/fe/fe_hierarchic_shape_2D.C
@@ -20,7 +20,7 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 #include "libmesh/number_lookups.h"
-
+#include "libmesh/enum_to_string.h"
 
 // Anonymous namespace for functions shared by HIERARCHIC and
 // L2_HIERARCHIC implementations. Implementations appear at the bottom
@@ -480,7 +480,7 @@ Real fe_hierarchic_2D_shape(const Elem * elem,
       }
 
     default:
-      libmesh_error_msg("ERROR: Unsupported element type = " << elem->type());
+      libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(elem->type()));
     }
 
   return 0.;
@@ -620,7 +620,7 @@ Real fe_hierarchic_2D_shape_deriv(const Elem * elem,
       }
 
     default:
-      libmesh_error_msg("ERROR: Unsupported element type = " << type);
+      libmesh_error_msg("ERROR: Unsupported element type = " << Utility::enum_to_string(type));
     }
 
   return 0.;

--- a/src/fe/fe_hierarchic_shape_3D.C
+++ b/src/fe/fe_hierarchic_shape_3D.C
@@ -20,7 +20,7 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 #include "libmesh/number_lookups.h"
-
+#include "libmesh/enum_to_string.h"
 
 // Anonymous namespace for functions shared by HIERARCHIC and
 // L2_HIERARCHIC implementations. Implementations appear at the bottom
@@ -945,7 +945,7 @@ Real fe_hierarchic_3D_shape(const Elem * elem,
       }
 
     default:
-      libmesh_error_msg("Invalid element type = " << type);
+      libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
     }
 
 #else // LIBMESH_DIM != 3

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -118,7 +118,7 @@ FEInterface::is_InfFE_elem(const ElemType et)
         libmesh_assert_equal_to (dim, 2);                               \
         prefix FE<2,SUBDIVISION>::func_and_args suffix                  \
       default:                                                          \
-        libmesh_error_msg("Unsupported family = " << fe_t.family);      \
+        libmesh_error_msg("Unsupported family = " << Utility::enum_to_string(fe_t.family)); \
       }                                                                 \
   } while (0)
 
@@ -160,7 +160,7 @@ FEInterface::is_InfFE_elem(const ElemType et)
       case NEDELEC_ONE:                                                 \
         prefix FENedelecOne<dim>::func_and_args suffix                  \
       default:                                                          \
-        libmesh_error_msg("Unsupported family = " << fe_t.family);      \
+        libmesh_error_msg("Unsupported family = " << Utility::enum_to_string(fe_t.family)); \
       }                                                                 \
   } while (0)
 
@@ -200,7 +200,7 @@ FEInterface::is_InfFE_elem(const ElemType et)
       case MONOMIAL_VEC:                                                \
         libmesh_error_msg("Error: Can only request scalar valued elements for Real FEInterface::func_and_args"); \
       default:                                                          \
-        libmesh_error_msg("Unsupported family = " << fe_t.family);      \
+        libmesh_error_msg("Unsupported family = " << Utility::enum_to_string(fe_t.family)); \
       }                                                                 \
   } while (0)
 
@@ -229,7 +229,7 @@ FEInterface::is_InfFE_elem(const ElemType et)
       case SUBDIVISION:                                                 \
         libmesh_error_msg("Error: Can only request vector valued elements for RealGradient FEInterface::shape"); \
       default:                                                          \
-        libmesh_error_msg("Unsupported family = " << fe_t.family);      \
+        libmesh_error_msg("Unsupported family = " << Utility::enum_to_string(fe_t.family)); \
       }                                                                 \
   } while (0)
 
@@ -260,7 +260,7 @@ FEInterface::is_InfFE_elem(const ElemType et)
         libmesh_assert_equal_to (dim, 2);                               \
         prefix FE<2,SUBDIVISION>::func_and_args suffix                  \
       default:                                                          \
-        libmesh_error_msg("Unsupported family = " << fe_t.family);      \
+        libmesh_error_msg("Unsupported family = " << Utility::enum_to_string(fe_t.family)); \
       }                                                                 \
   } while (0)
 
@@ -296,7 +296,7 @@ FEInterface::is_InfFE_elem(const ElemType et)
       case NEDELEC_ONE:                                                 \
         prefix FENedelecOne<dim>::func_and_args suffix                  \
       default:                                                          \
-        libmesh_error_msg("Unsupported family = " << fe_t.family);      \
+        libmesh_error_msg("Unsupported family = " << Utility::enum_to_string(fe_t.family)); \
       }                                                                 \
   } while (0)
 
@@ -330,7 +330,7 @@ FEInterface::is_InfFE_elem(const ElemType et)
       case MONOMIAL_VEC:                                                \
         libmesh_error_msg("Error: Can only request scalar valued elements for Real FEInterface::func_and_args"); \
       default:                                                          \
-        libmesh_error_msg("Unsupported family = " << fe_t.family);      \
+        libmesh_error_msg("Unsupported family = " << Utility::enum_to_string(fe_t.family)); \
       }                                                                 \
   } while (0)
 
@@ -356,7 +356,7 @@ FEInterface::is_InfFE_elem(const ElemType et)
       case SUBDIVISION:                                                 \
         libmesh_error_msg("Error: Can only request vector valued elements for RealGradient FEInterface::func_and_args"); \
       default:                                                          \
-        libmesh_error_msg("Unsupported family = " << fe_t.family);      \
+        libmesh_error_msg("Unsupported family = " << Utility::enum_to_string(fe_t.family)); \
       }                                                                 \
   } while (0)
 #endif

--- a/src/fe/fe_interface_inf_fe.C
+++ b/src/fe/fe_interface_inf_fe.C
@@ -26,6 +26,7 @@
 #include "libmesh/fe_interface_macros.h"
 #include "libmesh/inf_fe.h"
 #include "libmesh/elem.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {
@@ -366,7 +367,7 @@ void FEInterface::ifem_nodal_soln(const unsigned int dim,
             }
 
           default:
-            libmesh_error_msg("ERROR: Bad FEType.radial_family= " << fe_t.radial_family);
+            libmesh_error_msg("ERROR: Bad FEType.radial_family == " << Utility::enum_to_string(fe_t.radial_family));
           }
 
         break;
@@ -444,7 +445,7 @@ void FEInterface::ifem_nodal_soln(const unsigned int dim,
             }
 
           default:
-            libmesh_error_msg("ERROR: Bad FEType.radial_family= " << fe_t.radial_family);
+            libmesh_error_msg("ERROR: Bad FEType.radial_family == " << Utility::enum_to_string(fe_t.radial_family));
           }
 
         break;
@@ -524,7 +525,7 @@ void FEInterface::ifem_nodal_soln(const unsigned int dim,
 
 
           default:
-            libmesh_error_msg("ERROR: Bad FEType.radial_family= " << fe_t.radial_family);
+            libmesh_error_msg("ERROR: Bad FEType.radial_family == " << Utility::enum_to_string(fe_t.radial_family));
           }
 
         break;
@@ -563,7 +564,7 @@ Point FEInterface::ifem_map (const unsigned int dim,
     case ELLIPSOIDAL:
       libmesh_not_implemented_msg("ERROR: Spherical and Ellipsoidal IFEMs not (yet) implemented.");
     default:
-      libmesh_error_msg("Invalid map = " << fe_t.inf_map);
+      libmesh_error_msg("Invalid map = " << Utility::enum_to_string(fe_t.inf_map));
     }
 }
 
@@ -599,7 +600,7 @@ Point FEInterface::ifem_inverse_map (const unsigned int dim,
             */
 
           default:
-            libmesh_error_msg("Invalid map = " << fe_t.inf_map);
+            libmesh_error_msg("Invalid map = " << Utility::enum_to_string(fe_t.inf_map));
           }
       }
 
@@ -625,7 +626,7 @@ Point FEInterface::ifem_inverse_map (const unsigned int dim,
             */
 
           default:
-            libmesh_error_msg("Invalid map = " << fe_t.inf_map);
+            libmesh_error_msg("Invalid map = " << Utility::enum_to_string(fe_t.inf_map));
           }
       }
 
@@ -651,7 +652,7 @@ Point FEInterface::ifem_inverse_map (const unsigned int dim,
             */
 
           default:
-            libmesh_error_msg("Invalid map = " << fe_t.inf_map);
+            libmesh_error_msg("Invalid map = " << Utility::enum_to_string(fe_t.inf_map));
           }
       }
 
@@ -682,7 +683,7 @@ void FEInterface::ifem_inverse_map (const unsigned int dim,
             return;
 
           default:
-            libmesh_error_msg("Invalid map = " << fe_t.inf_map);
+            libmesh_error_msg("Invalid map = " << Utility::enum_to_string(fe_t.inf_map));
           }
       }
 
@@ -697,7 +698,7 @@ void FEInterface::ifem_inverse_map (const unsigned int dim,
             return;
 
           default:
-            libmesh_error_msg("Invalid map = " << fe_t.inf_map);
+            libmesh_error_msg("Invalid map = " << Utility::enum_to_string(fe_t.inf_map));
           }
       }
 
@@ -712,7 +713,7 @@ void FEInterface::ifem_inverse_map (const unsigned int dim,
             return;
 
           default:
-            libmesh_error_msg("Invalid map = " << fe_t.inf_map);
+            libmesh_error_msg("Invalid map = " << Utility::enum_to_string(fe_t.inf_map));
           }
       }
 

--- a/src/fe/fe_lagrange_shape_2D.C
+++ b/src/fe/fe_lagrange_shape_2D.C
@@ -20,7 +20,7 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 #include "libmesh/fe_lagrange_shape_1D.h"
-
+#include "libmesh/enum_to_string.h"
 
 // Anonymous namespace for functions shared by LAGRANGE and
 // L2_LAGRANGE implementations. Implementations appear at the bottom
@@ -377,7 +377,7 @@ Real fe_lagrange_2D_shape(const ElemType type,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unsupported 2D element type: " << type);
+            libmesh_error_msg("ERROR: Unsupported 2D element type: " << Utility::enum_to_string(type));
           }
       }
 
@@ -476,7 +476,7 @@ Real fe_lagrange_2D_shape(const ElemType type,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unsupported 2D element type: " << type);
+            libmesh_error_msg("ERROR: Unsupported 2D element type: " << Utility::enum_to_string(type));
           }
       }
 
@@ -602,7 +602,7 @@ Real fe_lagrange_2D_shape_deriv(const ElemType type,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unsupported 2D element type: " << type);
+            libmesh_error_msg("ERROR: Unsupported 2D element type: " << Utility::enum_to_string(type));
           }
       }
 
@@ -805,7 +805,7 @@ Real fe_lagrange_2D_shape_deriv(const ElemType type,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unsupported 2D element type: " << type);
+            libmesh_error_msg("ERROR: Unsupported 2D element type: " << Utility::enum_to_string(type));
           }
       }
 
@@ -888,7 +888,7 @@ Real fe_lagrange_2D_shape_second_deriv(const ElemType type,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unsupported 2D element type: " << type);
+            libmesh_error_msg("ERROR: Unsupported 2D element type: " << Utility::enum_to_string(type));
 
           } // end switch (type)
       } // end case FIRST
@@ -1142,7 +1142,7 @@ Real fe_lagrange_2D_shape_second_deriv(const ElemType type,
             }  // end case TRI6
 
           default:
-            libmesh_error_msg("ERROR: Unsupported 2D element type: " << type);
+            libmesh_error_msg("ERROR: Unsupported 2D element type: " << Utility::enum_to_string(type));
           }
       } // end case SECOND
 

--- a/src/fe/fe_lagrange_shape_3D.C
+++ b/src/fe/fe_lagrange_shape_3D.C
@@ -20,7 +20,7 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 #include "libmesh/fe_lagrange_shape_1D.h"
-
+#include "libmesh/enum_to_string.h"
 
 // Anonymous namespace for functions shared by LAGRANGE and
 // L2_LAGRANGE implementations. Implementations appear at the bottom
@@ -437,7 +437,7 @@ Real fe_lagrange_3D_shape(const ElemType type,
 
 
           default:
-            libmesh_error_msg("ERROR: Unsupported 3D element type!: " << type);
+            libmesh_error_msg("ERROR: Unsupported 3D element type!: " << Utility::enum_to_string(type));
           }
       }
 
@@ -820,7 +820,7 @@ Real fe_lagrange_3D_shape(const ElemType type,
 
 
           default:
-            libmesh_error_msg("ERROR: Unsupported 3D element type!: " << type);
+            libmesh_error_msg("ERROR: Unsupported 3D element type!: " << Utility::enum_to_string(type));
           }
       }
 
@@ -1123,7 +1123,7 @@ Real fe_lagrange_3D_shape_deriv(const ElemType type,
 
 
           default:
-            libmesh_error_msg("ERROR: Unsupported 3D element type!: " << type);
+            libmesh_error_msg("ERROR: Unsupported 3D element type!: " << Utility::enum_to_string(type));
           }
       }
 
@@ -2161,7 +2161,7 @@ Real fe_lagrange_3D_shape_deriv(const ElemType type,
 
 
           default:
-            libmesh_error_msg("ERROR: Unsupported 3D element type!: " << type);
+            libmesh_error_msg("ERROR: Unsupported 3D element type!: " << Utility::enum_to_string(type));
           }
       }
 
@@ -2393,7 +2393,7 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unsupported 3D element type!: " << type);
+            libmesh_error_msg("ERROR: Unsupported 3D element type!: " << Utility::enum_to_string(type));
           }
 
       }
@@ -3879,7 +3879,7 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unsupported 3D element type!: " << type);
+            libmesh_error_msg("ERROR: Unsupported 3D element type!: " << Utility::enum_to_string(type));
           }
       }
 

--- a/src/fe/fe_nedelec_one_shape_2D.C
+++ b/src/fe/fe_nedelec_one_shape_2D.C
@@ -16,11 +16,10 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {
@@ -136,7 +135,7 @@ RealGradient FE<2,NEDELEC_ONE>::shape(const Elem * elem,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unsupported 2D element type!: " << elem->type());
+            libmesh_error_msg("ERROR: Unsupported 2D element type!: " << Utility::enum_to_string(elem->type()));
           }
       }
 
@@ -312,7 +311,7 @@ RealGradient FE<2,NEDELEC_ONE>::shape_deriv(const Elem * elem,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unsupported 2D element type!: " << elem->type());
+            libmesh_error_msg("ERROR: Unsupported 2D element type!: " << Utility::enum_to_string(elem->type()));
           }
       }
       // unsupported order
@@ -396,7 +395,7 @@ RealGradient FE<2,NEDELEC_ONE>::shape_second_deriv(const Elem * elem,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unsupported 2D element type!: " << elem->type());
+            libmesh_error_msg("ERROR: Unsupported 2D element type!: " << Utility::enum_to_string(elem->type()));
 
           } // end switch (type)
       } // end case FIRST

--- a/src/fe/fe_nedelec_one_shape_3D.C
+++ b/src/fe/fe_nedelec_one_shape_3D.C
@@ -16,11 +16,10 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {
@@ -163,7 +162,7 @@ RealGradient FE<3,NEDELEC_ONE>::shape(const Elem * elem,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unsupported 3D element type!: " << elem->type());
+            libmesh_error_msg("ERROR: Unsupported 3D element type!: " << Utility::enum_to_string(elem->type()));
           }
       }
 
@@ -473,7 +472,7 @@ RealGradient FE<3,NEDELEC_ONE>::shape_deriv(const Elem * elem,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unsupported 3D element type!: " << elem->type());
+            libmesh_error_msg("ERROR: Unsupported 3D element type!: " << Utility::enum_to_string(elem->type()));
           }
       }
 
@@ -747,7 +746,7 @@ RealGradient FE<3,NEDELEC_ONE>::shape_second_deriv(const Elem * elem,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unsupported 3D element type!: " << elem->type());
+            libmesh_error_msg("ERROR: Unsupported 3D element type!: " << Utility::enum_to_string(elem->type()));
 
           } //switch(type)
 

--- a/src/fe/fe_subdivision_2D.C
+++ b/src/fe/fe_subdivision_2D.C
@@ -25,7 +25,7 @@
 #include "libmesh/fe_macro.h"
 #include "libmesh/dense_matrix.h"
 #include "libmesh/utility.h"
-
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {
@@ -720,11 +720,11 @@ Real FE<2,SUBDIVISION>::shape(const ElemType type,
             libmesh_assert_less(i, 12);
             return FESubdivision::regular_shape(i,p(0),p(1));
           default:
-            libmesh_error_msg("ERROR: Unsupported element type!");
+            libmesh_error_msg("ERROR: Unsupported element type == " << Utility::enum_to_string(type));
           }
       }
     default:
-      libmesh_error_msg("ERROR: Unsupported polynomial order!");
+      libmesh_error_msg("ERROR: Unsupported polynomial order == " << order);
     }
 }
 
@@ -776,11 +776,11 @@ Real FE<2,SUBDIVISION>::shape_deriv(const ElemType type,
             libmesh_assert_less(i, 12);
             return FESubdivision::regular_shape_deriv(i,j,p(0),p(1));
           default:
-            libmesh_error_msg("ERROR: Unsupported element type!");
+            libmesh_error_msg("ERROR: Unsupported element type == " << Utility::enum_to_string(type));
           }
       }
     default:
-      libmesh_error_msg("ERROR: Unsupported polynomial order!");
+      libmesh_error_msg("ERROR: Unsupported polynomial order == " << order);
     }
 }
 
@@ -835,11 +835,11 @@ Real FE<2,SUBDIVISION>::shape_second_deriv(const ElemType type,
             libmesh_assert_less(i, 12);
             return FESubdivision::regular_shape_second_deriv(i,j,p(0),p(1));
           default:
-            libmesh_error_msg("ERROR: Unsupported element type!");
+            libmesh_error_msg("ERROR: Unsupported element type == " << Utility::enum_to_string(type));
           }
       }
     default:
-      libmesh_error_msg("ERROR: Unsupported polynomial order!");
+      libmesh_error_msg("ERROR: Unsupported polynomial order == " << order);
     }
 }
 

--- a/src/fe/fe_szabab_shape_2D.C
+++ b/src/fe/fe_szabab_shape_2D.C
@@ -15,22 +15,20 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-
-
-// C++ includes
-#include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
-#include <cmath> // for std::sqrt
-
-
 // Local includes
 #include "libmesh/libmesh_config.h"
 
 #ifdef LIBMESH_ENABLE_HIGHER_ORDER_SHAPES
 
+// libmesh includes
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 #include "libmesh/utility.h"
+#include "libmesh/enum_to_string.h"
 
+// C++ includes
+#include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
+#include <cmath> // for std::sqrt
 
 // Anonymous namespace to hold static std::sqrt values
 namespace
@@ -126,7 +124,7 @@ Real FE<2,SZABAB>::shape(const Elem * elem,
             }
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
           }
       }
 
@@ -225,7 +223,7 @@ Real FE<2,SZABAB>::shape(const Elem * elem,
             }
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
           }
       }
 
@@ -327,7 +325,7 @@ Real FE<2,SZABAB>::shape(const Elem * elem,
             }
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
           }
       }
 
@@ -443,7 +441,7 @@ Real FE<2,SZABAB>::shape(const Elem * elem,
             } // case QUAD8/QUAD9
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
 
           } // switch type
 
@@ -568,7 +566,7 @@ Real FE<2,SZABAB>::shape(const Elem * elem,
             } // case QUAD8/QUAD9
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
 
           } // switch type
 
@@ -709,7 +707,7 @@ Real FE<2,SZABAB>::shape(const Elem * elem,
             } // case QUAD8/QUAD9
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
 
           } // switch type
 
@@ -848,7 +846,7 @@ Real FE<2,SZABAB>::shape_deriv(const Elem * elem,
             }
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
           }
       }
 
@@ -952,7 +950,7 @@ Real FE<2,SZABAB>::shape_deriv(const Elem * elem,
             }
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
           }
       }
 
@@ -1059,7 +1057,7 @@ Real FE<2,SZABAB>::shape_deriv(const Elem * elem,
             }
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
           }
       }
 
@@ -1169,7 +1167,7 @@ Real FE<2,SZABAB>::shape_deriv(const Elem * elem,
             }
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
           }
       }
 
@@ -1277,7 +1275,7 @@ Real FE<2,SZABAB>::shape_deriv(const Elem * elem,
             }
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
           }
       }
 
@@ -1389,7 +1387,7 @@ Real FE<2,SZABAB>::shape_deriv(const Elem * elem,
             }
 
           default:
-            libmesh_error_msg("Invalid element type = " << type);
+            libmesh_error_msg("Invalid element type = " << Utility::enum_to_string(type));
           }
       }
 

--- a/src/fe/fe_transformation_base.C
+++ b/src/fe/fe_transformation_base.C
@@ -20,6 +20,7 @@
 #include "libmesh/hcurl_fe_transformation.h"
 #include "libmesh/fe_type.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {
@@ -61,7 +62,7 @@ std::unique_ptr<FETransformationBase<OutputShape>> FETransformationBase<OutputSh
       return libmesh_make_unique<H1FETransformation<OutputShape>>();
 
     default:
-      libmesh_error_msg("Unknown family = " << fe_type.family);
+      libmesh_error_msg("Unknown family = " << Utility::enum_to_string(fe_type.family));
     }
 }
 

--- a/src/fe/inf_fe_base_radial.C
+++ b/src/fe/inf_fe_base_radial.C
@@ -19,11 +19,14 @@
 
 // Local includes
 #include "libmesh/libmesh_config.h"
+
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
 #include "libmesh/inf_fe.h"
 #include "libmesh/inf_fe_macro.h"
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {
@@ -77,7 +80,7 @@ ElemType InfFEBase::get_elem_type (const ElemType type)
       return INVALID_ELEM;
 
     default:
-      libmesh_error_msg("ERROR: Unsupported element type!: " << type);
+      libmesh_error_msg("ERROR: Unsupported element type!: " << Utility::enum_to_string(type));
     }
 }
 

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -16,15 +16,18 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// Local includes
 #include "libmesh/libmesh_config.h"
+
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+// libmesh includes
 #include "libmesh/inf_fe.h"
 #include "libmesh/inf_fe_macro.h"
 #include "libmesh/fe.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/fe_compute_data.h"
 #include "libmesh/elem.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {
@@ -816,7 +819,7 @@ void InfFE<Dim,T_radial,T_map>::compute_node_indices (const ElemType inf_elem_ty
 
 
     default:
-      libmesh_error_msg("ERROR: Bad infinite element type=" << inf_elem_type << ", node=" << outer_node_index);
+      libmesh_error_msg("ERROR: Bad infinite element type=" << Utility::enum_to_string(inf_elem_type) << ", node=" << outer_node_index);
     }
 }
 
@@ -909,7 +912,7 @@ void InfFE<Dim,T_radial,T_map>::compute_node_indices_fast (const ElemType inf_el
             break;
           }
         default:
-          libmesh_error_msg("ERROR: Bad infinite element type=" << inf_elem_type << ", node=" << outer_node_index);
+          libmesh_error_msg("ERROR: Bad infinite element type=" << Utility::enum_to_string(inf_elem_type) << ", node=" << outer_node_index);
         }
 
 
@@ -1087,7 +1090,7 @@ void InfFE<Dim,T_radial,T_map>::compute_shape_indices (const FEType & fet,
       }
 
     default:
-      libmesh_error_msg("Unrecognized inf_elem_type = " << inf_elem_type);
+      libmesh_error_msg("Unrecognized inf_elem_type = " << Utility::enum_to_string(inf_elem_type));
     }
 
 

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -329,7 +329,7 @@ std::unique_ptr<Elem> Elem::build(const ElemType type,
 #endif
 
     default:
-      libmesh_error_msg("ERROR: Undefined element type!");
+      libmesh_error_msg("ERROR: Undefined element type == " << Utility::enum_to_string(type));
     }
 }
 

--- a/src/mesh/gmsh_io.C
+++ b/src/mesh/gmsh_io.C
@@ -15,14 +15,6 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-// C++ includes
-#include <fstream>
-#include <set>
-#include <cstring> // std::memcpy
-#include <numeric>
-#include <unordered_map>
-#include <cstddef>
-
 // Local includes
 #include "libmesh/libmesh_config.h"
 #include "libmesh/libmesh_logging.h"
@@ -32,6 +24,15 @@
 #include "libmesh/mesh_base.h"
 #include "libmesh/int_range.h"
 #include "libmesh/utility.h" // map_find
+#include "libmesh/enum_to_string.h"
+
+// C++ includes
+#include <fstream>
+#include <set>
+#include <cstring> // std::memcpy
+#include <numeric>
+#include <unordered_map>
+#include <cstddef>
 
 namespace libMesh
 {
@@ -1105,7 +1106,7 @@ void GmshIO::write_post (const std::string & fname,
                   break;
                 }
               default:
-                libmesh_error_msg("ERROR: Nonexistent element type " << elem->type());
+                libmesh_error_msg("ERROR: Nonexistent element type " << Utility::enum_to_string(elem->type()));
               }
           }
       }

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -17,7 +17,7 @@
 
 
 
-// Local includes
+// libmesh includes
 #include "libmesh/mesh_generation.h"
 #include "libmesh/unstructured_mesh.h"
 #include "libmesh/mesh_refinement.h"
@@ -50,6 +50,7 @@
 #include "libmesh/int_range.h"
 #include "libmesh/parallel.h"
 #include "libmesh/parallel_ghost_sync.h"
+#include "libmesh/enum_to_string.h"
 
 // C++ includes
 #include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
@@ -93,7 +94,7 @@ unsigned int idx(const ElemType type,
       }
 
     default:
-      libmesh_error_msg("ERROR: Unrecognized 2D element type.");
+      libmesh_error_msg("ERROR: Unrecognized 2D element type == " << Utility::enum_to_string(type));
     }
 
   return libMesh::invalid_uint;
@@ -133,7 +134,7 @@ unsigned int idx(const ElemType type,
       }
 
     default:
-      libmesh_error_msg("ERROR: Unrecognized element type.");
+      libmesh_error_msg("ERROR: Unrecognized element type == " << Utility::enum_to_string(type));
     }
 
   return libMesh::invalid_uint;
@@ -389,7 +390,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unrecognized 1D element type.");
+            libmesh_error_msg("ERROR: Unrecognized 1D element type == " << Utility::enum_to_string(type));
           }
 
         // Reserve nodes
@@ -415,7 +416,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unrecognized 1D element type.");
+            libmesh_error_msg("ERROR: Unrecognized 1D element type == " << Utility::enum_to_string(type));
           }
 
 
@@ -449,7 +450,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unrecognized 1D element type.");
+            libmesh_error_msg("ERROR: Unrecognized 1D element type == " << Utility::enum_to_string(type));
 
           }
 
@@ -513,7 +514,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unrecognized 1D element type.");
+            libmesh_error_msg("ERROR: Unrecognized 1D element type == " << Utility::enum_to_string(type));
           }
 
         // Move the nodes to their final locations.
@@ -579,7 +580,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unrecognized 2D element type.");
+            libmesh_error_msg("ERROR: Unrecognized 2D element type == " << Utility::enum_to_string(type));
           }
 
 
@@ -606,7 +607,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
 
 
           default:
-            libmesh_error_msg("ERROR: Unrecognized 2D element type.");
+            libmesh_error_msg("ERROR: Unrecognized 2D element type == " << Utility::enum_to_string(type));
           }
 
 
@@ -645,7 +646,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
 
 
           default:
-            libmesh_error_msg("ERROR: Unrecognized 2D element type.");
+            libmesh_error_msg("ERROR: Unrecognized 2D element type == " << Utility::enum_to_string(type));
           }
 
 
@@ -795,7 +796,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
 
 
           default:
-            libmesh_error_msg("ERROR: Unrecognized 2D element type.");
+            libmesh_error_msg("ERROR: Unrecognized 2D element type == " << Utility::enum_to_string(type));
           }
 
 
@@ -881,7 +882,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unrecognized 3D element type.");
+            libmesh_error_msg("ERROR: Unrecognized 3D element type == " << Utility::enum_to_string(type));
           }
 
 
@@ -918,7 +919,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
             }
 
           default:
-            libmesh_error_msg("ERROR: Unrecognized 3D element type.");
+            libmesh_error_msg("ERROR: Unrecognized 3D element type == " << Utility::enum_to_string(type));
           }
 
 
@@ -964,7 +965,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
 
 
           default:
-            libmesh_error_msg("ERROR: Unrecognized 3D element type.");
+            libmesh_error_msg("ERROR: Unrecognized 3D element type == " << Utility::enum_to_string(type));
           }
 
 
@@ -1238,7 +1239,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
 
 
           default:
-            libmesh_error_msg("ERROR: Unrecognized 3D element type.");
+            libmesh_error_msg("ERROR: Unrecognized 3D element type == " << Utility::enum_to_string(type));
           }
 
 

--- a/src/mesh/mesh_triangle_interface.C
+++ b/src/mesh/mesh_triangle_interface.C
@@ -20,9 +20,7 @@
 
 #ifdef LIBMESH_HAVE_TRIANGLE
 
-// C/C++ includes
-#include <sstream>
-
+// llibmesh includes
 #include "libmesh/mesh_triangle_interface.h"
 #include "libmesh/unstructured_mesh.h"
 #include "libmesh/face_tri3.h"
@@ -33,6 +31,11 @@
 #include "libmesh/mesh_triangle_holes.h"
 #include "libmesh/mesh_triangle_wrapper.h"
 #include "libmesh/enum_elem_type.h"
+#include "libmesh/enum_to_string.h"
+
+// C/C++ includes
+#include <sstream>
+
 
 namespace libMesh
 {
@@ -342,7 +345,7 @@ void TriangleInterface::triangulate()
       }
 
     default:
-      libmesh_error_msg("ERROR: Unrecognized triangular element type.");
+      libmesh_error_msg("ERROR: Unrecognized triangular element type == " << Utility::enum_to_string(_elem_type));
     }
 
 

--- a/src/mesh/mesh_triangle_wrapper.C
+++ b/src/mesh/mesh_triangle_wrapper.C
@@ -20,15 +20,15 @@
 
 #ifdef LIBMESH_HAVE_TRIANGLE
 
-// Local includes
+// libmesh includes
 #include "libmesh/mesh_triangle_wrapper.h"
-
 #include "libmesh/boundary_info.h"
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/face_tri3.h"
 #include "libmesh/face_tri6.h"
 #include "libmesh/point.h"
 #include "libmesh/unstructured_mesh.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {
@@ -164,7 +164,7 @@ void TriangleWrapper::copy_tri_to_mesh(const triangulateio & triangle_data_input
           }
 
         default:
-          libmesh_error_msg("ERROR: Unrecognized triangular element type.");
+          libmesh_error_msg("ERROR: Unrecognized triangular element type == " << Utility::enum_to_string(type));
         }
     }
 

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -30,6 +30,7 @@
 #include "libmesh/partitioner.h"
 #include "libmesh/enum_order.h"
 #include "libmesh/mesh_communication.h"
+#include "libmesh/enum_to_string.h"
 
 // C++ includes
 #include <fstream>
@@ -1152,7 +1153,7 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
     {
       // make sure it is linear order
       libmesh_error_msg_if(lo_elem->default_order() != FIRST,
-                           "ERROR: This is not a linear element: type=" << lo_elem->type());
+                           "ERROR: This is not a linear element: type=" << Utility::enum_to_string(lo_elem->type()));
 
       // this does _not_ work for refined elements
       libmesh_assert_equal_to (lo_elem->level (), 0);

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -34,6 +34,7 @@
 #include "libmesh/cell_prism6.h"
 #include "libmesh/utility.h"
 #include "libmesh/boundary_info.h"
+#include "libmesh/enum_to_string.h"
 
 // C++ includes
 #include <array>
@@ -1116,7 +1117,7 @@ void UNVIO::elements_out(std::ostream & out_file)
           }
 
         default:
-          libmesh_error_msg("ERROR: Element type = " << elem->type() << " not supported in " << "UNVIO!");
+          libmesh_error_msg("ERROR: Element type = " << Utility::enum_to_string(elem->type()) << " not supported in " << "UNVIO!");
         }
 
       dof_id_type elem_id = elem->id();

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -17,9 +17,6 @@
 
 
 
-// C++ includes
-#include <sstream>   // for std::ostringstream
-
 // Local includes
 #include "libmesh/dof_map.h"
 #include "libmesh/equation_systems.h"
@@ -51,6 +48,9 @@
 #include "libmesh/vector_value.h"
 #include "libmesh/tensor_tools.h"
 #include "libmesh/enum_norm_type.h"
+
+// C++ includes
+#include <sstream>   // for std::ostringstream
 
 namespace libMesh
 {
@@ -1520,7 +1520,7 @@ Real System::discrete_var_norm(const NumericVector<Number> & v,
   if (norm_type == DISCRETE_L_INF)
     return v.subset_linfty_norm(var_indices);
   else
-    libmesh_error_msg("Invalid norm_type = " << norm_type);
+    libmesh_error_msg("Invalid norm_type = " << Utility::enum_to_string(norm_type));
 }
 
 
@@ -1578,7 +1578,7 @@ Real System::calculate_norm(const NumericVector<Number> & v,
           if (norm_type0 == DISCRETE_L_INF)
             return v.linfty_norm();
           else
-            libmesh_error_msg("Invalid norm_type0 = " << norm_type0);
+            libmesh_error_msg("Invalid norm_type0 = " << Utility::enum_to_string(norm_type0));
         }
 
       for (auto var : make_range(this->n_vars()))


### PR DESCRIPTION
We still have many places where you can get cryptic numbers in error messages, e.g.
```
ERROR: This is not a linear element: type=9
```
which is annoying for normal users as well as developers who haven't memorized all the enumerations. This PR fixes many of them with `Utility::enum_to_string()`, but there might still be a few others lurking.
