### PR TITLE
Make dummy return values more foolproof

### DIFF
--- a/include/systems/diff_system.h
+++ b/include/systems/diff_system.h
@@ -161,8 +161,8 @@ public:
   virtual std::unique_ptr<DifferentiablePhysics> clone_physics() override
   {
     libmesh_not_implemented();
-    // dummy
-    return std::unique_ptr<DifferentiablePhysics>(this);
+    // dummy to avoid compiler warnings, not a real implementation
+    return std::unique_ptr<DifferentiablePhysics>(nullptr);
   }
 
   /**
@@ -171,8 +171,8 @@ public:
   virtual std::unique_ptr<DifferentiableQoI> clone() override
   {
     libmesh_not_implemented();
-    // dummy
-    return std::unique_ptr<DifferentiableQoI>(this);
+    // dummy to avoid compiler warnings, not a real implementation
+    return std::unique_ptr<DifferentiableQoI>(nullptr);
   }
 
   /**


### PR DESCRIPTION
Hopefully the comment is now clearer that this code shouldn't be copied,
and the code itself is safer if it is copied and used - it would die
promptly from an easy-to-debug nullptr dereference, rather than after a
long delay from a confusing dangling pointer dereference or a corrupt
heap.

Refs #2910