### PR TITLE
Only *non-empty* constraint_rows is experimental

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1661,10 +1661,10 @@ public:
     constraint_rows_type;
 
   constraint_rows_type & get_constraint_rows()
-  { libmesh_experimental(); return _constraint_rows; }
+  { return _constraint_rows; }
 
   const constraint_rows_type & get_constraint_rows() const
-  { libmesh_experimental(); return _constraint_rows; }
+  { return _constraint_rows; }
 
   /**
    * Search the mesh and cache the different dimensions of the elements

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1892,6 +1892,9 @@ void DofMap::process_mesh_constraint_rows(const MeshBase & mesh)
   libmesh_assert(!constraint_rows_empty);
 #endif
 
+  // This is fairly new code, still a bit experimental.
+  libmesh_experimental();
+
   // We can't handle periodic boundary conditions on spline meshes
   // yet.
 #ifdef LIBMESH_ENABLE_PERIODIC


### PR DESCRIPTION
Especially with distributed meshes I still feel like IGA (and hopefully
in the future other) uses of this new constraint_rows data structure are
tricky enough to warn users about, but we have more than enough coverage
of the empty-constraint_rows case to be certain I haven't regressed
anything there.

Fixes #2841