### PR TITLE
--disable-amr fixes

### DIFF
--- a/examples/adjoints/adjoints_ex7/adjoints_ex7.C
+++ b/examples/adjoints/adjoints_ex7/adjoints_ex7.C
@@ -312,6 +312,7 @@ void set_system_parameters(HeatSystem &system, FEMParameters &param)
     }
 }
 
+#ifdef LIBMESH_ENABLE_AMR
 std::unique_ptr<AdjointRefinementEstimator>
 build_adjoint_refinement_error_estimator(QoISet &qois, FEMPhysics* supplied_physics, FEMParameters &/*param*/)
 {
@@ -334,6 +335,7 @@ build_adjoint_refinement_error_estimator(QoISet &qois, FEMPhysics* supplied_phys
 
   return adjoint_refinement_estimator;
 }
+#endif // LIBMESH_ENABLE_AMR
 
 // The main program.
 int main (int argc, char ** argv)

--- a/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
+++ b/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
@@ -148,8 +148,13 @@ int main (int argc, char ** argv)
     n_refinements = command_line.next(n_refinements);
 
   // Refine the mesh if requested
+  // Skip adaptive runs on a non-adaptive libMesh build
+#ifndef LIBMESH_ENABLE_AMR
+  libmesh_example_requires(n_refinements==0, "--enable-amr");
+#else
   MeshRefinement mesh_refinement (mesh);
   mesh_refinement.uniformly_refine (n_refinements);
+#endif
 
   // Print information about the mesh to the screen.
   mesh.print_info();

--- a/examples/miscellaneous/miscellaneous_ex8/miscellaneous_ex8.C
+++ b/examples/miscellaneous/miscellaneous_ex8/miscellaneous_ex8.C
@@ -241,10 +241,16 @@ int main(int argc, char ** argv)
 
       // Refine the meshes if requested
       const int n_refinements = input("n_refinements", 0);
+
+      // Skip adaptive runs on a non-adaptive libMesh build
+#ifndef LIBMESH_ENABLE_AMR
+      libmesh_example_requires(n_refinements==0, "--enable-amr");
+#else
       MeshRefinement mesh_refinement_a(mesh_a);
       mesh_refinement_a.uniformly_refine(n_refinements);
       MeshRefinement mesh_refinement_b(mesh_b);
       mesh_refinement_b.uniformly_refine(n_refinements);
+#endif
 
       // Create equation systems objects.
       EquationSystems

--- a/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.C
@@ -103,8 +103,13 @@ int main (int argc, char ** argv)
   mesh.read("systems_of_equations_ex8.exo");
 
   const unsigned int n_refinements = infile("n_refinements", 0);
+  // Skip adaptive runs on a non-adaptive libMesh build
+#ifndef LIBMESH_ENABLE_AMR
+  libmesh_example_requires(n_refinements==0, "--enable-amr");
+#else
   MeshRefinement mesh_refinement(mesh);
   mesh_refinement.uniformly_refine(n_refinements);
+#endif
 
   mesh.print_info();
 

--- a/examples/systems_of_equations/systems_of_equations_ex9/systems_of_equations_ex9.C
+++ b/examples/systems_of_equations/systems_of_equations_ex9/systems_of_equations_ex9.C
@@ -410,8 +410,13 @@ int main (int argc, char ** argv)
 
   GetPot input(argc, argv);
   const unsigned int n_refinements = input("n_refinements", 0);
+  // Skip adaptive runs on a non-adaptive libMesh build
+#ifndef LIBMESH_ENABLE_AMR
+  libmesh_example_requires(n_refinements==0, "--enable-amr");
+#else
   MeshRefinement mesh_refinement(mesh);
   mesh_refinement.uniformly_refine(n_refinements);
+#endif
 
   // Print information about the mesh to the screen.
   mesh.print_info();

--- a/include/solvers/adaptive_time_solver.h
+++ b/include/solvers/adaptive_time_solver.h
@@ -84,7 +84,9 @@ public:
 
   virtual void integrate_adjoint_sensitivity(const QoISet & qois, const ParameterVector & parameter_vector, SensitivityData & sensitivities) override = 0;
 
+#ifdef LIBMESH_ENABLE_AMR
   virtual void integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error) override = 0;
