### PR TITLE
Make MeshRefinement tests const

### DIFF
--- a/include/mesh/mesh_refinement.h
+++ b/include/mesh/mesh_refinement.h
@@ -290,7 +290,7 @@ public:
    * Aborts the program if \p libmesh_assert_yes is true and the mesh
    * does not satisfy the level one restriction.
    */
-  bool test_level_one (bool libmesh_assert_yes = false);
+  bool test_level_one (bool libmesh_assert_yes = false) const;
 
   /**
    * \returns \p true if the mesh has no elements flagged to be
@@ -299,7 +299,7 @@ public:
    * Aborts the program if libmesh_assert_yes is true and the mesh has
    * flagged elements.
    */
-  bool test_unflagged (bool libmesh_assert_yes = false);
+  bool test_unflagged (bool libmesh_assert_yes = false) const;
 
   /**
    * Add a node to the mesh.  The node should be node n of child c of
@@ -733,7 +733,7 @@ private:
    */
   Elem * topological_neighbor (Elem * elem,
                                const PointLocatorBase * point_locator,
-                               const unsigned int side);
+                               const unsigned int side) const;
 
   /**
    * Local dispatch function for checking the correct has_neighbor
@@ -741,7 +741,7 @@ private:
    */
   bool has_topological_neighbor (const Elem * elem,
                                  const PointLocatorBase * point_locator,
-                                 const Elem * neighbor);
+                                 const Elem * neighbor) const;
 
   /**
    * Data structure that holds the new nodes information.

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -354,7 +354,7 @@ void MeshRefinement::update_nodes_map ()
 
 
 
-bool MeshRefinement::test_level_one (bool libmesh_dbg_var(libmesh_assert_pass))
+bool MeshRefinement::test_level_one (bool libmesh_dbg_var(libmesh_assert_pass)) const
 {
   // This function must be run on all processors at once
   parallel_object_only();
@@ -429,7 +429,7 @@ bool MeshRefinement::test_level_one (bool libmesh_dbg_var(libmesh_assert_pass))
 
 
 
-bool MeshRefinement::test_unflagged (bool libmesh_dbg_var(libmesh_assert_pass))
+bool MeshRefinement::test_unflagged (bool libmesh_dbg_var(libmesh_assert_pass)) const
 {
   // This function must be run on all processors at once
   parallel_object_only();
@@ -1794,7 +1794,7 @@ void MeshRefinement::uniformly_coarsen (unsigned int n)
 
 Elem * MeshRefinement::topological_neighbor(Elem * elem,
                                             const PointLocatorBase * point_locator,
-                                            const unsigned int side)
+                                            const unsigned int side) const
 {
 #ifdef LIBMESH_ENABLE_PERIODIC
   if (_periodic_boundaries && !_periodic_boundaries->empty())
@@ -1810,7 +1810,7 @@ Elem * MeshRefinement::topological_neighbor(Elem * elem,
 
 bool MeshRefinement::has_topological_neighbor(const Elem * elem,
                                               const PointLocatorBase * point_locator,
-                                              const Elem * neighbor)
+                                              const Elem * neighbor) const
 {
 #ifdef LIBMESH_ENABLE_PERIODIC
   if (_periodic_boundaries && !_periodic_boundaries->empty())


### PR DESCRIPTION
@jwpeterson noticed this while debugging #2865 - it looks to me like an
atavism, either a simple mistake from when these functions were first
added or possibly a temporary workaround from before we made
sub_point_locator() const and the master point locator mutable.