### PR TITLE
Read/write numeric vector projection/type info

### DIFF
--- a/configure
+++ b/configure
@@ -43912,7 +43912,7 @@ _ACEOF
 
 
 cat >>confdefs.h <<_ACEOF
-#define IO_COMPATIBILITY_VERSION "0.7.4"
+#define IO_COMPATIBILITY_VERSION "1.7.0"
 _ACEOF
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -290,7 +290,7 @@ AC_DEFINE_UNQUOTED(MICRO_VERSION,            [$LIBMESH_NUMERIC_POINT_VERSION],  
 AC_DEFINE_UNQUOTED(LIB_VERSION,              ["$VERSION"],         [libMesh version number])
 AC_DEFINE_UNQUOTED(LIB_RELEASE,              ["$BUILD_DEVSTATUS"], [libMesh source code version])
 AC_DEFINE_UNQUOTED(CXX,                      ["$CXX"],             [C++ compiler])
-AC_DEFINE_UNQUOTED(IO_COMPATIBILITY_VERSION, ["0.7.4"],            [libMesh I/O file format compatibility string])
+AC_DEFINE_UNQUOTED(IO_COMPATIBILITY_VERSION, ["1.7.0"],            [libMesh I/O file format compatibility string])
 
 
 


### PR DESCRIPTION
I ran into an issue where I was reading at a ghost dof location with a
vector that should be ghosted, but when reading `System` information
from xdr before this PR we add vectors as default `ParallelType PARALLEL` if the
vectors are not already present in the `System` object; the result was a
failed read and a triggered assertion in debugging modes/a segmentation
fault in optimized modes. So here I add the writing of both vector
projection and type so that users are safe to use ghosted vectors
without considering whether their vector has been created at the time we
read xdr `System` information. I know I'll need to add versioning
information because of this change.

Refs idaholab/moose#17399