### PR TITLE
Distributed mesh interior_parent fix

### DIFF
--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -929,6 +929,20 @@ const Elem * Elem::interior_parent () const
                   (interior_p == remote_elem) ||
                   (interior_p->dim() > this->dim()));
 
+  // If an element in a multi-dimensional mesh has an interior_parent
+  // link, it should be at our level or coarser, just like a neighbor
+  // link.  Our collect_families() code relies on this, but it might
+  // be tempting for users to manually assign something that breaks
+  // it.
+  //
+  // However, we *also* create temporary side elements, and we don't
+  // bother with creating ancestors for those, so they can be at level
+  // 0 even when they're sides of non-level-0 elements.
+  libmesh_assert (!interior_p ||
+                  (interior_p->level() <= this->level()) ||
+                  (this->level() == 0 &&
+                   this->id() == DofObject::invalid_id));
+
   return interior_p;
 }
 

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -2096,10 +2096,11 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
                    mesh.pid_elements_end(DofObject::invalid_processor_id),
                    elements_to_keep);
 
-  // The elements we need should have their ancestors and their
-  // subactive children present too.  If the mesh has any
-  // constraint rows, then elements with constrained nodes need
-  // elements with constraining nodes to remain present.
+  // The elements we need should have their ancestors, their
+  // interior_parent links, and their subactive children present too.
+  // If the mesh has any constraint rows, then elements with
+  // constrained nodes need elements with constraining nodes to remain
+  // present.
   connect_families(elements_to_keep, &mesh);
 
   // Don't delete nodes that our semilocal elements need

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -271,10 +271,18 @@ void connect_families(std::set<const Elem *, CompareElemIdsByLevel> & connected_
 
       total_family_insert(elem);
 
-      // We also need any interior parents, which will then need their
-      // own ancestors and descendants.
+      // We also need any interior parents on this mesh, which will
+      // then need their own ancestors and descendants.
       const Elem * interior_parent = elem->interior_parent();
+
+      // Don't try to grab interior parents from other meshes, e.g. if
+      // this was a BoundaryMesh associated with a separate Mesh.
+
+      // We can't test this if someone's using the pre-mesh-ptr API
+      libmesh_assert(!interior_parent || mesh);
+
       if (interior_parent &&
+          interior_parent == mesh->query_elem_ptr(interior_parent->id()) &&
           !connected_elements.count(interior_parent))
         {
           connected_elements.insert (interior_parent);

--- a/tests/geom/volume_test.C
+++ b/tests/geom/volume_test.C
@@ -5,6 +5,7 @@
 #include <libmesh/mesh_modification.h>
 #include <libmesh/mesh.h>
 #include <libmesh/reference_elem.h>
+#include <libmesh/replicated_mesh.h>
 #include <libmesh/node.h>
 #include <libmesh/enum_to_string.h>
 #include <libmesh/tensor_value.h>


### PR DESCRIPTION
This is an update to the now-reverted #2941; it fixes the same bug with distributed multiple-manifold-dimension meshes, but this time it doesn't regress our distributed mesh support for interior_parent links between different meshes.

This isn't is the last fix we'll need for the distributed multiple-manifold-dimension adaptive mesh refinement case.  fem_system_ex4 now works fine for me with --enable-distmesh on 17 through 23 processors, but with 24 processors it looks like MeshRefinement::limit_overrefined_boundary is failing somehow on a distributed mesh, leaving us in an infinite loop when we try to do flag smoothing for the second refinement step.