### PR TITLE
Disable HDF5 file locking unless the user insists

### DIFF
--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -46,6 +46,7 @@
 #include <omp.h>
 #endif
 
+#include "stdlib.h" // C, not C++ - we need setenv() from POSIX
 #include "signal.h"
 
 
@@ -651,6 +652,22 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
 
   if (libMesh::on_command_line("--enable-segv"))
     libMesh::enableSEGV(true);
+
+#ifdef LIBMESH_HAVE_HDF5
+  // We may be running with ExodusII configured not to use HDF5 (in
+  // which case user code which wants to lock files has to do flock()
+  // itself) or with ExodusII configured to use HDF5 (which will
+  // helpfully try to get an exclusive flock() itself, and then scream
+  // and die if user code has already locked the file.  To get
+  // consistent behavior, we need to disable file locking.  The only
+  // reliable way I can see to do this is via an HDF5 environment
+  // variable.
+  //
+  // If the user set this environment variable then we'll trust that
+  // they know what they're doing.  If not then we'll set FALSE,
+  // because that's a better default for us than the unset default.
+  setenv("HDF5_USE_FILE_LOCKING", "FALSE", /*overwrite=false*/0);
+#endif // LIBMESH_HAVE_HDF5
 
   // The library is now ready for use
   libMeshPrivateData::_is_initialized = true;


### PR DESCRIPTION
Their file locking was conflicting with Moose file locking, breaking
Moose Exodus output when (at least some versions of) HDF5 was enabled.

C++ doesn't actually guarantee a way to set environment variables, so I think it's safer to include stdlib.h here (which should be POSIX compatible on any systems we use) rather than cstdlib (which might strip out non-standard-C++ as soon as someone's C++ library decides to get strict enough).  We already include stdlib.h in rb_construction.C and a couple C++ apps so doing this doesn't seem likely to cause problems.