### PR TITLE
chunked_mapvector storage option

### DIFF
--- a/configure
+++ b/configure
@@ -1196,6 +1196,8 @@ enable_periodic
 enable_dirichlet
 enable_nodeconstraint
 enable_parmesh
+enable_distmesh
+with_mapvector_chunk_size
 enable_ghosted
 enable_node_valence
 enable_1D_only
@@ -2002,7 +2004,8 @@ Optional Features:
   --disable-periodic      build without periodic boundary condition support
   --disable-dirichlet     build without Dirichlet boundary constraint support
   --enable-nodeconstraint build with node constraints support
-  --enable-parmesh        Use distributed ParallelMesh as Mesh
+  --enable-parmesh        Deprecated alias of --enable-distmesh
+  --enable-distmesh       Use DistributedMesh as Mesh
   --disable-ghosted       Use dense instead of sparse/ghosted local vectors
   --disable-node-valence  Do not compute and store node valence values
   --enable-1D-only        build with support for 1D meshes only
@@ -2122,6 +2125,8 @@ Optional Packages:
                           subdomain_id [2]
   --with-unique-id-bytes=<1|2|4|8>
                           bytes used per unique id [8]
+  --with-mapvector-chunk-size=<uint, e.g. 64>
+                          objects per DistributedMesh mapvector chunk [1]
   --with-boost[=ARG]      use Boost library from a standard location
                           (ARG=yes), from the specified location (ARG=<path>),
                           or disable it (ARG=no) [ARG=yes]
@@ -46808,6 +46813,7 @@ fi
 
 # -------------------------------------------------------------
 # Mesh == ParallelMesh -- disabled by default for max compatibility
+# This flag is old/deprecated
 # -------------------------------------------------------------
 # Check whether --enable-parmesh was given.
 if test "${enable_parmesh+set}" = set; then :
@@ -46817,16 +46823,58 @@ else
 fi
 
 
-if test "$enableparmesh" != no; then :
+if test "$enabledistmesh" != no; then :
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< --enable-parmesh is deprecated; use --enable-distmesh >>>" >&5
+$as_echo "<<< --enable-parmesh is deprecated; use --enable-distmesh >>>" >&6; }
+
+fi
+# -------------------------------------------------------------
+
+# -------------------------------------------------------------
+# Mesh == DistributedMesh -- disabled by default for max
+# compatibility, so DistributedMesh must be chosen manually
+# -------------------------------------------------------------
+# Check whether --enable-distmesh was given.
+if test "${enable_distmesh+set}" = set; then :
+  enableval=$enable_distmesh; enabledistmesh=$enableval
+else
+  enabledistmesh=$enableparmesh
+fi
+
+
+if test "$enabledistmesh" != no; then :
 
 
 $as_echo "#define ENABLE_PARMESH 1" >>confdefs.h
 
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library to use ParallelMesh >>>" >&5
-$as_echo "<<< Configuring library to use ParallelMesh >>>" >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Defaulting library to DistributedMesh >>>" >&5
+$as_echo "<<< Defaulting library to DistributedMesh >>>" >&6; }
 
 fi
 # -------------------------------------------------------------
+#
+
+# -------------------------------------------------------------
+# size of mapvector/chunked_mapvector nodes -- default 1 object
+# -------------------------------------------------------------
+
+# Check whether --with-mapvector_chunk_size was given.
+if test "${with_mapvector_chunk_size+set}" = set; then :
+  withval=$with_mapvector_chunk_size; mapvector_chunk_size="$withval"
+else
+  mapvector_chunk_size=1
+fi
+
+
+
+cat >>confdefs.h <<_ACEOF
+#define MAPVECTOR_CHUNK_SIZE $mapvector_chunk_size
+_ACEOF
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: configuring size of mapvector chunks: $mapvector_chunk_size" >&5
+$as_echo "configuring size of mapvector chunks: $mapvector_chunk_size" >&6; }
+
 
 
 

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -1025,6 +1025,7 @@ include_HEADERS = \
         timpi_shims/request.h \
         timpi_shims/standard_type.h \
         timpi_shims/status.h \
