### PR TITLE
Deprecate Side, SideEdge proxy classes; add fill-based edge_ptr methods

### DIFF
--- a/include/geom/cell_hex20.h
+++ b/include/geom/cell_hex20.h
@@ -161,7 +161,7 @@ public:
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds a \p QUAD8 built coincident with face i.

--- a/include/geom/cell_hex20.h
+++ b/include/geom/cell_hex20.h
@@ -175,6 +175,11 @@ public:
    */
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override;
 
+  /**
+   * Rebuilds a \p EDGE3 built coincident with edge i.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -191,6 +191,11 @@ public:
    */
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override;
 
+  /**
+   * Rebuilds a \p EDGE3 built coincident with edge i.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -177,7 +177,7 @@ public:
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds a \p QUAD9 built coincident with face i.

--- a/include/geom/cell_hex8.h
+++ b/include/geom/cell_hex8.h
@@ -134,7 +134,7 @@ public:
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds a \p QUAD4 built coincident with face i.

--- a/include/geom/cell_hex8.h
+++ b/include/geom/cell_hex8.h
@@ -148,6 +148,11 @@ public:
    */
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override;
 
+  /**
+   * Rebuilds a \p EDGE2 built coincident with edge i.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/cell_inf_hex16.h
+++ b/include/geom/cell_inf_hex16.h
@@ -157,7 +157,7 @@ public:
    * \note The \p std::unique_ptr<Elem> takes care of freeing memory.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds a \p QUAD8 built coincident with face 0, or an \p

--- a/include/geom/cell_inf_hex16.h
+++ b/include/geom/cell_inf_hex16.h
@@ -174,6 +174,12 @@ public:
    */
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override;
 
+  /**
+   * Rebuilds a \p EDGE3 built coincident with edges 0 to 3, or \p
+   * INFEDGE2 built coincident with edges 4 to 11.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -163,6 +163,12 @@ public:
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override;
 
   /**
+   * Rebuilds a \p EDGE3 built coincident with edges 0 to 3, or \p
+   * INFEDGE2 built coincident with edges 4 to 11.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override;
+
+  /**
    * Don't hide Elem::key() defined in the base class.
    */
   using Elem::key;

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -145,7 +145,7 @@ public:
    * \note The \p std::unique_ptr<Elem> takes care of freeing memory.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds a \p QUAD9 built coincident with face 0, or an \p

--- a/include/geom/cell_inf_hex8.h
+++ b/include/geom/cell_inf_hex8.h
@@ -130,7 +130,7 @@ public:
    * \note that the \p std::unique_ptr<Elem> takes care of freeing memory.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds a \p QUAD4 built coincident with face 0, or an \p INFQUAD4

--- a/include/geom/cell_inf_hex8.h
+++ b/include/geom/cell_inf_hex8.h
@@ -147,6 +147,12 @@ public:
    */
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override;
 
+  /**
+   * Rebuilds a \p EDGE2 built coincident with edges 0 to 3, or \p
+   * INFEDGE2 built coincident with edges 4 to 11.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/cell_inf_prism12.h
+++ b/include/geom/cell_inf_prism12.h
@@ -150,7 +150,7 @@ public:
    * \note that the \p std::unique_ptr<Elem> takes care of freeing memory.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds a \p TRI6 built coincident with face 0, or an \p

--- a/include/geom/cell_inf_prism12.h
+++ b/include/geom/cell_inf_prism12.h
@@ -167,6 +167,12 @@ public:
    */
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override;
 
+  /**
+   * Rebuilds a \p EDGE3 built coincident with edges 0 to 2, or \p
+   * INFEDGE2 built coincident with edges 3 to 5.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/cell_inf_prism6.h
+++ b/include/geom/cell_inf_prism6.h
@@ -151,6 +151,12 @@ public:
    */
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override;
 
+  /**
+   * Rebuilds a \p EDGE3 built coincident with edges 0 to 2, or \p
+   * INFEDGE2 built coincident with edges 3 to 5.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/cell_inf_prism6.h
+++ b/include/geom/cell_inf_prism6.h
@@ -134,7 +134,7 @@ public:
    * \note The \p std::unique_ptr<Elem> takes care of freeing memory.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds a \p TRI3 built coincident with face 0, or an \p INFQUAD4

--- a/include/geom/cell_prism15.h
+++ b/include/geom/cell_prism15.h
@@ -166,7 +166,7 @@ public:
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds a \p QUAD8 or \p TRI6 built coincident with face i.

--- a/include/geom/cell_prism15.h
+++ b/include/geom/cell_prism15.h
@@ -180,6 +180,12 @@ public:
    */
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override;
 
+  /**
+   * Rebuilds a \p EDGE3 built coincident with edges 0 to 2, or \p
+   * INFEDGE2 built coincident with edges 3 to 5.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -182,7 +182,7 @@ public:
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds a \p QUAD9 or \p TRI6 built coincident with face i.

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -196,6 +196,12 @@ public:
    */
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override;
 
+  /**
+   * Rebuilds a \p EDGE3 built coincident with edges 0 to 2, or \p
+   * INFEDGE2 built coincident with edges 3 to 5.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/cell_prism6.h
+++ b/include/geom/cell_prism6.h
@@ -132,7 +132,7 @@ public:
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds a \p QUAD4 or \p TRI3 built coincident with face i.

--- a/include/geom/cell_prism6.h
+++ b/include/geom/cell_prism6.h
@@ -146,6 +146,12 @@ public:
    */
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override;
 
+  /**
+   * Rebuilds a \p EDGE2 built coincident with edges 0 to 2, or \p
+   * INFEDGE2 built coincident with edges 3 to 5.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/cell_pyramid13.h
+++ b/include/geom/cell_pyramid13.h
@@ -179,6 +179,11 @@ public:
    */
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override;
 
+  /**
+   * Rebuilds a \p EDGE3 coincident with edge i.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/cell_pyramid13.h
+++ b/include/geom/cell_pyramid13.h
@@ -165,7 +165,7 @@ public:
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds a \p QUAD8 or \p TRI6 built coincident with face i.

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -198,6 +198,11 @@ public:
    */
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override;
 
+  /**
+   * Rebuilds a \p EDGE3 coincident with edge i.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -184,7 +184,7 @@ public:
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds a \p QUAD9 or \p TRI6 built coincident with face i.

--- a/include/geom/cell_pyramid5.h
+++ b/include/geom/cell_pyramid5.h
@@ -131,7 +131,7 @@ public:
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds a \p QUAD4 or \p TRI3 built coincident with face i.

--- a/include/geom/cell_pyramid5.h
+++ b/include/geom/cell_pyramid5.h
@@ -145,6 +145,11 @@ public:
    */
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override;
 
