### PR TITLE
Re-reserve non-zero pattern after Eigen::SparseMatrix::setZero

### DIFF
--- a/src/numerics/eigen_sparse_matrix.C
+++ b/src/numerics/eigen_sparse_matrix.C
@@ -179,7 +179,15 @@ void EigenSparseMatrix<T>::clear ()
 template <typename T>
 void EigenSparseMatrix<T>::zero ()
 {
+  // This doesn't just zero, it clears the entire non-zero structure!
   _mat.setZero();
+
+  if (this->_sp)
+  {
+    // Re-reserve our non-zero structure
+    const std::vector<numeric_index_type> & n_nz = this->_sp->get_n_nz();
+    _mat.reserve(n_nz);
+  }
 }
 
 


### PR DESCRIPTION
`Eigen::SparseMatrix::setZero` clears the entire non-zero pattern, so we have to
re-reserve after zeroing in order to not have very expensive recalls to
`Eigen::SparseMatrix::reserveInnerVectors`. This solves the problem reported in
#2845 .

Previous graph after merge of #2845:
![image](https://user-images.githubusercontent.com/10248304/106972035-ec7bd280-6704-11eb-9c41-0092e6ec21a0.png)
Graph after this fix:
![re-reserve](https://user-images.githubusercontent.com/10248304/106972075-00bfcf80-6705-11eb-9190-cea1017b31ea.png)
