### PR TITLE
make periodic BC setup work for vector FEFieldType

### DIFF
--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -2187,14 +2187,24 @@ void FEInterface::compute_periodic_constraints (DofConstraints & constraints,
                                                 const unsigned int variable_number,
                                                 const Elem * elem)
 {
-  // No element-specific optimizations currently exist
-  FEBase::compute_periodic_constraints (constraints,
-                                        dof_map,
-                                        boundaries,
-                                        mesh,
-                                        point_locator,
-                                        variable_number,
-                                        elem);
+  const FEType & fe_t = dof_map.variable_type(variable_number);
+  // No element-specific optimizations currently exist, although
+  // we do have to select the right compute_periodic_constraints
+  // for the OutputType of this FEType.
+  switch (field_type(fe_t))
+  {
+    case TYPE_SCALAR:
+      FEBase::compute_periodic_constraints(
+          constraints, dof_map, boundaries, mesh, point_locator, variable_number, elem);
+      break;
+    case TYPE_VECTOR:
+      FEVectorBase::compute_periodic_constraints(
+          constraints, dof_map, boundaries, mesh, point_locator, variable_number, elem);
+      break;
+    default:
+      libmesh_error_msg(
+          "compute_periodic_constraints only set up for vector or scalar FEFieldTypes");
+  }
 }
 
 #endif // #ifdef LIBMESH_ENABLE_PERIODIC


### PR DESCRIPTION
As it stands, if you try to set up periodic BCs for a vector variable, libMesh fails. I have tested this in MOOSE and confirmed this fix does the trick. I plan to add the input file [listed here](https://github.com/idaholab/moose/issues/17823) as a test in MOOSE once this gets incorporated to libMesh.