### PR TITLE
Add PointLocator implementation based on Nanoflann

### DIFF
--- a/configure
+++ b/configure
@@ -1279,6 +1279,7 @@ enable_cppunit
 with_cppunit_include
 with_cppunit_lib
 enable_nanoflann
+enable_nanoflann_pointlocator
 enable_metaphysicl
 enable_metaphysicl_required
 '
@@ -2069,6 +2070,8 @@ Optional Features:
                           Build fparser with bytecode debugging functions
   --disable-cppunit       Build without cppunit C++ unit testing support
   --disable-nanoflann     build without nanoflann KD-tree support
+  --enable-nanoflann-pointlocator
+                          use Nanoflann-based PointLocator (experimental)
   --disable-metaphysicl   build without MetaPhysicL suppport
   --enable-metaphysicl-required
                           Error if MetaPhysicL is not detected by configure
@@ -55591,6 +55594,21 @@ else
 fi
 
 
+      # Check whether --enable-nanoflann-pointlocator was given.
+if test "${enable_nanoflann_pointlocator+set}" = set; then :
+  enableval=$enable_nanoflann_pointlocator; case "${enableval}" in #(
+  yes) :
+    enablenanoflannpointlocator=yes ;; #(
+  no) :
+    enablenanoflannpointlocator=no ;; #(
+  *) :
+    as_fn_error $? "bad value ${enableval} for --enable-nanoflann-pointlocator" "$LINENO" 5 ;;
+esac
+else
+  enablenanoflannpointlocator=no
+fi
+
+
       if test "x$enablenanoflann" = "xyes"; then :
 
           NANOFLANN_INCLUDE="-I\$(top_srcdir)/contrib/nanoflann/include"
@@ -55599,6 +55617,16 @@ $as_echo "#define HAVE_NANOFLANN 1" >>confdefs.h
 
           { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with nanoflann KDtree support >>>" >&5
 $as_echo "<<< Configuring library with nanoflann KDtree support >>>" >&6; }
+
+          if test "x$enablenanoflannpointlocator" = "xyes"; then :
+
+
+$as_echo "#define ENABLE_NANOFLANN_POINTLOCATOR 1" >>confdefs.h
+
+                  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with Nanoflann-based PointLocator >>>" >&5
+$as_echo "<<< Configuring library with Nanoflann-based PointLocator >>>" >&6; }
+
+fi
 
 else
 

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -1044,6 +1044,7 @@ include_HEADERS = \
         utils/perfmon.h \
         utils/plt_loader.h \
         utils/point_locator_base.h \
+        utils/point_locator_nanoflann.h \
         utils/point_locator_tree.h \
         utils/pointer_to_pointer_iter.h \
         utils/pool_allocator.h \

--- a/include/enums/enum_point_locator_type.h
+++ b/include/enums/enum_point_locator_type.h
@@ -36,6 +36,7 @@ enum PointLocatorType : int {
                        TREE = 0,
                        TREE_ELEMENTS,
                        TREE_LOCAL_ELEMENTS,
+                       NANOFLANN,
                        // Invalid
                        INVALID_LOCATOR};
 }

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -456,6 +456,7 @@ include_HEADERS =  \
         utils/perfmon.h \
         utils/plt_loader.h \
         utils/point_locator_base.h \
+        utils/point_locator_nanoflann.h \
         utils/point_locator_tree.h \
         utils/pointer_to_pointer_iter.h \
         utils/pool_allocator.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -452,6 +452,7 @@ BUILT_SOURCES = \
         perfmon.h \
         plt_loader.h \
         point_locator_base.h \
+        point_locator_nanoflann.h \
         point_locator_tree.h \
         pointer_to_pointer_iter.h \
         pool_allocator.h \
@@ -1889,6 +1890,9 @@ plt_loader.h: $(top_srcdir)/include/utils/plt_loader.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 point_locator_base.h: $(top_srcdir)/include/utils/point_locator_base.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+point_locator_nanoflann.h: $(top_srcdir)/include/utils/point_locator_nanoflann.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 point_locator_tree.h: $(top_srcdir)/include/utils/point_locator_tree.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -652,14 +652,14 @@ BUILT_SOURCES = auto_ptr.h default_coupling.h dirichlet_boundaries.h \
 	libmesh_nullptr.h location_maps.h mapvector.h \
 	null_output_iterator.h number_lookups.h ostream_proxy.h \
 	parameters.h perf_log.h perfmon.h plt_loader.h \
