### PR TITLE
Inter mesh projection fixup

### DIFF
--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -85,7 +85,7 @@ public:
                 const FunctionBase<Number> * master=nullptr);
 
   /**
-   * A regular copy constructor. Replicates the steps of MeshFunction::clone().
+   * A regular copy constructor.
    */
   MeshFunction (const MeshFunction & mf);
 

--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -85,12 +85,16 @@ public:
                 const FunctionBase<Number> * master=nullptr);
 
   /**
+   * A regular copy constructor. Replicates the steps of MeshFunction::clone().
+   */
+  MeshFunction (const MeshFunction & mf);
+
+  /**
    * Special functions.
    * - This class conains a unique_ptr so it can't be default copy constructed.
    * - This class contains const references so it can't be default copy/move assigned.
    * - The destructor is defaulted out-of-line.
    */
-  MeshFunction (const MeshFunction &) = delete;
   MeshFunction (MeshFunction &&) = default;
   MeshFunction & operator= (const MeshFunction &) = delete;
   MeshFunction & operator= (MeshFunction &&) = delete;

--- a/include/systems/inter_mesh_projection.h
+++ b/include/systems/inter_mesh_projection.h
@@ -87,7 +87,7 @@ public:
 
   virtual std::unique_ptr<FunctionBase<Gradient>> clone () const
   {
-    return libmesh_make_unique<GradientMeshFunction>(*(mesh_function.get()));
+    return libmesh_make_unique<GradientMeshFunction>(*mesh_function);
   }
 
   virtual Gradient operator() (const Point & , const Real)

--- a/include/systems/inter_mesh_projection.h
+++ b/include/systems/inter_mesh_projection.h
@@ -87,7 +87,6 @@ public:
 
   virtual std::unique_ptr<FunctionBase<Gradient>> clone () const
   {
-    //return libmesh_make_unique<GradientMeshFunction>(dynamic_cast<MeshFunction *>(mesh_function.get()));
     return libmesh_make_unique<GradientMeshFunction>(mesh_function.get());
   }
 

