### PR TITLE
Wrap Petsc include for dmimpl.h in ignore and restore warnings.

### DIFF
--- a/src/solvers/petscdmlibmeshimpl.C
+++ b/src/solvers/petscdmlibmeshimpl.C
@@ -21,12 +21,16 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 
+#include "libmesh/ignore_warnings.h"
+
 // PETSc includes
 #if !PETSC_RELEASE_LESS_THAN(3,6,0)
 # include <petsc/private/dmimpl.h>
 #else
 # include <petsc-private/dmimpl.h>
 #endif
+
+#include "libmesh/restore_warnings.h"
 
 // Local Includes
 #include "libmesh/libmesh_common.h"


### PR DESCRIPTION
While compiling libMesh with paranoid warnings and werror, I get an error in PETSc:
include/petsc/private/petscdsimpl.h:62:46:
error: cast from type ‘const void*’ to type ‘PetscHashFormKey* {aka _PetscHashFormKey*}’ casts away qualifiers [-Werror=cast-qual].

Using ignore and restore warnings to ignore this.