### PR TITLE
FEMContext::active_vars()

### DIFF
--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -65,16 +65,22 @@ public:
 
   /**
    * Constructor.  Allocates some but fills no data structures.
+   *
+   * Optionally specify a limited number of variables to be "active"
+   * and thus calculated on.  If \p active_vars is null then
+   * calculations will be prepared for every variable in \p sys.
    */
   explicit
-  FEMContext (const System & sys);
+  FEMContext (const System & sys,
+              const std::vector<unsigned int> * active_vars = nullptr);
 
   /**
    * Constructor.  Specify the extra quadrature order instead
-   * of getting it from \p sys.  Optionally specify a limited number
-   * of variables to be "active" and thus calculated on.  If
-   * \p active_vars is null then calculations will be prepared for
-   * every variable in \p sys.
+   * of getting it from \p sys.
+   *
+   * Optionally specify a limited number of variables to be "active"
+   * and thus calculated on.  If \p active_vars is null then
+   * calculations will be prepared for every variable in \p sys.
    */
   explicit
   FEMContext (const System & sys,

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -994,16 +994,6 @@ public:
   void set_jacobian_tolerance(Real tol);
 
   /**
-   * System from which to acquire moving mesh information
-   */
-  System * _mesh_sys;
-
-  /**
-   * Variables from which to acquire moving mesh information
-   */
-  unsigned int _mesh_x_var, _mesh_y_var, _mesh_z_var;
-
-  /**
    * Current side for side_* to examine
    */
   unsigned char side;
@@ -1036,6 +1026,16 @@ public:
                                             const int get_derivative_level = -1) const;
 
 protected:
+
+  /**
+   * System from which to acquire moving mesh information
+   */
+  System * _mesh_sys;
+
+  /**
+   * Variables from which to acquire moving mesh information
+   */
+  unsigned int _mesh_x_var, _mesh_y_var, _mesh_z_var;
 
   /**
    * Keep track of what type of algebra reinitialization is to be done

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -71,10 +71,16 @@ public:
 
   /**
    * Constructor.  Specify the extra quadrature order instead
-   * of getting it from \p sys.
+   * of getting it from \p sys.  Optionally specify a limited number
+   * of variables to be "active" and thus calculated on.  If
+   * \p active_vars is null then calculations will be prepared for
+   * every variable in \p sys.
    */
   explicit
-  FEMContext (const System & sys, int extra_quadrature_order);
+  FEMContext (const System & sys,
+              int extra_quadrature_order,
+              const std::vector<unsigned int> * active_vars = nullptr);
+
 
   /**
    * Destructor.
@@ -1026,6 +1032,12 @@ public:
                                             const int get_derivative_level = -1) const;
 
 protected:
+
+  /**
+   * Variables on which to enable calculations, or nullptr if all
+   * variables in the System are to be enabled
+   */
+  std::unique_ptr<const std::vector<unsigned int>> _active_vars;
 
   /**
    * System from which to acquire moving mesh information

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -1026,6 +1026,12 @@ public:
   void attach_quadrature_rules();
 
   /**
+   * Return a pointer to the vector of active variables being computed
+   * for, or a null pointer if all variables in the system are active.
+   */
+  const std::vector<unsigned int> * active_vars() const { return _active_vars.get(); }
+
+  /**
    * Helper function to reduce some code duplication in the *_point_* methods.
    *
    * get_derivative_level should be -1 to get_ everything, 0 to

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -42,7 +42,9 @@ FEMContext::FEMContext (const System & sys)
   init_internal_data(sys);
 }
 
-FEMContext::FEMContext (const System & sys, int extra_quadrature_order)
+FEMContext::FEMContext (const System & sys,
+                        int extra_quadrature_order,
+                        const std::vector<unsigned int> * active_vars)
   : DiffContext(sys),
     side(0), edge(0),
     _mesh_sys(nullptr),
@@ -60,6 +62,10 @@ FEMContext::FEMContext (const System & sys, int extra_quadrature_order)
     _side_qrule(4),
     _extra_quadrature_order(extra_quadrature_order)
 {
+  if (active_vars)
+    _active_vars =
+      libmesh_make_unique<std::vector<unsigned int>>(*active_vars);
+
   init_internal_data(sys);
 }
 

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -64,8 +64,15 @@ FEMContext::FEMContext (const System & sys,
     _extra_quadrature_order(extra_quadrature_order)
 {
   if (active_vars)
-    _active_vars =
-      libmesh_make_unique<std::vector<unsigned int>>(*active_vars);
+    {
+      auto vars_copy =
+        libmesh_make_unique<std::vector<unsigned int>>(*active_vars);
+
+      // We want to do quick binary_search later
+      std::sort(vars_copy->begin(), vars_copy->end());
+
+      _active_vars = std::move(vars_copy);
+    }
 
   init_internal_data(sys);
 }

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -36,8 +36,9 @@
 namespace libMesh
 {
 
-FEMContext::FEMContext (const System & sys)
-  : FEMContext(sys, sys.extra_quadrature_order)
+FEMContext::FEMContext (const System & sys,
+                        const std::vector<unsigned int> * active_vars)
+  : FEMContext(sys, sys.extra_quadrature_order, active_vars)
 {
   init_internal_data(sys);
 }

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -37,33 +37,18 @@ namespace libMesh
 {
 
 FEMContext::FEMContext (const System & sys)
-  : DiffContext(sys),
-    _mesh_sys(nullptr),
-    _mesh_x_var(0),
-    _mesh_y_var(0),
-    _mesh_z_var(0),
-    side(0), edge(0),
-    _atype(CURRENT),
-    _custom_solution(nullptr),
-    _boundary_info(sys.get_mesh().get_boundary_info()),
-    _elem(nullptr),
-    _dim(cast_int<unsigned char>(sys.get_mesh().mesh_dimension())),
-    _elem_dim(0), /* This will be reset in set_elem(). */
-    _elem_dims(sys.get_mesh().elem_dimensions()),
-    _element_qrule(4),
-    _side_qrule(4),
-    _extra_quadrature_order(sys.extra_quadrature_order)
+  : FEMContext(sys, sys.extra_quadrature_order)
 {
   init_internal_data(sys);
 }
 
 FEMContext::FEMContext (const System & sys, int extra_quadrature_order)
   : DiffContext(sys),
