### PR TITLE
Add Elem::has_invertible_map() and overrides for some element types

### DIFF
--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -136,6 +136,11 @@ public:
   virtual bool has_affine_map () const override { return true; }
 
   /**
+   * \returns \p true if the element has non-zero volume(), false otherwise.
+   */
+  virtual bool has_invertible_map(Real tol) const override;
+
+  /**
    * \returns \p true if the Lagrange shape functions on this element
    * are linear.
    */

--- a/include/geom/edge_edge2.h
+++ b/include/geom/edge_edge2.h
@@ -111,6 +111,11 @@ public:
   virtual bool has_affine_map () const override { return true; }
 
   /**
+   * \returns \p true if the element has non-zero volume(), false otherwise.
+   */
+  virtual bool has_invertible_map(Real tol) const override;
+
+  /**
    * \returns \p true if the Lagrange shape functions on this element
    * are linear.
    */

--- a/include/geom/edge_edge3.h
+++ b/include/geom/edge_edge3.h
@@ -118,9 +118,10 @@ public:
   virtual bool has_affine_map () const override;
 
   /**
-   * \returns \p true if the Jacobian vector dx/dxi(xi) satisfies
-   * sgn(dot(dx/dxi(0), dx/dxi(-1))) == sgn(dot(dx/dxi(0), dx/dxi(1))),
-   * false otherwise.
+   * \returns \p true if the element map is everywhere invertible,
+   * false otherwise. The user can pass a custom tol >= 0 to this
+   * function if desired to make the check more stringent, i.e.
+   * to also catch elements which are "almost" non-invertible.
    */
   virtual bool has_invertible_map(Real tol) const override;
 

--- a/include/geom/edge_edge3.h
+++ b/include/geom/edge_edge3.h
@@ -118,6 +118,13 @@ public:
   virtual bool has_affine_map () const override;
 
   /**
+   * \returns \p true if the Jacobian vector dx/dxi(xi) satisfies
+   * sgn(dot(dx/dxi(0), dx/dxi(-1))) == sgn(dot(dx/dxi(0), dx/dxi(1))),
+   * false otherwise.
+   */
+  virtual bool has_invertible_map(Real tol) const override;
+
+  /**
    * \returns \p EDGE3.
    */
   virtual ElemType type() const override { return EDGE3; }

