### PR TITLE
Turn assert into error in PBCs::neighbor()

### DIFF
--- a/src/base/periodic_boundaries.C
+++ b/src/base/periodic_boundaries.C
@@ -104,9 +104,10 @@ const Elem * PeriodicBoundaries::neighbor(boundary_id_type boundary_id,
   // If we should have found a periodic neighbor but didn't then
   // either we're on a ghosted element with a remote periodic neighbor
   // or we're on a mesh with an inconsistent periodic boundary.
-  libmesh_assert_msg(!mesh.is_serial() &&
-                     (e->processor_id() != mesh.processor_id()),
-                     "Periodic boundary neighbor not found");
+  libmesh_error_msg_if(mesh.is_serial() ||
+                       (e->processor_id() == mesh.processor_id()),
+                       "Periodic boundary neighbor not found");
+
   if (neigh_side)
     *neigh_side = libMesh::invalid_uint;
   return remote_elem;


### PR DESCRIPTION
This should fix #2958

I don't like putting opt mode tests into anything called on a single
element; that's just asking to bloat kernel runtimes ... but in this
case, when we don't actually have broken PBC ids/displacements, we never
hit the test on a replicated or serialized mesh, and we never hit the
test when calling PBCs::neighbor() on a local element, and at least
within the library itself it looks like we're only calling
PBCs::neighbor from local elements.  So this change ought to be safe for
performance after all.