### PR TITLE
Make FEMap::map_fe_type usable outside library

### DIFF
--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -42,7 +42,6 @@
 namespace libMesh
 {
 
-inline
 FEFamily
 FEMap::map_fe_type(const Elem & elem)
 {


### PR DESCRIPTION
It took [Mac testing](https://civet.inl.gov/job/817866/) on idaholab/moose#18395
in order to discover what I think is undesirable behavior. We
define `map_fe_type` as a public static function, which to me makes
me think it should be safe to use outside the library, but then we
put its definition in the source file which makes it unusable outside
of the library since `static` forces internal linkage. So I think
we should move the definition to the header