### PR TITLE
Support configure --with-metaphysicl* directory specifications

### DIFF
--- a/configure
+++ b/configure
@@ -654,6 +654,8 @@ libmesh_optional_INCLUDES
 LIBMESH_ENABLE_METAPHYSICL_FALSE
 LIBMESH_ENABLE_METAPHYSICL_TRUE
 METAPHYSICL_INCLUDE
+BUILD_METAPHYSICL_FALSE
+BUILD_METAPHYSICL_TRUE
 LIBMESH_ENABLE_NANOFLANN_FALSE
 LIBMESH_ENABLE_NANOFLANN_TRUE
 NANOFLANN_INCLUDE
@@ -1291,6 +1293,8 @@ with_cppunit_lib
 enable_nanoflann
 enable_nanoflann_pointlocator
 enable_metaphysicl
+with_metaphysicl
+with_metaphysicl_include
 enable_metaphysicl_required
 '
       ac_precious_vars='build_alias
@@ -2190,6 +2194,10 @@ Optional Packages:
   --with-cppunit-include=PATH
                           Specify a path for cppunit header files
   --with-cppunit-lib=PATH Specify a path for cppunit libs
+  --with-metaphysicl=<internal,/some/dir>
+                          internal: build from contrib
+  --with-metaphysicl-include=</some/includedir>
+
 
 Some influential environment variables:
   PETSC_DIR   path to PETSc installation
@@ -56239,6 +56247,44 @@ else
 fi
 
 
+
+# Check whether --with-metaphysicl was given.
+if test "${with_metaphysicl+set}" = set; then :
+  withval=$with_metaphysicl; case "${withval}" in #(
+  internal) :
+    build_metaphysicl=yes ;; #(
+  yes) :
+    build_metaphysicl=yes ;; #(
+  *) :
+    METAPHYSICL_DIR="${withval}"
+                        build_metaphysicl=no ;;
+esac
+               enablemetaphysicl=yes
+else
+  build_metaphysicl=yes
+fi
+
+
+
+# Check whether --with-metaphysicl-include was given.
+if test "${with_metaphysicl_include+set}" = set; then :
+  withval=$with_metaphysicl_include; METAPHYSICL_INCLUDE="-I${withval}"
+               METAPHYSICL_INC="-I${withval}"
+               enablemetaphysicl=yes
+               build_metaphysicl=no
+else
+  if test "x$build_metaphysicl" = "xyes"; then :
+  METAPHYSICL_INCLUDE="-I\$(top_srcdir)/contrib/metaphysicl/src/numerics/include -I\$(top_srcdir)/contrib/metaphysicl/src/core/include -I\$(top_srcdir)/contrib/metaphysicl/src/utilities/include"
+                      METAPHYSICL_INC="-I$top_srcdir/contrib/metaphysicl/src/numerics/include -I$top_srcdir/contrib/metaphysicl/src/core/include -I$top_srcdir/contrib/metaphysicl/src/utilities/include"
+else
+  METAPHYSICL_INCLUDE="-I$METAPHYSICL_DIR/include"
+                      METAPHYSICL_INC="-I$METAPHYSICL_DIR/include"
+fi
+
+fi
+
+
+
                 # Check whether --enable-metaphysicl-required was given.
 if test "${enable_metaphysicl_required+set}" = set; then :
   enableval=$enable_metaphysicl_required; case "${enableval}" in #(
@@ -56258,13 +56304,64 @@ fi
   enablemetaphysicl=yes
 fi
 
