### PR TITLE
modify two unit tests

### DIFF
--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1668,7 +1668,8 @@ void ExodusII_IO_Helper::initialize(std::string str_title, const MeshBase & mesh
     {
       const boundary_id_type id = pair.first;
 
-      if (std::find(unique_side_boundaries.begin(),unique_side_boundaries.end(),id)
+      if (std::find(unique_side_boundaries.begin(),
+                    unique_side_boundaries.end(), id)
             == unique_side_boundaries.end())
         unique_side_boundaries.push_back(id);
     }
@@ -1678,7 +1679,8 @@ void ExodusII_IO_Helper::initialize(std::string str_title, const MeshBase & mesh
     {
       const boundary_id_type id = pair.first;
 
-      if (std::find(unique_node_boundaries.begin(),unique_node_boundaries.end(),id)
+      if (std::find(unique_node_boundaries.begin(),
+                    unique_node_boundaries.end(), id)
             == unique_node_boundaries.end())
         unique_node_boundaries.push_back(id);
     }
@@ -2300,7 +2302,8 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
     {
       const boundary_id_type id = pair.first;
 
-      if (std::find(side_boundary_ids.begin(),side_boundary_ids.end(),id)
+      if (std::find(side_boundary_ids.begin(),
+                    side_boundary_ids.end(), id)
             == side_boundary_ids.end())
         side_boundary_ids.push_back(id);
     }
@@ -2333,7 +2336,7 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
             {
               sets[i].num_entry = elem_it->second.size();
               sets[i].entry_list = elem_it->second.data();
-              sets[i].extra_list = libmesh_map_find(side,ss_id).data();
+              sets[i].extra_list = libmesh_map_find(side, ss_id).data();
             }
         }
 
@@ -2377,7 +2380,8 @@ void ExodusII_IO_Helper::write_nodesets(const MeshBase & mesh)
     {
       const boundary_id_type id = pair.first;
 
-      if (std::find(node_boundary_ids.begin(),node_boundary_ids.end(),id)
+      if (std::find(node_boundary_ids.begin(),
+                    node_boundary_ids.end(), id)
             == node_boundary_ids.end())
         node_boundary_ids.push_back(id);
     }

--- a/tests/mesh/write_nodeset_data.C
+++ b/tests/mesh/write_nodeset_data.C
@@ -35,6 +35,9 @@ public:
                                         -1., 1.,
                                         QUAD4);
 
+    // Add an empty nodeset
+    mesh.get_boundary_info().nodeset_name(4) = "empty";
+
     BoundaryInfo & bi = mesh.get_boundary_info();
 
     // Meshes created via build_square() don't have any nodesets
@@ -47,11 +50,12 @@ public:
     std::vector<BoundaryInfo::NodeBCTuple> all_bc_tuples = bi.build_node_list();
 
     // Data structures to be passed to ExodusII_IO::write_nodeset_data()
-    std::vector<std::string> var_names = {"var1", "var2"};
+    std::vector<std::string> var_names = {"var1", "var2", "var3"};
     std::vector<std::set<boundary_id_type>> node_boundary_ids =
       {
         {0, 2}, // var1 is defined on nodesets 0 and 2
-        {1, 3}  // var2 is defined on nodesets 1 and 3
+        {1, 3}, // var2 is defined on nodesets 1 and 3
+        {4}     // var3 is only defined on the empty nodeset 4
       };
 
     // Data structure mapping (node, id) tuples to Real values that

--- a/tests/mesh/write_sideset_data.C
+++ b/tests/mesh/write_sideset_data.C
@@ -41,16 +41,20 @@ public:
                                         -1., 1.,
                                         QUAD4);
 
+    // Add an empty sideset
+    mesh.get_boundary_info().sideset_name(4) = "empty";
+
     // Get list of all (elem, side, id) tuples
     std::vector<BoundaryInfo::BCTuple> all_bc_tuples =
       mesh.get_boundary_info().build_side_list();
 
     // Data structures to be passed to ExodusII_IO::write_sideset_data
-    std::vector<std::string> var_names = {"var1", "var2"};
+    std::vector<std::string> var_names = {"var1", "var2", "var3"};
     std::vector<std::set<boundary_id_type>> side_ids =
       {
         {0, 2}, // var1 is defined on sidesets 0 and 2
-        {1, 3}  // var2 is defined on sidesets 1 and 3
+        {1, 3}, // var2 is defined on sidesets 1 and 3
+        {4}     // var3 is only defined on the empty sideset 4
       };
 
     // Data structure mapping (elem, side, id) tuples to Real values that


### PR DESCRIPTION
I'm demonstrating a current limitation: if a nodeset/sideset is empty, it won't be written to exodus.