### PR TITLE
Avoid building an FE just to check its FEContinuity

### DIFF
--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1743,7 +1743,7 @@ void DofMap::set_implicit_neighbor_dofs(bool implicit_neighbor_dofs)
 }
 
 
-bool DofMap::use_coupled_neighbor_dofs(const MeshBase & mesh) const
+bool DofMap::use_coupled_neighbor_dofs(const MeshBase & /*mesh*/) const
 {
   // If we were asked on the command line, then we need to
   // include sensitivities between neighbor degrees of freedom
@@ -1787,8 +1787,7 @@ bool DofMap::use_coupled_neighbor_dofs(const MeshBase & mesh) const
     bool all_discontinuous_dofs = true;
 
     for (auto var : make_range(this->n_variables()))
-      if (FEAbstract::build (mesh.mesh_dimension(),
-                             this->variable_type(var))->get_continuity() !=  DISCONTINUOUS)
+      if (FEInterface::get_continuity(this->variable_type(var)) !=  DISCONTINUOUS)
         all_discontinuous_dofs = false;
 
     if (all_discontinuous_dofs)


### PR DESCRIPTION
This issue came up because DofMap::use_coupled_neighbor_dofs() is
called from the DofMap destructor. If this desctructor is called
during stack unwinding and "new" throws for some reason, then the code
will immediately abort, as seen in the stack trace below.

In general it's safest for destructors to be noexcept, so a larger
question is whether we can actually skip calling the non-trivial
DofMap::clear() from the DofMap desctructor, however this should be a
relatively simple change that would at least allow the stack to unwind
cleanly in this case.
```
0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
1  0x00007ffff0cd1921 in __GI_abort () at abort.c:79
2  0x00007ffff0d1a967 in __libc_message (action=action@entry=do_abort, fmt=fmt@entry=0x7ffff0e47b0d "%s\n") at ../sysdeps/posix/libc_fatal.c:181
3  0x00007ffff0d219da in malloc_printerr (str=str@entry=0x7ffff0e45c3a "corrupted double-linked list") at malloc.c:5342
4  0x00007ffff0d21b94 in malloc_consolidate (av=av@entry=0x7ffff107cc40 <main_arena>) at malloc.c:4486
5  0x00007ffff0d25968 in _int_malloc (av=av@entry=0x7ffff107cc40 <main_arena>, bytes=bytes@entry=1080) at malloc.c:3713
6  0x00007ffff0d283cd in __GI___libc_malloc (bytes=1080) at malloc.c:3075
7  0x00007ffff238e298 in operator new(unsigned long) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
8  0x00007ffff57ee4fc in libMesh::FEMap::build(libMesh::FEType) ()
9  0x00007ffff56ccc0b in libMesh::FEAbstract::FEAbstract(unsigned int, libMesh::FEType const&) ()
10 0x00007ffff566d119 in libMesh::FE<2u, (libMesh::FEFamily)7>::FE(libMesh::FEType const&) ()
11 0x00007ffff56cf7d8 in libMesh::FEAbstract::build(unsigned int, libMesh::FEType const&) ()
12 0x00007ffff551c2e2 in libMesh::DofMap::use_coupled_neighbor_dofs(libMesh::MeshBase const&) const ()
13 0x00007ffff5521d7e in libMesh::DofMap::clear() ()
14 0x00007ffff552c984 in libMesh::DofMap::~DofMap() ()
```
Note: this change also means that a Mesh no longer needs to be passed
to the DofMap::use_coupled_neighbor_dofs() function... removing that
would be an API change, though, so for now we just avoid the unused
parameter warning.