### PR TITLE
Command-line override of default Metis-vs-Parmetis

### DIFF
--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -649,6 +649,7 @@ include_HEADERS = \
         enums/enum_norm_type.h \
         enums/enum_order.h \
         enums/enum_parallel_type.h \
+        enums/enum_partitioner_type.h \
         enums/enum_point_locator_type.h \
         enums/enum_preconditioner_type.h \
         enums/enum_quadrature_type.h \

--- a/include/enums/enum_partitioner_type.h
+++ b/include/enums/enum_partitioner_type.h
@@ -1,0 +1,48 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2021 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#ifndef LIBMESH_ENUM_PARTITIONER_TYPE_H
+#define LIBMESH_ENUM_PARTITIONER_TYPE_H
+
+namespace libMesh {
+
+/**
+ * Defines an \p enum for mesh partitioner types
+ *
+ * The fixed type, i.e. ": int", enumeration syntax used here allows
+ * this enum to be forward declared as
+ * enum EigenSolverType : int;
+ * reducing header file dependencies.
+ */
+enum PartitionerType : int {
+                      CENTROID_PARTITIONER=0,
+                      LINEAR_PARTITIONER,
+                      SFC_PARTITIONER,
+                      HILBERT_SFC_PARTITIONER,
+                      MORTON_SFC_PARTITIONER,
+                      METIS_PARTITIONER,
+                      PARMETIS_PARTITIONER,
+                      SUBDOMAIN_PARTITIONER,
+                      MAPPED_SUBDOMAIN_PARTITIONER,
+                      // Invalid
+                      INVALID_PARTITIONER};
+
+} // namespace libMesh
+
+#endif

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -61,6 +61,7 @@ include_HEADERS =  \
         enums/enum_norm_type.h \
         enums/enum_order.h \
         enums/enum_parallel_type.h \
+        enums/enum_partitioner_type.h \
         enums/enum_point_locator_type.h \
         enums/enum_preconditioner_type.h \
         enums/enum_quadrature_type.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -51,6 +51,7 @@ BUILT_SOURCES = \
         enum_norm_type.h \
         enum_order.h \
         enum_parallel_type.h \
+        enum_partitioner_type.h \
         enum_point_locator_type.h \
         enum_preconditioner_type.h \
         enum_quadrature_type.h \
@@ -688,6 +689,9 @@ enum_order.h: $(top_srcdir)/include/enums/enum_order.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 enum_parallel_type.h: $(top_srcdir)/include/enums/enum_parallel_type.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+enum_partitioner_type.h: $(top_srcdir)/include/enums/enum_partitioner_type.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 enum_point_locator_type.h: $(top_srcdir)/include/enums/enum_point_locator_type.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -516,9 +516,10 @@ BUILT_SOURCES = auto_ptr.h default_coupling.h dirichlet_boundaries.h \
 	enum_error_estimator_type.h enum_fe_family.h \
 	enum_inf_map_type.h enum_io_package.h enum_matrix_build_type.h \
 	enum_norm_type.h enum_order.h enum_parallel_type.h \
-	enum_point_locator_type.h enum_preconditioner_type.h \
-	enum_quadrature_type.h enum_solver_package.h \
-	enum_solver_type.h enum_subset_solve_mode.h enum_xdr_mode.h \
+	enum_partitioner_type.h enum_point_locator_type.h \
+	enum_preconditioner_type.h enum_quadrature_type.h \
+	enum_solver_package.h enum_solver_type.h \
+	enum_subset_solve_mode.h enum_xdr_mode.h \
 	adjoint_refinement_estimator.h \
 	adjoint_residual_error_estimator.h discontinuity_measure.h \
 	error_estimator.h exact_error_estimator.h exact_solution.h \
@@ -1032,6 +1033,9 @@ enum_order.h: $(top_srcdir)/include/enums/enum_order.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 enum_parallel_type.h: $(top_srcdir)/include/enums/enum_parallel_type.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+enum_partitioner_type.h: $(top_srcdir)/include/enums/enum_partitioner_type.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 enum_point_locator_type.h: $(top_srcdir)/include/enums/enum_point_locator_type.h

