### PR TITLE
Compilation fixes

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex14/miscellaneous_ex14.C
+++ b/examples/miscellaneous/miscellaneous_ex14/miscellaneous_ex14.C
@@ -245,7 +245,7 @@ int main (int argc, char** argv)
   //fetch the solver-object used internally to be able to manipulate it using the self-written class
   // to set the transformation
   SlepcEigenSolver<Number> * solver =
-    libmesh_cast_ptr<SlepcEigenSolver<Number>* >( &eig_sys.get_eigen_solver() );
+    cast_ptr<SlepcEigenSolver<Number>* >( &eig_sys.get_eigen_solver() );
 
   // setup of our class @SlepcSolverConfiguration
   SlepcSolverConfiguration ConfigSolver(*solver);

--- a/tests/mesh/mesh_assign.C
+++ b/tests/mesh/mesh_assign.C
@@ -9,6 +9,7 @@
 #include <libmesh/dirichlet_boundaries.h>
 #include <libmesh/dof_map.h>
 #include <libmesh/parallel.h>
+#include <libmesh/replicated_mesh.h>
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"


### PR DESCRIPTION
These fix test builds with --enable-parmesh and example builds with --disable-deprecated, respectively.