### PR TITLE
DofMap: add const DofConstraints accessor

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1013,6 +1013,12 @@ public:
   DofConstraints::const_iterator constraint_rows_end() const
   { return _dof_constraints.end(); }
 
+  /**
+   * Provide a const accessor to the DofConstraints map. This allows the user
+   * to quickly search the data structure rather than just iterating over it.
+   */
+  const DofConstraints & get_dof_constraints() const { return _dof_constraints; }
+
   void stash_dof_constraints()
   {
     libmesh_assert(_stashed_dof_constraints.empty());


### PR DESCRIPTION
We have a case where it would be useful to be able to quickly get a (const) reference to the `DofConstraintRow` for a given DOF, but currently the `DofMap` only provides the `constraint_rows_begin()` and `constraint_rows_end()` iterators. This PR adds a const accessor for the `DofConstraints` object itself.
