### PR TITLE
Don't try to autodetect headers for tecio in system

### DIFF
--- a/configure
+++ b/configure
@@ -51575,10 +51575,6 @@ fi
 
                                         if test "x$withteciox11inc" != "xno"; then :
   TECIO_CPPFLAGS="-I$withteciox11inc"
-elif                                 test -r /usr/include/X11/Intrinsic.h; then :
-  TECIO_CPPFLAGS="-I/usr/include"
-elif                 test -r /opt/X11/include/X11/Intrinsic.h; then :
-  TECIO_CPPFLAGS="-I/opt/X11/include"
 fi
 
                     if test "x$TECIO_CPPFLAGS" != "x"; then :

--- a/m4/tecio.m4
+++ b/m4/tecio.m4
@@ -27,12 +27,7 @@ AC_DEFUN([CONFIGURE_TECIO],
           dnl If the user specified a path to look for X11 headers in, honor
           dnl that and don't try to look elsewhere.  If the compilation fails
           dnl then they must figure out why on their own.
-          AS_IF([test "x$withteciox11inc" != "xno"], [TECIO_CPPFLAGS="-I$withteciox11inc"],
-                dnl The user did not specify where to look, so see if the file
-                dnl exists in the usual Linux location...
-                [test -r /usr/include/X11/Intrinsic.h], [TECIO_CPPFLAGS="-I/usr/include"],
-                dnl ... and if not there, try the Mac (XQuartz) location.
-                [test -r /opt/X11/include/X11/Intrinsic.h], [TECIO_CPPFLAGS="-I/opt/X11/include"])
+          AS_IF([test "x$withteciox11inc" != "xno"], [TECIO_CPPFLAGS="-I$withteciox11inc"])
 
           dnl Print a status message
           AS_IF([test "x$TECIO_CPPFLAGS" != "x"],


### PR DESCRIPTION
Refs #2896 

I thought about being more ambitious and tackling some other packages that toss in `/usr/include` and I ran into eigen...which we use a lot more, and so I got nervous and decided to go with the low-hanging fruit.