--- a/include/partitioning/partitioner.h
+++ b/include/partitioning/partitioner.h
@@ -36,6 +36,7 @@ namespace libMesh
 
 // Forward Declarations
 class ErrorVector;
+enum PartitionerType : int;
 
 /**
  * The \p Partitioner class provides a uniform interface for
@@ -65,6 +66,13 @@ public:
   Partitioner & operator= (const Partitioner &) = default;
   Partitioner & operator= (Partitioner &&) = default;
   virtual ~Partitioner() = default;
+
+  /**
+   * Builds a \p Partitioner of the type specified by
+   * \p partitioner_type
+   */
+  static std::unique_ptr<Partitioner>
+  build(const PartitionerType solver_package);
 
   /**
    * \returns A copy of this partitioner wrapped in a smart pointer.

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -25,6 +25,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_communication.h"
+#include "libmesh/metis_partitioner.h"
 #include "libmesh/parmetis_partitioner.h"
 
 // TIMPI includes
@@ -54,8 +55,10 @@ DistributedMesh::DistributedMesh (const Parallel::Communicator & comm_in,
   _next_unique_id = this->processor_id();
 #endif
 
-  // FIXME: give parmetis the communicator!
-  _partitioner = libmesh_make_unique<ParmetisPartitioner>();
+  if (libMesh::on_command_line("--use-metis-partitioner"))
+    _partitioner = libmesh_make_unique<MetisPartitioner>();
+  else
+    _partitioner = libmesh_make_unique<ParmetisPartitioner>();
 }
 
 DistributedMesh & DistributedMesh::operator= (DistributedMesh && other_mesh)

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -25,8 +25,8 @@
 #include "libmesh/elem.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_communication.h"
-#include "libmesh/metis_partitioner.h"
-#include "libmesh/parmetis_partitioner.h"
+#include "libmesh/partitioner.h"
+#include "libmesh/string_to_enum.h"
 
 // TIMPI includes
 #include "timpi/parallel_implementation.h"
@@ -55,10 +55,12 @@ DistributedMesh::DistributedMesh (const Parallel::Communicator & comm_in,
   _next_unique_id = this->processor_id();
 #endif
 
-  if (libMesh::on_command_line("--use-metis-partitioner"))
-    _partitioner = libmesh_make_unique<MetisPartitioner>();
-  else
-    _partitioner = libmesh_make_unique<ParmetisPartitioner>();
+  const std::string default_partitioner = "parmetis";
+  const std::string my_partitioner =
+    libMesh::command_line_value("--default-partitioner",
+                                default_partitioner);
+  _partitioner = Partitioner::build
+    (Utility::string_to_enum<PartitionerType>(my_partitioner));
 }
 
 DistributedMesh & DistributedMesh::operator= (DistributedMesh && other_mesh)

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -22,6 +22,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/metis_partitioner.h"
+#include "libmesh/parmetis_partitioner.h"
 #include "libmesh/replicated_mesh.h"
 #include "libmesh/utility.h"
 #include "libmesh/parallel.h"
@@ -92,7 +93,10 @@ ReplicatedMesh::ReplicatedMesh (const Parallel::Communicator & comm_in,
   // here in the constructor.
   _next_unique_id = 0;
 #endif
-  _partitioner = libmesh_make_unique<MetisPartitioner>();
+  if (libMesh::on_command_line("--use-parmetis-partitioner"))
+    _partitioner = libmesh_make_unique<ParmetisPartitioner>();
+  else
+    _partitioner = libmesh_make_unique<MetisPartitioner>();
 }
 
 

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -21,12 +21,12 @@
 #include "libmesh/boundary_info.h"
 #include "libmesh/elem.h"
 #include "libmesh/libmesh_logging.h"
-#include "libmesh/metis_partitioner.h"
-#include "libmesh/parmetis_partitioner.h"
+#include "libmesh/partitioner.h"
 #include "libmesh/replicated_mesh.h"
 #include "libmesh/utility.h"
 #include "libmesh/parallel.h"
 #include "libmesh/point.h"
+#include "libmesh/string_to_enum.h"
 #ifdef LIBMESH_HAVE_NANOFLANN
 #include "libmesh/nanoflann.hpp"
 #endif
@@ -93,10 +93,13 @@ ReplicatedMesh::ReplicatedMesh (const Parallel::Communicator & comm_in,
   // here in the constructor.
   _next_unique_id = 0;
 #endif
-  if (libMesh::on_command_line("--use-parmetis-partitioner"))
-    _partitioner = libmesh_make_unique<ParmetisPartitioner>();
-  else
-    _partitioner = libmesh_make_unique<MetisPartitioner>();
+
+  const std::string default_partitioner = "metis";
+  const std::string my_partitioner =
+    libMesh::command_line_value("--default-partitioner",
+                                default_partitioner);
+  _partitioner = Partitioner::build
+    (Utility::string_to_enum<PartitionerType>(my_partitioner));
 }
 
 

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -20,6 +20,7 @@
 // libMesh includes
 #include "libmesh/partitioner.h"
 #include "libmesh/elem.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/int_range.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_base.h"
@@ -27,6 +28,18 @@
 #include "libmesh/mesh_communication.h"
 #include "libmesh/parallel_ghost_sync.h"
 #include "libmesh/wrapped_petsc.h"
+
+// Subclasses to build()
+#include "libmesh/enum_partitioner_type.h"
+#include "libmesh/centroid_partitioner.h"
+#include "libmesh/hilbert_sfc_partitioner.h"
+#include "libmesh/linear_partitioner.h"
+#include "libmesh/mapped_subdomain_partitioner.h"
+#include "libmesh/metis_partitioner.h"
+#include "libmesh/morton_sfc_partitioner.h"
+#include "libmesh/parmetis_partitioner.h"
+#include "libmesh/sfc_partitioner.h"
+#include "libmesh/subdomain_partitioner.h"
 
 // TIMPI includes
 #include "timpi/parallel_implementation.h"
@@ -132,6 +145,38 @@ const dof_id_type Partitioner::communication_blocksize =
 
 // ------------------------------------------------------------
 // Partitioner implementation
+
+std::unique_ptr<Partitioner>
+Partitioner::build (const PartitionerType partitioner_type)
+{
+  switch (partitioner_type)
+  {
+    case CENTROID_PARTITIONER:
+      return libmesh_make_unique<CentroidPartitioner>();
+    case LINEAR_PARTITIONER:
+      return libmesh_make_unique<LinearPartitioner>();
+    case MAPPED_SUBDOMAIN_PARTITIONER:
+      return libmesh_make_unique<MappedSubdomainPartitioner>();
+    case METIS_PARTITIONER:
+      return libmesh_make_unique<MetisPartitioner>();
+    case PARMETIS_PARTITIONER:
+      return libmesh_make_unique<ParmetisPartitioner>();
+    case HILBERT_SFC_PARTITIONER:
+      return libmesh_make_unique<HilbertSFCPartitioner>();
+    case MORTON_SFC_PARTITIONER:
+      return libmesh_make_unique<MortonSFCPartitioner>();
+    case SFC_PARTITIONER:
+      return libmesh_make_unique<SFCPartitioner>();
+    case SUBDOMAIN_PARTITIONER:
+      return libmesh_make_unique<SubdomainPartitioner>();
+    default:
+      libmesh_error_msg("Invalid partitioner type: " <<
+                        Utility::enum_to_string(partitioner_type));
+  }
+}
+
+
+
 void Partitioner::partition (MeshBase & mesh)
 {
   this->partition(mesh,mesh.n_processors());

--- a/src/utils/string_to_enum.C
+++ b/src/utils/string_to_enum.C
@@ -35,6 +35,7 @@
 #include "libmesh/enum_norm_type.h"
 #include "libmesh/enum_order.h"
 #include "libmesh/enum_parallel_type.h"
+#include "libmesh/enum_partitioner_type.h"
 #include "libmesh/enum_point_locator_type.h"
 #include "libmesh/enum_preconditioner_type.h"
 #include "libmesh/enum_quadrature_type.h"
@@ -290,6 +291,37 @@ void init_quadrature_type_to_enum ()
       quadrature_type_to_enum["QCLOUGH"    ]=QCLOUGH;
       quadrature_type_to_enum["QGAUSS_LOBATTO"    ]=QGAUSS_LOBATTO;
       quadrature_type_to_enum["QNODAL"]=QNODAL;
+    }
+}
+
+
+INSTANTIATE_ENUM_MAPS(PartitionerType, partitioner_type)
+
+// Initialize partitioner_type_to_enum on first call
+void init_partitioner_type_to_enum ()
+{
+  if (partitioner_type_to_enum.empty())
+    {
+      partitioner_type_to_enum["CENTROID_PARTITIONER"        ]=CENTROID_PARTITIONER;
+      partitioner_type_to_enum["LINEAR_PARTITIONER"          ]=LINEAR_PARTITIONER;
+      partitioner_type_to_enum["SFC_PARTITIONER"             ]=SFC_PARTITIONER;
+      partitioner_type_to_enum["HILBERT_SFC_PARTITIONER"     ]=HILBERT_SFC_PARTITIONER;
+      partitioner_type_to_enum["MORTON_SFC_PARTITIONER"      ]=MORTON_SFC_PARTITIONER;
+      partitioner_type_to_enum["METIS_PARTITIONER"           ]=METIS_PARTITIONER;
+      partitioner_type_to_enum["PARMETIS_PARTITIONER"        ]=PARMETIS_PARTITIONER;
+      partitioner_type_to_enum["SUBDOMAIN_PARTITIONER"       ]=SUBDOMAIN_PARTITIONER;
+      partitioner_type_to_enum["MAPPED_SUBDOMAIN_PARTITIONER"]=MAPPED_SUBDOMAIN_PARTITIONER;
+
+      //shorter
+      partitioner_type_to_enum["CENTROID"                    ]=CENTROID_PARTITIONER;
+      partitioner_type_to_enum["LINEAR"                      ]=LINEAR_PARTITIONER;
+      partitioner_type_to_enum["SFC"                         ]=SFC_PARTITIONER;
+      partitioner_type_to_enum["HILBERT_SFC"                 ]=HILBERT_SFC_PARTITIONER;
+      partitioner_type_to_enum["MORTON_SFC"                  ]=MORTON_SFC_PARTITIONER;
+      partitioner_type_to_enum["METIS"                       ]=METIS_PARTITIONER;
+      partitioner_type_to_enum["PARMETIS"                    ]=PARMETIS_PARTITIONER;
+      partitioner_type_to_enum["SUBDOMAIN"                   ]=SUBDOMAIN_PARTITIONER;
+      partitioner_type_to_enum["MAPPED_SUBDOMAIN"            ]=MAPPED_SUBDOMAIN_PARTITIONER;
     }
 }
 
@@ -646,6 +678,7 @@ INSTANTIATE_STRING_TO_ENUM(Order,order)
 INSTANTIATE_STRING_TO_ENUM(FEFamily,fefamily)
 INSTANTIATE_STRING_TO_ENUM(InfMapType,inf_map_type)
 INSTANTIATE_STRING_TO_ENUM(QuadratureType,quadrature_type)
+INSTANTIATE_STRING_TO_ENUM(PartitionerType,partitioner_type)
 INSTANTIATE_STRING_TO_ENUM(PreconditionerType,preconditioner_type)
 
 #ifdef LIBMESH_ENABLE_AMR


### PR DESCRIPTION
Using Parmetis for ReplicatedMesh doesn't seem to make any difference in performance on our benchmark set in #2935, but this might be useful or might make a performance difference in other contexts.