### PR TITLE
Only write Xdr header info on proc 0

### DIFF
--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -960,13 +960,18 @@ void RBEvaluation::write_out_vectors(System & sys,
   Xdr bf_data(file_name.str(),
               write_binary_vectors ? ENCODE : WRITE);
 
-  std::string version("libMesh-" + libMesh::get_io_compatibility_version());
+  // Following EquationSystems::write(), we should only write the header information
+  // if we're proc 0
+  if (sys.comm().rank() == 0)
+    {
+      std::string version("libMesh-" + libMesh::get_io_compatibility_version());
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
-  version += " with infinite elements";
+      version += " with infinite elements";
 #endif
-  bf_data.data(version ,"# File Format Identifier");
+      bf_data.data(version ,"# File Format Identifier");
 
-  sys.write_header(bf_data, /*(unused arg)*/ version, /*write_additional_data=*/false);
+      sys.write_header(bf_data, /*(unused arg)*/ version, /*write_additional_data=*/false);
+    }
 
   // Following EquationSystemsIO::write, we use a temporary numbering (node major)
   // before writing out the data

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -2253,12 +2253,12 @@ std::size_t System::read_serialized_vectors (Xdr & io,
       // Get the buffer size
       io.data(vector_length);
 
-      libmesh_assert_equal_to (num_vecs, vectors.size());
+      libmesh_error_msg_if (num_vecs != vectors.size(), "Unexpected value of num_vecs");
 
       if (num_vecs != 0)
         {
-          libmesh_assert_not_equal_to (vectors[0], 0);
-          libmesh_assert_equal_to     (vectors[0]->size(), vector_length);
+          libmesh_error_msg_if (vectors[0] == nullptr, "vectors[0] should not be null");
+          libmesh_error_msg_if (vectors[0]->size() != vector_length, "Inconsistent vector sizes");
         }
     }
 


### PR DESCRIPTION
Fixed race condition in writing header in RBEvaluation::write_out_vectors().