### PR TITLE
fparser: update deprecated throw specifications

### DIFF
--- a/contrib/fparser/fparser_ad.cc
+++ b/contrib/fparser/fparser_ad.cc
@@ -94,10 +94,10 @@ private:
 
   // Exceptions
   class UnsupportedOpcode : public std::exception {
-    virtual const char* what() const throw() { return "Unsupported opcode"; }
+    virtual const char* what() const noexcept { return "Unsupported opcode"; }
   } UnsupportedOpcodeException;
   class RefuseToTakeCrazyDerivative : public std::exception {
-    virtual const char* what() const throw() { return "The derivative of this expression would be undefined at a countable number of points."; }
+    virtual const char* what() const noexcept { return "The derivative of this expression would be undefined at a countable number of points."; }
   } RefuseToTakeCrazyDerivativeException;
 };
 

--- a/contrib/fparser/fparser_ad.hh
+++ b/contrib/fparser/fparser_ad.hh
@@ -196,10 +196,10 @@ protected:
 
   // Exceptions
   class UnknownVariable : public std::exception {
-    virtual const char* what() const throw() override { return "Unknown variable"; }
+    virtual const char* what() const noexcept override { return "Unknown variable"; }
   } UnknownVariableException;
   class UnknownSerializationVersion : public std::exception {
-    virtual const char* what() const throw() override { return "Unknown serialization file version"; }
+    virtual const char* what() const noexcept override { return "Unknown serialization file version"; }
   } UnknownSerializationVersionException;
 };
 


### PR DESCRIPTION
[The C++03 "throw()" specification is deprecated, and should be replaced with "noexcept" where possible](https://stackoverflow.com/questions/22352927/throw-after-function-declaration-in-c-exception-struct).

I noticed this in the diff for 86f717579 where the `override` keyword was added.