### PR TITLE
Update to add EIM observation points

### DIFF
--- a/contrib/capnproto/rb_data.capnp
+++ b/contrib/capnproto/rb_data.capnp
@@ -116,8 +116,7 @@ struct RBEIMEvaluationReal @0xf8121d2237427a80 {
   interpolationMatrix        @9  :List(Real);
   eimSolutionsForTrainingSet @10 :List(List(Real));
   observationPointsXyz       @11 :List(Point3D);
-  observationPointsComp      @12 :List(Integer);
-  observationPointsValue     @13 :List(List(Real));
+  observationPointsValues    @12 :List(List(List(Real)));
 }
 struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   nBfs                       @0  :Integer;
@@ -132,6 +131,5 @@ struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   interpolationMatrix        @9  :List(Complex);
   eimSolutionsForTrainingSet @10 :List(List(Complex));
   observationPointsXyz       @11 :List(Point3D);
-  observationPointsComp      @12 :List(Integer);
-  observationPointsValue     @13 :List(List(Complex));
+  observationPointsValues    @12 :List(List(List(Complex)));
 }

--- a/contrib/capnproto/rb_data.capnp
+++ b/contrib/capnproto/rb_data.capnp
@@ -115,6 +115,9 @@ struct RBEIMEvaluationReal @0xf8121d2237427a80 {
   interpolationXyzPerturb    @8  :List(List(Point3D));
   interpolationMatrix        @9  :List(Real);
   eimSolutionsForTrainingSet @10 :List(List(Real));
+  observationPointsXyz       @11 :List(Point3D);
+  observationPointsComp      @12 :List(Integer);
+  observationPointsValue     @13 :List(List(Real));
 }
 struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   nBfs                       @0  :Integer;
@@ -128,4 +131,7 @@ struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   interpolationXyzPerturb    @8  :List(List(Point3D));
   interpolationMatrix        @9  :List(Complex);
   eimSolutionsForTrainingSet @10 :List(List(Complex));
+  observationPointsXyz       @11 :List(Point3D);
+  observationPointsComp      @12 :List(Integer);
+  observationPointsValue     @13 :List(List(Complex));
 }

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -361,9 +361,9 @@ private:
    * in the training set. These values are used to obtain the observation values that are stored in
    * RBEIMEvaluation.
    *
-   * Indexing is: training_index --> observation point index --> value.
+   * Indexing is: training_index --> observation point index --> component --> value.
    */
-  std::vector<std::vector<Number>> _parametrized_functions_for_training_obs_values;
+  std::vector<std::vector<std::vector<Number>>> _parametrized_functions_for_training_obs_values;
 
 };
 

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -232,6 +232,15 @@ private:
   void initialize_qp_data();
 
   /**
+   * Initialize the \p elem_ids and \p sbd_ids associated with the observation
+   * points so that we can subsequently evaluate parametrized functions at the
+   * observations points.
+   */
+  void initialize_observation_points_data(
+    std::vector<dof_id_type> & observation_points_elem_ids,
+    std::vector<subdomain_id_type> & observation_points_sbd_ids);
+
+  /**
    * Evaluate the inner product of vec1 and vec2 which specify values at
    * quadrature points. The inner product includes the JxW contributions
    * stored in _local_quad_point_JxW, so that this is equivalent to
@@ -346,6 +355,16 @@ private:
    * to the mapping function derivatives.
    */
   std::unordered_map<dof_id_type, std::vector<std::vector<Point>> > _local_quad_point_locations_perturbations;
+
+  /**
+   * We also optionally store the values at the "observation points" for all parametrized functions
+   * in the training set. These values are used to obtain the observation values that are stored in
+   * RBEIMEvaluation.
+   *
+   * Indexing is: training_index --> observation point index --> value.
+   */
+  std::vector<std::vector<Number>> _parametrized_functions_for_training_obs_values;
+
 };
 
 } // namespace libMesh

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -279,6 +279,16 @@ public:
   const std::vector<unsigned int> & get_observation_components() const;
 
   /**
+   * Get the observation value for the specified basis function and observation point.
+   */
+  Number get_observation_value(unsigned int bf_index, unsigned int obs_pt_index) const;
+
+  /**
+   * Add values at the observation points for a new basis function.
+   */
+  void add_observation_values_for_basis_function(const std::vector<Number> & values);
+
+  /**
    * Write out all the basis functions to file.
    * \p sys is used for file IO
    * \p directory_name specifies which directory to write files to
@@ -416,26 +426,12 @@ private:
    * for i=1,...,n_bfs, and j=1,...,n.
    *
    * These observation values can be used to observe the EIM approximation
-   * at specific points of interest, defined by the observation points.
+   * at specific points of interest, where the points of interest are defined
+   * by the observation points.
    */
   std::vector<Point> _observation_points_xyz;
   std::vector<unsigned int> _observation_points_comp;
   std::vector<std::vector<Number>> _observation_points_values;
