### PR TITLE
Update DenseMatrix/Vector use in examples

### DIFF
--- a/examples/fem_system/fem_system_ex2/nonlinear_neohooke_cc.C
+++ b/examples/fem_system/fem_system_ex2/nonlinear_neohooke_cc.C
@@ -106,13 +106,13 @@ void NonlinearNeoHookeCurrentConfig::get_residual(DenseVector<Real> & residuum,
 void NonlinearNeoHookeCurrentConfig::tensor_to_voigt(const RealTensor & tensor,
                                                      DenseVector<Real> & vec)
 {
-  vec(0) = tensor(0, 0);
-  vec(1) = tensor(1, 1);
-  vec(2) = tensor(2, 2);
-  vec(3) = tensor(0, 1);
-  vec(4) = tensor(1, 2);
-  vec(5) = tensor(0, 2);
-
+  vec = {
+    tensor(0, 0),
+    tensor(1, 1),
+    tensor(2, 2),
+    tensor(0, 1),
+    tensor(1, 2),
+    tensor(0, 2)};
 }
 
 void NonlinearNeoHookeCurrentConfig::get_linearized_stiffness(DenseMatrix<Real> & stiffness,


### PR DESCRIPTION
* Use new std::initializer_list syntax
* Use fixed-size Tensor/VectorValue<T> instead of heap-allocated DenseMatrix/Vector
* systems_of_equations_ex7: u_vec was computed but not used
* Simplify array initialization