+  /**
+   * Rebuilds a \p EDGE2 coincident with edge i.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/cell_tet10.h
+++ b/include/geom/cell_tet10.h
@@ -162,7 +162,7 @@ public:
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds a TRI6 built coincident with face i.

--- a/include/geom/cell_tet10.h
+++ b/include/geom/cell_tet10.h
@@ -176,6 +176,11 @@ public:
    */
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override;
 
+  /**
+   * Rebuilds a \p EDGE3 coincident with edge i.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -165,6 +165,11 @@ public:
    */
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override;
 
+  /**
+   * Rebuilds a \p EDGE2 coincident with edge i.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -151,7 +151,7 @@ public:
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds a TRI3 built coincident with face i.

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -174,6 +174,12 @@ public:
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int) override final
   { libmesh_not_implemented(); return std::unique_ptr<Elem>(); }
 
+  /**
+   * The \p Elem::build_edge_ptr() member makes no sense for edges.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> &, const unsigned int) override final
+  { libmesh_not_implemented(); }
+
   virtual std::vector<unsigned int> nodes_on_side(const unsigned int s) const override;
 
   virtual std::vector<unsigned int> nodes_on_edge(const unsigned int e) const override;

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -160,7 +160,7 @@ public:
    * \returns A pointer to a NodeElem for the specified node.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override final;
+                                                bool proxy=false) override final;
 
   /**
    * Rebuilds a NODEELEM for the specified node.

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -820,18 +820,16 @@ public:
    * delete the object.
    *
    * The second argument, which is true by default, specifies that a
-   * "proxy" element (of type Side) will be returned.  This type of
-   * value is useful because it does not allocate additional
-   * memory, and is usually sufficient for FE calculation purposes.
-   * If you really need a full-ordered, non-proxy side object, call
-   * this function with proxy=false.
+   * "proxy" element (of type Side) will be returned.  This option is
+   * now deprecated; full-featured elements have been made more
+   * efficient.
    *
    * The const version of this function is non-virtual; it simply
    * calls the virtual non-const version and const_casts the return
    * type.
    */
-  virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i, bool proxy=true) = 0;
-  std::unique_ptr<const Elem> build_side_ptr (const unsigned int i, bool proxy=true) const;
+  virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i, bool proxy=false) = 0;
+  std::unique_ptr<const Elem> build_side_ptr (const unsigned int i, bool proxy=false) const;
 
   /**
    * Resets the loose element \p side, which may currently point to a

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -866,6 +866,24 @@ public:
   std::unique_ptr<const Elem> build_edge_ptr (const unsigned int i) const;
 
   /**
+   * Resets the loose element \p edge, which may currently point to a
+   * different edge than \p i or even a different element than \p
+   * this, to point to edge \p i on \p this.  If \p edge is currently
+   * an element of the wrong type, it will be freed and a new element
+   * allocated; otherwise no memory allocation will occur.
+   *
+   * This should not be called with proxy SideEdge elements.  This will
+   * cause \p side to be a full-ordered element, even if it is handed
+   * a lower-ordered element that must be replaced.
+   *
+   * The const version of this function is non-virtual; it simply
+   * calls the virtual non-const version and const_casts the return
+   * type.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) = 0;
+  void build_edge_ptr (std::unique_ptr<const Elem> & edge, const unsigned int i) const;
+
+  /**
    * \returns The default approximation order for this element type.
    * This is the order that will be used to compute the map to the
    * reference element.

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -2334,6 +2334,11 @@ Elem::simple_build_side_ptr (const unsigned int i,
     face->set_parent(nullptr);
   face->set_interior_parent(this);
 
+  face->subdomain_id() = this->subdomain_id();
+#ifdef LIBMESH_ENABLE_AMR
+  face->set_p_level(this->p_level());
+#endif
+
   return face;
 }
 

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -2305,7 +2305,7 @@ Elem::side_ptr (std::unique_ptr<const Elem> & elem,
   Elem * me = const_cast<Elem *>(this);
   std::unique_ptr<Elem> e {const_cast<Elem *>(elem.release())};
   me->side_ptr(e, i);
-  elem.reset(e.release());
+  elem = std::move(e);
 }
 
 
@@ -2332,7 +2332,7 @@ Elem::build_side_ptr (std::unique_ptr<const Elem> & elem,
   Elem * me = const_cast<Elem *>(this);
   std::unique_ptr<Elem> e {const_cast<Elem *>(elem.release())};
   me->build_side_ptr(e, i);
-  elem.reset(e.release());
+  elem = std::move(e);
 }
 
 
@@ -2452,7 +2452,7 @@ Elem::build_edge_ptr (std::unique_ptr<const Elem> & elem,
   Elem * me = const_cast<Elem *>(this);
   std::unique_ptr<Elem> e {const_cast<Elem *>(elem.release())};
   me->build_edge_ptr(e, i);
-  elem.reset(e.release());
+  elem = std::move(e);
 }
 
 

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -2425,6 +2425,19 @@ Elem::build_edge_ptr (const unsigned int i) const
 
 
 
+inline
+void
+Elem::build_edge_ptr (std::unique_ptr<const Elem> & elem,
+                      const unsigned int i) const
+{
+  // Hand off to the non-const version of this function
+  Elem * me = const_cast<Elem *>(this);
+  std::unique_ptr<Elem> e {const_cast<Elem *>(elem.release())};
+  me->build_edge_ptr(e, i);
+  elem.reset(e.release());
+}
+
+
 template <typename Edgeclass, typename Subclass>
 inline
 std::unique_ptr<Elem>

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -2313,7 +2313,14 @@ Elem::simple_build_side_ptr (const unsigned int i,
 
   std::unique_ptr<Elem> face;
   if (proxy)
-    face = libmesh_make_unique<Side<Sideclass,Subclass>>(this,i);
+    {
+#ifdef LIBMESH_ENABLE_DEPRECATED
+      face = libmesh_make_unique<Side<Sideclass,Subclass>>(this,i);
+      libmesh_deprecated();
+#else
+      libmesh_error();
+#endif
+    }
   else
     {
       face = libmesh_make_unique<Sideclass>(this);

--- a/include/geom/face.h
+++ b/include/geom/face.h
@@ -73,6 +73,12 @@ public:
   { return build_side_ptr(i); }
 
   /**
+   * build_side and build_edge are identical for faces.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override final
+  { build_side_ptr(edge, i); }
+
+ /**
    * is_edge_on_side is trivial in 2D.
    */
   virtual bool is_edge_on_side(const unsigned int e,

--- a/include/geom/face_inf_quad.h
+++ b/include/geom/face_inf_quad.h
@@ -178,6 +178,12 @@ public:
   { return build_side_ptr(i); }
 
   /**
+   * side and edge are identical for faces.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override final
+  { build_side_ptr(edge, i); }
+
+  /**
    * is_edge_on_side is trivial in 2D.
    */
   virtual bool is_edge_on_side(const unsigned int e,

--- a/include/geom/face_inf_quad4.h
+++ b/include/geom/face_inf_quad4.h
@@ -125,7 +125,7 @@ public:
    * the sides 1, 2.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds an EDGE2 or INFEDGE2 coincident with face i.

--- a/include/geom/face_inf_quad6.h
+++ b/include/geom/face_inf_quad6.h
@@ -147,7 +147,7 @@ public:
    * the sides 1, 2.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds an EDGE3 or INFEDGE2 coincident with face i.

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -123,7 +123,7 @@ public:
   virtual Order default_order() const override;
 
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds an EDGE2 coincident with face i.

--- a/include/geom/face_quad8.h
+++ b/include/geom/face_quad8.h
@@ -148,7 +148,7 @@ public:
                                        unsigned int side_node) const override;
 
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds an EDGE3 coincident with face i.

--- a/include/geom/face_quad9.h
+++ b/include/geom/face_quad9.h
@@ -156,7 +156,7 @@ public:
                                        unsigned int side_node) const override;
 
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds an EDGE3 coincident with face i.

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -137,7 +137,7 @@ public:
   virtual Order default_order() const override;
 
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds an EDGE2 coincident with face i.