--- a/include/systems/inter_mesh_projection.h
+++ b/include/systems/inter_mesh_projection.h
@@ -78,7 +78,7 @@ class GradientMeshFunction : public FunctionBase<Gradient>
 {
 public:
   // Constructor
-  GradientMeshFunction(MeshFunction * _mesh_function);
+  GradientMeshFunction(const MeshFunction & _mesh_function);
 
   // Destructor
   virtual ~GradientMeshFunction () { }
@@ -87,7 +87,7 @@ public:
 
   virtual std::unique_ptr<FunctionBase<Gradient>> clone () const
   {
-    return libmesh_make_unique<GradientMeshFunction>(mesh_function.get());
+    return libmesh_make_unique<GradientMeshFunction>(*(mesh_function.get()));
   }
 
   virtual Gradient operator() (const Point & , const Real)

--- a/include/systems/inter_mesh_projection.h
+++ b/include/systems/inter_mesh_projection.h
@@ -37,71 +37,71 @@
 namespace libMesh
 {
 
-    // Forward declarations
+// Forward declarations
 
-    /**
-     * This class implements inter mesh projection, i.e. projection of
-     * vectors defined on a given mesh (from_mesh associated with from_system)
-     * to another mesh (to_mesh of to_system).
-     */
+/**
+ * This class implements inter mesh projection, i.e. projection of
+ * vectors defined on a given mesh (from_mesh associated with from_system)
+ * to another mesh (to_mesh of to_system).
+ */
 
-    class InterMeshProjection
-    {
-        public:
+class InterMeshProjection
+{
+public:
 
-        // Constructor, specifies the _from_system whose vectors will be
-        // projected onto the _to_mesh
-        InterMeshProjection(System & _from_system, System & _to_mesh);
+  // Constructor, specifies the _from_system whose vectors will be
+  // projected onto the _to_mesh
+  InterMeshProjection(System & _from_system, System & _to_mesh);
 
-        // Projects from_system vectors onto the to_mesh
-        void project_system_vectors();
+  // Projects from_system vectors onto the to_mesh
+  void project_system_vectors();
 
-        static Number fptr(const Point & p, const Parameters &, const std::string & libmesh_dbg_var(sys_name), const std::string & unknown_name);
+  static Number fptr(const Point & p, const Parameters &, const std::string & libmesh_dbg_var(sys_name), const std::string & unknown_name);
 
-        static Gradient gptr(const Point & p, const Parameters &, const std::string & libmesh_dbg_var(sys_name), const std::string & unknown_name);
+  static Gradient gptr(const Point & p, const Parameters &, const std::string & libmesh_dbg_var(sys_name), const std::string & unknown_name);
 
-        private:
+private:
 
-        // Local copy of the _from_system
-        System & from_system;
+  // Local copy of the _from_system
+  System & from_system;
 
-        // Local copy of the _to_system
-        System & to_system;
+  // Local copy of the _to_system
+  System & to_system;
 
-    };
+};
 
-    // This class provides the functor we will supply to System::project_vector
-    // inside InterMeshProjection::project_system_vectors.
-    // Object is constructed by passing in a pointer to the mesh function whose
-    // gradient we want to shim via operator().
-    class GradientMeshFunction : public FunctionBase<Gradient>
-    {
-        public:
-        // Constructor
-        GradientMeshFunction(MeshFunction * _mesh_function);
+// This class provides the functor we will supply to System::project_vector
+// inside InterMeshProjection::project_system_vectors.
+// Object is constructed by passing in a pointer to the mesh function whose
+// gradient we want to shim via operator().
+class GradientMeshFunction : public FunctionBase<Gradient>
+{
+public:
+  // Constructor
+  GradientMeshFunction(MeshFunction * _mesh_function);
 
-        // Destructor
-        virtual ~GradientMeshFunction () { }
+  // Destructor
+  virtual ~GradientMeshFunction () { }
 
-        virtual void init () { }
+  virtual void init () { }
 
-        virtual std::unique_ptr<FunctionBase<Gradient>> clone () const
-        {
-          //return libmesh_make_unique<GradientMeshFunction>(dynamic_cast<MeshFunction *>(mesh_function.get()));
-          return libmesh_make_unique<GradientMeshFunction>(mesh_function.get());
-        }
+  virtual std::unique_ptr<FunctionBase<Gradient>> clone () const
+  {
+    //return libmesh_make_unique<GradientMeshFunction>(dynamic_cast<MeshFunction *>(mesh_function.get()));
+    return libmesh_make_unique<GradientMeshFunction>(mesh_function.get());
+  }
 
-        virtual Gradient operator() (const Point & , const Real)
-        { libmesh_not_implemented(); }
+  virtual Gradient operator() (const Point & , const Real)
+  { libmesh_not_implemented(); }
 
-        virtual void operator() (const Point & p, const Real, DenseVector<Gradient> & output);
+  virtual void operator() (const Point & p, const Real, DenseVector<Gradient> & output);
 
-        private:
+private:
 
-        // Local copy of the passed in mesh function.
-        std::unique_ptr<MeshFunction> mesh_function;
+  // Local copy of the passed in mesh function.
+  std::unique_ptr<MeshFunction> mesh_function;
 
-    };
+};
 }
 
 #endif // LIBMESH_INTER_MESH_PROJECTION_H

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -71,7 +71,18 @@ MeshFunction::MeshFunction (const EquationSystems & eqn_systems,
 {
 }
 
-
+MeshFunction::MeshFunction (const MeshFunction & mf):
+  FunctionBase<Number> (mf._master),
+  ParallelObject       (mf._eqn_systems),
+  _eqn_systems         (mf._eqn_systems),
+  _vector              (mf._vector),
+  _dof_map             (mf._dof_map),
+  _system_vars         (mf._system_vars),
+  _out_of_mesh_mode    (false)
+{
+  this->init();
+  this->set_point_locator_tolerance(mf.get_point_locator().get_close_to_point_tol());
+}
 
 MeshFunction::~MeshFunction () = default;
 
@@ -132,7 +143,7 @@ std::unique_ptr<FunctionBase<Number>> MeshFunction::clone () const
   if (this->initialized())
     mf_clone->init();
   mf_clone->set_point_locator_tolerance(
-    this->get_point_locator().get_close_to_point_tol());
+                                        this->get_point_locator().get_close_to_point_tol());
 
   return std::unique_ptr<FunctionBase<Number>>(mf_clone);
 }
@@ -724,11 +735,11 @@ const Elem * MeshFunction::find_element(const Point & p,
       element->find_point_neighbors(p, point_neighbors);
       element = nullptr;
       for (const auto & elem : point_neighbors)
-          if (elem->processor_id() == this->processor_id())
-            {
-              element = elem;
-              break;
-            }
+        if (elem->processor_id() == this->processor_id())
+          {
+            element = elem;
+            break;
+          }
     }
 
   return element;

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -78,10 +78,18 @@ MeshFunction::MeshFunction (const MeshFunction & mf):
   _vector              (mf._vector),
   _dof_map             (mf._dof_map),
   _system_vars         (mf._system_vars),
