### PR TITLE
Greatly reduce has_affine_map tolerance

### DIFF
--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -121,7 +121,7 @@ typedef LIBMESH_DEFAULT_SCALAR_TYPE Real;
 // For example, v == 0 is changed to std::abs(v) < TOLERANCE.
 
 #ifdef LIBMESH_DEFAULT_SINGLE_PRECISION
-static const Real TOLERANCE = 2.5e-3;
+static constexpr Real TOLERANCE = 2.5e-3;
 # if defined (LIBMESH_DEFAULT_TRIPLE_PRECISION) || \
      defined (LIBMESH_DEFAULT_QUADRUPLE_PRECISION)
 #  error Cannot define multiple precision levels
@@ -129,20 +129,20 @@ static const Real TOLERANCE = 2.5e-3;
 #endif
 
 #ifdef LIBMESH_DEFAULT_TRIPLE_PRECISION
-static const Real TOLERANCE = 1.e-8;
+static constexpr Real TOLERANCE = 1.e-8;
 # if defined (LIBMESH_DEFAULT_QUADRUPLE_PRECISION)
 #  error Cannot define multiple precision levels
 # endif
 #endif
 
 #ifdef LIBMESH_DEFAULT_QUADRUPLE_PRECISION
-static const Real TOLERANCE = 1.e-11;
+static constexpr Real TOLERANCE = 1.e-11;
 #endif
 
 #if !defined (LIBMESH_DEFAULT_SINGLE_PRECISION) && \
     !defined (LIBMESH_DEFAULT_TRIPLE_PRECISION) && \
     !defined (LIBMESH_DEFAULT_QUADRUPLE_PRECISION)
