### PR TITLE
Create multi_evaluable predicate

### DIFF
--- a/include/base/multi_predicates.h
+++ b/include/base/multi_predicates.h
@@ -733,6 +733,23 @@ struct Evaluable: abstract_multi_predicate<T>
   }
 };
 
+
+
+/**
+ * Used to iterate over elements where solutions indexed by a given
+ * vector of DofMaps are evaluable for all variables
+ */
+template <typename T>
+struct MultiEvaluable: abstract_multi_predicate<T>
+{
+  MultiEvaluable(const std::vector<const DofMap *> & dof_maps)
+  {
+    this->_predicates.push_back(new not_null<T>);
+    this->_predicates.push_back(new active<T>);
+    this->_predicates.push_back(new multi_evaluable<T>(dof_maps));
+  }
+};
+
 }
 
 

--- a/include/base/single_predicates.h
+++ b/include/base/single_predicates.h
@@ -467,7 +467,7 @@ protected:
 
 
 /**
- * \returns \p true if the pointer (which must be a local element) has
+ * \returns \p true if the pointer (which must be a non-null dof object) has
  * degrees of freedom which can be evaluated for the specified DofMap
  * and variable.
  */
@@ -486,6 +486,26 @@ protected:
   virtual predicate<T> * clone() const override { return new evaluable<T>(*this); }
   const DofMap & _dof_map;
   unsigned int _var_num;
+};
+
+/**
+ * \returns \p true if the pointer (which must be a non-null dof object) has
+ * degrees of freedom which can be evaluated for all variables in all the provided
+ * \p DofMaps
+ */
+template <typename T>
+struct multi_evaluable : predicate<T>
+{
+  multi_evaluable(const std::vector<const DofMap *> & dof_maps) :
+      _dof_maps(dof_maps) {}
+  virtual ~multi_evaluable() {}
+
+  // op()
+  virtual bool operator()(const T & it) const override;
+
+protected:
+  virtual predicate<T> * clone() const override { return new multi_evaluable<T>(*this); }
+  const std::vector<const DofMap *> & _dof_maps;
 };
 
 

--- a/include/base/single_predicates.h
+++ b/include/base/single_predicates.h
@@ -496,7 +496,7 @@ protected:
 template <typename T>
 struct multi_evaluable : predicate<T>
 {
-  multi_evaluable(const std::vector<const DofMap *> & dof_maps) :
+  multi_evaluable(std::vector<const DofMap *> dof_maps) :
       _dof_maps(dof_maps) {}
   virtual ~multi_evaluable() {}
 
@@ -505,7 +505,7 @@ struct multi_evaluable : predicate<T>
 
 protected:
   virtual predicate<T> * clone() const override { return new multi_evaluable<T>(*this); }
-  const std::vector<const DofMap *> & _dof_maps;
+  std::vector<const DofMap *> _dof_maps;
 };
 
 

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -514,16 +514,16 @@ public:
                           unsigned int var_num = libMesh::invalid_uint) const override;
 
   virtual element_iterator
-  multi_evaluable_elements_begin (const std::vector<const DofMap *> & dof_maps) override;
+  multi_evaluable_elements_begin (std::vector<const DofMap *> dof_maps) override;
 
   virtual element_iterator
-  multi_evaluable_elements_end (const std::vector<const DofMap *> & dof_maps) override;
+  multi_evaluable_elements_end (std::vector<const DofMap *> dof_maps) override;
 
   virtual const_element_iterator
-  multi_evaluable_elements_begin (const std::vector<const DofMap *> & dof_maps) const override;
+  multi_evaluable_elements_begin (std::vector<const DofMap *> dof_maps) const override;
 
   virtual const_element_iterator
-  multi_evaluable_elements_end (const std::vector<const DofMap *> & dof_maps) const override;
+  multi_evaluable_elements_end (std::vector<const DofMap *> dof_maps) const override;
 
 #ifdef LIBMESH_ENABLE_AMR
   virtual element_iterator flagged_elements_begin (unsigned char rflag) override;
@@ -592,13 +592,13 @@ public:
                        unsigned int var_num = libMesh::invalid_uint) const override;
 
   virtual node_iterator
-  multi_evaluable_nodes_begin (const std::vector<const DofMap *> & dof_maps) override;
+  multi_evaluable_nodes_begin (std::vector<const DofMap *> dof_maps) override;
   virtual node_iterator
-  multi_evaluable_nodes_end (const std::vector<const DofMap *> & dof_maps) override;
+  multi_evaluable_nodes_end (std::vector<const DofMap *> dof_maps) override;
   virtual const_node_iterator
-  multi_evaluable_nodes_begin (const std::vector<const DofMap *> & dof_maps) const override;
+  multi_evaluable_nodes_begin (std::vector<const DofMap *> dof_maps) const override;
   virtual const_node_iterator
-  multi_evaluable_nodes_end (const std::vector<const DofMap *> & dof_maps) const override;
+  multi_evaluable_nodes_end (std::vector<const DofMap *> dof_maps) const override;
 
 protected:
 

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -513,6 +513,18 @@ public:
   evaluable_elements_end (const DofMap & dof_map,
                           unsigned int var_num = libMesh::invalid_uint) const override;
 
+  virtual element_iterator
+  multi_evaluable_elements_begin (const std::vector<const DofMap *> & dof_maps) override;
+
+  virtual element_iterator
+  multi_evaluable_elements_end (const std::vector<const DofMap *> & dof_maps) override;
+
+  virtual const_element_iterator
+  multi_evaluable_elements_begin (const std::vector<const DofMap *> & dof_maps) const override;
+
+  virtual const_element_iterator
+  multi_evaluable_elements_end (const std::vector<const DofMap *> & dof_maps) const override;
+
 #ifdef LIBMESH_ENABLE_AMR
   virtual element_iterator flagged_elements_begin (unsigned char rflag) override;
   virtual element_iterator flagged_elements_end (unsigned char rflag) override;
@@ -579,6 +591,14 @@ public:
   evaluable_nodes_end (const DofMap & dof_map,
                        unsigned int var_num = libMesh::invalid_uint) const override;
 
+  virtual node_iterator
+  multi_evaluable_nodes_begin (const std::vector<const DofMap *> & dof_maps) override;
+  virtual node_iterator
+  multi_evaluable_nodes_end (const std::vector<const DofMap *> & dof_maps) override;
+  virtual const_node_iterator
+  multi_evaluable_nodes_begin (const std::vector<const DofMap *> & dof_maps) const override;
+  virtual const_node_iterator
+  multi_evaluable_nodes_end (const std::vector<const DofMap *> & dof_maps) const override;
 
 protected:
 

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1489,16 +1489,16 @@ public:
    * distributed by the given DofMaps) can be evaluated for all variables
    */
   virtual element_iterator
