### PR TITLE
Add shape functions for NEDELEC_ONE FEs on TET10 mesh elements

### DIFF
--- a/examples/vector_fe/vector_fe_ex4/run.sh
+++ b/examples/vector_fe/vector_fe_ex4/run.sh
@@ -10,6 +10,9 @@ example_name=vector_fe_ex4
 # preconditioners like ILU don't all work very well.  We currently
 # force Jacobi in these examples.
 
+options="element_type=TET10 -pc_type jacobi"
+run_example_no_extra_options "$example_name" "$options"
+
 options="element_type=HEX20 -pc_type jacobi"
 run_example_no_extra_options "$example_name" "$options"
 

--- a/examples/vector_fe/vector_fe_ex4/vector_fe_ex4.C
+++ b/examples/vector_fe/vector_fe_ex4/vector_fe_ex4.C
@@ -76,9 +76,9 @@ int main (int argc, char ** argv)
     command_line_value(std::string("element_type"),
                        std::string("HEX27"));
 
-  libmesh_error_msg_if(elem_str != "HEX20" && elem_str != "HEX27",
+  libmesh_error_msg_if(elem_str != "TET10" && elem_str != "HEX20" && elem_str != "HEX27",
                        "You entered: " << elem_str <<
-                       " but this example must be run with HEX20 or HEX27.");
+                       " but this example must be run with TET10, HEX20 or HEX27.");
 
   MeshTools::Generation::build_cube (mesh,
                                      grid_size,

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -2536,6 +2536,7 @@ unsigned int FEInterface::max_order(const FEType & fe_t,
         case TRI6:
         case QUAD8:
         case QUAD9:
+        case TET10:
         case HEX20:
         case HEX27:
           return 1;

--- a/src/fe/fe_nedelec_one.C
+++ b/src/fe/fe_nedelec_one.C
@@ -81,11 +81,11 @@ void nedelec_one_nodal_soln(const Elem * elem,
             {
               libmesh_assert_equal_to (elem_soln.size(), 6);
               libmesh_assert_equal_to (nodal_soln.size(), 10*3);
-              
+
               break;
             }
 
-            
+
           case HEX20:
           case HEX27:
             {

--- a/src/fe/fe_nedelec_one.C
+++ b/src/fe/fe_nedelec_one.C
@@ -81,13 +81,11 @@ void nedelec_one_nodal_soln(const Elem * elem,
             {
               libmesh_assert_equal_to (elem_soln.size(), 6);
               libmesh_assert_equal_to (nodal_soln.size(), 10*3);
-
-              libmesh_not_implemented();
-
+              
               break;
             }
 
-
+            
           case HEX20:
           case HEX27:
             {

--- a/src/fe/fe_nedelec_one_shape_3D.C
+++ b/src/fe/fe_nedelec_one_shape_3D.C
@@ -157,7 +157,57 @@ RealGradient FE<3,NEDELEC_ONE>::shape(const Elem * elem,
             {
               libmesh_assert_less (i, 6);
 
-              libmesh_not_implemented();
+              const Real xi   = p(0);
+              const Real eta  = p(1);
+              const Real zeta = p(2);
+
+              switch(i)
+                {
+                case 0:
+                  {
+                    if (elem->point(0) > elem->point(1))
+                      return RealGradient( -1.0+eta+zeta, -xi, -xi );
+                    else
+                      return RealGradient( 1.0-eta-zeta, xi, xi );
+                  }
+                case 1:
+                  {
+                    if (elem->point(1) > elem->point(2))
+                      return RealGradient( eta,  -xi, 0.0 );
+                    else
+                      return RealGradient( -eta, xi, 0.0 );
+                  }
+                case 2:
+                  {
+                    if (elem->point(0) > elem->point(2))
+                      return RealGradient( -eta, -1.0+xi+zeta, -eta );
+                    else
+                      return RealGradient( eta, 1.0-xi-zeta, eta );
+                  }
+                case 3:
+                  {
+                    if (elem->point(0) > elem->point(3))
+                      return RealGradient( -zeta, -zeta, -1.0+xi+eta );
+                    else
+                      return RealGradient( zeta, zeta, 1.0-xi-eta );
+                  }
+                case 4:
+                  {
+                    if (elem->point(1) > elem->point(3))
+                      return RealGradient( zeta, 0.0, -xi );
+                    else
+                      return RealGradient( -zeta, 0.0, xi );
+                  }
+                case 5:
+                  {
+                    if (elem->point(2) > elem->point(3))
+                      return RealGradient( 0.0, zeta, -eta );
+                    else
+                      return RealGradient( 0.0, -zeta, eta );
+                  }
+                default:
+                  libmesh_error_msg("Invalid i = " << i);
+                }
               return RealGradient();
             }
 
@@ -467,7 +517,162 @@ RealGradient FE<3,NEDELEC_ONE>::shape_deriv(const Elem * elem,
             {
               libmesh_assert_less (i, 6);
 
-              libmesh_not_implemented();
+
+              switch (j) //loop over components of vector shape function
+                {
+                  // d()/dxi
+                case 0:
+                  {
+                    switch(i)
+                      {
+                      case 0:
+                        {
+                          if (elem->point(0) > elem->point(1))
+                            return RealGradient( 0.0, -1.0, -1.0 );
+                          else
+                            return RealGradient( 0.0, 1.0, 1.0 );
+                        }
+                      case 1:
+                        {
+                          if (elem->point(1) > elem->point(2))
+                            return RealGradient( 0.0,  -1.0, 0.0 );
+                          else
+                            return RealGradient( 0.0, 1.0, 0.0 );
+                        }
+                      case 2:
+                        {
+                          if (elem->point(0) > elem->point(2))
+                            return RealGradient( 0.0, 1.0, 0.0 );
+                          else
+                            return RealGradient( 0.0, -1.0, 0.0 );
+                        }
+                      case 3:
+                        {
+                          if (elem->point(0) > elem->point(3))
+                            return RealGradient( 0.0, 0.0, 1.0 );
+                          else
+                            return RealGradient( 0.0, 0.0, -1.0 );
+                        }
+                      case 4:
+                        {
+                          if (elem->point(1) > elem->point(3))
+                            return RealGradient( 0.0, 0.0, -1.0 );
+                          else
+                            return RealGradient( 0.0, 0.0, 1.0 );
+                        }
+                      case 5:
+                        {
+                          return RealGradient();
+                        }
+
+                      default:
+                        libmesh_error_msg("Invalid i = " << i);
+                      } // switch(i)
+
+                  } // j=0
+
+                  // d()/deta
+                case 1:
+                  {
+                    switch(i)
+                      {
+                        case 0:
+                          {
+                            if (elem->point(0) > elem->point(1))
+                              return RealGradient( 1.0, 0.0, 0.0 );
+                            else
+                              return RealGradient( -1.0, 0.0, 0.0 );
+                          }
+                        case 1:
+                          {
+                            if (elem->point(1) > elem->point(2))
+                              return RealGradient( 1.0,  0.0, 0.0 );
+                            else
+                              return RealGradient( -1.0, 0.0, 0.0 );
+                          }
+                        case 2:
+                          {
+                            if (elem->point(0) > elem->point(2))
+                              return RealGradient( -1.0, 0.0, -1.0 );
+                            else
+                              return RealGradient( 1.0, 0.0, 1.0 );
+                          }
+                        case 3:
+                          {
+                            if (elem->point(0) > elem->point(3))
+                              return RealGradient( 0.0, 0.0, 1.0 );
+                            else
+                              return RealGradient( 0.0, 0.0, -1.0 );
+                          }
+                        case 4:
+                          {
+                            return RealGradient();
+                          }
+                        case 5:
+                          {
+                            if (elem->point(2) > elem->point(3))
+                              return RealGradient( 0.0, 0.0, -1.0 );
+                            else
+                              return RealGradient( 0.0, 0.0, 1.0 );
+                          }
+                      default:
+                        libmesh_error_msg("Invalid i = " << i);
+                      } // switch(i)
+
+                  } // j=1
+
+                  // d()/dzeta
+                case 2:
+                  {
+                    switch(i)
+                      {
+                        case 0:
+                          {
+                            if (elem->point(0) > elem->point(1))
+                              return RealGradient( 1.0, 0.0, 0.0 );
+                            else
+                              return RealGradient( -1.0, 0.0, 0.0 );
+                          }
+                        case 1:
+                          {
+                            return RealGradient();
+                          }
+                        case 2:
+                          {
+                            if (elem->point(0) > elem->point(2))
+                              return RealGradient( 0.0, 1.0, 0.0 );
+                            else
+                              return RealGradient( 0.0, -1.0, 0.0 );
+                          }
+                        case 3:
+                          {
+                            if (elem->point(0) > elem->point(3))
+                              return RealGradient( -1.0, -1.0, 0.0 );
+                            else
+                              return RealGradient( 1.0, 1.0, 0.0 );
+                          }
+                        case 4:
+                          {
+                            if (elem->point(1) > elem->point(3))
+                              return RealGradient( 1.0, 0.0, 0.0 );
+                            else
+                              return RealGradient( -1.0, 0.0, 0.0 );
+                          }
+                        case 5:
+                          {
+                            if (elem->point(2) > elem->point(3))
+                              return RealGradient( 0.0, 1.0, 0.0 );
+                            else
+                              return RealGradient( 0.0, -1.0, 0.0 );
+                          }
+                      default:
+                        libmesh_error_msg("Invalid i = " << i);
+                      } // switch(i)
+                  } // j = 2
+
+                default:
+                  libmesh_error_msg("Invalid j = " << j);
+                }
               return RealGradient();
             }
 
@@ -475,7 +680,6 @@ RealGradient FE<3,NEDELEC_ONE>::shape_deriv(const Elem * elem,
             libmesh_error_msg("ERROR: Unsupported 3D element type!: " << Utility::enum_to_string(elem->type()));
           }
       }
-
       // unsupported order
     default:
       libmesh_error_msg("ERROR: Unsupported 3D FE order!: " << totalorder);
@@ -740,8 +944,6 @@ RealGradient FE<3,NEDELEC_ONE>::shape_second_deriv(const Elem * elem,
           case TET10:
             {
               libmesh_assert_less (i, 6);
-
-              libmesh_not_implemented();
               return RealGradient();
             }
 


### PR DESCRIPTION
I've added a set of shape functions for NEDELEC_ONE elements on  TET10 meshes in 3D, based on the implementation in MFEM [here](https://mfem.github.io/doxygen/html/fe_8cpp_source.html), working to extend the range of FEs available in libMesh as in #1456. I've also extended the vector_fe/vector_fe_ex4 example to test the curl-curl problem on TET10s, just as was previously done on HEX20 and HEX27 mesh elements in 3D in #130.

There does appear to be some additional artifacts in the Paraview visualisations for these examples over each element, but H_curl error estimates seem reasonable compared to the case for hexehedral meshes (and solutions appear to converge to the right values as mesh size decreases). 

Any comments/recommendations welcome!  