### PR TITLE
Skip ConstrainDirichlet on empty adjoint dirichlet boundaries

### DIFF
--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1857,10 +1857,14 @@ void DofMap::create_dof_constraints(const MeshBase & mesh, Real time)
 
       for (auto qoi_index : index_range(_adjoint_dirichlet_boundaries))
         {
-          Threads::parallel_for
-            (range.reset(),
-             ConstrainDirichlet(*this, mesh, time, *(_adjoint_dirichlet_boundaries[qoi_index]),
-                                AddAdjointConstraint(*this, qoi_index)));
+          const DirichletBoundaries & adb_q =
+            *(_adjoint_dirichlet_boundaries[qoi_index]);
+
+          if (!adb_q.empty())
+            Threads::parallel_for
+              (range.reset(),
+               ConstrainDirichlet(*this, mesh, time, adb_q,
+                                  AddAdjointConstraint(*this, qoi_index)));
         }
     }
 


### PR DESCRIPTION
Otherwise we can run into an assertion failure later.

This should fix the regression that was committed in #2761 and reported
in https://github.com/grinsfem/grins/issues/602