### PR TITLE
The SHAPE and SKEW bounds for Quad elements should have similar bounds.

### DIFF
--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -371,11 +371,6 @@ std::pair<Real, Real> Quad::qual_bounds (const ElemQuality q) const
       bounds.second = 4.;
       break;
 
-    case SKEW:
-      bounds.first  = 0.;
-      bounds.second = 0.5;
-      break;
-
     case TAPER:
       bounds.first  = 0.;
       bounds.second = 0.7;
@@ -413,6 +408,7 @@ std::pair<Real, Real> Quad::qual_bounds (const ElemQuality q) const
 
     case SHEAR:
     case SHAPE:
+    case SKEW:
     case SIZE:
       bounds.first  = 0.3;
       bounds.second = 1.;


### PR DESCRIPTION
After updating these metrics in 60487b58446, I should have also updated the bounds. Note that Knupp does not give explicit bounds on these metrics for a "good" quality element in his paper, but both have an upper bound of 1, so the previous values for SKEW were just wrong.
