### PR TITLE
Enable plotting of EIM functions

### DIFF
--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -96,6 +96,11 @@ public:
   RBEIMEvaluation & get_rb_eim_evaluation();
 
   /**
+   * Get a const reference to the RBEvaluation object.
+   */
+  const RBEIMEvaluation & get_rb_eim_evaluation() const;
+
+  /**
    * Perform initialization of this object to prepare for running
    * train_eim_approximation().
    */
@@ -201,6 +206,12 @@ public:
    * initializing the look-up table data.
    */
   void store_eim_solutions_for_training_set();
+
+  /**
+   * Get a const reference to the specified parametrized function from
+   * the training set.
+   */
+  const QpDataMap & get_parametrized_function_from_training_set(unsigned int training_index) const;
 
   /**
    * Enum that indicates which type of "best fit" algorithm
@@ -331,6 +342,15 @@ private:
    * The training sample index at which we found _max_abs_value_in_training_set.
    */
   unsigned int _max_abs_value_in_training_set_index;
+
+  /**
+   * Keep track of a scaling factor for each component of the parametrized functions in
+   * the training set which "scales up" each component to have a similar magnitude as
+   * the largest component encountered in the training set. This can give more uniform
+   * scaling across all components and is helpful in cases where components have widely
+   * varying magnitudes.
+   */
+  std::vector<Real> _component_scaling_in_training_set;
 
   /**
    * The quadrature point locations, quadrature point weights (JxW), and subdomain IDs

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -336,6 +336,36 @@ public:
                                const std::string & directory_name = "offline_data",
                                bool read_binary_basis_functions = true);
 
+  /**
+   * Project variable \p var of \p bf_data into the solution vector of System.
+   */
+  void project_qp_data_map_onto_system(System & sys,
+                                       const QpDataMap & bf_data,
+                                       unsigned int var);
+
+  /**
+   * Return a set that specifies which EIM variables will be projected
+   * and written out in write_out_projected_basis_functions().
+   * By default this returns an empty vector, but can be overridden in
+   * subclasses to specify the EIM variables that are relevant for visualization.
+   */
+  virtual std::set<unsigned int> get_eim_vars_to_project_and_write() const;
+
+  /**
+   * Project all basis functions using project_qp_data_map_onto_system() and
+   * then write out the resulting vectors.
+   */
+  void write_out_projected_basis_functions(System & sys,
+                                           const std::string & directory_name = "offline_data");
+
+  /**
+   * Indicate whether we should apply scaling to the components of the parametrized
+   * function during basis function enrichment in order give an approximately uniform
+   * magnitude for all components. This is helpful in cases where the components vary
+   * widely in magnitude.
+   */
+  virtual bool scale_components_in_enrichment() const;
+
 private:
 
   /**

--- a/include/reduced_basis/rb_evaluation.h
+++ b/include/reduced_basis/rb_evaluation.h
@@ -206,11 +206,11 @@ public:
    * Same as write_out_basis_functions, except in this case we pass in the vectors to be
    * written.
    */
-  virtual void write_out_vectors(System & sys,
-                                 std::vector<NumericVector<Number>*> & vectors,
-                                 const std::string & directory_name = "offline_data",
-                                 const std::string & data_name = "bf",
-                                 const bool write_binary_basis_functions = true);
+  static void write_out_vectors(System & sys,
+                                std::vector<NumericVector<Number>*> & vectors,
+                                const std::string & directory_name = "offline_data",
+                                const std::string & data_name = "bf",
+                                const bool write_binary_basis_functions = true);
 
   /**
    * Read in all the basis functions from file.
@@ -228,11 +228,11 @@ public:
    * written. We assume that the size of vectors indicates the number of vectors
    * that need to be read in.
    */