--- a/include/geom/face_tri6.h
+++ b/include/geom/face_tri6.h
@@ -158,7 +158,7 @@ public:
                                        unsigned int side_node) const override;
 
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy=true) override;
+                                                bool proxy=false) override;
 
   /**
    * Rebuilds an EDGE2 coincident with face i.

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -153,6 +153,12 @@ public:
   { libmesh_not_implemented(); return std::unique_ptr<Elem>(); }
 
   /**
+   * The \p Elem::build_edge_ptr() member makes no sense for nodes.
+   */
+  virtual void build_edge_ptr (std::unique_ptr<Elem> &, const unsigned int) override
+  { libmesh_not_implemented(); }
+
+  /**
    * \returns 1.
    */
   virtual unsigned int n_sub_elem() const override { return 1; }

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -198,6 +198,9 @@ public:
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int) override
   { libmesh_not_implemented(); return std::unique_ptr<Elem>(); }
 
+  virtual void build_edge_ptr (std::unique_ptr<Elem> &, const unsigned int) override
+  { libmesh_not_implemented(); }
+
   virtual Order default_order () const override
   { libmesh_not_implemented(); return static_cast<Order>(1); }
 

--- a/include/geom/side.h
+++ b/include/geom/side.h
@@ -96,7 +96,6 @@ private:
   const unsigned int _side_number;
 };
 
