### PR TITLE
Reduced Basis EIM update: Add phi values

### DIFF
--- a/contrib/capnproto/rb_data.capnp
+++ b/contrib/capnproto/rb_data.capnp
@@ -117,6 +117,7 @@ struct RBEIMEvaluationReal @0xf8121d2237427a80 {
   eimSolutionsForTrainingSet @10 :List(List(Real));
   observationPointsXyz       @11 :List(Point3D);
   observationPointsValues    @12 :List(List(List(Real)));
+  interpolationPhiValues     @13 :List(List(Real));
 }
 struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   nBfs                       @0  :Integer;
@@ -132,4 +133,5 @@ struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   eimSolutionsForTrainingSet @10 :List(List(Complex));
   observationPointsXyz       @11 :List(Point3D);
   observationPointsValues    @12 :List(List(List(Complex)));
+  interpolationPhiValues     @13 :List(List(Real));
 }

--- a/examples/reduced_basis/reduced_basis_ex4/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex4/assembly.h
@@ -56,7 +56,8 @@ struct ShiftedGaussian : public RBParametrizedFunction
            dof_id_type /*elem_id*/,
            unsigned int /*qp*/,
            subdomain_id_type /*subdomain_id*/,
-           const std::vector<Point> & /*p_perturb*/) override
+           const std::vector<Point> & /*p_perturb*/,
+           const std::vector<Real> & /*phi_i_qp*/) override
   {
     Real center_x = mu.get_value("center_x");
     Real center_y = mu.get_value("center_y");

--- a/examples/reduced_basis/reduced_basis_ex6/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex6/assembly.h
@@ -59,7 +59,8 @@ struct Gxyz : public RBParametrizedFunction
            dof_id_type /*elem_id*/,
            unsigned int /*qp*/,
            subdomain_id_type /*subdomain_id*/,
-           const std::vector<Point> & /*p_perturb*/) override
+           const std::vector<Point> & /*p_perturb*/,
+           const std::vector<Real> & /*phi_i_qp*/) override
   {
     Real curvature = mu.get_value("curvature");
 

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -230,6 +230,7 @@ public:
   void add_interpolation_points_xyz_perturbations(const std::vector<Point> & perturbs);
   void add_interpolation_points_elem_id(dof_id_type elem_id);
   void add_interpolation_points_qp(unsigned int qp);
+  void add_interpolation_points_phi_i_qp(const std::vector<Real> & phi_i_qp);
 
   /**
    * Get the data associated with EIM interpolation points.
@@ -240,6 +241,7 @@ public:
   const std::vector<Point> & get_interpolation_points_xyz_perturbations(unsigned int index) const;
   dof_id_type get_interpolation_points_elem_id(unsigned int index) const;
   unsigned int get_interpolation_points_qp(unsigned int index) const;
+  const std::vector<Real> & get_interpolation_points_phi_i_qp(unsigned int index) const;
 
   /**
    * Set entry of the EIM interpolation matrix.
@@ -261,7 +263,8 @@ public:
     dof_id_type elem_id,
     subdomain_id_type subdomain_id,
     unsigned int qp,
-    const std::vector<Point> & perturbs);
+    const std::vector<Point> & perturbs,
+    const std::vector<Real> & phi_i_qp);
 
   /**
    * Set the observation points and components.
@@ -422,6 +425,13 @@ private:
    */
   std::vector<dof_id_type> _interpolation_points_elem_id;
   std::vector<unsigned int> _interpolation_points_qp;
+
+  /**
+   * We store the shape function values at the qp as well. These values
+   * allows us to evaluate parametrized functions that depend on nodal
+   * data.
+   */
+  std::vector<std::vector<Real>> _interpolation_points_phi_i_qp;
 
   /**
    * Store the parametrized function that will be approximated

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -33,6 +33,7 @@ namespace libMesh
 
 class RBParameters;
 class Point;
+class System;
 
 /**
  * A simple functor class that provides a RBParameter-dependent function.
@@ -85,7 +86,8 @@ public:
                                dof_id_type elem_id,
                                unsigned int qp,
                                subdomain_id_type subdomain_id,
-                               const std::vector<Point> & xyz_perturb);
+                               const std::vector<Point> & xyz_perturb,
+                               const std::vector<Real> & phi_i_qp);
 
   /**
    * Evaluate the parametrized function at the specified point for
@@ -99,7 +101,8 @@ public:
                                        dof_id_type elem_id,
                                        unsigned int qp,
                                        subdomain_id_type subdomain_id,
-                                       const std::vector<Point> & xyz_perturb) = 0;
+                                       const std::vector<Point> & xyz_perturb,
+                                       const std::vector<Real> & phi_i_qp) = 0;
 
   /**
    * Vectorized version of evaluate. If requires_xyz_perturbations==false, then all_xyz_perturb will not be used.
@@ -110,6 +113,7 @@ public:
                                    const std::vector<unsigned int> & qps,
                                    const std::vector<subdomain_id_type> & sbd_ids,
                                    const std::vector<std::vector<Point>> & all_xyz_perturb,
+                                   const std::vector<std::vector<Real>> & phi_i_qp,
                                    std::vector<std::vector<std::vector<Number>>> & output);
 
   /**
@@ -120,7 +124,8 @@ public:
   virtual void preevaluate_parametrized_function_on_mesh(const RBParameters & mu,
                                                          const std::unordered_map<dof_id_type, std::vector<Point>> & all_xyz,
                                                          const std::unordered_map<dof_id_type, subdomain_id_type> & sbd_ids,
-                                                         const std::unordered_map<dof_id_type, std::vector<std::vector<Point>> > & all_xyz_perturb);
+                                                         const std::unordered_map<dof_id_type, std::vector<std::vector<Point>> > & all_xyz_perturb,
+                                                         const System & sys);
 
   /**
    * Look up the preevaluate values of the parametrized function for

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -859,6 +859,28 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
         rb_eim_evaluation.set_observation_values(observation_values);
       }
     }
+
+  // The shape function values at the interpolation points. This can be used to evaluate nodal data
+  // at EIM interpolation points, which are at quadrature points.
+  {
+    auto interpolation_points_list_outer =
+      rb_eim_evaluation_reader.getInterpolationPhiValues();
+
+    libmesh_error_msg_if(interpolation_points_list_outer.size() != n_bfs,
+                         "Size error while reading the eim interpolation points.");
+
+    for (unsigned int i=0; i<n_bfs; ++i)
+      {
+        auto interpolation_points_list_inner = interpolation_points_list_outer[i];
+
+        std::vector<Real> phi_i_qp(interpolation_points_list_inner.size());
+        for (unsigned int j=0; j<phi_i_qp.size(); j++)
+          {
+            phi_i_qp[j] = load_scalar_value(interpolation_points_list_inner[j]);
+          }
+        rb_eim_evaluation.add_interpolation_points_phi_i_qp(phi_i_qp);
+      }
+  }
 }
 
 #if defined(LIBMESH_HAVE_SLEPC) && (LIBMESH_HAVE_GLPK)

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -725,6 +725,25 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
           }
       }
     }
+
+  // The shape function values at the interpolation points. This can be used to evaluate nodal data
+  // at EIM interpolation points, which are at quadrature points.
+  {
+    auto interpolation_points_list_outer =
+      rb_eim_evaluation_builder.initInterpolationPhiValues(n_bfs);
+    for (unsigned int i=0; i < n_bfs; ++i)
+      {
+        const std::vector<Real> & phi_i_qp_vec = rb_eim_evaluation.get_interpolation_points_phi_i_qp(i);
+        auto interpolation_points_list_inner = interpolation_points_list_outer.init(i, phi_i_qp_vec.size());
+
+        for (unsigned int j : index_range(phi_i_qp_vec))
+          {
+            set_scalar_in_list(interpolation_points_list_inner,
+                               j,
+                               phi_i_qp_vec[j]);
+          }
+      }
+  }
 }
 
 #if defined(LIBMESH_HAVE_SLEPC) && (LIBMESH_HAVE_GLPK)

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -668,7 +668,8 @@ void RBEIMConstruction::initialize_parametrized_functions_in_training_set()
       eim_eval.get_parametrized_function().preevaluate_parametrized_function_on_mesh(get_parameters(),
                                                                                      _local_quad_point_locations,
                                                                                      _local_quad_point_subdomain_ids,
-                                                                                     _local_quad_point_locations_perturbations);
+                                                                                     _local_quad_point_locations_perturbations,
+                                                                                     *this);
 
       for (const auto & pr : _local_quad_point_locations)
       {
@@ -1042,14 +1043,32 @@ void RBEIMConstruction::enrich_eim_approximation(unsigned int training_index)
   subdomain_id_type optimal_subdomain_id = 0;
   unsigned int optimal_qp = 0;
   std::vector<Point> optimal_point_perturbs;
+  std::vector<Real> optimal_point_phi_i_qp;
 
   // Initialize largest_abs_value to be negative so that it definitely gets updated.
   Real largest_abs_value = -1.;
+
+  // In order to compute phi_i_qp, we initialize a FEMContext
+  FEMContext con(*this);
+  for (auto dim : con.elem_dimensions())
+    {
+      auto fe = con.get_element_fe(/*var=*/0, dim);
+      fe->get_phi();
+    }
 
   for (const auto & pr : local_pf)
     {
       dof_id_type elem_id = pr.first;
       const auto & comp_and_qp = pr.second;
+
+      // Also initialize phi in order to compute phi_i_qp
+      const Elem & elem_ref = get_mesh().elem_ref(elem_id);
+      con.pre_fe_reinit(*this, &elem_ref);
+
+      auto elem_fe = con.get_element_fe(/*var=*/0, elem_ref.dim());
+      const std::vector<std::vector<Real>> & phi = elem_fe->get_phi();
+
+      elem_fe->reinit(&elem_ref);
 
       for (const auto & comp : index_range(comp_and_qp))
         {
@@ -1067,6 +1086,10 @@ void RBEIMConstruction::enrich_eim_approximation(unsigned int training_index)
                   optimal_comp = comp;
                   optimal_elem_id = elem_id;
                   optimal_qp = qp;
+
+                  optimal_point_phi_i_qp.resize(phi.size());
+                  for(unsigned int i : index_range(phi))
+                    optimal_point_phi_i_qp[i] = phi[i][qp];
 
                   const auto & point_list =
                     libmesh_map_find(_local_quad_point_locations, elem_id);
@@ -1103,6 +1126,7 @@ void RBEIMConstruction::enrich_eim_approximation(unsigned int training_index)
   this->comm().broadcast(optimal_subdomain_id, proc_ID_index);
   this->comm().broadcast(optimal_qp, proc_ID_index);
   this->comm().broadcast(optimal_point_perturbs, proc_ID_index);
+  this->comm().broadcast(optimal_point_phi_i_qp, proc_ID_index);
 
   libmesh_error_msg_if(optimal_elem_id == DofObject::invalid_id, "Error: Invalid element ID");
 
@@ -1119,7 +1143,8 @@ void RBEIMConstruction::enrich_eim_approximation(unsigned int training_index)
                                                      optimal_elem_id,
                                                      optimal_subdomain_id,
                                                      optimal_qp,
-                                                     optimal_point_perturbs);
+                                                     optimal_point_perturbs,
+                                                     optimal_point_phi_i_qp);
 
   if (has_obs_vals)
     {

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -1074,7 +1074,7 @@ void RBEIMConstruction::enrich_eim_approximation(unsigned int training_index)
         {
           const std::vector<Number> & qp_values = comp_and_qp[comp];
 
-          for (unsigned int qp : index_range(qp_values))
+          for (auto qp : index_range(qp_values))
             {
               Number value = qp_values[qp];
               Real abs_value = std::abs(value);
@@ -1088,7 +1088,7 @@ void RBEIMConstruction::enrich_eim_approximation(unsigned int training_index)
                   optimal_qp = qp;
 
                   optimal_point_phi_i_qp.resize(phi.size());
-                  for(unsigned int i : index_range(phi))
+                  for(auto i : index_range(phi))
                     optimal_point_phi_i_qp[i] = phi[i][qp];
 
                   const auto & point_list =

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -61,6 +61,7 @@ void RBEIMEvaluation::clear()
   _interpolation_points_xyz_perturbations.clear();
   _interpolation_points_elem_id.clear();
   _interpolation_points_qp.clear();
+  _interpolation_points_phi_i_qp.clear();
 
   _interpolation_matrix.resize(0,0);
 
@@ -77,6 +78,7 @@ void RBEIMEvaluation::resize_data_structures(const unsigned int Nmax)
   _interpolation_points_xyz_perturbations.clear();
   _interpolation_points_elem_id.clear();
   _interpolation_points_qp.clear();
+  _interpolation_points_phi_i_qp.clear();
 
   _interpolation_matrix.resize(Nmax,Nmax);
 }
@@ -168,6 +170,7 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
                                                   _interpolation_points_qp,
                                                   _interpolation_points_subdomain_id,
                                                   _interpolation_points_xyz_perturbations,
+                                                  _interpolation_points_phi_i_qp,
                                                   output_all_comps);
 
   std::vector<std::vector<Number>> evaluated_values_at_interp_points(output_all_comps.size());
@@ -403,6 +406,11 @@ void RBEIMEvaluation::add_interpolation_points_qp(unsigned int qp)
   _interpolation_points_qp.emplace_back(qp);
 }
 