-  void read_in_vectors(System & sys,
-                       std::vector<std::unique_ptr<NumericVector<Number>>> & vectors,
-                       const std::string & directory_name,
-                       const std::string & data_name,
-                       const bool read_binary_vectors);
+  static void read_in_vectors(System & sys,
+                              std::vector<std::unique_ptr<NumericVector<Number>>> & vectors,
+                              const std::string & directory_name,
+                              const std::string & data_name,
+                              const bool read_binary_vectors);
 
   /**
    * Performs read_in_vectors for a list of directory names and data names.
@@ -240,11 +240,11 @@ public:
    * way. This function only renumbers the dofs once at the start (and reverts
    * it at the end), which can save a lot of work compared to renumbering on every read.
    */
-  void read_in_vectors_from_multiple_files(System & sys,
-                                           std::vector<std::vector<std::unique_ptr<NumericVector<Number>>> *> multiple_vectors,
-                                           const std::vector<std::string> & multiple_directory_names,
-                                           const std::vector<std::string> & multiple_data_names,
-                                           const bool read_binary_vectors);
+  static void read_in_vectors_from_multiple_files(System & sys,
+                                                  std::vector<std::vector<std::unique_ptr<NumericVector<Number>>> *> multiple_vectors,
+                                                  const std::vector<std::string> & multiple_directory_names,
+                                                  const std::vector<std::string> & multiple_data_names,
+                                                  const bool read_binary_vectors);
 
   //----------- PUBLIC DATA MEMBERS -----------//
 
@@ -345,7 +345,7 @@ protected:
   /**
    * Helper function that checks if \p file_name exists.
    */
-  void assert_file_exists(const std::string & file_name);
+  static void assert_file_exists(const std::string & file_name);
 
 private:
 

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -1204,14 +1204,9 @@ void RBEIMEvaluation::project_qp_data_map_onto_system(System & sys,
   sys.solution->close();
   repeat_count->close();
 
-  numeric_index_type first = sys.solution->first_local_index();
-  numeric_index_type last = sys.solution->last_local_index();
-  for (numeric_index_type i=first; i<last; i++)
-    {
-      Number soln_value = (*sys.solution)(i);
-      Number repeat_count_value = (*repeat_count)(i);
-      sys.solution->set(i, soln_value/repeat_count_value);
-    }
+  // Average the projected QP values to get nodal values
+  (*sys.solution) /= (*repeat_count);
+
   sys.solution->close();
 }
 

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -944,14 +944,14 @@ void RBEvaluation::write_out_vectors(System & sys,
 {
   LOG_SCOPE("write_out_vectors()", "RBEvaluation");
 
-  if (this->processor_id() == 0)
+  if (sys.comm().rank() == 0)
     {
       // Make a directory to store all the data files
       Utility::mkdir(directory_name.c_str());
     }
 
   // Make sure processors are synced up before we begin
-  this->comm().barrier();
+  sys.comm().barrier();
 
   std::ostringstream file_name;
   const std::string basis_function_suffix = (write_binary_vectors ? ".xdr" : ".dat");
@@ -1046,7 +1046,7 @@ void RBEvaluation::read_in_vectors_from_multiple_files(System & sys,
     return;
 
   // Make sure processors are synced up before we begin
-  this->comm().barrier();
+  sys.comm().barrier();
 
   std::ostringstream file_name;
   const std::string basis_function_suffix = (read_binary_vectors ? ".xdr" : ".dat");
@@ -1081,7 +1081,7 @@ void RBEvaluation::read_in_vectors_from_multiple_files(System & sys,
                 << "_data" << basis_function_suffix;
 
       // On processor zero check to be sure the file exists
-      if (this->processor_id() == 0)
+      if (sys.comm().rank() == 0)
         {
           struct stat stat_info;
           int stat_result = stat(file_name.str().c_str(), &stat_info);


### PR DESCRIPTION
Enable plotting of EIM functions (e.g. basis functions or training functions). These functions are stored at quadrature points, so this enables plotting based on L2-projection of the quadrature point data into the FE space. Updated reduced_basis_ex4 to plot some EIM functions.

This does not change any existing behavior.