-    if test "x$enablemetaphysicl" = "xyes" && test -r $top_srcdir/contrib/metaphysicl/README; then :
-  enablemetaphysicl=yes
+    if test "x$enablemetaphysicl" = "xyes"; then :
+
+          { $as_echo "$as_me:${as_lineno-$LINENO}: checking for MetaPhysicL NumberArray support" >&5
+$as_echo_n "checking for MetaPhysicL NumberArray support... " >&6; }
+          ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+          old_CXXFLAGS="$CXXFLAGS"
+          CXXFLAGS="$CXXFLAGS $METAPHYSICL_INC"
+
+          cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+          #include "metaphysicl/numberarray.h"
+
+int
+main ()
+{
+
+              MetaPhysicL::NumberArray<4, double> x;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+              enablemetaphysicl=yes
+              { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
 else
 
-          { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> Configuring metaphysicl failed, you may need to run 'git submodule update --init' first <<<" >&5
-$as_echo ">>> Configuring metaphysicl failed, you may need to run 'git submodule update --init' first <<<" >&6; }
-          enablemetaphysicl=no
+              enablemetaphysicl=no
+              { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+              if test "x$build_metaphysicl" = "xyes"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> Metaphysicl not found, you may need to run 'git submodule update --init' first <<<" >&5
+$as_echo ">>> Metaphysicl not found, you may need to run 'git submodule update --init' first <<<" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> Metaphysicl not found in specified location <<<" >&5
+$as_echo ">>> Metaphysicl not found in specified location <<<" >&6; }
+fi
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+                    CXXFLAGS="$old_CXXFLAGS"
+          ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
 
 fi
 
@@ -56272,9 +56369,8 @@ fi
   as_fn_error 5 "*** MetaPhysicL was not found, but --enable-metaphysicl-required was specified." "$LINENO" 5
 fi
 
-        if test "x$enablemetaphysicl" = "xyes"; then :
+  if test "x$enablemetaphysicl" = "xyes"; then :
 
-          METAPHYSICL_INCLUDE="-I\$(top_srcdir)/contrib/metaphysicl/src/numerics/include -I\$(top_srcdir)/contrib/metaphysicl/src/core/include -I\$(top_srcdir)/contrib/metaphysicl/src/utilities/include"
 
 $as_echo "#define HAVE_METAPHYSICL 1" >>confdefs.h
 
@@ -56298,6 +56394,10 @@ fi
                               my_top_srcdir="$(cd $srcdir && pwd)"
 
 
+          if test "x$build_metaphysicl" = "xyes"; then :
+
+                 { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with built-in MetaPhysicL support >>>" >&5
+$as_echo "<<< Configuring library with built-in MetaPhysicL support >>>" >&6; }
 
 
   # Various preliminary checks.
@@ -56417,11 +56517,24 @@ $as_echo "$as_me: WARNING: could not find source tree for $ax_dir" >&2;}
 
 
 else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with external MetaPhysicL support >>>" >&5
+$as_echo "<<< Configuring library with external MetaPhysicL support >>>" >&6; }
+fi
+
+else
 
           METAPHYSICL_INCLUDE=""
-          enablemetaphysicl=no
 
 fi
+
+   if test x$build_metaphysicl = xyes; then
+  BUILD_METAPHYSICL_TRUE=
+  BUILD_METAPHYSICL_FALSE='#'
+else
+  BUILD_METAPHYSICL_TRUE='#'
+  BUILD_METAPHYSICL_FALSE=
+fi
+
 
 
 
@@ -57524,6 +57637,10 @@ $as_echo "$as_me: running $SHELL $ax_sub_configure $ax_sub_configure_args --cach
         cd "$ax_popdir"
       fi
 
+if test -z "${BUILD_METAPHYSICL_TRUE}" && test -z "${BUILD_METAPHYSICL_FALSE}"; then
+  as_fn_error $? "conditional \"BUILD_METAPHYSICL\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
 if test -z "${LIBMESH_ENABLE_METAPHYSICL_TRUE}" && test -z "${LIBMESH_ENABLE_METAPHYSICL_FALSE}"; then
   as_fn_error $? "conditional \"LIBMESH_ENABLE_METAPHYSICL\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -250,13 +250,16 @@ devel_libs += timpi/src/libtimpi_devel.la
 prof_libs  += timpi/src/libtimpi_prof.la
 oprof_libs += timpi/src/libtimpi_oprof.la
 
+
 ######################################################################
 # This must come *after* timpi - we now use TIMPI headers in
 # MetaPhysicL when they're available
 ######################################################################
 if LIBMESH_ENABLE_METAPHYSICL
+if BUILD_METAPHYSICL
   SUBDIRS += metaphysicl
   # header-only library for the parts we use - no library dependencies
+endif
 endif
 
 

--- a/contrib/Makefile.in
+++ b/contrib/Makefile.in
@@ -234,7 +234,7 @@ target_triplet = @target@
 # This must come *after* timpi - we now use TIMPI headers in
 # MetaPhysicL when they're available
 ######################################################################
-@LIBMESH_ENABLE_METAPHYSICL_TRUE@am__append_136 = metaphysicl
+@BUILD_METAPHYSICL_TRUE@@LIBMESH_ENABLE_METAPHYSICL_TRUE@am__append_136 = metaphysicl
 @LIBMESH_OPT_MODE_TRUE@am__append_137 = libcontrib_opt.la
 @LIBMESH_DBG_MODE_TRUE@am__append_138 = libcontrib_dbg.la
 @LIBMESH_DEVEL_MODE_TRUE@am__append_139 = libcontrib_devel.la