-  multi_evaluable_elements_begin (const std::vector<const DofMap *> & dof_maps) = 0;
+  multi_evaluable_elements_begin (std::vector<const DofMap *> dof_maps) = 0;
 
   virtual element_iterator
-  multi_evaluable_elements_end (const std::vector<const DofMap *> & dof_maps) = 0;
+  multi_evaluable_elements_end (std::vector<const DofMap *> dof_maps) = 0;
 
   virtual const_element_iterator
-  multi_evaluable_elements_begin (const std::vector<const DofMap *> & dof_maps) const = 0;
+  multi_evaluable_elements_begin (std::vector<const DofMap *> dof_maps) const = 0;
 
   virtual const_element_iterator
-  multi_evaluable_elements_end (const std::vector<const DofMap *> & dof_maps) const = 0;
+  multi_evaluable_elements_end (std::vector<const DofMap *> dof_maps) const = 0;
 
 #ifdef LIBMESH_ENABLE_AMR
   /**
@@ -1712,16 +1712,16 @@ public:
    * distributed by the given DofMaps) can be evaluated for all variables
    */
   virtual node_iterator
-  multi_evaluable_nodes_begin (const std::vector<const DofMap *> & dof_maps) = 0;
+  multi_evaluable_nodes_begin (std::vector<const DofMap *> dof_maps) = 0;
 
   virtual node_iterator
-  multi_evaluable_nodes_end (const std::vector<const DofMap *> & dof_maps) = 0;
+  multi_evaluable_nodes_end (std::vector<const DofMap *> dof_maps) = 0;
 
   virtual const_node_iterator
-  multi_evaluable_nodes_begin (const std::vector<const DofMap *> & dof_maps) const = 0;
+  multi_evaluable_nodes_begin (std::vector<const DofMap *> dof_maps) const = 0;
 
   virtual const_node_iterator