-
-  /**
-   * We also store the element ID and qp index of each observation
-   * point so that we can evaluate our basis functions at these
-   * points by simply looking up the appropriate stored values.
-   * This data is only needed during the EIM training since it
-   * helps us to set up _observation_points_values correctly.
-   *
-   * Note: This approach assumes that we use the closet qp to
-   * the observation point to "look up" the value at the EIM
-   * point. This is the natural approach to use here since
-   * the EIM functions are only stored at qps.
-   */
-  std::vector<dof_id_type> _observation_points_elem_id;
-  std::vector<unsigned int> _observation_points_qp;
 
 };
 

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -284,9 +284,20 @@ public:
   Number get_observation_value(unsigned int bf_index, unsigned int obs_pt_index) const;
 
   /**
+   * Get a const reference to all the observation values, indexed as follows:
+   *  basis_function index --> observation point index --> value.
+   */
+  const std::vector<std::vector<Number>> & get_observation_values() const;
+
+  /**
    * Add values at the observation points for a new basis function.
    */
   void add_observation_values_for_basis_function(const std::vector<Number> & values);
+
+  /**
+   * Set all observation values.
+   */
+  void set_observation_values(const std::vector<std::vector<Number>> & values);
 
   /**
    * Write out all the basis functions to file.
@@ -428,10 +439,13 @@ private:
    * These observation values can be used to observe the EIM approximation
    * at specific points of interest, where the points of interest are defined
    * by the observation points.
+   *
+   * _observation_points_value is indexed as follows:
+   *  basis_function index --> observatio point index --> value
    */
   std::vector<Point> _observation_points_xyz;
   std::vector<unsigned int> _observation_points_comp;
-  std::vector<std::vector<Number>> _observation_points_values;
+  std::vector<std::vector<Number>> _observation_points_value;
 
 };
 

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -257,6 +257,28 @@ public:
     const std::vector<Point> & perturbs);
 
   /**
+   * Set the observation points and components.
+   */
+  void set_observation_points_and_components(
+    const std::vector<Point> & observation_points_xyz,
+    const std::vector<unsigned int> & observation_points_comp);
+
+  /**
+   * Get the number of observation points.
+   */
+  unsigned int get_n_observation_points() const;
+
+  /**
+   * Get the observation points.
+   */
+  const std::vector<Point> & get_observation_points() const;
+
+  /**
+   * Get the observation components.
+   */
+  const std::vector<unsigned int> & get_observation_components() const;
+
+  /**
    * Write out all the basis functions to file.
    * \p sys is used for file IO
    * \p directory_name specifies which directory to write files to
@@ -360,7 +382,7 @@ private:
    * is as follows:
    *   basis function index --> element ID --> variable --> quadrature point --> value
    * We use a map to index the element ID, since the IDs on this processor in
-   * generally will not start at zero.
+   * general will not start at zero.
    */
   std::vector<QpDataMap> _local_eim_basis_functions;
 
@@ -383,6 +405,38 @@ private:
    * they are read in on processor 0.
    */
   void distribute_bfs(const System & sys);
+
+  /**
+   * Let {p_1,...,p_n} be a set of n "observation points", where we can
+   * observe the values of our EIM basis functions. Also, let
+   * {comp_1,...,comp_n} be the component on the EIM basis function that
+   * we will observe. Then the corresponding observation values, v_ij,
+   * are given by:
+   *  v_ij = eim_basis_function[i][comp_j](p_j),
+   * for i=1,...,n_bfs, and j=1,...,n.
+   *
+   * These observation values can be used to observe the EIM approximation
+   * at specific points of interest, defined by the observation points.
+   */
+  std::vector<Point> _observation_points_xyz;
+  std::vector<unsigned int> _observation_points_comp;
+  std::vector<std::vector<Number>> _observation_points_values;
+
+  /**
+   * We also store the element ID and qp index of each observation
+   * point so that we can evaluate our basis functions at these
+   * points by simply looking up the appropriate stored values.
+   * This data is only needed during the EIM training since it
+   * helps us to set up _observation_points_values correctly.
+   *
+   * Note: This approach assumes that we use the closet qp to
+   * the observation point to "look up" the value at the EIM
+   * point. This is the natural approach to use here since
+   * the EIM functions are only stored at qps.
+   */
+  std::vector<dof_id_type> _observation_points_elem_id;
+  std::vector<unsigned int> _observation_points_qp;
+
 };
 
 }

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -195,6 +195,13 @@ public:
   const QpDataMap & get_basis_function(unsigned int i) const;
 
   /**
+   * Set _rb_eim_solutions. Normally we update _rb_eim_solutions by performing
+   * and EIM solve, but in some cases we want to set the EIM solution coefficients
+   * elsewhere, so this setter enables us to do that.
+   */
+  void set_rb_eim_solutions(const std::vector<DenseVector<Number>> & rb_eim_solutions);
+
+  /**
    * Return the EIM solution coefficients from the most recent call to rb_eim_solves().
    */
   const std::vector<DenseVector<Number>> & get_rb_eim_solutions() const;
