### PR TITLE
RB: skip reinit when there are no DOFs on Elem

### DIFF
--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -728,6 +728,11 @@ void RBConstruction::add_scaled_matrix_and_vector(Number scalar,
         }
 
       context.pre_fe_reinit(*this, elem);
+
+      // Do nothing in case there are no dof_indices on the current element
+      if ( context.get_dof_indices().empty() )
+        continue;
+
       context.elem_fe_reinit();
 
       if (elemtype != NODEELEM)


### PR DESCRIPTION
This prevents the otherwise mysterious MKL warning:

    Intel MKL ERROR: Parameter 8 was incorrect on entry to DGEMM

which arises when DGEMM encounters a 0x0 matrix.