+        utils/chunked_mapvector.h \
         utils/compare_types.h \
         utils/enum_to_string.h \
         utils/error_vector.h \

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -437,6 +437,7 @@ include_HEADERS =  \
         timpi_shims/request.h \
         timpi_shims/standard_type.h \
         timpi_shims/status.h \
+        utils/chunked_mapvector.h \
         utils/compare_types.h \
         utils/enum_to_string.h \
         utils/error_vector.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -433,6 +433,7 @@ BUILT_SOURCES = \
         request.h \
         standard_type.h \
         status.h \
+        chunked_mapvector.h \
         compare_types.h \
         enum_to_string.h \
         error_vector.h \
@@ -1833,6 +1834,9 @@ standard_type.h: $(top_srcdir)/include/timpi_shims/standard_type.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 status.h: $(top_srcdir)/include/timpi_shims/status.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+chunked_mapvector.h: $(top_srcdir)/include/utils/chunked_mapvector.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 compare_types.h: $(top_srcdir)/include/utils/compare_types.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -647,19 +647,20 @@ BUILT_SOURCES = auto_ptr.h default_coupling.h dirichlet_boundaries.h \
 	post_wait_dereference_shared_ptr.h post_wait_dereference_tag.h \
 	post_wait_free_buffer.h post_wait_unpack_buffer.h \
 	post_wait_work.h request.h standard_type.h status.h \
-	compare_types.h enum_to_string.h error_vector.h hashing.h \
-	hashword.h ignore_warnings.h int_range.h jacobi_polynomials.h \
-	libmesh_nullptr.h location_maps.h mapvector.h \
-	null_output_iterator.h number_lookups.h ostream_proxy.h \
-	parameters.h perf_log.h perfmon.h plt_loader.h \
-	point_locator_base.h point_locator_nanoflann.h \
-	point_locator_tree.h pointer_to_pointer_iter.h \
-	pool_allocator.h restore_warnings.h simple_range.h \
-	statistics.h string_to_enum.h timestamp.h topology_map.h \
-	tree.h tree_base.h tree_node.h utility.h vectormap.h xdr_cxx.h \
-	parallel_communicator_specializations $(am__append_1) \
-	$(am__append_3) $(am__append_5) $(am__append_7) \
-	$(am__append_9) $(am__append_11) libmesh_config.h
+	chunked_mapvector.h compare_types.h enum_to_string.h \
+	error_vector.h hashing.h hashword.h ignore_warnings.h \
+	int_range.h jacobi_polynomials.h libmesh_nullptr.h \
+	location_maps.h mapvector.h null_output_iterator.h \
+	number_lookups.h ostream_proxy.h parameters.h perf_log.h \
+	perfmon.h plt_loader.h point_locator_base.h \
+	point_locator_nanoflann.h point_locator_tree.h \
+	pointer_to_pointer_iter.h pool_allocator.h restore_warnings.h \
+	simple_range.h statistics.h string_to_enum.h timestamp.h \
+	topology_map.h tree.h tree_base.h tree_node.h utility.h \
+	vectormap.h xdr_cxx.h parallel_communicator_specializations \
+	$(am__append_1) $(am__append_3) $(am__append_5) \
+	$(am__append_7) $(am__append_9) $(am__append_11) \
+	libmesh_config.h
 DISTCLEANFILES = $(BUILT_SOURCES) $(am__append_2) $(am__append_4) \
 	$(am__append_6) $(am__append_8) $(am__append_10) \
 	$(am__append_12) libmesh_config.h
@@ -2177,6 +2178,9 @@ standard_type.h: $(top_srcdir)/include/timpi_shims/standard_type.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 status.h: $(top_srcdir)/include/timpi_shims/status.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+chunked_mapvector.h: $(top_srcdir)/include/utils/chunked_mapvector.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 compare_types.h: $(top_srcdir)/include/utils/compare_types.h

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -623,6 +623,9 @@
 /* libMesh major version number */
 #undef MAJOR_VERSION
 
+/* size of mapvector chunks */
+#undef MAPVECTOR_CHUNK_SIZE
+
 /* libMesh micro version number */
 #undef MICRO_VERSION
 

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -21,8 +21,14 @@
 #define LIBMESH_DISTRIBUTED_MESH_H
 
 // Local Includes
