### PR TITLE
Prerequest nothing on side FE in RB ex2

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex2/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex2/rb_classes.h
@@ -156,6 +156,10 @@ public:
     elem_fe->get_JxW();
     elem_fe->get_phi();
     elem_fe->get_dphi();
+
+    FEBase * side_fe = nullptr;
+    c.get_side_fe(u_var, side_fe);
+    side_fe->get_nothing();
   }
 
   /**


### PR DESCRIPTION
This has been broken for forever, I just never noticed until now.  I
must have been forgetting to --disable-deprecated on builds with both
SLEPc and GLPK enabled, and without --disable-deprecated this behavior
is just an inefficiency that doesn't throw any errors.