### PR TITLE
PointLocatorTree: use std::shared_ptr to manage tree

### DIFF
--- a/include/utils/point_locator_tree.h
+++ b/include/utils/point_locator_tree.h
@@ -26,6 +26,7 @@
 
 // C++ includes
 #include <cstddef>
+#include <memory> // std::shared_ptr
 
 namespace libMesh
 {
@@ -165,10 +166,10 @@ public:
 protected:
   /**
    * Pointer to our tree.  The tree is built at run-time
-   * through \p init().  For servant PointLocators (not master),
+   * through \p init().  For non-master PointLocators,
    * this simply points to the tree of the master.
    */
-  TreeBase * _tree;
+  std::shared_ptr<TreeBase> _tree;
 
   /**
    * Pointer to the last element that was found by the tree.


### PR DESCRIPTION
The master/sub PointLocator models `std::shared_ptr` ownership semantics, so it makes sense to use that rather than raw new/delete to manage the resource. This also means that the destructor can be defaulted.

Refs #2865