@@ -291,6 +298,16 @@ public:
    * Set all observation values.
    */
   void set_observation_values(const std::vector<std::vector<std::vector<Number>>> & values);
+
+  /**
+   * Set _preserve_rb_eim_solutions.
+   */
+  void set_preserve_rb_eim_solutions(bool preserve_rb_eim_solutions);
+
+  /**
+   * Get _preserve_rb_eim_solutions.
+   */
+  bool get_preserve_rb_eim_solutions() const;
 
   /**
    * Write out all the basis functions to file.
@@ -437,6 +454,13 @@ private:
    */
   std::vector<Point> _observation_points_xyz;
   std::vector<std::vector<std::vector<Number>>> _observation_points_values;
+
+  /**
+   * Boolean to indicate if we skip updating _rb_eim_solutions in rb_eim_solves().
+   * This is relevant for cases when we set up _rb_eim_solutions elsewhere and we
+   * want to avoid changing it.
+   */
+  bool _preserve_rb_eim_solutions;
 
 };
 

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -260,8 +260,7 @@ public:
    * Set the observation points and components.
    */
   void set_observation_points_and_components(
-    const std::vector<Point> & observation_points_xyz,
-    const std::vector<unsigned int> & observation_points_comp);
+    const std::vector<Point> & observation_points_xyz);
 
   /**
    * Get the number of observation points.
@@ -274,30 +273,25 @@ public:
   const std::vector<Point> & get_observation_points() const;
 
   /**
-   * Get the observation components.
-   */
-  const std::vector<unsigned int> & get_observation_components() const;
-
-  /**
    * Get the observation value for the specified basis function and observation point.
    */
-  Number get_observation_value(unsigned int bf_index, unsigned int obs_pt_index) const;
+  const std::vector<Number> & get_observation_values(unsigned int bf_index, unsigned int obs_pt_index) const;
 
   /**
    * Get a const reference to all the observation values, indexed as follows:
    *  basis_function index --> observation point index --> value.
    */
-  const std::vector<std::vector<Number>> & get_observation_values() const;
+  const std::vector<std::vector<std::vector<Number>>> & get_observation_values() const;
 
   /**
    * Add values at the observation points for a new basis function.
    */
-  void add_observation_values_for_basis_function(const std::vector<Number> & values);
+  void add_observation_values_for_basis_function(const std::vector<std::vector<Number>> & values);
 
   /**
    * Set all observation values.
    */
-  void set_observation_values(const std::vector<std::vector<Number>> & values);
+  void set_observation_values(const std::vector<std::vector<std::vector<Number>>> & values);
 
   /**
    * Write out all the basis functions to file.
@@ -430,22 +424,20 @@ private:
   /**
    * Let {p_1,...,p_n} be a set of n "observation points", where we can
    * observe the values of our EIM basis functions. Also, let
-   * {comp_1,...,comp_n} be the component on the EIM basis function that
-   * we will observe. Then the corresponding observation values, v_ij,
+   * {comp_k} be the components of the EIM basis function that
+   * we will observe. Then the corresponding observation values, v_ijk,
    * are given by:
-   *  v_ij = eim_basis_function[i][comp_j](p_j),
-   * for i=1,...,n_bfs, and j=1,...,n.
+   *  v_ijk = eim_basis_function[i][p_j][comp_k].
    *
    * These observation values can be used to observe the EIM approximation
    * at specific points of interest, where the points of interest are defined
    * by the observation points.
    *
    * _observation_points_value is indexed as follows:
-   *  basis_function index --> observatio point index --> value
+   *  basis_function index --> observation point index --> comp index --> value
    */
   std::vector<Point> _observation_points_xyz;
-  std::vector<unsigned int> _observation_points_comp;
-  std::vector<std::vector<Number>> _observation_points_value;
+  std::vector<std::vector<std::vector<Number>>> _observation_points_values;
 
 };
 

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -259,8 +259,7 @@ public:
   /**
    * Set the observation points and components.
    */
-  void set_observation_points_and_components(
-    const std::vector<Point> & observation_points_xyz);
+  void set_observation_points(const std::vector<Point> & observation_points_xyz);
 
   /**
    * Get the number of observation points.

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -139,6 +139,18 @@ public:
                                         subdomain_id_type sbd_id) const;
 
   /**
+   * Evaluate the parametrized function for the parameter \p mu at the set of
+   * \p observation_points. We return only the component of the function specified
+   * by \p observation_components, and we also provide \p elem_ids and \p sbd_ids
+   * since that info can be required for the evaluation in some cases.
+   */
+  virtual std::vector<Number> evaluate_at_observation_points(const RBParameters & mu,
+                                                             const std::vector<Point> & observation_points,
+                                                             const std::vector<unsigned int> & observation_components,
+                                                             const std::vector<dof_id_type> & elem_ids,
+                                                             const std::vector<subdomain_id_type> & sbd_ids);
+
+  /**
    * Storage for pre-evaluated values. The indexing is given by:
    *   parameter index --> point index --> component index --> value.
    */

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -140,15 +140,15 @@ public:
 
   /**
    * Evaluate the parametrized function for the parameter \p mu at the set of
-   * \p observation_points. We return only the component of the function specified
-   * by \p observation_components, and we also provide \p elem_ids and \p sbd_ids
+   * \p observation_points. We return a vector of values at each observation
+   * point since we may want to evaluate more than one component of the
+   * parametrized function. We also provide \p elem_ids and \p sbd_ids
    * since that info can be required for the evaluation in some cases.
    */
