### PR TITLE
Fix has_affine_map()

### DIFF
--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -158,23 +158,29 @@ bool Tet10::is_child_on_side(const unsigned int /*c*/,
 bool Tet10::has_affine_map() const
 {
   // Make sure edges are straight
-  if (!this->point(4).relative_fuzzy_equals
-      ((this->point(0) + this->point(1))/2))
+  Point v = this->point(1) - this->point(0);
+  if (!v.relative_fuzzy_equals
+      ((this->point(4) - this->point(0))*2))
     return false;
-  if (!this->point(5).relative_fuzzy_equals
-      ((this->point(1) + this->point(2))/2))
+  v = this->point(2) - this->point(1);
+  if (!v.relative_fuzzy_equals
+      ((this->point(5) - this->point(1))*2))
     return false;
-  if (!this->point(6).relative_fuzzy_equals
-      ((this->point(2) + this->point(0))/2))
+  v = this->point(2) - this->point(0);
+  if (!v.relative_fuzzy_equals
+      ((this->point(6) - this->point(0))*2))
     return false;
-  if (!this->point(7).relative_fuzzy_equals
-      ((this->point(3) + this->point(0))/2))
+  v = this->point(3) - this->point(0);
+  if (!v.relative_fuzzy_equals
+      ((this->point(7) - this->point(0))*2))
     return false;
-  if (!this->point(8).relative_fuzzy_equals
-      ((this->point(3) + this->point(1))/2))
+  v = this->point(3) - this->point(1);
+  if (!v.relative_fuzzy_equals
+      ((this->point(8) - this->point(1))*2))
     return false;
-  if (!this->point(9).relative_fuzzy_equals
-      ((this->point(3) + this->point(2))/2))
+  v = this->point(3) - this->point(2);
+  if (!v.relative_fuzzy_equals
+      ((this->point(9) - this->point(2))*2))
     return false;
   return true;
 }

--- a/src/geom/edge_edge3.C
+++ b/src/geom/edge_edge3.C
@@ -94,8 +94,9 @@ bool Edge3::is_node_on_edge(const unsigned int,
 
 bool Edge3::has_affine_map() const
 {
-  return (this->point(2).relative_fuzzy_equals
-          ((this->point(0) + this->point(1))/2));
+  Point v = this->point(1) - this->point(0);
+  return (v.relative_fuzzy_equals
+          ((this->point(2) - this->point(0))*2));
 }
 
 

--- a/src/geom/edge_edge4.C
+++ b/src/geom/edge_edge4.C
@@ -93,11 +93,12 @@ bool Edge4::is_node_on_edge(const unsigned int,
 
 bool Edge4::has_affine_map() const
 {
-  if (!this->point(2).relative_fuzzy_equals
-      ((this->point(0)*2. + this->point(1))/3.))
+  Point v = this->point(1) - this->point(0);
+  if (!v.relative_fuzzy_equals
+      ((this->point(2) - this->point(0))*3))
     return false;
-  if (!this->point(3).relative_fuzzy_equals
-      ((this->point(0) + this->point(1)*2.)/3.))
+  if (!v.relative_fuzzy_equals
+      ((this->point(3) - this->point(0))*1.5))
     return false;
   return true;
 }

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -143,14 +143,17 @@ Tri6::nodes_on_edge(const unsigned int e) const
 bool Tri6::has_affine_map() const
 {
   // Make sure edges are straight
-  if (!this->point(3).relative_fuzzy_equals
-      ((this->point(0) + this->point(1))/2.))
+  Point v = this->point(1) - this->point(0);
+  if (!v.relative_fuzzy_equals
+      ((this->point(3) - this->point(0))*2))
     return false;
-  if (!this->point(4).relative_fuzzy_equals
-      ((this->point(1) + this->point(2))/2.))
+  v = this->point(2) - this->point(1);
+  if (!v.relative_fuzzy_equals
+      ((this->point(4) - this->point(1))*2))
     return false;
-  if (!this->point(5).relative_fuzzy_equals
-      ((this->point(2) + this->point(0))/2.))
+  v = this->point(2) - this->point(0);
+  if (!v.relative_fuzzy_equals
+      ((this->point(5) - this->point(0))*2))
     return false;
 
   return true;

--- a/tests/mesh/mesh_generation_test.C
+++ b/tests/mesh/mesh_generation_test.C
@@ -93,6 +93,11 @@ public:
     BoundingBox bbox = MeshTools::create_bounding_box(mesh);
     CPPUNIT_ASSERT_EQUAL(bbox.min()(0), Real(-1.0));
     CPPUNIT_ASSERT_EQUAL(bbox.max()(0), Real(2.0));
+
+    // Do serial assertions *after* all parallel assertions, so we
+    // stay in sync after failure on only some processor(s)
+    for (auto & elem : mesh.element_ptr_range())
+      CPPUNIT_ASSERT(elem->has_affine_map());
   }
 
   void testBuildSquare(UnstructuredMesh & mesh, unsigned int n, ElemType type)
@@ -129,6 +134,11 @@ public:
     CPPUNIT_ASSERT(bbox.max()(0) >= Real(3.0));
     CPPUNIT_ASSERT(bbox.min()(1) <= Real(-4.0));
     CPPUNIT_ASSERT(bbox.max()(1) >= Real(5.0));
+
+    // Do serial assertions *after* all parallel assertions, so we
+    // stay in sync after failure on only some processor(s)
+    for (auto & elem : mesh.element_ptr_range())
+      CPPUNIT_ASSERT(elem->has_affine_map());
   }
 
   void testBuildCube(UnstructuredMesh & mesh, unsigned int n, ElemType type)
@@ -206,6 +216,17 @@ public:
     CPPUNIT_ASSERT(bbox.max()(1) >= Real(5.0));
     CPPUNIT_ASSERT(bbox.min()(2) <= Real(-6.0));
     CPPUNIT_ASSERT(bbox.max()(2) >= Real(7.0));
+
+    // We don't yet try to do affine map optimizations on pyramids
+    if (type == PYRAMID5 ||
+        type == PYRAMID13 ||
+        type == PYRAMID14)
+      return;
+
+    // Do serial assertions *after* all parallel assertions, so we
+    // stay in sync after failure on only some processor(s)
+    for (auto & elem : mesh.element_ptr_range())
+      CPPUNIT_ASSERT(elem->has_affine_map());
   }
 
   void testBuildSphere(unsigned int n_ref, ElemType type)


### PR DESCRIPTION
As discovered in #2989, we have some subclasses using the wrong type of vector (and thus the wrong fuzzy comparison relative tolerances) in `has_affine_map()`.

Assuming I've cherry picked them out of all the Tri7 work correctly, this should fix and add more testing for those methods.