-  _out_of_mesh_mode    (false)
+  _out_of_mesh_mode    (mf._out_of_mesh_mode)
 {
-  this->init();
-  this->set_point_locator_tolerance(mf.get_point_locator().get_close_to_point_tol());
+  // Initialize the mf and set the point locator if the
+  // input mf had done so.
+  if(mf.initialized())
+  {
+    this->init();
+
+    if(mf.get_point_locator().initialized())
+      this->set_point_locator_tolerance(mf.get_point_locator().get_close_to_point_tol());
+
+  }
 }
 
 MeshFunction::~MeshFunction () = default;
@@ -137,15 +145,7 @@ MeshFunction::clear ()
 
 std::unique_ptr<FunctionBase<Number>> MeshFunction::clone () const
 {
-  MeshFunction * mf_clone =
-    new MeshFunction(_eqn_systems, _vector, _dof_map, _system_vars, this);
-
-  if (this->initialized())
-    mf_clone->init();
-  mf_clone->set_point_locator_tolerance(
-                                        this->get_point_locator().get_close_to_point_tol());
-
-  return std::unique_ptr<FunctionBase<Number>>(mf_clone);
+  return libmesh_make_unique<MeshFunction>(*this);
 }
 
 

--- a/src/systems/inter_mesh_projection.C
+++ b/src/systems/inter_mesh_projection.C
@@ -20,8 +20,8 @@
 
 namespace libMesh
 {
-GradientMeshFunction::GradientMeshFunction(MeshFunction * _mesh_function):
-  mesh_function(libmesh_make_unique<MeshFunction>(*_mesh_function))
+GradientMeshFunction::GradientMeshFunction(const MeshFunction & _mesh_function):
+  mesh_function(libmesh_make_unique<MeshFunction>(_mesh_function))
 {
   libmesh_experimental();
 }
@@ -82,7 +82,7 @@ void InterMeshProjection::project_system_vectors()
   // For some element types (say C1) we also need to pass a gradient evaluation MeshFunction
   // To do this evaluate, a new shim class GradientMeshFunction has been added which redirects
   // gptr::operator evaluations inside projection methods into MeshFunction::gradient calls.
-  GradientMeshFunction gptr_solution(&mesh_func_solution);
+  GradientMeshFunction gptr_solution(mesh_func_solution);
   gptr_solution.init();
 
   to_system.project_vector(*to_system.solution, &mesh_func_solution, &gptr_solution);
@@ -109,7 +109,7 @@ void InterMeshProjection::project_system_vectors()
 
       // Project the current system vector, you need to check if this vector is an adjoint to pass
       // the right options to project_vector
-      GradientMeshFunction gptr(&mesh_func);
+      GradientMeshFunction gptr(mesh_func);
       gptr.init();
 
       // The fourth argument here is whether the vector is an adjoint solution or not, we will be getting that information

--- a/src/systems/inter_mesh_projection.C
+++ b/src/systems/inter_mesh_projection.C
@@ -20,124 +20,118 @@
 
 namespace libMesh
 {
-    GradientMeshFunction::GradientMeshFunction(MeshFunction * _mesh_function)
+GradientMeshFunction::GradientMeshFunction(MeshFunction * _mesh_function):
+  mesh_function(libmesh_make_unique<MeshFunction>(*_mesh_function))
+{
+  libmesh_experimental();
+}
+
+void GradientMeshFunction::operator() (const Point & p, const Real, DenseVector<Gradient> & output)
+{
+  Real time = 0.0;
+  mesh_function->gradient(p, time, output.get_values());
+  return;
+}
+
+InterMeshProjection::InterMeshProjection(System & _from_system, System & _to_system) :
+  from_system(_from_system),
+  to_system(_to_system)
+{
+  libmesh_experimental();
+}
+
+void InterMeshProjection::project_system_vectors()
+{
+  // Number of vectors to be projected
+  libmesh_assert_equal_to (to_system.n_vectors(), from_system.n_vectors());
+
+  // Number of variable components in each vector
+  unsigned int n_vars = from_system.n_vars();
+  libmesh_assert_equal_to (to_system.n_vars(), n_vars);
+
+  // We are going to use the multi-variable MeshFunction, so we can pass
+  // a single vector of variables rather than have a MeshFunction for each variable
+  std::vector<unsigned int> variables_vector;
+
+  for (unsigned int j = 0; j != n_vars; ++j)
     {
-    // This looks odd and might yet not be the right/best thing to do. But the logic here is
-    // that we would ideally like to simply clone the passed in MeshFunction, but that returns
-    // a FunctionBase<Number> unique ptr. So we clone, release the obtained unique ptr to be able
-    // to reassign its ownership, and then cast this released ptr as a MeshFunction * to complete
-    // the assignment. Looks complicated, but other approaches to this assignment led to hard to
-    // untangle Seg Faults.
-     mesh_function = std::unique_ptr<MeshFunction>(cast_ptr<MeshFunction *>((_mesh_function->clone()).release()));
-     libmesh_experimental();
+      libmesh_assert_equal_to (to_system.variable_name(j), from_system.variable_name(j));
+      variables_vector.push_back(j);
     }
 
-    void GradientMeshFunction::operator() (const Point & p, const Real, DenseVector<Gradient> & output)
+  // Any system holds the solution along with the other vectors system.vectors
+  // We will first project the solution and then move to the system.vectors
+
+  // Construct local version of the current system vector
+  // This has to be a serial vector
+  // Roy's FIXME: Technically it just has to be a ghosted vector whose algebraically
+  // ghosted values cover a domain which is a superset of the to-system's domain ...
+  // that's hard to do and we can skip it until the poor scalability bites someone.
+  std::unique_ptr<NumericVector<Number>> solution_vector_serial = NumericVector<Number>::build(from_system.comm());
+  solution_vector_serial->init(from_system.solution->size(), true, SERIAL);
+
+  std::vector<Number> solution_vector;
+  from_system.update_global_solution(solution_vector);
+  (*solution_vector_serial) = solution_vector;
+
+  // Construct a MeshFunction for the solution
+  MeshFunction * mesh_func_solution =
+    new MeshFunction(from_system.get_equation_systems(), *solution_vector_serial,
+                     from_system.get_dof_map(), variables_vector);
+
+  mesh_func_solution->init();
+
+  // For some element types (say C1) we also need to pass a gradient evaluation MeshFunction
+  // To do this evaluate, a new shim class GradientMeshFunction has been added which redirects
+  // gptr::operator evaluations inside projection methods into MeshFunction::gradient calls.
+  GradientMeshFunction * gptr_solution = new GradientMeshFunction(mesh_func_solution);
+  gptr_solution->init();
+
+  to_system.project_vector(*to_system.solution, mesh_func_solution, gptr_solution);
+
+  // Delete all the MeshFunctions associated with the solution
+  delete mesh_func_solution;
+  delete gptr_solution;
+
+  // Now loop over the vectors in system.vectors (includes old_nonlin_sol, rhs, adjoints, adjoint_rhs, sensitivity_rhs)
+  for (System::vectors_iterator vec = from_system.vectors_begin(), vec_end = from_system.vectors_end(); vec != vec_end; ++vec)
     {
-     Real time = 0.0;
-     mesh_function->gradient(p, time, output.get_values());
-     return;
+      // The name of this vector
+      const std::string & vec_name = vec->first;
+
+      // Construct local version of the current system vector
+      // This has to be a serial vector
+      // Roy's FIXME: Technically it just has to be a ghosted vector whose algebraically
+      // ghosted values cover a domain which is a superset of the to-system's domain ...
+      // that's hard to do and we can skip it until the poor scalability bites someone.
+      std::unique_ptr<NumericVector<Number>> current_vector_proxy = NumericVector<Number>::build(from_system.comm());
+      current_vector_proxy->init(from_system.get_vector(vec_name).size(), true, SERIAL);
+
+      from_system.get_vector(vec_name).localize(*current_vector_proxy);
+
+      // Construct a MeshFunction for the current component
+      MeshFunction * mesh_func =
+        new MeshFunction(from_system.get_equation_systems(), *current_vector_proxy,
+                         from_system.get_dof_map(), variables_vector);
+
+      mesh_func->init();
+
+      // Project the current system vector, you need to check if this vector is an adjoint to pass
+      // the right options to project_vector
+      GradientMeshFunction * gptr = new GradientMeshFunction(mesh_func);
+      gptr->init();
+
+      // The fourth argument here is whether the vector is an adjoint solution or not, we will be getting that information
+      // via the from_system instead of the to_system in case the user has not set the System::_vector_is_adjoint map to true.
+      to_system.project_vector(to_system.get_vector(vec_name), mesh_func, gptr, from_system.vector_is_adjoint(vec_name));
+
+      // Delete all the MeshFunctions associated with the current vector
+      delete mesh_func;
+      delete gptr;
     }
+  // End loop over the vectors in the system
 
-    InterMeshProjection::InterMeshProjection(System & _from_system, System & _to_system) :
-    from_system(_from_system),
-    to_system(_to_system)
-    {
-     libmesh_experimental();
-    }
-
-    void InterMeshProjection::project_system_vectors()
-    {
-        // Number of vectors to be projected
-        libmesh_assert_equal_to (to_system.n_vectors(), from_system.n_vectors());
-
-        // Number of variable components in each vector
-        unsigned int n_vars = from_system.n_vars();
-        libmesh_assert_equal_to (to_system.n_vars(), n_vars);
-
-        // We are going to use the multi-variable MeshFunction, so we can pass
-        // a single vector of variables rather than have a MeshFunction for each variable
-        std::vector<unsigned int> variables_vector;
-
-        for (unsigned int j = 0; j != n_vars; ++j)
-        {
-          libmesh_assert_equal_to (to_system.variable_name(j), from_system.variable_name(j));
-          variables_vector.push_back(j);
-        }
-
-        // Any system holds the solution along with the other vectors system.vectors
-        // We will first project the solution and then move to the system.vectors
-
-        // Construct local version of the current system vector
-        // This has to be a serial vector
-        // Roy's FIXME: Technically it just has to be a ghosted vector whose algebraically
-        // ghosted values cover a domain which is a superset of the to-system's domain ...
-        // that's hard to do and we can skip it until the poor scalability bites someone.
-        std::unique_ptr<NumericVector<Number>> solution_vector_serial = NumericVector<Number>::build(from_system.comm());
-        solution_vector_serial->init(from_system.solution->size(), true, SERIAL);
-
-        std::vector<Number> solution_vector;
-        from_system.update_global_solution(solution_vector);
-        (*solution_vector_serial) = solution_vector;
-
-        // Construct a MeshFunction for the solution
-        MeshFunction * mesh_func_solution =
-            new MeshFunction(from_system.get_equation_systems(), *solution_vector_serial,
-                             from_system.get_dof_map(), variables_vector);
-
-        mesh_func_solution->init();
-
-        // For some element types (say C1) we also need to pass a gradient evaluation MeshFunction
-        // To do this evaluate, a new shim class GradientMeshFunction has been added which redirects
-        // gptr::operator evaluations inside projection methods into MeshFunction::gradient calls.
-        GradientMeshFunction * gptr_solution = new GradientMeshFunction(mesh_func_solution);
-        gptr_solution->init();
-
-        to_system.project_vector(*to_system.solution, mesh_func_solution, gptr_solution);
-
-        // Delete all the MeshFunctions associated with the solution
-        delete mesh_func_solution;
-        delete gptr_solution;
-
-        // Now loop over the vectors in system.vectors (includes old_nonlin_sol, rhs, adjoints, adjoint_rhs, sensitivity_rhs)
-        for (System::vectors_iterator vec = from_system.vectors_begin(), vec_end = from_system.vectors_end(); vec != vec_end; ++vec)
-        {
-            // The name of this vector
-            const std::string & vec_name = vec->first;
-
-            // Construct local version of the current system vector
-            // This has to be a serial vector
-            // Roy's FIXME: Technically it just has to be a ghosted vector whose algebraically
-            // ghosted values cover a domain which is a superset of the to-system's domain ...
-            // that's hard to do and we can skip it until the poor scalability bites someone.
-            std::unique_ptr<NumericVector<Number>> current_vector_proxy = NumericVector<Number>::build(from_system.comm());
-            current_vector_proxy->init(from_system.get_vector(vec_name).size(), true, SERIAL);
-
-            from_system.get_vector(vec_name).localize(*current_vector_proxy);
-
-            // Construct a MeshFunction for the current component
-            MeshFunction * mesh_func =
-            new MeshFunction(from_system.get_equation_systems(), *current_vector_proxy,
-                             from_system.get_dof_map(), variables_vector);
-
-            mesh_func->init();
-
-            // Project the current system vector, you need to check if this vector is an adjoint to pass
-            // the right options to project_vector
-            GradientMeshFunction * gptr = new GradientMeshFunction(mesh_func);
-            gptr->init();
-
-            // The fourth argument here is whether the vector is an adjoint solution or not, we will be getting that information
-            // via the from_system instead of the to_system in case the user has not set the System::_vector_is_adjoint map to true.
-            to_system.project_vector(to_system.get_vector(vec_name), mesh_func, gptr, from_system.vector_is_adjoint(vec_name));
-
-            // Delete all the MeshFunctions associated with the current vector
-            delete mesh_func;
-            delete gptr;
-        }
-        // End loop over the vectors in the system
-
-    }
-    // End InterMeshProjection::project_system_vectors
+}
+// End InterMeshProjection::project_system_vectors
 }
 // End namespace libMesh

--- a/src/systems/inter_mesh_projection.C
+++ b/src/systems/inter_mesh_projection.C
@@ -75,18 +75,17 @@ void InterMeshProjection::project_system_vectors()
   (*solution_vector_serial) = solution_vector;
 
   // Construct a MeshFunction for the solution
-  std::unique_ptr<MeshFunction> mesh_func_solution(new MeshFunction(from_system.get_equation_systems(), *solution_vector_serial,
-                     from_system.get_dof_map(), variables_vector));
+  MeshFunction mesh_func_solution(from_system.get_equation_systems(), *solution_vector_serial, from_system.get_dof_map(), variables_vector);
 
-  mesh_func_solution->init();
+  mesh_func_solution.init();
 
   // For some element types (say C1) we also need to pass a gradient evaluation MeshFunction
   // To do this evaluate, a new shim class GradientMeshFunction has been added which redirects
   // gptr::operator evaluations inside projection methods into MeshFunction::gradient calls.
-  std::unique_ptr<GradientMeshFunction> gptr_solution(new GradientMeshFunction(mesh_func_solution.get()));
-  gptr_solution->init();
+  GradientMeshFunction gptr_solution(&mesh_func_solution);
+  gptr_solution.init();
 
-  to_system.project_vector(*to_system.solution, mesh_func_solution.get(), gptr_solution.get());
+  to_system.project_vector(*to_system.solution, &mesh_func_solution, &gptr_solution);
 
   // Now loop over the vectors in system.vectors (includes old_nonlin_sol, rhs, adjoints, adjoint_rhs, sensitivity_rhs)
   for (System::vectors_iterator vec = from_system.vectors_begin(), vec_end = from_system.vectors_end(); vec != vec_end; ++vec)
@@ -105,18 +104,17 @@ void InterMeshProjection::project_system_vectors()
       from_system.get_vector(vec_name).localize(*current_vector_proxy);
 
       // Construct a MeshFunction for the current component
-      std::unique_ptr<MeshFunction> mesh_func(new MeshFunction(from_system.get_equation_systems(), *current_vector_proxy,
-                     from_system.get_dof_map(), variables_vector));
-      mesh_func->init();
+      MeshFunction mesh_func(from_system.get_equation_systems(), *current_vector_proxy, from_system.get_dof_map(), variables_vector);
+      mesh_func.init();
 
       // Project the current system vector, you need to check if this vector is an adjoint to pass
       // the right options to project_vector
-      std::unique_ptr<GradientMeshFunction> gptr(new GradientMeshFunction(mesh_func.get()));
-      gptr->init();
+      GradientMeshFunction gptr(&mesh_func);
+      gptr.init();
 
       // The fourth argument here is whether the vector is an adjoint solution or not, we will be getting that information
       // via the from_system instead of the to_system in case the user has not set the System::_vector_is_adjoint map to true.
-      to_system.project_vector(to_system.get_vector(vec_name), mesh_func.get(), gptr.get(), from_system.vector_is_adjoint(vec_name));
+      to_system.project_vector(to_system.get_vector(vec_name), &mesh_func, &gptr, from_system.vector_is_adjoint(vec_name));
 
     }
   // End loop over the vectors in the system


### PR DESCRIPTION
Code improvements for inter mesh projection branch which was merged earlier:

1)  Addition of MeshFunction copy constructor, which is now used instead of MeshFunction::clone() to avoid casting.
2) Raw new/delete replaced by unique_ptr.
3) Reindentation of all changed files.

Ref: https://github.com/libMesh/libmesh/pull/2855
https://github.com/libMesh/libmesh/pull/2826