### PR TITLE
Improve the performance of BoundingBox::contains_point 

### DIFF
--- a/src/geom/bounding_box.C
+++ b/src/geom/bounding_box.C
@@ -27,7 +27,7 @@
 namespace libMesh
 {
 // Small helper function to make contains_point() more readable.
-bool is_between(Real min, Real check, Real max)
+inline bool is_between(Real min, Real check, Real max)
 {
   return min <= check && check <= max;
 }


### PR DESCRIPTION
by marking `is_between` as an inline function

```
3.28s  130:      if (bboxes[i_from].contains_point(*node + _to_positions[i_to]))

520ms  130:      if (bboxes[i_from].contains_point(*node + _to_positions[i_to]))
```