### PR TITLE
Add a missing pointer to the DofMap's sparsity pattern.

### DIFF
--- a/src/numerics/sparse_matrix.C
+++ b/src/numerics/sparse_matrix.C
@@ -56,6 +56,8 @@ template <typename T>
 void SparseMatrix<T>::attach_dof_map (const DofMap & dof_map)
 {
   _dof_map = &dof_map;
+  if (!_sp)
+    _sp = dof_map.get_sparsity_pattern();
 }
 
 


### PR DESCRIPTION
The documentation states that this function will

    Set a pointer to the \p DofMap to use.  If a separate sparsity
    pattern is not being used, use the one from the DofMap.

Hence it should explicitly set the pointer to the sparsity pattern computed by the DofMap should one not already be set.

Fixes #2883 - the fix suggested by @roystgnr is much better than my original plan!