-#endif // LIBMESH_ENABLE_DEPRECATED
 
 
 /**
@@ -122,6 +121,10 @@ public:
     EdgeType(const_cast<Elem *>(my_parent)),
     _edge_number(my_edge)
   {
+    // Our more-optimized non-proxy side code makes this class
+    // obsolete.
+    libmesh_deprecated();
+
     libmesh_assert(my_parent);
     libmesh_assert_less (_edge_number, this->parent()->n_edges());
     libmesh_assert_equal_to (this->dim(), 1);
@@ -148,6 +151,7 @@ private:
   const unsigned int _edge_number;
 };
 
+#endif // LIBMESH_ENABLE_DEPRECATED
 
 } // namespace libMesh
 

--- a/include/geom/side.h
+++ b/include/geom/side.h
@@ -31,6 +31,8 @@ namespace libMesh
 class Point;
 class Node;
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
+
 /**
  * This defines the \p Side class.  A \p Side is basically a proxy
  * (or stand-in replacement) class for an element's side.  It acts
@@ -57,6 +59,10 @@ public:
     SideType(const_cast<Elem *>(parent_in)),
     _side_number(side_in)
   {
+    // Our more-optimized non-proxy side code makes this class
+    // obsolete.
+    libmesh_deprecated();
+
     libmesh_assert(parent_in);
     // may not be true when building infinite element sides
     // libmesh_assert_less (_side_number, this->parent()->n_sides());
@@ -90,6 +96,7 @@ private:
   const unsigned int _side_number;
 };
 
+#endif // LIBMESH_ENABLE_DEPRECATED
 
 
 /**

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -226,6 +226,13 @@ std::unique_ptr<Elem> Hex20::build_edge_ptr (const unsigned int i)
 
 
 
+void Hex20::build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i)
+{
+  this->simple_build_edge_ptr<Hex20>(edge, i, EDGE3);
+}
+
+
+
 void Hex20::connectivity(const unsigned int sc,
                          const IOPackage iop,
                          std::vector<dof_id_type> & conn) const

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -221,9 +221,7 @@ unsigned int Hex20::local_edge_node(unsigned int edge,
 
 std::unique_ptr<Elem> Hex20::build_edge_ptr (const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_edges());
-
-  return libmesh_make_unique<SideEdge<Edge3,Hex20>>(this,i);
+  return this->simple_build_edge_ptr<Edge3,Hex20>(i);
 }
 
 

--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -284,6 +284,13 @@ std::unique_ptr<Elem> Hex27::build_edge_ptr (const unsigned int i)
 
 
 
+void Hex27::build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i)
+{
+  this->simple_build_edge_ptr<Hex27>(edge, i, EDGE3);
+}
+
+
+
 void Hex27::connectivity(const unsigned int sc,
                          const IOPackage iop,
                          std::vector<dof_id_type> & conn) const

--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -279,9 +279,7 @@ void Hex27::build_side_ptr (std::unique_ptr<Elem> & side,
 
 std::unique_ptr<Elem> Hex27::build_edge_ptr (const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_edges());
-
-  return libmesh_make_unique<SideEdge<Edge3,Hex27>>(this,i);
+  return this->simple_build_edge_ptr<Edge3,Hex27>(i);
 }
 
 

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -181,6 +181,13 @@ std::unique_ptr<Elem> Hex8::build_edge_ptr (const unsigned int i)
 
 
 
+void Hex8::build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i)
+{
+  this->simple_build_edge_ptr<Hex8>(edge, i, EDGE2);
+}
+
+
+
 void Hex8::connectivity(const unsigned int libmesh_dbg_var(sc),
                         const IOPackage iop,
                         std::vector<dof_id_type> & conn) const

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -176,9 +176,7 @@ void Hex8::build_side_ptr (std::unique_ptr<Elem> & side,
 
 std::unique_ptr<Elem> Hex8::build_edge_ptr (const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_edges());
-
-  return libmesh_make_unique<SideEdge<Edge2,Hex8>>(this,i);
+  return this->simple_build_edge_ptr<Edge2,Hex8>(i);
 }
 
 

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -185,6 +185,8 @@ std::unique_ptr<Elem> InfHex16::build_side_ptr (const unsigned int i,
   std::unique_ptr<Elem> face;
   if (proxy)
     {
+#ifdef LIBMESH_ENABLE_DEPRECATED
+      libmesh_deprecated();
       switch (i)
         {
           // base
@@ -207,8 +209,10 @@ std::unique_ptr<Elem> InfHex16::build_side_ptr (const unsigned int i,
         default:
           libmesh_error_msg("Invalid side i = " << i);
         }
+#else
+      libmesh_error();
+#endif // LIBMESH_ENABLE_DEPRECATED
     }
-
   else
     {
       // Think of a unit cube: (-1,1) x (-1,1) x (1,1)

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -246,6 +246,11 @@ std::unique_ptr<Elem> InfHex16::build_side_ptr (const unsigned int i,
     face->set_parent(nullptr);
   face->set_interior_parent(this);
 
+  face->subdomain_id() = this->subdomain_id();
+#ifdef LIBMESH_ENABLE_AMR
+  face->set_p_level(this->p_level());
+#endif
+
   return face;
 }
 

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -316,6 +316,58 @@ std::unique_ptr<Elem> InfHex16::build_edge_ptr (const unsigned int i)
 }
 
 
+
+void InfHex16::build_edge_ptr (std::unique_ptr<Elem> & edge,
+                               const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_edges());
+
+  switch (i)
+    {
+      // the base edges
+    case 0:
+    case 1:
+    case 2:
+    case 3:
+      {
+        if (!edge.get() || edge->type() != EDGE3)
+          {
+            edge = this->build_edge_ptr(i);
+            return;
+          }
+        break;
+      }
+
+      // the infinite edges
+    case 4:
+    case 5:
+    case 6:
+    case 7:
+      {
+        if (!edge.get() || edge->type() != INFEDGE2)
+          {
+            edge = this->build_edge_ptr(i);
+            return;
+          }
+        break;
+      }
+
+    default:
+      libmesh_error_msg("Invalid edge i = " << i);
+    }
+
+  edge->subdomain_id() = this->subdomain_id();
+#ifdef LIBMESH_ENABLE_AMR
+  edge->set_p_level(this->p_level());
+#endif
+
+  // Set the nodes
+  for (auto n : edge->node_index_range())
+    edge->set_node(n) = this->node_ptr(InfHex16::edge_nodes_map[i][n]);
+}
+
+
+
 void InfHex16::connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -308,13 +308,11 @@ void InfHex16::build_side_ptr (std::unique_ptr<Elem> & side,
 
 std::unique_ptr<Elem> InfHex16::build_edge_ptr (const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_edges());
-
   if (i < 4) // base edges
-    return libmesh_make_unique<SideEdge<Edge3,InfHex16>>(this,i);
+    return this->simple_build_edge_ptr<Edge3,InfHex16>(i);
 
   // infinite edges
-  return libmesh_make_unique<SideEdge<InfEdge2,InfHex16>>(this,i);
+  return this->simple_build_edge_ptr<InfEdge2,InfHex16>(i);
 }
 
 

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -328,13 +328,11 @@ void InfHex18::build_side_ptr (std::unique_ptr<Elem> & side,
 
 std::unique_ptr<Elem> InfHex18::build_edge_ptr (const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_edges());
-
   if (i < 4) // base edges
-    return libmesh_make_unique<SideEdge<Edge3,InfHex18>>(this,i);
+    return this->simple_build_edge_ptr<Edge3,InfHex18>(i);
 
   // infinite edges
-  return libmesh_make_unique<SideEdge<InfEdge2,InfHex18>>(this,i);
+  return this->simple_build_edge_ptr<InfEdge2,InfHex18>(i);
 }
 
 

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -206,6 +206,8 @@ std::unique_ptr<Elem> InfHex18::build_side_ptr (const unsigned int i,
   std::unique_ptr<Elem> face;
   if (proxy)
     {
+#ifdef LIBMESH_ENABLE_DEPRECATED
+      libmesh_deprecated();
       switch (i)
         {
           // base
@@ -228,8 +230,10 @@ std::unique_ptr<Elem> InfHex18::build_side_ptr (const unsigned int i,
         default:
           libmesh_error_msg("Invalid side i = " << i);
         }
+#else
+      libmesh_error();
+#endif // LIBMESH_ENABLE_DEPRECATED
     }
-
   else
     {
       // Think of a unit cube: (-1,1) x (-1,1) x (1,1)

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -266,6 +266,11 @@ std::unique_ptr<Elem> InfHex18::build_side_ptr (const unsigned int i,
     face->set_parent(nullptr);
   face->set_interior_parent(this);
 
+  face->subdomain_id() = this->subdomain_id();
+#ifdef LIBMESH_ENABLE_AMR
+  face->set_p_level(this->p_level());
+#endif
+
   return face;
 }
 

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -337,6 +337,57 @@ std::unique_ptr<Elem> InfHex18::build_edge_ptr (const unsigned int i)
 
 
 
+void InfHex18::build_edge_ptr (std::unique_ptr<Elem> & edge,
+                               const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_edges());
+
+  switch (i)
+    {
+      // the base edges
+    case 0:
+    case 1:
+    case 2:
+    case 3:
+      {
+        if (!edge.get() || edge->type() != EDGE3)
+          {
+            edge = this->build_edge_ptr(i);
+            return;
+          }
+        break;
+      }
+
+      // the infinite edges
+    case 4:
+    case 5:
+    case 6:
+    case 7:
+      {
+        if (!edge.get() || edge->type() != INFEDGE2)
+          {
+            edge = this->build_edge_ptr(i);
+            return;
+          }
+        break;
+      }
+
+    default:
+      libmesh_error_msg("Invalid edge i = " << i);
+    }
+
+  edge->subdomain_id() = this->subdomain_id();
+#ifdef LIBMESH_ENABLE_AMR
+  edge->set_p_level(this->p_level());
+#endif
+
+  // Set the nodes
+  for (auto n : edge->node_index_range())
+    edge->set_node(n) = this->node_ptr(InfHex18::edge_nodes_map[i][n]);
+}
+
+
+
 void InfHex18::connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -148,6 +148,8 @@ std::unique_ptr<Elem> InfHex8::build_side_ptr (const unsigned int i,
   std::unique_ptr<Elem> face;
   if (proxy)
     {
+#ifdef LIBMESH_ENABLE_DEPRECATED
+      libmesh_deprecated();
       switch (i)
         {
           // base
@@ -170,8 +172,10 @@ std::unique_ptr<Elem> InfHex8::build_side_ptr (const unsigned int i,
         default:
           libmesh_error_msg("Invalid side i = " << i);
         }
+#else
+      libmesh_error();
+#endif // LIBMESH_ENABLE_DEPRECATED
     }
-
   else
     {
       // Think of a unit cube: (-1,1) x (-1,1) x (1,1)

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -239,6 +239,58 @@ std::unique_ptr<Elem> InfHex8::build_edge_ptr (const unsigned int i)
 }
 
 
+
+void InfHex8::build_edge_ptr (std::unique_ptr<Elem> & edge,
+                              const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_edges());
+
+  switch (i)
+    {
+      // the base edges
+    case 0:
+    case 1:
+    case 2:
+    case 3:
+      {
+        if (!edge.get() || edge->type() != EDGE2)
+          {
+            edge = this->build_edge_ptr(i);
+            return;
+          }
+        break;
+      }
+
+      // the infinite edges
+    case 4:
+    case 5:
+    case 6:
+    case 7:
+      {
+        if (!edge.get() || edge->type() != INFEDGE2)
+          {
+            edge = this->build_edge_ptr(i);
+            return;
+          }
+        break;
+      }
+
+    default:
+      libmesh_error_msg("Invalid edge i = " << i);
+    }
+
+  edge->subdomain_id() = this->subdomain_id();
+#ifdef LIBMESH_ENABLE_AMR
+  edge->set_p_level(this->p_level());
+#endif
+
+  // Set the nodes
+  for (auto n : edge->node_index_range())
+    edge->set_node(n) = this->node_ptr(InfHex8::edge_nodes_map[i][n]);
+}
+
+
+
 void InfHex8::connectivity(const unsigned int libmesh_dbg_var(sc),
                            const IOPackage iop,
                            std::vector<dof_id_type> & conn) const

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -231,13 +231,11 @@ void InfHex8::build_side_ptr (std::unique_ptr<Elem> & side,
 
 std::unique_ptr<Elem> InfHex8::build_edge_ptr (const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_edges());
-
   if (i < 4) // base edges
-    return libmesh_make_unique<SideEdge<Edge2,InfHex8>>(this,i);
+    return this->simple_build_edge_ptr<Edge2,InfHex8>(i);
 
   // infinite edges
-  return libmesh_make_unique<SideEdge<InfEdge2,InfHex8>>(this,i);
+  return this->simple_build_edge_ptr<InfEdge2,InfHex8>(i);
 }
 
 

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -208,6 +208,11 @@ std::unique_ptr<Elem> InfHex8::build_side_ptr (const unsigned int i,
     face->set_parent(nullptr);
   face->set_interior_parent(this);
 
+  face->subdomain_id() = this->subdomain_id();
+#ifdef LIBMESH_ENABLE_AMR
+  face->set_p_level(this->p_level());
+#endif
+
   return face;
 }
 

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -179,6 +179,8 @@ std::unique_ptr<Elem> InfPrism12::build_side_ptr (const unsigned int i,
   std::unique_ptr<Elem> face;
   if (proxy)
     {
+#ifdef LIBMESH_ENABLE_DEPRECATED
+      libmesh_deprecated();
       switch (i)
         {
           // base
@@ -200,6 +202,9 @@ std::unique_ptr<Elem> InfPrism12::build_side_ptr (const unsigned int i,
         default:
           libmesh_error_msg("Invalid side i = " << i);
         }
+#else
+      libmesh_error();
+#endif // LIBMESH_ENABLE_DEPRECATED
     }
 
   else

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -235,6 +235,11 @@ std::unique_ptr<Elem> InfPrism12::build_side_ptr (const unsigned int i,
     face->set_parent(nullptr);
   face->set_interior_parent(this);
 
+  face->subdomain_id() = this->subdomain_id();
+#ifdef LIBMESH_ENABLE_AMR
+  face->set_p_level(this->p_level());
+#endif
+
   return face;
 }
 

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -292,13 +292,11 @@ void InfPrism12::build_side_ptr (std::unique_ptr<Elem> & side,
 
 std::unique_ptr<Elem> InfPrism12::build_edge_ptr (const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_edges());
-
   if (i < 3) // base edges
-    return libmesh_make_unique<SideEdge<Edge3,InfPrism12>>(this,i);
+    return this->simple_build_edge_ptr<Edge3,InfPrism12>(i);
 
   // infinite edges
-  return libmesh_make_unique<SideEdge<InfEdge2,InfPrism12>>(this,i);
+  return this->simple_build_edge_ptr<InfEdge2,InfPrism12>(i);
 }
 
 

--- a/src/geom/cell_inf_prism6.C
+++ b/src/geom/cell_inf_prism6.C
@@ -229,13 +229,11 @@ void InfPrism6::build_side_ptr (std::unique_ptr<Elem> & side,
 
 std::unique_ptr<Elem> InfPrism6::build_edge_ptr (const unsigned int i)
 {
-  libmesh_assert_less (i, n_edges());
-
   if (i < 3)
-    return libmesh_make_unique<SideEdge<Edge2,InfPrism6>>(this,i);
+    return this->simple_build_edge_ptr<Edge2,InfPrism6>(i);
 
   // infinite edges
-  return libmesh_make_unique<SideEdge<InfEdge2,InfPrism6>>(this,i);
+  return this->simple_build_edge_ptr<InfEdge2,InfPrism6>(i);
 }
 
 void InfPrism6::connectivity(const unsigned int libmesh_dbg_var(sc),

--- a/src/geom/cell_inf_prism6.C
+++ b/src/geom/cell_inf_prism6.C
@@ -236,6 +236,57 @@ std::unique_ptr<Elem> InfPrism6::build_edge_ptr (const unsigned int i)
   return this->simple_build_edge_ptr<InfEdge2,InfPrism6>(i);
 }
 
+
+
+void InfPrism6::build_edge_ptr (std::unique_ptr<Elem> & edge,
+                                const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_edges());
+
+  switch (i)
+    {
+      // the base edges
+    case 0:
+    case 1:
+    case 2:
+      {
+        if (!edge.get() || edge->type() != EDGE2)
+          {
+            edge = this->build_edge_ptr(i);
+            return;
+          }
+        break;
+      }
+
+      // the infinite edges
+    case 3:
+    case 4:
+    case 5:
+      {
+        if (!edge.get() || edge->type() != INFEDGE2)
+          {
+            edge = this->build_edge_ptr(i);
+            return;
+          }
+        break;
+      }
+
+    default:
+      libmesh_error_msg("Invalid edge i = " << i);
+    }
+
+  edge->subdomain_id() = this->subdomain_id();
+#ifdef LIBMESH_ENABLE_AMR
+  edge->set_p_level(this->p_level());
+#endif
+
+  // Set the nodes
+  for (auto n : edge->node_index_range())
+    edge->set_node(n) = this->node_ptr(InfPrism6::edge_nodes_map[i][n]);
+}
+
+
+
 void InfPrism6::connectivity(const unsigned int libmesh_dbg_var(sc),
                              const IOPackage iop,
                              std::vector<dof_id_type> & conn) const

--- a/src/geom/cell_inf_prism6.C
+++ b/src/geom/cell_inf_prism6.C
@@ -207,6 +207,11 @@ std::unique_ptr<Elem> InfPrism6::build_side_ptr (const unsigned int i,
     face->set_parent(nullptr);
   face->set_interior_parent(this);
 
+  face->subdomain_id() = this->subdomain_id();
+#ifdef LIBMESH_ENABLE_AMR
+  face->set_p_level(this->p_level());
+#endif
+
   return face;
 }
 

--- a/src/geom/cell_inf_prism6.C
+++ b/src/geom/cell_inf_prism6.C
@@ -151,6 +151,8 @@ std::unique_ptr<Elem> InfPrism6::build_side_ptr (const unsigned int i,
   std::unique_ptr<Elem> face;
   if (proxy)
     {
+#ifdef LIBMESH_ENABLE_DEPRECATED
+      libmesh_deprecated();
       switch (i)
         {
           // base
@@ -172,8 +174,10 @@ std::unique_ptr<Elem> InfPrism6::build_side_ptr (const unsigned int i,
         default:
           libmesh_error_msg("Invalid side i = " << i);
         }
+#else
+      libmesh_error();
+#endif // LIBMESH_ENABLE_DEPRECATED
     }
-
   else
     {
       switch (i)

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -257,6 +257,11 @@ std::unique_ptr<Elem> Prism15::build_side_ptr (const unsigned int i,
     face->set_parent(nullptr);
   face->set_interior_parent(this);
 
+  face->subdomain_id() = this->subdomain_id();
+#ifdef LIBMESH_ENABLE_AMR
+  face->set_p_level(this->p_level());
+#endif
+
   return face;
 }
 

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -319,6 +319,14 @@ std::unique_ptr<Elem> Prism15::build_edge_ptr (const unsigned int i)
 }
 
 
+
+void Prism15::build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i)
+{
+  this->simple_build_edge_ptr<Prism15>(edge, i, EDGE3);
+}
+
+
+
 void Prism15::connectivity(const unsigned int libmesh_dbg_var(sc),
                            const IOPackage iop,
                            std::vector<dof_id_type> & conn) const

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -315,9 +315,7 @@ void Prism15::build_side_ptr (std::unique_ptr<Elem> & side,
 
 std::unique_ptr<Elem> Prism15::build_edge_ptr (const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_edges());
-
-  return libmesh_make_unique<SideEdge<Edge3,Prism15>>(this,i);
+  return this->simple_build_edge_ptr<Edge3,Prism15>(i);
 }
 
 

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -203,6 +203,8 @@ std::unique_ptr<Elem> Prism15::build_side_ptr (const unsigned int i,
   std::unique_ptr<Elem> face;
   if (proxy)
     {
+#ifdef LIBMESH_ENABLE_DEPRECATED
+      libmesh_deprecated();
       switch (i)
         {
         case 0:  // the triangular face at z=-1
@@ -223,8 +225,10 @@ std::unique_ptr<Elem> Prism15::build_side_ptr (const unsigned int i,
         default:
           libmesh_error_msg("Invalid side i = " << i);
         }
+#else
+      libmesh_error();
+#endif // LIBMESH_ENABLE_DEPRECATED
     }
-
   else
     {
       switch (i)

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -242,6 +242,8 @@ std::unique_ptr<Elem> Prism18::build_side_ptr (const unsigned int i,
   std::unique_ptr<Elem> face;
   if (proxy)
     {
+#ifdef LIBMESH_ENABLE_DEPRECATED
+      libmesh_deprecated();
       switch(i)
         {
         case 0:
@@ -262,8 +264,10 @@ std::unique_ptr<Elem> Prism18::build_side_ptr (const unsigned int i,
         default:
           libmesh_error_msg("Invalid side i = " << i);
         }
+#else
+      libmesh_error();
+#endif // LIBMESH_ENABLE_DEPRECATED
     }
-
   else
     {
       switch (i)

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -296,6 +296,11 @@ std::unique_ptr<Elem> Prism18::build_side_ptr (const unsigned int i,
     face->set_parent(nullptr);
   face->set_interior_parent(this);
 
+  face->subdomain_id() = this->subdomain_id();
+#ifdef LIBMESH_ENABLE_AMR
+  face->set_p_level(this->p_level());
+#endif
+
   return face;
 }
 

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -360,6 +360,13 @@ std::unique_ptr<Elem> Prism18::build_edge_ptr (const unsigned int i)
 
 
 
+void Prism18::build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i)
+{
+  this->simple_build_edge_ptr<Prism18>(edge, i, EDGE3);
+}
+
+
+
 void Prism18::connectivity(const unsigned int sc,
                            const IOPackage iop,
                            std::vector<dof_id_type> & conn) const

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -355,9 +355,7 @@ void Prism18::build_side_ptr (std::unique_ptr<Elem> & side,
 
 std::unique_ptr<Elem> Prism18::build_edge_ptr (const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_edges());
-
-  return libmesh_make_unique<SideEdge<Edge3,Prism18>>(this,i);
+  return this->simple_build_edge_ptr<Edge3,Prism18>(i);
 }
 
 

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -246,6 +246,13 @@ std::unique_ptr<Elem> Prism6::build_edge_ptr (const unsigned int i)
 
 
 
+void Prism6::build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i)
+{
+  this->simple_build_edge_ptr<Prism6>(edge, i, EDGE2);
+}
+
+
+
 void Prism6::connectivity(const unsigned int libmesh_dbg_var(sc),
                           const IOPackage iop,
                           std::vector<dof_id_type> & conn) const

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -241,9 +241,7 @@ void Prism6::build_side_ptr (std::unique_ptr<Elem> & side,
 
 std::unique_ptr<Elem> Prism6::build_edge_ptr (const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_edges());
-
-  return libmesh_make_unique<SideEdge<Edge2,Prism6>>(this,i);
+  return this->simple_build_edge_ptr<Edge2,Prism6>(i);
 }
 
 

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -163,6 +163,8 @@ std::unique_ptr<Elem> Prism6::build_side_ptr (const unsigned int i,
   std::unique_ptr<Elem> face;
   if (proxy)
     {
+#ifdef LIBMESH_ENABLE_DEPRECATED
+      libmesh_deprecated();
       switch(i)
         {
         case 0:
@@ -183,8 +185,10 @@ std::unique_ptr<Elem> Prism6::build_side_ptr (const unsigned int i,
         default:
           libmesh_error_msg("Invalid side i = " << i);
         }
+#else
+      libmesh_error();
+#endif // LIBMESH_ENABLE_DEPRECATED
     }
-
   else
     {
       switch (i)

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -217,6 +217,11 @@ std::unique_ptr<Elem> Prism6::build_side_ptr (const unsigned int i,
     face->set_parent(nullptr);
   face->set_interior_parent(this);
 
+  face->subdomain_id() = this->subdomain_id();
+#ifdef LIBMESH_ENABLE_AMR
+  face->set_p_level(this->p_level());
+#endif
+
   return face;
 }
 

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -297,9 +297,7 @@ void Pyramid13::build_side_ptr (std::unique_ptr<Elem> & side,
 
 std::unique_ptr<Elem> Pyramid13::build_edge_ptr (const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_edges());
-
-  return libmesh_make_unique<SideEdge<Edge3,Pyramid13>>(this,i);
+  return this->simple_build_edge_ptr<Edge3,Pyramid13>(i);
 }
 
 

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -240,6 +240,11 @@ std::unique_ptr<Elem> Pyramid13::build_side_ptr (const unsigned int i, bool prox
     face->set_parent(nullptr);
   face->set_interior_parent(this);
 
+  face->subdomain_id() = this->subdomain_id();
+#ifdef LIBMESH_ENABLE_AMR
+  face->set_p_level(this->p_level());
+#endif
+
   return face;
 }
 

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -186,6 +186,8 @@ std::unique_ptr<Elem> Pyramid13::build_side_ptr (const unsigned int i, bool prox
   std::unique_ptr<Elem> face;
   if (proxy)
     {
+#ifdef LIBMESH_ENABLE_DEPRECATED
+      libmesh_deprecated();
       switch (i)
         {
         case 0:
@@ -206,8 +208,10 @@ std::unique_ptr<Elem> Pyramid13::build_side_ptr (const unsigned int i, bool prox
         default:
           libmesh_error_msg("Invalid side i = " << i);
         }
+#else
+      libmesh_error();
+#endif // LIBMESH_ENABLE_DEPRECATED
     }
-
   else
     {
       switch (i)

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -302,6 +302,13 @@ std::unique_ptr<Elem> Pyramid13::build_edge_ptr (const unsigned int i)
 
 
 
+void Pyramid13::build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i)
+{
+  this->simple_build_edge_ptr<Pyramid13>(edge, i, EDGE3);
+}
+
+
+
 void Pyramid13::connectivity(const unsigned int libmesh_dbg_var(sc),
                              const IOPackage iop,
                              std::vector<dof_id_type> & /*conn*/) const

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -329,6 +329,13 @@ std::unique_ptr<Elem> Pyramid14::build_edge_ptr (const unsigned int i)
 
 
 
