### PR TITLE
Add SVD in preconditioner type

### DIFF
--- a/include/enums/enum_preconditioner_type.h
+++ b/include/enums/enum_preconditioner_type.h
@@ -45,6 +45,7 @@ enum PreconditionerType : int {
                          USER_PRECOND,
                          SHELL_PRECOND,
                          AMG_PRECOND,
+                         SVD_PRECOND,
                          // Invalid
                          INVALID_PRECONDITIONER};
 }

--- a/src/numerics/petsc_preconditioner.C
+++ b/src/numerics/petsc_preconditioner.C
@@ -212,6 +212,11 @@ void PetscPreconditioner<T>::set_petsc_preconditioner_type (const Preconditioner
       CHKERRABORT(comm,ierr);
       break;
 
+    case SVD_PRECOND:
+      ierr = PCSetType (pc, const_cast<KSPType>(PCSVD));
+      CHKERRABORT(comm,ierr);
+      break;
+
     case USER_PRECOND:
       ierr = PCSetType (pc, const_cast<KSPType>(PCMAT));
       CHKERRABORT(comm,ierr);

--- a/src/utils/string_to_enum.C
+++ b/src/utils/string_to_enum.C
@@ -367,6 +367,7 @@ void init_preconditioner_type_to_enum ()
       preconditioner_type_to_enum["USER_PRECOND"          ]=USER_PRECOND;
       preconditioner_type_to_enum["SHELL_PRECOND"         ]=SHELL_PRECOND;
       preconditioner_type_to_enum["AMG_PRECOND"           ]=AMG_PRECOND;
+      preconditioner_type_to_enum["SVD_PRECOND"           ]=SVD_PRECOND;
       preconditioner_type_to_enum["INVALID_PRECONDITIONER"]=INVALID_PRECONDITIONER;
 
       //shorter
@@ -384,6 +385,7 @@ void init_preconditioner_type_to_enum ()
       preconditioner_type_to_enum["USER"        ]=USER_PRECOND;
       preconditioner_type_to_enum["SHELL"       ]=SHELL_PRECOND;
       preconditioner_type_to_enum["AMG"         ]=AMG_PRECOND;
+      preconditioner_type_to_enum["SVD"         ]=SVD_PRECOND;
       preconditioner_type_to_enum["INVALID"     ]=INVALID_PRECONDITIONER;
     }
 }


### PR DESCRIPTION
Add SVD in the preconditioner type in order to monitor condition number for the system. 

This is especially useful in evaluating the conditioner number for the condensed system produced by the variable condensation preconditioner (https://github.com/idaholab/moose/pull/16017)

Ping @fdkong 