### PR TITLE
MeshFunction: add non-const accessor for underlying PointLocator

### DIFF
--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -265,6 +265,7 @@ public:
    * is called.
    */
   const PointLocatorBase & get_point_locator () const;
+  PointLocatorBase & get_point_locator ();
 
   /**
    * Enables out-of-mesh mode.  In this mode, if asked for a point

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -800,6 +800,12 @@ const PointLocatorBase & MeshFunction::get_point_locator () const
   return *_point_locator;
 }
 
+PointLocatorBase & MeshFunction::get_point_locator ()
+{
+  libmesh_assert (this->initialized());
+  return *_point_locator;
+}
+
 void MeshFunction::enable_out_of_mesh_mode(const DenseVector<Number> & value)
 {
   libmesh_assert (this->initialized());


### PR DESCRIPTION
We already had a const accessor for the PointLocator, so while this is
technically encapsulation-breaking, it isn't something that couldn't
have already been hacked with a const_cast.

This allows us to set flags, etc. directly on the MeshFunction's
underlying PointLocator. Now that the PointLocator can be either
OctTree-based or Nanoflann-based, we may want to have different
behaviors based on the value of the

LIBMESH_ENABLE_NANOFLANN_POINTLOCATOR

define. It currently only makes sense to call certain APIs on some
subclasses, and we also don't want to have to add a MeshFunction API
for every flag we want to set on the PointLocator.