### PR TITLE
Make RadialBasisInterpolation quiet

### DIFF
--- a/include/solution_transfer/radial_basis_interpolation.h
+++ b/include/solution_transfer/radial_basis_interpolation.h
@@ -81,7 +81,7 @@ public:
     InverseDistanceInterpolation<KDDim> (comm_in,8,2),
     _r_bbox(0.),
     _r_override(radius)
-  { libmesh_experimental(); }
+  { }
 
   /**
    * Clears all internal data structures and restores to a

--- a/src/solution_transfer/radial_basis_interpolation.C
+++ b/src/solution_transfer/radial_basis_interpolation.C
@@ -85,9 +85,10 @@ void RadialBasisInterpolation<KDDim,RBF>::prepare_for_use()
       }
   }
 
-  libMesh::out << "bounding box is \n"
-               << _src_bbox.min() << '\n'
-               << _src_bbox.max() << std::endl;
+  // Debugging code
+  // libMesh::out << "bounding box is \n"
+  //              << _src_bbox.min() << '\n'
+  //              << _src_bbox.max() << std::endl;
 
 
   // Construct the Radial Basis Function, giving it the size of the domain
@@ -98,11 +99,11 @@ void RadialBasisInterpolation<KDDim,RBF>::prepare_for_use()
 
   RBF rbf(_r_bbox);
 
-  libMesh::out << "bounding box is \n"
-               << _src_bbox.min() << '\n'
-               << _src_bbox.max() << '\n'
-               << "r_bbox = " << _r_bbox << '\n'
-               << "rbf(r_bbox/2) = " << rbf(_r_bbox/2) << std::endl;
+  // libMesh::out << "bounding box is \n"
+  //              << _src_bbox.min() << '\n'
+  //              << _src_bbox.max() << '\n'
+  //              << "r_bbox = " << _r_bbox << '\n'
+  //              << "rbf(r_bbox/2) = " << rbf(_r_bbox/2) << std::endl;
 
 
   // Construct the projection Matrix


### PR DESCRIPTION
The debugging to cout didn't look worth giving a verbose option to, but
I'll leave it in comments in case anyone runs into whatever Ben was
suspicious about.

libmesh_experimental(); is probably unnecessary for an 8-year-old class;
if people have been using this and happy with the API for that long then
I think we'll keep it.

Fixes #2913