### PR TITLE
Updated how we evaluate observation points for EIM basis functions

### DIFF
--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -159,7 +159,8 @@ public:
   virtual std::vector<std::vector<Number>> evaluate_at_observation_points(const RBParameters & mu,
                                                                           const std::vector<Point> & observation_points,
                                                                           const std::vector<dof_id_type> & elem_ids,
-                                                                          const std::vector<subdomain_id_type> & sbd_ids);
+                                                                          const std::vector<subdomain_id_type> & sbd_ids,
+                                                                          const System & sys);
 
   /**
    * Storage for pre-evaluated values. The indexing is given by:

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -746,7 +746,8 @@ void RBEIMConstruction::initialize_parametrized_functions_in_training_set()
             eim_eval.get_parametrized_function().evaluate_at_observation_points(get_parameters(),
                                                                                 eim_eval.get_observation_points(),
                                                                                 observation_points_elem_ids,
-                                                                                observation_points_sbd_ids);
+                                                                                observation_points_sbd_ids,
+                                                                                *this);
 
           libmesh_error_msg_if(_parametrized_functions_for_training_obs_values[i].size() != eim_eval.get_n_observation_points(),
                                "Number of observation values should match number of observation points");

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -271,8 +271,7 @@ std::vector<std::vector<Number>> RBParametrizedFunction::evaluate_at_observation
           /*secure*/ true,
           /*extra_checks*/ false);
 
-      std::vector<Point> obs_pt_ref_coords_vec;
-      obs_pt_ref_coords_vec.push_back(obs_pt_ref_coords);
+      std::vector<Point> obs_pt_ref_coords_vec = {obs_pt_ref_coords};
 
       con.pre_fe_reinit(sys, &elem_ref);
       con.get_element_fe(/*var*/ 0, elem_ref.dim())->reinit(&elem_ref, &obs_pt_ref_coords_vec);


### PR DESCRIPTION
This update provides a default implementation of `RBParametrizedFunction::evaluate_at_observation_points()` which should work in most cases since it uses `RBParametrizedFunction::vectorized_evaluate()`.