### PR TITLE
Dual shape function modifications for 3D mortar and edge dropping

### DIFF
--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -452,6 +452,10 @@ public:
                        const std::vector<Point> * const pts = nullptr,
                        const std::vector<Real> * const weights = nullptr) override;
 
+  virtual void reinit_dual_shape_coeffs (const Elem * elem,
+                                         const std::vector<Point> & pts,
+                                         const std::vector<Real> & JxW) override;
+
   /**
    * Reinitializes all the physical element-dependent data based on
    * the \p side of \p face.  The \p tolerance parameter is passed to

--- a/include/fe/fe_abstract.h
+++ b/include/fe/fe_abstract.h
@@ -150,6 +150,10 @@ public:
                        const std::vector<Point> * const pts = nullptr,
                        const std::vector<Real> * const weights = nullptr) = 0;
 
+  virtual void reinit_dual_shape_coeffs (const Elem * elem,
+                                         const std::vector<Point> & pts,
+                                         const std::vector<Real> & JxW) = 0;
+
   /**
    * Reinitializes all the physical element-dependent data based on
    * the \p side of the element \p elem.  The \p tolerance parameter

--- a/include/fe/fe_base.h
+++ b/include/fe/fe_base.h
@@ -591,7 +591,7 @@ protected:
    * Compute the dual basis coefficients \p dual_coeff
    * the default qrule for element dimension and quadrature order is needed
    */
