### PR TITLE
$LIBMESH_BENCHMARK selection of benchmarking examples

### DIFF
--- a/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
+++ b/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
@@ -181,15 +181,18 @@ int main (int argc, char ** argv)
       libmesh_error_msg("ERROR: Initial timestep not specified!");
     }
 
-  // This value is also obtained from the command line, and specifies
-  // the number of time steps to take.
+  // This command line value specifies how many time steps to take.
   unsigned int n_timesteps = 0;
 
-  // Again do a search on the command line for the argument
   if (command_line.search("-n_timesteps"))
     n_timesteps = command_line.next(0);
   else
     libmesh_error_msg("ERROR: Number of timesteps not specified");
+
+  // This command line value specifies how far to allow refinement
+  unsigned int max_h_level = 5;
+  if (command_line.search("-max_h_level"))
+    max_h_level = command_line.next(n_timesteps);
 
 
   // Skip this 2D example if libMesh was compiled as 1D-only.
@@ -402,7 +405,7 @@ int main (int argc, char ** argv)
               // coarsened.
               mesh_refinement.refine_fraction() = 0.80;
               mesh_refinement.coarsen_fraction() = 0.07;
-              mesh_refinement.max_h_level() = 5;
+              mesh_refinement.max_h_level() = max_h_level;
               mesh_refinement.flag_elements_by_error_fraction (error);
 
               // This call actually refines and coarsens the flagged

--- a/examples/adaptivity/adaptivity_ex2/run.sh
+++ b/examples/adaptivity/adaptivity_ex2/run.sh
@@ -18,15 +18,23 @@ output_freq=10
 
 options=" \[-read_solution\] -n_timesteps $n_timesteps -n_refinements $n_refinements -init_timestep \[0\|$n_timesteps\]"
 
+# Run from scratch with either example parameters or benchmark parameters
+
 options="-n_timesteps $n_timesteps -n_refinements $n_refinements -output_freq $output_freq -init_timestep 0"
 run_example "$example_name" "$options"
+
+benchmark_options="-n_timesteps 25 -n_refinements 7 -max_h_level 7 -output_freq 10 -init_timestep 0"
+benchmark_example 1 "$example_name" "$benchmark_options"
 
 echo " "
 echo "***** Finished first" $n_timesteps "steps, now read in" \
     "saved solution and continue *****"
 echo " "
 
+# Then run from the restart with either example parameters or benchmark parameters
+
 options="-read_solution -n_timesteps $n_timesteps -output_freq $output_freq -init_timestep $n_timesteps"
 run_example "$example_name" "$options"
 
-options=" \[-read_solution\] -n_timesteps $n_timesteps -n_refinements $n_refinements -init_timestep \[0\|$n_timesteps\]"
+benchmark_options="-read_solution -n_timesteps 25 -max_h_level 7 -output_freq 10 -init_timestep 25"
+benchmark_example 1 "$example_name" "$benchmark_options"

--- a/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
+++ b/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
@@ -345,6 +345,11 @@ int main(int argc, char ** argv)
       // Compute the error.
       exact_sol.compute_error("Laplace", "u");
 
+      // The error should at least be sane, but it isn't if the solver
+      // failed badly enough
+      if (libmesh_isnan(exact_sol.l2_error("Laplace", "u")))
+        libmesh_error_msg("NaN solve result");
+
       // Print out the error values
       libMesh::out << "L2-Error is: "
                    << exact_sol.l2_error("Laplace", "u")

--- a/examples/adaptivity/adaptivity_ex3/run.sh
+++ b/examples/adaptivity/adaptivity_ex3/run.sh
@@ -25,3 +25,7 @@ run_example "$example_name" dimension=1 approx_type=HERMITE approx_order=3 refin
 run_example "$example_name" dimension=1 approx_type=HERMITE approx_order=3 refinement_type=p max_r_steps=6
 run_example "$example_name" dimension=1 approx_type=HERMITE approx_order=3 refinement_type=hp max_r_steps=8
 run_example "$example_name" dimension=1 approx_type=HERMITE approx_order=3 refinement_type=matchedhp max_r_steps=4
+
+# Examples to use for benchmarking
+benchmark_example 1 "$example_name" dimension=3 approx_type=LAGRANGE approx_order=2 refinement_type=h max_r_steps=12
+benchmark_example 1 "$example_name" dimension=3 approx_type=HIERARCHIC approx_order=3 refinement_type=h

--- a/examples/adaptivity/adaptivity_ex3/run.sh
+++ b/examples/adaptivity/adaptivity_ex3/run.sh
@@ -15,12 +15,13 @@ run_example "$example_name" refinement_type=matchedhp max_r_steps=4
 
 # Let's get some 1D coverage too; that's cheap.
 run_example "$example_name" dimension=1 refinement_type=h
-run_example "$example_name" dimension=1 refinement_type=p
+# After enough p refinement we start breaking non-pivoting ILU preconditioners
+run_example "$example_name" dimension=1 refinement_type=p max_r_steps=8
 run_example "$example_name" dimension=1 refinement_type=hp max_r_steps=6
 run_example "$example_name" dimension=1 refinement_type=matchedhp max_r_steps=4
 
 # And try out another element type
 run_example "$example_name" dimension=1 approx_type=HERMITE approx_order=3 refinement_type=h
-run_example "$example_name" dimension=1 approx_type=HERMITE approx_order=3 refinement_type=p
+run_example "$example_name" dimension=1 approx_type=HERMITE approx_order=3 refinement_type=p max_r_steps=6
 run_example "$example_name" dimension=1 approx_type=HERMITE approx_order=3 refinement_type=hp max_r_steps=8
 run_example "$example_name" dimension=1 approx_type=HERMITE approx_order=3 refinement_type=matchedhp max_r_steps=4

--- a/examples/adaptivity/adaptivity_ex4/run.sh
+++ b/examples/adaptivity/adaptivity_ex4/run.sh
@@ -14,3 +14,6 @@ run_example "$example_name" dimension=1 approx_type=HERMITE approx_order=FOURTH
 # CLOUGH elements don't currently support threads
 run_example_no_extra_options "$example_name" approx_type=CLOUGH $LIBMESH_OPTIONS --n_threads=1
 #run_example "$example_name" approx_type=SECOND  # Broken?
+
+# Examples to use for benchmarking
+benchmark_example 1 "$example_name" dimension=3 approx_type=HERMITE approx_order=THIRD max_r_steps=6

--- a/examples/adaptivity/adaptivity_ex5/run.sh
+++ b/examples/adaptivity/adaptivity_ex5/run.sh
@@ -15,44 +15,14 @@ n_refinements=5
 # Specify how often to write output files
 output_freq=10
 
+# Lack of '' around the fparser function is intentional, as is lack of
+# whitespace in the function.  Yes, we need a better way to pass
+# these.
 options="-n_timesteps $n_timesteps -n_refinements $n_refinements \
     -output_freq $output_freq -init_timestep 0 \
-    -exact_solution '10*exp(-(pow(x-0.8*t-0.2,2)+pow(y-0.8*t-0.2,2))/(0.01*(4*t+1)))/(4*t+1)'"
+    -exact_solution 10*exp(-(pow(x-0.8*t-0.2,2)+pow(y-0.8*t-0.2,2))/(0.01*(4*t+1)))/(4*t+1)"
 
-
-# This is frustrating - I cannot get the fparser expression to survive as a shell variable
-
-# run_example "$example_name" $options
-# run_example "$example_name" -n_timesteps $n_timesteps -n_refinements $n_refinements \
-#         -output_freq $output_freq -init_timestep 0 \
-#         -exact_solution '10*exp(-(pow(x-0.8*t-0.2,2) + pow(y-0.8*t-0.2,2))/(0.01*(4*t+1)))/(4*t+1)'
-
-for method in ${METHODS}; do
-    
-    case "${method}" in
-	optimized|opt)      executable=example-opt   ;;
-	debug|dbg)          executable=example-dbg   ;;
-	devel)              executable=example-devel ;;
-	profiling|pro|prof) executable=example-prof  ;;
-	oprofile|oprof)     executable=example-oprof ;;
-	*) echo "ERROR: unknown method: ${method}!" ; exit 1 ;;
-    esac
-    
-    if (test ! -x ${executable}); then
-	echo "ERROR: cannot find ${executable}!"
-	exit 1
-    fi
-    
-    message_running $example_name $executable $options
-    
-    $LIBMESH_RUN ./$executable -n_timesteps $n_timesteps -n_refinements $n_refinements \
-        -output_freq $output_freq -init_timestep 0 \
-        -exact_solution '10*exp(-(pow(x-0.8*t-0.2,2) + pow(y-0.8*t-0.2,2))/(0.01*(4*t+1)))/(4*t+1)' \
-        $LIBMESH_OPTIONS || exit $?
-    
-    message_done_running $example_name $executable $options
-done
-
+run_example "$example_name" $options
 
 echo " "
 echo "***** Finished first" $n_timesteps "steps, now read in" \
@@ -62,5 +32,3 @@ echo " "
 options="-read_solution -n_timesteps $n_timesteps \
     -output_freq $output_freq -init_timestep $n_timesteps"
 run_example "$example_name" "$options"
-
-options="\[-read_solution\] -n_timesteps $n_timesteps -init_timestep \[0\|$n_timesteps\]"

--- a/examples/adjoints/adjoints_ex1/run.sh
+++ b/examples/adjoints/adjoints_ex1/run.sh
@@ -19,3 +19,6 @@ run_example "$example_name" mesh_partitioner_type=Hilbert coarserefinements=2 ma
 run_example "$example_name" mesh_partitioner_type=Morton coarserefinements=2 max_adaptivesteps=4
 run_example "$example_name" mesh_partitioner_type=Linear coarserefinements=2 max_adaptivesteps=4
 run_example "$example_name" mesh_partitioner_type=Centroid coarserefinements=2 max_adaptivesteps=4
