### PR TITLE
Reduced Basis EIM update to add elem_id and qp arguments

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex4/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex4/assembly.h
@@ -40,6 +40,7 @@ using libMesh::RealGradient;
 using libMesh::Elem;
 using libMesh::FEBase;
 using libMesh::subdomain_id_type;
+using libMesh::dof_id_type;
 using libMesh::Utility::pow;
 
 struct ShiftedGaussian : public RBParametrizedFunction
@@ -52,6 +53,8 @@ struct ShiftedGaussian : public RBParametrizedFunction
   virtual std::vector<Number>
   evaluate(const RBParameters & mu,
            const Point & p,
+           dof_id_type /*elem_id*/,
+           unsigned int /*qp*/,
            subdomain_id_type /*subdomain_id*/,
            const std::vector<Point> & /*p_perturb*/) override
   {

--- a/examples/reduced_basis/reduced_basis_ex6/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex6/assembly.h
@@ -43,6 +43,7 @@ using libMesh::RealGradient;
 using libMesh::Elem;
 using libMesh::FEBase;
 using libMesh::subdomain_id_type;
+using libMesh::dof_id_type;
 
 // The function we're approximating with EIM
 struct Gxyz : public RBParametrizedFunction
@@ -55,6 +56,8 @@ struct Gxyz : public RBParametrizedFunction
   virtual std::vector<Number>
   evaluate(const RBParameters & mu,
            const Point & p,
+           dof_id_type /*elem_id*/,
+           unsigned int /*qp*/,
            subdomain_id_type /*subdomain_id*/,
            const std::vector<Point> & /*p_perturb*/) override
   {

--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -835,6 +835,12 @@ protected:
    */
   void preevaluate_thetas();
 
+  /**
+   * Reset the _preevaluate_thetas_completed flag to false. We can use this to force
+   * us to recalculate preevaluate thetas, in cases where that is necessary.
+   */
+  void reset_preevaluate_thetas_completed();
+
   //----------- PROTECTED DATA MEMBERS -----------//
 
   /**
@@ -969,6 +975,13 @@ private:
    * Flag to indicate if we preevaluate the theta functions
    */
   bool _preevaluate_thetas_flag;
+
+  /**
+   * Flag to indicate if the preevaluate_thetas function has been called, since
+   * this allows us to avoid calling preevaluate_thetas more than once, which is
+   * typically unnecessary.
+   */
+  bool _preevaluate_thetas_completed;
 
   /**
    * The current training parameter index during reduced basis training.

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -102,31 +102,12 @@ public:
                                        const std::vector<Point> & xyz_perturb) = 0;
 
   /**
-   * Same as above except without the elem_id and qp arguments. This is the original API and is retained
-   * for backwards compatibility.
-   */
-  virtual std::vector<Number> evaluate(const RBParameters & mu,
-                                       const Point & xyz,
-                                       subdomain_id_type subdomain_id,
-                                       const std::vector<Point> & xyz_perturb);
-
-  /**
    * Vectorized version of evaluate. If requires_xyz_perturbations==false, then all_xyz_perturb will not be used.
    */
   virtual void vectorized_evaluate(const std::vector<RBParameters> & mus,
                                    const std::vector<Point> & all_xyz,
                                    const std::vector<dof_id_type> & elem_ids,
                                    const std::vector<unsigned int> & qps,
-                                   const std::vector<subdomain_id_type> & sbd_ids,
-                                   const std::vector<std::vector<Point>> & all_xyz_perturb,
-                                   std::vector<std::vector<std::vector<Number>>> & output);
-
-  /**
-   * Same as above except without the elem_id and qp arguments. This is the original API and is retained
-   * for backwards compatibility.
-   */
-  virtual void vectorized_evaluate(const std::vector<RBParameters> & mus,
-                                   const std::vector<Point> & all_xyz,
                                    const std::vector<subdomain_id_type> & sbd_ids,
                                    const std::vector<std::vector<Point>> & all_xyz_perturb,
                                    std::vector<std::vector<std::vector<Number>>> & output);

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -102,12 +102,31 @@ public:
                                        const std::vector<Point> & xyz_perturb) = 0;
 
   /**
+   * Same as above except without the elem_id and qp arguments. This is the original API and is retained
+   * for backwards compatibility.
+   */
+  virtual std::vector<Number> evaluate(const RBParameters & mu,
+                                       const Point & xyz,
+                                       subdomain_id_type subdomain_id,
+                                       const std::vector<Point> & xyz_perturb);
+
+  /**
    * Vectorized version of evaluate. If requires_xyz_perturbations==false, then all_xyz_perturb will not be used.
    */
   virtual void vectorized_evaluate(const std::vector<RBParameters> & mus,
                                    const std::vector<Point> & all_xyz,
                                    const std::vector<dof_id_type> & elem_ids,
                                    const std::vector<unsigned int> & qps,
+                                   const std::vector<subdomain_id_type> & sbd_ids,
+                                   const std::vector<std::vector<Point>> & all_xyz_perturb,
+                                   std::vector<std::vector<std::vector<Number>>> & output);
+
+  /**
+   * Same as above except without the elem_id and qp arguments. This is the original API and is retained
+   * for backwards compatibility.
+   */
+  virtual void vectorized_evaluate(const std::vector<RBParameters> & mus,
+                                   const std::vector<Point> & all_xyz,
                                    const std::vector<subdomain_id_type> & sbd_ids,
                                    const std::vector<std::vector<Point>> & all_xyz_perturb,
                                    std::vector<std::vector<std::vector<Number>>> & output);

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -82,6 +82,8 @@ public:
   virtual Number evaluate_comp(const RBParameters & mu,
                                unsigned int comp,
                                const Point & xyz,
+                               dof_id_type elem_id,
+                               unsigned int qp,
                                subdomain_id_type subdomain_id,
                                const std::vector<Point> & xyz_perturb);
 
@@ -94,6 +96,8 @@ public:
    */
   virtual std::vector<Number> evaluate(const RBParameters & mu,
                                        const Point & xyz,
+                                       dof_id_type elem_id,
+                                       unsigned int qp,
                                        subdomain_id_type subdomain_id,
                                        const std::vector<Point> & xyz_perturb) = 0;
 
@@ -102,6 +106,8 @@ public:
    */
   virtual void vectorized_evaluate(const std::vector<RBParameters> & mus,
                                    const std::vector<Point> & all_xyz,
+                                   const std::vector<dof_id_type> & elem_ids,
+                                   const std::vector<unsigned int> & qps,
                                    const std::vector<subdomain_id_type> & sbd_ids,
                                    const std::vector<std::vector<Point>> & all_xyz_perturb,
                                    std::vector<std::vector<std::vector<Number>>> & output);

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -87,7 +87,8 @@ RBConstruction::RBConstruction (EquationSystems & es,
     abs_training_tolerance(1.e-12),
     normalize_rb_bound_in_greedy(false),
     RB_training_type("Greedy"),
-    _preevaluate_thetas_flag(false)
+    _preevaluate_thetas_flag(false),
+    _preevaluate_thetas_completed(false)
 {
   // set assemble_before_solve flag to false
   // so that we control matrix assembly.
@@ -2642,6 +2643,10 @@ void RBConstruction::preevaluate_thetas()
 
   _evaluated_thetas.resize(get_local_n_training_samples());
 
+  // Early return if we've already preevaluated thetas.
+  if (_preevaluate_thetas_completed)
+    return;
+
   if ( get_local_n_training_samples() == 0 )
     return;
 
@@ -2675,6 +2680,13 @@ void RBConstruction::preevaluate_thetas()
       for (auto i : make_range(get_local_n_training_samples()))
         _evaluated_thetas[i][n_A_terms + q_f] = F_vals[i];
     }
+
+  _preevaluate_thetas_completed = true;
+}
+
+void RBConstruction::reset_preevaluate_thetas_completed()
+{
+  _preevaluate_thetas_completed = false;
 }
 
 } // namespace libMesh

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -164,6 +164,8 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
   std::vector<std::vector<std::vector<Number>>> output_all_comps;
   get_parametrized_function().vectorized_evaluate(mus,
                                                   _interpolation_points_xyz,
+                                                  _interpolation_points_elem_id,
+                                                  _interpolation_points_qp,
                                                   _interpolation_points_subdomain_id,
                                                   _interpolation_points_xyz_perturbations,
                                                   output_all_comps);

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -53,6 +53,16 @@ RBParametrizedFunction::evaluate_comp(const RBParameters & mu,
   return values[comp];
 }
 