-  void compute_dual_shape_coeffs(const QBase & default_qrule);
+  void compute_dual_shape_coeffs(const std::vector<Real> & JxW, const std::vector<std::vector<OutputShape>> & phi);
 
   /**
    * Compute \p dual_phi, \p dual_dphi, \p dual_d2phi
@@ -795,7 +795,7 @@ void FEGenericBase<OutputType>::compute_dual_shape_functions ()
 }
 
 template <typename OutputType>
-void FEGenericBase<OutputType>::compute_dual_shape_coeffs (const QBase & /*default_qrule*/)
+void FEGenericBase<OutputType>::compute_dual_shape_coeffs(const std::vector<Real> & /*JxW*/, std::vector<std::vector<OutputShape>> & /*phi_vals*/)
 {
   libmesh_error_msg(
       "Computation of dual shape functions for vector finite element "
@@ -808,7 +808,7 @@ template <>
 void FEGenericBase<Real>::compute_dual_shape_functions();
 
 template <>
-void FEGenericBase<Real>::compute_dual_shape_coeffs(const QBase & default_qrule);
+void FEGenericBase<Real>::compute_dual_shape_coeffs(const std::vector<Real> & /*JxW*/, std::vector<std::vector<OutputShape>> & /*phi_vals*/);
 
 
 // Typedefs for convenience and backwards compatibility

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -298,37 +298,35 @@ void FE<Dim,T>::reinit(const Elem * elem,
       {
         if (T != LAGRANGE)
           nonlagrange_dual_warning();
-        if (this->calculate_dual_coeff)
-        {
-          // In order for the matrices for the biorthogonality condition to be
-          // non-singular, the dual basis coefficients must be computed when the
-          // primal shape functions are evaluated with a quadrature rule. *But* a
-          // user may be reiniting with integration points from a mortar segment,
-          // which is valid, so a simple `if (!pts)` check is not
-          // appropriate. We're just gonna have to trust the user on this one. If
-          // they "screw up" we'll throw an exception from the LU decomposition,
-          // and they can choose to handle it or not
-
-          // instead of using the customized qrule from mortar segments,
-          // we need the default qrule for computing the dual coefficients
-          FEType default_fe_type(this->get_order(), T);
-          QGauss default_qrule(elem->dim(), default_fe_type.default_quadrature_order());
-          default_qrule.init(elem->type(), elem->p_level());
-          // In preparation of computing dual_coeff, we compute the default shape
-          // function values and save these in dual_phi (instead of declaring a
-          // new container). The TRUE dual_phi values are computed in
-          // compute_dual_shape_functions()
-          all_shapes(elem, default_fe_type.order, default_qrule.get_points(), this->dual_phi);
-          this->compute_dual_shape_coeffs(default_qrule);
-          // only compute the dual coefficient once
-          this->calculate_dual_coeff = false;
-        }
         // the dual shape functions relies on the customized shape functions
         // and the coefficient matrix, \p dual_coeff
         this->compute_dual_shape_functions();
       }
     }
 }
+
+template <unsigned int Dim, FEFamily T>
+void FE<Dim,T>::reinit_dual_shape_coeffs(const Elem * elem,
+                                         const std::vector<Point> & pts,
+                                         const std::vector<Real> & JxW)
+{
+  // Set the type and p level for this element
+  this->elem_type = elem->type();
+  this->_p_level = elem->p_level();
+
+  const unsigned int n_shapes =
+    this->n_shape_functions(this->get_type(),
+                            this->get_order());
+
+  std::vector<std::vector<OutputShape>> phi_vals;
+  phi_vals.resize(n_shapes);
+  for (const auto i : make_range(phi_vals.size()))
+    phi_vals[i].resize(pts.size());
+
+  all_shapes(elem, this->get_order(), pts, phi_vals);
+  this->compute_dual_shape_coeffs(JxW, phi_vals);
+}
+
 
 template <unsigned int Dim, FEFamily T>
 void FE<Dim,T>::init_dual_shape_functions(const unsigned int n_shapes, const unsigned int n_qp)

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -743,38 +743,37 @@ void FEGenericBase<OutputType>::compute_shape_functions (const Elem * elem,
     this->_fe_trans->map_div(this->dim, elem, qp, (*this), this->div_phi);
 }
 
+
+// Note I am passing points instead of using members because size changes between calls
 template <>
-void FEGenericBase<Real>::compute_dual_shape_coeffs (const QBase & default_qrule)
+void FEGenericBase<Real>::compute_dual_shape_coeffs (const std::vector<Real> & JxW, const std::vector<std::vector<OutputShape>> & phi_vals)
 {
   // Start logging the dual coeff computation
   LOG_SCOPE("compute_dual_shape_coeffs()", "FE");
 
-  unsigned int sz=phi.size();
-  libmesh_error_msg_if(!sz, "ERROR:  dual basis should be computed after the primal basis");
+  unsigned int sz=phi_vals.size();
 
   //compute dual basis coefficient (dual_coeff)
   dual_coeff.resize(sz, sz);
   DenseMatrix<Real> A(sz, sz), D(sz, sz);
 
-  const std::vector<Real> & weights = default_qrule.get_weights();
-  // we do not need J here as it will be canceled in the A^-1*D calculation anyways
-  for (const auto i : index_range(dual_phi))
-    for (const auto qp : index_range(dual_phi[i]))
+  for (const auto i : index_range(phi_vals))
+    for (const auto qp : index_range(phi_vals[i]))
     {
-      D(i,i) += weights[qp]*dual_phi[i][qp];
-      for (const auto j : index_range(dual_phi))
-        A(i,j) += weights[qp]*dual_phi[i][qp]*dual_phi[j][qp];
+      D(i,i) += JxW[qp]*phi_vals[i][qp];
+      for (const auto j : index_range(phi_vals))
+        A(i,j) += JxW[qp]*phi_vals[i][qp]*phi_vals[j][qp];
     }
 
   // dual_coeff = A^-1*D
-  for (const auto j : index_range(dual_phi))
+  for (const auto j : index_range(phi_vals))
   {
     DenseVector<Real> Dcol(sz), coeffcol(sz);
-    for (const auto i : index_range(dual_phi))
+    for (const auto i : index_range(phi_vals))
       Dcol(i) = D(i, j);
     A.cholesky_solve(Dcol, coeffcol);
 
-    for (const auto row : index_range(dual_phi))
+    for (const auto row : index_range(phi_vals))
       dual_coeff(row, j)=coeffcol(row);
   }
 }

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -99,6 +99,9 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
     //Preallocate Memory if necessary
     this->reserve_nodes(other_mesh.n_nodes());
 
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+    unique_id_type potentially_next_unique_id = _next_unique_id;
+#endif
     for (const auto & oldn : other_mesh.node_ptr_range())
       {
         processor_id_type added_pid = cast_int<processor_id_type>
@@ -116,9 +119,15 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
                                   oldn->get_extra_integer(i));
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
-        newn->set_unique_id(oldn->unique_id() + unique_id_offset);
-#endif
+        const unique_id_type new_unique_id = oldn->unique_id() + unique_id_offset;
+        newn->set_unique_id(new_unique_id);
+        potentially_next_unique_id = std::max(new_unique_id+1, potentially_next_unique_id);
       }
+
+    this->set_next_unique_id(potentially_next_unique_id);
+#else
+      }
+#endif
   }
 
   //Copy in Elements


### PR DESCRIPTION
This simply separates the computation of dual functions from the reinit routine so that we can compute dual shape functions on a different set of points that we reinit with. I'm not super happy with these fixes, should at least add some protections for making sure dual shape functions have been reinited before computation. MOOSE PR [#18885](https://github.com/idaholab/moose/pull/18885) has the corresponding changes for getting the mortar quadrature to initialize the dual shape functions. 

I'm not intending for this to be merged as is, its going to need a bit more work.