### PR TITLE
Add missing (w/--enable-distmesh) header to test

### DIFF
--- a/tests/geom/volume_test.C
+++ b/tests/geom/volume_test.C
@@ -5,6 +5,7 @@
 #include <libmesh/mesh_modification.h>
 #include <libmesh/mesh.h>
 #include <libmesh/reference_elem.h>
+#include <libmesh/replicated_mesh.h>
 #include <libmesh/node.h>
 #include <libmesh/enum_to_string.h>
 #include <libmesh/tensor_value.h>


### PR DESCRIPTION
At some point (possibly #2978 ?) we added some explicit ReplicatedMesh declarations without the replicated_mesh.h header.

We really need to enable cppunit in CI.  Perhaps after we're done putting out the fires related to the Moose next->devel merge problems and the libMesh has_affine_map tolerance drop.