### PR TITLE
MeshFunction updates

### DIFF
--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -101,15 +101,17 @@ public:
   ~MeshFunction ();
 
   /**
-   * Override the FunctionBase::init() member function by calling our
-   * own and specifying the Trees::NODES method.  specifies the method
-   * to use when building a \p PointLocator
+   * Override the FunctionBase::init() member function.
    */
-  virtual void init () override { this->init(Trees::NODES); }
+  virtual void init () override;
 
   /**
    * The actual initialization process.  Takes an optional argument which
    * specifies the method to use when building a \p PointLocator
+   *
+   * \deprecated The input argument is not used (was it ever?) to
+   * control the PointLocator type which is built, so one should
+   * instead call the version of init() taking no args.
    */
   void init (const Trees::BuildType point_locator_build_type);
 

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -814,6 +814,7 @@ void MeshFunction::disable_out_of_mesh_mode()
 void MeshFunction::set_point_locator_tolerance(Real tol)
 {
   _point_locator->set_close_to_point_tol(tol);
+  _point_locator->set_contains_point_tol(tol);
 }
 
 void MeshFunction::unset_point_locator_tolerance()

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -77,7 +77,7 @@ MeshFunction::~MeshFunction () = default;
 
 
 
-void MeshFunction::init (const Trees::BuildType /*point_locator_build_type*/)
+void MeshFunction::init ()
 {
   // are indices of the desired variable(s) provided?
   libmesh_assert_greater (this->_system_vars.size(), 0);
@@ -97,6 +97,19 @@ void MeshFunction::init (const Trees::BuildType /*point_locator_build_type*/)
   // ready for use
   this->_initialized = true;
 }
+
+
+
+void MeshFunction::init (const Trees::BuildType /*point_locator_build_type*/)
+{
+  libmesh_deprecated();
+
+  // Call the init() taking no args instead. Note: this is backwards
+  // compatible because the argument was not used for anything
+  // previously anyway.
+  this->init();
+}
+
 
 
 void

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -89,13 +89,9 @@ void MeshFunction::init (const Trees::BuildType /*point_locator_build_type*/)
       return;
     }
 
-  /*
-   * set up the PointLocator: currently we always get this from the
-   * MeshBase we're associated with.
-   */
+  // The Mesh owns the "master" PointLocator, while handing us a
+  // PointLocator "proxy" that forwards all requests to the master.
   const MeshBase & mesh = this->_eqn_systems.get_mesh();
-
-  // Take ownership
   _point_locator = mesh.sub_point_locator();
 
   // ready for use


### PR DESCRIPTION
Previously `MeshFunction::set_point_locator_tolerance()` only set the tolerance used in `PointLocator` `Elem::close_to_point()` checks, but now it will set the tolerance used in `Elem::contains_point()` and `BoundingBox` checks done within the `PointLocator` as well. This is more consistent with the user's likely intention in calling the function in the first place, and helps prevent situations in which the `PointLocator`'s performance degrades dramatically as it falls back on doing many linear searches. I think what happened here is probably that additional tolerances were added on the `PointLocator` side, but the `MeshFunction` API was not updated at that time.