+    side(0), edge(0),
     _mesh_sys(nullptr),
     _mesh_x_var(0),
     _mesh_y_var(0),
     _mesh_z_var(0),
-    side(0), edge(0),
     _atype(CURRENT),
     _custom_solution(nullptr),
     _boundary_info(sys.get_mesh().get_boundary_info()),
@@ -77,6 +62,7 @@ FEMContext::FEMContext (const System & sys, int extra_quadrature_order)
 {
   init_internal_data(sys);
 }
+
 
 
 FEType FEMContext::find_hardest_fe_type()

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -385,8 +385,8 @@ void System::project_vector (const NumericVector<Number> & old_v,
                          OldSolutionValue<Gradient, &FEMContext::point_gradient>,
                          Number, VectorSetAction<Number>> FEMProjector;
 
-      OldSolutionValue<Number,   &FEMContext::point_value>    f(*this, old_vector);
-      OldSolutionValue<Gradient, &FEMContext::point_gradient> g(*this, old_vector);
+      OldSolutionValue<Number,   &FEMContext::point_value>    f(*this, old_vector, &regular_vars);
+      OldSolutionValue<Gradient, &FEMContext::point_gradient> g(*this, old_vector, &regular_vars);
       VectorSetAction<Number> setter(new_vector);
 
       FEMProjector projector(*this, f, &g, setter, regular_vars);
@@ -397,8 +397,8 @@ void System::project_vector (const NumericVector<Number> & old_v,
                          OldSolutionValue<Tensor, &FEMContext::point_gradient>,
                          Gradient, VectorSetAction<Number>> FEMVectorProjector;
 
-      OldSolutionValue<Gradient, &FEMContext::point_value> f_vector(*this, old_vector);
-      OldSolutionValue<Tensor, &FEMContext::point_gradient> g_vector(*this, old_vector);
+      OldSolutionValue<Gradient, &FEMContext::point_value> f_vector(*this, old_vector, &vector_vars);
+      OldSolutionValue<Tensor, &FEMContext::point_gradient> g_vector(*this, old_vector, &vector_vars);
 
       FEMVectorProjector vector_projector(*this, f_vector, &g_vector, setter, vector_vars);
       vector_projector.project(active_local_elem_range);
@@ -518,14 +518,15 @@ public:
   typedef DSNA ValuePushType;
   typedef DSNA FunctorValue;
 
-  OldSolutionCoefs(const libMesh::System & sys_in) :
-    OldSolutionBase<Output, point_output>(sys_in)
+  OldSolutionCoefs(const libMesh::System & sys_in,
+                   const std::vector<unsigned int> * vars) :
+    OldSolutionBase<Output, point_output>(sys_in, vars)
   {
     this->old_context.set_algebraic_type(FEMContext::OLD_DOFS_ONLY);
   }
 
   OldSolutionCoefs(const OldSolutionCoefs & in) :
-    OldSolutionBase<Output, point_output>(in.sys)
+    OldSolutionBase<Output, point_output>(in.sys, in.old_context.active_vars())
   {
     this->old_context.set_algebraic_type(FEMContext::OLD_DOFS_ONLY);
   }
@@ -974,8 +975,8 @@ void System::projection_matrix (SparseMatrix<Number> & proj_mat) const
                          DynamicSparseNumberArray<Real,dof_id_type>,
                          MatrixFillAction<Real, Number> > ProjMatFiller;
 
-      OldSolutionValueCoefs    f(*this);
-      OldSolutionGradientCoefs g(*this);
+      OldSolutionValueCoefs    f(*this, &vars);
+      OldSolutionGradientCoefs g(*this, &vars);
       MatrixFillAction<Real, Number> setter(proj_mat);
 
       ProjMatFiller mat_filler(*this, f, &g, setter, vars);


### PR DESCRIPTION
This lets us restrict a FEMContext's underlying FE objects to a subset of the variables in the system, not just for efficiency, but for correctness in the --disable-deprecated configuration under our newer "never try to reinit a FE you haven't requested data from" rules.