-	point_locator_base.h point_locator_tree.h \
-	pointer_to_pointer_iter.h pool_allocator.h restore_warnings.h \
-	simple_range.h statistics.h string_to_enum.h timestamp.h \
-	topology_map.h tree.h tree_base.h tree_node.h utility.h \
-	vectormap.h xdr_cxx.h parallel_communicator_specializations \
-	$(am__append_1) $(am__append_3) $(am__append_5) \
-	$(am__append_7) $(am__append_9) $(am__append_11) \
-	libmesh_config.h
+	point_locator_base.h point_locator_nanoflann.h \
+	point_locator_tree.h pointer_to_pointer_iter.h \
+	pool_allocator.h restore_warnings.h simple_range.h \
+	statistics.h string_to_enum.h timestamp.h topology_map.h \
+	tree.h tree_base.h tree_node.h utility.h vectormap.h xdr_cxx.h \
+	parallel_communicator_specializations $(am__append_1) \
+	$(am__append_3) $(am__append_5) $(am__append_7) \
+	$(am__append_9) $(am__append_11) libmesh_config.h
 DISTCLEANFILES = $(BUILT_SOURCES) $(am__append_2) $(am__append_4) \
 	$(am__append_6) $(am__append_8) $(am__append_10) \
 	$(am__append_12) libmesh_config.h
@@ -2234,6 +2234,9 @@ plt_loader.h: $(top_srcdir)/include/utils/plt_loader.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 point_locator_base.h: $(top_srcdir)/include/utils/point_locator_base.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+point_locator_nanoflann.h: $(top_srcdir)/include/utils/point_locator_nanoflann.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 point_locator_tree.h: $(top_srcdir)/include/utils/point_locator_tree.h

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -138,6 +138,10 @@
 /* Flag indicating if the library should be built with infinite elements */
 #undef ENABLE_INFINITE_ELEMENTS
 
+/* Flag indicating whether the library will use the (experimental)
+   Nanoflann-based PointLocator */
+#undef ENABLE_NANOFLANN_POINTLOCATOR
+
 /* Flag indicating if the library should be built with node constraints
    support */
 #undef ENABLE_NODE_CONSTRAINTS

--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -191,6 +191,14 @@ public:
   virtual Real get_contains_point_tol() const;
 
   /**
+   * The contains_point_tol may be nonzero (in fact it defaults to
+   * non-zero) but unless the user calls set_contains_point_tol(), it
+   * won't actually be *used*. This const accessor can be used to
+   * determine the current status of this flag.
+   */
+  bool get_use_contains_point_tol() const { return _use_contains_point_tol; }
+
+  /**
    * Get a const reference to this PointLocator's mesh.
    */
   const MeshBase & get_mesh() const;

--- a/include/utils/point_locator_nanoflann.h
+++ b/include/utils/point_locator_nanoflann.h
@@ -51,6 +51,20 @@ class Elem;
  * libmesh must be built with nanoflann enabled for this class to
  * work.
  *
+ * This PointLocator is still considered "experimental", so it is not
+ * enabled in libMesh by default. In particular, there may be false
+ * negatives (i.e. failures to find a containing Elem for a given
+ * Point even though there actually is one in the Mesh) on adaptively
+ * refined meshes, meshes with intersecting mixed-dimension manifolds,
+ * and meshes with large aspect ratio changes across neighboring
+ * elements. That said, the Nanoflann PointLocator did successfully
+ * pass all the MOOSE CI testing that we threw at it (and even
+ * uncovered some bugs in said tests) so it will likely work well for
+ * most applications outside of the categories mentioned above.
+ *
+ * You must configure libmesh with --enable-nanoflann-pointlocator in
+ * order to use this class.
+ *
  * \author John W. Peterson
  * \date 2021
  */

--- a/include/utils/point_locator_nanoflann.h
+++ b/include/utils/point_locator_nanoflann.h
@@ -205,14 +205,8 @@ protected:
    * These are shared_ptrs to vectors since, if we are not the "master"
    * PointLocator, they need to point at the master's vectors instead.
    */
-  std::shared_ptr<std::vector<dof_id_type>> _ids;
+  std::shared_ptr<std::vector<Elem *>> _elems;
   std::shared_ptr<std::vector<Point>> _point_cloud;
-
-  /**
-   * We can use a local BoundingBox check to quickly rule out
-   * exhaustive KD-Tree searches.
-   */
-  std::shared_ptr<BoundingBox> _local_bbox;
 
   // kd_tree will be initialized during init() and then automatically
   // cleaned up by the destructor. We always create a LIBMESH_DIM
@@ -230,6 +224,12 @@ protected:
   mutable std::vector<Real> _out_dist_sqr;
 
   /**
+   * Vector of indices used by indirect sort. Stored as a class member
+   * so we don't have to allocate it from scratch for every search.
+   */
+  mutable std::vector<std::size_t> _b;
+
+  /**
    * Helper function that wraps the call to the KDTree's
    * findNeighbors() routine.  Must be passed the Point to search for
    * and the number of results to return. Stores the results of the
@@ -240,14 +240,6 @@ protected:
   nanoflann::KNNResultSet<Real>
   kd_tree_find_neighbors(const Point & p,
                          std::size_t num_results) const;
-
-  /**
-   * Before performing a KD-Tree search, check if it is even possible
-   * for the Point to be found on this processor.  Note: if a custom
-   * contains_point() tolerance is used, this does an "inflated" bbox
-   * intersection check, otherwise it just does a contains_point() check.
-   */
-  bool search_local_bbox(const Point & p) const;
 };
 
 } // namespace libMesh

