### PR TITLE
RB EIM update

### DIFF
--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -326,6 +326,11 @@ private:
   Real _max_abs_value_in_training_set;
 
   /**
+   * The training sample index at which we found _max_abs_value_in_training_set.
+   */
+  unsigned int _max_abs_value_in_training_set_index;
+
+  /**
    * The quadrature point locations, quadrature point weights (JxW), and subdomain IDs
    * on every element local to this processor.
    *


### PR DESCRIPTION
Set the initial sample to avoid a zero initial basis function, since that can lead to NaNs.