### PR TITLE
Add/use LOG_CALL() macro

### DIFF
--- a/include/base/libmesh_logging.h
+++ b/include/base/libmesh_logging.h
@@ -119,6 +119,12 @@ private:
 
 #endif
 
+// If performance logging is disabled, the LOG_SCOPE(a,b) will be a no-op.
+#define LOG_CALL(a,b,X)   \
+  do {                    \
+    LOG_SCOPE(a,b);       \
+    X;                    \
+  } while (0)
 
 
 

--- a/src/apps/meshplot.C
+++ b/src/apps/meshplot.C
@@ -15,20 +15,18 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-
-
-// Open the mesh and solution file named in command line arguments,
-// and plot them out to the given filename.
+// libmesh includes
 #include "libmesh/libmesh.h"
-
 #include "libmesh/equation_systems.h"
 #include "libmesh/mesh.h"
 #include "libmesh/namebased_io.h"
 
+using namespace libMesh;
+
+// Open the mesh and solution file named in command line arguments,
+// and plot them out to the given filename.
 int main(int argc, char ** argv)
 {
-  using namespace libMesh;
-
   LibMeshInit init(argc, argv);
 
   Mesh mesh(init.comm());
@@ -39,39 +37,40 @@ int main(int argc, char ** argv)
       ("Usage: " << argv[0] <<
        " inputmesh [inputsolution] outputplot");
 
+  LOG_CALL("mesh.read()", "main", mesh.read(argv[1]));
 
-  START_LOG("mesh.read()", "main");
-  mesh.read(argv[1]);
-  STOP_LOG("mesh.read()", "main");
   libMesh::out << "Loaded mesh " << argv[1] << std::endl;
   mesh.print_info();
 
   if (argc > 3)
     {
-      START_LOG("es.read()", "main");
       std::string solnname = argv[2];
 
-      es.read(solnname,
-              EquationSystems::READ_HEADER |
-              EquationSystems::READ_DATA |
-              EquationSystems::READ_ADDITIONAL_DATA |
-              EquationSystems::READ_BASIC_ONLY);
-      STOP_LOG("es.read()", "main");
+      LOG_CALL("es.read()", "main",
+               es.read(solnname,
+                       EquationSystems::READ_HEADER |
+                       EquationSystems::READ_DATA |
+                       EquationSystems::READ_ADDITIONAL_DATA |
+                       EquationSystems::READ_BASIC_ONLY));
+
       libMesh::out << "Loaded solution " << solnname << std::endl;
       es.print_info();
     }
 
-  START_LOG("write_equation_systems()", "main");
   std::string outputname(argv[argc-1]);
-  if ((outputname.find(".xda") != std::string::npos) ||
-      (outputname.find(".xdr") != std::string::npos))
-    {
-      mesh.write("mesh-"+outputname);
-      es.write("soln-"+outputname);
-    }
-  else
-    NameBasedIO(mesh).write_equation_systems (outputname, es);
-  STOP_LOG("write_equation_systems()", "main");
+  {
+    LOG_SCOPE("write_equation_systems()", "main");
+    if ((outputname.find(".xda") != std::string::npos) ||
+        (outputname.find(".xdr") != std::string::npos))
+      {
+        mesh.write("mesh-"+outputname);
+        es.write("soln-"+outputname);
+      }
+    else
+      NameBasedIO(mesh).write_equation_systems (outputname, es);
+  }
 
   libMesh::out << "Wrote output " << outputname << std::endl;
+
+  return 0;
 }