@@ -1318,7 +1318,7 @@ uninstall-am:
 @LIBMESH_ENABLE_FPARSER_TRUE@  # ATM always compile fparser with optimized flags,
 @LIBMESH_ENABLE_FPARSER_TRUE@  # and reuse in all methods
 @LIBMESH_ENABLE_NANOFLANN_TRUE@  # header-only library - no library dependencies
-@LIBMESH_ENABLE_METAPHYSICL_TRUE@  # header-only library for the parts we use - no library dependencies
+@BUILD_METAPHYSICL_TRUE@@LIBMESH_ENABLE_METAPHYSICL_TRUE@  # header-only library for the parts we use - no library dependencies
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/m4/libmesh_metaphysicl.m4
+++ b/m4/libmesh_metaphysicl.m4
@@ -17,6 +17,7 @@ AC_DEFUN([CONFIGURE_METAPHYSICL],
                              [internal: build from contrib]),
               [AS_CASE("${withval}",
                        [internal], [build_metaphysicl=yes],
+                       [yes], [build_metaphysicl=yes],
                        [METAPHYSICL_DIR="${withval}"
                         build_metaphysicl=no])
                enablemetaphysicl=yes],

--- a/m4/libmesh_metaphysicl.m4
+++ b/m4/libmesh_metaphysicl.m4
@@ -12,6 +12,34 @@ AC_DEFUN([CONFIGURE_METAPHYSICL],
                          [AC_MSG_ERROR(bad value ${enableval} for --enable-metaphysicl)])],
                 [enablemetaphysicl=$enablenested])
 
+  AC_ARG_WITH(metaphysicl,
+              AS_HELP_STRING([--with-metaphysicl=<internal,/some/dir>],
+                             [internal: build from contrib]),
+              [AS_CASE("${withval}",
+                       [internal], [build_metaphysicl=yes],
+                       [METAPHYSICL_DIR="${withval}"
+                        build_metaphysicl=no])
+               enablemetaphysicl=yes],
+              [build_metaphysicl=yes])
+
+  AC_ARG_WITH(metaphysicl-include,
+              AS_HELP_STRING([--with-metaphysicl-include=</some/includedir>]),
+              [METAPHYSICL_INCLUDE="-I${withval}"
+               METAPHYSICL_INC="-I${withval}"
+               enablemetaphysicl=yes
+               build_metaphysicl=no],
+              [AS_IF([test "x$build_metaphysicl" = "xyes"],
+                     [METAPHYSICL_INCLUDE="-I\$(top_srcdir)/contrib/metaphysicl/src/numerics/include -I\$(top_srcdir)/contrib/metaphysicl/src/core/include -I\$(top_srcdir)/contrib/metaphysicl/src/utilities/include"
+                      METAPHYSICL_INC="-I$top_srcdir/contrib/metaphysicl/src/numerics/include -I$top_srcdir/contrib/metaphysicl/src/core/include -I$top_srcdir/contrib/metaphysicl/src/utilities/include"],
+                     [METAPHYSICL_INCLUDE="-I$METAPHYSICL_DIR/include"
+                      METAPHYSICL_INC="-I$METAPHYSICL_DIR/include"])]
+             )
+
+  dnl The above distinction is to make it easier to add
+  dnl --with-metaphysicl-lib later, but we don't care about
+  dnl metaphysicl_version(); right now everything we need from
+  dnl MetaPhysicL is header-only.
+
   dnl Setting --enable-metaphysicl-required causes an error to be
   dnl emitted during configure if the MetaPhysicL library is not
   dnl detected successfully.  This is useful for app codes which require
@@ -34,12 +62,33 @@ AC_DEFUN([CONFIGURE_METAPHYSICL],
   AS_IF([test "x$enablemetaphysicl" = "xno" && test "x$metaphysiclrequired" = "xyes"],
         [enablemetaphysicl=yes])
 
-  dnl Check for existence of a file that should always be in metaphysicl
-  AS_IF([test "x$enablemetaphysicl" = "xyes" && test -r $top_srcdir/contrib/metaphysicl/README],
-        [enablemetaphysicl=yes],
+  dnl Check for existence of files that should always be in metaphysicl
+  AS_IF([test "x$enablemetaphysicl" = "xyes"],
         [
-          AC_MSG_RESULT([>>> Configuring metaphysicl failed, you may need to run 'git submodule update --init' first <<<])
-          enablemetaphysicl=no
+          AC_MSG_CHECKING(for MetaPhysicL NumberArray support)
+          AC_LANG_PUSH([C++])
+
+          old_CXXFLAGS="$CXXFLAGS"
+          CXXFLAGS="$CXXFLAGS $METAPHYSICL_INC"
+
+          AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+          @%:@include "metaphysicl/numberarray.h"
+          ]], [[
+              MetaPhysicL::NumberArray<4, double> x;
+          ]])],[
+              enablemetaphysicl=yes
+              AC_MSG_RESULT(yes)
+          ],[
+              enablemetaphysicl=no
+              AC_MSG_RESULT(no)
+              AS_IF([test "x$build_metaphysicl" = "xyes"],
+                    [AC_MSG_RESULT([>>> Metaphysicl not found, you may need to run 'git submodule update --init' first <<<])],
+                    [AC_MSG_RESULT([>>> Metaphysicl not found in specified location <<<])])
+          ])
+
+          dnl Reset old flags
+          CXXFLAGS="$old_CXXFLAGS"
+          AC_LANG_POP([C++])
         ])
 
   dnl If metaphysicl was required but isn't available, throw an error.