+#endif // LIBMESH_ENABLE_AMR
 
   virtual Real last_completed_timestep_size() override { return completed_timestep_size; };
 

--- a/include/solvers/euler2_solver.h
+++ b/include/solvers/euler2_solver.h
@@ -75,6 +75,7 @@ public:
    */
   virtual void integrate_qoi_timestep() override;
 
+#ifdef LIBMESH_ENABLE_AMR
   /**
    * A method to compute the adjoint refinement error estimate at the current timestep.
    * int_{tstep_start}^{tstep_end} R(u^h,z) dt.
@@ -84,6 +85,7 @@ public:
    * CURRENTLY ONLY SUPPORTED for Backward Euler.
    */
   virtual void integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error) override;
+#endif // LIBMESH_ENABLE_AMR
 
   /**
    * This method uses the DifferentiablePhysics'

--- a/include/solvers/euler_solver.h
+++ b/include/solvers/euler_solver.h
@@ -97,6 +97,7 @@ public:
    */
   virtual void integrate_qoi_timestep() override;
 
+#ifdef LIBMESH_ENABLE_AMR
   /**
    * A method to compute the adjoint refinement error estimate at the current timestep.
    * int_{tstep_start}^{tstep_end} R(u^h,z) dt
@@ -106,6 +107,7 @@ public:
    * CURRENTLY ONLY SUPPORTED for Backward Euler.
    */
   virtual void integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error) override;
+#endif // LIBMESH_ENABLE_AMR
 
   /**
    * The value for the theta method to employ: 1.0 corresponds

--- a/include/solvers/first_order_unsteady_solver.h
+++ b/include/solvers/first_order_unsteady_solver.h
@@ -92,7 +92,9 @@ public:
 
   virtual void integrate_qoi_timestep() override = 0;
 
+#ifdef LIBMESH_ENABLE_AMR
   virtual void integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error) override = 0;
+#endif // LIBMESH_ENABLE_AMR
 
 protected:
 

--- a/include/solvers/steady_solver.h
+++ b/include/solvers/steady_solver.h
@@ -122,6 +122,7 @@ public:
    */
   virtual void integrate_adjoint_sensitivity(const QoISet & qois, const ParameterVector & parameter_vector, SensitivityData & sensitivities) override;
 
+#ifdef LIBMESH_ENABLE_AMR
   /**
    * A method to compute the adjoint refinement error estimate at the current timestep.
    * int_{tstep_start}^{tstep_end} R(u^h,z) dt
@@ -130,6 +131,7 @@ public:
    * CURRENTLY ONLY SUPPORTED for Backward Euler.
    */
   virtual void integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error) override;
+#endif // LIBMESH_ENABLE_AMR
 
 protected:
 

--- a/include/solvers/time_solver.h
+++ b/include/solvers/time_solver.h
@@ -145,6 +145,7 @@ public:
    */
   virtual void integrate_adjoint_sensitivity(const QoISet & qois, const ParameterVector & parameter_vector, SensitivityData & sensitivities);
 
+#ifdef LIBMESH_ENABLE_AMR
   /**
    * A method to compute the adjoint refinement error estimate at the current timestep.
    * int_{tstep_start}^{tstep_end} R(u^h,z) dt
@@ -153,6 +154,7 @@ public:
    * CURRENTLY ONLY SUPPORTED for Backward Euler.
    */
   virtual void integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error);
+#endif // LIBMESH_ENABLE_AMR
 
   /**
    * This method uses the DifferentiablePhysics

--- a/include/solvers/twostep_time_solver.h
+++ b/include/solvers/twostep_time_solver.h
@@ -83,6 +83,7 @@ public:
    */
   virtual void integrate_adjoint_sensitivity(const QoISet & qois, const ParameterVector & parameter_vector, SensitivityData & sensitivities) override;
 
+#ifdef LIBMESH_ENABLE_AMR
   /**
    * A method to compute the adjoint refinement error estimate at the current timestep.
    * int_{tstep_start}^{tstep_end} R(u^h,z) dt
@@ -91,6 +92,7 @@ public:
    * CURRENTLY ONLY SUPPORTED for Backward Euler.
    */
   virtual void integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error) override;
