### PR TITLE
undef MAJOR_VERSION and MINOR_VERSION before including petsc.h in config tests

### DIFF
--- a/configure
+++ b/configure
@@ -48927,6 +48927,8 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
           cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
+          #undef MAJOR_VERSION
+          #undef MINOR_VERSION
           #include <petsc.h>
           static char help[]="";
 
@@ -48983,6 +48985,8 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
           cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
+          #undef MAJOR_VERSION
+          #undef MINOR_VERSION
           #include <petsctao.h>
           static char help[]="";
 

--- a/m4/petsc.m4
+++ b/m4/petsc.m4
@@ -97,6 +97,8 @@ AC_DEFUN([CONFIGURE_PETSC],
           CXXFLAGS="$saveCXXFLAGS $PETSCINCLUDEDIRS"
 
           AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+          @%:@undef MAJOR_VERSION
+          @%:@undef MINOR_VERSION
           @%:@include <petsc.h>
           static char help[]="";
 
@@ -131,6 +133,8 @@ AC_DEFUN([CONFIGURE_PETSC],
           CFLAGS="$saveCFLAGS $PETSCINCLUDEDIRS"
 
           AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+          @%:@undef MAJOR_VERSION
+          @%:@undef MINOR_VERSION
           @%:@include <petsctao.h>
           static char help[]="";
 


### PR DESCRIPTION
I think the issue could be bigger than what I have fixed. LibMesh defines in `configure.ac` the defines `MAJOR_VERSION` and `MINOR_VERSION`. I have build PETSc with CUDA support, i.e. `petsc.h` pulls in cuda headers, which have an enum defined that looks like this:
```
typedef enum libraryPropertyType_t
{
        MAJOR_VERSION,
        MINOR_VERSION,
        PATCH_LEVEL
} libraryPropertyType;
```
This clearly clashes with `#define MAJOR_VERSION 1` that will be added in the conftest. I changed the test to undef MAJOR/MINOR_VERSION before including `petsc.h`, and it successfully finds PETSc now.
I think the issue could be bigger, because any 3rdparty library that pulls in CUDA headers and you do a compilation test at configure stage will suffer from the same problem.
Later `MAJOR_VERSION` is renamed to `LIBMESH_MAJOR_VERSION`, and there is no problem at all. I think a clean solution should rename `MAJOR_VERSION` already at configure stage to `LIBMESH_MAJOR_VERSION`.