--- a/src/mesh/inf_elem_builder.C
+++ b/src/mesh/inf_elem_builder.C
@@ -88,7 +88,7 @@ const Point InfElemBuilder::build_inf_elem (const InfElemOriginValue & origin_x,
                                             const bool be_verbose,
                                             std::vector<const Node *> * inner_boundary_nodes)
 {
-  START_LOG("build_inf_elem()", "InfElemBuilder");
+  LOG_SCOPE("build_inf_elem()", "InfElemBuilder");
 
   // first determine the origin of the
   // infinite elements.  For this, the
@@ -252,9 +252,6 @@ const Point InfElemBuilder::build_inf_elem (const InfElemOriginValue & origin_x,
       // There are no inner boundary nodes, so simply build the infinite elements
       this->build_inf_elem(origin, x_sym, y_sym, z_sym, be_verbose);
     }
-
-
-  STOP_LOG("build_inf_elem()", "InfElemBuilder");
 
   // when finished with building the Ifems,
   // it remains to prepare the mesh for use:

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -311,7 +311,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                                        const ElemType type,
                                        const bool gauss_lobatto_grid)
 {
-  START_LOG("build_cube()", "MeshTools::Generation");
+  LOG_SCOPE("build_cube()", "MeshTools::Generation");
 
   // Declare that we are using the indexing utility routine
   // in the "Private" part of our current namespace.  If this doesn't
@@ -1528,10 +1528,6 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
       libmesh_error_msg("Unknown dimension " << mesh.mesh_dimension());
     }
 
-  STOP_LOG("build_cube()", "MeshTools::Generation");
-
-
-
   // Done building the mesh.  Now prepare it for use.
   mesh.prepare_for_use ();
 }
@@ -1630,7 +1626,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
   libmesh_assert_greater (rad, 0.);
   //libmesh_assert_greater (nr, 0); // must refine at least once otherwise will end up with a square/cube
 
-  START_LOG("build_sphere()", "MeshTools::Generation");
+  LOG_SCOPE("build_sphere()", "MeshTools::Generation");
 
   // Clear the mesh and start from scratch, but save the original
   // mesh_dimension, since the original intent of this function was to
@@ -2120,9 +2116,6 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
       if (!elem->neighbor_ptr(s))
         boundary_info.add_side(elem, s, 0);
 
-  STOP_LOG("build_sphere()", "MeshTools::Generation");
-
-
   // Done building the mesh.  Now prepare it for use.
   mesh.prepare_for_use();
 }
@@ -2137,10 +2130,10 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
                                              RealVectorValue extrusion_vector,
                                              QueryElemSubdomainIDBase * elem_subdomain)
 {
+  LOG_SCOPE("build_extrusion()", "MeshTools::Generation");
+
   if (!cross_section.n_elem())
     return;
-
-  START_LOG("build_extrusion()", "MeshTools::Generation");
 
   dof_id_type orig_elem = cross_section.n_elem();
   dof_id_type orig_nodes = cross_section.n_nodes();
@@ -2458,8 +2451,6 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
             }
         }
     }
