### PR TITLE
init_names() at more points

### DIFF
--- a/src/solvers/time_solver.C
+++ b/src/solvers/time_solver.C
@@ -61,6 +61,8 @@ void TimeSolver::reinit ()
     this->linear_solver()->init((_system.name()+"_").c_str());
   else
     this->linear_solver()->init();
+
+  this->_linear_solver->init_names(_system);
 }
 
 
@@ -86,6 +88,8 @@ void TimeSolver::init_data ()
     this->linear_solver()->init((_system.name()+"_").c_str());
   else
     this->linear_solver()->init();
+
+  this->linear_solver()->init_names(_system);
 }
 
 

--- a/src/systems/continuation_system.C
+++ b/src/systems/continuation_system.C
@@ -69,6 +69,8 @@ ContinuationSystem::ContinuationSystem (EquationSystems & es,
     linear_solver->init((this->name()+"_").c_str());
   else
     linear_solver->init();
+
+  linear_solver->init_names(*this);
 }
 
 

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -1200,6 +1200,8 @@ LinearSolver<Number> * ImplicitSystem::get_linear_solver() const
   else
     linear_solver->init();
 
+  linear_solver->init_names(*this);
+
   return linear_solver.get();
 }
 

--- a/src/systems/linear_implicit_system.C
+++ b/src/systems/linear_implicit_system.C
@@ -118,6 +118,8 @@ void LinearImplicitSystem::solve ()
   else
     linear_solver->init();
 
+  linear_solver->init_names(*this);
+
   // Get the user-specified linear solver tolerance
   const double tol =
     double(es.parameters.get<Real>("linear solver tolerance"));

--- a/src/systems/nonlinear_implicit_system.C
+++ b/src/systems/nonlinear_implicit_system.C
@@ -65,6 +65,9 @@ void NonlinearImplicitSystem::clear ()
   // clear the nonlinear solver
   nonlinear_solver->clear();
 
+  // FIXME - this is necessary for petsc_auto_fieldsplit
+  // nonlinear_solver->init_names(*this);
+
   // clear the parent data
   Parent::clear();
 }
@@ -75,6 +78,9 @@ void NonlinearImplicitSystem::reinit ()
 {
   // re-initialize the nonlinear solver interface
   nonlinear_solver->clear();
+
+  // FIXME - this is necessary for petsc_auto_fieldsplit
+  // nonlinear_solver->init_names(*this);
 
   if (diff_solver.get())
     diff_solver->reinit();
@@ -172,6 +178,9 @@ void NonlinearImplicitSystem::solve ()
         nonlinear_solver->init((this->name()+"_").c_str());
       else
         nonlinear_solver->init();
+
+      // FIXME - this is necessary for petsc_auto_fieldsplit
+      // nonlinear_solver->init_names(*this);
 
       // Solve the nonlinear system.
       const std::pair<unsigned int, Real> rval =


### PR DESCRIPTION
This is necessary to enable petsc_auto_fieldsplit whenever it's
requested on the command line, which lets us use pc_type fieldsplit
without bringing in the whole PETSc DM

I want to merge this separately from and pull it out of #2935 - it doesn't backport well (there's a conflict even with 1.6.1) and I'd like to be able to try backporting the rest of that a ways to let us look for any historical performance regressions.

More to the point, this is independent of the benchmarking commit - I originally did it to make it easier to use fieldsplit solves in the hope that one of the adjoints example incompressible-flow-and-transport problems would work better with a Schur complement solver, but that didn't pan out.