### PR TITLE
Exodus version choice fix for --enable-exodus

### DIFF
--- a/configure
+++ b/configure
@@ -54752,7 +54752,14 @@ fi
   # Check whether --enable-exodus was given.
 if test "${enable_exodus+set}" = set; then :
   enableval=$enable_exodus; case "${enableval}" in #(
-  yes|v811) :
+  yes) :
+    enableexodus=yes
+                                      if test "x$enablehdf5" = "xyes"; then :
+  exodusversion=v8.11
+else
+  exodusversion=v5.22
+fi ;; #(
+  v811) :
     enableexodus=yes
                                       exodusversion="v8.11" ;; #(
   new|v522) :

--- a/m4/exodus.m4
+++ b/m4/exodus.m4
@@ -7,7 +7,11 @@ AC_DEFUN([CONFIGURE_EXODUS],
                 AS_HELP_STRING([--disable-exodus],
                                [build without ExodusII API support]),
                 [AS_CASE("${enableval}",
-                         [yes|v811], [enableexodus=yes
+                         [yes],      [enableexodus=yes
+                                      AS_IF([test "x$enablehdf5" = "xyes"],
+                                            [exodusversion=v8.11],
+                                            [exodusversion=v5.22])],
+                         [v811],     [enableexodus=yes
                                       exodusversion="v8.11"],
                          [new|v522], [enableexodus=yes
                                       exodusversion="v5.22"],


### PR DESCRIPTION
Unless someone explicitly requests Exodus 8, we don't want to try giving it to them unless we know they have HDF5 support.

This fixes #3029 on my system.

This should be backported to the release branch if it works for others too.