+std::vector<Number> RBParametrizedFunction::evaluate(const RBParameters & mu,
+                                                     const Point & xyz,
+                                                     subdomain_id_type subdomain_id,
+                                                     const std::vector<Point> & xyz_perturb)
+{
+  // Use default values of elem_id and qp, since the assumption is they are not needed
+  // in this case.
+  return evaluate(mu, xyz, /*elem_id*/ 0, /*qp*/ 0, subdomain_id, xyz_perturb);
+}
+
 void RBParametrizedFunction::vectorized_evaluate(const std::vector<RBParameters> & mus,
                                                  const std::vector<Point> & all_xyz,
                                                  const std::vector<dof_id_type> & elem_ids,
@@ -98,6 +108,23 @@ void RBParametrizedFunction::vectorized_evaluate(const std::vector<RBParameters>
             }
         }
     }
+}
+
+void RBParametrizedFunction::vectorized_evaluate(const std::vector<RBParameters> & mus,
+                                                 const std::vector<Point> & all_xyz,
+                                                 const std::vector<subdomain_id_type> & sbd_ids,
+                                                 const std::vector<std::vector<Point>> & all_xyz_perturb,
+                                                 std::vector<std::vector<std::vector<Number>>> & output)
+{
+  // Use default values of elem_id and qp, since the assumption is they are not needed
+  // in this case.
+  return vectorized_evaluate(mus,
+                             all_xyz,
+                             /*elem_ids*/ {},
+                             /*qps*/ {},
+                             sbd_ids,
+                             all_xyz_perturb,
+                             output);
 }
 
 void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh(const RBParameters & mu,

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -53,16 +53,6 @@ RBParametrizedFunction::evaluate_comp(const RBParameters & mu,
   return values[comp];
 }
 
-std::vector<Number> RBParametrizedFunction::evaluate(const RBParameters & mu,
-                                                     const Point & xyz,
-                                                     subdomain_id_type subdomain_id,
-                                                     const std::vector<Point> & xyz_perturb)
-{
-  // Use default values of elem_id and qp, since the assumption is they are not needed
-  // in this case.
-  return evaluate(mu, xyz, /*elem_id*/ 0, /*qp*/ 0, subdomain_id, xyz_perturb);
-}
-
 void RBParametrizedFunction::vectorized_evaluate(const std::vector<RBParameters> & mus,
                                                  const std::vector<Point> & all_xyz,
                                                  const std::vector<dof_id_type> & elem_ids,
@@ -108,23 +98,6 @@ void RBParametrizedFunction::vectorized_evaluate(const std::vector<RBParameters>
             }
         }
     }
-}
-
-void RBParametrizedFunction::vectorized_evaluate(const std::vector<RBParameters> & mus,
-                                                 const std::vector<Point> & all_xyz,
-                                                 const std::vector<subdomain_id_type> & sbd_ids,
-                                                 const std::vector<std::vector<Point>> & all_xyz_perturb,
-                                                 std::vector<std::vector<std::vector<Number>>> & output)
-{
-  // Use default values of elem_id and qp, since the assumption is they are not needed
-  // in this case.
-  return vectorized_evaluate(mus,
-                             all_xyz,
-                             /*elem_ids*/ {},
-                             /*qps*/ {},
-                             sbd_ids,
-                             all_xyz_perturb,
-                             output);
 }
 
 void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh(const RBParameters & mu,


### PR DESCRIPTION
Add elem_id and qp arguments in RBParametrizedFunction, since this can be needed in some cases (e.g. if the RBParametrizedFunction uses mesh-based data).