--- a/include/geom/edge_edge4.h
+++ b/include/geom/edge_edge4.h
@@ -119,6 +119,16 @@ public:
   virtual bool has_affine_map () const override;
 
   /**
+   * \returns \p true if the scalar quantity j(xi) := dot(dx/dxi(0),
+   * dx/dxi(xi)) is of single sign (either positive or negative)
+   * throughout the element.  For the Edge4, j(xi) is a quadratic
+   * function of xi, so the min/max can occur somewhere on the
+   * interior of the element, and it is therefore not sufficient to
+   * check only the vertex values.
+   */
+  virtual bool has_invertible_map(Real tol) const override;
+
+  /**
    * \returns \p EDGE4.
    */
   virtual ElemType type() const override { return EDGE4; }

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -967,6 +967,16 @@ public:
   virtual bool has_affine_map () const { return false; }
 
   /**
+   * \returns \p true if the element map is invertible everywhere on
+   * the element, to within a user-specified tolerance. The tolerance
+   * is generally used in comparisons against zero, so it should be an
+   * absolute rather than a relative tolerance. Throws a
+   * libmesh_not_implemented() error unless specialized by derived
+   * classes.
+   */
+  virtual bool has_invertible_map(Real tol = TOLERANCE*TOLERANCE) const;
+
+  /**
    * \returns \p true if the Lagrange shape functions on this element
    * are linear.
    */

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -118,6 +118,11 @@ public:
   virtual bool has_affine_map () const override;
 
   /**
+   * \returns \p true if the element convex, false otherwise.
+   */
+  virtual bool has_invertible_map(Real tol) const override;
+
+  /**
    * \returns FIRST.
    */
   virtual Order default_order() const override;

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -126,6 +126,11 @@ public:
   virtual bool has_affine_map () const override { return true; }
 
   /**
+   * \returns \p true if the element has non-zero volume, false otherwise.
+   */
+  virtual bool has_invertible_map(Real tol) const override;
+
+  /**
    * \returns \p true if the Lagrange shape functions on this element
    * are linear.
    */

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -209,6 +209,11 @@ public:
   virtual bool has_affine_map () const override { return true; }
 
   /**
+   * \returns \p true because it doesn't really make sense for a NodeElem.
+   */
+  virtual bool has_invertible_map(Real /*tol*/) const override { return true; }
+
+  /**
    * \returns \p true if the Lagrange shape functions on this element
    * are linear.
    */

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -131,6 +131,12 @@ bool Tet4::is_child_on_side(const unsigned int /*c*/,
 
 
 
+bool Tet4::has_invertible_map(Real tol) const
+{
+  return this->volume() > tol;
+}
+
+
 
 bool Tet4::is_node_on_side(const unsigned int n,
                            const unsigned int s) const

--- a/src/geom/edge_edge2.C
+++ b/src/geom/edge_edge2.C
@@ -93,6 +93,13 @@ Order Edge2::default_order() const
 
 
 
+bool Edge2::has_invertible_map(Real tol) const
+{
+  return this->volume() > tol;
+}
+
+
+
 void Edge2::connectivity(const unsigned int libmesh_dbg_var(sc),
                          const IOPackage iop,
                          std::vector<dof_id_type> & conn) const

--- a/src/geom/edge_edge3.C
+++ b/src/geom/edge_edge3.C
@@ -102,6 +102,9 @@ bool Edge3::has_affine_map() const
 
 bool Edge3::has_invertible_map(Real tol) const
 {
+  // At the moment this only makes sense for Lagrange elements
+  libmesh_assert_equal_to(this->mapping_type(), LAGRANGE_MAP);
+
   // The "Jacobian vector" (dx/dxi, dy/dxi, dz/dxi) is:
   // j(xi) := a*xi + b, where
   Point a = this->point(0) + this->point(1) - 2 * this->point(2);

--- a/src/geom/edge_edge3.C
+++ b/src/geom/edge_edge3.C
@@ -102,28 +102,37 @@ bool Edge3::has_affine_map() const
 
 bool Edge3::has_invertible_map(Real tol) const
 {
+  // The "Jacobian vector" (dx/dxi, dy/dxi, dz/dxi) is:
+  // j(xi) := a*xi + b, where
   Point a = this->point(0) + this->point(1) - 2 * this->point(2);
   Point b = .5 * (this->point(1) - this->point(0));
 
-  // Normalized midpoint value of Jacobian. If b==0, then the
-  // endpoints of the Edge3 are at the same location, and the map is
-  // not invertible. We use <= in the comparison so that it makes sense
-  // for tol == 0
-  Real b_norm = b.norm();
-  if (b_norm <= tol)
+  // Now we solve for the point xi_m where j(xi_m) \cdot j(0) = 0.
+  // If this occurs somewhere on the reference element, then the
+  // element is not invertible.
+  // j(xi_m) . j(0) = 0
+  // <=>
+  // (a*xi_m + b) . b = 0
+  // <=>
+  // (a.b)*xi_m + b.b = 0
+  // <=>
+  // xi_m = -(b.b) / (a.b)
+
+  // 1.) If b.b==0, then the endpoints of the Edge3 are at the same
+  //     location, and the map is therefore not invertible.
+  Real b_norm2 = b.norm_sq();
+  if (b_norm2 <= tol*tol)
     return false;
 
-  Point n = b / b_norm;
+  // 2.) If a.b==0, but b != 0 (see above), then the element is
+  //     invertible but we don't want to divide by zero in the
+  //     formula, so simply return true.
+  Real ab = a * b;
+  if (std::abs(ab) <= tol*tol)
+    return true;
 
-  // Compute n * (a*xi + b) at each endpoint and compare signs.
-  Real jac0 = n * (-a + b);
-  Real jac1 = n * ( a + b);
-
-  // Debugging
-  // libMesh::out << "jac0 = " << jac0 << std::endl;
-  // libMesh::out << "jac1 = " << jac1 << std::endl;
-
-  return ((jac0 > 0 && jac1 > 0) || (jac0 < 0 && jac1 < 0));
+  Real xi_m = -b_norm2 / ab;
+  return (xi_m < -1.) || (xi_m > 1.);
 }
 
 

--- a/src/geom/edge_edge3.C
+++ b/src/geom/edge_edge3.C
@@ -100,6 +100,34 @@ bool Edge3::has_affine_map() const
 
 
 
+bool Edge3::has_invertible_map(Real tol) const
+{
+  Point a = this->point(0) + this->point(1) - 2 * this->point(2);
+  Point b = .5 * (this->point(1) - this->point(0));
+
+  // Normalized midpoint value of Jacobian. If b==0, then the
+  // endpoints of the Edge3 are at the same location, and the map is
+  // not invertible. We use <= in the comparison so that it makes sense
+  // for tol == 0
+  Real b_norm = b.norm();
+  if (b_norm <= tol)
+    return false;
+
+  Point n = b / b_norm;
+
+  // Compute n * (a*xi + b) at each endpoint and compare signs.
+  Real jac0 = n * (-a + b);
+  Real jac1 = n * ( a + b);
+
+  // Debugging
+  // libMesh::out << "jac0 = " << jac0 << std::endl;
+  // libMesh::out << "jac1 = " << jac1 << std::endl;
+
+  return ((jac0 > 0 && jac1 > 0) || (jac0 < 0 && jac1 < 0));
+}
+
+
+
 Order Edge3::default_order() const
 {
   return SECOND;

--- a/src/geom/edge_edge4.C
+++ b/src/geom/edge_edge4.C
@@ -106,6 +106,9 @@ bool Edge4::has_affine_map() const
 
 bool Edge4::has_invertible_map(Real tol) const
 {
+  // At the moment this only makes sense for Lagrange elements
+  libmesh_assert_equal_to(this->mapping_type(), LAGRANGE_MAP);
+
   // dx/dxi = a*xi^2 + b*xi + c,
   // where a, b, and c are vector quantities that depend on the
   // nodal positions as follows:

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -2241,6 +2241,16 @@ bool Elem::point_test(const Point & p, Real box_tol, Real map_tol) const
 
 
 
+bool Elem::has_invertible_map(Real /*tol*/) const
+{
+  libmesh_not_implemented();
+
+  // We won't get here
+  return true;
+}
+
+
+
 void Elem::print_info (std::ostream & os) const
 {
   os << this->get_info()

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -141,6 +141,9 @@ bool Quad4::has_affine_map() const
 
 bool Quad4::has_invertible_map(Real tol) const
 {
+  // At the moment this only makes sense for Lagrange elements
+  libmesh_assert_equal_to(this->mapping_type(), LAGRANGE_MAP);
+
   // Side vectors
   Point s0 = this->point(1) - this->point(0);
   Point s1 = this->point(2) - this->point(1);

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -139,6 +139,69 @@ bool Quad4::has_affine_map() const
 
 
 
+bool Quad4::has_invertible_map(Real tol) const
+{
+  // Side vectors
+  Point s0 = this->point(1) - this->point(0);
+  Point s1 = this->point(2) - this->point(1);
+  Point s2 = this->point(3) - this->point(2);
+  Point s3 = this->point(0) - this->point(3);
+
+  // Cross products of side vectors
+  Point v1 = s3.cross(s0);
+  Point v2 = s2.cross(s0);
+  Point v3 = s3.cross(s1);
+
+  // A unit vector in the direction of:
+  // f(xi, eta) = (v1 + xi*v2 + eta*v3)
+  // at the midpoint (xi, eta) = (1/2, 1/2) of the element. (Note that
+  // we are using the [0,1]^2 reference element definition for the
+  // Quad4 instead of the [-1,1]^2 reference element that is typically
+  // used for FEM calculations.) We use this as a "reference" vector
+  // and compare the sign of dot(n,f) at each vertex.
+  Point n = v1 + .5 * (v2 + v3);
+  Real norm_n = n.norm();
+
+  // If the Jacobian vector at the midpoint of the element is zero,
+  // then it must be either zero for the entire element, or change
+  // sign at the vertices. Either way the element is non-invertible.
+  if (norm_n <= tol)
+    return false;
+
+  n /= norm_n;
+
+  // Debugging
+  // std::cout << "n=" << n << std::endl;
+
+  // Compute scalar quantity n * (v1 + xi*v2 + eta*v3) at each
+  // vertex. If it is non-zero and has the same sign at each
+  // vertex, the the element is invertible, otherwise it is not.
+  std::array<Real, 4> vertex_vals;
+  unsigned int ctr = 0;
+  for (unsigned int i=0; i<2; ++i)
+    for (unsigned int j=0; j<2; ++j)
+      vertex_vals[ctr++] = n * (v1 + Real(i)*v2 + Real(j)*v3);
+
+  // Debugging:
+  // std::cout << "Vertex values: ";
+  // for (const auto & val : vertex_vals)
+  //   std::cout << val << " ";
+  // std::cout << std::endl;
+
+  auto result = std::minmax_element(vertex_vals.begin(), vertex_vals.end());
+  Real min_vertex = *(result.first);
+  Real max_vertex = *(result.second);
+
+  // Debugging
+  // std::cout << "min_vertex=" << min_vertex << std::endl;
+  // std::cout << "max_vertex=" << max_vertex << std::endl;
+
+  // If max and min are both on the same side of 0, we are invertible, otherwise we are not.
+  return ((max_vertex > 0 && min_vertex > 0) || (max_vertex < 0 && min_vertex < 0));
+}
+
+
+
 Order Quad4::default_order() const
 {
   return FIRST;

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -128,6 +128,11 @@ Order Tri3::default_order() const
   return FIRST;
 }
 
+bool Tri3::has_invertible_map(Real tol) const
+{
+  return this->volume() > tol;
+}
+
 std::unique_ptr<Elem> Tri3::build_side_ptr (const unsigned int i,
                                             bool proxy)
 {

--- a/tests/geom/volume_test.C
+++ b/tests/geom/volume_test.C
@@ -3,6 +3,10 @@
 #include <libmesh/enum_elem_type.h>
 #include <libmesh/mesh_generation.h>
 #include <libmesh/mesh.h>
+#include <libmesh/reference_elem.h>
+#include <libmesh/node.h>
+#include <libmesh/enum_to_string.h>
+#include <libmesh/tensor_value.h>
 
 // unit test includes
 #include "test_comm.h"
@@ -16,6 +20,9 @@ class VolumeTest : public CppUnit::TestCase
 public:
   CPPUNIT_TEST_SUITE( VolumeTest );
   CPPUNIT_TEST( testEdge3Volume );
+  CPPUNIT_TEST( testEdge3Invertible );
+  CPPUNIT_TEST( testEdge4Invertible );
+  CPPUNIT_TEST( testQuad4Invertible );
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -67,6 +74,194 @@ public:
     middle_node = Point(0.5, 0.1, 0.);
     right_node = Point(1., 0., 0.);
     LIBMESH_ASSERT_FP_EQUAL(edge3->Elem::volume(), edge3->volume(), std::sqrt(TOLERANCE));
+  }
+
+  void testEdge3Invertible()
+  {
+    // 1.) This is the original test which started the investigation
+    // of determining invertibility.  In this test, the actual
+    // midpoint of nodes 0 and 1 is 0.5*(1.100328e2 + 1.176528e2) =
+    // 113.8428, so we can see that the middle node is closer to the
+    // left endpoint. In this case, it is too close and the element is
+    // not invertible.
+    bool invertible = test_elem({
+      Point(-3.566160e1, -6.690970e-1, 1.100328e2),
+      Point(-3.566160e1, -6.690970e-1, 1.176528e2),
+      Point(-3.566160e1, -6.690970e-1, 1.115568e2)}, EDGE3);
+    CPPUNIT_ASSERT(!invertible);
+
+    // 2.) Just like case 1, but now node 2 is at the midpoint, so
+    // this case is invertible.
+    invertible = test_elem({
+      Point(-3.566160e1, -6.690970e-1, 1.100328e2),
+      Point(-3.566160e1, -6.690970e-1, 1.176528e2),
+      Point(-3.566160e1, -6.690970e-1, 113.8428)}, EDGE3);
+    CPPUNIT_ASSERT(invertible);
+
+    // 3.) Non-collinear case where the mid-edge node is "above" and "way
+    // past" the right endpoint. This case is not invertible
+    invertible = test_elem({Point(0, 0, 0), Point(1, 0, 0), Point(3.5, 1.5, 0)}, EDGE3);
+    CPPUNIT_ASSERT(!invertible);
+  }
+
+  void testEdge4Invertible()
+  {
+    // Reference Elem should be invertible
+    {
+      const Elem & edge4 = ReferenceElem::get(EDGE4);
+      CPPUNIT_ASSERT(edge4.has_invertible_map());
+    }
+
+    // If node 2 goes to the left past -5/9 = -.555, the element becomes non-invertible
+    {
+      // x2 > -5/9, the map is still invertible
+      bool invertible =
+        test_elem({Point(-1, 0, 0), Point(1, 0, 0), Point(-0.5, 0, 0), Point(Real(1)/3, 0, 0)},
+                  EDGE4);
+      CPPUNIT_ASSERT(invertible);
+
+      // x2 < -5/9, it is too close to x0 now
+      invertible =
+        test_elem({Point(-1, 0, 0), Point(1, 0, 0), Point(-0.57, 0, 0), Point(Real(1)/3, 0, 0)},
+                  EDGE4);
+      CPPUNIT_ASSERT(!invertible);
+    }
+
+    // If node 2 goes to the right past 5/21 ~ 0.2381, the element becomes non-invertible
+    {
+      // x2 < 5/21, the map should still be invertible
+      bool invertible =
+        test_elem({Point(-1, 0, 0), Point(1, 0, 0), Point(Real(3)/21, 0, 0), Point(Real(1)/3, 0, 0)},
+                  EDGE4);
+      CPPUNIT_ASSERT(invertible);
+
+      // x2 > 5/21, x2 is too close to x3 now
+      invertible =
+        test_elem({Point(-1, 0, 0), Point(1, 0, 0), Point(Real(6)/21, 0, 0), Point(Real(1)/3, 0, 0)},
+                  EDGE4);
+      CPPUNIT_ASSERT(!invertible);
+    }
+  }
+
+  void testQuad4Invertible()
+  {
+    // Case 1: Test that rigid body rotations have no effect on the
+    // invertibility of the reference element
+    {
+      // 1a) The reference element rotated into various different different planes.
+      std::vector<Point> pts = {Point(0, 0, 0), Point(1, 0, 0), Point(1, 1, 0), Point(0, 1, 0)};
+      bool invertible = test_elem(pts, QUAD4);
+      CPPUNIT_ASSERT(invertible);
+
+      // 1b) Rotate all points about x-axis by 90 degrees
+      Real cost = std::cos(.5*libMesh::pi);
+      Real sint = std::sin(.5*libMesh::pi);
+      RealTensorValue Rx(1, 0, 0,
+                         0, cost, sint,
+                         0, sint, cost);
+
+      for (auto & pt : pts)
+        pt = Rx * pt;
+
+      invertible = test_elem(pts, QUAD4);
+      CPPUNIT_ASSERT(invertible);
+
+      // 1c) Rotate all points about z-axis by 90 degrees
+      RealTensorValue Rz(cost, -sint, 0,
+                         sint,  cost, 0,
+                         0,        0, 1);
+
+      for (auto & pt : pts)
+        pt = Rz * pt;
+
+      invertible = test_elem(pts, QUAD4);
+      CPPUNIT_ASSERT(invertible);
+
+      // 1d) Rotate all points about y-axis by 270 degrees
+      RealTensorValue Ry(cost,  0, sint,
+                         0,     1, 0,
+                         -sint, 0, cost);
+
+      for (int cnt=0; cnt<3; ++cnt)
+        for (auto & pt : pts)
+          pt = Ry * pt;
+
+      invertible = test_elem(pts, QUAD4);
+      CPPUNIT_ASSERT(invertible);
+    }
+
+    // Case 2: Planar quad with top right vertex displaced to the position
+    // (alpha, alpha). Some different cases are described below.
+    // .) alpha==1: affine case, always invertible
+    // .) 1/2 < alpha < 1: planar case, invertible
+    // .) alpha<=1/2: planar case but node is now at center of the
+    //    element, should give a zero/negative Jacobian on the displaced
+    //    Node -> not invertible.
+    {
+      const Real alpha = .5;
+
+      bool invertible =
+        test_elem({Point(0, 0, 0), Point(1, 0, 0), Point(alpha, alpha, 0), Point(0, 1, 0)}, QUAD4);
+
+      CPPUNIT_ASSERT(!invertible);
+    }
+
+    // Case 3) Top right corner is moved to (alpha, 1, 0). Element
+    // becomes non-invertible when alpha < 0.
+    {
+      const Real alpha = -0.25;
+
+      bool invertible =
+        test_elem({Point(0, 0, 0), Point(1, 0, 0), Point(alpha, 1, 0), Point(0, 1, 0)}, QUAD4);
+
+      CPPUNIT_ASSERT(!invertible);
+    }
+
+    // Case 4) Degenerate case - all 4 points at same location. This
+    // zero-volume element does not have an invertible map.
+    {
+      const Real alpha = std::log(2);
+
+      bool invertible =
+        test_elem({Point(alpha, alpha, alpha),
+                   Point(alpha, alpha, alpha),
+                   Point(alpha, alpha, alpha),
+                   Point(alpha, alpha, alpha)}, QUAD4);
+
+      CPPUNIT_ASSERT(!invertible);
+    }
+  }
+
+protected:
+
+  // Helper function that builds the specified type of Elem from a
+  // vector of Points and returns the value of has_invertible_map()
+  // for that Elem.
+  bool test_elem(const std::vector<Point> & pts,
+                 ElemType elem_type)
+  {
+    const unsigned int n_points = pts.size();
+
+    // Create Nodes
+    std::vector<std::unique_ptr<Node>> nodes(n_points);
+    for (unsigned int i=0; i<n_points; i++)
+      nodes[i] = Node::build(pts[i], /*id*/ i);
+
+    // Create Elem, assign nodes
+    std::unique_ptr<Elem> elem = Elem::build(elem_type, /*parent*/ nullptr);
+
+    // Make sure we were passed consistent input to build this type of Elem
+    libmesh_error_msg_if(elem->n_nodes() != n_points,
+                         "Wrong number of points "
+                         << n_points
+                         << " provided to build a "
+                         << Utility::enum_to_string(elem_type));
+
+    for (unsigned int i=0; i<n_points; i++)
+      elem->set_node(i) = nodes[i].get();
+
+    // Return whether or not this Elem has an invertible map
+    return elem->has_invertible_map();
   }
 };
 


### PR DESCRIPTION
This is a branch that I actually worked on last year, but it kind of got buried since then. I envision that the main use for this function will be debugging. For us it came up in a situation where we need to create an `Edge3` element "on the fly" out of three basically co-linear points. In one case when we did this, the mid-node was too close to one of the vertex nodes, and the map was therefore non-invertible, but we didn't have a way of checking that at the time. The result was that we were getting weird `inverse_map()` results -- not errors but wrong/unexpected values.

For 1D (Edge3 and Edge4) elements, I look at the vector 
```
N := d\vec{x}/ d(xi) := (dx/dxi, dy/dxi, dz/dxi)
```
and compute xi_m such that `N(xi_m) \cdot N(0) = 0`. If -1 <= xi_m <= 1, then the element map is not invertible.

For the Quad4, we look at the surface "normal" vector, 
```
N := d\vec{x} / d(xi) \cross d\vec{x} / d(eta)
```
and do basically the same thing.

For "quadratic" elements like Edge3, N varies linearly with xi, so we only need to look at the vertex values to determine whether it goes to zero anywhere in the element. For a cubic element like Edge4, N varies quadratically, so the min can occur internally to the element and we have to be a bit more careful with our check. 

So far this is only implemented for a few of the simpler elements but the goal would be to eventually enable it for all element types.

