### PR TITLE
active_local_subdomain_set iterators, range

### DIFF
--- a/include/base/multi_predicates.h
+++ b/include/base/multi_predicates.h
@@ -678,6 +678,28 @@ struct ActiveSubdomainSet : abstract_multi_predicate<T>
 
 
 /**
+ * Used to iterate over non-nullptr, active elements with a given PID
+ * whose subdomains are in a user-specified set.
+ */
+template <typename T>
+struct ActiveLocalSubdomainSet : abstract_multi_predicate<T>
+{
+  ActiveLocalSubdomainSet(processor_id_type my_pid,
+                          std::set<subdomain_id_type> sset)
+  {
+    this->_predicates.push_back(new not_null<T>);
+    this->_predicates.push_back(new active<T>);
+    this->_predicates.push_back(new pid<T>(my_pid));
+    this->_predicates.push_back(new subdomain_set<T>(sset));
+  }
+};
+
+
+
+
+
+
+/**
  * Used to iterate over non-nullptr elements not owned by a given
  * processor but semi-local to that processor, i.e. ghost elements.
  */

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -469,6 +469,15 @@ public:
   virtual SimpleRange<const_element_iterator> active_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) const override
   { return {active_subdomain_set_elements_begin(ss), active_subdomain_set_elements_end(ss)}; }
 
+  virtual element_iterator active_local_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) override;
+  virtual element_iterator active_local_subdomain_set_elements_end (std::set<subdomain_id_type> ss) override;
+  virtual const_element_iterator active_local_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) const override;
+  virtual const_element_iterator active_local_subdomain_set_elements_end (std::set<subdomain_id_type> ss) const override;
+  virtual SimpleRange<element_iterator> active_local_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) override
+  { return {active_local_subdomain_set_elements_begin(ss), active_local_subdomain_set_elements_end(ss)}; }
+  virtual SimpleRange<const_element_iterator> active_local_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) const override
+  { return {active_local_subdomain_set_elements_begin(ss), active_local_subdomain_set_elements_end(ss)}; }
+
   virtual element_iterator ghost_elements_begin () override;
   virtual element_iterator ghost_elements_end () override;
   virtual const_element_iterator ghost_elements_begin () const override;

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1560,6 +1560,13 @@ public:
   virtual SimpleRange<element_iterator> active_local_subdomain_elements_ptr_range(subdomain_id_type subdomain_id) = 0;
   virtual SimpleRange<const_element_iterator> active_local_subdomain_elements_ptr_range(subdomain_id_type subdomain_id) const = 0;
 
+  virtual element_iterator active_local_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) = 0;
+  virtual element_iterator active_local_subdomain_set_elements_end (std::set<subdomain_id_type> ss) = 0;
+  virtual const_element_iterator active_local_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) const = 0;
+  virtual const_element_iterator active_local_subdomain_set_elements_end (std::set<subdomain_id_type> ss) const = 0;
+  virtual SimpleRange<element_iterator> active_local_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) = 0;
+  virtual SimpleRange<const_element_iterator> active_local_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) const = 0;
+
   virtual element_iterator local_level_elements_begin (unsigned int level) = 0;
   virtual element_iterator local_level_elements_end (unsigned int level) = 0;
   virtual const_element_iterator local_level_elements_begin (unsigned int level) const = 0;

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -430,6 +430,15 @@ public:
   virtual SimpleRange<const_element_iterator> active_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) const override
   { return {active_subdomain_set_elements_begin(ss), active_subdomain_set_elements_end(ss)}; }
 
+  virtual element_iterator active_local_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) override;
+  virtual element_iterator active_local_subdomain_set_elements_end (std::set<subdomain_id_type> ss) override;
+  virtual const_element_iterator active_local_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) const override;
+  virtual const_element_iterator active_local_subdomain_set_elements_end (std::set<subdomain_id_type> ss) const override;
+  virtual SimpleRange<element_iterator> active_local_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) override
+  { return {active_local_subdomain_set_elements_begin(ss), active_local_subdomain_set_elements_end(ss)}; }
+  virtual SimpleRange<const_element_iterator> active_local_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) const override
+  { return {active_local_subdomain_set_elements_begin(ss), active_local_subdomain_set_elements_end(ss)}; }
+
   virtual element_iterator ghost_elements_begin () override;
   virtual element_iterator ghost_elements_end () override;
   virtual const_element_iterator ghost_elements_begin () const override;

--- a/src/mesh/mesh_iterators.C
+++ b/src/mesh/mesh_iterators.C
@@ -165,9 +165,10 @@ INSTANTIATE_ELEM_ACCESSORS(flagged_elements,                Flagged,            
 INSTANTIATE_ELEM_ACCESSORS(flagged_pid_elements,            FlaggedPID,           unsigned char rflag LIBMESH_COMMA processor_id_type pid,    rflag, pid)
 #endif
 
-INSTANTIATE_ELEM_ACCESSORS(local_level_elements,            LocalLevel,           unsigned int level,             this->processor_id(), level)
-INSTANTIATE_ELEM_ACCESSORS(local_not_level_elements,        LocalNotLevel,        unsigned int level,             this->processor_id(), level)
-INSTANTIATE_ELEM_ACCESSORS(active_local_subdomain_elements, ActiveLocalSubdomain, subdomain_id_type subdomain_id, this->processor_id(), subdomain_id)
+INSTANTIATE_ELEM_ACCESSORS(local_level_elements,                LocalLevel,              unsigned int level,             this->processor_id(), level)
+INSTANTIATE_ELEM_ACCESSORS(local_not_level_elements,            LocalNotLevel,           unsigned int level,             this->processor_id(), level)
+INSTANTIATE_ELEM_ACCESSORS(active_local_subdomain_elements,     ActiveLocalSubdomain,    subdomain_id_type subdomain_id, this->processor_id(), subdomain_id)
+INSTANTIATE_ELEM_ACCESSORS(active_local_subdomain_set_elements, ActiveLocalSubdomainSet, std::set<subdomain_id_type> ss, this->processor_id(), ss)
 
 // Instantiate various node iterator accessor functions.
 INSTANTIATE_NODE_ACCESSORS(nodes,        NotNull, EMPTY,                               EMPTY)


### PR DESCRIPTION
This is necessary in order to tell a GenericProjector to do a proper
projection onto just a union of subdomains of the mesh.