-// #include "libmesh/chunked_mapvector.h"
-#include "libmesh/mapvector.h"
+#include "libmesh_config.h"
+
+#if LIBMESH_MAPVECTOR_CHUNK_SIZE == 1
+#  include "libmesh/mapvector.h"
+#else
+#  include "libmesh/chunked_mapvector.h"
+#endif
+
 #include "libmesh/unstructured_mesh.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
 
@@ -53,8 +59,11 @@ class DistributedMesh : public UnstructuredMesh
 public:
 
   template <typename Obj>
+#if LIBMESH_MAPVECTOR_CHUNK_SIZE == 1
   using dofobject_container = mapvector<Obj *, dof_id_type>;
-//  using dofobject_container = chunked_mapvector<Obj *, dof_id_type, 64>;
+#else
+  using dofobject_container = chunked_mapvector<Obj *, dof_id_type, LIBMESH_MAPVECTOR_CHUNK_SIZE>;
+#endif
 
   /**
    * Constructor.  Takes \p dim, the dimension of the mesh.

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -21,6 +21,7 @@
 #define LIBMESH_DISTRIBUTED_MESH_H
 
 // Local Includes
+// #include "libmesh/chunked_mapvector.h"
 #include "libmesh/mapvector.h"
 #include "libmesh/unstructured_mesh.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
@@ -50,6 +51,10 @@ class Node;
 class DistributedMesh : public UnstructuredMesh
 {
 public:
+
+  template <typename Obj>
+  using dofobject_container = mapvector<Obj *, dof_id_type>;
+//  using dofobject_container = chunked_mapvector<Obj *, dof_id_type, 64>;
 
   /**
    * Constructor.  Takes \p dim, the dimension of the mesh.
@@ -157,7 +162,7 @@ public:
    * Calls libmesh_assert() on each possible failure in that container.
    */
   template <typename T>
-  void libmesh_assert_valid_parallel_object_ids(const mapvector<T *,dof_id_type> &) const;
+  void libmesh_assert_valid_parallel_object_ids(const dofobject_container<T> &) const;
 
   /**
    * Verify id and processor_id consistency of our elements and
@@ -185,7 +190,7 @@ public:
    * \returns The smallest globally unused id for that container.
    */
   template <typename T>
-  dof_id_type renumber_dof_objects (mapvector<T *,dof_id_type> &);
+  dof_id_type renumber_dof_objects (dofobject_container<T> &);
 
   /**
    * Remove nullptr elements from arrays.
@@ -576,12 +581,12 @@ protected:
   /**
    * The vertices (spatial coordinates) of the mesh.
    */
-  mapvector<Node *, dof_id_type> _nodes;
+  dofobject_container<Node> _nodes;
 
   /**
    * The elements in the mesh.
    */
-  mapvector<Elem *, dof_id_type> _elements;
+  dofobject_container<Elem> _elements;
 
   /**
    * A boolean remembering whether we're serialized or not
@@ -623,18 +628,16 @@ protected:
 private:
 
   /**
-   * Typedefs for the container implementation.  In this case,
-   * it's just a std::vector<Elem *>.
+   * Typedefs for the container implementation.
    */
-  typedef mapvector<Elem *, dof_id_type>::veclike_iterator             elem_iterator_imp;
-  typedef mapvector<Elem *, dof_id_type>::const_veclike_iterator const_elem_iterator_imp;
+  typedef dofobject_container<Elem>::veclike_iterator             elem_iterator_imp;
+  typedef dofobject_container<Elem>::const_veclike_iterator const_elem_iterator_imp;
 
   /**
-   * Typedefs for the container implementation.  In this case,
-   * it's just a std::vector<Node *>.
+   * Typedefs for the container implementation.
    */
-  typedef mapvector<Node *, dof_id_type>::veclike_iterator             node_iterator_imp;
-  typedef mapvector<Node *, dof_id_type>::const_veclike_iterator const_node_iterator_imp;
+  typedef dofobject_container<Node>::veclike_iterator             node_iterator_imp;
+  typedef dofobject_container<Node>::const_veclike_iterator const_node_iterator_imp;
 };
 
 