+void RBEIMEvaluation::add_interpolation_points_phi_i_qp(const std::vector<Real> & phi_i_qp)
+{
+  _interpolation_points_phi_i_qp.emplace_back(phi_i_qp);
+}
+
 Point RBEIMEvaluation::get_interpolation_points_xyz(unsigned int index) const
 {
   libmesh_error_msg_if(index >= _interpolation_points_xyz.size(), "Error: Invalid index");
@@ -443,6 +451,13 @@ unsigned int RBEIMEvaluation::get_interpolation_points_qp(unsigned int index) co
   libmesh_error_msg_if(index >= _interpolation_points_qp.size(), "Error: Invalid index");
 
   return _interpolation_points_qp[index];
+}
+
+const std::vector<Real> & RBEIMEvaluation::get_interpolation_points_phi_i_qp(unsigned int index) const
+{
+  libmesh_error_msg_if(index >= _interpolation_points_phi_i_qp.size(), "Error: Invalid index");
+
+  return _interpolation_points_phi_i_qp[index];
 }
 
 void RBEIMEvaluation::set_interpolation_matrix_entry(unsigned int i, unsigned int j, Number value)
@@ -513,7 +528,8 @@ void RBEIMEvaluation::add_basis_function_and_interpolation_data(
   dof_id_type elem_id,
   subdomain_id_type subdomain_id,
   unsigned int qp,
-  const std::vector<Point> & perturbs)
+  const std::vector<Point> & perturbs,
+  const std::vector<Real> & phi_i_qp)
 {
   _local_eim_basis_functions.emplace_back(bf);
 
@@ -523,6 +539,7 @@ void RBEIMEvaluation::add_basis_function_and_interpolation_data(
   _interpolation_points_subdomain_id.emplace_back(subdomain_id);
   _interpolation_points_qp.emplace_back(qp);
   _interpolation_points_xyz_perturbations.emplace_back(perturbs);
+  _interpolation_points_phi_i_qp.emplace_back(phi_i_qp);
 }
 
 void RBEIMEvaluation::

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -161,7 +161,7 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh(const RBP
 
       elem_fe->reinit(&elem_ref);
 
-      for (unsigned int qp : index_range(xyz_vec))
+      for (auto qp : index_range(xyz_vec))
         {
           mesh_to_preevaluated_values_map[elem_id][qp] = counter;
 
@@ -171,7 +171,7 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh(const RBP
           sbd_ids_vec[counter] = subdomain_id;
 
           phi_i_qp_vec[counter].resize(phi.size());
-          for(unsigned int i : index_range(phi))
+          for(auto i : index_range(phi))
             phi_i_qp_vec[counter][i] = phi[i][qp];
 
           if (requires_xyz_perturbations)


### PR DESCRIPTION
In some cases we want to be able to interpolate nodal data onto the "EIM interpolation points", which are at quadrature points. To do this, we need access to the shape function values (i.e. the "phi" values). This MR provides this access.