### PR TITLE
Ban using broken PETScs with (par)metis.

### DIFF
--- a/configure
+++ b/configure
@@ -51949,6 +51949,10 @@ if test "${with_metis_include+set}" = set; then :
 fi
 
 
+      if test "x$enablepetsc" = "xno" && test "x$build_metis" = "xpetsc"; then :
+  as_fn_error $? "--with-metis=PETSc cannot be used without a working copy of PETSc." "$LINENO" 5
+fi
+
       if test "x$petsc_have_metis" != "x" && test $petsc_have_metis -gt 0; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Using PETSc Metis support to avoid PETSc conflict>>>" >&5
 $as_echo "<<< Using PETSc Metis support to avoid PETSc conflict>>>" >&6; }
@@ -52111,6 +52115,10 @@ if test "${with_parmetis_include+set}" = set; then :
               build_parmetis=no
 fi
 
+
+      if test "x$enablepetsc" = "xno" && test "x$build_parmetis" = "xpetsc"; then :
+  as_fn_error $? "--with-parmetis=PETSc cannot be used without a working copy of PETSc." "$LINENO" 5
+fi
 
       if test "x$petsc_have_metis" = "x"; then :
   petsc_have_metis=0

--- a/m4/metis.m4
+++ b/m4/metis.m4
@@ -31,6 +31,11 @@ AC_DEFUN([CONFIGURE_METIS],
               build_metis=no],
              [])
 
+  dnl Sanity check - it doesn't make any sense to specify metis with PETSc when
+  dnl PETSc itself is not available
+  AS_IF([test "x$enablepetsc" = "xno" && test "x$build_metis" = "xpetsc"],
+        [AC_MSG_ERROR(--with-metis=PETSc cannot be used without a working copy of PETSc.)])
+
   dnl If PETSc has its own METIS, default to using that one regardless
   dnl of what the user specified (if anything) in --with-metis.
   AS_IF([test "x$petsc_have_metis" != "x" && test $petsc_have_metis -gt 0],

--- a/m4/parmetis.m4
+++ b/m4/parmetis.m4
@@ -30,6 +30,11 @@ AC_DEFUN([CONFIGURE_PARMETIS],
               build_parmetis=no],
              [])
 
+  dnl Sanity check - it doesn't make any sense to specify parmetis with PETSc
+  dnl when PETSc itself is not available
+  AS_IF([test "x$enablepetsc" = "xno" && test "x$build_parmetis" = "xpetsc"],
+        [AC_MSG_ERROR(--with-parmetis=PETSc cannot be used without a working copy of PETSc.)])
+
   dnl Initialize $petsc_have_* to 0 if not already set. They may be
   dnl unset if the user configured with --disable-petsc
   AS_IF([test "x$petsc_have_metis" = "x"], [petsc_have_metis=0])


### PR DESCRIPTION
Also related to #3047 - we should just error out if the user asks for something impossible (in this case, use metis with petsc when petsc cannot be used).