--- a/include/utils/chunked_mapvector.h
+++ b/include/utils/chunked_mapvector.h
@@ -1,0 +1,266 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2021 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#ifndef LIBMESH_CHUNKED_MAPVECTOR_H
+#define LIBMESH_CHUNKED_MAPVECTOR_H
+
+// C++ Includes   -----------------------------------
+#include <map>
+
+namespace libMesh
+{
+
+/**
+ * This \p chunked_mapvector templated class is intended to provide
+ * the asymptotic performance characteristics of a std::map with an
+ * interface more closely resembling that of a std::vector, for use
+ * with DistributedMesh.
+ *
+ * The intermediate array "chunks" give better constants on
+ * performance, for the typical sparsity structure we see on meshes in
+ * practice, where large swaths of ids are contiguous.
+ *
+ * \author  Roy H. Stogner
+ */
+
+template <typename Val, typename index_t=unsigned int, unsigned int N=16>
+class chunked_mapvector : public std::map<index_t, std::array<Val,N>>
+{
+public:
+  typedef std::map<index_t, std::array<Val,N>> maptype;
+
+  typedef unsigned int iter_t; // Only has to hold 0 through N
+
+  template <typename MapIter>
+  class veclike_iterator_base
+  {
+  public:
+    veclike_iterator_base(const MapIter & i,
+                     const iter_t idx)
+      : it(i), array_index(idx) {}
+
+    veclike_iterator_base(const veclike_iterator_base & i) = default;
+
+    template <typename T>
+    veclike_iterator_base(const veclike_iterator_base<T> & i)
+      : it(i.it), array_index(i.idx) {}
+
+    veclike_iterator_base & operator++() {
+      ++array_index;
+      if (array_index >= N)
+        {
+          array_index = 0;
+          ++it;
+        }
+      return *this;
+    }
+
+    veclike_iterator_base operator++(int) {
+      veclike_iterator i = *this;
+      ++(*this);
+      return i;
+    }
+
+    bool operator==(const veclike_iterator_base & other) const {
+      return (it == other.it && array_index == other.array_index);
+    }
+
+    bool operator!=(const veclike_iterator_base & other) const {
+      return (it != other.it || array_index != other.array_index);
+    }
+
+    index_t index() const { return this->it->first * N + this->array_index; }
+
+  private:
+    friend class chunked_mapvector;
+
+    MapIter it;
+
+    iter_t array_index;
+  };
+
+  class veclike_iterator :
+    public veclike_iterator_base<typename maptype::iterator>
+  {
+  public:
+    veclike_iterator(const typename maptype::iterator & i,
+                     const iter_t idx)
+      : veclike_iterator_base<typename maptype::iterator>(i,idx) {}
+
+    Val & operator*() const { return (this->it->second)[this->array_index]; }
+
+    Val * operator->() const { return &((this->it->second)[this->array_index]); }
+  };
+
+
+  class const_veclike_iterator :
+    public veclike_iterator_base<typename maptype::const_iterator>
+  {
+  public:
+    const_veclike_iterator(const typename maptype::const_iterator & i,
+                           const iter_t idx)
+      : veclike_iterator_base<typename maptype::const_iterator>(i,idx) {}
+
+    const Val & operator*() const { return (this->it->second)[this->array_index]; }
+
+    const Val * operator->() const { return &((this->it->second)[this->array_index]); }
+  };
+
+  class const_reverse_veclike_iterator
+  {
+  public:
+    const_reverse_veclike_iterator(const typename maptype::const_reverse_iterator & i,
+                                   const iter_t idx)
+      : it(i), array_index(idx) {}
+
+    const_reverse_veclike_iterator(const const_reverse_veclike_iterator & i) = default;
+
+    const_reverse_veclike_iterator & operator++() {
+      if (array_index == 0)
+        {
+          array_index = N-1;
+          ++it;
+        }
+      else
+        --array_index;
+      return *this;
+    }
+
+    const_reverse_veclike_iterator operator++(int) {
+      veclike_iterator i = *this;
+      ++(*this);
+      return i;
+    }
+
+    const Val & operator*() const { return (this->it->second)[this->array_index]; }
+
+    const Val * operator->() const { return &((this->it->second)[this->array_index]); }
+
+    index_t index() const { return this->it->first * N + this->array_index; }
+
+    bool operator==(const const_reverse_veclike_iterator & other) const {
+      return (it == other.it && array_index == other.array_index);
+    }
+
+    bool operator!=(const const_reverse_veclike_iterator & other) const {
+      return (it != other.it || array_index != other.array_index);
+    }
+
+  private:
+    typename maptype::const_reverse_iterator it;
+
+    iter_t array_index;
+  };
+
+  veclike_iterator find (const index_t & k)
+  {
+    auto sub_it = maptype::find(k/N);
+    if (sub_it == maptype::end())
+      return veclike_iterator(sub_it, 0);
+
+    veclike_iterator it {sub_it, iter_t(k%N)};
+    if (*it)
+      return it;
+    return this->end();
+  }
+
+  const_veclike_iterator find (const index_t & k) const
+  {
+    auto sub_it = maptype::find(k/N);
+    if (sub_it == maptype::end())
+      return const_veclike_iterator(sub_it, 0);
+
+    const_veclike_iterator it {sub_it, iter_t(k%N)};
+    if (*it)
+      return it;
+    return this->end();
+  }
+
+  Val & operator[] (const index_t & k)
+  {
+    return maptype::operator[](k/N)[k%N];
+  }
+
+  Val operator[] (const index_t & k) const
+  {
+    typename maptype::const_iterator it = maptype::find(k/N);
+    return it == this->end().it? Val() : (it->second)[k%N];
+  }
+
+  void erase(index_t i) {
+    typename maptype::iterator it = maptype::find(i/N);
+    if (it == maptype::end())
+      return;
+
+    (it->second)[i%N] = Val();
+    for (auto v : it->second)
+      if (v != Val())
+        return;
+
+    maptype::erase(it);
+  }
+
+  veclike_iterator erase(const veclike_iterator & pos) {
+    if (pos.it == maptype::end())
+      return pos;
+    *pos = Val();
+
+    veclike_iterator newpos = pos;
+    do {
+      ++newpos;
+    } while (newpos.it == pos.it &&
+             *newpos == Val());
+
+    for (auto v : pos.it->second)
+      if (v != Val())
+        return newpos;
+
+    maptype::erase(pos.it);
+
+    return newpos;
+  }
+
+  veclike_iterator begin() {
+    return veclike_iterator(maptype::begin(), 0);
+  }
+
+  const_veclike_iterator begin() const {
+    return const_veclike_iterator(maptype::begin(), 0);
+  }
+
+  veclike_iterator end() {
+    return veclike_iterator(maptype::end(), 0);
+  }
+
+  const_veclike_iterator end() const {
+    return const_veclike_iterator(maptype::end(), 0);
+  }
+
+  const_reverse_veclike_iterator rbegin() const {
+    return const_reverse_veclike_iterator(maptype::rbegin(), N-1);
+  }
+
+  const_reverse_veclike_iterator rend() const {
+    return const_reverse_veclike_iterator(maptype::rend(), N-1);
+  }
+};
+
+} // namespace libMesh
+
+#endif // LIBMESH_CHUNKED_MAPVECTOR_H

