### PR TITLE
Add elem_num_map and node_num_map accessors to ExodusII_IO

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -423,6 +423,27 @@ public:
    */
   const std::vector<std::string> & get_global_var_names();
 
+  /**
+   * Returns a const reference to the elem_num_map, which is a vector
+   * that is created when a Mesh is read from file.  LibMesh will
+   * number its mesh elements consistently with the elem_num_map
+   * array, except that the indices in this array are 1-based, and
+   * libmesh always uses a 0-based numbering. For example, given:
+   * elem_num_map = [4,2,3,1]
+   * libmesh will assign the first element it reads from the Exodus
+   * file elem->id() == 3, the second will get elem->id() == 1, and so
+   * on. We note that not all Exodus files contain an elem_num_map,
+   * and in that case, calling this function will return a reference
+   * to a vector containing the 1-based identity array, [1,2,3,...]
+   */
+  const std::vector<int> & get_elem_num_map() const;
+
+  /**
+   * Idential to the behavior of get_elem_num_map(), but for the
+   * node_num_map instead.
+   */
+  const std::vector<int> & get_node_num_map() const;
+
 #ifdef LIBMESH_HAVE_EXODUS_API
   /**
    * Return a reference to the ExodusII_IO_Helper object.

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1809,6 +1809,21 @@ const std::vector<std::string> & ExodusII_IO::get_global_var_names()
   return exio_helper->global_var_names;
 }
 
+const std::vector<int> & ExodusII_IO::get_elem_num_map() const
+{
+  // We could make this function non-const and have it call
+  // exio_helper->read_elem_num_map() before returning a reference...
+  // but the intention is that this will be called some time after a
+  // mesh is read in, in which case it would be doing extra work to
+  // read in the elem_num_map twice.
+  return exio_helper->elem_num_map;
+}
+
+const std::vector<int> & ExodusII_IO::get_node_num_map() const
+{
+  return exio_helper->node_num_map;
+}
+
 ExodusII_IO_Helper & ExodusII_IO::get_exio_helper()
 {
   // Provide a warning when accessing the helper object

--- a/tests/mesh/extra_integers.C
+++ b/tests/mesh/extra_integers.C
@@ -221,6 +221,19 @@ public:
     exreader.set_extra_integer_vars({"material_id"});
     exreader.read(filename);
 
+    // Test that the ExodusII_IO::get_{elem,node}_num_map() APIs give
+    // us something sensible.  Note: this is unrelated to reading
+    // extra integers, but, in my opinion, it does not warrant its own
+    // standalone test either.
+    const auto & elem_num_map = exreader.get_elem_num_map();
+    const auto & node_num_map = exreader.get_node_num_map();
+
+    // This mesh has trivial elem_num_map and node_num_map
+    for (int i=0; i != 9; ++i)
+      CPPUNIT_ASSERT_EQUAL(elem_num_map[i], i+1);
+    for (int i=0; i != 16; ++i)
+      CPPUNIT_ASSERT_EQUAL(node_num_map[i], i+1);
+
     CPPUNIT_ASSERT(mesh.has_elem_integer("material_id"));
     unsigned int int_idx = mesh.get_elem_integer_index("material_id");
     for (dof_id_type i=0; i != 9; ++i)


### PR DESCRIPTION
These weren't needed by anyone in the past, but we now have a case where we store elemental and nodal values directly from the Exodus file in arrays, and then need to index into those arrays later based on (mapped) elem ids. Having these maps will help make that indexing possible. Also adds a unit test at the request of @roystgnr but there's not much to test here.
