### PR TITLE
complement solver/preconditioner to string_to_enum.

### DIFF
--- a/src/utils/string_to_enum.C
+++ b/src/utils/string_to_enum.C
@@ -301,14 +301,14 @@ void init_preconditioner_type_to_enum ()
   if (preconditioner_type_to_enum.empty())
     {
       preconditioner_type_to_enum["IDENTITY_PRECOND"      ]=IDENTITY_PRECOND;
-      preconditioner_type_to_enum["JACOBI_PRECOND"    ]=JACOBI_PRECOND;
+      preconditioner_type_to_enum["JACOBI_PRECOND"        ]=JACOBI_PRECOND;
       preconditioner_type_to_enum["BLOCK_JACOBI_PRECOND"  ]=BLOCK_JACOBI_PRECOND;
       preconditioner_type_to_enum["SOR_PRECOND"           ]=SOR_PRECOND;
       preconditioner_type_to_enum["SSOR_PRECOND"          ]=SSOR_PRECOND;
-      preconditioner_type_to_enum["EISENSTAT_PRECOND"    ]=EISENSTAT_PRECOND;
-      preconditioner_type_to_enum["ASM_PRECOND"    ]=ASM_PRECOND;
-      preconditioner_type_to_enum["CHOLESKY_PRECOND"    ]=CHOLESKY_PRECOND;
-      preconditioner_type_to_enum["ICC_PRECOND"    ]=ICC_PRECOND;
+      preconditioner_type_to_enum["EISENSTAT_PRECOND"     ]=EISENSTAT_PRECOND;
+      preconditioner_type_to_enum["ASM_PRECOND"           ]=ASM_PRECOND;
+      preconditioner_type_to_enum["CHOLESKY_PRECOND"      ]=CHOLESKY_PRECOND;
+      preconditioner_type_to_enum["ICC_PRECOND"           ]=ICC_PRECOND;
       preconditioner_type_to_enum["ILU_PRECOND"           ]=ILU_PRECOND;
       preconditioner_type_to_enum["LU_PRECOND"            ]=LU_PRECOND;
       preconditioner_type_to_enum["USER_PRECOND"          ]=USER_PRECOND;
@@ -391,6 +391,7 @@ void init_solvertype_to_enum ()
       solvertype_to_enum["TCQMR"         ]=TCQMR;
       solvertype_to_enum["TFQMR"         ]=TFQMR;
       solvertype_to_enum["BICG"          ]=BICG;
+      solvertype_to_enum["BICGSTAB"      ]=BICGSTAB;
       solvertype_to_enum["MINRES"        ]=MINRES;
       solvertype_to_enum["GMRES"         ]=GMRES;
       solvertype_to_enum["LSQR"          ]=LSQR;
@@ -400,6 +401,7 @@ void init_solvertype_to_enum ()
       solvertype_to_enum["SSOR"          ]=SSOR;
       solvertype_to_enum["RICHARDSON"    ]=RICHARDSON;
       solvertype_to_enum["CHEBYSHEV"     ]=CHEBYSHEV;
+      solvertype_to_enum["SPARSELU"      ]=SPARSELU;
       solvertype_to_enum["INVALID_SOLVER"]=INVALID_SOLVER;
     }
 }


### PR DESCRIPTION
I have realized that the `BICGSTAB` and `SPARSELU` solver types were missing in the `solver_to_enum`-list.

Please let me know about the reformatting of `preconditioners`; I can remove this from the PR if prefered.

Best regards