+#endif // LIBMESH_ENABLE_AMR
 
 };
 

--- a/include/solvers/unsteady_solver.h
+++ b/include/solvers/unsteady_solver.h
@@ -129,6 +129,7 @@ public:
    */
   virtual void integrate_adjoint_sensitivity(const QoISet & qois, const ParameterVector & parameter_vector, SensitivityData & sensitivities) override;
 
+#ifdef LIBMESH_ENABLE_AMR
   /**
    * A method to compute the adjoint refinement error estimate at the current timestep.
    * int_{tstep_start}^{tstep_end} R(u^h,z) dt
@@ -137,6 +138,7 @@ public:
    * CURRENTLY ONLY SUPPORTED for Backward Euler.
    */
   virtual void integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & /*adjoint_refinement_error_estimator*/, ErrorVector & /*QoI_elementwise_error*/) override;
+#endif // LIBMESH_ENABLE_AMR
 
   /**
    * This method should return the expected convergence order of the

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -633,11 +633,11 @@ void DofMap::reinit(MeshBase & mesh)
           if (!vg_description.active_on_subdomain(elem->subdomain_id()))
             continue;
 
-          const ElemType type = elem->type();
-
           FEType fe_type = base_fe_type;
 
 #ifdef LIBMESH_ENABLE_AMR
+          const ElemType type = elem->type();
+
           // Make sure we haven't done more p refinement than we can
           // handle
           if (elem->p_level() + base_fe_type.order >

--- a/src/base/ghost_point_neighbors.C
+++ b/src/base/ghost_point_neighbors.C
@@ -125,6 +125,7 @@ void GhostPointNeighbors::operator()
               if (!equal_level_periodic_neigh || equal_level_periodic_neigh == remote_elem)
                 continue;
 
+#ifdef LIBMESH_ENABLE_AMR
               equal_level_periodic_neigh->active_family_tree_by_topological_neighbor(
                 active_periodic_neighbors,
                 elem,
@@ -132,6 +133,9 @@ void GhostPointNeighbors::operator()
                 *point_locator,
                 _periodic_bcs,
                 /*reset=*/true);
+#else
+              active_periodic_neighbors = { equal_level_periodic_neigh };
+#endif
 
               for (const Elem * const active_periodic_neigh : active_periodic_neighbors)
                 {

--- a/src/solvers/euler2_solver.C
+++ b/src/solvers/euler2_solver.C
@@ -318,6 +318,7 @@ void Euler2Solver::integrate_qoi_timestep()
   }
 }
 
+#ifdef LIBMESH_ENABLE_AMR
 void Euler2Solver::integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error)
 {
   // Currently, we only support this functionality when Backward-Euler time integration is used.
@@ -480,5 +481,6 @@ void Euler2Solver::integrate_adjoint_refinement_error_estimate(AdjointRefinement
   }
 
 }
+#endif // LIBMESH_ENABLE_AMR
 
 } // namespace libMesh

--- a/src/solvers/euler_solver.C
+++ b/src/solvers/euler_solver.C
@@ -251,6 +251,7 @@ void EulerSolver::integrate_qoi_timestep()
   }
 }
 
+#ifdef LIBMESH_ENABLE_AMR
 void EulerSolver::integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error)
 {
   // Currently, we only support this functionality when Backward-Euler time integration is used.
@@ -413,5 +414,6 @@ void EulerSolver::integrate_adjoint_refinement_error_estimate(AdjointRefinementE
   }
 
 }
+#endif // LIBMESH_ENABLE_AMR
 
 } // namespace libMesh

--- a/src/solvers/steady_solver.C
+++ b/src/solvers/steady_solver.C
@@ -109,6 +109,7 @@ void SteadySolver::integrate_adjoint_sensitivity(const QoISet & qois, const Para
   return;
 }
 
+#ifdef LIBMESH_ENABLE_AMR
 void SteadySolver::integrate_adjoint_refinement_error_estimate
   (AdjointRefinementEstimator & adjoint_refinement_error_estimator,
    ErrorVector & QoI_elementwise_error)