+
+# Benchmark parameters
+benchmark_example 1 "$example_name" coarserefinements=6

--- a/examples/adjoints/adjoints_ex2/adjoints_ex2.C
+++ b/examples/adjoints/adjoints_ex2/adjoints_ex2.C
@@ -292,9 +292,12 @@ int main (int argc, char ** argv)
     std::ifstream i("general.in");
     libmesh_error_msg_if(!i, '[' << init.comm().rank() << "] Can't find general.in; exiting early.");
   }
-  GetPot infile("general.in");
 
   // Read in parameters from the input file
+  GetPot infile("general.in");
+  // But allow the command line to override it.
+  infile.parse_command_line(argc, argv);
+
   FEMParameters param(init.comm());
   param.read(infile);
 

--- a/examples/adjoints/adjoints_ex2/run.sh
+++ b/examples/adjoints/adjoints_ex2/run.sh
@@ -9,3 +9,6 @@ example_name=adjoints_ex2
 example_dir=examples/adjoints/$example_name
 
 run_example "$example_name"
+
+# Benchmark parameters
+benchmark_example 1 "$example_name" coarserefinements=4

--- a/examples/adjoints/adjoints_ex3/adjoints_ex3.C
+++ b/examples/adjoints/adjoints_ex3/adjoints_ex3.C
@@ -744,9 +744,12 @@ int main (int argc, char ** argv)
     libmesh_error_msg_if(!i, '[' << init.comm().rank() << "] Can't find general.in; exiting early.");
   }
 
+  // Read in parameters from the input file
   GetPot infile("general.in");
 
-  // Read in parameters from the input file
+  // But allow the command line to override it.
+  infile.parse_command_line(argc, argv);
+
   FEMParameters param(init.comm());
   param.read(infile);
 

--- a/examples/adjoints/adjoints_ex3/run.sh
+++ b/examples/adjoints/adjoints_ex3/run.sh
@@ -8,9 +8,7 @@ example_name=adjoints_ex3
 
 example_dir=examples/adjoints/$example_name
 
-options="-pc_type jacobi"
-
 run_example "$example_name" $options
 
-# Benchmark parameters
-benchmark_example 1 "$example_name" max_adaptivesteps=18
+# This example needs better solvers on larger meshes + processor counts
+benchmark_example 1 "$example_name" "max_adaptivesteps=18 -pc_type bjacobi -sub_pc_factor_levels 4"

--- a/examples/adjoints/adjoints_ex3/run.sh
+++ b/examples/adjoints/adjoints_ex3/run.sh
@@ -11,4 +11,18 @@ example_dir=examples/adjoints/$example_name
 run_example "$example_name" $options
 
 # This example needs better solvers on larger meshes + processor counts
-benchmark_example 1 "$example_name" "max_adaptivesteps=18 -pc_type bjacobi -sub_pc_factor_levels 4"
+#benchmark_example 1 "$example_name" "max_adaptivesteps=18 -pc_type bjacobi -sub_pc_factor_levels 4"
+
+# This example needs even better solvers on larger meshes + much larger processor counts
+
+# This is the best I can do that works on any processor count, but on
+# one core it takes 6 minutes...
+#benchmark_example 1 "$example_name" "max_adaptivesteps=15 --solver_variable_names --solver_group_u=0 --solver_group_v=0 --solver_group_C=0 --solver_group_p=1 -pc_type fieldsplit -pc_fieldsplit_type schur -fieldsplit_0_pc_type lu -fieldsplit_1_pc_type jacobi -fieldsplit_1_ksp_type tfqmr -ksp_monitor -fieldsplit_1_ksp_converged_reason"
+
+# This only takes me 17s on one proc, 10s on two ... but 20s on three,
+# then hits 10k iterations and fails line search on four
+#benchmark_example 1 "$example_name" "max_adaptivesteps=15 --solver_variable_names --solver_group_u=0 --solver_group_v=0 --solver_group_C=0 --solver_group_p=1 -pc_type bjacobi -sub_pc_type ilu"
+
+# Even more factor levels plus a shift type and we don't fail until
+# 13 ... but this is starting to make us as slow as Schur
+#benchmark_example 1 "$example_name" "max_adaptivesteps=15 --solver_variable_names --solver_group_u=0 --solver_group_v=0 --solver_group_C=0 --solver_group_p=1 -pc_type asm -pc_asm_overlap 4 -sub_pc_type ilu -sub_pc_factor_levels 4 -sub_pc_factor_shift_type nonzero"

--- a/examples/adjoints/adjoints_ex3/run.sh
+++ b/examples/adjoints/adjoints_ex3/run.sh
@@ -11,3 +11,6 @@ example_dir=examples/adjoints/$example_name
 options="-pc_type jacobi"
 
 run_example "$example_name" $options
+
+# Benchmark parameters
+benchmark_example 1 "$example_name" max_adaptivesteps=18

--- a/examples/adjoints/adjoints_ex4/adjoints_ex4.C
+++ b/examples/adjoints/adjoints_ex4/adjoints_ex4.C
@@ -264,9 +264,13 @@ int main (int argc, char** argv)
     std::ifstream i("general.in");
     libmesh_error_msg_if(!i, '[' << init.comm().rank() << "] Can't find general.in; exiting early.");
   }
-  GetPot infile("general.in");
 
   // Read in parameters from the input file
+  GetPot infile("general.in");
+
+  // But allow the command line to override it.
+  infile.parse_command_line(argc, argv);
+
   FEMParameters param(init.comm());
   param.read(infile);
 

--- a/examples/adjoints/adjoints_ex4/run.sh
+++ b/examples/adjoints/adjoints_ex4/run.sh
@@ -9,3 +9,5 @@ example_name=adjoints_ex4
 example_dir=examples/adjoints/$example_name
 
 run_example "$example_name"
+
+benchmark_example 1 "$example_name" max_adaptivesteps=4

--- a/examples/adjoints/adjoints_ex5/run.sh
+++ b/examples/adjoints/adjoints_ex5/run.sh
@@ -19,3 +19,7 @@ run_example "$example_name" n_timesteps=10 timesolver_tolerance=0.0 timesolver_u
 run_example "$example_name" n_timesteps=7 timesolver_tolerance=1.0 timesolver_upper_tolerance=1.2 solution_history_type=memory
 # Save previous timestep solution on disk
 run_example "$example_name" n_timesteps=7 timesolver_tolerance=1.0 timesolver_upper_tolerance=1.2 solution_history_type=file
+
+# Benchmark examples - just using adaptivity here
+benchmark_example 1 "$example_name" extrarefinements=6 n_timesteps=7 timesolver_tolerance=1.0 timesolver_upper_tolerance=1.2 solution_history_type=memory
+benchmark_example 1 "$example_name" extrarefinements=6 n_timesteps=7 timesolver_tolerance=1.0 timesolver_upper_tolerance=1.2 solution_history_type=file

--- a/examples/adjoints/adjoints_ex6/adjoints_ex6.C
+++ b/examples/adjoints/adjoints_ex6/adjoints_ex6.C
@@ -232,9 +232,13 @@ int main (int argc, char ** argv)
     std::ifstream i("general.in");
     libmesh_error_msg_if(!i, '[' << init.comm().rank() << "] Can't find general.in; exiting early.");
   }
-  GetPot infile("general.in");
 
   // Read in parameters from the input file
+  GetPot infile("general.in");
+
+  // But allow the command line to override it.
+  infile.parse_command_line(argc, argv);
+
   FEMParameters param(init.comm());
   param.read(infile);
 

--- a/examples/adjoints/adjoints_ex6/run.sh
+++ b/examples/adjoints/adjoints_ex6/run.sh
@@ -9,3 +9,5 @@ example_name=adjoints_ex6
 example_dir=examples/adjoints/$example_name
 
 run_example "$example_name"
+
+benchmark_example 1 "$example_name" max_adaptivesteps=5

--- a/examples/eigenproblems/eigenproblems_ex1/eigenproblems_ex1.C
+++ b/examples/eigenproblems/eigenproblems_ex1/eigenproblems_ex1.C
@@ -47,6 +47,7 @@
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/dof_map.h"
+#include "libmesh/getpot.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;
@@ -80,8 +81,22 @@ int main (int argc, char ** argv)
 
   libMesh::out << std::endl << std::endl;
 
-  // Get the number of eigen values to be computed from argv[2]
-  const unsigned int nev = std::atoi(argv[2]);
+  // Get the number of eigen values to be computed from "-n", and
+  // possibly the mesh size from -nx and -ny
+
+  GetPot command_line (argc, argv);
+
+  int nev = 5;
+  if (command_line.search(1, "-n"))
+    nev = command_line.next(nev);
+
+  int nx = 20;
+  if (command_line.search(1, "-nx"))
+    nx = command_line.next(nx);
+
+  int ny = 20;
+  if (command_line.search(1, "-ny"))
+    ny = command_line.next(ny);
 
   // Skip this 2D example if libMesh was compiled as 1D-only.
   libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");
@@ -93,7 +108,7 @@ int main (int argc, char ** argv)
   // Use the internal mesh generator to create a uniform
   // 2D grid on a square.
   MeshTools::Generation::build_square (mesh,
-                                       20, 20,
+                                       nx, ny,
                                        -1., 1.,
                                        -1., 1.,
                                        QUAD4);

--- a/examples/eigenproblems/eigenproblems_ex1/run.sh
+++ b/examples/eigenproblems/eigenproblems_ex1/run.sh
@@ -8,3 +8,6 @@ example_name=eigenproblems_ex1
 
 options="-n 5"
 run_example "$example_name" "$options"
+
+# No benchmark_example here - it spends 98+% of its time in the SLEPc
+# solve at scale, no room to improve on our end.

--- a/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
+++ b/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
@@ -49,6 +49,7 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/enum_eigen_solver_type.h"
+#include "libmesh/getpot.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;
@@ -92,8 +93,23 @@ int main (int argc, char ** argv)
 
   libMesh::out << std::endl << std::endl;
 