-  multi_evaluable_nodes_end (const std::vector<const DofMap *> & dof_maps) const = 0;
+  multi_evaluable_nodes_end (std::vector<const DofMap *> dof_maps) const = 0;
 
   /**
    * \returns A writable reference to the whole subdomain name map

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1484,6 +1484,22 @@ public:
   evaluable_elements_end (const DofMap & dof_map,
                           unsigned int var_num = libMesh::invalid_uint) const = 0;
 
+  /**
+   * Iterate over elements in the Mesh where the solutions (as
+   * distributed by the given DofMaps) can be evaluated for all variables
+   */
+  virtual element_iterator
+  multi_evaluable_elements_begin (const std::vector<const DofMap *> & dof_maps) = 0;
+
+  virtual element_iterator
+  multi_evaluable_elements_end (const std::vector<const DofMap *> & dof_maps) = 0;
+
+  virtual const_element_iterator
+  multi_evaluable_elements_begin (const std::vector<const DofMap *> & dof_maps) const = 0;
+
+  virtual const_element_iterator
+  multi_evaluable_elements_end (const std::vector<const DofMap *> & dof_maps) const = 0;
+
 #ifdef LIBMESH_ENABLE_AMR
   /**
    * Iterate over all elements with a specified refinement flag.
@@ -1690,6 +1706,22 @@ public:
   virtual const_node_iterator
   evaluable_nodes_end (const DofMap & dof_map,
                        unsigned int var_num = libMesh::invalid_uint) const = 0;
+
+  /**
+   * Iterate over nodes in the Mesh where the solutions (as
+   * distributed by the given DofMaps) can be evaluated for all variables
+   */
+  virtual node_iterator
+  multi_evaluable_nodes_begin (const std::vector<const DofMap *> & dof_maps) = 0;
+
+  virtual node_iterator
+  multi_evaluable_nodes_end (const std::vector<const DofMap *> & dof_maps) = 0;
+
+  virtual const_node_iterator
+  multi_evaluable_nodes_begin (const std::vector<const DofMap *> & dof_maps) const = 0;
+
+  virtual const_node_iterator
+  multi_evaluable_nodes_end (const std::vector<const DofMap *> & dof_maps) const = 0;
 
   /**
    * \returns A writable reference to the whole subdomain name map

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -461,16 +461,16 @@ public:
                           unsigned int var_num = libMesh::invalid_uint) const override;
 
   virtual element_iterator
-  multi_evaluable_elements_begin (const std::vector<const DofMap *> & dof_maps) override;
+  multi_evaluable_elements_begin (std::vector<const DofMap *> dof_maps) override;
 
   virtual element_iterator
-  multi_evaluable_elements_end (const std::vector<const DofMap *> & dof_maps) override;
+  multi_evaluable_elements_end (std::vector<const DofMap *> dof_maps) override;
 
   virtual const_element_iterator
-  multi_evaluable_elements_begin (const std::vector<const DofMap *> & dof_maps) const override;
+  multi_evaluable_elements_begin (std::vector<const DofMap *> dof_maps) const override;
 
   virtual const_element_iterator
-  multi_evaluable_elements_end (const std::vector<const DofMap *> & dof_maps) const override;
+  multi_evaluable_elements_end (std::vector<const DofMap *> dof_maps) const override;
 
 #ifdef LIBMESH_ENABLE_AMR
   virtual element_iterator flagged_elements_begin (unsigned char rflag) override;
@@ -539,13 +539,13 @@ public:
                        unsigned int var_num = libMesh::invalid_uint) const override;
 
   virtual node_iterator
-  multi_evaluable_nodes_begin (const std::vector<const DofMap *> & dof_maps) override;
+  multi_evaluable_nodes_begin (std::vector<const DofMap *> dof_maps) override;
   virtual node_iterator
-  multi_evaluable_nodes_end (const std::vector<const DofMap *> & dof_maps) override;
+  multi_evaluable_nodes_end (std::vector<const DofMap *> dof_maps) override;
   virtual const_node_iterator
-  multi_evaluable_nodes_begin (const std::vector<const DofMap *> & dof_maps) const override;
+  multi_evaluable_nodes_begin (std::vector<const DofMap *> dof_maps) const override;
   virtual const_node_iterator
-  multi_evaluable_nodes_end (const std::vector<const DofMap *> & dof_maps) const override;
+  multi_evaluable_nodes_end (std::vector<const DofMap *> dof_maps) const override;
 
 protected:
 

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -460,6 +460,18 @@ public:
   evaluable_elements_end (const DofMap & dof_map,
                           unsigned int var_num = libMesh::invalid_uint) const override;
 
+  virtual element_iterator
+  multi_evaluable_elements_begin (const std::vector<const DofMap *> & dof_maps) override;
+
+  virtual element_iterator
+  multi_evaluable_elements_end (const std::vector<const DofMap *> & dof_maps) override;
+
+  virtual const_element_iterator
+  multi_evaluable_elements_begin (const std::vector<const DofMap *> & dof_maps) const override;
+
+  virtual const_element_iterator
+  multi_evaluable_elements_end (const std::vector<const DofMap *> & dof_maps) const override;
+
 #ifdef LIBMESH_ENABLE_AMR
   virtual element_iterator flagged_elements_begin (unsigned char rflag) override;
   virtual element_iterator flagged_elements_end (unsigned char rflag) override;
@@ -526,6 +538,14 @@ public:
   evaluable_nodes_end (const DofMap & dof_map,
                        unsigned int var_num = libMesh::invalid_uint) const override;
 
+  virtual node_iterator
+  multi_evaluable_nodes_begin (const std::vector<const DofMap *> & dof_maps) override;
+  virtual node_iterator
+  multi_evaluable_nodes_end (const std::vector<const DofMap *> & dof_maps) override;
+  virtual const_node_iterator
+  multi_evaluable_nodes_begin (const std::vector<const DofMap *> & dof_maps) const override;
+  virtual const_node_iterator
+  multi_evaluable_nodes_end (const std::vector<const DofMap *> & dof_maps) const override;
 
 protected:
 

--- a/src/base/single_predicates.C
+++ b/src/base/single_predicates.C
@@ -52,15 +52,31 @@ evaluable<T>::operator()(const T & it) const
   return _dof_map.is_evaluable(**it, _var_num);
 }
 
+template <typename T>
+bool
+multi_evaluable<T>::operator()(const T & it) const
+{
+  for (const auto * const dof_map : _dof_maps)
+  {
+    libmesh_assert(dof_map);
+    if (!dof_map->is_evaluable(**it))
+      return false;
+  }
+
+  return true;
+}
+
 
 // Instantiate with the useful values of T
-#define INSTANTIATE_NODAL_PREDICATES(IterType)                          \
-  template bool bid<IterType>::operator()(const IterType &) const;      \
-  template bool bnd<IterType>::operator()(const IterType &) const;      \
-  template bool evaluable<IterType>::operator()(const IterType &) const
+#define INSTANTIATE_NODAL_PREDICATES(IterType)                                \
+  template bool bid<IterType>::operator()(const IterType &) const;            \
+  template bool bnd<IterType>::operator()(const IterType &) const;            \
+  template bool evaluable<IterType>::operator()(const IterType &) const;      \
+  template bool multi_evaluable<IterType>::operator()(const IterType &) const
 
-#define INSTANTIATE_ELEM_PREDICATES(IterType)                           \
-  template bool evaluable<IterType>::operator()(const IterType &) const
+#define INSTANTIATE_ELEM_PREDICATES(IterType)                                 \
+  template bool evaluable<IterType>::operator()(const IterType &) const;      \
+  template bool multi_evaluable<IterType>::operator()(const IterType &) const
 
 // Handle commas in macro arguments
 #define LIBMESH_COMMA ,

--- a/src/mesh/mesh_iterators.C
+++ b/src/mesh/mesh_iterators.C
@@ -157,6 +157,7 @@ INSTANTIATE_ELEM_ACCESSORS(active_subdomain_elements,       ActiveSubdomain,    
 INSTANTIATE_ELEM_ACCESSORS(active_subdomain_set_elements,   ActiveSubdomainSet,   std::set<subdomain_id_type> ss, ss)
 INSTANTIATE_ELEM_ACCESSORS(ghost_elements,                  Ghost,                EMPTY,                          this->processor_id())
 INSTANTIATE_ELEM_ACCESSORS(evaluable_elements,              Evaluable,            const DofMap & dof_map LIBMESH_COMMA unsigned int var_num, dof_map, var_num)
+INSTANTIATE_ELEM_ACCESSORS(multi_evaluable_elements,        MultiEvaluable,       const std::vector<const DofMap *> & dof_maps, dof_maps)
 INSTANTIATE_ELEM_ACCESSORS(unpartitioned_elements,          PID,                  EMPTY,                          DofObject::invalid_processor_id)
 INSTANTIATE_ELEM_ACCESSORS(active_unpartitioned_elements,   ActivePID,            EMPTY,                          DofObject::invalid_processor_id)
 
@@ -178,5 +179,6 @@ INSTANTIATE_NODE_ACCESSORS(pid_nodes,    PID,     processor_id_type proc_id,    
 INSTANTIATE_NODE_ACCESSORS(bnd_nodes,    BND,     EMPTY,                               this->get_boundary_info())
 INSTANTIATE_NODE_ACCESSORS(bid_nodes,    BID,     boundary_id_type bndry_id, bndry_id, this->get_boundary_info())
 INSTANTIATE_NODE_ACCESSORS(evaluable_nodes, Evaluable, const DofMap & dof_map LIBMESH_COMMA unsigned int var_num, dof_map, var_num)
+INSTANTIATE_NODE_ACCESSORS(multi_evaluable_nodes, MultiEvaluable, const std::vector<const DofMap *> & dof_maps, dof_maps)
 
 } // namespace libMesh

--- a/src/mesh/mesh_iterators.C
+++ b/src/mesh/mesh_iterators.C
@@ -157,7 +157,7 @@ INSTANTIATE_ELEM_ACCESSORS(active_subdomain_elements,       ActiveSubdomain,    
 INSTANTIATE_ELEM_ACCESSORS(active_subdomain_set_elements,   ActiveSubdomainSet,   std::set<subdomain_id_type> ss, ss)
 INSTANTIATE_ELEM_ACCESSORS(ghost_elements,                  Ghost,                EMPTY,                          this->processor_id())
 INSTANTIATE_ELEM_ACCESSORS(evaluable_elements,              Evaluable,            const DofMap & dof_map LIBMESH_COMMA unsigned int var_num, dof_map, var_num)
-INSTANTIATE_ELEM_ACCESSORS(multi_evaluable_elements,        MultiEvaluable,       const std::vector<const DofMap *> & dof_maps, dof_maps)
+INSTANTIATE_ELEM_ACCESSORS(multi_evaluable_elements,        MultiEvaluable,       std::vector<const DofMap *> dof_maps, dof_maps)
 INSTANTIATE_ELEM_ACCESSORS(unpartitioned_elements,          PID,                  EMPTY,                          DofObject::invalid_processor_id)
 INSTANTIATE_ELEM_ACCESSORS(active_unpartitioned_elements,   ActivePID,            EMPTY,                          DofObject::invalid_processor_id)
 
@@ -179,6 +179,6 @@ INSTANTIATE_NODE_ACCESSORS(pid_nodes,    PID,     processor_id_type proc_id,    
 INSTANTIATE_NODE_ACCESSORS(bnd_nodes,    BND,     EMPTY,                               this->get_boundary_info())
 INSTANTIATE_NODE_ACCESSORS(bid_nodes,    BID,     boundary_id_type bndry_id, bndry_id, this->get_boundary_info())
 INSTANTIATE_NODE_ACCESSORS(evaluable_nodes, Evaluable, const DofMap & dof_map LIBMESH_COMMA unsigned int var_num, dof_map, var_num)
-INSTANTIATE_NODE_ACCESSORS(multi_evaluable_nodes, MultiEvaluable, const std::vector<const DofMap *> & dof_maps, dof_maps)
+INSTANTIATE_NODE_ACCESSORS(multi_evaluable_nodes, MultiEvaluable, std::vector<const DofMap *> dof_maps, dof_maps)
 
 } // namespace libMesh

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -26,6 +26,7 @@ unit_tests_sources = \
   base/getpot_test.C \
   base/point_neighbor_coupling_test.C \
   base/overlapping_coupling_test.C \
+  base/multi_evaluable_pred_test.C \
   fe/fe_bernstein_test.C \
   fe/fe_clough_test.C \
   fe/fe_hermite_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -194,7 +194,8 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	stream_redirector.h test_comm.h base/dof_object_test.h \
 	base/dof_map_test.C base/default_coupling_test.C \
 	base/getpot_test.C base/point_neighbor_coupling_test.C \
-	base/overlapping_coupling_test.C fe/fe_bernstein_test.C \
+	base/overlapping_coupling_test.C \
+	base/multi_evaluable_pred_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
 	fe/fe_hierarchic_test.C fe/inf_fe_radial_test.C \
 	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
@@ -264,6 +265,7 @@ am__objects_3 = unit_tests_dbg-driver.$(OBJEXT) \
 	base/unit_tests_dbg-getpot_test.$(OBJEXT) \
 	base/unit_tests_dbg-point_neighbor_coupling_test.$(OBJEXT) \
 	base/unit_tests_dbg-overlapping_coupling_test.$(OBJEXT) \
+	base/unit_tests_dbg-multi_evaluable_pred_test.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_bernstein_test.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_hermite_test.$(OBJEXT) \
@@ -367,7 +369,8 @@ am__unit_tests_devel_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	stream_redirector.h test_comm.h base/dof_object_test.h \
 	base/dof_map_test.C base/default_coupling_test.C \
 	base/getpot_test.C base/point_neighbor_coupling_test.C \
-	base/overlapping_coupling_test.C fe/fe_bernstein_test.C \
+	base/overlapping_coupling_test.C \
+	base/multi_evaluable_pred_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
 	fe/fe_hierarchic_test.C fe/inf_fe_radial_test.C \
 	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
@@ -435,6 +438,7 @@ am__objects_5 = unit_tests_devel-driver.$(OBJEXT) \
 	base/unit_tests_devel-getpot_test.$(OBJEXT) \
 	base/unit_tests_devel-point_neighbor_coupling_test.$(OBJEXT) \
 	base/unit_tests_devel-overlapping_coupling_test.$(OBJEXT) \
+	base/unit_tests_devel-multi_evaluable_pred_test.$(OBJEXT) \
 	fe/unit_tests_devel-fe_bernstein_test.$(OBJEXT) \
 	fe/unit_tests_devel-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_devel-fe_hermite_test.$(OBJEXT) \
@@ -534,7 +538,8 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	stream_redirector.h test_comm.h base/dof_object_test.h \
 	base/dof_map_test.C base/default_coupling_test.C \
 	base/getpot_test.C base/point_neighbor_coupling_test.C \
-	base/overlapping_coupling_test.C fe/fe_bernstein_test.C \
+	base/overlapping_coupling_test.C \
+	base/multi_evaluable_pred_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
 	fe/fe_hierarchic_test.C fe/inf_fe_radial_test.C \
 	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
@@ -602,6 +607,7 @@ am__objects_7 = unit_tests_oprof-driver.$(OBJEXT) \
 	base/unit_tests_oprof-getpot_test.$(OBJEXT) \
 	base/unit_tests_oprof-point_neighbor_coupling_test.$(OBJEXT) \
 	base/unit_tests_oprof-overlapping_coupling_test.$(OBJEXT) \
+	base/unit_tests_oprof-multi_evaluable_pred_test.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_bernstein_test.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_hermite_test.$(OBJEXT) \
@@ -701,7 +707,8 @@ am__unit_tests_opt_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	stream_redirector.h test_comm.h base/dof_object_test.h \
 	base/dof_map_test.C base/default_coupling_test.C \
 	base/getpot_test.C base/point_neighbor_coupling_test.C \
-	base/overlapping_coupling_test.C fe/fe_bernstein_test.C \
+	base/overlapping_coupling_test.C \
+	base/multi_evaluable_pred_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
 	fe/fe_hierarchic_test.C fe/inf_fe_radial_test.C \
 	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
@@ -769,6 +776,7 @@ am__objects_9 = unit_tests_opt-driver.$(OBJEXT) \
 	base/unit_tests_opt-getpot_test.$(OBJEXT) \
 	base/unit_tests_opt-point_neighbor_coupling_test.$(OBJEXT) \
 	base/unit_tests_opt-overlapping_coupling_test.$(OBJEXT) \
+	base/unit_tests_opt-multi_evaluable_pred_test.$(OBJEXT) \
 	fe/unit_tests_opt-fe_bernstein_test.$(OBJEXT) \
 	fe/unit_tests_opt-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_opt-fe_hermite_test.$(OBJEXT) \
@@ -868,7 +876,8 @@ am__unit_tests_prof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	stream_redirector.h test_comm.h base/dof_object_test.h \
 	base/dof_map_test.C base/default_coupling_test.C \
 	base/getpot_test.C base/point_neighbor_coupling_test.C \
-	base/overlapping_coupling_test.C fe/fe_bernstein_test.C \
+	base/overlapping_coupling_test.C \
+	base/multi_evaluable_pred_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
 	fe/fe_hierarchic_test.C fe/inf_fe_radial_test.C \
 	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
@@ -936,6 +945,7 @@ am__objects_11 = unit_tests_prof-driver.$(OBJEXT) \
 	base/unit_tests_prof-getpot_test.$(OBJEXT) \
 	base/unit_tests_prof-point_neighbor_coupling_test.$(OBJEXT) \
 	base/unit_tests_prof-overlapping_coupling_test.$(OBJEXT) \
+	base/unit_tests_prof-multi_evaluable_pred_test.$(OBJEXT) \
 	fe/unit_tests_prof-fe_bernstein_test.$(OBJEXT) \
 	fe/unit_tests_prof-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_prof-fe_hermite_test.$(OBJEXT) \
@@ -1054,26 +1064,31 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_dbg-dof_map_test.Po \
 	base/$(DEPDIR)/unit_tests_dbg-getpot_test.Po \
+	base/$(DEPDIR)/unit_tests_dbg-multi_evaluable_pred_test.Po \
 	base/$(DEPDIR)/unit_tests_dbg-overlapping_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_dbg-point_neighbor_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_devel-dof_map_test.Po \
 	base/$(DEPDIR)/unit_tests_devel-getpot_test.Po \
+	base/$(DEPDIR)/unit_tests_devel-multi_evaluable_pred_test.Po \
 	base/$(DEPDIR)/unit_tests_devel-overlapping_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_devel-point_neighbor_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_oprof-dof_map_test.Po \
 	base/$(DEPDIR)/unit_tests_oprof-getpot_test.Po \
+	base/$(DEPDIR)/unit_tests_oprof-multi_evaluable_pred_test.Po \
 	base/$(DEPDIR)/unit_tests_oprof-overlapping_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_oprof-point_neighbor_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_opt-dof_map_test.Po \
 	base/$(DEPDIR)/unit_tests_opt-getpot_test.Po \
+	base/$(DEPDIR)/unit_tests_opt-multi_evaluable_pred_test.Po \
 	base/$(DEPDIR)/unit_tests_opt-overlapping_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_opt-point_neighbor_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_prof-dof_map_test.Po \
 	base/$(DEPDIR)/unit_tests_prof-getpot_test.Po \
+	base/$(DEPDIR)/unit_tests_prof-multi_evaluable_pred_test.Po \
 	base/$(DEPDIR)/unit_tests_prof-overlapping_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_prof-point_neighbor_coupling_test.Po \
 	fe/$(DEPDIR)/unit_tests_dbg-dual_shape_verification_test.Po \
@@ -1973,7 +1988,8 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 	test_comm.h base/dof_object_test.h base/dof_map_test.C \
 	base/default_coupling_test.C base/getpot_test.C \
 	base/point_neighbor_coupling_test.C \
-	base/overlapping_coupling_test.C fe/fe_bernstein_test.C \
+	base/overlapping_coupling_test.C \
+	base/multi_evaluable_pred_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
 	fe/fe_hierarchic_test.C fe/inf_fe_radial_test.C \
 	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
@@ -2153,6 +2169,8 @@ base/unit_tests_dbg-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 base/unit_tests_dbg-point_neighbor_coupling_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_dbg-overlapping_coupling_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
+base/unit_tests_dbg-multi_evaluable_pred_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 fe/$(am__dirstamp):
 	@$(MKDIR_P) fe
@@ -2418,6 +2436,8 @@ base/unit_tests_devel-point_neighbor_coupling_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_devel-overlapping_coupling_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
+base/unit_tests_devel-multi_evaluable_pred_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_devel-fe_bernstein_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_devel-fe_clough_test.$(OBJEXT): fe/$(am__dirstamp) \
@@ -2615,6 +2635,8 @@ base/unit_tests_oprof-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 base/unit_tests_oprof-point_neighbor_coupling_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_oprof-overlapping_coupling_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
+base/unit_tests_oprof-multi_evaluable_pred_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_oprof-fe_bernstein_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
@@ -2814,6 +2836,8 @@ base/unit_tests_opt-point_neighbor_coupling_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_opt-overlapping_coupling_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
+base/unit_tests_opt-multi_evaluable_pred_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_opt-fe_bernstein_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_opt-fe_clough_test.$(OBJEXT): fe/$(am__dirstamp) \
@@ -3011,6 +3035,8 @@ base/unit_tests_prof-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 base/unit_tests_prof-point_neighbor_coupling_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_prof-overlapping_coupling_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
+base/unit_tests_prof-multi_evaluable_pred_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_prof-fe_bernstein_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
@@ -3227,26 +3253,31 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-dof_map_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-getpot_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-multi_evaluable_pred_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-overlapping_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-point_neighbor_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-dof_map_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-getpot_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-multi_evaluable_pred_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-overlapping_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-point_neighbor_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-dof_map_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-getpot_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-multi_evaluable_pred_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-overlapping_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-point_neighbor_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-dof_map_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-getpot_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-multi_evaluable_pred_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-overlapping_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-point_neighbor_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-dof_map_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-getpot_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-multi_evaluable_pred_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-overlapping_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-point_neighbor_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_dbg-dual_shape_verification_test.Po@am__quote@ # am--include-marker
@@ -3803,6 +3834,20 @@ base/unit_tests_dbg-overlapping_coupling_test.obj: base/overlapping_coupling_tes
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/overlapping_coupling_test.C' object='base/unit_tests_dbg-overlapping_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_dbg-overlapping_coupling_test.obj `if test -f 'base/overlapping_coupling_test.C'; then $(CYGPATH_W) 'base/overlapping_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/overlapping_coupling_test.C'; fi`
+
+base/unit_tests_dbg-multi_evaluable_pred_test.o: base/multi_evaluable_pred_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_dbg-multi_evaluable_pred_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_dbg-multi_evaluable_pred_test.Tpo -c -o base/unit_tests_dbg-multi_evaluable_pred_test.o `test -f 'base/multi_evaluable_pred_test.C' || echo '$(srcdir)/'`base/multi_evaluable_pred_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_dbg-multi_evaluable_pred_test.Tpo base/$(DEPDIR)/unit_tests_dbg-multi_evaluable_pred_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/multi_evaluable_pred_test.C' object='base/unit_tests_dbg-multi_evaluable_pred_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_dbg-multi_evaluable_pred_test.o `test -f 'base/multi_evaluable_pred_test.C' || echo '$(srcdir)/'`base/multi_evaluable_pred_test.C
+
+base/unit_tests_dbg-multi_evaluable_pred_test.obj: base/multi_evaluable_pred_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_dbg-multi_evaluable_pred_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_dbg-multi_evaluable_pred_test.Tpo -c -o base/unit_tests_dbg-multi_evaluable_pred_test.obj `if test -f 'base/multi_evaluable_pred_test.C'; then $(CYGPATH_W) 'base/multi_evaluable_pred_test.C'; else $(CYGPATH_W) '$(srcdir)/base/multi_evaluable_pred_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_dbg-multi_evaluable_pred_test.Tpo base/$(DEPDIR)/unit_tests_dbg-multi_evaluable_pred_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/multi_evaluable_pred_test.C' object='base/unit_tests_dbg-multi_evaluable_pred_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_dbg-multi_evaluable_pred_test.obj `if test -f 'base/multi_evaluable_pred_test.C'; then $(CYGPATH_W) 'base/multi_evaluable_pred_test.C'; else $(CYGPATH_W) '$(srcdir)/base/multi_evaluable_pred_test.C'; fi`
 
 fe/unit_tests_dbg-fe_bernstein_test.o: fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_dbg-fe_bernstein_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_dbg-fe_bernstein_test.Tpo -c -o fe/unit_tests_dbg-fe_bernstein_test.o `test -f 'fe/fe_bernstein_test.C' || echo '$(srcdir)/'`fe/fe_bernstein_test.C
@@ -5120,6 +5165,20 @@ base/unit_tests_devel-overlapping_coupling_test.obj: base/overlapping_coupling_t
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_devel-overlapping_coupling_test.obj `if test -f 'base/overlapping_coupling_test.C'; then $(CYGPATH_W) 'base/overlapping_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/overlapping_coupling_test.C'; fi`
 
+base/unit_tests_devel-multi_evaluable_pred_test.o: base/multi_evaluable_pred_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_devel-multi_evaluable_pred_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_devel-multi_evaluable_pred_test.Tpo -c -o base/unit_tests_devel-multi_evaluable_pred_test.o `test -f 'base/multi_evaluable_pred_test.C' || echo '$(srcdir)/'`base/multi_evaluable_pred_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_devel-multi_evaluable_pred_test.Tpo base/$(DEPDIR)/unit_tests_devel-multi_evaluable_pred_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/multi_evaluable_pred_test.C' object='base/unit_tests_devel-multi_evaluable_pred_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_devel-multi_evaluable_pred_test.o `test -f 'base/multi_evaluable_pred_test.C' || echo '$(srcdir)/'`base/multi_evaluable_pred_test.C
+
+base/unit_tests_devel-multi_evaluable_pred_test.obj: base/multi_evaluable_pred_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_devel-multi_evaluable_pred_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_devel-multi_evaluable_pred_test.Tpo -c -o base/unit_tests_devel-multi_evaluable_pred_test.obj `if test -f 'base/multi_evaluable_pred_test.C'; then $(CYGPATH_W) 'base/multi_evaluable_pred_test.C'; else $(CYGPATH_W) '$(srcdir)/base/multi_evaluable_pred_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_devel-multi_evaluable_pred_test.Tpo base/$(DEPDIR)/unit_tests_devel-multi_evaluable_pred_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/multi_evaluable_pred_test.C' object='base/unit_tests_devel-multi_evaluable_pred_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_devel-multi_evaluable_pred_test.obj `if test -f 'base/multi_evaluable_pred_test.C'; then $(CYGPATH_W) 'base/multi_evaluable_pred_test.C'; else $(CYGPATH_W) '$(srcdir)/base/multi_evaluable_pred_test.C'; fi`
+
 fe/unit_tests_devel-fe_bernstein_test.o: fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_devel-fe_bernstein_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_devel-fe_bernstein_test.Tpo -c -o fe/unit_tests_devel-fe_bernstein_test.o `test -f 'fe/fe_bernstein_test.C' || echo '$(srcdir)/'`fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fe/$(DEPDIR)/unit_tests_devel-fe_bernstein_test.Tpo fe/$(DEPDIR)/unit_tests_devel-fe_bernstein_test.Po
@@ -6435,6 +6494,20 @@ base/unit_tests_oprof-overlapping_coupling_test.obj: base/overlapping_coupling_t
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/overlapping_coupling_test.C' object='base/unit_tests_oprof-overlapping_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_oprof-overlapping_coupling_test.obj `if test -f 'base/overlapping_coupling_test.C'; then $(CYGPATH_W) 'base/overlapping_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/overlapping_coupling_test.C'; fi`
+
+base/unit_tests_oprof-multi_evaluable_pred_test.o: base/multi_evaluable_pred_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_oprof-multi_evaluable_pred_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_oprof-multi_evaluable_pred_test.Tpo -c -o base/unit_tests_oprof-multi_evaluable_pred_test.o `test -f 'base/multi_evaluable_pred_test.C' || echo '$(srcdir)/'`base/multi_evaluable_pred_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_oprof-multi_evaluable_pred_test.Tpo base/$(DEPDIR)/unit_tests_oprof-multi_evaluable_pred_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/multi_evaluable_pred_test.C' object='base/unit_tests_oprof-multi_evaluable_pred_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_oprof-multi_evaluable_pred_test.o `test -f 'base/multi_evaluable_pred_test.C' || echo '$(srcdir)/'`base/multi_evaluable_pred_test.C
+
+base/unit_tests_oprof-multi_evaluable_pred_test.obj: base/multi_evaluable_pred_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_oprof-multi_evaluable_pred_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_oprof-multi_evaluable_pred_test.Tpo -c -o base/unit_tests_oprof-multi_evaluable_pred_test.obj `if test -f 'base/multi_evaluable_pred_test.C'; then $(CYGPATH_W) 'base/multi_evaluable_pred_test.C'; else $(CYGPATH_W) '$(srcdir)/base/multi_evaluable_pred_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_oprof-multi_evaluable_pred_test.Tpo base/$(DEPDIR)/unit_tests_oprof-multi_evaluable_pred_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/multi_evaluable_pred_test.C' object='base/unit_tests_oprof-multi_evaluable_pred_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_oprof-multi_evaluable_pred_test.obj `if test -f 'base/multi_evaluable_pred_test.C'; then $(CYGPATH_W) 'base/multi_evaluable_pred_test.C'; else $(CYGPATH_W) '$(srcdir)/base/multi_evaluable_pred_test.C'; fi`
 
 fe/unit_tests_oprof-fe_bernstein_test.o: fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_oprof-fe_bernstein_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_oprof-fe_bernstein_test.Tpo -c -o fe/unit_tests_oprof-fe_bernstein_test.o `test -f 'fe/fe_bernstein_test.C' || echo '$(srcdir)/'`fe/fe_bernstein_test.C
@@ -7752,6 +7825,20 @@ base/unit_tests_opt-overlapping_coupling_test.obj: base/overlapping_coupling_tes
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_opt-overlapping_coupling_test.obj `if test -f 'base/overlapping_coupling_test.C'; then $(CYGPATH_W) 'base/overlapping_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/overlapping_coupling_test.C'; fi`
 
+base/unit_tests_opt-multi_evaluable_pred_test.o: base/multi_evaluable_pred_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_opt-multi_evaluable_pred_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_opt-multi_evaluable_pred_test.Tpo -c -o base/unit_tests_opt-multi_evaluable_pred_test.o `test -f 'base/multi_evaluable_pred_test.C' || echo '$(srcdir)/'`base/multi_evaluable_pred_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_opt-multi_evaluable_pred_test.Tpo base/$(DEPDIR)/unit_tests_opt-multi_evaluable_pred_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/multi_evaluable_pred_test.C' object='base/unit_tests_opt-multi_evaluable_pred_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_opt-multi_evaluable_pred_test.o `test -f 'base/multi_evaluable_pred_test.C' || echo '$(srcdir)/'`base/multi_evaluable_pred_test.C
+
+base/unit_tests_opt-multi_evaluable_pred_test.obj: base/multi_evaluable_pred_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_opt-multi_evaluable_pred_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_opt-multi_evaluable_pred_test.Tpo -c -o base/unit_tests_opt-multi_evaluable_pred_test.obj `if test -f 'base/multi_evaluable_pred_test.C'; then $(CYGPATH_W) 'base/multi_evaluable_pred_test.C'; else $(CYGPATH_W) '$(srcdir)/base/multi_evaluable_pred_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_opt-multi_evaluable_pred_test.Tpo base/$(DEPDIR)/unit_tests_opt-multi_evaluable_pred_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/multi_evaluable_pred_test.C' object='base/unit_tests_opt-multi_evaluable_pred_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_opt-multi_evaluable_pred_test.obj `if test -f 'base/multi_evaluable_pred_test.C'; then $(CYGPATH_W) 'base/multi_evaluable_pred_test.C'; else $(CYGPATH_W) '$(srcdir)/base/multi_evaluable_pred_test.C'; fi`
+
 fe/unit_tests_opt-fe_bernstein_test.o: fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_opt-fe_bernstein_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_opt-fe_bernstein_test.Tpo -c -o fe/unit_tests_opt-fe_bernstein_test.o `test -f 'fe/fe_bernstein_test.C' || echo '$(srcdir)/'`fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fe/$(DEPDIR)/unit_tests_opt-fe_bernstein_test.Tpo fe/$(DEPDIR)/unit_tests_opt-fe_bernstein_test.Po
@@ -9067,6 +9154,20 @@ base/unit_tests_prof-overlapping_coupling_test.obj: base/overlapping_coupling_te
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/overlapping_coupling_test.C' object='base/unit_tests_prof-overlapping_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_prof-overlapping_coupling_test.obj `if test -f 'base/overlapping_coupling_test.C'; then $(CYGPATH_W) 'base/overlapping_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/overlapping_coupling_test.C'; fi`
+
+base/unit_tests_prof-multi_evaluable_pred_test.o: base/multi_evaluable_pred_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_prof-multi_evaluable_pred_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_prof-multi_evaluable_pred_test.Tpo -c -o base/unit_tests_prof-multi_evaluable_pred_test.o `test -f 'base/multi_evaluable_pred_test.C' || echo '$(srcdir)/'`base/multi_evaluable_pred_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_prof-multi_evaluable_pred_test.Tpo base/$(DEPDIR)/unit_tests_prof-multi_evaluable_pred_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/multi_evaluable_pred_test.C' object='base/unit_tests_prof-multi_evaluable_pred_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_prof-multi_evaluable_pred_test.o `test -f 'base/multi_evaluable_pred_test.C' || echo '$(srcdir)/'`base/multi_evaluable_pred_test.C
+
+base/unit_tests_prof-multi_evaluable_pred_test.obj: base/multi_evaluable_pred_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_prof-multi_evaluable_pred_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_prof-multi_evaluable_pred_test.Tpo -c -o base/unit_tests_prof-multi_evaluable_pred_test.obj `if test -f 'base/multi_evaluable_pred_test.C'; then $(CYGPATH_W) 'base/multi_evaluable_pred_test.C'; else $(CYGPATH_W) '$(srcdir)/base/multi_evaluable_pred_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_prof-multi_evaluable_pred_test.Tpo base/$(DEPDIR)/unit_tests_prof-multi_evaluable_pred_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/multi_evaluable_pred_test.C' object='base/unit_tests_prof-multi_evaluable_pred_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_prof-multi_evaluable_pred_test.obj `if test -f 'base/multi_evaluable_pred_test.C'; then $(CYGPATH_W) 'base/multi_evaluable_pred_test.C'; else $(CYGPATH_W) '$(srcdir)/base/multi_evaluable_pred_test.C'; fi`
 
 fe/unit_tests_prof-fe_bernstein_test.o: fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_prof-fe_bernstein_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_prof-fe_bernstein_test.Tpo -c -o fe/unit_tests_prof-fe_bernstein_test.o `test -f 'fe/fe_bernstein_test.C' || echo '$(srcdir)/'`fe/fe_bernstein_test.C
@@ -10670,26 +10771,31 @@ distclean: distclean-am
 	-rm -f base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_dbg-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_dbg-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_dbg-multi_evaluable_pred_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_dbg-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_dbg-point_neighbor_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_devel-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_devel-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_devel-multi_evaluable_pred_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_devel-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_devel-point_neighbor_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_oprof-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_oprof-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_oprof-multi_evaluable_pred_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_oprof-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_oprof-point_neighbor_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_opt-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_opt-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_opt-multi_evaluable_pred_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_opt-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_opt-point_neighbor_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_prof-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_prof-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_prof-multi_evaluable_pred_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_prof-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_prof-point_neighbor_coupling_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_dbg-dual_shape_verification_test.Po
@@ -11187,26 +11293,31 @@ maintainer-clean: maintainer-clean-am
 	-rm -f base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_dbg-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_dbg-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_dbg-multi_evaluable_pred_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_dbg-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_dbg-point_neighbor_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_devel-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_devel-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_devel-multi_evaluable_pred_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_devel-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_devel-point_neighbor_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_oprof-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_oprof-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_oprof-multi_evaluable_pred_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_oprof-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_oprof-point_neighbor_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_opt-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_opt-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_opt-multi_evaluable_pred_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_opt-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_opt-point_neighbor_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_prof-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_prof-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_prof-multi_evaluable_pred_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_prof-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_prof-point_neighbor_coupling_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_dbg-dual_shape_verification_test.Po

--- a/tests/base/multi_evaluable_pred_test.C
+++ b/tests/base/multi_evaluable_pred_test.C
@@ -1,0 +1,156 @@
+#include <libmesh/partitioner.h>
+#include <libmesh/mesh.h>
+#include <libmesh/auto_ptr.h>
+#include <libmesh/mesh_generation.h>
+#include <libmesh/equation_systems.h>
+#include <libmesh/elem.h>
+#include <libmesh/system.h>
+#include <libmesh/dof_map.h>
+#include <timpi/communicator.h>
+
+#include "test_comm.h"
+#include "libmesh_cppunit.h"
+
+using namespace libMesh;
+
+class ContrivedPartitioner : public Partitioner
+{
+public:
+  ContrivedPartitioner() = default;
+  ContrivedPartitioner(const ContrivedPartitioner &) = default;
+  ContrivedPartitioner(ContrivedPartitioner &&) = default;
+  ContrivedPartitioner & operator=(const ContrivedPartitioner &) = default;
+  ContrivedPartitioner & operator=(ContrivedPartitioner &&) = default;
+  virtual ~ContrivedPartitioner() = default;
+
+  std::unique_ptr<Partitioner> clone() const override
+  {
+    return libmesh_make_unique<ContrivedPartitioner>(*this);
+  }
+
+protected:
+  void _do_partition(MeshBase & mesh, const unsigned int n) override
+  {
+    libmesh_assert(n > 1);
+
+    unsigned int n_interior_elems = 0;
+    for (Elem * const elem : as_range(mesh.elements_begin(), mesh.elements_end()))
+    {
+      bool internal_elem = true;
+      for (const Elem * const neighbor : elem->neighbor_ptr_range())
+        if (!neighbor)
+        {
+          internal_elem = false;
+          break;
+        }
+
+      // The interior element will go on processor 1. Other elements will go on processor 0. For a
+      // system/DofMap that has all nodal variables all elements on processor 0 will appear
+      // evaluable. However, for a system/DofMap that has any elemental variables the interior
+      // element will not appear evaluable on processor 0
+      n_interior_elems += internal_elem;
+      elem->processor_id() = internal_elem;
+    }
+
+    // This test is hand-crafted for one interior element
+    libmesh_assert(n_interior_elems == 1);
+  }
+};
+
+class MultiEvaluablePredTest : public CppUnit::TestCase
+{
+public:
+  CPPUNIT_TEST_SUITE(MultiEvaluablePredTest);
+
+  CPPUNIT_TEST(test);
+
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp() {}
+
+  void tearDown() {}
+
+  void test()
+  {
+    const auto rank = TestCommWorld->rank();
+    Mesh mesh(*TestCommWorld);
+    mesh.partitioner() = libmesh_make_unique<ContrivedPartitioner>();
+    MeshTools::Generation::build_square(mesh, 3, 3, 0, 3, 0, 3, QUAD4);
+
+    EquationSystems es(mesh);
+    auto & nodal_system = es.add_system<System>("nodal_system");
+    nodal_system.add_variable("nodal", FIRST, LAGRANGE);
+    auto & nodal_dof_map = nodal_system.get_dof_map();
+    nodal_dof_map.remove_default_ghosting();
+    auto & elem_system = es.add_system<System>("elem_system");
+    elem_system.add_variable("elem", CONSTANT, MONOMIAL);
+    auto & elem_dof_map = elem_system.get_dof_map();
+    elem_dof_map.remove_default_ghosting();
+
+    es.init();
+
+    {
+      auto n_evaluable = std::distance(mesh.evaluable_elements_begin(nodal_dof_map),
+                                       mesh.evaluable_elements_end(nodal_dof_map));
+      typedef decltype(n_evaluable) comp_type;
+      switch (rank)
+      {
+        case 0:
+          CPPUNIT_ASSERT_EQUAL(n_evaluable, comp_type(9));
+          break;
+
+        case 1:
+          CPPUNIT_ASSERT_EQUAL(n_evaluable, comp_type(1));
+          break;
+
+        default:
+          CPPUNIT_ASSERT_EQUAL(n_evaluable, comp_type(0));
+          break;
+      }
+    }
+
+    {
+      auto n_evaluable = std::distance(mesh.evaluable_elements_begin(elem_dof_map),
+                                       mesh.evaluable_elements_end(elem_dof_map));
+      typedef decltype(n_evaluable) comp_type;
+      switch (rank)
+      {
+        case 0:
+          CPPUNIT_ASSERT_EQUAL(n_evaluable, comp_type(TestCommWorld->size() == 1 ? 9 : 8));
+          break;
+
+        case 1:
+          CPPUNIT_ASSERT_EQUAL(n_evaluable, comp_type(1));
+          break;
+
+        default:
+          CPPUNIT_ASSERT_EQUAL(n_evaluable, comp_type(0));
+          break;
+      }
+    }
+
+    {
+      std::vector<const DofMap *> dof_maps = {&nodal_dof_map, &elem_dof_map};
+      auto n_evaluable = std::distance(mesh.multi_evaluable_elements_begin(dof_maps),
+                                       mesh.multi_evaluable_elements_end(dof_maps));
+      typedef decltype(n_evaluable) comp_type;
+      switch (rank)
+      {
+        case 0:
+          CPPUNIT_ASSERT_EQUAL(n_evaluable, comp_type(TestCommWorld->size() == 1 ? 9 : 8));
+          break;
+
+        case 1:
+          CPPUNIT_ASSERT_EQUAL(n_evaluable, comp_type(1));
+          break;
+
+        default:
+          CPPUNIT_ASSERT_EQUAL(n_evaluable, comp_type(0));
+          break;
+      }
+    }
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(MultiEvaluablePredTest);


### PR DESCRIPTION
Anyone got a great idea for a unit test? Conceptually I'd want a test in which I ghost every element around a given element and have one system with Lagrange and one with monomial and then check and see that the element is marked as evaluable for the single predicate with the first system DofMap, and not evaluable when all DofMaps are considered but I don't know how easy this would be to do (especially for different processor counts).

@hugary1995 do you want to play around with this? You'd have to change the MOOSE `FEProblemBase::getEvaluableElementRange` method (which we will want to do anyways)