### PR TITLE
Add global data structures for mesh subdomain and boundary ids

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -731,12 +731,17 @@ public:
    * \returns A set of the boundary ids which exist on semilocal parts
    * of the mesh.
    *
-   * DistributedMesh-compatible code may need a set_union or other
-   * manipulations to work with sets of boundary ids which include ids
-   * on remote parts of the mesh.
+   * Code that wishes to access boundary ids on all parts of the mesh, including
+   * non-local parts, should call \p get_global_boundary_ids
    */
   const std::set<boundary_id_type> & get_boundary_ids () const
   { return _boundary_ids; }
+
+  /**
+   * \returns A set of the boundary ids which exist globally
+   * on the mesh. Relies on the mesh being prepared
+   */
+  const std::set<boundary_id_type> & get_global_boundary_ids () const;
 
   /**
    * \returns A reference to the set of the boundary IDs specified on
@@ -927,6 +932,18 @@ private:
    * This only contains information related to this process's local and ghosted elements
    */
   std::set<boundary_id_type> _boundary_ids;
+
+  /**
+   * A collection of user-specified boundary ids for sides, edges, nodes,
+   * and shell faces.
+   * See _side_boundary_ids, _edge_boundary_ids, _node_boundary_ids, and
+   * _shellface_boundary_ids for sets containing IDs for only sides, edges,
+   * nodes, and shell faces, respectively.
+   *
+   * Unlike \p _boundary_ids, this member should contain boundary ids from across
+   * all processors after the mesh is prepared
+   */
+  std::set<boundary_id_type> _global_boundary_ids;
 
   /**
    * Set of user-specified boundary IDs for sides *only*.

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -234,11 +234,11 @@ public:
 
   /**
    * Most of the time you should not need to call this, as the element
-   * dimensions will be set automatically by a call to cache_elem_dims(),
+   * dimensions will be set automatically by a call to cache_elem_data(),
    * therefore only call this if you know what you're doing.
    *
    * In some specialized situations, for example when adding a single
-   * Elem on all procs, it can be faster to skip calling cache_elem_dims()
+   * Elem on all procs, it can be faster to skip calling cache_elem_data()
    * and simply specify the element dimensions manually, which is why this
    * setter exists.
    */
@@ -996,7 +996,7 @@ public:
    *  1.) call \p find_neighbors()
    *  2.) call \p partition()
    *  3.) call \p renumber_nodes_and_elements()
-   *  4.) call \p cache_elem_dims()
+   *  4.) call \p cache_elem_data()
    *
    * The argument to skip renumbering is now deprecated - to prevent a
    * mesh from being renumbered, set allow_renumbering(false). The argument to skip
@@ -1696,17 +1696,37 @@ public:
   { return _constraint_rows; }
 
   /**
+   * \deprecated This method has ben replaced by \p cache_elem_data which
+   * caches data in addition to elem dimensions (e.g. elem subdomain ids)
    * Search the mesh and cache the different dimensions of the elements
    * present in the mesh.  This is done in prepare_for_use(), but can
    * be done manually by other classes after major mesh modifications.
    */
   void cache_elem_dims();
 
+  /*
+   * Search the mesh and cache data for the elements
+   * present in the mesh.  This is done in prepare_for_use(), but can
+   * be done manually by other classes after major mesh modifications.
+   * Data cached includes:
+   *   - elem dimensions
+   *   - elem subdomains
+   */
+  void cache_elem_data();
+
   /**
    * Search the mesh for elements that have a neighboring element
    * of dim+1 and set that element as the interior parent
    */
   void detect_interior_parents();
+
+  /**
+   * \return The cached mesh subdomains. As long as the mesh is prepared, this
+   * should contain all the subdomain ids across processors. Relies on the mesh
+   * being prepared
+   */
+  const std::set<subdomain_id_type> & get_mesh_subdomains() const
+  { libmesh_assert(this->is_prepared()); return _mesh_subdomains; }
 
 
   /**
@@ -1836,6 +1856,11 @@ protected:
    * will contain 1 and 2.
    */
   std::set<unsigned char> _elem_dims;
+
+  /**
+   * We cache the subdomain ids of the elements present in the mesh.
+   */
+  std::set<subdomain_id_type> _mesh_subdomains;
 
   /**
    * The "spatial dimension" of the Mesh.  See the documentation for

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1183,7 +1183,7 @@ void MeshCommunication::broadcast (MeshBase & mesh) const
                                        mesh_inserter_iterator<Elem>(mesh));
 
   // Make sure mesh_dimension and elem_dimensions are consistent.
-  mesh.cache_elem_dims();
+  mesh.cache_elem_data();
 
   // We may have constraint rows on IsoGeometric Analysis meshes.  We
   // don't want to send these along with constrained nodes (like we
@@ -2117,10 +2117,6 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
   // If we had a point locator, it's invalid now that some of the
   // elements it pointed to have been deleted.
   mesh.clear_point_locator();
-
-  // Much of our boundary info may have been for now-remote parts of
-  // the mesh, in which case we don't want to keep local copies.
-  mesh.get_boundary_info().regenerate_id_sets();
 
   // Many of our constraint rows may have been for non-local parts of
   // the mesh, which we don't need, and which we didn't specifically


### PR DESCRIPTION
This kind of information is used significantly in MOOSE where we have
historically unioned this information ourselves. However, I have a case
where I want to query boundary/subdomain information between when the
libmesh mesh is prepared and when we build these MOOSE global data
structures. Moreover, I think having this information available is of
general utility and belongs upstream. Refs my work for
idaholab/moose#17189.