@@ -50,12 +99,8 @@ AC_DEFUN([CONFIGURE_METAPHYSICL],
   AS_IF([test "x$enablemetaphysicl" = "xno" && test "x$metaphysiclrequired" = "xyes"],
         [AC_MSG_ERROR([*** MetaPhysicL was not found, but --enable-metaphysicl-required was specified.], 5)])
 
-  dnl The MetaPhysicL API is distributed with libmesh, so we don't have
-  dnl to guess where it might be installed.  This needs to be replaced
-  dnl someday with an option to include an external version instead.
   AS_IF([test "x$enablemetaphysicl" = "xyes"],
         [
-          METAPHYSICL_INCLUDE="-I\$(top_srcdir)/contrib/metaphysicl/src/numerics/include -I\$(top_srcdir)/contrib/metaphysicl/src/core/include -I\$(top_srcdir)/contrib/metaphysicl/src/utilities/include"
           AC_DEFINE(HAVE_METAPHYSICL, 1, [Flag indicating whether the library will be compiled with MetaPhysicL support])
           AC_MSG_RESULT(<<< Configuring library with MetaPhysicL support >>>)
 
@@ -79,12 +124,18 @@ AC_DEFUN([CONFIGURE_METAPHYSICL],
           dnl currently the best way to get MetaPhysicL to recognize
           dnl that we really want TIMPI.
 
-          AX_SUBDIRS_CONFIGURE([contrib/metaphysicl],[[--with-cxx-std=20$acsm_cxx_version],[CPPFLAGS=-I$my_top_srcdir/contrib/timpi/src/algorithms/include/ -I$my_top_srcdir/contrib/timpi/src/parallel/include/ -I$my_top_srcdir/contrib/timpi/src/utilities/include/ -I$ac_abs_top_builddir/contrib/timpi/src/utilities/include/ $CPPFLAGS],[LDFLAGS=-L$ac_abs_top_builddir/contrib/timpi/src/ $LDFLAGS],[TIMPI_DIR=$my_top_srcdir/contrib/timpi/],[--with-timpi-method=$my_method]])
+          AS_IF([test "x$build_metaphysicl" = "xyes"],
+                [
+                 AC_MSG_RESULT(<<< Configuring library with built-in MetaPhysicL support >>>)
+                 AX_SUBDIRS_CONFIGURE([contrib/metaphysicl],[[--with-cxx-std=20$acsm_cxx_version],[CPPFLAGS=-I$my_top_srcdir/contrib/timpi/src/algorithms/include/ -I$my_top_srcdir/contrib/timpi/src/parallel/include/ -I$my_top_srcdir/contrib/timpi/src/utilities/include/ -I$ac_abs_top_builddir/contrib/timpi/src/utilities/include/ $CPPFLAGS],[LDFLAGS=-L$ac_abs_top_builddir/contrib/timpi/src/ $LDFLAGS],[TIMPI_DIR=$my_top_srcdir/contrib/timpi/],[--with-timpi-method=$my_method]])
+                ],
+                [AC_MSG_RESULT(<<< Configuring library with external MetaPhysicL support >>>)])
         ],
         [
           METAPHYSICL_INCLUDE=""
-          enablemetaphysicl=no
         ])
+
+  AM_CONDITIONAL(BUILD_METAPHYSICL, test x$build_metaphysicl = xyes)
 
   AC_SUBST(METAPHYSICL_INCLUDE)
 ])


### PR DESCRIPTION
We can now `configure --with-metaphysicl=/foo` or `configure --with-metaphysicl=/foo/include` to use headers like `/foo/include/metaphysicl/dynamicsparsenumberarray.h` from an external MetaPhysicL installation, in which case we don't bother to use or install anything from our contrib submodule.

Hopefully this is solid enough to backport, in which case it ought to be a solution for #3065