### PR TITLE
Deprecate Elem::centroid(), add Elem::true_centroid() and Elem::vertex_average() alternatives

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex14/miscellaneous_ex14.C
+++ b/examples/miscellaneous/miscellaneous_ex14/miscellaneous_ex14.C
@@ -612,7 +612,7 @@ void assemble_SchroedingerEquation(EquationSystems &es, const std::string &syste
             Real tol=0.01*elem->hmin();
             while (found_s==0){
                for(unsigned int n=0; n< elem->n_sides(); n++){
-                  if (relevant_neighbor->close_to_point(elem->side_ptr(n)->centroid(), tol)){
+                  if (relevant_neighbor->close_to_point(elem->side_ptr(n)->vertex_average(), tol)){
                      found_s++;
                      side=n;
 #ifndef DEBUG

--- a/examples/miscellaneous/miscellaneous_ex9/augment_sparsity_on_interface.C
+++ b/examples/miscellaneous/miscellaneous_ex9/augment_sparsity_on_interface.C
@@ -31,9 +31,9 @@ void AugmentSparsityOnInterface::mesh_reinit ()
   // Loop over all elements (not just local elements) to make sure we find
   // "neighbor" elements on opposite sides of the crack.
 
-  // Map from (elem, side) to centroid
-  std::map<std::pair<const Elem *, unsigned char>, Point> lower_centroids;
-  std::map<std::pair<const Elem *, unsigned char>, Point> upper_centroids;
+  // Map from (elem, side) to vertex average
+  std::map<std::pair<const Elem *, unsigned char>, Point> lower_avgs;
+  std::map<std::pair<const Elem *, unsigned char>, Point> upper_avgs;
 
   for (const auto & elem : _mesh.active_element_ptr_range())
     for (auto side : elem->side_index_range())
@@ -43,22 +43,22 @@ void AugmentSparsityOnInterface::mesh_reinit ()
             {
               std::unique_ptr<const Elem> side_elem = elem->build_side_ptr(side);
 
-              lower_centroids[std::make_pair(elem, side)] = side_elem->vertex_average();
+              lower_avgs[std::make_pair(elem, side)] = side_elem->vertex_average();
             }
 
           if (_mesh.get_boundary_info().has_boundary_id(elem, side, _crack_boundary_upper))
             {
               std::unique_ptr<const Elem> side_elem = elem->build_side_ptr(side);
 
-              upper_centroids[std::make_pair(elem, side)] = side_elem->vertex_average();
+              upper_avgs[std::make_pair(elem, side)] = side_elem->vertex_average();
             }
         }
 
   // If we're doing a reinit on a distributed mesh then we may not see
-  // all the centroids, or even a matching number of centroids.
-  // std::size_t n_lower_centroids = lower_centroids.size();
-  // std::size_t n_upper_centroids = upper_centroids.size();
-  // libmesh_assert(n_lower_centroids == n_upper_centroids);
+  // all the vertex averages, or even a matching number of vertex averages.
+  // std::size_t n_lower_avgs = lower_avgs.size();
+  // std::size_t n_upper_avgs = upper_avgs.size();
+  // libmesh_assert(n_lower_avgs == n_upper_avgs);
 
   // Clear _lower_to_upper. This map will be used for matrix assembly later on.
   _lower_to_upper.clear();
@@ -68,26 +68,26 @@ void AugmentSparsityOnInterface::mesh_reinit ()
   // parallel, and sparsity calculations
   _upper_to_lower.clear();
 
-  // We do an N^2 search to find elements with matching centroids. This could be optimized,
-  // e.g. by first sorting the centroids based on their (x,y,z) location.
+  // We do an N^2 search to find elements with matching vertex averages. This could be optimized,
+  // e.g. by first sorting the vertex averages based on their (x,y,z) location.
   {
-    std::map<std::pair<const Elem *, unsigned char>, Point>::iterator it     = lower_centroids.begin();
-    std::map<std::pair<const Elem *, unsigned char>, Point>::iterator it_end = lower_centroids.end();
+    std::map<std::pair<const Elem *, unsigned char>, Point>::iterator it     = lower_avgs.begin();
+    std::map<std::pair<const Elem *, unsigned char>, Point>::iterator it_end = lower_avgs.end();
     for ( ; it != it_end; ++it)
       {
-        Point lower_centroid = it->second;
+        Point lower_avg = it->second;
 
-        // find closest centroid in upper_centroids
+        // find closest vertex average in upper_avgs
         Real min_distance = std::numeric_limits<Real>::max();
 
-        std::map<std::pair<const Elem *, unsigned char>, Point>::iterator inner_it     = upper_centroids.begin();
-        std::map<std::pair<const Elem *, unsigned char>, Point>::iterator inner_it_end = upper_centroids.end();
+        std::map<std::pair<const Elem *, unsigned char>, Point>::iterator inner_it     = upper_avgs.begin();
+        std::map<std::pair<const Elem *, unsigned char>, Point>::iterator inner_it_end = upper_avgs.end();
 
         for ( ; inner_it != inner_it_end; ++inner_it)
           {
-            Point upper_centroid = inner_it->second;
+            Point upper_avg = inner_it->second;
 
-            Real distance = (upper_centroid - lower_centroid).norm();
+            Real distance = (upper_avg - lower_avg).norm();
             if (distance < min_distance)
               {
                 min_distance = distance;
@@ -115,8 +115,8 @@ void AugmentSparsityOnInterface::mesh_reinit ()
 
     // Let's make sure we didn't miss any upper elements either
 #ifndef NDEBUG
-    std::map<std::pair<const Elem *, unsigned char>, Point>::iterator inner_it     = upper_centroids.begin();
-    std::map<std::pair<const Elem *, unsigned char>, Point>::iterator inner_it_end = upper_centroids.end();
+    std::map<std::pair<const Elem *, unsigned char>, Point>::iterator inner_it     = upper_avgs.begin();
+    std::map<std::pair<const Elem *, unsigned char>, Point>::iterator inner_it_end = upper_avgs.end();
 
     for ( ; inner_it != inner_it_end; ++inner_it)
       {

--- a/examples/miscellaneous/miscellaneous_ex9/augment_sparsity_on_interface.C
+++ b/examples/miscellaneous/miscellaneous_ex9/augment_sparsity_on_interface.C
@@ -43,14 +43,14 @@ void AugmentSparsityOnInterface::mesh_reinit ()
             {
               std::unique_ptr<const Elem> side_elem = elem->build_side_ptr(side);
 
-              lower_centroids[std::make_pair(elem, side)] = side_elem->centroid();
+              lower_centroids[std::make_pair(elem, side)] = side_elem->vertex_average();
             }
 
           if (_mesh.get_boundary_info().has_boundary_id(elem, side, _crack_boundary_upper))
             {
               std::unique_ptr<const Elem> side_elem = elem->build_side_ptr(side);
 
-              upper_centroids[std::make_pair(elem, side)] = side_elem->centroid();
+              upper_centroids[std::make_pair(elem, side)] = side_elem->vertex_average();
             }
         }
 

--- a/examples/miscellaneous/miscellaneous_ex9/augment_sparsity_on_interface.C
+++ b/examples/miscellaneous/miscellaneous_ex9/augment_sparsity_on_interface.C
@@ -32,8 +32,8 @@ void AugmentSparsityOnInterface::mesh_reinit ()
   // "neighbor" elements on opposite sides of the crack.
 
   // Map from (elem, side) to vertex average
-  std::map<std::pair<const Elem *, unsigned char>, Point> lower_avgs;
-  std::map<std::pair<const Elem *, unsigned char>, Point> upper_avgs;
+  std::map<std::pair<const Elem *, unsigned char>, Point> lower;
+  std::map<std::pair<const Elem *, unsigned char>, Point> upper;
 
   for (const auto & elem : _mesh.active_element_ptr_range())
     for (auto side : elem->side_index_range())
@@ -43,22 +43,22 @@ void AugmentSparsityOnInterface::mesh_reinit ()
             {
               std::unique_ptr<const Elem> side_elem = elem->build_side_ptr(side);
 
-              lower_avgs[std::make_pair(elem, side)] = side_elem->vertex_average();
+              lower[std::make_pair(elem, side)] = side_elem->vertex_average();
             }
 
           if (_mesh.get_boundary_info().has_boundary_id(elem, side, _crack_boundary_upper))
             {
               std::unique_ptr<const Elem> side_elem = elem->build_side_ptr(side);
 
-              upper_avgs[std::make_pair(elem, side)] = side_elem->vertex_average();
+              upper[std::make_pair(elem, side)] = side_elem->vertex_average();
             }
         }
 
   // If we're doing a reinit on a distributed mesh then we may not see
   // all the vertex averages, or even a matching number of vertex averages.
-  // std::size_t n_lower_avgs = lower_avgs.size();
-  // std::size_t n_upper_avgs = upper_avgs.size();
-  // libmesh_assert(n_lower_avgs == n_upper_avgs);
+  // std::size_t n_lower = lower.size();
+  // std::size_t n_upper = upper.size();
+  // libmesh_assert(n_lower == n_upper);
 
   // Clear _lower_to_upper. This map will be used for matrix assembly later on.
   _lower_to_upper.clear();
@@ -71,34 +71,31 @@ void AugmentSparsityOnInterface::mesh_reinit ()
   // We do an N^2 search to find elements with matching vertex averages. This could be optimized,
   // e.g. by first sorting the vertex averages based on their (x,y,z) location.
   {
-    std::map<std::pair<const Elem *, unsigned char>, Point>::iterator it     = lower_avgs.begin();
-    std::map<std::pair<const Elem *, unsigned char>, Point>::iterator it_end = lower_avgs.end();
-    for ( ; it != it_end; ++it)
+    for (const auto & lower_pr : lower)
       {
-        Point lower_avg = it->second;
+        const auto & lower_key = lower_pr.first;
+        const Point & lower_val = lower_pr.second;
 
-        // find closest vertex average in upper_avgs
+        // find closest vertex average in upper
         Real min_distance = std::numeric_limits<Real>::max();
 
-        std::map<std::pair<const Elem *, unsigned char>, Point>::iterator inner_it     = upper_avgs.begin();
-        std::map<std::pair<const Elem *, unsigned char>, Point>::iterator inner_it_end = upper_avgs.end();
-
-        for ( ; inner_it != inner_it_end; ++inner_it)
+        for (const auto & upper_pr : upper)
           {
-            Point upper_avg = inner_it->second;
+            const auto & upper_key = upper_pr.first;
+            const Point & upper_val = upper_pr.second;
 
-            Real distance = (upper_avg - lower_avg).norm();
+            Real distance = (upper_val - lower_val).norm();
             if (distance < min_distance)
               {
                 min_distance = distance;
-                _lower_to_upper[it->first] = inner_it->first.first;
+                _lower_to_upper[lower_key] = upper_key.first;
               }
           }
 
         // For pairs with local elements, we should have found a
         // matching pair by now.
-        const Elem * elem     = it->first.first;
-        const Elem * neighbor = _lower_to_upper[it->first];
+        const Elem * elem     = lower_key.first;
+        const Elem * neighbor = _lower_to_upper[lower_key];
         if (min_distance < TOLERANCE)
           {
             // fill up the inverse map
@@ -109,18 +106,15 @@ void AugmentSparsityOnInterface::mesh_reinit ()
             libmesh_assert_not_equal_to(elem->processor_id(), _mesh.processor_id());
             // This must have a false positive; a remote element would
             // have been closer.
-            _lower_to_upper.erase(it->first);
+            _lower_to_upper.erase(lower_key);
           }
       }
 
     // Let's make sure we didn't miss any upper elements either
 #ifndef NDEBUG
-    std::map<std::pair<const Elem *, unsigned char>, Point>::iterator inner_it     = upper_avgs.begin();
-    std::map<std::pair<const Elem *, unsigned char>, Point>::iterator inner_it_end = upper_avgs.end();
-
-    for ( ; inner_it != inner_it_end; ++inner_it)
+    for (const auto & upper_pr : upper)
       {
-        const Elem * neighbor = inner_it->first.first;
+        const Elem * neighbor = upper_pr.first.first;
         if (neighbor->processor_id() != _mesh.processor_id())
           continue;
         ElementMap::const_iterator utl_it =

--- a/examples/reduced_basis/reduced_basis_ex1/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex1/assembly.h
@@ -181,9 +181,9 @@ struct OutputAssembly : ElemAssembly
 
     Real output_area = (max_x-min_x) * (max_y-min_y);
 
-    Point centroid = c.get_elem().vertex_average();
-    if ((min_x <= centroid(0)) && (centroid(0) <= max_x) &&
-        (min_y <= centroid(1)) && (centroid(1) <= max_y))
+    Point avg = c.get_elem().vertex_average();
+    if ((min_x <= avg(0)) && (avg(0) <= max_x) &&
+        (min_y <= avg(1)) && (avg(1) <= max_y))
       for (unsigned int qp=0; qp != n_qpoints; qp++)
         for (unsigned int i=0; i != n_u_dofs; i++)
           c.get_elem_residual()(i) += JxW[qp] * (1.*phi[i][qp]) / output_area;

--- a/examples/reduced_basis/reduced_basis_ex1/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex1/assembly.h
@@ -181,7 +181,7 @@ struct OutputAssembly : ElemAssembly
 
     Real output_area = (max_x-min_x) * (max_y-min_y);
 
-    Point centroid = c.get_elem().centroid();
+    Point centroid = c.get_elem().vertex_average();
     if ((min_x <= centroid(0)) && (centroid(0) <= max_x) &&
         (min_y <= centroid(1)) && (centroid(1) <= max_y))
       for (unsigned int qp=0; qp != n_qpoints; qp++)

--- a/examples/reduced_basis/reduced_basis_ex2/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex2/assembly.h
@@ -94,7 +94,7 @@ struct A0 : ElemAssembly
       min_x=0.,
       max_x=0.5;
 
-    Point centroid = c.get_elem().centroid();
+    Point centroid = c.get_elem().vertex_average();
     if ((min_x <= centroid(0)) && (centroid(0) < max_x))
       for (unsigned int qp=0; qp != n_qpoints; qp++)
         for (unsigned int i=0; i != n_u_dofs; i++)
@@ -129,7 +129,7 @@ struct A1 : ElemAssembly
       min_x=0.5,
       max_x=1.;
 
-    Point centroid = c.get_elem().centroid();
+    Point centroid = c.get_elem().vertex_average();
     if ((min_x <= centroid(0)) && (centroid(0) <= max_x))
       for (unsigned int qp=0; qp != n_qpoints; qp++)
         for (unsigned int i=0; i != n_u_dofs; i++)
@@ -224,7 +224,7 @@ struct OutputAssembly : ElemAssembly
 
     Real output_area = (max_x-min_x) * (max_y-min_y);
 
-    Point centroid = c.get_elem().centroid();
+    Point centroid = c.get_elem().vertex_average();
     if ((min_x <= centroid(0)) && (centroid(0) <= max_x) &&
         (min_y <= centroid(1)) && (centroid(1) <= max_y))
       for (unsigned int qp=0; qp != n_qpoints; qp++)

--- a/examples/reduced_basis/reduced_basis_ex2/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex2/assembly.h
@@ -94,8 +94,8 @@ struct A0 : ElemAssembly
       min_x=0.,
       max_x=0.5;
 
-    Point centroid = c.get_elem().vertex_average();
-    if ((min_x <= centroid(0)) && (centroid(0) < max_x))
+    Point avg = c.get_elem().vertex_average();
+    if ((min_x <= avg(0)) && (avg(0) < max_x))
       for (unsigned int qp=0; qp != n_qpoints; qp++)
         for (unsigned int i=0; i != n_u_dofs; i++)
           for (unsigned int j=0; j != n_u_dofs; j++)
@@ -129,8 +129,8 @@ struct A1 : ElemAssembly
       min_x=0.5,
       max_x=1.;
 
-    Point centroid = c.get_elem().vertex_average();
-    if ((min_x <= centroid(0)) && (centroid(0) <= max_x))
+    Point avg = c.get_elem().vertex_average();
+    if ((min_x <= avg(0)) && (avg(0) <= max_x))
       for (unsigned int qp=0; qp != n_qpoints; qp++)
         for (unsigned int i=0; i != n_u_dofs; i++)
           for (unsigned int j=0; j != n_u_dofs; j++)
@@ -224,9 +224,9 @@ struct OutputAssembly : ElemAssembly
 
     Real output_area = (max_x-min_x) * (max_y-min_y);
 
-    Point centroid = c.get_elem().vertex_average();
-    if ((min_x <= centroid(0)) && (centroid(0) <= max_x) &&
-        (min_y <= centroid(1)) && (centroid(1) <= max_y))
+    Point avg = c.get_elem().vertex_average();
+    if ((min_x <= avg(0)) && (avg(0) <= max_x) &&
+        (min_y <= avg(1)) && (avg(1) <= max_y))
       for (unsigned int qp=0; qp != n_qpoints; qp++)
         for (unsigned int i=0; i != n_u_dofs; i++)
           c.get_elem_residual()(i) += JxW[qp] * (1.*phi[i][qp]) / output_area;

--- a/examples/reduced_basis/reduced_basis_ex3/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex3/assembly.h
@@ -209,7 +209,7 @@ struct OutputAssembly : ElemAssembly
 
     Real output_area = (max_x-min_x) * (max_y-min_y);
 
-    Point centroid = c.get_elem().centroid();
+    Point centroid = c.get_elem().vertex_average();
     if ((min_x <= centroid(0)) && (centroid(0) <= max_x) &&
         (min_y <= centroid(1)) && (centroid(1) <= max_y))
       for (unsigned int qp=0; qp != n_qpoints; qp++)

--- a/examples/reduced_basis/reduced_basis_ex3/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex3/assembly.h
@@ -209,9 +209,9 @@ struct OutputAssembly : ElemAssembly
 
     Real output_area = (max_x-min_x) * (max_y-min_y);
 
-    Point centroid = c.get_elem().vertex_average();
-    if ((min_x <= centroid(0)) && (centroid(0) <= max_x) &&
-        (min_y <= centroid(1)) && (centroid(1) <= max_y))
+    Point avg = c.get_elem().vertex_average();
+    if ((min_x <= avg(0)) && (avg(0) <= max_x) &&
+        (min_y <= avg(1)) && (avg(1) <= max_y))
       for (unsigned int qp=0; qp != n_qpoints; qp++)
         for (unsigned int i=0; i != n_u_dofs; i++)
           c.get_elem_residual()(i) += JxW[qp] * (1.*phi[i][qp]) / output_area;

--- a/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
+++ b/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
@@ -171,7 +171,7 @@ int main(int argc, char ** argv)
         for (auto side : elem->side_index_range())
           if (!elem->neighbor_ptr(side))
             {
-              Point side_center = elem->build_side_ptr(side)->centroid();
+              Point side_center = elem->build_side_ptr(side)->vertex_average();
               // Yes, BOUNDARY_ID_MIN_X is a weird ID to use at
               // min(z), but we got an IGA cantilever mesh with the
               // lever arm in the z direction

--- a/examples/subdomains/subdomains_ex1/subdomains_ex1.C
+++ b/examples/subdomains/subdomains_ex1/subdomains_ex1.C
@@ -238,7 +238,7 @@ int main (int argc, char ** argv)
   // Print information about the mesh to the screen.
   mesh.print_info();
 
-  // Now set the subdomain_id of all elements whose centroid is inside
+  // Now set the subdomain_id of all elements whose vertex average is inside
   // the circle to 1.
   for (auto elem : mesh.element_ptr_range())
     {

--- a/examples/subdomains/subdomains_ex1/subdomains_ex1.C
+++ b/examples/subdomains/subdomains_ex1/subdomains_ex1.C
@@ -242,7 +242,7 @@ int main (int argc, char ** argv)
   // the circle to 1.
   for (auto elem : mesh.element_ptr_range())
     {
-      Real d = elem->centroid().norm();
+      Real d = elem->vertex_average().norm();
       if (d < 0.8)
         elem->subdomain_id() = 1;
     }

--- a/examples/subdomains/subdomains_ex2/subdomains_ex2.C
+++ b/examples/subdomains/subdomains_ex2/subdomains_ex2.C
@@ -189,7 +189,7 @@ int main (int argc, char ** argv)
 
   for (auto & elem : mesh.element_ptr_range())
     {
-      const Point cent = elem->centroid();
+      const Point cent = elem->vertex_average();
       if (dim > 1)
         {
           if ((cent(0) > 0) == (cent(1) > 0))

--- a/include/geom/cell_pyramid5.h
+++ b/include/geom/cell_pyramid5.h
@@ -182,6 +182,13 @@ public:
   static const unsigned int edge_sides_map[num_edges][2];
 
   /**
+   * According to Wikipedia: The centroid of a 5-node pyramid is 1/4
+   * of the way up from the base on the line segment connecting the
+   * centroid of the base and the Pyramid apex..
+   */
+  virtual Point centroid () const override;
+
+  /**
    * Specialization for computing the volume of a pyramid.
    */
   virtual Real volume () const override;

--- a/include/geom/cell_pyramid5.h
+++ b/include/geom/cell_pyramid5.h
@@ -186,7 +186,7 @@ public:
    * of the way up from the base on the line segment connecting the
    * centroid of the base and the Pyramid apex..
    */
-  virtual Point centroid () const override;
+  virtual Point true_centroid () const override;
 
   /**
    * Specialization for computing the volume of a pyramid.

--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -210,7 +210,7 @@ public:
    * The centroid of a 4-node tetrahedron is simply given by the
    * average of its vertex positions.
    */
-  virtual Point centroid () const override;
+  virtual Point true_centroid () const override;
 
   /**
    * An optimized method for computing the area of a

--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -207,6 +207,12 @@ public:
   static const unsigned int edge_sides_map[num_edges][2];
 
   /**
+   * The centroid of a 4-node tetrahedron is simply given by the
+   * average of its vertex positions.
+   */
+  virtual Point centroid () const override;
+
+  /**
    * An optimized method for computing the area of a
    * 4-node tetrahedron.
    */

--- a/include/geom/edge_edge2.h
+++ b/include/geom/edge_edge2.h
@@ -136,6 +136,12 @@ public:
                             std::vector<dof_id_type> & conn) const override;
 
   /**
+   * An optimized method for computing the centroid of a
+   * 2-node edge.
+   */
+  virtual Point true_centroid () const override;
+
+  /**
    * An optimized method for computing the length of a 2-node edge.
    */
   virtual Real volume () const override;

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -903,6 +903,16 @@ public:
   virtual Point centroid () const;
 
   /**
+   * \returns A Point at the average of the elment's vertices.
+   *
+   * \note This used to be the base class centroid() implementation, but
+   * the centroid is only equal to the vertex average in some special cases.
+   * The centroid() implementation now returns the "true" centroid of the
+   * element (up to quadrature error).
+   */
+  Point vertex_average () const;
+
+  /**
    * \returns The minimum vertex separation for the element.
    */
   virtual Real hmin () const;

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -893,14 +893,24 @@ public:
    */
   virtual Order default_order () const = 0;
 
+  // TODO: deprecate this
+  // virtual Point centroid () const;
+
   /**
-   * \returns The centroid of the element. The centroid is
-   * computed as the average of all the element vertices.
+   * \returns The "true" geometric centroid of the element, c=(cx, cy,
+   * cz), where:
    *
-   * This method is virtual since some derived elements
-   * might want to use shortcuts to compute their centroid.
+   * [cx]            [\int x dV]
+   * [cy] := (1/V) * [\int y dV]
+   * [cz]            [\int z dV]
+   *
+   * This method is virtual since some derived elements might want to
+   * use shortcuts to compute their centroid. For most element types,
+   * this method is more expensive than calling vertex_average(), so
+   * if you only need a point which is located "somewhere" in the
+   * interior of the element, consider calling vertex_average() instead.
    */
-  virtual Point centroid () const;
+  virtual Point true_centroid () const;
 
   /**
    * \returns A Point at the average of the elment's vertices.

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -893,8 +893,14 @@ public:
    */
   virtual Order default_order () const = 0;
 
-  // TODO: deprecate this
-  // virtual Point centroid () const;
+  /**
+   * Calls Elem::vertex_average() for backwards compatibility. This
+   * method has now been deprecated, so it will be removed at some
+   * point in the future.  Calls to Elem::centroid() in user code
+   * should be updated to either call Elem::vertex_average() or
+   * Elem::true_centroid() on a case by case basis.
+   */
+  virtual Point centroid () const;
 
   /**
    * \returns The "true" geometric centroid of the element, c=(cx, cy,

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -158,7 +158,7 @@ public:
    * An optimized method for computing the centroid of a
    * 4-node quad with straight sides.
    */
-  virtual Point centroid () const override;
+  virtual Point true_centroid () const override;
 
   /**
    * An optimized method for computing the area of a

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -155,6 +155,12 @@ public:
   static const unsigned int side_nodes_map[num_sides][nodes_per_side];
 
   /**
+   * An optimized method for computing the centroid of a
+   * 4-node quad with straight sides.
+   */
+  virtual Point centroid () const override;
+
+  /**
    * An optimized method for computing the area of a
    * 4-node quad with straight sides, but not necessarily a
    * parallelogram.

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -169,6 +169,12 @@ public:
   static const unsigned int side_nodes_map[num_sides][nodes_per_side];
 
   /**
+   * The centroid of a 3-node triangle is simply given by the
+   * average of its vertex positions.
+   */
+  virtual Point centroid () const override;
+
+  /**
    * An optimized method for computing the area of a 3-node triangle.
    */
   virtual Real volume () const override;

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -172,7 +172,7 @@ public:
    * The centroid of a 3-node triangle is simply given by the
    * average of its vertex positions.
    */
-  virtual Point centroid () const override;
+  virtual Point true_centroid () const override;
 
   /**
    * An optimized method for computing the area of a 3-node triangle.

--- a/include/parallel/parallel_ghost_sync.h
+++ b/include/parallel/parallel_ghost_sync.h
@@ -48,7 +48,7 @@ namespace Parallel {
 /**
  * Request data about a range of ghost nodes uniquely identified by
  * their xyz location or a range of active ghost elements uniquely
- * identified by their centroids' xyz location.  Fulfill requests
+ * identified by their vertex averages' xyz location.  Fulfill requests
  * with
  * sync.gather_data(const std::vector<unsigned int> & ids,
  *                  std::vector<sync::datum> & data),

--- a/include/partitioning/centroid_partitioner.h
+++ b/include/partitioning/centroid_partitioner.h
@@ -35,11 +35,16 @@ namespace libMesh
 class Elem;
 
 /**
- * Partitions the Mesh based on the locations of element centroids.
+ * Partitions the Mesh based on the locations of element vertex averages.
  * You must define what you mean by "less than" for the list of
- * element centroids, e.g. if you only care about distance in the
+ * element vertex averages, e.g. if you only care about distance in the
  * z-direction, you would define "less than" differently than if you
  * cared about radial distance.
+ *
+ * \note The name of this partitioner is historical: we do not
+ * partition based on the "true" geometric centroid since the vertex
+ * average is much easier to compute and works just as well as far as
+ * partitioning is concerned.
  *
  * \author John W. Peterson
  * \author Benjamin S. Kirk
@@ -51,7 +56,7 @@ public:
 
   /**
    * A typedef which controls the sorting method used for ordering the
-   * centroids. If e.g. \p X is chosen, then the centroids will be
+   * vertex averages. If e.g. \p X is chosen, then the vertex averages will be
    * sorted according to their x-coordinate.
    */
   enum CentroidSortMethod {X=0,
@@ -114,34 +119,34 @@ protected:
 private:
 
   /**
-   * Computes a list of element centroids for the mesh.
+   * Computes a list of element vertex averages for the mesh.
    */
-  void compute_centroids (MeshBase::element_iterator it,
-                          MeshBase::element_iterator end);
+  void compute_vertex_avgs (MeshBase::element_iterator it,
+                            MeshBase::element_iterator end);
 
   /**
-   * Helper function which sorts by the centroid's x-coordinate in the
+   * Helper function which sorts by the vertex average's x-coordinate in the
    * internal std::sort call.
    */
   static bool sort_x (const std::pair<Point, Elem *> & lhs,
                       const std::pair<Point, Elem *> & rhs);
 
   /**
-   * Helper function which sorts by the centroid's y-coordinate in the
+   * Helper function which sorts by the vertex average's y-coordinate in the
    * internal std::sort call.
    */
   static bool sort_y (const std::pair<Point, Elem *> & lhs,
                       const std::pair<Point, Elem *> & rhs);
 
   /**
-   * Helper function which sorts by the centroid's z-coordinate in the
+   * Helper function which sorts by the vertex average's z-coordinate in the
    * internal std::sort call.
    */
   static bool sort_z (const std::pair<Point, Elem *> & lhs,
                       const std::pair<Point, Elem *> & rhs);
 
   /**
-   * Helper function which sorts by the centroid's distance from the
+   * Helper function which sorts by the vertex averages's distance from the
    * origin in the internal std::sort call.
    */
   static bool sort_radial (const std::pair<Point, Elem *> & lhs,
@@ -153,10 +158,10 @@ private:
   CentroidSortMethod _sort_method;
 
   /**
-   * Vector which holds pairs of centroids and their respective
+   * Vector which holds pairs of vertex averages and their respective
    * element pointers.
    */
-  std::vector<std::pair<Point, Elem *>> _elem_centroids;
+  std::vector<std::pair<Point, Elem *>> _elem_vertex_avgs;
 };
 
 } // namespace libMesh

--- a/include/utils/point_locator_nanoflann.h
+++ b/include/utils/point_locator_nanoflann.h
@@ -173,14 +173,14 @@ public:
 
   /**
    * Returns the squared distance between the vector (p1[0], p1[1], p1[2])
-   * and the centroid of Elem "idx_p2" stored in _mesh
+   * and the vertex average of Elem "idx_p2" stored in _mesh
    */
   coord_t kdtree_distance(const coord_t * p1,
                           const std::size_t idx_p2,
                           std::size_t size) const;
 
   /**
-   * Returns the dim'th component of the idx'th centroid.
+   * Returns the dim'th component of the idx'th vertex average.
    */
   coord_t kdtree_get_pt(const std::size_t idx, int dim) const;
 
@@ -212,7 +212,7 @@ protected:
   /**
    * Lists of Points and ids which make up the "point cloud" that is
    * to be searched via Nanoflann. The point cloud can be comprised of
-   * Elem centroids or mesh Nodes, depending on the type of tree
+   * Elem vertex averages or mesh Nodes, depending on the type of tree
    * created. We keep two separate vectors since the Points in the
    * cloud may not be numbered contiguously in general.
    *

--- a/src/apps/meshbcid.C
+++ b/src/apps/meshbcid.C
@@ -163,7 +163,7 @@ int main(int argc, char ** argv)
           const Point & n = face_normals[0];
 
           //libMesh::out << "elem = " << elem->id() << std::endl;
-          //libMesh::out << "centroid = " << elem->vertex_average() << std::endl;
+          //libMesh::out << "vertex average = " << elem->vertex_average() << std::endl;
           //libMesh::out << "p = " << p << std::endl;
           //libMesh::out << "n = " << n << std::endl;
 

--- a/src/apps/meshbcid.C
+++ b/src/apps/meshbcid.C
@@ -163,7 +163,7 @@ int main(int argc, char ** argv)
           const Point & n = face_normals[0];
 
           //libMesh::out << "elem = " << elem->id() << std::endl;
-          //libMesh::out << "centroid = " << elem->centroid() << std::endl;
+          //libMesh::out << "centroid = " << elem->vertex_average() << std::endl;
           //libMesh::out << "p = " << p << std::endl;
           //libMesh::out << "n = " << n << std::endl;
 

--- a/src/base/periodic_boundaries.C
+++ b/src/base/periodic_boundaries.C
@@ -65,7 +65,7 @@ const Elem * PeriodicBoundaries::neighbor(boundary_id_type boundary_id,
   std::unique_ptr<const Elem> neigh_side_proxy;
 
   // Find a point on that side (and only that side)
-  Point p = e->build_side_ptr(side)->centroid();
+  Point p = e->build_side_ptr(side)->vertex_average();
 
   const PeriodicBoundaryBase * b = this->boundary(boundary_id);
   libmesh_assert (b);

--- a/src/fe/fe_xyz_shape_1D.C
+++ b/src/fe/fe_xyz_shape_1D.C
@@ -40,16 +40,16 @@ Real FE<1,XYZ>::shape(const Elem * elem,
   libmesh_assert(elem);
   libmesh_assert_less_equal (i, order + add_p_level * elem->p_level());
 
-  Point centroid = elem->vertex_average();
+  Point avg = elem->vertex_average();
   Real max_distance = 0.;
   for (const Point & p : elem->node_ref_range())
     {
-      const Real distance = std::abs(centroid(0) - p(0));
+      const Real distance = std::abs(avg(0) - p(0));
       max_distance = std::max(distance, max_distance);
     }
 
   const Real x  = point_in(0);
-  const Real xc = centroid(0);
+  const Real xc = avg(0);
   const Real dx = (x - xc)/max_distance;
 
   // monomials. since they are hierarchic we only need one case block.
@@ -86,7 +86,7 @@ Real FE<1,XYZ>::shape(const ElemType,
                       const unsigned int,
                       const Point &)
 {
-  libmesh_error_msg("XYZ polynomials require the element \nbecause the centroid is needed.");
+  libmesh_error_msg("XYZ polynomials require the element.");
   return 0.;
 }
 
@@ -119,16 +119,16 @@ Real FE<1,XYZ>::shape_deriv(const Elem * elem,
 
   libmesh_assert_equal_to (j, 0);
 
-  Point centroid = elem->vertex_average();
+  Point avg = elem->vertex_average();
   Real max_distance = 0.;
   for (const Point & p : elem->node_ref_range())
     {
-      const Real distance = std::abs(centroid(0) - p(0));
+      const Real distance = std::abs(avg(0) - p(0));
       max_distance = std::max(distance, max_distance);
     }
 
   const Real x  = point_in(0);
-  const Real xc = centroid(0);
+  const Real xc = avg(0);
   const Real dx = (x - xc)/max_distance;
 
   // monomials. since they are hierarchic we only need one case block.
@@ -166,7 +166,7 @@ Real FE<1,XYZ>::shape_deriv(const ElemType,
                             const unsigned int,
                             const Point &)
 {
-  libmesh_error_msg("XYZ polynomials require the element \nbecause the centroid is needed.");
+  libmesh_error_msg("XYZ polynomials require the element.");
   return 0.;
 }
 
@@ -205,16 +205,16 @@ Real FE<1,XYZ>::shape_second_deriv(const Elem * elem,
 
   libmesh_assert_equal_to (j, 0);
 
-  Point centroid = elem->vertex_average();
+  Point avg = elem->vertex_average();
   Real max_distance = 0.;
   for (const Point & p : elem->node_ref_range())
     {
-      const Real distance = std::abs(centroid(0) - p(0));
+      const Real distance = std::abs(avg(0) - p(0));
       max_distance = std::max(distance, max_distance);
     }
 
   const Real x  = point_in(0);
-  const Real xc = centroid(0);
+  const Real xc = avg(0);
   const Real dx = (x - xc)/max_distance;
   const Real dist2 = pow(max_distance,2.);
 
@@ -250,7 +250,7 @@ Real FE<1,XYZ>::shape_second_deriv(const ElemType,
                                    const unsigned int,
                                    const Point &)
 {
-  libmesh_error_msg("XYZ polynomials require the element \nbecause the centroid is needed.");
+  libmesh_error_msg("XYZ polynomials require the element.");
   return 0.;
 }
 

--- a/src/fe/fe_xyz_shape_1D.C
+++ b/src/fe/fe_xyz_shape_1D.C
@@ -40,7 +40,7 @@ Real FE<1,XYZ>::shape(const Elem * elem,
   libmesh_assert(elem);
   libmesh_assert_less_equal (i, order + add_p_level * elem->p_level());
 
-  Point centroid = elem->centroid();
+  Point centroid = elem->vertex_average();
   Real max_distance = 0.;
   for (const Point & p : elem->node_ref_range())
     {
@@ -119,7 +119,7 @@ Real FE<1,XYZ>::shape_deriv(const Elem * elem,
 
   libmesh_assert_equal_to (j, 0);
 
-  Point centroid = elem->centroid();
+  Point centroid = elem->vertex_average();
   Real max_distance = 0.;
   for (const Point & p : elem->node_ref_range())
     {
@@ -205,7 +205,7 @@ Real FE<1,XYZ>::shape_second_deriv(const Elem * elem,
 
   libmesh_assert_equal_to (j, 0);
 
-  Point centroid = elem->centroid();
+  Point centroid = elem->vertex_average();
   Real max_distance = 0.;
   for (const Point & p : elem->node_ref_range())
     {

--- a/src/fe/fe_xyz_shape_2D.C
+++ b/src/fe/fe_xyz_shape_2D.C
@@ -41,19 +41,19 @@ Real FE<2,XYZ>::shape(const Elem * elem,
 
   libmesh_assert(elem);
 
-  Point centroid = elem->vertex_average();
+  Point avg = elem->vertex_average();
   Point max_distance = Point(0.,0.,0.);
   for (const Point & p : elem->node_ref_range())
     for (unsigned int d = 0; d < 2; d++)
       {
-        const Real distance = std::abs(centroid(d) - p(d));
+        const Real distance = std::abs(avg(d) - p(d));
         max_distance(d) = std::max(distance, max_distance(d));
       }
 
   const Real x  = point_in(0);
   const Real y  = point_in(1);
-  const Real xc = centroid(0);
-  const Real yc = centroid(1);
+  const Real xc = avg(0);
+  const Real yc = avg(1);
   const Real distx = max_distance(0);
   const Real disty = max_distance(1);
   const Real dx = (x - xc)/distx;
@@ -148,7 +148,7 @@ Real FE<2,XYZ>::shape(const ElemType,
                       const unsigned int,
                       const Point &)
 {
-  libmesh_error_msg("XYZ polynomials require the element \nbecause the centroid is needed.");
+  libmesh_error_msg("XYZ polynomials require the element.");
   return 0.;
 }
 
@@ -182,19 +182,19 @@ Real FE<2,XYZ>::shape_deriv(const Elem * elem,
   libmesh_assert_less (j, 2);
   libmesh_assert(elem);
 
-  Point centroid = elem->vertex_average();
+  Point avg = elem->vertex_average();
   Point max_distance = Point(0.,0.,0.);
   for (const Point & p : elem->node_ref_range())
     for (unsigned int d = 0; d < 2; d++)
       {
-        const Real distance = std::abs(centroid(d) - p(d));
+        const Real distance = std::abs(avg(d) - p(d));
         max_distance(d) = std::max(distance, max_distance(d));
       }
 
   const Real x  = point_in(0);
   const Real y  = point_in(1);
-  const Real xc = centroid(0);
-  const Real yc = centroid(1);
+  const Real xc = avg(0);
+  const Real yc = avg(1);
   const Real distx = max_distance(0);
   const Real disty = max_distance(1);
   const Real dx = (x - xc)/distx;
@@ -368,7 +368,7 @@ Real FE<2,XYZ>::shape_deriv(const ElemType,
                             const unsigned int,
                             const Point &)
 {
-  libmesh_error_msg("XYZ polynomials require the element \nbecause the centroid is needed.");
+  libmesh_error_msg("XYZ polynomials require the element.");
   return 0.;
 }
 
@@ -401,19 +401,19 @@ Real FE<2,XYZ>::shape_second_deriv(const Elem * elem,
   libmesh_assert_less_equal (j, 2);
   libmesh_assert(elem);
 
-  Point centroid = elem->vertex_average();
+  Point avg = elem->vertex_average();
   Point max_distance = Point(0.,0.,0.);
   for (unsigned int p = 0; p < elem->n_nodes(); p++)
     for (unsigned int d = 0; d < 2; d++)
       {
-        const Real distance = std::abs(centroid(d) - elem->point(p)(d));
+        const Real distance = std::abs(avg(d) - elem->point(p)(d));
         max_distance(d) = std::max(distance, max_distance(d));
       }
 
   const Real x  = point_in(0);
   const Real y  = point_in(1);
-  const Real xc = centroid(0);
-  const Real yc = centroid(1);
+  const Real xc = avg(0);
+  const Real yc = avg(1);
   const Real distx = max_distance(0);
   const Real disty = max_distance(1);
   const Real dx = (x - xc)/distx;
@@ -635,7 +635,7 @@ Real FE<2,XYZ>::shape_second_deriv(const ElemType,
                                    const unsigned int,
                                    const Point &)
 {
-  libmesh_error_msg("XYZ polynomials require the element \nbecause the centroid is needed.");
+  libmesh_error_msg("XYZ polynomials require the element.");
   return 0.;
 }
 

--- a/src/fe/fe_xyz_shape_2D.C
+++ b/src/fe/fe_xyz_shape_2D.C
@@ -41,7 +41,7 @@ Real FE<2,XYZ>::shape(const Elem * elem,
 
   libmesh_assert(elem);
 
-  Point centroid = elem->centroid();
+  Point centroid = elem->vertex_average();
   Point max_distance = Point(0.,0.,0.);
   for (const Point & p : elem->node_ref_range())
     for (unsigned int d = 0; d < 2; d++)
@@ -182,7 +182,7 @@ Real FE<2,XYZ>::shape_deriv(const Elem * elem,
   libmesh_assert_less (j, 2);
   libmesh_assert(elem);
 
-  Point centroid = elem->centroid();
+  Point centroid = elem->vertex_average();
   Point max_distance = Point(0.,0.,0.);
   for (const Point & p : elem->node_ref_range())
     for (unsigned int d = 0; d < 2; d++)
@@ -401,7 +401,7 @@ Real FE<2,XYZ>::shape_second_deriv(const Elem * elem,
   libmesh_assert_less_equal (j, 2);
   libmesh_assert(elem);
 
-  Point centroid = elem->centroid();
+  Point centroid = elem->vertex_average();
   Point max_distance = Point(0.,0.,0.);
   for (unsigned int p = 0; p < elem->n_nodes(); p++)
     for (unsigned int d = 0; d < 2; d++)

--- a/src/fe/fe_xyz_shape_3D.C
+++ b/src/fe/fe_xyz_shape_3D.C
@@ -40,21 +40,21 @@ Real FE<3,XYZ>::shape(const Elem * elem,
 #if LIBMESH_DIM == 3
   libmesh_assert(elem);
 
-  Point centroid = elem->vertex_average();
+  Point avg = elem->vertex_average();
   Point max_distance = Point(0.,0.,0.);
   for (unsigned int p = 0; p < elem->n_nodes(); p++)
     for (unsigned int d = 0; d < 3; d++)
       {
-        const Real distance = std::abs(centroid(d) - elem->point(p)(d));
+        const Real distance = std::abs(avg(d) - elem->point(p)(d));
         max_distance(d) = std::max(distance, max_distance(d));
       }
 
   const Real x  = point_in(0);
   const Real y  = point_in(1);
   const Real z  = point_in(2);
-  const Real xc = centroid(0);
-  const Real yc = centroid(1);
-  const Real zc = centroid(2);
+  const Real xc = avg(0);
+  const Real yc = avg(1);
+  const Real zc = avg(2);
   const Real distx = max_distance(0);
   const Real disty = max_distance(1);
   const Real distz = max_distance(2);
@@ -216,7 +216,7 @@ Real FE<3,XYZ>::shape(const ElemType,
                       const unsigned int,
                       const Point &)
 {
-  libmesh_error_msg("XYZ polynomials require the element \nbecause the centroid is needed.");
+  libmesh_error_msg("XYZ polynomials require the element.");
   return 0.;
 }
 
@@ -249,21 +249,21 @@ Real FE<3,XYZ>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
   libmesh_assert_less (j, 3);
 
-  Point centroid = elem->vertex_average();
+  Point avg = elem->vertex_average();
   Point max_distance = Point(0.,0.,0.);
   for (unsigned int p = 0; p < elem->n_nodes(); p++)
     for (unsigned int d = 0; d < 3; d++)
       {
-        const Real distance = std::abs(centroid(d) - elem->point(p)(d));
+        const Real distance = std::abs(avg(d) - elem->point(p)(d));
         max_distance(d) = std::max(distance, max_distance(d));
       }
 
   const Real x  = point_in(0);
   const Real y  = point_in(1);
   const Real z  = point_in(2);
-  const Real xc = centroid(0);
-  const Real yc = centroid(1);
-  const Real zc = centroid(2);
+  const Real xc = avg(0);
+  const Real yc = avg(1);
+  const Real zc = avg(2);
   const Real distx = max_distance(0);
   const Real disty = max_distance(1);
   const Real distz = max_distance(2);
@@ -705,7 +705,7 @@ Real FE<3,XYZ>::shape_deriv(const ElemType,
                             const unsigned int,
                             const Point &)
 {
-  libmesh_error_msg("XYZ polynomials require the element \nbecause the centroid is needed.");
+  libmesh_error_msg("XYZ polynomials require the element.");
   return 0.;
 }
 
@@ -739,21 +739,21 @@ Real FE<3,XYZ>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
   libmesh_assert_less (j, 6);
 
-  Point centroid = elem->vertex_average();
+  Point avg = elem->vertex_average();
   Point max_distance = Point(0.,0.,0.);
   for (const Point & p : elem->node_ref_range())
     for (unsigned int d = 0; d < 3; d++)
       {
-        const Real distance = std::abs(centroid(d) - p(d));
+        const Real distance = std::abs(avg(d) - p(d));
         max_distance(d) = std::max(distance, max_distance(d));
       }
 
   const Real x  = point_in(0);
   const Real y  = point_in(1);
   const Real z  = point_in(2);
-  const Real xc = centroid(0);
-  const Real yc = centroid(1);
-  const Real zc = centroid(2);
+  const Real xc = avg(0);
+  const Real yc = avg(1);
+  const Real zc = avg(2);
   const Real distx = max_distance(0);
   const Real disty = max_distance(1);
   const Real distz = max_distance(2);
@@ -1413,7 +1413,7 @@ Real FE<3,XYZ>::shape_second_deriv(const ElemType,
                                    const unsigned int,
                                    const Point &)
 {
-  libmesh_error_msg("XYZ polynomials require the element \nbecause the centroid is needed.");
+  libmesh_error_msg("XYZ polynomials require the element.");
   return 0.;
 }
 

--- a/src/fe/fe_xyz_shape_3D.C
+++ b/src/fe/fe_xyz_shape_3D.C
@@ -40,7 +40,7 @@ Real FE<3,XYZ>::shape(const Elem * elem,
 #if LIBMESH_DIM == 3
   libmesh_assert(elem);
 
-  Point centroid = elem->centroid();
+  Point centroid = elem->vertex_average();
   Point max_distance = Point(0.,0.,0.);
   for (unsigned int p = 0; p < elem->n_nodes(); p++)
     for (unsigned int d = 0; d < 3; d++)
@@ -249,7 +249,7 @@ Real FE<3,XYZ>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
   libmesh_assert_less (j, 3);
 
-  Point centroid = elem->centroid();
+  Point centroid = elem->vertex_average();
   Point max_distance = Point(0.,0.,0.);
   for (unsigned int p = 0; p < elem->n_nodes(); p++)
     for (unsigned int d = 0; d < 3; d++)
@@ -739,7 +739,7 @@ Real FE<3,XYZ>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
   libmesh_assert_less (j, 6);
 
-  Point centroid = elem->centroid();
+  Point centroid = elem->vertex_average();
   Point max_distance = Point(0.,0.,0.);
   for (const Point & p : elem->node_ref_range())
     for (unsigned int d = 0; d < 3; d++)

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -282,11 +282,11 @@ void Pyramid5::connectivity(const unsigned int libmesh_dbg_var(sc),
 }
 
 
-Point Pyramid5::centroid () const
+Point Pyramid5::true_centroid () const
 {
   // Centroid of the pyramid is (1/4) of the way along the line
   // segment joining the base (side 4) centroid and the apex (point 4).
-  return 0.75 * Elem::build_side_ptr(4)->centroid() + 0.25 * this->point(4);
+  return 0.75 * Elem::build_side_ptr(4)->true_centroid() + 0.25 * this->point(4);
 }
 
 Real Pyramid5::volume () const

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -282,6 +282,13 @@ void Pyramid5::connectivity(const unsigned int libmesh_dbg_var(sc),
 }
 
 
+Point Pyramid5::centroid () const
+{
+  // Centroid of the pyramid is (1/4) of the way along the line
+  // segment joining the base (side 4) centroid and the apex (point 4).
+  return 0.75 * Elem::build_side_ptr(4)->centroid() + 0.25 * this->point(4);
+}
+
 Real Pyramid5::volume () const
 {
   // The pyramid with a bilinear base has volume given by the

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -321,7 +321,7 @@ const float Tet4::_embedding_matrix[Tet4::num_children][Tet4::num_nodes][Tet4::n
 
 
 
-Point Tet4::centroid () const
+Point Tet4::true_centroid () const
 {
   return Elem::vertex_average();
 }

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -321,6 +321,13 @@ const float Tet4::_embedding_matrix[Tet4::num_children][Tet4::num_nodes][Tet4::n
 
 
 
+Point Tet4::centroid () const
+{
+  return Elem::vertex_average();
+}
+
+
+
 Real Tet4::volume () const
 {
   // The volume of a tetrahedron is 1/6 the box product formed

--- a/src/geom/edge_edge2.C
+++ b/src/geom/edge_edge2.C
@@ -133,6 +133,11 @@ void Edge2::connectivity(const unsigned int libmesh_dbg_var(sc),
 }
 
 
+Point Edge2::true_centroid () const
+{
+  return 0.5 * (this->point(0) + this->point(1));
+}
+
 Real Edge2::volume () const
 {
   // OK, so this is probably overkill, since it is equivalent to

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -355,6 +355,19 @@ const Elem * Elem::reference_elem () const
 
 
 
+Point Elem::centroid() const
+{
+  libmesh_do_once(libMesh::err
+                  << "Elem::centroid() has been deprecated. Replace with either "
+                  << "Elem::vertex_average() to maintain existing behavior, or "
+                  << "the more expensive Elem::true_centroid() "
+                  << "in cases where the true 'geometric' centroid is required."
+                  << std::endl);
+  libmesh_deprecated();
+
+  return Elem::vertex_average();
+}
+
 Point Elem::true_centroid() const
 {
   // The base class implementation builds a finite element of the correct

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -355,7 +355,7 @@ const Elem * Elem::reference_elem () const
 
 
 
-Point Elem::centroid() const
+Point Elem::true_centroid() const
 {
   // The base class implementation builds a finite element of the correct
   // order and computes the centroid, c=(cx, cy, cz), where:

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -265,6 +265,57 @@ void Quad4::connectivity(const unsigned int libmesh_dbg_var(sf),
 
 
 
+Point Quad4::centroid () const
+{
+  // Note: this function does a substantially similar behavior to the
+  // volume() calculation, so it would be good if they could share
+  // code somehow without losing any performance by introducing extra
+  // function calls, etc.
+
+  // Short-hand references to our vertices
+  const Point & x0 = point(0);
+  const Point & x1 = point(1);
+  const Point & x2 = point(2);
+  const Point & x3 = point(3);
+
+  // Construct "dx/d(xi)" and "dx/d(eta)" vectors which are columns of the Jacobian.
+  // \vec{x}_{\xi}  = \vec{a1}*eta + \vec{b1}
+  // \vec{x}_{\eta} = \vec{a2}*xi  + \vec{b2}
+  // This is copy-pasted directly from the output of a Python script.
+  Point
+    a1 = x0/4 - x1/4 + x2/4 - x3/4,
+    b1 = -x0/4 + x1/4 + x2/4 - x3/4,
+    a2 = a1,
+    b2 = -x0/4 - x1/4 + x2/4 + x3/4;
+
+  // Use 2x2 quadrature to compute the integral of each basis function
+  // (as defined on the [-1,1]^2 reference domain). We use a 4-point
+  // rule, which is exact for bi-cubics. The weights for this rule are
+  // all equal to 1.
+  const Real q[2] = {-std::sqrt(3.)/3, std::sqrt(3.)/3.};
+
+  // Nodal areas
+  Real A0 = 0., A1 = 0., A2 = 0., A3 = 0.;
+
+  for (unsigned int i=0; i<2; ++i)
+    for (unsigned int j=0; j<2; ++j)
+      {
+        Real xi = q[i];
+        Real eta = q[j];
+        Real jxw = cross_norm(eta*a1 + b1, xi*a2 + b2);
+
+        A0 += jxw * 0.25 * (1-xi) * (1-eta); // basis function phi_0
+        A1 += jxw * 0.25 * (1+xi) * (1-eta); // basis function phi_1
+        A2 += jxw * 0.25 * (1+xi) * (1+eta); // basis function phi_2
+        A3 += jxw * 0.25 * (1-xi) * (1+eta); // basis function phi_3
+      }
+
+  // Compute centroid
+  return Point(x0(0)*A0 + x1(0)*A1 + x2(0)*A2 + x3(0)*A3,
+               x0(1)*A0 + x1(1)*A1 + x2(1)*A2 + x3(1)*A3,
+               x0(2)*A0 + x1(2)*A1 + x2(2)*A2 + x3(2)*A3) / (A0 + A1 + A2 + A3);
+}
+
 Real Quad4::volume () const
 {
   // Make copies of our points.  It makes the subsequent calculations a bit

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -265,7 +265,7 @@ void Quad4::connectivity(const unsigned int libmesh_dbg_var(sf),
 
 
 
-Point Quad4::centroid () const
+Point Quad4::true_centroid () const
 {
   // Note: this function does a substantially similar behavior to the
   // volume() calculation, so it would be good if they could share

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -187,7 +187,7 @@ void Tri3::connectivity(const unsigned int libmesh_dbg_var(sf),
 
 
 
-Point Tri3::centroid () const
+Point Tri3::true_centroid () const
 {
   return Elem::vertex_average();
 }

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -187,6 +187,11 @@ void Tri3::connectivity(const unsigned int libmesh_dbg_var(sf),
 
 
 
+Point Tri3::centroid () const
+{
+  return Elem::vertex_average();
+}
+
 Real Tri3::volume () const
 {
   // 3-node triangles have the following formula for computing the area

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -376,9 +376,9 @@ void BoundaryInfo::get_side_and_node_maps (UnstructuredMesh & boundary_mesh,
       for (auto side : interior_parent->side_index_range())
         {
           interior_parent->build_side_ptr(interior_parent_side, side);
-          Real centroid_distance = (boundary_elem->vertex_average() - interior_parent_side->vertex_average()).norm();
+          Real va_distance = (boundary_elem->vertex_average() - interior_parent_side->vertex_average()).norm();
 
-          if (centroid_distance < (tolerance * boundary_elem->hmin()))
+          if (va_distance < (tolerance * boundary_elem->hmin()))
             {
               interior_parent_side_index = cast_int<unsigned char>(side);
               found_matching_sides = true;

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -370,13 +370,13 @@ void BoundaryInfo::get_side_and_node_maps (UnstructuredMesh & boundary_mesh,
       const Elem * interior_parent = boundary_elem->interior_parent();
 
       // Find out which side of interior_parent boundary_elem corresponds to.
-      // Use centroid comparison as a way to check.
+      // Use distance between average vertex location as a way to check.
       unsigned char interior_parent_side_index = 0;
       bool found_matching_sides = false;
       for (auto side : interior_parent->side_index_range())
         {
           interior_parent->build_side_ptr(interior_parent_side, side);
-          Real centroid_distance = (boundary_elem->centroid() - interior_parent_side->centroid()).norm();
+          Real centroid_distance = (boundary_elem->vertex_average() - interior_parent_side->vertex_average()).norm();
 
           if (centroid_distance < (tolerance * boundary_elem->hmin()))
             {

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -66,14 +66,14 @@ const std::vector<int> quadshell4_inverse_edge_map = {3, 4, 5, 6};
 const std::vector<int> hex27_node_map = {
   // Vertex and mid-edge nodes
   0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-  // Mid-face nodes and centroid
+  // Mid-face nodes and center node
   21, 25, 24, 26, 23, 22, 20};
 //20  21  22  23  24  25  26 // LibMesh indices
 
 const std::vector<int> hex27_inverse_node_map = {
   // Vertex and mid-edge nodes
   0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-  // Mid-face nodes and centroid
+  // Mid-face nodes and center node
   26, 20, 25, 24, 22, 21, 23};
 //20  21  22  23  24  25  26
 

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -93,7 +93,7 @@ get_dofobject_key (const Elem * e,
   Hilbert::HilbertIndices index;
   CFixBitVec icoords[3];
   Hilbert::BitVecType bv;
-  get_hilbert_coords (e->centroid(), bbox, icoords);
+  get_hilbert_coords (e->vertex_average(), bbox, icoords);
   Hilbert::coordsToIndex (icoords, 8*sizeof_inttype, 3, bv);
   index = bv;
 
@@ -252,13 +252,13 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
       //           {
       //             libMesh::err << "level " << (*elemj)->level()
       //                          << " elem\n" << (**elemj)
-      //                          << " centroid " << (*elemj)->centroid()
+      //                          << " centroid " << (*elemj)->vertex_average()
       //                          << " has HilbertIndices " << elem_keys[j]
       //                          << " or " << get_dofobject_key((*elemj), bbox)
       //                          << std::endl;
       //             libMesh::err << "level " << (*elemi)->level()
       //                          << " elem\n" << (**elemi)
-      //                          << " centroid " << (*elemi)->centroid()
+      //                          << " centroid " << (*elemi)->vertex_average()
       //                          << " has HilbertIndices " << elem_keys[i]
       //                          << " or " << get_dofobject_key((*elemi), bbox)
       //                          << std::endl;
@@ -645,14 +645,14 @@ void MeshCommunication::check_for_duplicate_global_indices (MeshBase & mesh) con
                   libMesh::err <<
                     "level " << (*elemj)->level() << " elem\n" <<
                     (**elemj) << " centroid " <<
-                    (*elemj)->centroid() << " has HilbertIndices " <<
+                    (*elemj)->vertex_average() << " has HilbertIndices " <<
                     elem_keys[j] << " or " <<
                     get_dofobject_key((*elemj), bbox) <<
                     std::endl;
                   libMesh::err <<
                     "level " << (*elemi)->level() << " elem\n" <<
                     (**elemi) << " centroid " <<
-                    (*elemi)->centroid() << " has HilbertIndices " <<
+                    (*elemi)->vertex_average() << " has HilbertIndices " <<
                     elem_keys[i] << " or " <<
                     get_dofobject_key((*elemi), bbox) <<
                     std::endl;

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -252,13 +252,13 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
       //           {
       //             libMesh::err << "level " << (*elemj)->level()
       //                          << " elem\n" << (**elemj)
-      //                          << " centroid " << (*elemj)->vertex_average()
+      //                          << " vertex average " << (*elemj)->vertex_average()
       //                          << " has HilbertIndices " << elem_keys[j]
       //                          << " or " << get_dofobject_key((*elemj), bbox)
       //                          << std::endl;
       //             libMesh::err << "level " << (*elemi)->level()
       //                          << " elem\n" << (**elemi)
-      //                          << " centroid " << (*elemi)->vertex_average()
+      //                          << " vertex average " << (*elemi)->vertex_average()
       //                          << " has HilbertIndices " << elem_keys[i]
       //                          << " or " << get_dofobject_key((*elemi), bbox)
       //                          << std::endl;
@@ -644,14 +644,14 @@ void MeshCommunication::check_for_duplicate_global_indices (MeshBase & mesh) con
                 {
                   libMesh::err <<
                     "level " << (*elemj)->level() << " elem\n" <<
-                    (**elemj) << " centroid " <<
+                    (**elemj) << " vertex average " <<
                     (*elemj)->vertex_average() << " has HilbertIndices " <<
                     elem_keys[j] << " or " <<
                     get_dofobject_key((*elemj), bbox) <<
                     std::endl;
                   libMesh::err <<
                     "level " << (*elemi)->level() << " elem\n" <<
-                    (**elemi) << " centroid " <<
+                    (**elemi) << " vertex average " <<
                     (*elemi)->vertex_average() << " has HilbertIndices " <<
                     elem_keys[i] << " or " <<
                     get_dofobject_key((*elemi), bbox) <<

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -1364,7 +1364,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
             // Create tetrahedra or pyramids
             for (auto & base_hex : mesh.element_ptr_range())
               {
-                // Get a pointer to the node located at the HEX27 centroid
+                // Get a pointer to the node located at the HEX27 center
                 Node * apex_node = base_hex->node_ptr(26);
 
                 // Container to catch ids handed back from BoundaryInfo
@@ -1392,7 +1392,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                             new_elements.push_back( Elem::build(TET4) );
                             auto & sub_elem = new_elements.back();
                             sub_elem->set_node(0) = side->node_ptr(sub_tet);
-                            sub_elem->set_node(1) = side->node_ptr(8);                           // centroid of the face
+                            sub_elem->set_node(1) = side->node_ptr(8);                           // center of the face
                             sub_elem->set_node(2) = side->node_ptr(sub_tet==3 ? 0 : sub_tet+1 ); // wrap-around
                             sub_elem->set_node(3) = apex_node;                                   // apex node always used!
 

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -548,7 +548,7 @@ void VariationalMeshSmoother::adjust_adapt_data()
       // Only do this for active elements
       if (adapt_data[i])
         {
-          Point centroid = (*el)->centroid();
+          Point centroid = (*el)->vertex_average();
           bool in_aoe = false;
 
           // See if the elements centroid lies in the aoe mesh

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -548,13 +548,13 @@ void VariationalMeshSmoother::adjust_adapt_data()
       // Only do this for active elements
       if (adapt_data[i])
         {
-          Point centroid = (*el)->vertex_average();
+          Point avg = (*el)->vertex_average();
           bool in_aoe = false;
 
-          // See if the elements centroid lies in the aoe mesh
+          // See if the element's vertex average lies in the aoe mesh
           // for (aoe_el=aoe_mesh.elements_begin(); aoe_el != aoe_end_el; ++aoe_el)
           // {
-          if ((*aoe_el)->contains_point(centroid))
+          if ((*aoe_el)->contains_point(avg))
             in_aoe = true;
           // }
 

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -520,8 +520,8 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                                      << ", Bad neighbor proc_ID = " << neigh->processor_id() << std::endl;
                         libMesh::err << "Bad element size = " << current_elem->hmin()
                                      << ", Bad neighbor size = " << neigh->hmin() << std::endl;
-                        libMesh::err << "Bad element center = " << current_elem->centroid()
-                                     << ", Bad neighbor center = " << neigh->centroid() << std::endl;
+                        libMesh::err << "Bad element center = " << current_elem->vertex_average()
+                                     << ", Bad neighbor center = " << neigh->vertex_average() << std::endl;
                         libMesh::err << "ERROR: "
                                      << (current_elem->active()?"Active":"Ancestor")
                                      << " Element at level "

--- a/src/partitioning/centroid_partitioner.C
+++ b/src/partitioning/centroid_partitioner.C
@@ -50,18 +50,18 @@ void CentroidPartitioner::partition_range(MeshBase & mesh,
   if (!mesh.is_serial())
     libmesh_not_implemented();
 
-  // Compute the element centroids.  Note: we used to skip this step
+  // Compute the element vertex averages.  Note: we used to skip this step
   // if the number of elements was unchanged from the last call, but
   // that doesn't account for elements that have moved a lot since the
   // last time the Partitioner was called...
-  this->compute_centroids (it, end);
+  this->compute_vertex_avgs (it, end);
 
   switch (this->sort_method())
     {
     case X:
       {
-        std::stable_sort(_elem_centroids.begin(),
-                         _elem_centroids.end(),
+        std::stable_sort(_elem_vertex_avgs.begin(),
+                         _elem_vertex_avgs.end(),
                          CentroidPartitioner::sort_x);
 
         break;
@@ -70,8 +70,8 @@ void CentroidPartitioner::partition_range(MeshBase & mesh,
 
     case Y:
       {
-        std::stable_sort(_elem_centroids.begin(),
-                         _elem_centroids.end(),
+        std::stable_sort(_elem_vertex_avgs.begin(),
+                         _elem_vertex_avgs.end(),
                          CentroidPartitioner::sort_y);
 
         break;
@@ -81,8 +81,8 @@ void CentroidPartitioner::partition_range(MeshBase & mesh,
 
     case Z:
       {
-        std::stable_sort(_elem_centroids.begin(),
-                         _elem_centroids.end(),
+        std::stable_sort(_elem_vertex_avgs.begin(),
+                         _elem_vertex_avgs.end(),
                          CentroidPartitioner::sort_z);
 
         break;
@@ -91,8 +91,8 @@ void CentroidPartitioner::partition_range(MeshBase & mesh,
 
     case RADIAL:
       {
-        std::stable_sort(_elem_centroids.begin(),
-                         _elem_centroids.end(),
+        std::stable_sort(_elem_vertex_avgs.begin(),
+                         _elem_vertex_avgs.end(),
                          CentroidPartitioner::sort_radial);
 
         break;
@@ -103,11 +103,11 @@ void CentroidPartitioner::partition_range(MeshBase & mesh,
 
   // Compute target_size, the approximate number of elements on each processor.
   const dof_id_type target_size = cast_int<dof_id_type>
-    (_elem_centroids.size() / n);
+    (_elem_vertex_avgs.size() / n);
 
-  for (auto i : index_range(_elem_centroids))
+  for (auto i : index_range(_elem_vertex_avgs))
     {
-      Elem * elem = _elem_centroids[i].second;
+      Elem * elem = _elem_vertex_avgs[i].second;
 
       // FIXME: All "extra" elements go on the last processor... this
       // could probably be improved.
@@ -130,13 +130,13 @@ void CentroidPartitioner::_do_partition (MeshBase & mesh,
 
 
 
-void CentroidPartitioner::compute_centroids (MeshBase::element_iterator it,
-                                             MeshBase::element_iterator end)
+void CentroidPartitioner::compute_vertex_avgs (MeshBase::element_iterator it,
+                                               MeshBase::element_iterator end)
 {
-  _elem_centroids.clear();
+  _elem_vertex_avgs.clear();
 
   for (auto & elem : as_range(it, end))
-    _elem_centroids.emplace_back(elem->vertex_average(), elem);
+    _elem_vertex_avgs.emplace_back(elem->vertex_average(), elem);
 }
 
 

--- a/src/partitioning/centroid_partitioner.C
+++ b/src/partitioning/centroid_partitioner.C
@@ -136,7 +136,7 @@ void CentroidPartitioner::compute_centroids (MeshBase::element_iterator it,
   _elem_centroids.clear();
 
   for (auto & elem : as_range(it, end))
-    _elem_centroids.emplace_back(elem->centroid(), elem);
+    _elem_centroids.emplace_back(elem->vertex_average(), elem);
 }
 
 

--- a/src/partitioning/sfc_partitioner.C
+++ b/src/partitioning/sfc_partitioner.C
@@ -110,7 +110,7 @@ void SFCPartitioner::partition_range(MeshBase & mesh,
     {
       libmesh_assert_less (elem->id(), forward_map.size());
 
-      const Point p = elem->centroid();
+      const Point p = elem->vertex_average();
 
       x[forward_map[elem->id()]] = double(p(0));
       y[forward_map[elem->id()]] = double(p(1));

--- a/src/partitioning/sfc_partitioner.C
+++ b/src/partitioning/sfc_partitioner.C
@@ -105,7 +105,7 @@ void SFCPartitioner::partition_range(MeshBase & mesh,
     }
   libmesh_assert_equal_to (el_num, n_range_elem);
 
-  // Get the centroid for each range element.
+  // Get the vertex average for each range element.
   for (const auto & elem : as_range(beg, end))
     {
       libmesh_assert_less (elem->id(), forward_map.size());

--- a/src/utils/location_maps.C
+++ b/src/utils/location_maps.C
@@ -103,7 +103,7 @@ Point LocationMap<Node>::point_of(const Node & node) const
 template <>
 Point LocationMap<Elem>::point_of(const Elem & elem) const
 {
-  return elem.centroid();
+  return elem.vertex_average();
 }
 
 

--- a/src/utils/point_locator_nanoflann.C
+++ b/src/utils/point_locator_nanoflann.C
@@ -103,7 +103,7 @@ PointLocatorNanoflann::init ()
           for (const auto & elem : _mesh.active_element_ptr_range())
             {
               _elems->push_back(elem);
-              _point_cloud->push_back(elem->centroid());
+              _point_cloud->push_back(elem->vertex_average());
             }
 
           // Construct the KD-Tree

--- a/src/utils/point_locator_nanoflann.C
+++ b/src/utils/point_locator_nanoflann.C
@@ -79,13 +79,13 @@ PointLocatorNanoflann::init ()
       bool we_are_master = (_master == nullptr);
 
       // If we are the master PointLocator, fill in the _point_cloud
-      // data structure with active, local element centroids.
+      // data structure with active, local element vertex averages.
       if (we_are_master)
         {
           _elems = std::make_shared<std::vector<Elem *>>();
           _point_cloud = std::make_shared<std::vector<Point>>();
 
-          // Make the KD-Tree out of active element centroids.
+          // Make the KD-Tree out of active element vertex averages.
           //
           // Note: we use active elements rather than active+local
           // elements since we sometimes need to be able to locate
@@ -186,7 +186,7 @@ PointLocatorNanoflann::operator() (const Point & p,
 
   // The results from Nanoflann are already sorted by (squared)
   // distance, but within that list of results, there may be some
-  // centroids which are equidistant from the searched-for
+  // vertex averages which are equidistant from the searched-for
   // Point. Therefore, we will now indirect_sort the results based on
   // elem id, so that the lowest-id Elem from the class of Elems which
   // are the same distance away from the search Point is always
@@ -236,7 +236,7 @@ PointLocatorNanoflann::operator() (const Point & p,
       const Elem * candidate_elem = (*_elems)[nanoflann_index];
 
       // Debugging: print the results
-      // libMesh::err << "Centroid/Elem id = " << candidate_elem->id()
+      // libMesh::err << "Vertex average/Elem id = " << candidate_elem->id()
       //              << ", dist^2 = " << _out_dist_sqr[r]
       //              << std::endl;
 
@@ -285,21 +285,21 @@ PointLocatorNanoflann::operator() (const Point & p,
   if (!_out_of_mesh_mode && !found_elem)
     {
       // Debugging: we are about to throw an error, but before we do,
-      // print information about the closest elements (by centroid
+      // print information about the closest elements (by vertex average
       // distance) that the Point was not found in.
       // for (auto r : make_range(result_set.size()))
       //   {
       //     auto nanoflann_index = _ret_index[_b[r]];
       //     const Elem * candidate_elem = (*_elems)[nanoflann_index];
       //
-      //     libMesh::err << "Centroid/Elem id = " << candidate_elem->id()
+      //     libMesh::err << "Vertex average/Elem id = " << candidate_elem->id()
       //                  << ", dist = " << std::sqrt(_out_dist_sqr[_b[r]])
       //                  << std::endl;
       //   } // end for(r)
 
 
       libmesh_error_msg("Point " << p << " was not contained within the closest " << n_elems_checked <<
-                        " elems (by centroid distance), and _out_of_mesh_mode was not enabled.");
+                        " elems (by vertex average distance), and _out_of_mesh_mode was not enabled.");
     }
 
   return found_elem;

--- a/tests/base/default_coupling_test.C
+++ b/tests/base/default_coupling_test.C
@@ -126,7 +126,7 @@ public:
                     CPPUNIT_ASSERT(sys.get_dof_map().is_evaluable(*n3));
                     evaluable_elements.insert(n3->id());
 
-                    Point p = n3->centroid();
+                    Point p = n3->vertex_average();
 
                     LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(0,p,n3)),
                                             libmesh_real(cubic_default_coupling_test(p,es.parameters,"","")),

--- a/tests/base/point_neighbor_coupling_test.C
+++ b/tests/base/point_neighbor_coupling_test.C
@@ -130,7 +130,7 @@ public:
 
                   libmesh_assert(sys.get_dof_map().is_evaluable(*n3, 0));
 
-                  Point p = n3->centroid();
+                  Point p = n3->vertex_average();
 
                   LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(0,p,n3)),
                                           libmesh_real(cubic_point_neighbor_coupling_test(p,es.parameters,"","")),

--- a/tests/fe/inf_fe_radial_test.C
+++ b/tests/fe/inf_fe_radial_test.C
@@ -253,7 +253,7 @@ public:
     unsigned int side_num=7;
     MeshBase::const_element_iterator           el = mesh.elements_begin();
     const MeshBase::const_element_iterator end_el = mesh.elements_end();
-    Point side_pt = infinite_elem->side_ptr(0)->centroid();
+    Point side_pt = infinite_elem->side_ptr(0)->vertex_average();
 
     Elem * finite_elem = infinite_elem->neighbor_ptr(0);
     for(unsigned int i=0; i<finite_elem->n_sides(); ++i)

--- a/tests/geom/elem_test.C
+++ b/tests/geom/elem_test.C
@@ -46,8 +46,6 @@ public:
       {
         const BoundingBox bbox = elem->loose_bounding_box();
 
-        const Point centroid = elem->centroid();
-
         // The "loose" bounding box should actually be pretty tight
         // in most of these cases, but for weirdly aligned triangles
         // (such as occur in pyramid elements) it won't be, so we'll

--- a/tests/mesh/boundary_mesh.C
+++ b/tests/mesh/boundary_mesh.C
@@ -74,7 +74,7 @@ protected:
 
     for (auto & elem : _mesh->active_element_ptr_range())
       {
-        const Point c = elem->centroid();
+        const Point c = elem->vertex_average();
         if (c(0) < 0.6 && c(1) < 0.4)
           elem->subdomain_id() = 1;
         else
@@ -127,7 +127,7 @@ protected:
 
     for (auto & elem : _mesh->active_element_ptr_range())
       {
-        const Point c = elem->centroid();
+        const Point c = elem->vertex_average();
         if (c(0) < 0.6 && c(1) < 0.4)
           {
             if (c(0) > 0.4)
@@ -227,7 +227,7 @@ public:
             CPPUNIT_ASSERT_EQUAL(pip->level(), elem->level());
 
             // We only added right edges
-            LIBMESH_ASSERT_FP_EQUAL(0.8, elem->centroid()(0),
+            LIBMESH_ASSERT_FP_EQUAL(0.8, elem->vertex_average()(0),
                                     TOLERANCE*TOLERANCE);
           }
         else
@@ -256,7 +256,7 @@ public:
         CPPUNIT_ASSERT_EQUAL(pip->level(), elem->level());
 
         // We only added left edges
-        LIBMESH_ASSERT_FP_EQUAL(0.2, elem->centroid()(0),
+        LIBMESH_ASSERT_FP_EQUAL(0.2, elem->vertex_average()(0),
                                 TOLERANCE*TOLERANCE);
       }
 

--- a/tests/mesh/contains_point.C
+++ b/tests/mesh/contains_point.C
@@ -63,8 +63,8 @@ public:
       elem->set_node(2) = &two;
       elem->set_node(3) = &three;
 
-      // The centroid must be inside the element.
-      CPPUNIT_ASSERT (elem->contains_point(elem->centroid()));
+      // The centroid (equal to vertex average for Tet4) must be inside the element.
+      CPPUNIT_ASSERT (elem->contains_point(elem->vertex_average()));
 
       // The vertices must be contained in the element.
       CPPUNIT_ASSERT (elem->contains_point(zero));
@@ -96,8 +96,8 @@ public:
       elem->set_node(2) = &two;
       elem->set_node(3) = &three;
 
-      // The centroid must be inside the element.
-      CPPUNIT_ASSERT (elem->contains_point(elem->centroid()));
+      // The centroid (equal to vertex average for Tet4) must be inside the element.
+      CPPUNIT_ASSERT (elem->contains_point(elem->vertex_average()));
 
       // The vertices must be contained in the element.
       CPPUNIT_ASSERT (elem->contains_point(zero));
@@ -138,8 +138,8 @@ protected:
     Point oop(va.cross(vb));
     Point oop_unit = oop.unit();
 
-    // The triangle must contain its own centroid
-    CPPUNIT_ASSERT (elem->contains_point(elem->centroid()));
+    // The centroid (equal to vertex average for Tri3) must be inside the element.
+    CPPUNIT_ASSERT (elem->contains_point(elem->vertex_average()));
 
     // triangle should contain all its vertices
     CPPUNIT_ASSERT (elem->contains_point(a));
@@ -147,7 +147,7 @@ protected:
     CPPUNIT_ASSERT (elem->contains_point(c));
 
     // out of plane from the centroid, should *not* be in the element
-    CPPUNIT_ASSERT (!elem->contains_point(elem->centroid() + std::sqrt(TOLERANCE) * oop_unit));
+    CPPUNIT_ASSERT (!elem->contains_point(elem->vertex_average() + std::sqrt(TOLERANCE) * oop_unit));
 
     // These points should be outside the triangle
     CPPUNIT_ASSERT (!elem->contains_point(a + va * TOLERANCE * 10));

--- a/tests/mesh/mesh_function.C
+++ b/tests/mesh/mesh_function.C
@@ -73,7 +73,7 @@ public:
     // Set a subdomain id for all elements, based on location.
     for (auto & elem : mesh.active_element_ptr_range())
       {
-        Point c = elem->centroid();
+        Point c = elem->vertex_average();
         elem->subdomain_id() =
           subdomain_id_type(c(0)*4) + subdomain_id_type(c(1)*4)*10;
       }
@@ -107,7 +107,7 @@ public:
     // at the nodes
     for (auto & elem : mesh.active_local_element_ptr_range())
       {
-        const Point c = elem->centroid();
+        const Point c = elem->vertex_average();
         const Real expected_value =
           libmesh_real(trilinear_function(c, es.parameters, dummy, dummy));
         const std::vector<Point> offsets

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -379,7 +379,7 @@ public:
       for (const auto & elem : mesh.active_element_ptr_range())
         for (auto i : index_range(file_var_names))
           {
-            Real read_val = sys.point_value(i, elem->centroid());
+            Real read_val = sys.point_value(i, elem->vertex_average());
             LIBMESH_ASSERT_FP_EQUAL
               (expected_values[i], read_val, TOLERANCE*TOLERANCE);
           }
@@ -556,7 +556,7 @@ public:
         for (unsigned int side=0; side != 4; ++side)
           if (elem->neighbor_ptr(side))
             n_neighbors++;
-        Point c = elem->centroid();
+        Point c = elem->vertex_average();
 
         if (c(0) > 0.2 && c(0) < 0.8)
           n_neighbors_expected++;

--- a/tests/mesh/mesh_stitch.C
+++ b/tests/mesh/mesh_stitch.C
@@ -170,7 +170,7 @@ public:
     for (const auto & elem : mesh0.element_ptr_range())
       {
         CPPUNIT_ASSERT_EQUAL(elem->n_extra_integers(), 5u);
-        const Point c = elem->centroid();
+        const Point c = elem->vertex_average();
         if (c(0) > 0 && c(1) > 0) // this came from mesh1
           CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(foo0e_idx), dof_id_type(2));
         else

--- a/tests/mesh/slit_mesh_test.C
+++ b/tests/mesh/slit_mesh_test.C
@@ -38,7 +38,7 @@ public:
 
     const Real & x = p(0);
     const Real & y = p(1);
-    const Point centroid = c.get_elem().centroid();
+    const Point centroid = c.get_elem().vertex_average();
     const Real sign = centroid(1)/std::abs(centroid(1));
 
     // For testing we want something discontinuous on the slit,
@@ -402,7 +402,7 @@ public:
 
     for (const auto & elem : mesh2.active_local_element_ptr_range())
       {
-        const Elem * mesh1_elem = (*locator)(elem->centroid());
+        const Elem * mesh1_elem = (*locator)(elem->vertex_average());
         if (mesh1_elem)
           {
             CPPUNIT_ASSERT_EQUAL( elem->unique_id(),

--- a/tests/systems/periodic_bc_test.C
+++ b/tests/systems/periodic_bc_test.C
@@ -128,7 +128,7 @@ void periodic_bc_test_poisson(EquationSystems& es,
       for(unsigned int s=0; s != elem->n_sides(); ++s)
       {
         elem->build_side_ptr(elem_side, s);
-        Point centroid = elem_side->centroid();
+        Point centroid = elem_side->vertex_average();
         if (std::abs(centroid(1) - 1) < TOLERANCE)
           {
             fe_face->reinit(elem, s);

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -1120,14 +1120,14 @@ public:
                                       0., 0.,
                                       QUAD4);
 
-    auto el_beg = mesh.elements_begin();
-    auto el_end = mesh.elements_end();
-    auto el = mesh.elements_begin();
-    for (; el != el_end; ++el)
-      if ((*el)->centroid()(0) <= 0.5 && (*el)->centroid()(1) <= 0.5)
-        (*el)->subdomain_id() = 0;
-      else
-        (*el)->subdomain_id() = 1;
+    for (const auto & elem : mesh.element_ptr_range())
+      {
+        Point c = elem->vertex_average();
+        if (c(0) <= 0.5 && c(1) <= 0.5)
+          elem->subdomain_id() = 0;
+        else
+          elem->subdomain_id() = 1;
+      }
 
     mesh.prepare_for_use();
 


### PR DESCRIPTION
This PR deprecates `Elem::centroid()`, replacing it with a shim that calls `Elem::vertex_average()` to mimic the previous behavior. It also adds `Elem::true_centroid()` which computes the "geometric" centroid of the element using optimized formulas where possible, and numerical quadrature otherwise. 

In my non-scientific testing, I found that it's quite a bit slower to call `Elem::true_centroid()` when all you need is a point "somehwere" in the interior of the Elem, so after some discussion, @roystgnr and I decided to make people "opt in" to the more expensive calculation only when it is actually needed by an application.

Refs #2976
