### PR TITLE
Turn off gdb backtraces by default

### DIFF
--- a/configure
+++ b/configure
@@ -31889,7 +31889,7 @@ $as_echo "---------------------------------------------" >&6; }
 if test "${with_gdb_command+set}" = set; then :
   withval=$with_gdb_command; gdb_command="$withval"
 else
-  gdb_command="gdb"
+  gdb_command="no"
 fi
 
 

--- a/m4/libmesh_core_features.m4
+++ b/m4/libmesh_core_features.m4
@@ -17,7 +17,7 @@ AC_ARG_WITH([gdb-command],
     AS_HELP_STRING([--with-gdb-command=commandname],
                    [Specify command to invoke gdb.  Use --without-gdb-command to disable GDB backtraces.]),
     [gdb_command="$withval"],
-    [gdb_command="gdb"])
+    [gdb_command="no"])
 
 AC_DEFINE_UNQUOTED(GDB_COMMAND, "$gdb_command", [command to invoke gdb])
 AC_MSG_RESULT([configuring gdb command... "$gdb_command"])


### PR DESCRIPTION
The user will now have to opt-in to gdb backtraces instead of opting out
with `--without-gdb-command`. There are many times that I forget to
configure with `--without-gdb-command` and then I sadly wait for a
minute to get my prompt back or switch to another terminal to kill the
process. There was some general support for this
change on our Moose developers libmesh slack channel