-  virtual std::vector<Number> evaluate_at_observation_points(const RBParameters & mu,
-                                                             const std::vector<Point> & observation_points,
-                                                             const std::vector<unsigned int> & observation_components,
-                                                             const std::vector<dof_id_type> & elem_ids,
-                                                             const std::vector<subdomain_id_type> & sbd_ids);
+  virtual std::vector<std::vector<Number>> evaluate_at_observation_points(const RBParameters & mu,
+                                                                          const std::vector<Point> & observation_points,
+                                                                          const std::vector<dof_id_type> & elem_ids,
+                                                                          const std::vector<subdomain_id_type> & sbd_ids);
 
   /**
    * Storage for pre-evaluated values. The indexing is given by:

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -836,7 +836,7 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
 
       {
         auto obs_values_list_outer =
-          rb_eim_evaluation_reader.getObservationPointsValue();
+          rb_eim_evaluation_reader.getObservationPointsValues();
 
         std::vector<std::vector<std::vector<Number>>> observation_values;
         observation_values.resize(obs_values_list_outer.size());

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -831,36 +831,28 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
             observation_points_xyz.emplace_back(p);
           }
 
-        auto observation_points_comp_list =
-          rb_eim_evaluation_reader.getObservationPointsComp();
-
-        std::vector<unsigned int> observation_points_comp;
-        for (unsigned int i=0; i<observation_points_comp_list.size(); ++i)
-          {
-            observation_points_comp.emplace_back(observation_points_comp_list[i]);
-          }
-
-        libmesh_error_msg_if(observation_points_xyz_list.size() != observation_points_comp.size(),
-                             "Size error while reading the EIM observation points.");
-
-        rb_eim_evaluation.set_observation_points_and_components(observation_points_xyz, observation_points_comp);
+        rb_eim_evaluation.set_observation_points(observation_points_xyz);
       }
 
       {
         auto obs_values_list_outer =
           rb_eim_evaluation_reader.getObservationPointsValue();
 
-        std::vector<std::vector<Number>> observation_values;
+        std::vector<std::vector<std::vector<Number>>> observation_values;
         observation_values.resize(obs_values_list_outer.size());
 
         for (auto i : make_range(obs_values_list_outer.size()))
           {
-            auto obs_values_list_inner = obs_values_list_outer[i];
+            auto obs_values_list_middle = obs_values_list_outer[i];
 
-            observation_values[i].resize(obs_values_list_inner.size());
+            observation_values[i].resize(obs_values_list_middle.size());
             for (auto j : index_range(observation_values[i]))
               {
-                observation_values[i][j] = load_scalar_value(obs_values_list_inner[j]);
+                auto obs_values_list_inner = obs_values_list_middle[j];
+
+                observation_values[i][j].resize(obs_values_list_inner.size());
+                for (auto k : index_range(observation_values[i]))
+                  observation_values[i][j][k] = load_scalar_value(obs_values_list_inner[k]);
               }
           }
 

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -851,7 +851,7 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
                 auto obs_values_list_inner = obs_values_list_middle[j];
 
                 observation_values[i][j].resize(obs_values_list_inner.size());
-                for (auto k : index_range(observation_values[i]))
+                for (auto k : index_range(observation_values[i][j]))
                   observation_values[i][j][k] = load_scalar_value(obs_values_list_inner[k]);
               }
           }

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -688,6 +688,50 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
             }
         }
     }
+
+  // Optionally store observation points data for the EIM basis functions
+  unsigned int n_obs_pts = rb_eim_evaluation.get_n_observation_points();
+  if (n_obs_pts > 0)
+    {
+      {
+        auto observation_points_list =
+          rb_eim_evaluation_builder.initObservationPointsXyz(n_obs_pts);
+
+        const std::vector<Point> & obs_pts = rb_eim_evaluation.get_observation_points();
+        for (unsigned int i=0; i < n_obs_pts; ++i)
+          add_point_to_builder(obs_pts[i],
+                              observation_points_list[i]);
+      }
+
+      {
+        auto observation_comps_list =
+          rb_eim_evaluation_builder.initObservationPointsComp(n_obs_pts);
+
+        const std::vector<unsigned int> & obs_comps = rb_eim_evaluation.get_observation_components();
+        for (unsigned int i=0; i < n_obs_pts; ++i)
+          observation_comps_list.set(i,
+                                     obs_comps[i]);
+      }
+
+      {
+        const std::vector<std::vector<Number>> & observation_values = rb_eim_evaluation.get_observation_values();
+
+        auto obs_values_list_outer =
+          rb_eim_evaluation_builder.initObservationPointsValue(observation_values.size());
+        for (auto i : make_range(observation_values.size()))
+          {
+            const std::vector<Number> & values = observation_values[i];
+            auto obs_values_list_inner = obs_values_list_outer.init(i, values.size());
+
+            for (auto j : index_range(values))
+              {
+                set_scalar_in_list(obs_values_list_inner,
+                                  j,
+                                  values[j]);
+              }
+          }
+      }
+    }
 }
 
 #if defined(LIBMESH_HAVE_SLEPC) && (LIBMESH_HAVE_GLPK)

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -700,7 +700,7 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
         const std::vector<Point> & obs_pts = rb_eim_evaluation.get_observation_points();
         for (unsigned int i=0; i < n_obs_pts; ++i)
           add_point_to_builder(obs_pts[i],
-                              observation_points_list[i]);
+                               observation_points_list[i]);
       }
 
       {
@@ -726,8 +726,8 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
             for (auto j : index_range(values))
               {
                 set_scalar_in_list(obs_values_list_inner,
-                                  j,
-                                  values[j]);
+                                   j,
+                                   values[j]);
               }
           }
       }

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -706,7 +706,7 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
       {
         const std::vector<std::vector<std::vector<Number>>> & observation_values = rb_eim_evaluation.get_observation_values();
         auto obs_values_list_outer =
-          rb_eim_evaluation_builder.initObservationPointsValue(observation_values.size());
+          rb_eim_evaluation_builder.initObservationPointsValues(observation_values.size());
 
         for (auto i : make_range(observation_values.size()))
           {

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -704,30 +704,23 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
       }
 
       {
-        auto observation_comps_list =
-          rb_eim_evaluation_builder.initObservationPointsComp(n_obs_pts);
-
-        const std::vector<unsigned int> & obs_comps = rb_eim_evaluation.get_observation_components();
-        for (unsigned int i=0; i < n_obs_pts; ++i)
-          observation_comps_list.set(i,
-                                     obs_comps[i]);
-      }
-
-      {
-        const std::vector<std::vector<Number>> & observation_values = rb_eim_evaluation.get_observation_values();
-
+        const std::vector<std::vector<std::vector<Number>>> & observation_values = rb_eim_evaluation.get_observation_values();
         auto obs_values_list_outer =
           rb_eim_evaluation_builder.initObservationPointsValue(observation_values.size());
+
         for (auto i : make_range(observation_values.size()))
           {
-            const std::vector<Number> & values = observation_values[i];
-            auto obs_values_list_inner = obs_values_list_outer.init(i, values.size());
+            auto obs_values_list_middle = obs_values_list_outer.init(i, observation_values[i].size());
 
-            for (auto j : index_range(values))
+            for (auto j : make_range(observation_values[i].size()))
               {
-                set_scalar_in_list(obs_values_list_inner,
-                                   j,
-                                   values[j]);
+                auto obs_values_list_inner = obs_values_list_middle.init(j, observation_values[i][j].size());
+                for (auto k : make_range(observation_values[i].size()))
+                  {
+                    set_scalar_in_list(obs_values_list_inner,
+                                       k,
+                                       observation_values[i][j][k]);
+                  }
               }
           }
       }

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -715,7 +715,7 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
             for (auto j : make_range(observation_values[i].size()))
               {
                 auto obs_values_list_inner = obs_values_list_middle.init(j, observation_values[i][j].size());
-                for (auto k : make_range(observation_values[i].size()))
+                for (auto k : make_range(observation_values[i][j].size()))
                   {
                     set_scalar_in_list(obs_values_list_inner,
                                        k,

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -707,7 +707,6 @@ void RBEIMConstruction::initialize_parametrized_functions_in_training_set()
           _parametrized_functions_for_training_obs_values[i] =
             eim_eval.get_parametrized_function().evaluate_at_observation_points(get_parameters(),
                                                                                 eim_eval.get_observation_points(),
-                                                                                eim_eval.get_observation_components(),
                                                                                 observation_points_elem_ids,
                                                                                 observation_points_sbd_ids);
 
@@ -981,7 +980,7 @@ void RBEIMConstruction::enrich_eim_approximation(unsigned int training_index)
           for (unsigned int i=0; i<RB_size; i++)
             for (unsigned int j=0; j<eim_eval.get_n_observation_points(); j++)
               for (unsigned int k=0; k<new_bf_obs_vals[j].size(); k++)
-                new_bf_obs_vals[j][k] -= rb_eim_solution(i) * eim_eval.get_observation_value(i,j)[k];
+                new_bf_obs_vals[j][k] -= rb_eim_solution(i) * eim_eval.get_observation_values(i,j)[k];
         }
     }
 

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -711,8 +711,8 @@ void RBEIMConstruction::initialize_parametrized_functions_in_training_set()
                                                                                 observation_points_elem_ids,
                                                                                 observation_points_sbd_ids);
 
-          if (_parametrized_functions_for_training_obs_values[i].size() != eim_eval.get_n_observation_points())
-            libmesh_error_msg("Number of observation values should match number of observation points");
+          libmesh_error_msg_if(_parametrized_functions_for_training_obs_values[i].size() != eim_eval.get_n_observation_points(),
+                               "Number of observation values should match number of observation points");
         }
     }
 
@@ -873,10 +873,7 @@ void RBEIMConstruction::initialize_observation_points_data(
       const Point & p = observation_points[obs_pt_index];
       const Elem * elem = (*point_locator)(p);
 
-      if (!elem)
-        {
-          libmesh_error_msg("No element containing observation found");
-        }
+      libmesh_error_msg_if (!elem, "No element containing observation found");
 
       observation_points_elem_ids[obs_pt_index] = elem->id();
       observation_points_sbd_ids[obs_pt_index] = elem->subdomain_id();

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -945,7 +945,7 @@ void RBEIMConstruction::enrich_eim_approximation(unsigned int training_index)
 
   bool has_obs_vals = (eim_eval.get_n_observation_points() > 0);
 
-  std::vector<Number> new_bf_obs_vals;
+  std::vector<std::vector<Number>> new_bf_obs_vals;
   if (has_obs_vals)
     new_bf_obs_vals = _parametrized_functions_for_training_obs_values[training_index];
 
@@ -980,7 +980,8 @@ void RBEIMConstruction::enrich_eim_approximation(unsigned int training_index)
         {
           for (unsigned int i=0; i<RB_size; i++)
             for (unsigned int j=0; j<eim_eval.get_n_observation_points(); j++)
-              new_bf_obs_vals[j] -= rb_eim_solution(i) * eim_eval.get_observation_value(i,j);
+              for (unsigned int k=0; k<new_bf_obs_vals[j].size(); k++)
+                new_bf_obs_vals[j][k] -= rb_eim_solution(i) * eim_eval.get_observation_value(i,j)[k];
         }
     }
 
@@ -1076,8 +1077,9 @@ void RBEIMConstruction::enrich_eim_approximation(unsigned int training_index)
     {
       // Apply the scame scaling to new_bf_obs_vals as we did to
       // the new basis function itself
-      for(Number & value : new_bf_obs_vals)
-        value *= 1./optimal_value;
+      for (unsigned int i=0; i<new_bf_obs_vals.size(); i++)
+        for (unsigned int j=0; j<new_bf_obs_vals[i].size(); j++)
+          new_bf_obs_vals[i][j] *= 1./optimal_value;
 
       eim_eval.add_observation_values_for_basis_function(new_bf_obs_vals);
     }

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -978,9 +978,9 @@ void RBEIMConstruction::enrich_eim_approximation(unsigned int training_index)
 
       if(has_obs_vals)
         {
-          for (unsigned int i=0; i<eim_eval.get_n_observation_points(); i++)
-            for (unsigned int j=0; j<RB_size; j++)
-              new_bf_obs_vals[i] -= rb_eim_solution(j) * eim_eval.get_observation_value(i,j);
+          for (unsigned int i=0; i<RB_size; i++)
+            for (unsigned int j=0; j<eim_eval.get_n_observation_points(); j++)
+              new_bf_obs_vals[j] -= rb_eim_solution(i) * eim_eval.get_observation_value(i,j);
         }
     }
 

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -438,11 +438,9 @@ const DenseMatrix<Number> & RBEIMEvaluation::get_interpolation_matrix() const
 }
 
 void RBEIMEvaluation::set_observation_points_and_components(
-  const std::vector<Point> & observation_points_xyz,
-  const std::vector<unsigned int> & observation_points_comp)
+  const std::vector<Point> & observation_points_xyz)
 {
   _observation_points_xyz = observation_points_xyz;
-  _observation_points_comp = observation_points_comp;
 }
 
 unsigned int RBEIMEvaluation::get_n_observation_points() const
@@ -455,32 +453,27 @@ const std::vector<Point> & RBEIMEvaluation::get_observation_points() const
   return _observation_points_xyz;
 }
 
-const std::vector<unsigned int> & RBEIMEvaluation::get_observation_components() const
-{
-  return _observation_points_comp;
-}
-
-Number RBEIMEvaluation::get_observation_value(unsigned int bf_index, unsigned int obs_pt_index) const
+const std::vector<Number> & RBEIMEvaluation:get_observation_values(unsigned int bf_index, unsigned int obs_pt_index) const
 {
   libmesh_error_msg_if(bf_index >= _observation_points_value.size(), "Invalid basis function index: " << bf_index);
   libmesh_error_msg_if(obs_pt_index >= _observation_points_value[bf_index].size(), "Invalid observation point index: " << obs_pt_index);
 
-  return _observation_points_value[bf_index][obs_pt_index];
+  return _observation_points_values[bf_index][obs_pt_index];
 }
 
-const std::vector<std::vector<Number>> & RBEIMEvaluation::get_observation_values() const
+const std::vector<std::vector<std::vector<Number>>> & RBEIMEvaluation::get_observation_values() const
 {
-  return _observation_points_value;
+  return _observation_points_values;
 }
 
-void RBEIMEvaluation::add_observation_values_for_basis_function(const std::vector<Number> & values)
+void RBEIMEvaluation::add_observation_values_for_basis_function(const std::vector<std::vector<Number>> & values)
 {
-  _observation_points_value.emplace_back(values);
+  _observation_points_values.emplace_back(values);
 }
 
-void RBEIMEvaluation::set_observation_values(const std::vector<std::vector<Number>> & values)
+void RBEIMEvaluation::set_observation_values(const std::vector<std::vector<std::vector<Number>>> & values)
 {
-  _observation_points_value = values;
+  _observation_points_values = values;
 }
 
 void RBEIMEvaluation::add_basis_function_and_interpolation_data(

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -372,7 +372,6 @@ void RBEIMEvaluation::add_interpolation_points_xyz_perturbations(const std::vect
   _interpolation_points_xyz_perturbations.emplace_back(perturbs);
 }
 
-
 void RBEIMEvaluation::add_interpolation_points_elem_id(dof_id_type elem_id)
 {
   _interpolation_points_elem_id.emplace_back(elem_id);
@@ -436,6 +435,29 @@ void RBEIMEvaluation::set_interpolation_matrix_entry(unsigned int i, unsigned in
 const DenseMatrix<Number> & RBEIMEvaluation::get_interpolation_matrix() const
 {
   return _interpolation_matrix;
+}
+
+void RBEIMEvaluation::set_observation_points_and_components(
+  const std::vector<Point> & observation_points_xyz,
+  const std::vector<unsigned int> & observation_points_comp)
+{
+  _observation_points_xyz = observation_points_xyz;
+  _observation_points_comp = observation_points_comp;
+}
+
+unsigned int RBEIMEvaluation::get_n_observation_points() const
+{
+  return _observation_points.size();
+}
+
+const std::vector<Point> & RBEIMEvaluation::get_observation_points() const
+{
+  return _observation_points;
+}
+
+const std::vector<unsigned int> & RBEIMEvaluation::get_observation_components() const
+{
+  return _observation_components;
 }
 
 void RBEIMEvaluation::add_basis_function_and_interpolation_data(

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -462,17 +462,25 @@ const std::vector<unsigned int> & RBEIMEvaluation::get_observation_components() 
 
 Number RBEIMEvaluation::get_observation_value(unsigned int bf_index, unsigned int obs_pt_index) const
 {
-  if (bf_index >= _observation_points_values.size())
-    libmesh_error_msg("Invalid basis function index: " << bf_index);
-  if (obs_pt_index >= _observation_points_values[bf_index].size())
-    libmesh_error_msg("Invalid observation point index: " << obs_pt_index);
+  libmesh_error_msg_if(bf_index >= _observation_points_value.size(), "Invalid basis function index: " << bf_index);
+  libmesh_error_msg_if(obs_pt_index >= _observation_points_value[bf_index].size(), "Invalid observation point index: " << obs_pt_index);
 
-  return _observation_points_values[bf_index][obs_pt_index];
+  return _observation_points_value[bf_index][obs_pt_index];
+}
+
+const std::vector<std::vector<Number>> & RBEIMEvaluation::get_observation_values() const
+{
+  return _observation_points_value;
 }
 
 void RBEIMEvaluation::add_observation_values_for_basis_function(const std::vector<Number> & values)
 {
-  _observation_points_values.emplace_back(values);
+  _observation_points_value.emplace_back(values);
+}
+
+void RBEIMEvaluation::set_observation_values(const std::vector<std::vector<Number>> & values)
+{
+  _observation_points_value = values;
 }
 
 void RBEIMEvaluation::add_basis_function_and_interpolation_data(

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -447,17 +447,32 @@ void RBEIMEvaluation::set_observation_points_and_components(
 
 unsigned int RBEIMEvaluation::get_n_observation_points() const
 {
-  return _observation_points.size();
+  return _observation_points_xyz.size();
 }
 
 const std::vector<Point> & RBEIMEvaluation::get_observation_points() const
 {
-  return _observation_points;
+  return _observation_points_xyz;
 }
 
 const std::vector<unsigned int> & RBEIMEvaluation::get_observation_components() const
 {
-  return _observation_components;
+  return _observation_points_comp;
+}
+
+Number RBEIMEvaluation::get_observation_value(unsigned int bf_index, unsigned int obs_pt_index) const
+{
+  if (bf_index >= _observation_points_values.size())
+    libmesh_error_msg("Invalid basis function index: " << bf_index);
+  if (obs_pt_index >= _observation_points_values[bf_index].size())
+    libmesh_error_msg("Invalid observation point index: " << obs_pt_index);
+
+  return _observation_points_values[bf_index][obs_pt_index];
+}
+
+void RBEIMEvaluation::add_observation_values_for_basis_function(const std::vector<Number> & values)
+{
+  _observation_points_values.emplace_back(values);
 }
 
 void RBEIMEvaluation::add_basis_function_and_interpolation_data(

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -437,8 +437,7 @@ const DenseMatrix<Number> & RBEIMEvaluation::get_interpolation_matrix() const
   return _interpolation_matrix;
 }
 
-void RBEIMEvaluation::set_observation_points_and_components(
-  const std::vector<Point> & observation_points_xyz)
+void RBEIMEvaluation::set_observation_points(const std::vector<Point> & observation_points_xyz)
 {
   _observation_points_xyz = observation_points_xyz;
 }
@@ -453,10 +452,10 @@ const std::vector<Point> & RBEIMEvaluation::get_observation_points() const
   return _observation_points_xyz;
 }
 
-const std::vector<Number> & RBEIMEvaluation:get_observation_values(unsigned int bf_index, unsigned int obs_pt_index) const
+const std::vector<Number> & RBEIMEvaluation::get_observation_values(unsigned int bf_index, unsigned int obs_pt_index) const
 {
-  libmesh_error_msg_if(bf_index >= _observation_points_value.size(), "Invalid basis function index: " << bf_index);
-  libmesh_error_msg_if(obs_pt_index >= _observation_points_value[bf_index].size(), "Invalid observation point index: " << obs_pt_index);
+  libmesh_error_msg_if(bf_index >= _observation_points_values.size(), "Invalid basis function index: " << bf_index);
+  libmesh_error_msg_if(obs_pt_index >= _observation_points_values[bf_index].size(), "Invalid observation point index: " << obs_pt_index);
 
   return _observation_points_values[bf_index][obs_pt_index];
 }

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -184,14 +184,13 @@ Number RBParametrizedFunction::get_parameter_independent_data(const std::string 
   return libmesh_map_find(libmesh_map_find(_parameter_independent_data, property_name), sbd_id);
 }
 
-std::vector<Number> RBParametrizedFunction::evaluate_at_observation_points(const RBParameters & mu,
-                                                                           const std::vector<Point> & observation_points,
-                                                                           const std::vector<unsigned int> & observation_components,
-                                                                           const std::vector<dof_id_type> & elem_ids,
-                                                                           const std::vector<subdomain_id_type> & sbd_ids)
+std::vector<std::vector<Number>> RBParametrizedFunction::evaluate_at_observation_points(const RBParameters & mu,
+                                                                                        const std::vector<Point> & observation_points,
+                                                                                        const std::vector<dof_id_type> & elem_ids,
+                                                                                        const std::vector<subdomain_id_type> & sbd_ids)
 {
   // return an empty vector by default, override this in subclasses if necessary
-  return std::vector<Number>();
+  return std::vector<std::vector<Number>>();
 }
 
 }

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -184,4 +184,14 @@ Number RBParametrizedFunction::get_parameter_independent_data(const std::string 
   return libmesh_map_find(libmesh_map_find(_parameter_independent_data, property_name), sbd_id);
 }
 
+std::vector<Number> RBParametrizedFunction::evaluate_at_observation_points(const RBParameters & mu,
+                                                                           const std::vector<Point> & observation_points,
+                                                                           const std::vector<unsigned int> & observation_components,
+                                                                           const std::vector<dof_id_type> & elem_ids,
+                                                                           const std::vector<subdomain_id_type> & sbd_ids)
+{
+  // return an empty vector by default, override this in subclasses if necessary
+  return std::vector<Number>();
+}
+
 }

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -184,10 +184,10 @@ Number RBParametrizedFunction::get_parameter_independent_data(const std::string 
   return libmesh_map_find(libmesh_map_find(_parameter_independent_data, property_name), sbd_id);
 }
 
-std::vector<std::vector<Number>> RBParametrizedFunction::evaluate_at_observation_points(const RBParameters & mu,
-                                                                                        const std::vector<Point> & observation_points,
-                                                                                        const std::vector<dof_id_type> & elem_ids,
-                                                                                        const std::vector<subdomain_id_type> & sbd_ids)
+std::vector<std::vector<Number>> RBParametrizedFunction::evaluate_at_observation_points(const RBParameters & /*mu*/,
+                                                                                        const std::vector<Point> & /*observation_points*/,
+                                                                                        const std::vector<dof_id_type> & /*elem_ids*/,
+                                                                                        const std::vector<subdomain_id_type> & /*sbd_ids*/)
 {
   // return an empty vector by default, override this in subclasses if necessary
   return std::vector<std::vector<Number>>();


### PR DESCRIPTION
Enable the user to set "observation points" where we store the values of EIM basis functions, and allows inspection of the resulting EIM approximation at these points.

This does not change any existing behavior.