### PR TITLE
MeshBase & member in BoundaryInfo changed to MeshBase *

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -882,9 +882,9 @@ private:
                       const std::set<subdomain_id_type> & subdomains_relative_to);
 
   /**
-   * The Mesh this boundary info pertains to.
+   * A pointer to the Mesh this boundary info pertains to.
    */
-  MeshBase & _mesh;
+  MeshBase * _mesh;
 
   /**
    * Data structure that maps nodes in the mesh


### PR DESCRIPTION
To enable future implementation of a move assignment operation for MeshBase and derived classes, the BoundaryInfo member of
MeshBase should be moved completely. This in turn means that the MeshBase member of BoundaryInfo should be reassignable, a pointer rather than a reference.