+void Pyramid14::build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i)
+{
+  this->simple_build_edge_ptr<Pyramid14>(edge, i, EDGE3);
+}
+
+
+
 void Pyramid14::connectivity(const unsigned int libmesh_dbg_var(sc),
                              const IOPackage iop,
                              std::vector<dof_id_type> & /*conn*/) const

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -324,9 +324,7 @@ void Pyramid14::build_side_ptr (std::unique_ptr<Elem> & side,
 
 std::unique_ptr<Elem> Pyramid14::build_edge_ptr (const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_edges());
-
-  return libmesh_make_unique<SideEdge<Edge3,Pyramid14>>(this,i);
+  return this->simple_build_edge_ptr<Edge3,Pyramid14>(i);
 }
 
 

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -266,6 +266,11 @@ std::unique_ptr<Elem> Pyramid14::build_side_ptr (const unsigned int i, bool prox
     face->set_parent(nullptr);
   face->set_interior_parent(this);
 
+  face->subdomain_id() = this->subdomain_id();
+#ifdef LIBMESH_ENABLE_AMR
+  face->set_p_level(this->p_level());
+#endif
+
   return face;
 }
 

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -212,6 +212,8 @@ std::unique_ptr<Elem> Pyramid14::build_side_ptr (const unsigned int i, bool prox
   std::unique_ptr<Elem> face;
   if (proxy)
     {
+#ifdef LIBMESH_ENABLE_DEPRECATED
+      libmesh_deprecated();
       switch (i)
         {
         case 0:
@@ -232,6 +234,9 @@ std::unique_ptr<Elem> Pyramid14::build_side_ptr (const unsigned int i, bool prox
         default:
           libmesh_error_msg("Invalid side i = " << i);
         }
+#else
+      libmesh_error();
+#endif // LIBMESH_ENABLE_DEPRECATED
     }
 
   else

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -205,6 +205,11 @@ std::unique_ptr<Elem> Pyramid5::build_side_ptr (const unsigned int i,
     face->set_parent(nullptr);
   face->set_interior_parent(this);
 
+  face->subdomain_id() = this->subdomain_id();
+#ifdef LIBMESH_ENABLE_AMR
+  face->set_p_level(this->p_level());
+#endif
+
   return face;
 }
 

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -229,9 +229,7 @@ void Pyramid5::build_side_ptr (std::unique_ptr<Elem> & side,
 
 std::unique_ptr<Elem> Pyramid5::build_edge_ptr (const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_edges());
-
-  return libmesh_make_unique<SideEdge<Edge2,Pyramid5>>(this,i);
+  return this->simple_build_edge_ptr<Edge2,Pyramid5>(i);
 }
 
 

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -234,6 +234,13 @@ std::unique_ptr<Elem> Pyramid5::build_edge_ptr (const unsigned int i)
 
 
 
+void Pyramid5::build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i)
+{
+  this->simple_build_edge_ptr<Pyramid5>(edge, i, EDGE2);
+}
+
+
+
 void Pyramid5::connectivity(const unsigned int libmesh_dbg_var(sc),
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -151,6 +151,8 @@ std::unique_ptr<Elem> Pyramid5::build_side_ptr (const unsigned int i,
   std::unique_ptr<Elem> face;
   if (proxy)
     {
+#ifdef LIBMESH_ENABLE_DEPRECATED
+      libmesh_deprecated();
       switch (i)
         {
         case 0:
@@ -171,8 +173,10 @@ std::unique_ptr<Elem> Pyramid5::build_side_ptr (const unsigned int i,
         default:
           libmesh_error_msg("Invalid side i = " << i);
         }
+#else
+      libmesh_error();
+#endif // LIBMESH_ENABLE_DEPRECATED
     }
-
   else
     {
       switch (i)

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -233,6 +233,13 @@ std::unique_ptr<Elem> Tet10::build_edge_ptr (const unsigned int i)
 
 
 
+void Tet10::build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i)
+{
+  this->simple_build_edge_ptr<Tet10>(edge, i, EDGE3);
+}
+
+
+
 void Tet10::connectivity(const unsigned int sc,
                          const IOPackage iop,
                          std::vector<dof_id_type> & conn) const

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -228,9 +228,7 @@ void Tet10::build_side_ptr (std::unique_ptr<Elem> & side,
 
 std::unique_ptr<Elem> Tet10::build_edge_ptr (const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_edges());
-
-  return libmesh_make_unique<SideEdge<Edge3,Tet10>>(this,i);
+  return this->simple_build_edge_ptr<Edge3,Tet10>(i);
 }
 
 

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -178,9 +178,7 @@ void Tet4::build_side_ptr (std::unique_ptr<Elem> & side,
 
 std::unique_ptr<Elem> Tet4::build_edge_ptr (const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_edges());
-
-  return libmesh_make_unique<SideEdge<Edge2,Tet4>>(this,i);
+  return this->simple_build_edge_ptr<Edge2,Tet4>(i);
 }
 
 

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -182,6 +182,14 @@ std::unique_ptr<Elem> Tet4::build_edge_ptr (const unsigned int i)
 }
 
 
+
+void Tet4::build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i)
+{
+  this->simple_build_edge_ptr<Tet4>(edge, i, EDGE2);
+}
+
+
+
 void Tet4::connectivity(const unsigned int libmesh_dbg_var(sc),
                         const IOPackage iop,
                         std::vector<dof_id_type> & conn) const

--- a/src/geom/face_inf_quad4.C
+++ b/src/geom/face_inf_quad4.C
@@ -248,6 +248,11 @@ std::unique_ptr<Elem> InfQuad4::build_side_ptr (const unsigned int i,
     edge->set_parent(nullptr);
   edge->set_interior_parent(this);
 
+  edge->subdomain_id() = this->subdomain_id();
+#ifdef LIBMESH_ENABLE_AMR
+  edge->set_p_level(this->p_level());
+#endif
+
   return edge;
 }
 

--- a/src/geom/face_inf_quad4.C
+++ b/src/geom/face_inf_quad4.C
@@ -193,6 +193,8 @@ std::unique_ptr<Elem> InfQuad4::build_side_ptr (const unsigned int i,
   std::unique_ptr<Elem> edge;
   if (proxy)
     {
+#ifdef LIBMESH_ENABLE_DEPRECATED
+      libmesh_deprecated();
       switch (i)
         {
           // base
@@ -213,8 +215,10 @@ std::unique_ptr<Elem> InfQuad4::build_side_ptr (const unsigned int i,
         default:
           libmesh_error_msg("Invalid side i = " << i);
         }
+#else
+      libmesh_error();
+#endif // LIBMESH_ENABLE_DEPRECATED
     }
-
   else
     {
       switch (i)

--- a/src/geom/face_inf_quad6.C
+++ b/src/geom/face_inf_quad6.C
@@ -175,6 +175,8 @@ std::unique_ptr<Elem> InfQuad6::build_side_ptr (const unsigned int i,
   std::unique_ptr<Elem> edge;
   if (proxy)
     {
+#ifdef LIBMESH_ENABLE_DEPRECATED
+      libmesh_deprecated();
       switch (i)
         {
         case 0:
@@ -193,8 +195,10 @@ std::unique_ptr<Elem> InfQuad6::build_side_ptr (const unsigned int i,
         default:
           libmesh_error_msg("Invalid side i = " << i);
         }
+#else
+      libmesh_error();
+#endif // LIBMESH_ENABLE_DEPRECATED
     }
-
   else
     {
       switch (i)

--- a/src/geom/face_inf_quad6.C
+++ b/src/geom/face_inf_quad6.C
@@ -228,6 +228,11 @@ std::unique_ptr<Elem> InfQuad6::build_side_ptr (const unsigned int i,
     edge->set_parent(nullptr);
   edge->set_interior_parent(this);
 
+  edge->subdomain_id() = this->subdomain_id();
+#ifdef LIBMESH_ENABLE_AMR
+  edge->set_p_level(this->p_level());
+#endif
+
   return edge;
 }
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -961,6 +961,8 @@ std::string MeshBase::get_info(const unsigned int verbosity /* = 0 */, const boo
         BoundingBox bbox;
       };
       std::map<boundary_id_type, EdgesetInfo> edgeset_info_map;
+      std::unique_ptr<const Elem> edge;
+
       for (const auto & pair : this->get_boundary_info().get_edgeset_map())
         {
           const Elem * elem = pair.first;
@@ -970,7 +972,7 @@ std::string MeshBase::get_info(const unsigned int verbosity /* = 0 */, const boo
           const auto id = pair.second.second;
           EdgesetInfo & info = edgeset_info_map[id];
 
-          const auto edge = elem->build_edge_ptr(pair.second.first);
+          elem->build_edge_ptr(edge, pair.second.first);
 
           ++info.num_edges;
           info.edge_elem_types.insert(edge->type());

--- a/src/mesh/mesh_refinement_smoothing.C
+++ b/src/mesh/mesh_refinement_smoothing.C
@@ -137,6 +137,7 @@ bool MeshRefinement::limit_level_mismatch_at_edge (const unsigned int max_mismat
   std::map<std::pair<unsigned int, unsigned int>, unsigned char>
     max_p_level_at_edge;
 
+  std::unique_ptr<const Elem> edge, pedge;
   // Loop over all the active elements & fill the maps
   for (auto & elem : _mesh.active_element_ptr_range())
     {
@@ -150,7 +151,7 @@ bool MeshRefinement::limit_level_mismatch_at_edge (const unsigned int max_mismat
       // Set the max_level at each edge
       for (auto n : elem->edge_index_range())
         {
-          std::unique_ptr<const Elem> edge = elem->build_edge_ptr(n);
+          elem->build_edge_ptr(edge, n);
           dof_id_type childnode0 = edge->node_id(0);
           dof_id_type childnode1 = edge->node_id(1);
           if (childnode1 < childnode0)
@@ -158,7 +159,7 @@ bool MeshRefinement::limit_level_mismatch_at_edge (const unsigned int max_mismat
 
           for (const Elem * p = elem; p != nullptr; p = p->parent())
             {
-              std::unique_ptr<const Elem> pedge = p->build_edge_ptr(n);
+              p->build_edge_ptr(pedge, n);
               dof_id_type node0 = pedge->node_id(0);
               dof_id_type node1 = pedge->node_id(1);
 
@@ -214,7 +215,7 @@ bool MeshRefinement::limit_level_mismatch_at_edge (const unsigned int max_mismat
       // Loop over the nodes, check for possible mismatch
       for (auto n : elem->edge_index_range())
         {
-          std::unique_ptr<Elem> edge = elem->build_edge_ptr(n);
+          elem->build_edge_ptr(edge, n);
           dof_id_type node0 = edge->node_id(0);
           dof_id_type node1 = edge->node_id(1);
           if (node1 < node0)


### PR DESCRIPTION
It's been a few years now since we made the Elem classes themselves more efficient and effectively made the Side and SideEdge proxies redundant.  We should deprecate them so we can get rid of them eventually.

In the process I finally noticed that we've never added the same reallocation-preventing overload to the `build_edge_ptr` methods that we long-ago added to `side_ptr` methods.  This PR also adds that feature (made possible by changing the existing methods to consistently construct real edge elements), and makes use of it wherever possible within library code.