### PR TITLE
More contains_vertex_of optimization

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -438,9 +438,12 @@ public:
 
   /**
    * \returns \p true if a vertex of \p e is contained
-   * in this element.
+   * in this element.  If \p mesh_connection is true, looks
+   * specifically for containment possibilities of an element \p e
+   * that is connected to \p this via membership in the same manifold
+   * of the same mesh.
    */
-  bool contains_vertex_of(const Elem * e) const;
+  bool contains_vertex_of(const Elem * e, bool mesh_connection=false) const;
 
   /**
    * \returns \p true if an edge of \p e is contained in

--- a/include/geom/elem_internal.h
+++ b/include/geom/elem_internal.h
@@ -403,8 +403,8 @@ find_point_neighbors(T this_elem,
 {
   libmesh_assert(start_elem);
   libmesh_assert(start_elem->active());
-  libmesh_assert(start_elem->contains_vertex_of(this_elem) ||
-                 this_elem->contains_vertex_of(start_elem));
+  libmesh_assert(start_elem->contains_vertex_of(this_elem, true) ||
+                 this_elem->contains_vertex_of(start_elem, true));
 
   neighbor_set.clear();
   neighbor_set.insert(start_elem);
@@ -424,8 +424,8 @@ find_point_neighbors(T this_elem,
                 {
                   if (current_neighbor->active())                // ... if it is active
                     {
-                      if (this_elem->contains_vertex_of(current_neighbor) // ... and touches us
-                          || current_neighbor->contains_vertex_of(this_elem))
+                      if (this_elem->contains_vertex_of(current_neighbor, true) // ... and touches us
+                          || current_neighbor->contains_vertex_of(this_elem, true))
                         {
                           // Make sure we'll test it
                           if (!neighbor_set.count(current_neighbor))
@@ -446,8 +446,8 @@ find_point_neighbors(T this_elem,
 
                       for (const auto & current_child : active_neighbor_children)
                         {
-                          if (this_elem->contains_vertex_of(current_child) ||
-                              current_child->contains_vertex_of(this_elem))
+                          if (this_elem->contains_vertex_of(current_child, true) ||
+                              current_child->contains_vertex_of(this_elem, true))
                             {
                               // Make sure we'll test it
                               if (!neighbor_set.count(current_child))
@@ -479,8 +479,8 @@ find_interior_neighbors(T this_elem,
     return;
 
   T ip = this_elem->interior_parent();
-  libmesh_assert (ip->contains_vertex_of(this_elem) ||
-                  this_elem->contains_vertex_of(ip));
+  libmesh_assert (ip->contains_vertex_of(this_elem, true) ||
+                  this_elem->contains_vertex_of(ip, true));
 
   libmesh_assert (!ip->subactive());
 
@@ -489,8 +489,8 @@ find_interior_neighbors(T this_elem,
     {                   // ip->child_ptr(c) is only good with AMR.
       for (auto & child : ip->child_ref_range())
         {
-          if (child.contains_vertex_of(this_elem) ||
-              this_elem->contains_vertex_of(&child))
+          if (child.contains_vertex_of(this_elem, true) ||
+              this_elem->contains_vertex_of(&child, true))
             {
               ip = &child;
               break;

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -547,19 +547,33 @@ unsigned int Elem::which_node_am_i(unsigned int side,
 
 
 
-bool Elem::contains_vertex_of(const Elem * e) const
+bool Elem::contains_vertex_of(const Elem * e, bool mesh_connection) const
 {
   // Our vertices are the first numbered nodes
   const unsigned int nv = e->n_vertices();
+  const unsigned int my_nv = this->n_vertices();
 
   // Check for vertex-to-vertex containment first; contains_point() is
   // expensive
-  for (auto n : make_range(e->n_vertices()))
+  for (auto n : make_range(nv))
     {
       const Node * vertex = e->node_ptr(n);
-      for (auto & my_n : this->node_ref_range())
-        if (&my_n == vertex)
+      for (auto my_n : make_range(my_nv))
+        if (&this->node_ref(my_n) == vertex)
           return true;
+    }
+
+  // If e is in our mesh, then we might be done testing
+  if (mesh_connection)
+    {
+      const unsigned int l = this->level();
+      const unsigned int el = e->level();
+
+      if (l >= el)
+        return false;
+
+      // We could also return false for l==el-1 iff we knew we had no
+      // triangular faces, but we don't have an API to check that.
     }
 
   // Our vertices are the first numbered nodes


### PR DESCRIPTION
I came up with this in a conversation with @jbadger95 a week ago, when he was asking about `contains_edge_of`.  Sadly I haven't yet actually improved the case *he* cared about (and probably won't soon; yes I'm still on vacation), but the question of "how much would this improve our point neighbor ghosting" kept nagging at me.

Turns out the answer is: our `LIBMESH_BENCHMARK` with `--enable-parmesh` gets 5% faster, and 3D refinement-heavy cases (like the uniform refinement tests @fdkong pointed me to) can get over 50% faster; all this is on top of the previous optimization in #2942, so that's something like a 5x speedup overall for distributed 3D mesh refinement.  I cannot fully express my embarrassment that we had performance that horrible in a common use case.  (We actually *still* have bad performance here, since `delete_remote_elements()` is half the cost of the solve in my test case, but it's no longer a dozen times the cost, so yay?)