-
-  STOP_LOG("build_extrusion()", "MeshTools::Generation");
 
   // Done building the mesh.  Now prepare it for use.
   mesh.prepare_for_use();

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -1081,6 +1081,8 @@ bool UnstructuredMesh::contract ()
 
 void UnstructuredMesh::all_first_order ()
 {
+  LOG_SCOPE("all_first_order()", "Mesh");
+
   /*
    * when the mesh is not prepared,
    * at least renumber the nodes and
@@ -1089,8 +1091,6 @@ void UnstructuredMesh::all_first_order ()
    */
   if (!this->_is_prepared)
     this->renumber_nodes_and_elements ();
-
-  START_LOG("all_first_order()", "Mesh");
 
   /**
    * Prepare to identify (and then delete) a bunch of no-longer-used nodes.
@@ -1215,8 +1215,6 @@ void UnstructuredMesh::all_first_order ()
   // caches are correct.
   this->get_boundary_info().regenerate_id_sets();
 
-  STOP_LOG("all_first_order()", "Mesh");
-
   // On hanging nodes that used to also be second order nodes, we
   // might now have an invalid nodal processor_id()
   Partitioner::set_node_processor_ids(*this);
@@ -1231,6 +1229,8 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
 {
   // This function must be run on all processors at once
   parallel_object_only();
+
+  LOG_SCOPE("all_second_order()", "Mesh");
 
   /*
    * when the mesh is not prepared,
@@ -1262,8 +1262,6 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
   this->comm().max(already_second_order);
   if (already_second_order)
     return;
-
-  START_LOG("all_second_order()", "Mesh");
 
   /*
    * this map helps in identifying second order
@@ -1422,8 +1420,6 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
 
 
 
-  STOP_LOG("all_second_order()", "Mesh");
-
   // On a DistributedMesh our ghost node processor ids may be bad,
   // the ids of nodes touching remote elements may be inconsistent,
   // unique_ids of newly added non-local nodes remain unset, and our
@@ -1462,6 +1458,14 @@ void UnstructuredMesh::all_complete_order ()
   parallel_object_only();
 
   /*
+   * If the mesh is already complete ordered then we have nothing to
+   * do ... but what if we have a hybrid mesh where some elements are
+   * of complete order and others aren't?  So we won't short-circuit
+   * here.
+   */
+  LOG_SCOPE("all_complete_order()", "Mesh");
+
+  /*
    * when the mesh is not prepared,
    * at least renumber the nodes and
    * elements, so that the node ids
@@ -1476,14 +1480,6 @@ void UnstructuredMesh::all_complete_order ()
    */
   if (!this->n_elem())
     return;
-
-  /*
-   * If the mesh is already complete ordered then we have nothing to
-   * do ... but what if we have a hybrid mesh where some elements are
-   * of complete order and others aren't?  So we won't short-circuit
-   * here.
-   */
-  START_LOG("all_complete_order()", "Mesh");
 
   /*
    * this map helps in identifying second order
@@ -1628,8 +1624,6 @@ void UnstructuredMesh::all_complete_order ()
 #endif
 
 
-
-  STOP_LOG("all_complete_order()", "Mesh");
 
   // On a DistributedMesh our ghost node processor ids may be bad,
   // the ids of nodes touching remote elements may be inconsistent,

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -116,7 +116,7 @@ void XdrIO::write (const std::string & name)
 
   Xdr io ((this->processor_id() == 0) ? name : "", this->binary() ? ENCODE : WRITE);
 
-  START_LOG("write()","XdrIO");
+  LOG_SCOPE("write()","XdrIO");
 
   // convenient reference to our mesh
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
@@ -241,8 +241,6 @@ void XdrIO::write (const std::string & name)
       // write the "shell face" boundary condition information
       this->write_serialized_shellface_bcs (io, n_shellface_bcs);
     }
-
-  STOP_LOG("write()","XdrIO");
 
   // pause all processes until the writing ends -- this will
   // protect for the pathological case where a write is

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -448,7 +448,7 @@ namespace libMesh
 
   void PetscDMWrapper::init_and_attach_petscdm(System & system, SNES & snes)
   {
-    START_LOG ("init_and_attach_petscdm()", "PetscDMWrapper");
+    LOG_SCOPE ("init_and_attach_petscdm()", "PetscDMWrapper");
 
     PetscErrorCode ierr;
 
@@ -570,13 +570,8 @@ namespace libMesh
         // Uniformly coarsen if not the coarsest grid and distribute dof info.
         if ( level != 1 )
           {
-            START_LOG ("PDM_coarsen", "PetscDMWrapper");
-            mesh_refinement.uniformly_coarsen(1);
-            STOP_LOG  ("PDM_coarsen", "PetscDMWrapper");
-
-            START_LOG ("PDM_dist_dof", "PetscDMWrapper");
-            system.get_dof_map().distribute_dofs(mesh);
-            STOP_LOG  ("PDM_dist_dof", "PetscDMWrapper");
+            LOG_CALL("PDM_coarsen", "PetscDMWrapper", mesh_refinement.uniformly_coarsen(1));
+            LOG_CALL("PDM_dist_dof", "PetscDMWrapper", system.get_dof_map().distribute_dofs(mesh));
           }
       } // End PETSc data structure creation
 
@@ -645,17 +640,9 @@ namespace libMesh
             _ctx_vec[0].dof_vec[v] = di;
           }
 
-        START_LOG ("PDM_refine", "PetscDMWrapper");
-        mesh_refinement.uniformly_refine(1);
-        STOP_LOG  ("PDM_refine", "PetscDMWrapper");
-
-        START_LOG ("PDM_dist_dof", "PetscDMWrapper");
-        system.get_dof_map().distribute_dofs(mesh);
-        STOP_LOG  ("PDM_dist_dof", "PetscDMWrapper");
-
-        START_LOG ("PDM_cnstrnts", "PetscDMWrapper");
-        system.reinit_constraints();
-        STOP_LOG ("PDM_cnstrnts", "PetscDMWrapper");
+        LOG_CALL ("PDM_refine", "PetscDMWrapper", mesh_refinement.uniformly_refine(1));
+        LOG_CALL ("PDM_dist_dof", "PetscDMWrapper", system.get_dof_map().distribute_dofs(mesh));
+        LOG_CALL ("PDM_cnstrnts", "PetscDMWrapper", system.reinit_constraints());
       }
 
     // Create the Interpolation Matrices between adjacent mesh levels
@@ -697,9 +684,7 @@ namespace libMesh
             //MatSetOption(_ctx_vec[i-1].K_interp_ptr->mat(), MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
 
             // Compute the interpolation matrix and set K_interp_ptr
-            START_LOG ("PDM_proj_mat", "PetscDMWrapper");
-            system.projection_matrix(*_ctx_vec[i-1].K_interp_ptr);
-            STOP_LOG  ("PDM_proj_mat", "PetscDMWrapper");
+            LOG_CALL ("PDM_proj_mat", "PetscDMWrapper", system.projection_matrix(*_ctx_vec[i-1].K_interp_ptr));
 
             // Always close matrix that contains altered data
             _ctx_vec[i-1].K_interp_ptr->close();
@@ -708,17 +693,9 @@ namespace libMesh
         // Move to next grid to make next projection
         if ( i != n_levels - 1 )
           {
-            START_LOG ("PDM_refine", "PetscDMWrapper");
-            mesh_refinement.uniformly_refine(1);
-            STOP_LOG  ("PDM_refine", "PetscDMWrapper");
-
-            START_LOG ("PDM_dist_dof", "PetscDMWrapper");
-            system.get_dof_map().distribute_dofs(mesh);
-            STOP_LOG ("PDM_dist_dof", "PetscDMWrapper");
-
-            START_LOG ("PDM_cnstrnts", "PetscDMWrapper");
-            system.reinit_constraints();
-            STOP_LOG  ("PDM_cnstrnts", "PetscDMWrapper");
+            LOG_CALL ("PDM_refine", "PetscDMWrapper", mesh_refinement.uniformly_refine(1));
+            LOG_CALL ("PDM_dist_dof", "PetscDMWrapper", system.get_dof_map().distribute_dofs(mesh));
+            LOG_CALL ("PDM_cnstrnts", "PetscDMWrapper", system.reinit_constraints());
           }
       } // End create transfer operators. System back at the finest grid
 
@@ -726,13 +703,11 @@ namespace libMesh
     DM & dm = this->get_dm(n_levels-1);
     ierr = SNESSetDM(snes, dm);
     CHKERRABORT(system.comm().get(),ierr);
-
-    STOP_LOG ("init_and_attach_petscdm()", "PetscDMWrapper");
   }
 
   void PetscDMWrapper::build_section( const System & system, PetscSection & section )
   {
-    START_LOG ("build_section()", "PetscDMWrapper");
+    LOG_SCOPE ("build_section()", "PetscDMWrapper");
 
     PetscErrorCode ierr;
     ierr = PetscSectionCreate(system.comm().get(),&section);
@@ -792,13 +767,11 @@ namespace libMesh
 
     // Sanity checking at least that local_n_dofs match
     libmesh_assert_equal_to(system.n_local_dofs(),this->check_section_n_dofs(section));
-
-    STOP_LOG ("build_section()", "PetscDMWrapper");
   }
 
   void PetscDMWrapper::build_sf( const System & system, PetscSF & star_forest )
   {
-    START_LOG ("build_sf()", "PetscDMWrapper");
+    LOG_SCOPE ("build_sf()", "PetscDMWrapper");
 
     const DofMap & dof_map = system.get_dof_map();
 
@@ -854,8 +827,6 @@ namespace libMesh
                            remote_dofs,
                            PETSC_COPY_VALUES);
     CHKERRABORT(system.comm().get(),ierr);
-
-    STOP_LOG ("build_sf()", "PetscDMWrapper");
   }
 
   void PetscDMWrapper::set_point_range_in_section (const System & system,

--- a/src/systems/equation_systems_io.C
+++ b/src/systems/equation_systems_io.C
@@ -269,7 +269,7 @@ void EquationSystems::_read_impl (const std::string & name,
     else
       libmesh_deprecated();
 
-    START_LOG("read()","EquationSystems");
+    LOG_SCOPE("read()", "EquationSystems");
 
     // 2.)
     // Read the number of equation systems
@@ -354,8 +354,6 @@ void EquationSystems::_read_impl (const std::string & name,
       if (!read_legacy_format && partition_agnostic)
         _mesh.fix_broken_node_and_element_numbering();
     }
-
-  STOP_LOG("read()","EquationSystems");
 
   // Localize each system's data
   this->update();

--- a/src/systems/frequency_system.C
+++ b/src/systems/frequency_system.C
@@ -345,10 +345,6 @@ void FrequencySystem::solve (const unsigned int n_start,
   const unsigned int maxits =
     es.parameters.get<unsigned int>("linear solver maximum iterations");
 
-
-  //   // return values
-  //   std::vector<std::pair<unsigned int, Real>> vec_rval;
-
   // start solver loop
   for (unsigned int n=n_start; n<= n_stop; n++)
     {
@@ -356,12 +352,7 @@ void FrequencySystem::solve (const unsigned int n_start,
       this->set_current_frequency(n);
 
       // Call the user-supplied pre-solve method
-      START_LOG("user_pre_solve()", "FrequencySystem");
-
-      this->solve_system (es, this->name());
-
-      STOP_LOG("user_pre_solve()", "FrequencySystem");
-
+      LOG_CALL("user_pre_solve()", "FrequencySystem", this->solve_system(es, this->name()));
 
       // Solve the linear system for this specific frequency
       const std::pair<unsigned int, Real> rval =
@@ -381,8 +372,6 @@ void FrequencySystem::solve (const unsigned int n_start,
 
   // sanity check
   //libmesh_assert_equal_to (vec_rval.size(), (n_stop-n_start+1));
-
-  //return vec_rval;
 }
 
 

--- a/src/systems/nonlinear_implicit_system.C
+++ b/src/systems/nonlinear_implicit_system.C
@@ -159,7 +159,7 @@ void NonlinearImplicitSystem::set_solver_parameters ()
 void NonlinearImplicitSystem::solve ()
 {
   // Log how long the nonlinear solve takes.
-  START_LOG("solve()", "System");
+  LOG_SCOPE("solve()", "System");
 
   this->set_solver_parameters();
 
@@ -193,9 +193,6 @@ void NonlinearImplicitSystem::solve ()
       _n_nonlinear_iterations   = rval.first;
       _final_nonlinear_residual = rval.second;
     }
-
-  // Stop logging the nonlinear solve
-  STOP_LOG("solve()", "System");
 
   // Update the system after the solve
   this->update();

--- a/src/systems/optimization_system.C
+++ b/src/systems/optimization_system.C
@@ -153,12 +153,10 @@ initialize_inequality_constraints_storage(const std::vector<std::set<numeric_ind
 
 void OptimizationSystem::solve ()
 {
-  START_LOG("solve()", "OptimizationSystem");
+  LOG_SCOPE("solve()", "OptimizationSystem");
 
   optimization_solver->init();
   optimization_solver->solve ();
-
-  STOP_LOG("solve()", "OptimizationSystem");
 
   this->update();
 }


### PR DESCRIPTION
* This is useful for getting exception safe logging of single function
  call, as is done, for example, in petsc_dm_wrapper.C.
* Replace START/STOP_LOG with LOG_SCOPE where applicable.
  Note: LOG_SCOPE is exception safe whereas using START/STOP_LOG pairs
  is both annoying (because you have to repeat the strings twice)
  and not (currently) exception safe.
* It should be possible to make the PerfLog and PerfItem more
  exception safe, this will be pursued in a separate PR.
* We had a few places where we used START/STOP_LOG to exclude timing
  of certain parts of a function, such as a prepare_for_use() call at
  the end of a MeshGeneration routine. However, as mentioned
  previously, this is not currently exception safe. If we do end
  up making START/STOP_LOG more exception safe in the future, then
  we could consider going back to this approach, but I still think
  it's annoying and error prone to have to repeat the strings when
  invoking the macro.