-  // Get the number of eigen values to be computed from argv[2]
-  const unsigned int nev = std::atoi(argv[2]);
+  // Get the number of eigen values to be computed from "-n", and
+  // possibly the mesh size from -nx and -ny
+
+  GetPot command_line (argc, argv);
+
+  int nev = 5;
+  if (command_line.search(1, "-n"))
+    nev = command_line.next(nev);
+
+  int nx = 20;
+  if (command_line.search(1, "-nx"))
+    nx = command_line.next(nx);
+
+  int ny = 20;
+  if (command_line.search(1, "-ny"))
+    ny = command_line.next(ny);
+
 
   // Skip this 2D example if libMesh was compiled as 1D-only.
   libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");
@@ -105,7 +121,7 @@ int main (int argc, char ** argv)
   // Use the internal mesh generator to create a uniform
   // 2D grid on a square.
   MeshTools::Generation::build_square (mesh,
-                                       20, 20,
+                                       nx, ny,
                                        -1., 1.,
                                        -1., 1.,
                                        QUAD4);

--- a/examples/eigenproblems/eigenproblems_ex2/run.sh
+++ b/examples/eigenproblems/eigenproblems_ex2/run.sh
@@ -8,3 +8,6 @@ example_name=eigenproblems_ex2
 
 options="-n 5 -eps_type lapack"
 run_example "$example_name" "$options"
+
+# No benchmark_example here - it spends 99.8+% of its time in the
+# SLEPc solve at even small scale, with that eps_type

--- a/examples/eigenproblems/eigenproblems_ex3/run.sh
+++ b/examples/eigenproblems/eigenproblems_ex3/run.sh
@@ -14,3 +14,6 @@ run_example_no_extra_options "$example_name" "$options"
 
 options="-n_evals 5 -mesh_name drum2 -plotting_index 2 $slepc_options"
 run_example_no_extra_options "$example_name" "$options"
+
+# No benchmark problems here - these are run on mesh files without
+# scaling built into the examples.

--- a/examples/fem_system/fem_system_ex1/run.sh
+++ b/examples/fem_system/fem_system_ex1/run.sh
@@ -37,6 +37,8 @@ run_example "$example_name" "solver_type=petscdiff coarsegridsize=6 transient=fa
 # And again with some timestepping coverage
 run_example "$example_name" "solver_type=petscdiff coarsegridsize=6 coarserefinements=1 transient=true n_timesteps=3 $fs_lu_options"
 
+benchmark_example 1 "$example_name" "solver_type=petscdiff coarsegridsize=6 coarserefinements=3 transient=true n_timesteps=3 $fs_lu_options"
+
 # Rerun with options demonstrating fieldpslit+gmg on the velocity
 # block, if we have a new enough PETSc
 
@@ -67,5 +69,9 @@ fs_gmg_options="--use_petsc_dm --node-major-dofs \
 
 run_example "$example_name" "solver_type=petscdiff coarsegridsize=6 coarserefinements=2 transient=false n_timesteps=1 $fs_gmg_options"
 
+benchmark_example 1 "$example_name" "solver_type=petscdiff coarsegridsize=6 coarserefinements=3 transient=false n_timesteps=1 $fs_gmg_options"
+
 # Now rerun same thing with over a distributed mesh
 run_example "$example_name" "mesh_type=distributed solver_type=petscdiff coarsegridsize=6 coarserefinements=2 transient=false n_timesteps=1 $fs_gmg_options"
+
+benchmark_example 1 "$example_name" "mesh_type=distributed solver_type=petscdiff coarsegridsize=6 coarserefinements=3 transient=false n_timesteps=1 $fs_gmg_options"

--- a/examples/fem_system/fem_system_ex2/fem_system_ex2.C
+++ b/examples/fem_system/fem_system_ex2/fem_system_ex2.C
@@ -68,6 +68,7 @@ void setup(EquationSystems & systems,
   double sizez = args("mesh/generation/size", 2.0, 2);
   MeshTools::Generation::build_cube(mesh, nx, ny, nz,
                                     origx, origx+sizex, origy, origy+sizey, origz, origz+sizez, eltype);
+  mesh.print_info();
 
   // Creating Systems
   SolidSystem & imms = systems.add_system<SolidSystem> ("solid");

--- a/examples/fem_system/fem_system_ex2/fem_system_ex2.C
+++ b/examples/fem_system/fem_system_ex2/fem_system_ex2.C
@@ -97,7 +97,9 @@ void run_timestepping(EquationSystems & systems, GetPot & args)
 
   SolidSystem & solid_system = systems.get_system<SolidSystem>("solid");
 
+#ifdef LIBMESH_HAVE_VTK
   std::unique_ptr<VTKIO> io = libmesh_make_unique<VTKIO>(systems.get_mesh());
+#endif
 
   Real duration = args("duration", 1.0);
 
@@ -131,6 +133,7 @@ void run_timestepping(EquationSystems & systems, GetPot & args)
       out << "Doing a reinit of the equation systems" << std::endl;
       systems.reinit();
 
+#ifdef LIBMESH_HAVE_VTK
       if (t_step % args("output/frequency", 1) == 0)
         {
           std::stringstream file_name;
@@ -143,6 +146,7 @@ void run_timestepping(EquationSystems & systems, GetPot & args)
 
           io->write_equation_systems(file_name.str(), systems);
         }
+#endif
       // Advance to the next timestep in a transient problem
       out << "Advancing to next step" << std::endl;
       solid_system.time_solver->advance_timestep();
@@ -159,11 +163,6 @@ int main(int argc, char ** argv)
   // This example requires a linear solver package.
   libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
                            "--enable-petsc, --enable-trilinos, or --enable-eigen");
-
-  // Skip this example if we do not meet certain requirements
-#ifndef LIBMESH_HAVE_VTK
-  libmesh_example_requires(false, "--enable-vtk");
-#endif
 
   // Trilinos gives us an inverted element on this one...
   libmesh_example_requires(libMesh::default_solver_package() != TRILINOS_SOLVERS, "--enable-petsc");

--- a/examples/fem_system/fem_system_ex2/fem_system_ex2.C
+++ b/examples/fem_system/fem_system_ex2/fem_system_ex2.C
@@ -180,6 +180,9 @@ int main(int argc, char ** argv)
   // read simulation parameters from file
   GetPot args = GetPot("solid.in");
 
+  // But allow the command line to override
+  args.parse_command_line(argc, argv);
+
   // Create System and Mesh
   int dim = args("mesh/generation/dimension", 3);
   libmesh_example_requires(dim <= LIBMESH_DIM, "3D support");

--- a/examples/fem_system/fem_system_ex2/run.sh
+++ b/examples/fem_system/fem_system_ex2/run.sh
@@ -9,3 +9,7 @@ example_name=fem_system_ex2
 example_dir=examples/fem_system/$example_name
 
 run_example "$example_name"
+
+# Skipping benchmarking until we fix up our bash scripts and get this
+# syntax working:
+# benchmark_example 1 "$example_name" mesh/generation/num_elem='1 1 1' testvar=1

--- a/examples/fem_system/fem_system_ex3/fem_system_ex3.C
+++ b/examples/fem_system/fem_system_ex3/fem_system_ex3.C
@@ -96,12 +96,16 @@ int main (int argc, char ** argv)
   // Make sure libMesh was compiled for 3D
   libmesh_example_requires(dim == LIBMESH_DIM, "3D support");
 
