### PR TITLE
Fix the other PETSc version guard

### DIFF
--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -1306,7 +1306,7 @@ Real PetscLinearSolver<T>::get_initial_residual()
 
   // Recent versions of PETSc require the residual
   // history vector pointer to be declared as const.
-#if PETSC_RELEASE_LESS_THAN(3,14,4)
+#if PETSC_RELEASE_LESS_THAN(3,15,0)
   PetscReal * p;
 #else
   const PetscReal * p;


### PR DESCRIPTION
In #2866 we only got one of the erroneous guards fixed.

Refs #2861