--- a/include/utils/point_locator_nanoflann.h
+++ b/include/utils/point_locator_nanoflann.h
@@ -1,0 +1,256 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2021 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#ifndef LIBMESH_POINT_LOCATOR_NANOFLANN_H
+#define LIBMESH_POINT_LOCATOR_NANOFLANN_H
+
+#include "libmesh/libmesh_config.h"
+
+// This class is not defined unless libmesh is built with Nanoflann support
+#ifdef LIBMESH_HAVE_NANOFLANN
+
+// libmesh includes
+#include "libmesh/point_locator_base.h"
+#include "libmesh/point.h"
+#include "libmesh/bounding_box.h"
+
+// contrib includes
+#include "libmesh/nanoflann.hpp"
+
+// C++ includes
+#include <vector>
+#include <memory>
+
+namespace libMesh
+{
+
+// Forward Declarations
+class MeshBase;
+class Point;
+class Elem;
+
+/**
+ * This is a PointLocator that uses Nanoflann for its implementation.
+ * Nanoflann is distributed with libmesh (see: contrib/nanoflann) and
+ * libmesh must be built with nanoflann enabled for this class to
+ * work.
+ *
+ * \author John W. Peterson
+ * \date 2021
+ */
+class PointLocatorNanoflann : public PointLocatorBase
+{
+public:
+  /**
+   * Constructor. Needs the \p mesh in which the points should be
+   * located. Optionally takes a pointer to a "master" PointLocator
+   * object. If non-nullptr, this object simply forwards its calls
+   * onto the master, so we can have multiple pointers that use the
+   * same Nanoflann KD-Tree data structure.
+   */
+  PointLocatorNanoflann (const MeshBase & mesh,
+                         const PointLocatorBase * master = nullptr);
+
+  /**
+   * Destructor.
+   */
+  virtual ~PointLocatorNanoflann ();
+
+  /**
+   * Restore to PointLocator to a just-constructed state.
+   */
+  virtual void clear() override;
+
+  /**
+   * Initializes the locator, so that the \p operator() methods can
+   * be used. This function allocates dynamic memory with "new".
+   */
+  virtual void init() override;
+
+  /**
+   * Locates the element in which the point with global coordinates \p
+   * p is located, optionally restricted to a set of allowed
+   * subdomains.
+   */
+  virtual const Elem * operator() (const Point & p,
+                                   const std::set<subdomain_id_type> * allowed_subdomains = nullptr) const override;
+
+  /**
+   * Locates a set of elements in proximity to the point with global
+   * coordinates \p p. Optionally allows the user to restrict the
+   * subdomains searched.  The idea here is that if a Point lies on
+   * the boundary between two elements, so that it is "in" both
+   * elements (to within some tolerance) then the candidate_elements
+   * set will contain both of these elements instead of just picking
+   * one or the other.
+   */
+  virtual void operator() (const Point & p,
+                           std::set<const Elem *> & candidate_elements,
+                           const std::set<subdomain_id_type> * allowed_subdomains = nullptr) const override;
+
+  /**
+   * Enables out-of-mesh mode. In this mode, if a searched-for Point
+   * is not contained in any element of the Mesh, return nullptr
+   * instead of throwing an error. By default, this mode is off.
+   */
+  virtual void enable_out_of_mesh_mode () override;
+
+  /**
+   * Disables out-of-mesh mode (default). See above.
+   */
+  virtual void disable_out_of_mesh_mode () override;
+
+  /**
+   * Set/get the number of results returned by each Nanoflann
+   * findNeighbors() search.  If a containing Elem (to within
+   * _contains_point_tol) is not found after linear searching the
+   * first _num_results Elems returned by Nanoflann, then we
+   * give up and return nullptr (or throw an error if not in
+   * out-of-mesh-mode).
+   *
+   * Remarks:
+   * 1.) Although we do a linear search through the Nanoflann results,
+   * the Nanoflann results are always sorted by distance to the
+   * searched-for Point, so it's likely that the containing Elem will
+   * be found at the beginning of the linear search rather than the
+   * end. For nicely shaped elements, the containing Elem is often the
+   * first or second one found in the Nanoflann results.
+   *
+   * 2.) I'm not sure about the relative cost of requesting more
+   * results from the Nanoflann search than one actually needs, but
+   * presumably reducing _num_results will result in better
+   * performance for your particular application up to a point. If, on
+   * the other hand, _num_results is too small, then you risk
+   * having a false negative result, so take this into account when
+   * choosing the parameter for a particular application.
+   */
+  std::size_t get_num_results() const;
+  void set_num_results(std::size_t val);
+
+  //
+  // Required Nanoflann typedefs and APIs
+  //
+
+  /**
+   * Floating point type used for storing coordinates
+   */
+  typedef Real coord_t;
+
+  /**
+   * Must return the number of data points
+   */
+  std::size_t kdtree_get_point_count() const;
+
+  /**
+   * Returns the squared distance between the vector (p1[0], p1[1], p1[2])
+   * and the centroid of Elem "idx_p2" stored in _mesh
+   */
+  coord_t kdtree_distance(const coord_t * p1,
+                          const std::size_t idx_p2,
+                          std::size_t size) const;
+
+  /**
+   * Returns the dim'th component of the idx'th centroid.
+   */
+  coord_t kdtree_get_pt(const std::size_t idx, int dim) const;
+
+  /**
+   * Optional bounding-box computation: return false to default to a
+   * standard bbox computation loop.  Return true if the BBOX can
+   * be computed more efficiently (and returned in "bb") than the
+   * standard bounding box computation. The BBOX template parameter
+   * must at least support bb.size() to find out the expected
+   * dimensionality of the box (e.g. 2 or 3 for point clouds).
+   */
+  template <class BBOX>
+  bool kdtree_get_bbox(BBOX & /*bb*/) const { return false; }
+
+protected:
+
+  /**
+   * \p true if out-of-mesh mode is enabled.  See \p
+   * enable_out_of_mesh_mode() for details.
+   */
+  bool _out_of_mesh_mode;
+
+  /**
+   * The number of results returned by Nanoflann when operator() is
+   * called.
+   */
+  std::size_t _num_results;
+
+  /**
+   * Lists of Points and ids which make up the "point cloud" that is
+   * to be searched via Nanoflann. The point cloud can be comprised of
+   * Elem centroids or mesh Nodes, depending on the type of tree
+   * created. We keep two separate vectors since the Points in the
+   * cloud may not be numbered contiguously in general.
+   *
+   * These are shared_ptrs to vectors since, if we are not the "master"
+   * PointLocator, they need to point at the master's vectors instead.
+   */
+  std::shared_ptr<std::vector<dof_id_type>> _ids;
+  std::shared_ptr<std::vector<Point>> _point_cloud;
+
+  /**
+   * We can use a local BoundingBox check to quickly rule out
+   * exhaustive KD-Tree searches.
+   */
+  std::shared_ptr<BoundingBox> _local_bbox;
+
+  // kd_tree will be initialized during init() and then automatically
+  // cleaned up by the destructor. We always create a LIBMESH_DIM
+  // dimensional Nanoflann object.
+  typedef nanoflann::L2_Simple_Adaptor<Real, PointLocatorNanoflann> adapter_t;
+  typedef nanoflann::KDTreeSingleIndexAdaptor<adapter_t, PointLocatorNanoflann, LIBMESH_DIM> kd_tree_t;
+  std::shared_ptr<kd_tree_t> _kd_tree;
+
+  /**
+   * The operator() functions on PointLocator-derived classes are
+   * const, so to avoid re-allocating these result data structures every
+   * time operator() is called, they have to be mutable.
+   */
+  mutable std::vector<std::size_t> _ret_index;
+  mutable std::vector<Real> _out_dist_sqr;
+
+  /**
+   * Helper function that wraps the call to the KDTree's
+   * findNeighbors() routine.  Must be passed the Point to search for
+   * and the number of results to return. Stores the results of the
+   * search in the _ret_index and _out_dist_sqr class members and
+   * returns a KNNResultSet, which has pointers to the index and
+   * distance data.
+   */
+  nanoflann::KNNResultSet<Real>
+  kd_tree_find_neighbors(const Point & p,
+                         std::size_t num_results) const;
+
+  /**
+   * Before performing a KD-Tree search, check if it is even possible
+   * for the Point to be found on this processor.  Note: if a custom
+   * contains_point() tolerance is used, this does an "inflated" bbox
+   * intersection check, otherwise it just does a contains_point() check.
+   */
+  bool search_local_bbox(const Point & p) const;
+};
+
+} // namespace libMesh
+
+#endif // LIBMESH_HAVE_NANOFLANN
+#endif // LIBMESH_POINT_LOCATOR_NANOFLANN_H