@@ -132,5 +133,6 @@ void SteadySolver::integrate_adjoint_refinement_error_estimate
 
   return;
 }
+#endif // LIBMESH_ENABLE_AMR
 
 } // namespace libMesh

--- a/src/solvers/time_solver.C
+++ b/src/solvers/time_solver.C
@@ -134,12 +134,14 @@ void TimeSolver::integrate_adjoint_sensitivity(const QoISet & /* qois */, const 
   libmesh_not_implemented();
 }
 
+#ifdef LIBMESH_ENABLE_AMR
 void TimeSolver::integrate_adjoint_refinement_error_estimate
   (AdjointRefinementEstimator & /* adjoint_refinement_error_estimator */,
    ErrorVector & /* QoI_elementwise_error */)
 {
   libmesh_not_implemented();
 }
+#endif // LIBMESH_ENABLE_AMR
 
 Real TimeSolver::last_completed_timestep_size()
 {

--- a/src/solvers/twostep_time_solver.C
+++ b/src/solvers/twostep_time_solver.C
@@ -380,6 +380,7 @@ void TwostepTimeSolver::integrate_adjoint_sensitivity(const QoISet & qois, const
      sensitivities[i][j] = sensitivities_first_half[i][j] + sensitivities_second_half[i][j];
 }
 
+#ifdef LIBMESH_ENABLE_AMR
 void TwostepTimeSolver::integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error)
 {
   // We use a numerical integration scheme consistent with the theta used for the timesolver.
@@ -431,5 +432,6 @@ void TwostepTimeSolver::integrate_adjoint_refinement_error_estimate(AdjointRefin
     }
   }
 }
+#endif // LIBMESH_ENABLE_AMR
 
 } // namespace libMesh

--- a/src/solvers/unsteady_solver.C
+++ b/src/solvers/unsteady_solver.C
@@ -310,10 +310,12 @@ void UnsteadySolver::integrate_qoi_timestep()
   libmesh_not_implemented();
 }
 
+#ifdef LIBMESH_ENABLE_AMR
 void UnsteadySolver::integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & /*adjoint_refinement_error_estimator*/, ErrorVector & /*QoI_elementwise_error*/)
 {
   libmesh_not_implemented();
 }
+#endif // LIBMESH_ENABLE_AMR
 
 Number UnsteadySolver::old_nonlinear_solution(const dof_id_type global_dof_number)
   const

--- a/tests/fe/inf_fe_radial_test.C
+++ b/tests/fe/inf_fe_radial_test.C
@@ -467,7 +467,8 @@ public:
 
   void testInfQuants_numericDeriv ()
   {
-#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+    // We use AMR internally to build_sphere
+#if defined(LIBMESH_ENABLE_INFINITE_ELEMENTS) && defined(LIBMESH_ENABLE_AMR)
     ReplicatedMesh mesh(*TestCommWorld);
     MeshTools::Generation::build_sphere
       (mesh, /*rad*/ 1,
@@ -648,7 +649,7 @@ public:
           }
       }
 
-#endif // LIBMESH_ENABLE_INFINITE_ELEMENTS
+#endif // LIBMESH_ENABLE_INFINITE_ELEMENTS && LIBMESH_ENABLE_AMR
   }
 
   void testDifferentOrders ()

--- a/tests/mesh/mesh_assign.C
+++ b/tests/mesh/mesh_assign.C
@@ -134,6 +134,7 @@ public:
         libmesh_error_msg("Error: specified mesh_type not understood");
        }
 
+#ifdef LIBMESH_ENABLE_AMR // We refine or read refined meshes for this test
        if(mesh_creation_type.compare("from_memory") == 0)
        {
          /**
@@ -199,6 +200,7 @@ public:
         {
          libmesh_error_msg("Error: invalid mesh two case type.");
         }
+#endif // LIBMESH_ENABLE_AMR
   }
 
   void testMeshMoveAssignFromMemory()


### PR DESCRIPTION
This should at least fix that one optional test from #2963.  I'm talking with @loganharbour to try to figure out how to make sure we don't wait this long between even oddball CI recipe invocations in the future.

Pinging @lindsayad to ask for a second set of eyes on my attempt to fix his GhostPointNeighbors code; everything else here is pretty trivial.