### PR TITLE
interior_parent fix on distributed refined multi-elem_dim meshes

### DIFF
--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -798,6 +798,20 @@ const Elem * Elem::interior_parent () const
                   (interior_p == remote_elem) ||
                   (interior_p->dim() > this->dim()));
 
+  // If an element in a multi-dimensional mesh has an interior_parent
+  // link, it should be at our level or coarser, just like a neighbor
+  // link.  Our collect_families() code relies on this, but it might
+  // be tempting for users to manually assign something that breaks
+  // it.
+  //
+  // However, we *also* create temporary side elements, and we don't
+  // bother with creating ancestors for those, so they can be at level
+  // 0 even when they're sides of non-level-0 elements.
+  libmesh_assert (!interior_p ||
+                  (interior_p->level() <= this->level()) ||
+                  (this->level() == 0 &&
+                   this->id() == DofObject::invalid_id));
+
   return interior_p;
 }
 

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -2089,10 +2089,11 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
                    mesh.pid_elements_end(DofObject::invalid_processor_id),
                    elements_to_keep);
 
-  // The elements we need should have their ancestors and their
-  // subactive children present too.  If the mesh has any
-  // constraint rows, then elements with constrained nodes need
-  // elements with constraining nodes to remain present.
+  // The elements we need should have their ancestors, their
+  // interior_parent links, and their subactive children present too.
+  // If the mesh has any constraint rows, then elements with
+  // constrained nodes need elements with constraining nodes to remain
+  // present.
   connect_families(elements_to_keep, &mesh);
 
   // Don't delete nodes that our semilocal elements need


### PR DESCRIPTION
The fem_system_ex4 example (the one with the multiple manifold dimensions in the mesh) took 17 processors to trigger a failure from this, which I guess is why it never showed up on one of our 1-16 processor Civet sweeps?  Or possibly the failure only showed up for me because of some quirk of my compiler; this was a dangling-pointer bug and those are incredibly good at hiding.