-static const Real TOLERANCE = 1.e-6;
+static constexpr Real TOLERANCE = 1.e-6;
 #endif
 
 // Define the type to use for complex numbers

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -1804,6 +1804,11 @@ public:
 protected:
 
   /**
+   * Default tolerance to use in has_affine_map().
+   */
+  static constexpr Real affine_tol = TOLERANCE*TOLERANCE;
+
+  /**
    * \returns A hash key computed from a single node id.
    */
   static dof_id_type compute_key (dof_id_type n0);

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -140,33 +140,33 @@ bool Hex20::has_affine_map() const
 {
   // Make sure x-edge endpoints are affine
   Point v = this->point(1) - this->point(0);
-  if (!v.relative_fuzzy_equals(this->point(2) - this->point(3)) ||
-      !v.relative_fuzzy_equals(this->point(5) - this->point(4)) ||
-      !v.relative_fuzzy_equals(this->point(6) - this->point(7)))
+  if (!v.relative_fuzzy_equals(this->point(2) - this->point(3), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(5) - this->point(4), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(6) - this->point(7), affine_tol))
     return false;
   // Make sure x-edges are straight
   v /= 2;
-  if (!v.relative_fuzzy_equals(this->point(8) - this->point(0)) ||
-      !v.relative_fuzzy_equals(this->point(10) - this->point(3)) ||
-      !v.relative_fuzzy_equals(this->point(16) - this->point(4)) ||
-      !v.relative_fuzzy_equals(this->point(18) - this->point(7)))
+  if (!v.relative_fuzzy_equals(this->point(8) - this->point(0), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(10) - this->point(3), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(16) - this->point(4), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(18) - this->point(7), affine_tol))
     return false;
   // Make sure xz-faces are identical parallelograms
   v = this->point(4) - this->point(0);
-  if (!v.relative_fuzzy_equals(this->point(7) - this->point(3)))
+  if (!v.relative_fuzzy_equals(this->point(7) - this->point(3), affine_tol))
     return false;
   v /= 2;
-  if (!v.relative_fuzzy_equals(this->point(12) - this->point(0)) ||
-      !v.relative_fuzzy_equals(this->point(13) - this->point(1)) ||
-      !v.relative_fuzzy_equals(this->point(14) - this->point(2)) ||
-      !v.relative_fuzzy_equals(this->point(15) - this->point(3)))
+  if (!v.relative_fuzzy_equals(this->point(12) - this->point(0), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(13) - this->point(1), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(14) - this->point(2), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(15) - this->point(3), affine_tol))
     return false;
   // Make sure y-edges are straight
   v = (this->point(3) - this->point(0))/2;
-  if (!v.relative_fuzzy_equals(this->point(11) - this->point(0)) ||
-      !v.relative_fuzzy_equals(this->point(9) - this->point(1)) ||
-      !v.relative_fuzzy_equals(this->point(17) - this->point(5)) ||
-      !v.relative_fuzzy_equals(this->point(19) - this->point(4)))
+  if (!v.relative_fuzzy_equals(this->point(11) - this->point(0), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(9) - this->point(1), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(17) - this->point(5), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(19) - this->point(4), affine_tol))
     return false;
   // If all the above checks out, the map is affine
   return true;

--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -146,41 +146,41 @@ bool Hex27::has_affine_map() const
 {
   // Make sure x-edge endpoints are affine
   Point v = this->point(1) - this->point(0);
-  if (!v.relative_fuzzy_equals(this->point(2) - this->point(3)) ||
-      !v.relative_fuzzy_equals(this->point(5) - this->point(4)) ||
-      !v.relative_fuzzy_equals(this->point(6) - this->point(7)))
+  if (!v.relative_fuzzy_equals(this->point(2) - this->point(3), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(5) - this->point(4), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(6) - this->point(7), affine_tol))
     return false;
   // Make sure x-edges are straight
   // and x-face and center points are centered
   v /= 2;
-  if (!v.relative_fuzzy_equals(this->point(8) - this->point(0)) ||
-      !v.relative_fuzzy_equals(this->point(10) - this->point(3)) ||
-      !v.relative_fuzzy_equals(this->point(16) - this->point(4)) ||
-      !v.relative_fuzzy_equals(this->point(18) - this->point(7)) ||
-      !v.relative_fuzzy_equals(this->point(20) - this->point(11)) ||
-      !v.relative_fuzzy_equals(this->point(21) - this->point(12)) ||
-      !v.relative_fuzzy_equals(this->point(23) - this->point(15)) ||
-      !v.relative_fuzzy_equals(this->point(25) - this->point(19)) ||
-      !v.relative_fuzzy_equals(this->point(26) - this->point(24)))
+  if (!v.relative_fuzzy_equals(this->point(8) - this->point(0), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(10) - this->point(3), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(16) - this->point(4), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(18) - this->point(7), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(20) - this->point(11), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(21) - this->point(12), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(23) - this->point(15), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(25) - this->point(19), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(26) - this->point(24), affine_tol))
     return false;
   // Make sure xz-faces are identical parallelograms
   v = this->point(4) - this->point(0);
-  if (!v.relative_fuzzy_equals(this->point(7) - this->point(3)))
+  if (!v.relative_fuzzy_equals(this->point(7) - this->point(3), affine_tol))
     return false;
   v /= 2;
-  if (!v.relative_fuzzy_equals(this->point(12) - this->point(0)) ||
-      !v.relative_fuzzy_equals(this->point(13) - this->point(1)) ||
-      !v.relative_fuzzy_equals(this->point(14) - this->point(2)) ||
-      !v.relative_fuzzy_equals(this->point(15) - this->point(3)) ||
-      !v.relative_fuzzy_equals(this->point(22) - this->point(9)) ||
-      !v.relative_fuzzy_equals(this->point(24) - this->point(11)))
+  if (!v.relative_fuzzy_equals(this->point(12) - this->point(0), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(13) - this->point(1), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(14) - this->point(2), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(15) - this->point(3), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(22) - this->point(9), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(24) - this->point(11), affine_tol))
     return false;
   // Make sure y-edges are straight
   v = (this->point(3) - this->point(0))/2;
-  if (!v.relative_fuzzy_equals(this->point(11) - this->point(0)) ||
-      !v.relative_fuzzy_equals(this->point(9) - this->point(1)) ||
-      !v.relative_fuzzy_equals(this->point(17) - this->point(5)) ||
-      !v.relative_fuzzy_equals(this->point(19) - this->point(4)))
+  if (!v.relative_fuzzy_equals(this->point(11) - this->point(0), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(9) - this->point(1), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(17) - this->point(5), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(19) - this->point(4), affine_tol))
     return false;
   // If all the above checks out, the map is affine
   return true;

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -141,13 +141,13 @@ bool Hex8::has_affine_map() const
 {
   // Make sure x-edge endpoints are affine
   Point v = this->point(1) - this->point(0);
-  if (!v.relative_fuzzy_equals(this->point(2) - this->point(3)) ||
-      !v.relative_fuzzy_equals(this->point(5) - this->point(4)) ||
-      !v.relative_fuzzy_equals(this->point(6) - this->point(7)))
+  if (!v.relative_fuzzy_equals(this->point(2) - this->point(3), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(5) - this->point(4), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(6) - this->point(7), affine_tol))
     return false;
   // Make sure xz-faces are identical parallelograms
   v = this->point(4) - this->point(0);
-  if (!v.relative_fuzzy_equals(this->point(7) - this->point(3)))
+  if (!v.relative_fuzzy_equals(this->point(7) - this->point(3), affine_tol))
     return false;
   // If all the above checks out, the map is affine
   return true;

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -135,26 +135,26 @@ bool Prism15::has_affine_map() const
 {
   // Make sure z edges are affine
   Point v = this->point(3) - this->point(0);
-  if (!v.relative_fuzzy_equals(this->point(4) - this->point(1)) ||
-      !v.relative_fuzzy_equals(this->point(5) - this->point(2)))
+  if (!v.relative_fuzzy_equals(this->point(4) - this->point(1), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(5) - this->point(2), affine_tol))
     return false;
   // Make sure edges are straight
   v /= 2;
-  if (!v.relative_fuzzy_equals(this->point(9) - this->point(0)) ||
-      !v.relative_fuzzy_equals(this->point(10) - this->point(1)) ||
-      !v.relative_fuzzy_equals(this->point(11) - this->point(2)))
+  if (!v.relative_fuzzy_equals(this->point(9) - this->point(0), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(10) - this->point(1), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(11) - this->point(2), affine_tol))
     return false;
   v = (this->point(1) - this->point(0))/2;
-  if (!v.relative_fuzzy_equals(this->point(6) - this->point(0)) ||
-      !v.relative_fuzzy_equals(this->point(12) - this->point(3)))
+  if (!v.relative_fuzzy_equals(this->point(6) - this->point(0), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(12) - this->point(3), affine_tol))
     return false;
   v = (this->point(2) - this->point(0))/2;
-  if (!v.relative_fuzzy_equals(this->point(8) - this->point(0)) ||
-      !v.relative_fuzzy_equals(this->point(14) - this->point(3)))
+  if (!v.relative_fuzzy_equals(this->point(8) - this->point(0), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(14) - this->point(3), affine_tol))
     return false;
   v = (this->point(2) - this->point(1))/2;
-  if (!v.relative_fuzzy_equals(this->point(7) - this->point(1)) ||
-      !v.relative_fuzzy_equals(this->point(13) - this->point(4)))
+  if (!v.relative_fuzzy_equals(this->point(7) - this->point(1), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(13) - this->point(4), affine_tol))
     return false;
   return true;
 }

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -140,29 +140,29 @@ bool Prism18::has_affine_map() const
 {
   // Make sure z edges are affine
   Point v = this->point(3) - this->point(0);
-  if (!v.relative_fuzzy_equals(this->point(4) - this->point(1)) ||
-      !v.relative_fuzzy_equals(this->point(5) - this->point(2)))
+  if (!v.relative_fuzzy_equals(this->point(4) - this->point(1), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(5) - this->point(2), affine_tol))
     return false;
   // Make sure edges are straight
   v /= 2;
-  if (!v.relative_fuzzy_equals(this->point(9) - this->point(0)) ||
-      !v.relative_fuzzy_equals(this->point(10) - this->point(1)) ||
-      !v.relative_fuzzy_equals(this->point(11) - this->point(2)) ||
-      !v.relative_fuzzy_equals(this->point(15) - this->point(6)) ||
-      !v.relative_fuzzy_equals(this->point(16) - this->point(7)) ||
-      !v.relative_fuzzy_equals(this->point(17) - this->point(8)))
+  if (!v.relative_fuzzy_equals(this->point(9) - this->point(0), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(10) - this->point(1), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(11) - this->point(2), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(15) - this->point(6), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(16) - this->point(7), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(17) - this->point(8), affine_tol))
     return false;
   v = (this->point(1) - this->point(0))/2;
-  if (!v.relative_fuzzy_equals(this->point(6) - this->point(0)) ||
-      !v.relative_fuzzy_equals(this->point(12) - this->point(3)))
+  if (!v.relative_fuzzy_equals(this->point(6) - this->point(0), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(12) - this->point(3), affine_tol))
     return false;
   v = (this->point(2) - this->point(0))/2;
-  if (!v.relative_fuzzy_equals(this->point(8) - this->point(0)) ||
-      !v.relative_fuzzy_equals(this->point(14) - this->point(3)))
+  if (!v.relative_fuzzy_equals(this->point(8) - this->point(0), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(14) - this->point(3), affine_tol))
     return false;
   v = (this->point(2) - this->point(1))/2;
-  if (!v.relative_fuzzy_equals(this->point(7) - this->point(1)) ||
-      !v.relative_fuzzy_equals(this->point(13) - this->point(4)))
+  if (!v.relative_fuzzy_equals(this->point(7) - this->point(1), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(13) - this->point(4), affine_tol))
     return false;
   return true;
 }

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -215,8 +215,8 @@ bool Prism6::has_affine_map() const
 {
   // Make sure z edges are affine
   Point v = this->point(3) - this->point(0);
-  if (!v.relative_fuzzy_equals(this->point(4) - this->point(1)) ||
-      !v.relative_fuzzy_equals(this->point(5) - this->point(2)))
+  if (!v.relative_fuzzy_equals(this->point(4) - this->point(1), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(5) - this->point(2), affine_tol))
     return false;
   return true;
 }

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -160,27 +160,27 @@ bool Tet10::has_affine_map() const
   // Make sure edges are straight
   Point v = this->point(1) - this->point(0);
   if (!v.relative_fuzzy_equals
-      ((this->point(4) - this->point(0))*2))
+      ((this->point(4) - this->point(0))*2, affine_tol))
     return false;
   v = this->point(2) - this->point(1);
   if (!v.relative_fuzzy_equals
-      ((this->point(5) - this->point(1))*2))
+      ((this->point(5) - this->point(1))*2, affine_tol))
     return false;
   v = this->point(2) - this->point(0);
   if (!v.relative_fuzzy_equals
-      ((this->point(6) - this->point(0))*2))
+      ((this->point(6) - this->point(0))*2, affine_tol))
     return false;
   v = this->point(3) - this->point(0);
   if (!v.relative_fuzzy_equals
-      ((this->point(7) - this->point(0))*2))
+      ((this->point(7) - this->point(0))*2, affine_tol))
     return false;
   v = this->point(3) - this->point(1);
   if (!v.relative_fuzzy_equals
-      ((this->point(8) - this->point(1))*2))
+      ((this->point(8) - this->point(1))*2, affine_tol))
     return false;
   v = this->point(3) - this->point(2);
   if (!v.relative_fuzzy_equals
-      ((this->point(9) - this->point(2))*2))
+      ((this->point(9) - this->point(2))*2, affine_tol))
     return false;
   return true;
 }