--- a/include/utils/tree_base.h
+++ b/include/utils/tree_base.h
@@ -55,7 +55,7 @@ namespace Trees
  * \date 2003
  * \brief Base class for different Tree types.
  */
-enum BuildType {NODES=0,
+enum BuildType : int {NODES=0,
                 ELEMENTS,
                 LOCAL_ELEMENTS,
                 INVALID_BUILD_TYPE };

--- a/m4/nanoflann.m4
+++ b/m4/nanoflann.m4
@@ -12,6 +12,17 @@ AC_DEFUN([CONFIGURE_NANOFLANN],
                          [AC_MSG_ERROR(bad value ${enableval} for --enable-nanoflann)])],
                 [enablenanoflann=$enableoptional])
 
+  dnl The Nanoflann PointLocator is not used by default, you can turn it on by configuring
+  dnl with --enable-nanoflann-pointlocator
+  AC_ARG_ENABLE(nanoflann-pointlocator,
+                AS_HELP_STRING([--enable-nanoflann-pointlocator],
+                               [use Nanoflann-based PointLocator (experimental)]),
+                [AS_CASE("${enableval}",
+                         [yes], [enablenanoflannpointlocator=yes],
+                         [no], [enablenanoflannpointlocator=no],
+                         [AC_MSG_ERROR(bad value ${enableval} for --enable-nanoflann-pointlocator)])],
+                [enablenanoflannpointlocator=no])
+
   dnl The NANOFLANN API is distributed with libmesh, so we don't have to guess
   dnl where it might be installed...
   AS_IF([test "x$enablenanoflann" = "xyes"],
@@ -19,6 +30,12 @@ AC_DEFUN([CONFIGURE_NANOFLANN],
           NANOFLANN_INCLUDE="-I\$(top_srcdir)/contrib/nanoflann/include"
           AC_DEFINE(HAVE_NANOFLANN, 1, [Flag indicating whether the library will be compiled with nanoflann KD-Tree support])
           AC_MSG_RESULT(<<< Configuring library with nanoflann KDtree support >>>)
+
+          AS_IF([test "x$enablenanoflannpointlocator" = "xyes"],
+                [
+                  AC_DEFINE(ENABLE_NANOFLANN_POINTLOCATOR, 1, [Flag indicating whether the library will use the (experimental) Nanoflann-based PointLocator])
+                  AC_MSG_RESULT([<<< Configuring library with Nanoflann-based PointLocator >>>])
+                ])
         ],
         [
           NANOFLANN_INCLUDE=""

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -425,6 +425,7 @@ libmesh_SOURCES =  \
         src/utils/plt_loader_read.C \
         src/utils/plt_loader_write.C \
         src/utils/point_locator_base.C \
+        src/utils/point_locator_nanoflann.C \
         src/utils/point_locator_tree.C \
         src/utils/statistics.C \
         src/utils/string_to_enum.C \

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -43,6 +43,7 @@
 #include "libmesh/enum_point_locator_type.h"
 #include "libmesh/enum_to_string.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/point_locator_nanoflann.h"
 
 namespace libMesh
 {
@@ -1206,7 +1207,11 @@ std::unique_ptr<PointLocatorBase> MeshBase::sub_point_locator () const
       // And it may require parallel communication
       parallel_object_only();
 
+#ifdef LIBMESH_HAVE_NANOFLANN
+      _point_locator = PointLocatorBase::build(NANOFLANN, *this);
+#else
       _point_locator = PointLocatorBase::build(TREE_ELEMENTS, *this);
+#endif
 
       if (_point_locator_close_to_point_tol > 0.)
         _point_locator->set_close_to_point_tol(_point_locator_close_to_point_tol);
@@ -1214,7 +1219,12 @@ std::unique_ptr<PointLocatorBase> MeshBase::sub_point_locator () const
 
   // Otherwise there was a master point locator, and we can grab a
   // sub-locator easily.
-  return PointLocatorBase::build(TREE_ELEMENTS, *this, _point_locator.get());
+  return
+#ifdef LIBMESH_HAVE_NANOFLANN
+    PointLocatorBase::build(NANOFLANN, *this, _point_locator.get());
+#else
+    PointLocatorBase::build(TREE_ELEMENTS, *this, _point_locator.get());
+#endif
 }
 
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -1207,7 +1207,7 @@ std::unique_ptr<PointLocatorBase> MeshBase::sub_point_locator () const
       // And it may require parallel communication
       parallel_object_only();
 
-#ifdef LIBMESH_HAVE_NANOFLANN
+#ifdef LIBMESH_ENABLE_NANOFLANN_POINTLOCATOR
       _point_locator = PointLocatorBase::build(NANOFLANN, *this);
 #else
       _point_locator = PointLocatorBase::build(TREE_ELEMENTS, *this);
@@ -1220,7 +1220,7 @@ std::unique_ptr<PointLocatorBase> MeshBase::sub_point_locator () const
   // Otherwise there was a master point locator, and we can grab a
   // sub-locator easily.
   return
-#ifdef LIBMESH_HAVE_NANOFLANN
+#ifdef LIBMESH_ENABLE_NANOFLANN_POINTLOCATOR
     PointLocatorBase::build(NANOFLANN, *this, _point_locator.get());
 #else
     PointLocatorBase::build(TREE_ELEMENTS, *this, _point_locator.get());

--- a/src/utils/point_locator_base.C
+++ b/src/utils/point_locator_base.C
@@ -22,6 +22,7 @@
 #include "libmesh/point_locator_tree.h"
 #include "libmesh/elem.h"
 #include "libmesh/enum_point_locator_type.h"
+#include "libmesh/point_locator_nanoflann.h"
 
 namespace libMesh
 {
@@ -79,6 +80,11 @@ std::unique_ptr<PointLocatorBase> PointLocatorBase::build (PointLocatorType t,
 
     case TREE_LOCAL_ELEMENTS:
       return libmesh_make_unique<PointLocatorTree>(mesh, Trees::LOCAL_ELEMENTS, master);
+
+#ifdef LIBMESH_HAVE_NANOFLANN
+    case NANOFLANN:
+      return libmesh_make_unique<PointLocatorNanoflann>(mesh, master);
+#endif
 
     default:
       libmesh_error_msg("ERROR: Bad PointLocatorType = " << t);

--- a/src/utils/point_locator_nanoflann.C
+++ b/src/utils/point_locator_nanoflann.C
@@ -1,0 +1,443 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2021 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+#include "libmesh/libmesh_config.h"
+
+// This class is not defined unless libmesh is built with Nanoflann support
+#ifdef LIBMESH_HAVE_NANOFLANN
+
+// libmesh includes
+#include "libmesh/point_locator_nanoflann.h"
+#include "libmesh/elem.h"
+#include "libmesh/libmesh_logging.h"
+#include "libmesh/mesh_base.h"
+#include "libmesh/mesh_tools.h"
+#include "libmesh/int_range.h" // make_range
+#include "libmesh/mesh_tools.h" // create_local_bounding_box
+
+// C++ includes
+#include <array>
+
+namespace libMesh
+{
+
+PointLocatorNanoflann::PointLocatorNanoflann (const MeshBase & mesh,
+                                              const PointLocatorBase * master) :
+  PointLocatorBase (mesh, master),
+  _out_of_mesh_mode(false),
+  _num_results(8)
+{
+  this->init();
+}
+
+
+
+PointLocatorNanoflann::~PointLocatorNanoflann () = default;
+
+
+
+void
+PointLocatorNanoflann::clear ()
+{
+  this->_initialized = false;
+  this->_out_of_mesh_mode = false;
+
+  // reset() actually frees the memory if we are master, otherwise it
+  // just reduces the ref. count.
+  _ids.reset();
+  _point_cloud.reset();
+  _local_bbox.reset();
+  _kd_tree.reset();
+}
+
+
+
+void
+PointLocatorNanoflann::init ()
+{
+  LOG_SCOPE("init()", "PointLocatorNanoflann");
+
+  if (!_initialized)
+    {
+      // If _master == nullptr, then we _are_ the master, and thus
+      // responsible for initializing.
+      bool we_are_master = (_master == nullptr);
+
+      // If we are the master PointLocator, fill in the _point_cloud
+      // data structure with active, local element centroids.
+      if (we_are_master)
+        {
+          _ids = std::make_shared<std::vector<dof_id_type>>();
+          _point_cloud = std::make_shared<std::vector<Point>>();
+
+          // Make the KD-Tree out of mesh element centroids.
+
+          // We can either reserve exactly the right amount of space or
+          // let push_back() take care of it, not sure what would be
+          // faster actually, since it takes some time to count the number
+          // of active+local elements.
+          auto n_active_local_elem = _mesh.n_active_local_elem();
+          _ids->reserve(n_active_local_elem);
+          _point_cloud->reserve(n_active_local_elem);
+
+          for (const auto & elem : _mesh.active_local_element_ptr_range())
+            {
+              _ids->push_back(elem->id());
+              _point_cloud->push_back(elem->centroid());
+            }
+
+          // Construct the KD-Tree
+          _kd_tree = std::make_shared<kd_tree_t>
+            (LIBMESH_DIM, *this, nanoflann::KDTreeSingleIndexAdaptorParams(/*max leaf=*/10));
+
+          _kd_tree->buildIndex();
+
+          // First, create a BoundingBox for the local elements
+          _local_bbox = std::make_shared<BoundingBox>(MeshTools::create_local_bounding_box(_mesh));
+        }
+      else // we are not master
+        {
+          // Cast the _master to the appropriate type, and point to
+          // its data arrays.
+          const auto my_master =
+            cast_ptr<const PointLocatorNanoflann *>(this->_master);
+
+          // Point our data structures at the master's
+          _ids = my_master->_ids;
+          _point_cloud = my_master->_point_cloud;
+          _local_bbox = my_master->_local_bbox;
+          _kd_tree = my_master->_kd_tree;
+        }
+
+      // We are initialized now
+      this->_initialized = true;
+    }
+}
+
+nanoflann::KNNResultSet<Real>
+PointLocatorNanoflann::kd_tree_find_neighbors(const Point & p,
+                                              std::size_t num_results) const
+{
+  // We are searching for the Point(s) closest to Point p.
+  //
+  // TODO: The kd_tree's findNeighbors() routine needs a pointer to
+  // Real of length LIBMESH_DIM. It might be convenient if libMesh
+  // Points had a data() member that provided this, for now we just
+  // copy the coordinates into a std::array of the appropriate size.
+  std::array<Real, LIBMESH_DIM> query_pt;
+  for (int i=0; i<LIBMESH_DIM; ++i)
+    query_pt[i] = p(i);
+
+  // Allocate storage for the indices and distances
+  _ret_index.resize(num_results);
+  _out_dist_sqr.resize(num_results);
+
+  // nanoflann::KNNResultSet cannot be resized/reused easily, I think
+  // it is just meant to be re-created for each search.
+  nanoflann::KNNResultSet<Real> result_set(num_results);
+
+  // Initialize the result_set
+  result_set.init(_ret_index.data(), _out_dist_sqr.data());
+
+  // Do the search
+  // We leave all the SearchParams() ctor args on their default values
+  // (note that the first arg is ignored anyway).
+  _kd_tree->findNeighbors(result_set, query_pt.data(), nanoflann::SearchParams());
+
+  return result_set;
+}
+
+
+
+bool
+PointLocatorNanoflann::search_local_bbox(const Point & p) const
+{
+  // If we are using a custom contains_point() tolerance, then we do a
+  // BoundingBox intersection check with a tiny BoundingBox centered
+  // on the search Point, otherwise we just do a simple
+  // contains_point() check.
+
+  if (_use_contains_point_tol)
+    {
+      Point min_copy = _local_bbox->min();
+      Point max_copy = _local_bbox->max();
+
+      // Compute absolute tolerance based on the bbox diagonal
+      const Real abstol = (max_copy - min_copy).norm() * _contains_point_tol;
+
+      // Inflate
+      for (int i=0; i<LIBMESH_DIM; ++i)
+        {
+          min_copy(i) -= abstol;
+          max_copy(i) += abstol;
+        }
+
+      BoundingBox p_bbox(min_copy, max_copy);
+      return _local_bbox->intersects(p_bbox);
+    }
+  else
+    return _local_bbox->contains_point(p);
+}
+
+
+
+const Elem *
+PointLocatorNanoflann::operator() (const Point & p,
+                                   const std::set<subdomain_id_type> * allowed_subdomains) const
+{
+  libmesh_assert (this->_initialized);
+
+  LOG_SCOPE("operator()", "PointLocatorNanoflann");
+
+  // Keep track of the number of elements checked in detail. This can
+  // be useful for determining an optimal _num_results for
+  // specific applications, by looking at the average and best/worse
+  // case of each linear search.
+  unsigned int n_elems_checked = 0;
+
+  // We are not going to do any searching on this processor if the
+  // Point doesn't fall in our (inflated) processor bounding box!
+  bool point_in_local_bbox = search_local_bbox(p);
+
+  // If a containing Elem is found locally, we will set this pointer.
+  const Elem * found_elem = nullptr;
+
+  // If the Point p is in our local bounding box, do a Nanoflann
+  // findNeighbors() search for it. This returns a sorted list of the
+  // closest _num_results elements which we then linearly
+  // search.
+  if (point_in_local_bbox)
+    {
+      auto result_set = this->kd_tree_find_neighbors(p, _num_results);
+
+      // Note: we use result_set.size() here rather than
+      // _num_results, in case the result returns fewer than
+      // _num_results results!
+      for (auto r : make_range(result_set.size()))
+        {
+          // Translate the Nanoflann index, which is from [0..n_points),
+          // into the corresponding Elem id from the mesh.
+          auto nanoflann_index = _ret_index[r];
+          auto elem_id = (*_ids)[nanoflann_index];
+
+          // Debugging: print the results
+          // libMesh::err << "Centroid/Elem id = " << elem_id
+          //              << ", dist^2 = " << _out_dist_sqr[r]
+          //              << std::endl;
+
+          const Elem * candidate_elem = _mesh.elem_ptr(elem_id);
+
+          // Before we even check whether the candidate Elem actually
+          // contains the Point, we may need to check whether the
+          // candidate Elem is from an allowed subdomain.  If the
+          // candidate Elem is not from an allowed subdomain, we continue
+          // to the next one.
+          if (allowed_subdomains && !allowed_subdomains->count(candidate_elem->subdomain_id()))
+            {
+              // Debugging
+              // libMesh::err << "Elem " << elem_id << " was not from an allowed subdomain, continuing search." << std::endl;
+              continue;
+            }
+
+          // If we made it here, then the candidate Elem is from an
+          // allowed subdomain, so let's next check whether it contains
+          // the point. If the user set a custom tolerance, then we
+          // actually check close_to_point() rather than contains_point(),
+          // since this latter function warns about using non-default
+          // tolerances, but otherwise does the same test.
+          bool inside = _use_contains_point_tol ?
+            candidate_elem->close_to_point(p, _contains_point_tol) :
+            candidate_elem->contains_point(p);
+
+          // Increment the number of elements checked
+          n_elems_checked++;
+
+          // If the point is inside an Elem from an allowed subdomain, we are done.
+          if (inside)
+            {
+              // Debugging: report the number of Elems checked
+              // libMesh::err << "Checked " << n_elems_checked << " nearby Elems before finding a containing Elem." << std::endl;
+
+              found_elem = candidate_elem;
+              break;
+            }
+        } // end for(r)
+    } // if (point_in_local_bbox)
+
+  // If we made it here, then at least one of the following happened:
+  // .) The search Point was not in the BoundingBox of local Elems.
+  // .) All the candidate elements were from non-allowed subdomains.
+  // .) The Point was not inside _any_ of the _num_results candidate Elems.
+  // Thus, if we are not in _out_of_mesh_mode, throw an error,
+  // otherwise return nullptr to indicate that no suitable element was
+  // found.
+  if (!_out_of_mesh_mode && !found_elem)
+    libmesh_error_msg("Point was not contained within the closest " << n_elems_checked <<
+                      " elems (by centroid distance), and _out_of_mesh_mode was not enabled.");
+
+  return found_elem;
+}
+
+
+void
+PointLocatorNanoflann::operator() (const Point & p,
+                                   std::set<const Elem *> & candidate_elements,
+                                   const std::set<subdomain_id_type> * allowed_subdomains) const
+{
+  libmesh_assert (this->_initialized);
+
+  LOG_SCOPE("operator() returning set", "PointLocatorNanoflann");
+
+  // Make sure the output set is initially empty
+  candidate_elements.clear();
+
+  // Keep track of the number of elements checked in detail
+  unsigned int n_elems_checked = 0;
+
+  // We are not going to do any searching on this processor if the
+  // Point doesn't fall in our (inflated) processor bounding box!
+  bool point_in_local_bbox = search_local_bbox(p);
+
+  // If the Point p is in our local bounding box, do a Nanoflann
+  // findNeighbors() search for it. We then store any of those
+  // elements which also contain the Point in the candidate_elements
+  // set.
+  if (point_in_local_bbox)
+    {
+      // Do the KD-Tree search
+      auto result_set = this->kd_tree_find_neighbors(p, _num_results);
+
+      for (auto r : make_range(result_set.size()))
+        {
+          // Translate the Nanoflann index, which is from [0..n_points),
+          // into the corresponding Elem id from the mesh.
+          auto nanoflann_index = _ret_index[r];
+          auto elem_id = (*_ids)[nanoflann_index];
+
+          const Elem * candidate_elem = _mesh.elem_ptr(elem_id);
+
+          // Before we even check whether the candidate Elem actually
+          // contains the Point, we may need to check whether the
+          // candidate Elem is from an allowed subdomain.  If the
+          // candidate Elem is not from an allowed subdomain, we continue
+          // to the next one.
+          if (allowed_subdomains && !allowed_subdomains->count(candidate_elem->subdomain_id()))
+            continue;
+
+          // If we made it here, then the candidate Elem is from an
+          // allowed subdomain, so let's next check whether it contains
+          // the point. If the user set a custom tolerance, then we
+          // actually check close_to_point() rather than contains_point(),
+          // since this latter function warns about using non-default
+          // tolerances, but otherwise does the same test.
+          bool inside = _use_contains_point_tol ?
+            candidate_elem->close_to_point(p, _contains_point_tol) :
+            candidate_elem->contains_point(p);
+
+          // Increment the number of elements checked
+          n_elems_checked++;
+
+          // If the point is contained in/close to an Elem from an
+          // allowed subdomain, add it to the list.
+          if (inside)
+            candidate_elements.insert(candidate_elem);
+        } // end for(r)
+    } // if (point_in_local_bbox)
+
+  // Debugging: for performance reasons, it may be useful to print the
+  // number of Elems actually checked during the search.
+  // libMesh::err << "Checked " << n_elems_checked << " nearby Elems before finding a containing Elem." << std::endl;
+}
+
+
+void
+PointLocatorNanoflann::enable_out_of_mesh_mode ()
+{
+  // Out-of-mesh mode should now work properly even on meshes with
+  // non-affine elements.
+  _out_of_mesh_mode = true;
+}
+
+
+void
+PointLocatorNanoflann::disable_out_of_mesh_mode ()
+{
+  _out_of_mesh_mode = false;
+}
+
+
+
+std::size_t
+PointLocatorNanoflann::get_num_results() const
+{
+  return _num_results;
+}
+
+
+
+void
+PointLocatorNanoflann::set_num_results(std::size_t val)
+{
+  // Must request at least 1 result
+  _num_results = std::max(static_cast<std::size_t>(1), val);
+}
+
+//
+// Required Nanoflann APIs
+//
+
+std::size_t PointLocatorNanoflann::kdtree_get_point_count() const
+{
+  return _point_cloud->size();
+}
+
+
+
+PointLocatorNanoflann::coord_t
+PointLocatorNanoflann::kdtree_distance(const coord_t * p1,
+                                       const std::size_t idx_p2,
+                                       std::size_t size) const
+{
+  // We only consider LIBMESH_DIM dimensional KD-Trees, so just make
+  // sure we were called consistently.
+  libmesh_assert(size == LIBMESH_DIM);
+
+  // Construct a libmesh Point object from the LIBMESH_DIM-dimensional
+  // input object, p1.
+  Point point1;
+  for (int i=0; i<LIBMESH_DIM; ++i)
+    point1(i) = p1[i];
+
+  // Compute Euclidean distance, squared
+  return (point1 - (*_point_cloud)[idx_p2]).norm_sq();
+}
+
+
+
+PointLocatorNanoflann::coord_t
+PointLocatorNanoflann::kdtree_get_pt(const std::size_t idx, int dim) const
+{
+  libmesh_assert_less (idx, _point_cloud->size());
+  libmesh_assert_less (dim, LIBMESH_DIM);
+
+  return (*_point_cloud)[idx](dim);
+}
+
+} // namespace libMesh
+
+#endif


### PR DESCRIPTION
This is kind of a big change, so I'm ~~not sure it's going~~ sure it's not going to pass all the tests... but in my internal testing this approach is moderately faster than our existing `PointLocatorTree` implementation, and it should not have some of the issues that the `PointLocatorTree` has exhibited over the years with e.g. multi-dimensional meshes and spider nodes. 