### PR TITLE
Fix recent Exodus IGA unit test

### DIFF
--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -986,8 +986,7 @@ public:
     {
       ExodusII_IO exii(mesh);
 
-      if (mesh.processor_id() == 0)
-        exii.write("exodus_file_mapping_out.e");
+      exii.write("exodus_file_mapping_out.e");
     }
 
   }


### PR DESCRIPTION
We may have to support people doing serial Exodus reads and people doing
Exodus reads with the same code, but doing a serial Exodus write in
parallel is simply a bug.