### PR TITLE
Fix for --enable-petsc-required 

### DIFF
--- a/configure
+++ b/configure
@@ -48760,22 +48760,13 @@ fi
 
 
 # -------------------------------------------------------------------
-# Petsc -- We arelady called CONFIGURE_PETSC in LIBMESH_SET_COMPILERS
+# Petsc -- We already called ACSM_SCRAPE_PETSC_CONFIGURE in
+# LIBMESH_SET_COMPILERS, so it's possible that the $enablepetsc
+# flag is already set to "no", in which case we won't do further
+# PETSc configuration here.
 # -------------------------------------------------------------------
-if test $enablepetsc != no; then :
 
-
-
-
-
-  # Setting --enable-petsc-required causes an error to be emitted
-  # during configure if PETSc is not detected successfully during
-  # configure.  This is useful for app codes which require PETSc (like
-  # MOOSE-based apps), since it prevents situations where libmesh is
-  # accidentally built without PETSc support (which may take a very
-  # long time), and then the app fails to compile, requiring you to
-  # redo everything.
-  # Check whether --enable-petsc-required was given.
+# Check whether --enable-petsc-required was given.
 if test "${enable_petsc_required+set}" = set; then :
   enableval=$enable_petsc_required; case "${enableval}" in #(
   yes) :
@@ -48790,18 +48781,12 @@ else
 fi
 
 
-  # Setting --enable-petsc-hypre-required causes an error to be
-  # emitted during configure if PETSc with builtin Hypre is not
-  # detected successfully.  This is useful for app codes which require
-  # both PETSc and Hypre (like MOOSE-based apps), since it prevents
-  # libmesh from being accidentally built without PETSc and Hypre
-  # support.
-  # Check whether --enable-petsc-hypre-required was given.
+# Check whether --enable-petsc-hypre-required was given.
 if test "${enable_petsc_hypre_required+set}" = set; then :
   enableval=$enable_petsc_hypre_required; case "${enableval}" in #(
   yes) :
     petschyprerequired=yes
-                                 petscrequired=yes ;; #(
+                               petscrequired=yes ;; #(
   no) :
     petschyprerequired=no ;; #(
   *) :
@@ -48810,6 +48795,20 @@ esac
 else
   petschyprerequired=no
 fi
+
+
+if test "x$enablepetsc" = "xno" && test "x$petscrequired" = "xyes"; then :
+                          as_fn_error 3 "*** PETSc was not found, but --enable-petsc-required was specified." "$LINENO" 5
+fi
+
+if test "x$enablepetsc" = "xno" && test "x$petschyprerequired" = "xyes"; then :
+  as_fn_error 4 "*** PETSc was not found, but --enable-petsc-hypre-required was specified." "$LINENO" 5
+fi
+
+if test "x$enablepetsc" != "xno"; then :
+
+
+
 
 
   if test "$enablepetsc" !=  no; then :

--- a/m4/petsc.m4
+++ b/m4/petsc.m4
@@ -9,38 +9,6 @@ AC_DEFUN([CONFIGURE_PETSC],
   dnl try compiles, try links, etc.
   AC_REQUIRE([LIBMESH_SET_COMPILERS])
 
-  # Setting --enable-petsc-required causes an error to be emitted
-  # during configure if PETSc is not detected successfully during
-  # configure.  This is useful for app codes which require PETSc (like
-  # MOOSE-based apps), since it prevents situations where libmesh is
-  # accidentally built without PETSc support (which may take a very
-  # long time), and then the app fails to compile, requiring you to
-  # redo everything.
-  AC_ARG_ENABLE(petsc-required,
-                AC_HELP_STRING([--enable-petsc-required],
-                               [Error if PETSc is not detected by configure]),
-                [AS_CASE("${enableval}",
-                         [yes], [petscrequired=yes],
-                         [no],  [petscrequired=no],
-                         [AC_MSG_ERROR(bad value ${enableval} for --enable-petsc-required)])],
-                     [petscrequired=no])
-
-  # Setting --enable-petsc-hypre-required causes an error to be
-  # emitted during configure if PETSc with builtin Hypre is not
-  # detected successfully.  This is useful for app codes which require
-  # both PETSc and Hypre (like MOOSE-based apps), since it prevents
-  # libmesh from being accidentally built without PETSc and Hypre
-  # support.
-  AC_ARG_ENABLE(petsc-hypre-required,
-                AC_HELP_STRING([--enable-petsc-hypre-required],
-                               [Error if a PETSc with Hypre is not detected by configure]),
-                [AS_CASE("${enableval}",
-                         [yes], [petschyprerequired=yes
-                                 petscrequired=yes],
-                         [no],  [petschyprerequired=no],
-                         [AC_MSG_ERROR(bad value ${enableval} for --enable-petsc-hypre-required)])],
-                     [petschyprerequired=no])
-
   AS_IF([test "$enablepetsc" !=  no],
         [
     # AC_REQUIRE:


### PR DESCRIPTION
At some point during the autoconf-submodule creation process, the logic of the m4 files was changed so that it was possible skip calling `CONFIGURE_PETSC` entirely... but the check for whether or not PETSc should be required is actually *inside* that function, so it was no longer being called. This PR moves the `--enable-petsc-required` check outside of that function, and configure once again throws an error if you don't have PETSc but you configured with `--enable-petsc-required`.