### PR TITLE
Check for gdb in command line in print_trace when compiling with no gdb backtrace by default

### DIFF
--- a/src/base/print_trace.C
+++ b/src/base/print_trace.C
@@ -204,8 +204,9 @@ void print_trace(std::ostream & out_stream)
 
   // Let the user disable GDB backtraces by configuring with
   // --without-gdb-command or with a command line option.
-  if (std::string(LIBMESH_GDB_COMMAND) != std::string("no") &&
-      !libMesh::on_command_line("--no-gdb-backtrace"))
+  if ((std::string(LIBMESH_GDB_COMMAND) != std::string("no") &&
+       !libMesh::on_command_line("--no-gdb-backtrace")) ||
+      libMesh::on_command_line("--gdb"))
     gdb_worked = gdb_backtrace(out_stream);
 
   // This part requires that your compiler at least supports


### PR DESCRIPTION
refs #2933