### PR TITLE
Remove an unused variable.

### DIFF
--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -158,7 +158,6 @@ void transfer_elem(const Elem & lo_elem,
 
           hi_node->set_unique_id(new_unique_id);
 #endif
-          libmesh_ignore(max_new_nodes_per_elem);
 
           /*
            * insert the new node with its defining vertex


### PR DESCRIPTION
I noticed that there was a release candidate so I took a look - I have some more patches incoming. This one is just for master, though.

As of be42425a2ed (which is not in 1.7.0) these are not function arguments when LIBMESH_ENABLE_UNIQUE_ID is not defined.