--- a/include/utils/mapvector.h
+++ b/include/utils/mapvector.h
@@ -75,6 +75,9 @@ public:
       return it != other.it;
     }
 
+  private:
+    friend class mapvector;
+
     typename maptype::iterator it;
   };
 
@@ -110,6 +113,9 @@ public:
       return it != other.it;
     }
 
+  private:
+    friend class mapvector;
+
     typename maptype::const_iterator it;
   };
 
@@ -142,6 +148,9 @@ public:
     bool operator!=(const const_reverse_veclike_iterator & other) const {
       return it != other.it;
     }
+
+  private:
+    friend class mapvector;
 
     typename maptype::const_reverse_iterator it;
   };

--- a/include/utils/mapvector.h
+++ b/include/utils/mapvector.h
@@ -47,16 +47,6 @@ public:
   typedef std::map<index_t, Val, std::less<index_t>,
                    FastPoolAllocator<std::pair<const index_t, Val>>> maptype;
 
-  Val & operator[] (const index_t & k)
-  {
-    return maptype::operator[](k);
-  }
-  Val operator[] (const index_t & k) const
-  {
-    typename maptype::const_iterator it = this->find(k);
-    return it == this->end().it? Val() : it->second;
-  }
-
   class veclike_iterator
   {
   public:
@@ -66,6 +56,8 @@ public:
     veclike_iterator(const veclike_iterator & i) = default;
 
     Val & operator*() const { return it->second; }
+
+    index_t index() const { return it->first; }
 
     veclike_iterator & operator++() { ++it; return *this; }
 
@@ -100,6 +92,8 @@ public:
 
     const Val & operator*() const { return it->second; }
 
+    index_t index() const { return it->first; }
+
     const_veclike_iterator & operator++() { ++it; return *this; }
 
     const_veclike_iterator operator++(int) {
@@ -118,6 +112,60 @@ public:
 
     typename maptype::const_iterator it;
   };
+
+  class const_reverse_veclike_iterator
+  {
+  public:
+    const_reverse_veclike_iterator(const typename maptype::const_reverse_iterator & i)
+      : it(i) {}
+
+    const_reverse_veclike_iterator(const const_veclike_iterator & i)
+      : it(i.it) {}
+
+    const_reverse_veclike_iterator(const veclike_iterator & i)
+      : it(i.it) {}
+
+    const Val & operator*() const { return it->second; }
+
+    const_reverse_veclike_iterator & operator++() { ++it; return *this; }
+
+    const_reverse_veclike_iterator operator++(int) {
+      const_reverse_veclike_iterator i = *this;
+      ++(*this);
+      return i;
+    }
+
+    bool operator==(const const_reverse_veclike_iterator & other) const {
+      return it == other.it;
+    }
+
+    bool operator!=(const const_reverse_veclike_iterator & other) const {
+      return it != other.it;
+    }
+
+    typename maptype::const_reverse_iterator it;
+  };
+
+  veclike_iterator find (const index_t & k)
+  {
+    return veclike_iterator(maptype::find(k));
+  }
+
+  const_veclike_iterator find (const index_t & k) const
+  {
+    return const_veclike_iterator(maptype::find(k));
+  }
+
+  Val & operator[] (const index_t & k)
+  {
+    return maptype::operator[](k);
+  }
+
+  Val operator[] (const index_t & k) const
+  {
+    auto it = this->maptype::find(k);
+    return it == this->end().it? Val() : it->second;
+  }
 
   void erase(index_t i) {
     maptype::erase(i);

--- a/m4/libmesh_core_features.m4
+++ b/m4/libmesh_core_features.m4
@@ -449,19 +449,50 @@ AS_IF([test "$enablenodeconstraint" != no],
 
 # -------------------------------------------------------------
 # Mesh == ParallelMesh -- disabled by default for max compatibility
+# This flag is old/deprecated
 # -------------------------------------------------------------
 AC_ARG_ENABLE(parmesh,
               AS_HELP_STRING([--enable-parmesh],
-                             [Use distributed ParallelMesh as Mesh]),
+                             [Deprecated alias of --enable-distmesh]),
               enableparmesh=$enableval,
               enableparmesh=no)
 
-AS_IF([test "$enableparmesh" != no],
+AS_IF([test "$enabledistmesh" != no],
       [
-        AC_DEFINE(ENABLE_PARMESH, 1, [Flag indicating if the library should use the experimental ParallelMesh as its default Mesh type])
-        AC_MSG_RESULT(<<< Configuring library to use ParallelMesh >>>)
+        AC_MSG_RESULT(<<< --enable-parmesh is deprecated; use --enable-distmesh >>>)
       ])
 # -------------------------------------------------------------
+
+# -------------------------------------------------------------
+# Mesh == DistributedMesh -- disabled by default for max
+# compatibility, so DistributedMesh must be chosen manually
+# -------------------------------------------------------------
+AC_ARG_ENABLE(distmesh,
+              AS_HELP_STRING([--enable-distmesh],
+                             [Use DistributedMesh as Mesh]),
+              enabledistmesh=$enableval,
+              enabledistmesh=$enableparmesh)
+
+AS_IF([test "$enabledistmesh" != no],
+      [
+        AC_DEFINE(ENABLE_PARMESH, 1, [Flag indicating if the library should use the experimental ParallelMesh as its default Mesh type])
+        AC_MSG_RESULT(<<< Defaulting library to DistributedMesh >>>)
+      ])
+# -------------------------------------------------------------
+#
+
+# -------------------------------------------------------------
+# size of mapvector/chunked_mapvector nodes -- default 1 object
+# -------------------------------------------------------------
+AC_ARG_WITH([mapvector_chunk_size],
+            AS_HELP_STRING([--with-mapvector-chunk-size=<uint, e.g. 64>],
+                           [objects per DistributedMesh mapvector chunk [1]]),
+            [mapvector_chunk_size="$withval"],
+            [mapvector_chunk_size=1])
+
+AC_DEFINE_UNQUOTED(MAPVECTOR_CHUNK_SIZE, $mapvector_chunk_size, [size of mapvector chunks])
+AC_MSG_RESULT([configuring size of mapvector chunks: $mapvector_chunk_size])
+
 
 
 

--- a/src/base/single_predicates.C
+++ b/src/base/single_predicates.C
@@ -20,7 +20,7 @@
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/boundary_info.h"
 #include "libmesh/dof_map.h"
-#include "libmesh/mapvector.h"
+#include "libmesh/distributed_mesh.h"
 
 namespace libMesh
 {
@@ -71,10 +71,10 @@ INSTANTIATE_ELEM_PREDICATES(std::vector<Elem *>::iterator);
 INSTANTIATE_ELEM_PREDICATES(std::vector<Elem *>::const_iterator);
 INSTANTIATE_NODAL_PREDICATES(std::vector<Node *>::iterator);
 INSTANTIATE_NODAL_PREDICATES(std::vector<Node *>::const_iterator);
-INSTANTIATE_ELEM_PREDICATES(mapvector<Elem * LIBMESH_COMMA dof_id_type>::veclike_iterator);
-INSTANTIATE_ELEM_PREDICATES(mapvector<Elem * LIBMESH_COMMA dof_id_type>::const_veclike_iterator);
-INSTANTIATE_NODAL_PREDICATES(mapvector<Node * LIBMESH_COMMA dof_id_type>::veclike_iterator);
-INSTANTIATE_NODAL_PREDICATES(mapvector<Node * LIBMESH_COMMA dof_id_type>::const_veclike_iterator);
+INSTANTIATE_ELEM_PREDICATES(DistributedMesh::dofobject_container<Elem>::veclike_iterator);
+INSTANTIATE_ELEM_PREDICATES(DistributedMesh::dofobject_container<Elem>::const_veclike_iterator);
+INSTANTIATE_NODAL_PREDICATES(DistributedMesh::dofobject_container<Node>::veclike_iterator);
+INSTANTIATE_NODAL_PREDICATES(DistributedMesh::dofobject_container<Node>::const_veclike_iterator);
 
 
 } // namespace Predicates

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -288,10 +288,10 @@ dof_id_type DistributedMesh::parallel_max_elem_id() const
 
   dof_id_type max_local = 0;
 
-  mapvector<Elem *,dof_id_type>::const_reverse_veclike_iterator
+  dofobject_container<Elem>::const_reverse_veclike_iterator
     rit = _elements.rbegin();
 
-  const mapvector<Elem *,dof_id_type>::const_reverse_veclike_iterator
+  const dofobject_container<Elem>::const_reverse_veclike_iterator
     rend = _elements.rend();
 
   // Look for the maximum element id.  Search backwards through
@@ -362,10 +362,10 @@ dof_id_type DistributedMesh::parallel_max_node_id() const
 
   dof_id_type max_local = 0;
 
-  mapvector<Node *,dof_id_type>::const_reverse_veclike_iterator
+  dofobject_container<Node>::const_reverse_veclike_iterator
     rit = _nodes.rbegin();
 
-  const mapvector<Node *,dof_id_type>::const_reverse_veclike_iterator
+  const dofobject_container<Node>::const_reverse_veclike_iterator
     rend = _nodes.rend();
 
   // Look for the maximum node id.  Search backwards through
@@ -547,9 +547,9 @@ Elem * DistributedMesh::add_elem (Elem * e)
         (this->n_processors() + 1) + this->processor_id();
 
 #ifndef NDEBUG
-    // We need a const mapvector so we don't inadvertently create
+    // We need a const dofobject_container so we don't inadvertently create
     // nullptr entries when testing for non-nullptr ones
-    const mapvector<Elem *, dof_id_type> & const_elements = _elements;
+    const dofobject_container<Elem> & const_elements = _elements;
 #endif
     libmesh_assert(!const_elements[_next_free_unpartitioned_elem_id]);
     libmesh_assert(!const_elements[_next_free_local_elem_id]);
@@ -807,9 +807,9 @@ Node * DistributedMesh::add_node (Node * n)
         (this->n_processors() + 1) + this->processor_id();
 
 #ifndef NDEBUG
-    // We need a const mapvector so we don't inadvertently create
+    // We need a const dofobject_container so we don't inadvertently create
     // nullptr entries when testing for non-nullptr ones
-    const mapvector<Node *,dof_id_type> & const_nodes = _nodes;
+    const dofobject_container<Node> & const_nodes = _nodes;
 #endif
     libmesh_assert(!const_nodes[_next_free_unpartitioned_node_id]);
     libmesh_assert(!const_nodes[_next_free_local_node_id]);
@@ -1033,7 +1033,7 @@ void DistributedMesh::update_post_partitioning ()
 
 
 template <typename T>
-void DistributedMesh::libmesh_assert_valid_parallel_object_ids(const mapvector<T *, dof_id_type> & objects) const
+void DistributedMesh::libmesh_assert_valid_parallel_object_ids(const dofobject_container<T> & objects) const
 {
   // This function must be run on all processors at once
   parallel_object_only();
@@ -1150,12 +1150,12 @@ void DistributedMesh::libmesh_assert_valid_parallel_flags () const
 
 template <typename T>
 dof_id_type
-DistributedMesh::renumber_dof_objects(mapvector<T *, dof_id_type> & objects)
+DistributedMesh::renumber_dof_objects(dofobject_container<T> & objects)
 {
   // This function must be run on all processors at once
   parallel_object_only();
 
-  typedef typename mapvector<T *,dof_id_type>::veclike_iterator object_iterator;
+  typedef typename dofobject_container<T>::veclike_iterator object_iterator;
 
   // In parallel we may not know what objects other processors have.
   // Start by figuring out how many
@@ -1576,16 +1576,16 @@ void DistributedMesh::delete_remote_elements()
 
   // Now make sure the containers actually shrink - strip
   // any newly-created nullptr voids out of the element array
-  mapvector<Elem *,dof_id_type>::veclike_iterator e_it        = _elements.begin();
-  const mapvector<Elem *,dof_id_type>::veclike_iterator e_end = _elements.end();
+  dofobject_container<Elem>::veclike_iterator e_it        = _elements.begin();
+  const dofobject_container<Elem>::veclike_iterator e_end = _elements.end();
   while (e_it != e_end)
     if (!*e_it)
       e_it = _elements.erase(e_it);
     else
       ++e_it;
 
-  mapvector<Node *,dof_id_type>::veclike_iterator n_it        = _nodes.begin();
-  const mapvector<Node *,dof_id_type>::veclike_iterator n_end = _nodes.end();
+  dofobject_container<Node>::veclike_iterator n_it        = _nodes.begin();
+  const dofobject_container<Node>::veclike_iterator n_end = _nodes.end();
   while (n_it != n_end)
     if (!*n_it)
       n_it = _nodes.erase(n_it);


### PR DESCRIPTION
A new chunked_mapvector container class, new abstraction to make it interchangeable with mapvector in DistributedMesh, and a configure option to choose between them as well as to tweak the new one.

I still want to benchmark the combination of this with custom allocators (though I don't expect much *combined* effect), but with around N=64 I'm seeing a few percent benchmark speedup over the mapvector-with-custom-allocator alone, which probably means much more speedup in the iterations and queries that are directly affected.