--- a/src/geom/edge_edge3.C
+++ b/src/geom/edge_edge3.C
@@ -96,7 +96,7 @@ bool Edge3::has_affine_map() const
 {
   Point v = this->point(1) - this->point(0);
   return (v.relative_fuzzy_equals
-          ((this->point(2) - this->point(0))*2));
+          ((this->point(2) - this->point(0))*2, affine_tol));
 }
 
 

--- a/src/geom/edge_edge4.C
+++ b/src/geom/edge_edge4.C
@@ -95,10 +95,10 @@ bool Edge4::has_affine_map() const
 {
   Point v = this->point(1) - this->point(0);
   if (!v.relative_fuzzy_equals
-      ((this->point(2) - this->point(0))*3))
+      ((this->point(2) - this->point(0))*3, affine_tol))
     return false;
   if (!v.relative_fuzzy_equals
-      ((this->point(3) - this->point(0))*1.5))
+      ((this->point(3) - this->point(0))*1.5, affine_tol))
     return false;
   return true;
 }

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -134,7 +134,7 @@ Quad4::nodes_on_edge(const unsigned int e) const
 bool Quad4::has_affine_map() const
 {
   Point v = this->point(3) - this->point(0);
-  return (v.relative_fuzzy_equals(this->point(2) - this->point(1)));
+  return (v.relative_fuzzy_equals(this->point(2) - this->point(1), affine_tol));
 }
 
 

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -153,16 +153,16 @@ bool Quad8::has_affine_map() const
 {
   // make sure corners form a parallelogram
   Point v = this->point(1) - this->point(0);
-  if (!v.relative_fuzzy_equals(this->point(2) - this->point(3)))
+  if (!v.relative_fuzzy_equals(this->point(2) - this->point(3), affine_tol))
     return false;
   // make sure sides are straight
   v /= 2;
-  if (!v.relative_fuzzy_equals(this->point(4) - this->point(0)) ||
-      !v.relative_fuzzy_equals(this->point(6) - this->point(3)))
+  if (!v.relative_fuzzy_equals(this->point(4) - this->point(0), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(6) - this->point(3), affine_tol))
     return false;
   v = (this->point(3) - this->point(0))/2;
-  if (!v.relative_fuzzy_equals(this->point(7) - this->point(0)) ||
-      !v.relative_fuzzy_equals(this->point(5) - this->point(1)))
+  if (!v.relative_fuzzy_equals(this->point(7) - this->point(0), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(5) - this->point(1), affine_tol))
     return false;
   return true;
 }

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -161,19 +161,19 @@ bool Quad9::has_affine_map() const
 {
   // make sure corners form a parallelogram
   Point v = this->point(1) - this->point(0);
-  if (!v.relative_fuzzy_equals(this->point(2) - this->point(3)))
+  if (!v.relative_fuzzy_equals(this->point(2) - this->point(3), affine_tol))
     return false;
   // make sure "horizontal" sides are straight
   v /= 2;
-  if (!v.relative_fuzzy_equals(this->point(4) - this->point(0)) ||
-      !v.relative_fuzzy_equals(this->point(6) - this->point(3)))
+  if (!v.relative_fuzzy_equals(this->point(4) - this->point(0), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(6) - this->point(3), affine_tol))
     return false;
   // make sure "vertical" sides are straight
   // and the center node is centered
   v = (this->point(3) - this->point(0))/2;
-  if (!v.relative_fuzzy_equals(this->point(7) - this->point(0)) ||
-      !v.relative_fuzzy_equals(this->point(5) - this->point(1)) ||
-      !v.relative_fuzzy_equals(this->point(8) - this->point(4)))
+  if (!v.relative_fuzzy_equals(this->point(7) - this->point(0), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(5) - this->point(1), affine_tol) ||
+      !v.relative_fuzzy_equals(this->point(8) - this->point(4), affine_tol))
     return false;
   return true;
 }

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -145,15 +145,15 @@ bool Tri6::has_affine_map() const
   // Make sure edges are straight
   Point v = this->point(1) - this->point(0);
   if (!v.relative_fuzzy_equals
-      ((this->point(3) - this->point(0))*2))
+      ((this->point(3) - this->point(0))*2, affine_tol))
     return false;
   v = this->point(2) - this->point(1);
   if (!v.relative_fuzzy_equals
-      ((this->point(4) - this->point(1))*2))
+      ((this->point(4) - this->point(1))*2, affine_tol))
     return false;
   v = this->point(2) - this->point(0);
   if (!v.relative_fuzzy_equals
-      ((this->point(5) - this->point(0))*2))
+      ((this->point(5) - this->point(0))*2, affine_tol))
     return false;
 
   return true;


### PR DESCRIPTION
From 1e-6 down to 1e-12 in the default double-precision configuration.

When doing a MOOSE libMesh submodule update in https://github.com/idaholab/moose/pull/18705 we discovered that our existing `has_affine_map()` tolerance is so loose that just tweaking the equations we use in implementations is resulting in noticeable diffs in some tests.

When I started using `relative_fuzzy_equals` in these calculations I didn't really think about tolerance issues, since surely there wouldn't be any elements that aren't affine but are only 1e-7 away from affine!  But mesh deformation problems produce exactly such elements, which means we're throwing as much as O(1e-6) relative error into mesh deformation problem calculations at that point, when the elements are nonlinear enough to need independent mapping gradient calculations at each quadrature point but not nonlinear enough for our loose tolerances to detect that fact.