+  const unsigned int nx = infile("nx", 32);
+  const unsigned int ny = infile("ny", 8);
+  const unsigned int nz = infile("nz", 4);
+
   // Create a 3D mesh distributed across the default MPI communicator.
   Mesh mesh(init.comm(), dim);
   MeshTools::Generation::build_cube (mesh,
-                                     32,
-                                     8,
-                                     4,
+                                     nx,
+                                     ny,
+                                     nz,
                                      0., 1.*x_scaling,
                                      0., 0.3,
                                      0., 0.1,

--- a/examples/fem_system/fem_system_ex3/run.sh
+++ b/examples/fem_system/fem_system_ex3/run.sh
@@ -17,15 +17,19 @@ petsc_options="-ksp_type cg -pc_type jacobi"
 # Note: Use 25 timesteps to simulate approximately three periods of oscillation.
 options="deltat=0.25 n_timesteps=5 time_solver=newmark $common_options $petsc_options"
 run_example_no_extra_options "$example_name" "$options"
+benchmark_example 1 "$example_name" "$options nx=64 ny=16 nz=8"
 
 options="time_solver=steady n_timesteps=1 $common_options $petsc_options"
 run_example_no_extra_options "$example_name" "$options"
+benchmark_example 1 "$example_name" "$options nx=48 ny=12 nz=6"
 
 # With first order solvers, the Jacobian is no longer symmetric
 petsc_options="-ksp_type gmres -pc_type bjacobi -sub_pc_type ilu"
 
 options="deltat=0.25 n_timesteps=5 time_solver=euler theta=0.5 $common_options $petsc_options"
 run_example_no_extra_options "$example_name" "$options"
+benchmark_example 1 "$example_name" "$options nx=48 ny=12 nz=6"
 
 options="deltat=0.25 n_timesteps=5 time_solver=euler2 theta=0.5 $common_options $petsc_options"
 run_example_no_extra_options "$example_name" "$options"
+benchmark_example 1 "$example_name" "$options nx=48 ny=12 nz=6"

--- a/examples/fem_system/fem_system_ex4/fem_system_ex4.C
+++ b/examples/fem_system/fem_system_ex4/fem_system_ex4.C
@@ -84,6 +84,9 @@ int main (int argc, char ** argv)
   // Parse the input file
   GetPot infile("fem_system_ex4.in");
 
+  // But allow the command line to override it.
+  infile.parse_command_line(argc, argv);
+
   // Read in parameters from the input file
   const Real global_tolerance          = infile("global_tolerance", 0.);
   const unsigned int nelem_target      = infile("n_elements", 400);

--- a/examples/fem_system/fem_system_ex4/fem_system_ex4.in
+++ b/examples/fem_system/fem_system_ex4/fem_system_ex4.in
@@ -21,6 +21,6 @@ solver_quiet = false
 dimension = 2
 
 # Nonlinear solver tolerance
-relative_step_tolerance = 1e-7
+relative_step_tolerance = 1e-6
 
-relative_residual_tolerance = 1.e-7
+relative_residual_tolerance = 1.e-6

--- a/examples/fem_system/fem_system_ex4/run.sh
+++ b/examples/fem_system/fem_system_ex4/run.sh
@@ -9,3 +9,5 @@ example_name=fem_system_ex4
 example_dir=examples/fem_system/$example_name
 
 run_example "$example_name"
+
+benchmark_example 1 "$example_name" coarserefinements=5

--- a/examples/fem_system/fem_system_ex5/run.sh
+++ b/examples/fem_system/fem_system_ex5/run.sh
@@ -29,3 +29,6 @@ run_example_no_extra_options "$example_name" "$options"
 
 options="deltat=0.25 n_timesteps=5 time_solver=euler2 theta=0.5 $common_options $petsc_options"
 run_example_no_extra_options "$example_name" "$options"
+
+# No benchmarks here - we don't do IGA refinement yet so it's hard to
+# scale this up.

--- a/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
+++ b/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
@@ -46,6 +46,7 @@
 #include "libmesh/linear_implicit_system.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/enum_xdr_mode.h"
+#include "libmesh/getpot.h"
 
 // Define the Finite and Infinite Element object.
 #include "libmesh/fe.h"
@@ -98,10 +99,17 @@ int main (int argc, char ** argv)
   // communicator.
   Mesh mesh(init.comm());
 
+  // Get command line arguments for mesh size
+  GetPot input(argc, argv);
+
+  const unsigned int nx = input("nx", 4),
+                     ny = input("ny", 4),
+                     nz = input("nz", 4);
+
   // Use the internal mesh generator to create elements
   // on the square [-1,1]^3, of type Hex8.
   MeshTools::Generation::build_cube (mesh,
-                                     4, 4, 4,
+                                     nx, ny, nz,
                                      -1., 1.,
                                      -1., 1.,
                                      -1., 1.,

--- a/examples/miscellaneous/miscellaneous_ex1/run.sh
+++ b/examples/miscellaneous/miscellaneous_ex1/run.sh
@@ -7,3 +7,5 @@ source $LIBMESH_DIR/examples/run_common.sh
 example_name=miscellaneous_ex1
 
 run_example "$example_name"
+
+benchmark_example 1 "$example_name" "nx=100 ny=100 nz=100"

--- a/examples/miscellaneous/miscellaneous_ex10/run.sh
+++ b/examples/miscellaneous/miscellaneous_ex10/run.sh
@@ -9,3 +9,5 @@ example_name=miscellaneous_ex10
 options="-n 2"
 
 run_example "$example_name" "$options"
+
+benchmark_example 1 "$example_name" "-n 7"

--- a/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
+++ b/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
@@ -59,6 +59,7 @@
 #include "libmesh/exodusII_io.h"
 #include "libmesh/enum_solver_package.h"
 #include "libmesh/parallel.h"
+#include "libmesh/getpot.h"
 
 // These are the include files typically needed for subdivision elements.
 #include "libmesh/face_tri3_subdivision.h"
@@ -114,11 +115,17 @@ int main (int argc, char ** argv)
   const Real L = 100.;
   MeshTools::Modification::scale(mesh, L, L, L);
 
+  // Get the number of mesh refinements from the command line
+  GetPot command_line (argc, argv);
+  int n_refinements = 3;
+  if (command_line.search(1, "-n_refinements"))
+    n_refinements = command_line.next(n_refinements);
+
   // Quadrisect the mesh triangles a few times to obtain a
   // finer mesh.  Subdivision surface elements require the
   // refinement data to be removed afterward.
   MeshRefinement mesh_refinement (mesh);
-  mesh_refinement.uniformly_refine (3);
+  mesh_refinement.uniformly_refine (n_refinements);
   MeshTools::Modification::flatten (mesh);
 
   // Write the mesh before the ghost elements are added.

--- a/examples/miscellaneous/miscellaneous_ex11/run.sh
+++ b/examples/miscellaneous/miscellaneous_ex11/run.sh
@@ -7,3 +7,6 @@ source $LIBMESH_DIR/examples/run_common.sh
 example_name=miscellaneous_ex11
 
 run_example "$example_name"
+
+# No benchmarks here - at larger scales this problem spends 95%+ time
+# in the linear solver

--- a/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
+++ b/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
@@ -57,6 +57,7 @@
 #include "libmesh/enum_solver_package.h"
 #include "libmesh/enum_solver_type.h"
 #include "libmesh/parallel.h"
+#include "libmesh/mesh_refinement.h"
 
 // Eigen includes
 #ifdef LIBMESH_HAVE_EIGEN
@@ -140,6 +141,15 @@ int main (int argc, char ** argv)
   }
   Mesh mesh (init.comm(), 3);
   mesh.read("cylinder.xdr");
+
+  // Get the number of mesh refinements from the command line
+  int n_refinements = 0;
+  if (command_line.search(1, "-n_refinements"))
+    n_refinements = command_line.next(n_refinements);
+
+  // Refine the mesh if requested
+  MeshRefinement mesh_refinement (mesh);
+  mesh_refinement.uniformly_refine (n_refinements);
 
   // Print information about the mesh to the screen.
   mesh.print_info();

--- a/examples/miscellaneous/miscellaneous_ex12/run.sh
+++ b/examples/miscellaneous/miscellaneous_ex12/run.sh
@@ -13,3 +13,6 @@ run_example "$example_name" "$options"
 options="-distributed_load 1 -pc_type jacobi -ksp_type cg"
 
 run_example "$example_name" "$options"
+
+# No benchmarks here - if we scale up a little we spend 90%+ of our
+# time in the solver

--- a/examples/miscellaneous/miscellaneous_ex13/run.sh
+++ b/examples/miscellaneous/miscellaneous_ex13/run.sh
@@ -13,3 +13,6 @@ run_example "$example_name" "$options"
 options="-distributed_load 1 -pc_type jacobi -ksp_type cg"
 
 run_example "$example_name" "$options"
+
+# No benchmarks here - I assume it's as efficient as its brother
+# miscellaneous_ex12

--- a/examples/miscellaneous/miscellaneous_ex3/run.sh
+++ b/examples/miscellaneous/miscellaneous_ex3/run.sh
@@ -9,3 +9,5 @@ example_name=miscellaneous_ex3
 options="-r 3 -o FIRST"
 
 run_example "$example_name" "$options"
+
+# No benchmark here - this example spends 95% of its time in the solve

--- a/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
+++ b/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
@@ -117,9 +117,15 @@ int main (int argc, char ** argv)
   // Create an equation systems object.
   EquationSystems equation_systems (mesh);
 
+  // Get command line arguments for mesh size
+  GetPot input(argc, argv);
+
+  const unsigned int nx = input("nx", 16);
+  const unsigned int ny = input("ny", 16);
+
   MeshTools::Generation::build_square (mesh,
-                                       16,
-                                       16,
+                                       nx,
+                                       ny,
                                        -1., 1.,
                                        -1., 1.,
                                        QUAD4);

--- a/examples/miscellaneous/miscellaneous_ex4/run.sh
+++ b/examples/miscellaneous/miscellaneous_ex4/run.sh
@@ -7,3 +7,5 @@ source $LIBMESH_DIR/examples/run_common.sh
 example_name=miscellaneous_ex4
 
 run_example "$example_name"
+
+benchmark_example 1 "$example_name" "nx=500 ny=500"

--- a/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
+++ b/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
@@ -508,6 +508,9 @@ int main (int argc, char** argv)
   //Parse the input file
   GetPot input_file("miscellaneous_ex5.in");
 
+  // But allow the command line to override it.
+  input_file.parse_command_line(argc, argv);
+
   //Read in parameters from the input file
   const unsigned int adaptive_refinement_steps = input_file("max_adaptive_r_steps", 3);
   const unsigned int uniform_refinement_steps  = input_file("uniform_h_r_steps", 3);

--- a/examples/miscellaneous/miscellaneous_ex5/run.sh
+++ b/examples/miscellaneous/miscellaneous_ex5/run.sh
@@ -9,3 +9,5 @@ example_name=miscellaneous_ex5
 example_dir=examples/miscellaneous/miscellaneous_ex5
 
 run_example "$example_name" 
+
+benchmark_example 1 "$example_name" "uniform_h_r_steps=5"

--- a/examples/miscellaneous/miscellaneous_ex6/run.sh
+++ b/examples/miscellaneous/miscellaneous_ex6/run.sh
@@ -7,3 +7,5 @@ source $LIBMESH_DIR/examples/run_common.sh
 example_name=miscellaneous_ex6
 
 run_example "$example_name"
+
+# No benchmarking here since the work is done upstream of libMesh

--- a/examples/miscellaneous/miscellaneous_ex7/run.sh
+++ b/examples/miscellaneous/miscellaneous_ex7/run.sh
@@ -9,3 +9,6 @@ example_name=miscellaneous_ex7
 options="--verbose dim=1 N=1024 initial_state=strip initial_center=0.5 initial_width=0.1 dt=1e-10 max_time=1e-8"
 
 run_example "$example_name" "$options"
+
+# No benchmark here - I can't seem to pick parameters that aren't
+# either way too easy or prone to solver convergence failure

--- a/examples/miscellaneous/miscellaneous_ex8/miscellaneous_ex8.C
+++ b/examples/miscellaneous/miscellaneous_ex8/miscellaneous_ex8.C
@@ -29,11 +29,13 @@
 #include "libmesh/meshfree_interpolation.h"
 #include "libmesh/radial_basis_interpolation.h"
 #include "libmesh/mesh.h"
+#include "libmesh/mesh_refinement.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/tecplot_io.h"
 #include "libmesh/threads.h"
 #include "libmesh/node.h"
+#include "libmesh/getpot.h"
 #include "meshless_interpolation_function.h"
 
 // C++ includes
@@ -134,6 +136,8 @@ int main(int argc, char ** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
   {
+    GetPot input(argc, argv);
+
     // Demonstration case 1
     {
       std::vector<Point>       tgt_pts;
@@ -152,7 +156,9 @@ int main(int argc, char ** argv)
       idi.set_field_variables (field_vars);
       rbi.set_field_variables (field_vars);
 
-      create_random_point_cloud (100,
+      const int n_source_points = input("n_source_points", 100);
+
+      create_random_point_cloud (n_source_points,
                                  idi.get_source_points());
 
 
@@ -182,7 +188,9 @@ int main(int argc, char ** argv)
 
       // Interpolate to some other random points, and evaluate the result
       {
-        create_random_point_cloud (10,
+        const int n_target_points = input("n_target_points", 100);
+
+        create_random_point_cloud (n_target_points,
                                    tgt_pts);
 
         //tgt_pts = rbi.get_source_points();
@@ -225,6 +233,13 @@ int main(int argc, char ** argv)
 
       mesh_a.read("struct.ucd.gz");
       mesh_b.read("unstruct.ucd.gz");
+
+      // Refine the meshes if requested
+      const int n_refinements = input("n_refinements", 0);
+      MeshRefinement mesh_refinement_a(mesh_a);
+      mesh_refinement_a.uniformly_refine(n_refinements);
+      MeshRefinement mesh_refinement_b(mesh_b);
+      mesh_refinement_b.uniformly_refine(n_refinements);
 
       // Create equation systems objects.
       EquationSystems

--- a/examples/miscellaneous/miscellaneous_ex8/miscellaneous_ex8.C
+++ b/examples/miscellaneous/miscellaneous_ex8/miscellaneous_ex8.C
@@ -50,7 +50,7 @@ void create_random_point_cloud (const unsigned int Npts,
                                 std::vector<Point> & pts,
                                 const Real max_range = 10)
 {
-  libMesh::out << "Generating "<< Npts << " point cloud...";
+  libMesh::out << "Generating "<< Npts << " local point cloud...";
   pts.resize(Npts);
 
   for (size_t i=0;i<Npts;i++)
@@ -158,7 +158,12 @@ int main(int argc, char ** argv)
 
       const int n_source_points = input("n_source_points", 100);
 
-      create_random_point_cloud (n_source_points,
+      // Source points are independent on each processor
+      const int my_n_source_points =
+        n_source_points / init.comm().size() +
+        (init.comm().rank() < n_source_points % init.comm().size());
+
+      create_random_point_cloud (my_n_source_points,
                                  idi.get_source_points());
 
 

--- a/examples/miscellaneous/miscellaneous_ex8/run.sh
+++ b/examples/miscellaneous/miscellaneous_ex8/run.sh
@@ -10,4 +10,7 @@ options=""
 
 run_example "$example_name" "$options"
 
-benchmark_example 1 "$example_name" "n_refinements=1 n_source_points=10000 n_target_points=100"
+# This is useless if we might want to run parallel benchmarks:
+# RadialBasisInterpolation::prepare_for_use() has a
+# very-embarrassingly-serial Eigen solve
+#benchmark_example 1 "$example_name" "n_refinements=1 n_source_points=10000 n_target_points=100"

--- a/examples/miscellaneous/miscellaneous_ex8/run.sh
+++ b/examples/miscellaneous/miscellaneous_ex8/run.sh
@@ -9,3 +9,5 @@ example_name=miscellaneous_ex8
 options=""
 
 run_example "$example_name" "$options"
+
+benchmark_example 1 "$example_name" "n_refinements=1 n_source_points=10000 n_target_points=100"

--- a/examples/miscellaneous/miscellaneous_ex9/run.sh
+++ b/examples/miscellaneous/miscellaneous_ex9/run.sh
@@ -9,3 +9,5 @@ example_name=miscellaneous_ex9
 options=""
 
 run_example "$example_name" "$options"
+
+benchmark_example 1 "$example_name" "-n_refinements 2"

--- a/examples/optimization/optimization_ex1/optimization_ex1.C
+++ b/examples/optimization/optimization_ex1/optimization_ex1.C
@@ -231,6 +231,7 @@ void AssembleOptimization::hessian (const NumericVector<Number> & /*soln*/,
                                     SparseMatrix<Number> & H_f,
                                     OptimizationSystem & /*sys*/)
 {
+  LOG_SCOPE("hessian()", "AssembleOptimization");
   H_f.zero();
   H_f.add(1., *A_matrix);
 }

--- a/examples/optimization/optimization_ex1/optimization_ex1.C
+++ b/examples/optimization/optimization_ex1/optimization_ex1.C
@@ -274,6 +274,8 @@ int main (int argc, char ** argv)
     }
 
   GetPot infile("optimization_ex1.in");
+  infile.parse_command_line(argc, argv);
+
   const std::string approx_order = infile("approx_order", "FIRST");
   const std::string fe_family = infile("fe_family", "LAGRANGE");
   const unsigned int n_elem = infile("n_elem", 10);

--- a/examples/optimization/optimization_ex1/run.sh
+++ b/examples/optimization/optimization_ex1/run.sh
@@ -10,3 +10,5 @@ example_dir=examples/optimization/$example_name
 
 options="-tao_monitor -tao_view -tao_type nls"
 run_example "$example_name" "$options"
+
+benchmark_example 1 "$example_name" "$options approx_order=SECOND n_elem=1000"

--- a/examples/reduced_basis/reduced_basis_ex1/reduced_basis_ex1.C
+++ b/examples/reduced_basis/reduced_basis_ex1/reduced_basis_ex1.C
@@ -105,6 +105,9 @@ int main (int argc, char ** argv)
   std::string parameters_filename = "reduced_basis_ex1.in";
   GetPot infile(parameters_filename);
 
+  // But allow the command line to override it
+  infile.parse_command_line(argc, argv);
+
   unsigned int n_elem = infile("n_elem", 1);       // Determines the number of elements in the "truth" mesh
   const unsigned int dim = 2;                      // The number of spatial dimensions
 

--- a/examples/reduced_basis/reduced_basis_ex1/run.sh
+++ b/examples/reduced_basis/reduced_basis_ex1/run.sh
@@ -13,3 +13,5 @@ run_example "$example_name" "$options"
 
 options="-online_mode 1"
 run_example "$example_name" "$options"
+
+# Not benchmarking - 95% of our time is in the offline linear solve

--- a/examples/reduced_basis/reduced_basis_ex2/run.sh
+++ b/examples/reduced_basis/reduced_basis_ex2/run.sh
@@ -13,3 +13,5 @@ run_example "$example_name" "$options"
 
 options="-online_mode 1"
 run_example "$example_name" "$options"
+
+# Not benchmarking - 95% of our time is in the offline SLEPc solve

--- a/examples/reduced_basis/reduced_basis_ex3/reduced_basis_ex3.C
+++ b/examples/reduced_basis/reduced_basis_ex3/reduced_basis_ex3.C
@@ -82,6 +82,9 @@ int main (int argc, char** argv)
   std::string parameters_filename = "reduced_basis_ex3.in";
   GetPot infile(parameters_filename);
 
+  // But allow the command line to override it.
+  infile.parse_command_line(argc, argv);
+
   unsigned int n_elem = infile("n_elem", 1);       // Determines the number of elements in the "truth" mesh
   const unsigned int dim = 2;                      // The number of spatial dimensions
 

--- a/examples/reduced_basis/reduced_basis_ex3/run.sh
+++ b/examples/reduced_basis/reduced_basis_ex3/run.sh
@@ -10,6 +10,8 @@ example_dir=examples/reduced_basis/$example_name
 
 options="-online_mode 0"
 run_example "$example_name" "$options"
+benchmark_example 1 "$example_name" "$options n_elem=150"
 
 options="-online_mode 1"
 run_example "$example_name" "$options"
+benchmark_example 1 "$example_name" "$options n_elem=150"

--- a/examples/run_common.sh
+++ b/examples/run_common.sh
@@ -32,6 +32,10 @@ message_done_running() {
 }
 
 run_example() {
+    # when benchmarking we only run specific benchmark examples
+    if (test "x${LIBMESH_BENCHMARK}" != "x"); then
+      return
+    fi
 
     example_name=$1
     shift
@@ -90,4 +94,40 @@ run_example() {
 
 run_example_no_extra_options() {
   LIBMESH_OPTIONS='' run_example $@
+}
+
+
+benchmark_example() {
+    benchmark_level=$1
+    shift
+    example_name=$1
+    shift
+    options=$@
+
+    # when benchmarking we only run specific benchmark examples
+    if (test "x${LIBMESH_BENCHMARK}" = "x"); then
+      return
+    fi
+
+    if (test ${LIBMESH_BENCHMARK} -lt ${benchmark_level}); then
+      return
+    fi
+
+    executable=example-opt
+
+    if (test ! -x ${executable}); then
+        echo "ERROR: cannot find ${executable}!"
+        exit 1
+    fi
+
+    message_running $example_name $executable $options
+
+    $LIBMESH_RUN ./$executable $options $LIBMESH_OPTIONS
+    RETVAL=$?
+    # If we don't return 'success' or 'skip', quit
+    if [ $RETVAL -ne 0 -a $RETVAL -ne 77 ]; then
+      exit $RETVAL
+    fi
+
+    message_done_running $example_name $executable $options
 }

--- a/examples/run_common.sh
+++ b/examples/run_common.sh
@@ -113,7 +113,11 @@ benchmark_example() {
       return
     fi
 
-    executable=example-opt
+    if (test "x${METHOD}" = "x"); then
+        METHOD=opt
+    fi
+
+    executable=example-${METHOD}
 
     if (test ! -x ${executable}); then
         echo "ERROR: cannot find ${executable}!"

--- a/examples/subdomains/subdomains_ex1/run.sh
+++ b/examples/subdomains/subdomains_ex1/run.sh
@@ -14,3 +14,7 @@ run_example "$example_name" "$options"
 
 options="-d 3 -n 15"
 run_example "$example_name" "$options"
+
+benchmark_example 1 "$example_name" "-d 1 -n 1000000"
+benchmark_example 1 "$example_name" "-d 2 -n 1000"
+benchmark_example 1 "$example_name" "-d 3 -n 120"

--- a/examples/subdomains/subdomains_ex2/run.sh
+++ b/examples/subdomains/subdomains_ex2/run.sh
@@ -14,3 +14,7 @@ run_example "$example_name" "$options"
 
 options="-d 3 -n 6"
 run_example "$example_name" "$options"
+
+# Only benchmarking 3D because 1-D and 2-D spend 95% of their time in
+# the linear solver
+benchmark_example 1 "$example_name" "-d 3 -n 50"

--- a/examples/subdomains/subdomains_ex3/run.sh
+++ b/examples/subdomains/subdomains_ex3/run.sh
@@ -11,3 +11,8 @@ run_example "$example_name" "$options"
 
 options="-d 3"
 run_example "$example_name" "$options"
+
+# No benchmarks here - if I bump n_refinements above 4 I get "must
+# have 3 input vertices" errors
+# benchmark_example 1 "$example_name" "-d 2 -n_refinements 6"
+# benchmark_example 1 "$example_name" "-d 3 -n_refinements 6"

--- a/examples/subdomains/subdomains_ex3/subdomains_ex3.C
+++ b/examples/subdomains/subdomains_ex3/subdomains_ex3.C
@@ -37,6 +37,7 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 #include "libmesh/parallel.h"
+#include "libmesh/getpot.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;
@@ -100,10 +101,14 @@ int main (int argc, char ** argv)
   // This class handles all the details of mesh refinement and coarsening.
   MeshRefinement mesh_refinement (mesh);
 
-  // Uniformly refine the mesh 4 times.  This is the
-  // first time we use the mesh refinement capabilities
-  // of the library.
-  mesh_refinement.uniformly_refine (4);
+  GetPot command_line (argc, argv);
+
+  // Uniformly refine the mesh, by default 4 times.
+  int n_refinements = 4;
+  if (command_line.search(1, "-n_refinements"))
+    n_refinements = command_line.next(n_refinements);
+
+  mesh_refinement.uniformly_refine (n_refinements);
 
   // Print information about the mesh to the screen.
   mesh.print_info();

--- a/examples/systems_of_equations/systems_of_equations_ex1/run.sh
+++ b/examples/systems_of_equations/systems_of_equations_ex1/run.sh
@@ -7,3 +7,6 @@ source $LIBMESH_DIR/examples/run_common.sh
 example_name=systems_of_equations_ex1
 
 run_example "$example_name" 
+
+# This is borderline, already ~85% in the linear solve.
+benchmark_example 1 "$example_name" "-n_elem 300"

--- a/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
+++ b/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
@@ -45,6 +45,7 @@
 #include "libmesh/dense_vector.h"
 #include "libmesh/linear_implicit_system.h"
 #include "libmesh/enum_solver_package.h"
+#include "libmesh/getpot.h"
 
 // For systems of equations the DenseSubMatrix
 // and DenseSubVector provide convenient ways for
@@ -87,13 +88,20 @@ int main (int argc, char ** argv)
   // across the default MPI communicator.
   Mesh mesh(init.comm());
 
+  // Get the mesh size from the command line.
+  GetPot command_line (argc, argv);
+
+  int n_elem = 15;
+  if (command_line.search(1, "-n_elem"))
+    n_elem = command_line.next(n_elem);
+
   // Use the MeshTools::Generation mesh generator to create a uniform
   // 2D grid on the square [-1,1]^2.  We instruct the mesh generator
   // to build a mesh of 8x8 Quad9 elements.  Building these
   // higher-order elements allows us to use higher-order
   // approximation, as in example 3.
   MeshTools::Generation::build_square (mesh,
-                                       15, 15,
+                                       n_elem, n_elem,
                                        0., 1.,
                                        0., 1.,
                                        QUAD9);

--- a/examples/systems_of_equations/systems_of_equations_ex2/run.sh
+++ b/examples/systems_of_equations/systems_of_equations_ex2/run.sh
@@ -8,5 +8,6 @@ example_name=systems_of_equations_ex2
 
 run_example "$example_name" 
 
-# This is borderline, already ~85% in the linear solve.
-benchmark_example 1 "$example_name" "-n_elem 40"
+# When we allow more complete linear solves, we finish faster ... but
+# we also end up with 93% of our time in the linear solver.
+#benchmark_example 1 "$example_name" "-n_elem 40 -max_iter 2500"

--- a/examples/systems_of_equations/systems_of_equations_ex2/run.sh
+++ b/examples/systems_of_equations/systems_of_equations_ex2/run.sh
@@ -7,3 +7,6 @@ source $LIBMESH_DIR/examples/run_common.sh
 example_name=systems_of_equations_ex2
 
 run_example "$example_name" 
+
+# This is borderline, already ~85% in the linear solve.
+benchmark_example 1 "$example_name" "-n_elem 40"

--- a/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
+++ b/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
@@ -58,6 +58,7 @@
 #include "libmesh/const_function.h"
 #include "libmesh/parsed_function.h"
 #include "libmesh/enum_solver_package.h"
+#include "libmesh/getpot.h"
 
 // C++ includes
 #include <iostream>
@@ -117,13 +118,20 @@ int main (int argc, char** argv)
   // across the default MPI communicator.
   Mesh mesh(init.comm());
 
+  // Get the mesh size from the command line.
+  GetPot command_line (argc, argv);
+
+  int n_elem = 20;
+  if (command_line.search(1, "-n_elem"))
+    n_elem = command_line.next(n_elem);
+
   // Use the MeshTools::Generation mesh generator to create a uniform
   // 2D grid on the square [-1,1]^2.  We instruct the mesh generator
   // to build a mesh of 8x8 Quad9 elements in 2D.  Building these
   // higher-order elements allows us to use higher-order polynomial
   // approximations for the velocity.
   MeshTools::Generation::build_square (mesh,
-                                       20, 20,
+                                       n_elem, n_elem,
                                        0., 1.,
                                        0., 1.,
                                        QUAD9);

--- a/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
+++ b/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
@@ -192,7 +192,11 @@ int main (int argc, char** argv)
 
   // We also set a standard linear solver flag in the EquationSystems object
   // which controls the maximum number of linear solver iterations allowed.
-  equation_systems.parameters.set<unsigned int>("linear solver maximum iterations") = 250;
+  int max_iter = 25;
+  if (command_line.search(1, "-max_iter"))
+    max_iter = command_line.next(max_iter);
+
+  equation_systems.parameters.set<unsigned int>("linear solver maximum iterations") = max_iter;
 
   // Tell the system of equations what the timestep is by using
   // the set_parameter function.  The matrix assembly routine can

--- a/examples/systems_of_equations/systems_of_equations_ex3/run.sh
+++ b/examples/systems_of_equations/systems_of_equations_ex3/run.sh
@@ -7,3 +7,5 @@ source $LIBMESH_DIR/examples/run_common.sh
 example_name=systems_of_equations_ex3
 
 run_example "$example_name" 
+
+benchmark_example 1 "$example_name" "-n_elem 80"

--- a/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
+++ b/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
@@ -54,6 +54,7 @@
 #include "libmesh/zero_function.h"
 #include "libmesh/const_function.h"
 #include "libmesh/enum_solver_package.h"
+#include "libmesh/getpot.h"
 
 // For systems of equations the DenseSubMatrix
 // and DenseSubVector provide convenient ways for
@@ -104,13 +105,20 @@ int main (int argc, char ** argv)
   // across the default MPI communicator.
   Mesh mesh(init.comm());
 
+  // Get the mesh size from the command line.
+  GetPot command_line (argc, argv);
+
+  int n_elem = 20;
+  if (command_line.search(1, "-n_elem"))
+    n_elem = command_line.next(n_elem);
+
   // Use the MeshTools::Generation mesh generator to create a uniform
   // 2D grid on the square [-1,1]^2.  We instruct the mesh generator
   // to build a mesh of 8x8 Quad9 elements in 2D.  Building these
   // higher-order elements allows us to use higher-order
   // approximation, as in example 3.
   MeshTools::Generation::build_square (mesh,
-                                       20, 20,
+                                       n_elem, n_elem,
                                        0., 1.,
                                        0., 1.,
                                        QUAD9);
@@ -173,7 +181,12 @@ int main (int argc, char ** argv)
 
   // We also set a standard linear solver flag in the EquationSystems object
   // which controls the maximum number of linear solver iterations allowed.
-  equation_systems.parameters.set<unsigned int>("linear solver maximum iterations") = 250;
+
+  int max_iter = 250;
+  if (command_line.search(1, "-max_iter"))
+    max_iter = command_line.next(max_iter);
+
+  equation_systems.parameters.set<unsigned int>("linear solver maximum iterations") = max_iter;
 
   // Tell the system of equations what the timestep is by using
   // the set_parameter function.  The matrix assembly routine can

--- a/examples/systems_of_equations/systems_of_equations_ex4/run.sh
+++ b/examples/systems_of_equations/systems_of_equations_ex4/run.sh
@@ -9,3 +9,6 @@ example_name=systems_of_equations_ex4
 options="-ksp_type cg"
 
 run_example "$example_name" "$options"
+
+# No benchmark here - this spends 98% of time in the linear solve
+# benchmark_example 1 "$example_name" "$options -nx 500 -ny 100"

--- a/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
+++ b/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
@@ -95,8 +95,18 @@ int main (int argc, char ** argv)
 
   // Create a 2D mesh distributed across the default MPI communicator.
   Mesh mesh(init.comm(), dim);
+
+  // Get the mesh size from the command line.
+  GetPot command_line (argc, argv);
+
+  int nx = 50, ny = 10;
+  if (command_line.search(1, "-nx"))
+    nx = command_line.next(nx);
+  if (command_line.search(1, "-ny"))
+    ny = command_line.next(ny);
+
   MeshTools::Generation::build_square (mesh,
-                                       50, 10,
+                                       nx, ny,
                                        0., 1.,
                                        0., 0.2,
                                        QUAD9);

--- a/examples/systems_of_equations/systems_of_equations_ex5/run.sh
+++ b/examples/systems_of_equations/systems_of_equations_ex5/run.sh
@@ -9,3 +9,6 @@ example_name=systems_of_equations_ex5
 options="-ksp_type cg"
 
 run_example "$example_name" "$options"
+
+# No benchmark here - this spends 97+% of time in the linear solve
+# benchmark_example 1 "$example_name" "$options -nx 500 -ny 100"

--- a/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
+++ b/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
@@ -100,10 +100,19 @@ int main (int argc, char ** argv)
   libmesh_example_requires(false, "--enable-dirichlet");
 #endif
 
+  // Get the mesh size from the command line.
+  GetPot command_line (argc, argv);
+
+  int nx = 50, ny = 10;
+  if (command_line.search(1, "-nx"))
+    nx = command_line.next(nx);
+  if (command_line.search(1, "-ny"))
+    ny = command_line.next(ny);
+
   // Create a 2D mesh distributed across the default MPI communicator.
   Mesh mesh(init.comm(), dim);
   MeshTools::Generation::build_square (mesh,
-                                       50, 10,
+                                       nx, ny,
                                        0., 1.,
                                        0., 0.2,
                                        QUAD9);

--- a/examples/systems_of_equations/systems_of_equations_ex6/run.sh
+++ b/examples/systems_of_equations/systems_of_equations_ex6/run.sh
@@ -9,3 +9,5 @@ example_name=systems_of_equations_ex6
 options=""
 
 run_example "$example_name" "$options"
+
+benchmark_example 1 "$example_name" "$options -nx 160 -ny 40 -nz 20"

--- a/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
+++ b/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
@@ -431,12 +431,24 @@ int main (int argc, char ** argv)
   libmesh_example_requires(false, "--enable-dirichlet");
 #endif
 
+  // Get the mesh size from the command line.
+  GetPot command_line (argc, argv);
+
+  int nx = 32, ny = 8, nz = 4;
+  if (command_line.search(1, "-nx"))
+    nx = command_line.next(nx);
+  if (command_line.search(1, "-ny"))
+    ny = command_line.next(ny);
+  if (command_line.search(1, "-nz"))
+    nz = command_line.next(nz);
+
+
   // Create a 3D mesh distributed across the default MPI communicator.
   Mesh mesh(init.comm(), dim);
   MeshTools::Generation::build_cube (mesh,
-                                     32,
-                                     8,
-                                     4,
+                                     nx,
+                                     ny,
+                                     nz,
                                      0., 1.*x_scaling,
                                      0., 0.3,
                                      0., 0.1,

--- a/examples/systems_of_equations/systems_of_equations_ex7/run.sh
+++ b/examples/systems_of_equations/systems_of_equations_ex7/run.sh
@@ -9,3 +9,5 @@ example_name=systems_of_equations_ex7
 options="-ksp_type cg -pc_type bjacobi -snes_linesearch_type basic"
 
 run_example "$example_name" "$options"
+
+benchmark_example 1 "$example_name" "$options n_elem_x=75 n_elem_y=15 n_elem_z=15"

--- a/examples/systems_of_equations/systems_of_equations_ex7/systems_of_equations_ex7.C
+++ b/examples/systems_of_equations/systems_of_equations_ex7/systems_of_equations_ex7.C
@@ -522,6 +522,9 @@ int main (int argc, char ** argv)
 #endif
 
   GetPot infile("systems_of_equations_ex7.in");
+
+  infile.parse_command_line(argc,argv);
+
   const Real x_length = infile("x_length", 0.);
   const Real y_length = infile("y_length", 0.);
   const Real z_length = infile("z_length", 0.);

--- a/examples/systems_of_equations/systems_of_equations_ex8/run.sh
+++ b/examples/systems_of_equations/systems_of_equations_ex8/run.sh
@@ -9,3 +9,5 @@ example_name=systems_of_equations_ex8
 options=""
 
 run_example "$example_name" "$options"
+
+benchmark_example 1 "$example_name" "n_refinements=1"

--- a/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.C
@@ -56,6 +56,7 @@
 #include "libmesh/nonlinear_implicit_system.h"
 #include "libmesh/petsc_macro.h"
 #include "libmesh/enum_solver_package.h"
+#include "libmesh/mesh_refinement.h"
 
 // Local includes
 #include "linear_elasticity_with_contact.h"
@@ -83,6 +84,8 @@ int main (int argc, char ** argv)
   libmesh_example_requires(libMesh::default_solver_package() == PETSC_SOLVERS, "--enable-petsc");
 
   GetPot infile("systems_of_equations_ex8.in");
+  infile.parse_command_line(argc,argv);
+
   const std::string approx_order = infile("approx_order", "FIRST");
   const std::string fe_family = infile("fe_family", "LAGRANGE");
 
@@ -98,6 +101,10 @@ int main (int argc, char ** argv)
   // This example code has not been written to cope with a distributed mesh
   ReplicatedMesh mesh(init.comm());
   mesh.read("systems_of_equations_ex8.exo");
+
+  const unsigned int n_refinements = infile("n_refinements", 0);
+  MeshRefinement mesh_refinement(mesh);
+  mesh_refinement.uniformly_refine(n_refinements);
 
   mesh.print_info();
 

--- a/examples/systems_of_equations/systems_of_equations_ex9/run.sh
+++ b/examples/systems_of_equations/systems_of_equations_ex9/run.sh
@@ -9,3 +9,6 @@ example_name=systems_of_equations_ex9
 options=""
 
 run_example "$example_name" "$options"
+
+# 81% in the linear solve, kind of borderline
+benchmark_example 1 "$example_name" "n_refinements=1"

--- a/examples/systems_of_equations/systems_of_equations_ex9/systems_of_equations_ex9.C
+++ b/examples/systems_of_equations/systems_of_equations_ex9/systems_of_equations_ex9.C
@@ -58,6 +58,7 @@
 #include "libmesh/dirichlet_boundaries.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/getpot.h"
+#include "libmesh/mesh_refinement.h"
 #include "libmesh/solver_configuration.h"
 #include "libmesh/petsc_linear_solver.h"
 #include "libmesh/petsc_macro.h"
@@ -406,6 +407,11 @@ int main (int argc, char ** argv)
 #endif // LIBMESH_ENABLE_PERIODIC
 
   mesh.read("systems_of_equations_ex9.exo");
+
+  GetPot input(argc, argv);
+  const unsigned int n_refinements = input("n_refinements", 0);
+  MeshRefinement mesh_refinement(mesh);
+  mesh_refinement.uniformly_refine(n_refinements);
 
   // Print information about the mesh to the screen.
   mesh.print_info();

--- a/examples/transient/transient_ex1/run.sh
+++ b/examples/transient/transient_ex1/run.sh
@@ -7,3 +7,5 @@ source $LIBMESH_DIR/examples/run_common.sh
 example_name=transient_ex1
 
 run_example "$example_name" 
+
+benchmark_example 1 "$example_name" "n_refinements=8"

--- a/examples/transient/transient_ex1/transient_ex1.C
+++ b/examples/transient/transient_ex1/transient_ex1.C
@@ -49,6 +49,7 @@
 #include "libmesh/dense_vector.h"
 #include "libmesh/exodusII_io.h"
 #include "libmesh/enum_solver_package.h"
+#include "libmesh/getpot.h"
 
 // This example will solve a linear transient system,
 // so we need to include the TransientLinearImplicitSystem definition.
@@ -122,8 +123,8 @@ int main (int argc, char ** argv)
 
   // Read the mesh from file.  This is the coarse mesh that will be used
   // in example 10 to demonstrate adaptive mesh refinement.  Here we will
-  // simply read it in and uniformly refine it 5 times before we compute
-  // with it.
+  // simply read it in and uniformly refine it before we compute with
+  // it.
   //
   // Create a mesh object, with dimension to be overridden later,
   // distributed across the default MPI communicator.
@@ -131,14 +132,16 @@ int main (int argc, char ** argv)
 
   mesh.read ("mesh.xda");
 
+  // Query the command line for the number of mesh refinements to use
+  GetPot input(argc, argv);
+  const unsigned int n_refinements = input("n_refinements", 5);
+
   // Create a MeshRefinement object to handle refinement of our mesh.
   // This class handles all the details of mesh refinement and coarsening.
   MeshRefinement mesh_refinement (mesh);
 
-  // Uniformly refine the mesh 5 times.  This is the
-  // first time we use the mesh refinement capabilities
-  // of the library.
-  mesh_refinement.uniformly_refine (5);
+  // Uniformly refine the mesh as requested.
+  mesh_refinement.uniformly_refine (n_refinements);
 
   // Print information about the mesh to the screen.
   mesh.print_info();

--- a/examples/transient/transient_ex2/run.sh
+++ b/examples/transient/transient_ex2/run.sh
@@ -9,3 +9,5 @@ example_dir=examples/transient/$example_name
 
 options="pipe-mesh.unv"
 run_example "$example_name" "$options"
+
+# No benchmark here; "result_node = 274" makes mesh modification iffy

--- a/examples/vector_fe/vector_fe_ex1/run.sh
+++ b/examples/vector_fe/vector_fe_ex1/run.sh
@@ -7,3 +7,6 @@ source $LIBMESH_DIR/examples/run_common.sh
 example_name=vector_fe_ex1
 
 run_example "$example_name" 
+
+# No benchmark here - this spends 95+% of time in the linear solve
+# benchmark_example 1 "$example_name" "-nx 200 -ny 200"

--- a/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
+++ b/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
@@ -39,6 +39,7 @@
 #include "libmesh/exodusII_io.h"
 #include "libmesh/gmv_io.h"
 #include "libmesh/enum_solver_package.h"
+#include "libmesh/getpot.h"
 
 // Define the Finite Element object.
 #include "libmesh/fe.h"
@@ -97,6 +98,15 @@ int main (int argc, char ** argv)
   // Skip this 2D example if libMesh was compiled as 1D-only.
   libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");
 
+  // Get the mesh size from the command line.
+  GetPot command_line (argc, argv);
+
+  int nx = 15, ny = 15;
+  if (command_line.search(1, "-nx"))
+    nx = command_line.next(nx);
+  if (command_line.search(1, "-ny"))
+    ny = command_line.next(ny);
+
   // Create a mesh, with dimension to be overridden later, on the
   // default MPI communicator.
   Mesh mesh(init.comm());
@@ -105,7 +115,7 @@ int main (int argc, char ** argv)
   // 2D grid on the square [-1,1]^2.  We instruct the mesh generator
   // to build a mesh of 15x15 QUAD9 elements.
   MeshTools::Generation::build_square (mesh,
-                                       15, 15,
+                                       nx, ny,
                                        -1., 1.,
                                        -1., 1.,
                                        QUAD9);

--- a/examples/vector_fe/vector_fe_ex2/run.sh
+++ b/examples/vector_fe/vector_fe_ex2/run.sh
@@ -7,3 +7,6 @@ source $LIBMESH_DIR/examples/run_common.sh
 example_name=vector_fe_ex2
 
 run_example "$example_name" 
+
+# compute_shape_functions is way too expensive here?
+benchmark_example 1 "$example_name" "grid_size=40"

--- a/examples/vector_fe/vector_fe_ex2/vector_fe_ex2.C
+++ b/examples/vector_fe/vector_fe_ex2/vector_fe_ex2.C
@@ -58,6 +58,9 @@ int main (int argc, char** argv)
   // Parse the input file
   GetPot infile("vector_fe_ex2.in");
 
+  // But allow the command line to override it.
+  infile.parse_command_line(argc, argv);
+
   // Read in parameters from the input file
   const unsigned int grid_size = infile("grid_size", 2);
 

--- a/examples/vector_fe/vector_fe_ex3/run.sh
+++ b/examples/vector_fe/vector_fe_ex3/run.sh
@@ -18,3 +18,5 @@ run_example_no_extra_options "$example_name" "$options"
 
 options="element_type=QUAD9 -pc_type jacobi"
 run_example_no_extra_options "$example_name" "$options"
+
+# No benchmark until we decide what to do about no_extra_options there

--- a/examples/vector_fe/vector_fe_ex4/run.sh
+++ b/examples/vector_fe/vector_fe_ex4/run.sh
@@ -18,3 +18,5 @@ run_example_no_extra_options "$example_name" "$options"
 
 options="element_type=HEX27 -pc_type jacobi"
 run_example_no_extra_options "$example_name" "$options"
+
+# No benchmark until we decide what to do about no_extra_options there

--- a/examples/vector_fe/vector_fe_ex5/run.sh
+++ b/examples/vector_fe/vector_fe_ex5/run.sh
@@ -7,3 +7,6 @@ source $LIBMESH_DIR/examples/run_common.sh
 example_name=vector_fe_ex5
 
 run_example "$example_name"
+
+# No benchmark here - this spends 88% of time in PETSc?
+# benchmark_example 1 "$example_name" "nx=250 ny=250"

--- a/examples/vector_fe/vector_fe_ex5/vector_fe_ex5.C
+++ b/examples/vector_fe/vector_fe_ex5/vector_fe_ex5.C
@@ -72,6 +72,9 @@ main(int argc, char ** argv)
   // Parse input file
   GetPot input_file("vector_fe_ex5.in");
 
+  // But allow the command line to override it.
+  input_file.parse_command_line(argc, argv);
+
   // Read DG parameters
   const Real epsilon = input_file("epsilon", -1);
   const Real sigma = input_file("sigma", 6);

--- a/src/geom/elem_cutter.C
+++ b/src/geom/elem_cutter.C
@@ -194,8 +194,10 @@ void ElemCutter::find_intersection_points(const Elem & elem,
               const Point x_star = (edge->point(0)*(1-d_star) +
                                     edge->point(1)*d_star);
 
+              /*
               std::cout << "adding cut point (d_star, x_star) = "
                         << d_star << " , " << x_star << std::endl;
+              */
 
               _intersection_pts.push_back (x_star);
             }
@@ -227,7 +229,7 @@ void ElemCutter::cut_2D (const Elem & elem,
 
 #else // OK, LIBMESH_HAVE_TRIANGLE
 
-  std::cout << "Inside cut face element!\n";
+  // std::cout << "Inside cut face element!\n";
 
   libmesh_assert (_inside_mesh_2D.get()  != nullptr);
   libmesh_assert (_outside_mesh_2D.get() != nullptr);
@@ -307,7 +309,7 @@ void ElemCutter::cut_3D (const Elem & elem,
 
 #else // OK, LIBMESH_HAVE_TETGEN
 
-  std::cout << "Inside cut cell element!\n";
+  // std::cout << "Inside cut cell element!\n";
 
   libmesh_assert (_inside_mesh_3D.get()  != nullptr);
   libmesh_assert (_outside_mesh_3D.get() != nullptr);

--- a/src/quadrature/quadrature_composite.C
+++ b/src/quadrature/quadrature_composite.C
@@ -105,7 +105,7 @@ void QComposite<QSubCell>::init (const Elem & elem,
   // inside subelem
   {
     const std::vector<Elem const *> & inside_elem (_elem_cutter.inside_elements());
-    std::cout << inside_elem.size() << " elements inside\n";
+    // std::cout << inside_elem.size() << " elements inside\n";
 
     this->add_subelem_values(inside_elem);
   }
@@ -113,12 +113,12 @@ void QComposite<QSubCell>::init (const Elem & elem,
   // outside subelem
   {
     const std::vector<Elem const *> & outside_elem (_elem_cutter.outside_elements());
-    std::cout << outside_elem.size() << " elements outside\n";
+    // std::cout << outside_elem.size() << " elements outside\n";
 
     this->add_subelem_values(outside_elem);
   }
 
-  this->print_info();
+  // this->print_info();
 }
 
 

--- a/src/solution_transfer/radial_basis_interpolation.C
+++ b/src/solution_transfer/radial_basis_interpolation.C
@@ -69,6 +69,8 @@ void RadialBasisInterpolation<KDDim,RBF>::prepare_for_use()
   libmesh_assert_equal_to (this->_src_vals.size(), n_src_pts*this->n_field_variables());
 
   {
+    LOG_SCOPE ("prepare_for_use():bbox", "RadialBasisInterpolation<>");
+
     Point
       &p_min(_src_bbox.min()),
       &p_max(_src_bbox.max());
@@ -112,6 +114,9 @@ void RadialBasisInterpolation<KDDim,RBF>::prepare_for_use()
 
   DynamicMatrix A(n_src_pts, n_src_pts), x(n_src_pts,n_vars), b(n_src_pts,n_vars);
 
+  {
+  LOG_SCOPE ("prepare_for_use():mat", "RadialBasisInterpolation<>");
+
   for (std::size_t i=0; i<n_src_pts; i++)
     {
       const Point & x_i (_src_pts[i]);
@@ -132,11 +137,16 @@ void RadialBasisInterpolation<KDDim,RBF>::prepare_for_use()
       for (unsigned int var=0; var<n_vars; var++)
         b(i,var) = _src_vals[i*n_vars + var];
     }
+  }
 
 
-  // Solve the linear system
-  x = A.ldlt().solve(b);
-  //x = A.fullPivLu().solve(b);
+  {
+    LOG_SCOPE ("prepare_for_use():solve", "RadialBasisInterpolation<>");
+
+    // Solve the linear system
+    x = A.ldlt().solve(b);
+    //x = A.fullPivLu().solve(b);
+  }
 
   // save  the weights for each variable
   _weights.resize (this->_src_vals.size());


### PR DESCRIPTION
Putting this up for discussion and further editing for a while before we consider merging.

With this PR, whenever an environment variable `$LIBMESH_BENCHMARK` is defined, running `make check` in the examples directory will skip ordinary `run_example` lines and will instead only run `benchmark_example` lines based on the version (currently a number, but we could make this a string or pattern later) in the environment variable.

The chosen examples are scaled up to take in the neighborhood of a minute each to execute (which I'm hoping is enough to let actual code speed not be overwhelmed by startup time but not so much that iterating over the whole set of dozens of examples takes prohibitively long) on one core for me, but also not to spend too much time in the linear solver (so we're actually benchmarking libMesh execution) and also not to be inflexible in the linear solver (so we can run on multiple cores without worrying about something failing to converge).

I haven't actually limited the set to examples that are *scalable* in the linear solver, though - we can run the whole suite in parallel (at least up to 64 cores) to make sure we aren't missing any parallel-only hotspots, but in the future we'll want other benchmark sets that let us properly look at weak scaling too.

I'm tempted to see how far I can backport this, and even to move some tests from Version 1 to Version 2 if they can't be backported very far, so we can check for possible historical performance regressions.