### PR TITLE
Fix matrix_matrix_mult()

### DIFF
--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -241,8 +241,10 @@ public:
 
   /**
    * Compute Y = A*X for matrix \p X.
+   * Set reuse = true if this->_mat and X have the same nonzero pattern as before,
+   * and Y is obtained from a previous call to this function with reuse = false
    */
-  virtual void matrix_matrix_mult (SparseMatrix<T> & X, SparseMatrix<T> & Y) override;
+  virtual void matrix_matrix_mult (SparseMatrix<T> & X, SparseMatrix<T> & Y, bool reuse = false) override;
 
   /**
     * Add \p scalar* \p spm to the rows and cols of this matrix (A):

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -300,7 +300,7 @@ public:
   /**
    * Compute Y = A*X for matrix \p X.
    */
-  virtual void matrix_matrix_mult (SparseMatrix<T> & /*X*/, SparseMatrix<T> & /*Y*/)
+  virtual void matrix_matrix_mult (SparseMatrix<T> & /*X*/, SparseMatrix<T> & /*Y*/, bool /*reuse*/)
   { libmesh_not_implemented(); }
 
   /**


### PR DESCRIPTION
- Let user specify if we should reuse the product matrix.
- Make sure we delete the output matrix if we do not reuse the matrix. Otherwise memory leak is possible.