### PR TITLE
Add override keyword in several places

### DIFF
--- a/contrib/fparser/fparser_ad.hh
+++ b/contrib/fparser/fparser_ad.hh
@@ -196,10 +196,10 @@ protected:
 
   // Exceptions
   class UnknownVariable : public std::exception {
-    virtual const char* what() const throw() { return "Unknown variable"; }
+    virtual const char* what() const throw() override { return "Unknown variable"; }
   } UnknownVariableException;
   class UnknownSerializationVersion : public std::exception {
-    virtual const char* what() const throw() { return "Unknown serialization file version"; }
+    virtual const char* what() const throw() override { return "Unknown serialization file version"; }
   } UnknownSerializationVersionException;
 };
 

--- a/include/base/libmesh_exceptions.h
+++ b/include/base/libmesh_exceptions.h
@@ -124,7 +124,7 @@ public:
   /**
    * Override the what() function to provide a generic error message.
    */
-  virtual const char * what() const noexcept
+  virtual const char * what() const noexcept override
   {
     // std::string::c_str() is noexcept in C++11, so it's safe to call
     // in what() because it can't throw.

--- a/include/error_estimation/adjoint_refinement_estimator.h
+++ b/include/error_estimation/adjoint_refinement_estimator.h
@@ -97,7 +97,7 @@ public:
   virtual void estimate_error (const System & system,
                                ErrorVector & error_per_cell,
                                const NumericVector<Number> * solution_vector = nullptr,
-                               bool estimate_parent_error = false);
+                               bool estimate_parent_error = false) override;
 
   /**
    * This is an accessor function to access the computed global
@@ -108,7 +108,7 @@ public:
     return computed_global_QoI_errors[qoi_index];
   }
 
-  virtual ErrorEstimatorType type() const;
+  virtual ErrorEstimatorType type() const override;
 
   /**
    * How many h refinements to perform to get the fine grid

--- a/include/numerics/const_fem_function.h
+++ b/include/numerics/const_fem_function.h
@@ -56,18 +56,18 @@ public:
   ConstFEMFunction & operator= (ConstFEMFunction &&) = default;
   virtual ~ConstFEMFunction () = default;
 
-  virtual std::unique_ptr<FEMFunctionBase<Output>> clone () const
+  virtual std::unique_ptr<FEMFunctionBase<Output>> clone () const override
   {return libmesh_make_unique<ConstFEMFunction>(*this); }
 
   virtual Output operator() (const FEMContext &,
                              const Point &,
-                             const Real /* time */ = 0.)
+                             const Real /* time */ = 0.) override
   { return _c; }
 
   virtual void operator() (const FEMContext &,
                            const Point &,
                            const Real,
-                           DenseVector<Output> & output)
+                           DenseVector<Output> & output) override
   {
     for (auto i : index_range(output))
       output(i) = _c;

--- a/include/numerics/parsed_fem_function_parameter.h
+++ b/include/numerics/parsed_fem_function_parameter.h
@@ -72,14 +72,14 @@ public:
   /**
    * Setter: change the value of the parameter we access.
    */
-  virtual void set (const T & new_value) {
+  virtual void set (const T & new_value) override {
     _func.set_inline_value(_name, new_value);
   }
 
   /**
    * \returns A constant reference to the value of the parameter we access.
    */
-  virtual const T & get () const {
+  virtual const T & get () const override {
     _current_val = _func.get_inline_value(_name);
     return _current_val;
   }
@@ -87,7 +87,7 @@ public:
   /**
    * \returns A new copy of the accessor.
    */
-  virtual std::unique_ptr<ParameterAccessor<T>> clone() const {
+  virtual std::unique_ptr<ParameterAccessor<T>> clone() const override {
     return libmesh_make_unique<ParsedFEMFunctionParameter<T>>(_func, _name);
   }
 

--- a/include/numerics/parsed_function_parameter.h
+++ b/include/numerics/parsed_function_parameter.h
@@ -70,14 +70,14 @@ public:
   /**
    * Setter: change the value of the parameter we access.
    */
-  virtual void set (const T & new_value) {
+  virtual void set (const T & new_value) override {
     _func.set_inline_value(_name, new_value);
   }
 
   /**
    * Getter: get the value of the parameter we access.
    */
-  virtual const T & get () const {
+  virtual const T & get () const override {
     _current_val = _func.get_inline_value(_name);
     return _current_val;
   }
@@ -85,7 +85,7 @@ public:
   /**
    * \returns A new copy of the accessor.
    */
-  virtual std::unique_ptr<ParameterAccessor<T>> clone() const {
+  virtual std::unique_ptr<ParameterAccessor<T>> clone() const override {
     return libmesh_make_unique<ParsedFunctionParameter<T>>(_func, _name);
   }
 

--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -81,6 +81,8 @@
 #pragma GCC diagnostic ignored "-Wlogical-op"
 // Ignore warnings from code that uses deprecated members of std, like std::auto_ptr.
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// This is mostly for the (deprecated...) C++ MPI wrappers
+#pragma GCC diagnostic ignored "-Wsuggest-override"
 #if (__GNUC__ > 5)
 // Ignore this for VTK
 #pragma GCC diagnostic ignored "-Wfloat-conversion"

--- a/include/utils/parameters.h
+++ b/include/utils/parameters.h
@@ -215,18 +215,18 @@ public:
     /**
      * String identifying the type of parameter stored.
      */
-    virtual std::string type () const;
+    virtual std::string type () const override;
 #endif // LIBMESH_HAVE_RTTI
 
     /**
      * Prints the parameter value to the specified stream.
      */
-    virtual void print(std::ostream &) const;
+    virtual void print(std::ostream &) const override;
 
     /**
      * Clone this value.  Useful in copy-construction.
      */
-    virtual Value * clone () const;
+    virtual Value * clone () const override;
 
   private:
     /**


### PR DESCRIPTION
As suggested by GCC's `-Wsuggest-override`. I want to call out 86f7175 since that changes `fparser`. I'm not sure if we forked `fparser` or not, so if not, we may want to exclude this commit from the PR and try to upstream it instead. This and libMesh/TIMPI#71 get all the libMesh-based warnings silenced when I build GRINS with `-Wsuggest-override`. I didn't drop this warning in libMesh yet so there may be others if we add this warning to libMesh proper.