### PR TITLE
PointLocatorTree: avoid Elem::contains_point() warning when using custom tolerances

### DIFF
--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -196,14 +196,21 @@ const Elem * PointLocatorTree::operator() (const Point & p,
   LOG_SCOPE("operator()", "PointLocatorTree");
 
   // If we're provided with an allowed_subdomains list and have a cached element, make sure it complies
-  if (allowed_subdomains && this->_element && !allowed_subdomains->count(this->_element->subdomain_id())) this->_element = nullptr;
+  if (allowed_subdomains && this->_element && !allowed_subdomains->count(this->_element->subdomain_id()))
+    this->_element = nullptr;
 
-  if (this->_element != nullptr) {
-    if (_use_contains_point_tol && !(this->_element->contains_point(p, _contains_point_tol)))
-      this->_element = nullptr;
-    else if (!(this->_element->contains_point(p)))
-      this->_element = nullptr;
-  }
+  if (this->_element != nullptr)
+    {
+      // If the user specified a custom tolerance, we actually call
+      // Elem::close_to_point() instead, since Elem::contains_point()
+      // warns about using non-default BoundingBox tolerances.
+      if (_use_contains_point_tol && !(this->_element->close_to_point(p, _contains_point_tol)))
+        this->_element = nullptr;
+
+      // Otherwise, just call contains_point(p) with default tolerances.
+      else if (!(this->_element->contains_point(p)))
+        this->_element = nullptr;
+    }
 
   // First check the element from last time before asking the tree
   if (this->_element==nullptr)

--- a/src/utils/tree_node.C
+++ b/src/utils/tree_node.C
@@ -586,8 +586,15 @@ TreeNode<N>::find_element (const Point & p,
         // Search the active elements in the active TreeNode.
         for (const auto & elem : elements)
           if (!allowed_subdomains || allowed_subdomains->count(elem->subdomain_id()))
-            if (elem->active() && elem->contains_point(p, relative_tol))
-              return elem;
+            if (elem->active())
+              {
+                bool found = relative_tol > TOLERANCE
+                  ? elem->close_to_point(p, relative_tol)
+                  : elem->contains_point(p);
+
+                if (found)
+                  return elem;
+              }
 
       // The point was not found in any element
       return nullptr;
@@ -614,8 +621,15 @@ TreeNode<N>::find_elements (const Point & p,
         // Search the active elements in the active TreeNode.
         for (const auto & elem : elements)
           if (!allowed_subdomains || allowed_subdomains->count(elem->subdomain_id()))
-            if (elem->active() && elem->contains_point(p, relative_tol))
-              candidate_elements.insert(elem);
+            if (elem->active())
+              {
+                bool found = relative_tol > TOLERANCE
+                  ? elem->close_to_point(p, relative_tol)
+                  : elem->contains_point(p);
+
+                if (found)
+                  candidate_elements.insert(elem);
+              }
     }
   else
     this->find_elements_in_children(p, candidate_elements,


### PR DESCRIPTION
Now that we are correctly setting a custom `contains_point()` tolerance on the `PointLocator` within `MeshFunction` (#2849), we are seeing the following warning from `Elem::contains_point()`:

    WARNING: Resizing bounding box to match user-specified tolerance!
    In the future, calls to Elem::contains_point() with tol > TOLERANCE
    will be more optimized, but should not be used
    to search for points 'close to' elements!
    Instead, use Elem::close_to_point() for this purpose.

The issue is that we should really be testing `Elem::close_to_point()` in the `PointLocator` (and associated classes) when the user passes in a custom tolerance > `TOLERANCE`, since that indicates the user's intent to locate "nearby" Elems rather than "strictly containing" Elems.

This commit updates the relevant `contains_point()` checks in `PointLocatorTree` and `TreeNode<N>::find_element()` so that we should no longer see this warning. Note that we still call the potentially optimized (currently only for `Tri3` and `Tet4`) `contains_point()` routine if the user does not set a custom `PointLocator` tolerance. 
