### PR TITLE
SolutionHistory based on HistoryData

### DIFF
--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -117,6 +117,7 @@
 #include <iostream>
 #include <sys/time.h>
 #include <iomanip>
+#include <fenv.h>
 
 void write_output(EquationSystems & es,
                   unsigned int t_step,       // The current time step count
@@ -350,6 +351,8 @@ void set_system_parameters(HeatSystem &system, FEMParameters &param)
 // The main program.
 int main (int argc, char ** argv)
 {
+  feenableexcept(FE_INVALID);
+
   // Skip adaptive examples on a non-adaptive libMesh build
 #ifndef LIBMESH_ENABLE_AMR
   libmesh_ignore(argc, argv);
@@ -627,6 +630,9 @@ int main (int argc, char ** argv)
       // dQ/dp = int_{0}^{T} partialQ/partialp - partialR/partialp(u,z;p) dt
       // The quantity partialQ/partialp - partialR/partialp(u,z;p) is evaluated internally by the ImplicitSystem::adjoint_qoi_parameter_sensitivity function.
       // This sensitivity evaluation is called internally by an overloaded TimeSolver::integrate_adjoint_sensitivity method which we call below.
+
+      // Reset the time
+      system.time = 0.0;
 
       // Prepare the quantities we need to pass to TimeSolver::integrate_adjoint_sensitivity
       QoISet qois;

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -271,10 +271,6 @@ void set_system_parameters(HeatSystem &system, FEMParameters &param)
         else
         libmesh_error_msg("Unrecognized solution history type: " << param.solution_history_type);
 
-        // The Memory/File Solution History object we will set the system SolutionHistory object to
-        FileSolutionHistory heatsystem_solution_history(system);
-        system.time_solver->set_solution_history(heatsystem_solution_history);
-
       }
     }
   else

--- a/examples/adjoints/adjoints_ex7/adjoints_ex7.C
+++ b/examples/adjoints/adjoints_ex7/adjoints_ex7.C
@@ -232,10 +232,6 @@ void set_system_parameters(HeatSystem &system, FEMParameters &param)
         else
         libmesh_error_msg("Unrecognized solution history type: " << param.solution_history_type);
 
-        // The Memory/File Solution History object we will set the system SolutionHistory object to
-        FileSolutionHistory heatsystem_solution_history(system);
-        system.time_solver->set_solution_history(heatsystem_solution_history);
-
       }
     }
   else

--- a/examples/adjoints/adjoints_ex7/adjoints_ex7.C
+++ b/examples/adjoints/adjoints_ex7/adjoints_ex7.C
@@ -82,6 +82,7 @@
 #include <iostream>
 #include <sys/time.h>
 #include <iomanip>
+#include <fenv.h>
 
 void write_output(EquationSystems & es,
                   unsigned int t_step,       // The current time step count
@@ -336,6 +337,8 @@ build_adjoint_refinement_error_estimator(QoISet &qois, FEMPhysics* supplied_phys
 // The main program.
 int main (int argc, char ** argv)
 {
+  feenableexcept(FE_INVALID);
+
   // Skip adaptive examples on a non-adaptive libMesh build
 #ifndef LIBMESH_ENABLE_AMR
   libmesh_ignore(argc, argv);
@@ -695,6 +698,9 @@ int main (int argc, char ** argv)
           primal_solution.swap(dual_solution_1);
         }
       // End adjoint timestep loop
+
+      // Reset the time before looping over time again
+      system.time = 0.0;
 
       // Now that we have computed both the primal and adjoint solutions, we can compute the goal-oriented error estimates.
       // For this, we will need to build a ARefEE error estimator object, and supply a pointer to the 'true physics' object,

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -950,9 +950,12 @@ include_HEADERS = \
         solvers/eigen_time_solver.h \
         solvers/euler2_solver.h \
         solvers/euler_solver.h \
+        solvers/file_history_data.h \
         solvers/file_solution_history.h \
         solvers/first_order_unsteady_solver.h \
+        solvers/history_data.h \
         solvers/linear_solver.h \
+        solvers/memory_history_data.h \
         solvers/memory_solution_history.h \
         solvers/newmark_solver.h \
         solvers/newton_solver.h \

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -362,9 +362,12 @@ include_HEADERS =  \
         solvers/eigen_time_solver.h \
         solvers/euler2_solver.h \
         solvers/euler_solver.h \
+        solvers/file_history_data.h \
         solvers/file_solution_history.h \
         solvers/first_order_unsteady_solver.h \
+        solvers/history_data.h \
         solvers/linear_solver.h \
+        solvers/memory_history_data.h \
         solvers/memory_solution_history.h \
         solvers/newmark_solver.h \
         solvers/newton_solver.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -358,10 +358,13 @@ BUILT_SOURCES = \
         eigen_time_solver.h \
         euler2_solver.h \
         euler_solver.h \
+        file_history_data.h \
         file_solution_history.h \
         first_order_unsteady_solver.h \
+        history_data.h \
         laspack_linear_solver.h \
         linear_solver.h \
+        memory_history_data.h \
         memory_solution_history.h \
         newmark_solver.h \
         newton_solver.h \
@@ -1625,16 +1628,25 @@ euler2_solver.h: $(top_srcdir)/include/solvers/euler2_solver.h
 euler_solver.h: $(top_srcdir)/include/solvers/euler_solver.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
+file_history_data.h: $(top_srcdir)/include/solvers/file_history_data.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
 file_solution_history.h: $(top_srcdir)/include/solvers/file_solution_history.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 first_order_unsteady_solver.h: $(top_srcdir)/include/solvers/first_order_unsteady_solver.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
+history_data.h: $(top_srcdir)/include/solvers/history_data.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
 laspack_linear_solver.h: $(top_srcdir)/include/solvers/laspack_linear_solver.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 linear_solver.h: $(top_srcdir)/include/solvers/linear_solver.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+memory_history_data.h: $(top_srcdir)/include/solvers/memory_history_data.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 memory_solution_history.h: $(top_srcdir)/include/solvers/memory_solution_history.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -621,10 +621,11 @@ BUILT_SOURCES = auto_ptr.h default_coupling.h dirichlet_boundaries.h \
 	radial_basis_interpolation.h solution_transfer.h \
 	adaptive_time_solver.h diff_solver.h eigen_solver.h \
 	eigen_sparse_linear_solver.h eigen_time_solver.h \
-	euler2_solver.h euler_solver.h file_solution_history.h \
-	first_order_unsteady_solver.h laspack_linear_solver.h \
-	linear_solver.h memory_solution_history.h newmark_solver.h \
-	newton_solver.h nlopt_optimization_solver.h \
+	euler2_solver.h euler_solver.h file_history_data.h \
+	file_solution_history.h first_order_unsteady_solver.h \
+	history_data.h laspack_linear_solver.h linear_solver.h \
+	memory_history_data.h memory_solution_history.h \
+	newmark_solver.h newton_solver.h nlopt_optimization_solver.h \
 	no_solution_history.h nonlinear_solver.h optimization_solver.h \
 	petsc_auto_fieldsplit.h petsc_diff_solver.h petsc_dm_wrapper.h \
 	petsc_linear_solver.h petsc_nonlinear_solver.h \
@@ -1963,16 +1964,25 @@ euler2_solver.h: $(top_srcdir)/include/solvers/euler2_solver.h
 euler_solver.h: $(top_srcdir)/include/solvers/euler_solver.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
+file_history_data.h: $(top_srcdir)/include/solvers/file_history_data.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
 file_solution_history.h: $(top_srcdir)/include/solvers/file_solution_history.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 first_order_unsteady_solver.h: $(top_srcdir)/include/solvers/first_order_unsteady_solver.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
+history_data.h: $(top_srcdir)/include/solvers/history_data.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
 laspack_linear_solver.h: $(top_srcdir)/include/solvers/laspack_linear_solver.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 linear_solver.h: $(top_srcdir)/include/solvers/linear_solver.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+memory_history_data.h: $(top_srcdir)/include/solvers/memory_history_data.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 memory_solution_history.h: $(top_srcdir)/include/solvers/memory_solution_history.h

--- a/include/solvers/file_history_data.h
+++ b/include/solvers/file_history_data.h
@@ -1,0 +1,65 @@
+#ifndef LIBMESH_FILE_HISTORY_DATA_H
+#define LIBMESH_FILE_HISTORY_DATA_H
+
+#include "libmesh/history_data.h"
+#include "libmesh/diff_system.h"
+
+namespace libMesh
+{
+
+    /** HistoryData subclass that provides a struct to store history data
+     * such as timestamps, mesh, primal and adjoint filenames and timestep sizes.
+     *
+     * \author Vikram Garg
+     * \date 2021
+     * \brief
+     */
+
+    class FileHistoryData : public HistoryData
+    {
+        public:
+
+        FileHistoryData(DifferentiableSystem & system) : HistoryData(), _system(system),mesh_filename(""), primal_filename(""), adjoint_filename("") {};
+
+        ~FileHistoryData() {};
+
+        // Accessors for FileHistory specific variables
+        std::string & get_mesh_filename()
+        { return mesh_filename; }
+
+        std::string & get_primal_filename()
+        { return primal_filename; }
+
+        std::string & get_adjoint_filename()
+        { return adjoint_filename; }
+
+        void set_mesh_filename(std::string & mesh_name)
+        { mesh_filename = mesh_name; }
+
+        void set_primal_filename(std::string & primal_sol_name)
+        { primal_filename = primal_sol_name; }
+
+        void set_adjoint_filename(std::string & adjoint_sol_name)
+        { adjoint_filename = adjoint_sol_name; }
+
+        virtual void store_initial_solution() override;
+        virtual void store_primal_solution(stored_data_iterator stored_datum) override;
+        virtual void store_adjoint_solution() override;
+        virtual void rewrite_stored_solution() override;
+
+        virtual void retrieve_primal_solution() override;
+        virtual void retrieve_adjoint_solution() override;
+
+        private:
+
+        // Reference to underlying system
+        DifferentiableSystem & _system;
+
+        // File History specific variables
+        std::string mesh_filename;
+        std::string primal_filename;
+        std::string adjoint_filename;
+
+    };
+}
+#endif

--- a/include/solvers/file_solution_history.h
+++ b/include/solvers/file_solution_history.h
@@ -26,6 +26,7 @@
 #include "libmesh/enum_xdr_mode.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/libmesh.h"
+#include "libmesh/diff_system.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // C++ includes
@@ -50,7 +51,7 @@ public:
    * Constructor, reference to system to be passed by user, set the
    * stored_sols iterator to some initial value
    */
-  FileSolutionHistory(System & system_);
+  FileSolutionHistory(DifferentiableSystem & system_);
   /**
    * Destructor
    */
@@ -67,18 +68,6 @@ public:
   virtual void retrieve(bool is_adjoint_solve, Real time) override;
 
   /**
-   * Virtual function retrieve which we will be overriding to erase timesteps
-   */
-  virtual void erase(Real time) override;
-
-  /**
-   * Typedef for Stored Solutions iterator, a list of pairs of the
-   * system time and filenames of the stored solutions
-   */
-  typedef std::map<Real, std::string> map_type;
-  typedef map_type::iterator stored_solutions_iterator;
-
-  /**
    * Definition of the clone function needed for the setter function
    */
   virtual std::unique_ptr<SolutionHistory > clone() const override
@@ -88,33 +77,8 @@ public:
 
 private:
 
-  // This list of pairs will hold the timestamp and filename of each stored solution
-  map_type stored_solutions;
-
-  // The stored solutions iterator
-  stored_solutions_iterator stored_sols;
-
-  // A helper function to locate entries at a given time
-  // Behaviour depends on whether we are calling this function
-  // while storing or retrieving/erasing entries.
-  // While storing, if no entry in our map matches our time key,
-  // we will create a new entry in the map. If we are not storing,
-  // not matching a given time key implies an error.
-  void find_stored_entry(Real time, bool storing = false);
-
   // A system reference
-  System & _system ;
-
-  // A 'timestamp' that belongs specifically to FSH, this will be used to generate filenames
-  unsigned int localTimestamp;
-
-  // To assign filenames a timestamp, we will maintain a datastructure within
-  // FileSolutionHistory which will map system.time to 'timestamps'
-  std::map<Real, unsigned int> timeTotimestamp;
-
-  // An iterator for the timeTotimestamp map, will help member functions distinguish
-  // between primal and adjoint time loops
-  std::map<Real, unsigned int>::iterator timeTotimestamp_iterator;
+  DifferentiableSystem & _system ;
 
   /**
    * A vector of pointers to vectors holding the adjoint solution at the last time step

--- a/include/solvers/history_data.h
+++ b/include/solvers/history_data.h
@@ -1,0 +1,84 @@
+#ifndef LIBMESH_HISTORY_DATA_H
+#define LIBMESH_HISTORY_DATA_H
+
+#include <cmath>
+#include "libmesh/system.h"
+
+// LOCAL INCLUDES
+
+namespace libMesh
+{
+
+    /** The History Data classes are companion classes to SolutionHistory and MeshHistory classes.
+     * These provide data structures to store different types of history data (timestamps,
+     * pointers, filenames) depending on the type of History being used.
+     *
+     * \author Vikram Garg
+     * \date 2021
+     * \brief Provides history data structures and I/O, memory operation functions.
+     */
+
+    class HistoryData
+    {
+        public:
+
+        // Constructor
+        HistoryData() : time_stamp(std::numeric_limits<unsigned int>::signaling_NaN()),
+        deltat_at(std::numeric_limits<double>::signaling_NaN()), previously_stored(false) {};
+
+        // Destructor
+        virtual ~HistoryData() {};
+
+        // Accessors for individual history members, common to all types of histories.
+        unsigned int get_time_stamp()
+        { return time_stamp; }
+
+        Real get_deltat_at()
+        { return deltat_at; }
+
+        bool get_previously_stored()
+        { return previously_stored; }
+
+        // Setters for common history members
+        void set_time_stamp(unsigned int time_stamp_val)
+        { time_stamp = time_stamp_val; }
+
+        void set_deltat_at(Real deltat_at_val)
+        { deltat_at = deltat_at_val; }
+
+        void set_previously_stored(bool previously_stored_val)
+        { previously_stored = previously_stored_val; }
+
+        // Some history storing functions take an iterator to a map as an argument.
+        // This iterator is necessary for setting time stamps and delta_ts.
+        typedef std::map<Real, std::unique_ptr<HistoryData>> map_type;
+        typedef map_type::iterator stored_data_iterator;
+
+        // Operations for SolutionHistory
+        virtual void store_initial_solution() = 0;
+        virtual void store_primal_solution(stored_data_iterator stored_datum) = 0;
+        virtual void store_adjoint_solution() = 0;
+        virtual void rewrite_stored_solution() = 0;
+
+        virtual void retrieve_primal_solution() = 0;
+        virtual void retrieve_adjoint_solution() = 0;
+
+        // Operations for MeshHistory
+
+        protected:
+
+        // Variable members common to all derived HistoryData types
+
+        // The index of the current time step
+        unsigned int time_stamp;
+
+        // The delta_t (timestep taken) at the current timestep.
+        Real deltat_at;
+
+        // To help check if we are storing fresh or overwriting.
+        bool previously_stored;
+
+    };
+} // end namespace libMesh
+
+#endif // LIBMESH_HISTORY_DATA_H

--- a/include/solvers/memory_history_data.h
+++ b/include/solvers/memory_history_data.h
@@ -1,0 +1,52 @@
+#ifndef MEMORY_HISTORY_DATA_H
+#define MEMORY_HISTORY_DATA_H
+
+// Local includes
+#include "libmesh/history_data.h"
+#include "libmesh/diff_system.h"
+
+#include "libmesh/numeric_vector.h"
+
+namespace libMesh
+{
+    /** MemoryHistoryData provides a data structure to store memory history data.
+     * This is a companion class to MemorySolutionHistory.
+     */
+
+    class MemoryHistoryData : public HistoryData
+    {
+        public:
+
+        // Constructor
+        MemoryHistoryData(DifferentiableSystem & system) : HistoryData(), _system(system), stored_vecs{}, stored_vec(stored_vecs.end()) {};
+
+        // Destructor
+        ~MemoryHistoryData() {};
+
+        virtual void store_initial_solution() override;
+        virtual void store_primal_solution(stored_data_iterator stored_datum) override;
+        virtual void store_adjoint_solution() override;
+        virtual void rewrite_stored_solution() override;
+
+        virtual void retrieve_primal_solution() override;
+        virtual void retrieve_adjoint_solution() override;
+
+        void store_vectors();
+        void retrieve_vectors();
+
+        private:
+
+        DifferentiableSystem & _system;
+
+        typedef std::map<std::string, std::unique_ptr<NumericVector<Number>>> map_type;
+        typedef map_type::iterator stored_vecs_iterator;
+
+        // Memory History specific Constituents
+        //std::unique_ptr<MeshBase> stored_mesh;
+        map_type stored_vecs;
+        stored_vecs_iterator stored_vec;
+
+    };
+
+}
+#endif

--- a/include/solvers/memory_solution_history.h
+++ b/include/solvers/memory_solution_history.h
@@ -23,6 +23,7 @@
 // Local includes
 #include "libmesh/numeric_vector.h"
 #include "libmesh/solution_history.h"
+#include "libmesh/diff_system.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // C++ includes
@@ -47,7 +48,7 @@ public:
    * Constructor, reference to system to be passed by user, set the
    * stored_sols iterator to some initial value
    */
-  MemorySolutionHistory(System & system_) : stored_sols(stored_solutions.end()), _system(system_)
+  MemorySolutionHistory(DifferentiableSystem & system_) : SolutionHistory(), _system(system_)
   { libmesh_experimental(); }
 
   /**
@@ -65,18 +66,7 @@ public:
    */
   virtual void retrieve(bool is_adjoint_solve, Real time) override;
 
-  /**
-   * Virtual function retrieve which we will be overriding to erase timesteps
-   */
-  virtual void erase(Real time) override;
-
-  /**
-   * Typedef for Stored Solutions iterator, a list of pairs of the current
-   * system time, map of strings and saved vectors
-   */
   typedef std::map<std::string, std::unique_ptr<NumericVector<Number>>> map_type;
-  typedef std::map<Real, map_type> map_map_type;
-  typedef map_map_type::iterator stored_solutions_iterator;
 
   /**
    * Definition of the clone function needed for the setter function
@@ -88,23 +78,8 @@ public:
 
 private:
 
-  // This list of pairs will hold the current time and stored vectors
-  // from each timestep
-  map_map_type stored_solutions;
-
-  // The stored solutions iterator
-  stored_solutions_iterator stored_sols;
-
-  // A helper function to locate entries at a given time
-  // Behaviour depends on whether we are calling this function
-  // while storing or retrieving/erasing entries.
-  // While storing, if no entry in our map matches our time key,
-  // we will create a new entry in the map. If we are not storing,
-  // not matching a given time key implies an error.
-  void find_stored_entry(Real time, bool storing = false);
-
   // A system reference
-  System & _system ;
+  DifferentiableSystem & _system ;
 };
 
 } // end namespace libMesh

--- a/include/solvers/no_solution_history.h
+++ b/include/solvers/no_solution_history.h
@@ -44,7 +44,7 @@ public:
   /**
    * Destructor
    */
-  virtual ~NoSolutionHistory() = default;
+  virtual ~NoSolutionHistory() {}
 
   /**
    * Virtual function store which we will be overriding
@@ -55,12 +55,6 @@ public:
    * Virtual function retrieve which we will be overriding
    */
   virtual void retrieve(bool is_adjoint_solve, Real time) override;
-
-  /**
-   * Virtual function erase which we will be overriding
-   */
-  virtual void erase(Real time) override;
-
 
   /**
    * Definition of the clone function needed for the setter function

--- a/include/solvers/solution_history.h
+++ b/include/solvers/solution_history.h
@@ -20,6 +20,7 @@
 
 // Local Includes
 #include "libmesh/system.h"
+#include "libmesh/history_data.h"
 
 namespace libMesh
 {
@@ -27,6 +28,10 @@ namespace libMesh
 /**
  * A SolutionHistory class that enables the storage and retrieval of
  * timesteps and (in the future) adaptive steps.
+ * SolutionHistory interfaces between the time solver and HistoryData.
+ * SolutionHistory organizes and manages the overall history record as a map,
+ * while HistoryData manages individual I/O, memory or preprocessing operations
+ * for the history data at a particular time.
  *
  * \author Vikram Garg
  * \date 2012
@@ -39,13 +44,13 @@ public:
   /**
    * Constructor
    */
-  SolutionHistory() :
-    overwrite_previously_stored(false) {}
+  SolutionHistory() : overwrite_previously_stored(false),
+   stored_datum(stored_data.end()) {}
 
   /**
    * Destructor
    */
-  virtual ~SolutionHistory () = default;
+  virtual ~SolutionHistory () {}
 
   /**
    * Function to store a solution, pure virtual
@@ -58,9 +63,9 @@ public:
   virtual void retrieve(bool is_adjoint_solve, Real time) = 0;
 
   /**
-   * Function to erase solution at a given time, pure virtual
+   * Erase stored_data entry at time
    */
-  virtual void erase(Real time) = 0;
+  void erase(Real time);
 
   /**
    * Cloning function for a std::unique_ptr, pure virtual, used in the
@@ -80,6 +85,24 @@ protected:
   // Flag to specify whether we want to overwrite previously stored
   // vectors at a given time or not
   bool overwrite_previously_stored;
+
+  // The abstract data structure that indexes and stores history data
+  // Any type of history, solution, mesh or any future type will use
+  // a realization of this map to store history information. This way,
+  // we avoid multiple histories scatterred across the code.
+  typedef std::map<Real, std::unique_ptr<HistoryData>> map_type;
+  map_type stored_data;
+  typedef map_type::iterator stored_data_iterator;
+  stored_data_iterator stored_datum;
+
+  // Function to locate entries at a given time
+  // Behaviour depends on whether we are calling this function
+  // while storing or retrieving/erasing entries.
+  // While storing, if no entry in our map matches our time key,
+  // we will create a new entry in the map. If we are not storing,
+  // not matching a given time key implies an error.
+  void find_stored_entry(Real time, bool storing = false);
+
 };
 
 } // end namespace libMesh

--- a/include/solvers/unsteady_solver.h
+++ b/include/solvers/unsteady_solver.h
@@ -195,6 +195,16 @@ public:
     first_adjoint_step = first_adjoint_step_setting;
   }
 
+  /*
+   * A setter for the first_solver boolean. Useful for example if we are using
+   * a nested time solver, and the outer solver wants to tell the inner one that
+   * the initial conditions have already been handled.
+   */
+  void set_first_solve(bool first_solve_setting)
+  {
+    first_solve = first_solve_setting;
+  }
+
 protected:
 
   /**

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -365,10 +365,12 @@ libmesh_SOURCES =  \
         src/solvers/eigen_time_solver.C \
         src/solvers/euler2_solver.C \
         src/solvers/euler_solver.C \
+        src/solvers/file_history_data.C \
         src/solvers/file_solution_history.C \
         src/solvers/first_order_unsteady_solver.C \
         src/solvers/laspack_linear_solver.C \
         src/solvers/linear_solver.C \
+        src/solvers/memory_history_data.C \
         src/solvers/memory_solution_history.C \
         src/solvers/newmark_solver.C \
         src/solvers/newton_solver.C \

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -387,6 +387,7 @@ libmesh_SOURCES =  \
         src/solvers/petscdmlibmeshimpl.C \
         src/solvers/second_order_unsteady_solver.C \
         src/solvers/slepc_eigen_solver.C \
+        src/solvers/solution_history.C \
         src/solvers/steady_solver.C \
         src/solvers/tao_optimization_solver.C \
         src/solvers/time_solver.C \

--- a/src/solvers/adaptive_time_solver.C
+++ b/src/solvers/adaptive_time_solver.C
@@ -97,6 +97,7 @@ void AdaptiveTimeSolver::advance_timestep ()
     // the initial condition. The actual solution computed via this solve
     // will be stored when we call advance_timestep in the user's timestep loop
     first_solve = false;
+    core_time_solver->set_first_solve(false);
     }
 
   // For the adaptive time solver, all SH operations

--- a/src/solvers/file_history_data.C
+++ b/src/solvers/file_history_data.C
@@ -1,0 +1,98 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2020 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+// Local includes
+#include "libmesh/file_history_data.h"
+
+#include "libmesh/enum_xdr_mode.h"
+#include "libmesh/equation_systems.h"
+
+namespace libMesh
+{
+  void FileHistoryData::store_initial_solution()
+  {
+    // The initial data should only be stored once.
+    libmesh_assert(previously_stored == false);
+
+    time_stamp = 0;
+
+    primal_filename = "primal.out.xda.";
+
+    primal_filename += std::to_string(time_stamp);
+
+    _system.get_equation_systems().write (primal_filename, WRITE, EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA);
+
+    // We wont know the deltat taken at this timestep until the solve is completed, which is done after the store operation.
+    deltat_at = std::numeric_limits<double>::signaling_NaN();
+
+    previously_stored = true;
+  }
+
+  void FileHistoryData::store_primal_solution(stored_data_iterator stored_datum)
+  {
+    // An iterator to the datum being stored has been passed. This is taken to imply
+    // that we are in a sequential time stepping sequence.
+
+    stored_data_iterator stored_datum_last = stored_datum;
+    stored_datum_last--;
+
+    time_stamp = (stored_datum_last->second)->get_time_stamp() + 1;
+
+    primal_filename = "primal.out.xda.";
+
+    primal_filename += std::to_string(time_stamp);
+
+    _system.get_equation_systems().write (primal_filename, WRITE, EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA);
+
+    // We dont know the deltat that will be taken at the current timestep.
+    deltat_at = std::numeric_limits<double>::signaling_NaN();
+
+    // But we know what deltat got us to the current time.
+    (stored_datum_last->second)->set_deltat_at(_system.time_solver->TimeSolver::last_completed_timestep_size());
+
+    previously_stored = true;
+  }
+
+  void FileHistoryData::store_adjoint_solution()
+    {
+     adjoint_filename = "adjoint.out.xda.";
+
+     adjoint_filename += std::to_string(time_stamp);
+
+     _system.get_equation_systems().write(adjoint_filename, WRITE, EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA);
+    }
+
+  void FileHistoryData::rewrite_stored_solution()
+    {
+     // We are rewriting.
+     libmesh_assert(previously_stored == true);
+
+     _system.get_equation_systems().write(primal_filename, WRITE, EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA);
+    }
+
+   void FileHistoryData::retrieve_primal_solution()
+    {
+     // Read in the primal solution stored at the current recovery time from the disk
+     _system.get_equation_systems().read(primal_filename, READ, EquationSystems::READ_DATA | EquationSystems::READ_ADDITIONAL_DATA);
+    }
+
+   void FileHistoryData::retrieve_adjoint_solution()
+    {
+     // Read in the adjoint solution stored at the current recovery time from the disk
+     _system.get_equation_systems().read(adjoint_filename, READ, EquationSystems::READ_DATA | EquationSystems::READ_ADDITIONAL_DATA);
+    }
+}

--- a/src/solvers/file_solution_history.C
+++ b/src/solvers/file_solution_history.C
@@ -19,6 +19,7 @@
 #include <iostream>
 // Local includes
 #include "libmesh/file_solution_history.h"
+#include "libmesh/file_history_data.h"
 
 #include "libmesh/diff_system.h"
 
@@ -30,165 +31,81 @@ namespace libMesh
 
 /**
    * Constructor, reference to system to be passed by user, set the
-   * stored_sols iterator to some initial value
+   * stored_datum iterator to some initial value
    */
-  FileSolutionHistory::FileSolutionHistory(System & system_)
-  : stored_sols(stored_solutions.end()),
-  _system(system_), localTimestamp(0),
-  timeTotimestamp()
+  FileSolutionHistory::FileSolutionHistory(DifferentiableSystem & system_)
+  : SolutionHistory(), _system(system_)
   {
     dual_solution_copies.resize(system_.n_qois());
 
     libmesh_experimental();
+
   }
 
 
-FileSolutionHistory::~FileSolutionHistory () = default;
-
-// This function finds, if it can, the entry where we're supposed to
-// be storing data, leaves stored_sols unchanged if it cant find an entry
-// with the key corresponding to time.
-void FileSolutionHistory::find_stored_entry(Real time, bool storing)
+FileSolutionHistory::~FileSolutionHistory ()
 {
-  if (stored_solutions.begin() == stored_solutions.end())
-    return;
-
-  // We will use the map::lower_bound operation to find the key which
-  // is the least upper bound among all existing keys for time.
-  // (key before map::lower_bound) < time < map::lower_bound, one of these
-  // should be within TOLERANCE of time (unless we are creating a new map entry)
-  // If the lower bound iterator points to:
-  // begin -> we are looking for the solution at the initial time
-  // end -> we are creating a new entry
-  // anything else, we are looking for an existing entry
-  stored_solutions_iterator lower_bound_it = stored_solutions.lower_bound(time);
-
-  // For the key right before the lower bound
-  stored_solutions_iterator lower_bound_it_decremented;
-
-  // If we are at end, we could be creating a new entry (depends on the storing bool), return
-  // Otherwise, get a decremented iterator for the sandwich test
-  if(lower_bound_it == stored_solutions.end())
-  {
-    // If we are storing and lower_bound_it points to stored_solutions.end(), we assume
-    // that this is a brand new entry in the map. We leave stored_sols unchanged.
-    if(storing)
-    {
-      return;
-    }
-    else
-    {
-      // We are trying to retrieve and none of the keys was an upper bound.
-      // We could have a situation in which the time is greatest key + FPE.
-      // So we can check the key before the end and see if it matches time, else we have an error.
-      lower_bound_it = std::prev(lower_bound_it);
-    }
-  }
-  else if(lower_bound_it == stored_solutions.begin()) // At the beginning, so we cant go back any further
-  {
-    stored_sols = stored_solutions.begin();
-    return;
-  }
-  else // A decremented iterator, to perform the sandwich test for the key closest to time
-  {
-    lower_bound_it_decremented = std::prev(lower_bound_it);
-  }
-
-  // Set the stored sols iterator as per the key which is within TOLERANCE of time
-  if(std::abs(lower_bound_it->first - time) < TOLERANCE)
-  {
-    stored_sols = lower_bound_it;
-  }
-  else if(std::abs(lower_bound_it_decremented->first - time) < TOLERANCE)
-  {
-    stored_sols = lower_bound_it_decremented;
-  }
-  else // Neither of the two candidate keys matched our time
-  {
-    if(storing) // If we are storing, this is fine, we need to create a new entry, so just return
-    {
-      return;
-    }
-    else // If we are not storing, then we expected to find something but didnt, so we have a problem
-    {
-      libmesh_error_msg("Failed to set stored solutions iterator to a valid value.");
-    }
-  }
-
-
 }
 
 // This functions writes the solution at the current system time to disk
 void FileSolutionHistory::store(bool is_adjoint_solve, Real time)
 {
-  // This will map the stored_sols iterator to the current time
+  // This will map the stored_datum iterator to the current time
   this->find_stored_entry(time, true);
 
   // In an empty history we create the first entry
-  if (stored_solutions.begin() == stored_solutions.end())
+  if (stored_data.begin() == stored_data.end())
     {
-      stored_solutions[time] = std::string();
-      stored_sols = stored_solutions.begin();
+      stored_data[time] = libmesh_make_unique<FileHistoryData>(_system);
+      stored_datum = stored_data.begin();
     }
 
   // If we're past the end we can create a new entry
-  if (time - stored_sols->first > TOLERANCE )
+  if (time - stored_datum->first > TOLERANCE )
     {
 #ifndef NDEBUG
-      ++stored_sols;
-      libmesh_assert (stored_sols == stored_solutions.end());
+      ++stored_datum;
+      libmesh_assert (stored_datum == stored_data.end());
 #endif
-      stored_solutions[time] = std::string();
-      stored_sols = stored_solutions.end();
-      --stored_sols;
+      stored_data[time] = libmesh_make_unique<FileHistoryData>(_system);
+      stored_datum = stored_data.end();
+      --stored_datum;
     }
 
   // If we're before the beginning we can create a new entry
-  else if (stored_sols->first - time > TOLERANCE)
+  else if (stored_datum->first - time > TOLERANCE)
     {
-      libmesh_assert (stored_sols == stored_solutions.begin());
-      stored_solutions[time] = std::string();
-      stored_sols = stored_solutions.begin();
+      libmesh_assert (stored_datum == stored_data.begin());
+      stored_data[time] = libmesh_make_unique<FileHistoryData>(_system);
+      stored_datum = stored_data.begin();
     }
 
   // We don't support inserting entries elsewhere
-  libmesh_assert(std::abs(stored_sols->first - time) < TOLERANCE);
+  libmesh_assert(std::abs(stored_datum->first - time) < TOLERANCE);
 
-  // The name of the file to in which we store the solution from the current timestep
-  std::string & solution_filename = stored_sols->second;
-
-  // This iterator will be used to check if we have already assigned a timestamp for this time key
-  // If we have, we are in the adjoint loop, if we have not, we are in the primal loop
-  timeTotimestamp_iterator = timeTotimestamp.find(time);
-
-  // Associate the localTimestamp to the current time, if we are in the primal solve loop
-  // Then increment the localTimestamp
+  // If we are in the primal loop, either reuse an existing timestamp if a write has been done for
+  // this time earlier. Else, we are at a new time and need to make a new entry in the timeTotimestamp map.
   if(!is_adjoint_solve)
   {
-    // Point solution_filename to the filename generated by the libMesh I/O object
-    solution_filename = "primal.out.xda.";
-    solution_filename += std::to_string(localTimestamp);
-
-    // Write the current primal solution out to file
-    _system.get_equation_systems().write (solution_filename, WRITE, EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA);
-
-    timeTotimestamp.insert( std::pair<Real, unsigned int>(time, localTimestamp) );
-
-    ++localTimestamp;
+     // First we handle the case of the initial data, this is the only case in which
+     // stored_data will have size one
+     if(stored_data.size() == 1)
+     {
+       (stored_datum->second)->store_initial_solution();
+     }
+    else if((stored_datum->second)->get_previously_stored() == false) // If we are not at the initial time, we are either creating a new entry or overwriting an existing one
+    {
+      (stored_datum->second)->store_primal_solution(stored_datum);
+    }
+    else
+    {
+      (stored_datum->second)->rewrite_stored_solution();
+    }
   }
   else // We are in the adjoint time stepping loop
   {
-    --localTimestamp;
-
-    // For the adjoint solution, we reuse the timestamps generated earlier during the primal time march
-    solution_filename = "adjoint.out.xda.";
-    solution_filename += std::to_string(localTimestamp);
-
-    // Write the current primal solution out to file
-    _system.get_equation_systems().write (solution_filename, WRITE, EquationSystems::WRITE_DATA | EquationSystems::WRITE_ADDITIONAL_DATA);
-
+    (stored_datum->second)->store_adjoint_solution();
   }
-
 
 }
 
@@ -196,63 +113,43 @@ void FileSolutionHistory::retrieve(bool is_adjoint_solve, Real time)
 {
   this->find_stored_entry(time, false);
 
-  // To set the deltat while using adaptive timestepping, we will utilize
-  // consecutive time entries in the stored solutions iterator
-  Real _current_time = stored_sols->first;
-
-  // If we are solving the adjoint, we are moving backwards, so decrement time
-  // else we are moving forwards, so increment time
+  // If we are solving the adjoint, the timestep we need to move to the past step
+  // is the one taken at that step to get to the current time.
+  // At the initial time, be ready for the primal time march again.
   if(is_adjoint_solve)
   {
-    stored_solutions_iterator stored_sols_decrement_time = stored_sols;
-
-    // Recovering deltats needs two different entries from the the
-    // stored solutions map
-    if(stored_sols_decrement_time != stored_solutions.begin())
+    if( stored_datum != stored_data.begin() )
     {
-      stored_sols_decrement_time--;
+      stored_data_iterator stored_datum_past = stored_datum;
+      stored_datum_past--;
 
-      Real _decremented_time = stored_sols_decrement_time->first;
-
-      try
-      {
-        dynamic_cast<DifferentiableSystem &>(_system).deltat = _current_time - _decremented_time;
-      }
-      catch(const std::bad_cast& e)
-      {
-        // For a non-diff system, only fixed time step sizes are supported as of now.
-      }
+      _system.deltat = (stored_datum_past->second)->get_deltat_at();
+    }
+    else
+    {
+      _system.deltat = (stored_datum->second)->get_deltat_at();
     }
   }
   else
   {
-    stored_solutions_iterator stored_sols_increment_time = stored_sols;
-
-    // Recovering deltats needs two different entries from the the
-    // stored solutions map
-    if(stored_sols_increment_time != std::prev(stored_solutions.end()) )
+    if( stored_datum != std::prev(stored_data.end()) )
+      _system.deltat = (stored_datum->second)->get_deltat_at();
+    else
     {
-      stored_sols_increment_time++;
+      stored_data_iterator stored_datum_past = stored_datum;
+      stored_datum_past--;
 
-      Real _incremented_time = stored_sols_increment_time->first;
-
-      try
-      {
-        dynamic_cast<DifferentiableSystem &>(_system).deltat = _incremented_time - _current_time;
-      }
-      catch(const std::bad_cast& e)
-      {
-        // For a non-diff system, only fixed time step sizes are supported as of now.
-      }
+      _system.deltat = (stored_datum_past->second)->get_deltat_at();
     }
+
   }
 
   // Get the time at which we are recovering the solution vectors
-  Real recovery_time = stored_sols->first;
+  Real recovery_time = stored_datum->first;
 
   // Do we not have a solution for this time?  Then
   // there's nothing to do.
-  if (stored_sols == stored_solutions.end() ||
+  if (stored_datum == stored_data.end() ||
       std::abs(recovery_time - time) > TOLERANCE)
     {
       //libMesh::out << "No more solutions to recover ! We are at time t = " <<
@@ -274,7 +171,7 @@ void FileSolutionHistory::retrieve(bool is_adjoint_solve, Real time)
     }
 
     // Read in the primal solution stored at the current recovery time from the disk
-    _system.get_equation_systems().read (stored_sols->second, READ, EquationSystems::READ_DATA | EquationSystems::READ_ADDITIONAL_DATA);
+    (stored_datum->second)->retrieve_primal_solution();
 
     // Swap back the copy of the last adjoint solution back in place
     for (auto j : make_range(_system.n_qois()))
@@ -284,38 +181,18 @@ void FileSolutionHistory::retrieve(bool is_adjoint_solve, Real time)
   }
   else
   {
-    // Read in the primal solution stored at the current recovery time from the disk
-    _system.get_equation_systems().read (stored_sols->second, READ, EquationSystems::READ_DATA | EquationSystems::READ_ADDITIONAL_DATA);
+    // // If we are not in the adjoint loop, we could be in the primal loop again having solved
+    // // only the primal problem, or in a primal postprocessing stage to evaluate a QoI for example.
+    // // If we can find an adjoint solution file, read that in, else read in the primal file
+    if(dynamic_cast<FileHistoryData &>(*(stored_datum->second)).get_adjoint_filename().empty())
+      (stored_datum->second)->retrieve_primal_solution();
+    else
+      (stored_datum->second)->retrieve_adjoint_solution();
   }
 
   // We need to call update to put system in a consistent state
   // with the solution that was read in
   _system.update();
-
-}
-
-void FileSolutionHistory::erase(Real time)
-{
-  // We cant erase the stored_sols iterator which is used in other places
-  // So save its current value for the future
-  stored_solutions_iterator stored_sols_last = stored_sols;
-
-  // This will map the stored_sols iterator to the current time
-  this->find_stored_entry(time, false);
-
-  // map::erase behaviour is undefined if the iterator is pointing
-  // to a non-existent element.
-  libmesh_assert(stored_sols != stored_solutions.end());
-
-  // We want to keep using the stored_sols iterator, so we have to create
-  // a new one to erase the concerned entry
-  stored_solutions_iterator stored_sols_copy = stored_sols;
-
-  // If we're asking to erase the entry at stored_sols, then move stored_sols somewhere safer first
-  if(stored_sols == stored_sols_last)
-    stored_sols--;
-
-  stored_solutions.erase(stored_sols_copy);
 
 }
 

--- a/src/solvers/memory_history_data.C
+++ b/src/solvers/memory_history_data.C
@@ -1,0 +1,125 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2020 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#include "libmesh/memory_history_data.h"
+
+namespace libMesh
+{
+    void MemoryHistoryData::store_initial_solution()
+    {
+     // The initial data should only be stored once.
+     libmesh_assert(previously_stored == false);
+
+     time_stamp = 0;
+
+     deltat_at = std::numeric_limits<double>::signaling_NaN();
+
+     store_vectors();
+
+     previously_stored = true;
+    }
+
+    void MemoryHistoryData::store_primal_solution(stored_data_iterator stored_datum)
+    {
+     stored_data_iterator stored_datum_last = stored_datum;
+     stored_datum_last--;
+
+     time_stamp = (stored_datum_last->second)->get_time_stamp() + 1;
+
+     // For the current time instant, we dont know yet what timestep the solver might decide, so a placeholder NaN for now.
+     deltat_at = std::numeric_limits<double>::signaling_NaN();
+
+     (stored_datum_last->second)->set_deltat_at(_system.time_solver->TimeSolver::last_completed_timestep_size());
+
+     store_vectors();
+
+     previously_stored = true;
+    }
+
+    void MemoryHistoryData::store_adjoint_solution()
+    {
+     libmesh_error_msg("For MemorySolutionHistory, primal and adjoints are stored in the same container.");
+    }
+
+    void MemoryHistoryData::rewrite_stored_solution()
+    {
+      // We are rewriting.
+      libmesh_assert(previously_stored == true);
+
+      store_vectors();
+    }
+
+    void MemoryHistoryData::retrieve_primal_solution()
+    {
+     retrieve_vectors();
+    }
+
+    void MemoryHistoryData::retrieve_adjoint_solution()
+    {
+     retrieve_vectors();
+    }
+
+    void MemoryHistoryData::store_vectors()
+    {
+     // Now save all the preserved vectors in stored_datum
+     // Loop over all the system vectors
+     for (System::vectors_iterator vec = _system.vectors_begin(),
+          vec_end = _system.vectors_end(); vec != vec_end; ++vec)
+     {
+      // The name of this vector
+      const std::string & vec_name = vec->first;
+
+      // Store the vector if it is to be preserved
+      if (_system.vector_preservation(vec_name))
+        {
+         stored_vecs[vec_name] = vec->second->clone();
+        }
+     }
+
+     // Of course, we will usually save the actual solution
+     std::string _solution("_solution");
+     if (_system.project_solution_on_reinit())
+     {
+      stored_vecs[_solution] = _system.solution->clone();
+     }
+    }
+
+    void MemoryHistoryData::retrieve_vectors()
+    {
+      // We are reading, hopefully something has been written before
+      libmesh_assert(previously_stored == true);
+
+      map_type::iterator vec = stored_vecs.begin();
+      map_type::iterator vec_end = stored_vecs.end();
+
+      // Loop over all the saved vectors
+      for (; vec != vec_end; ++vec)
+      {
+       // The name of this vector
+       const std::string & vec_name = vec->first;
+
+       // Get the vec_name entry in the saved vectors map and set the
+       // current system vec[vec_name] entry to it
+       if (vec_name != "_solution")
+         _system.get_vector(vec_name) = *(vec->second);
+      }
+
+      std::string _solution("_solution");
+      *(_system.solution) = *(stored_vecs[_solution]);
+
+    }
+}

--- a/src/solvers/memory_solution_history.C
+++ b/src/solvers/memory_solution_history.C
@@ -17,6 +17,7 @@
 
 // Local includes
 #include "libmesh/memory_solution_history.h"
+#include "libmesh/memory_history_data.h"
 
 #include "libmesh/diff_system.h"
 
@@ -26,201 +27,100 @@
 namespace libMesh
 {
 
-MemorySolutionHistory::~MemorySolutionHistory () = default;
-
-// This function finds, if it can, the entry where we're supposed to
-// be storing data
-void MemorySolutionHistory::find_stored_entry(Real time, bool storing)
+MemorySolutionHistory::~MemorySolutionHistory ()
 {
-  if (stored_solutions.begin() == stored_solutions.end())
-    return;
-
-  // We will use the map::lower_bound operation to find the key which
-  // is the least upper bound among all existing keys for time.
-  // (key before map::lower_bound) < time < map::lower_bound, one of these
-  // should be within TOLERANCE of time (unless we are creating a new map entry)
-  // If the lower bound iterator points to:
-  // begin -> we are looking for the solution at the initial time
-  // end -> we are creating a new entry
-  // anything else, we are looking for an existing entry
-  stored_solutions_iterator lower_bound_it = stored_solutions.lower_bound(time);
-
-  // For the key right before the lower bound
-  stored_solutions_iterator lower_bound_it_decremented;
-
-  // If we are at end, we are creating a new entry, nothing more to do
-  if(lower_bound_it == stored_solutions.end())
-  {
-    // If we are storing and lower_bound_it points to stored_solutions.end(), we assume
-    // that this is a brand new entry in the map. We leave stored_sols unchanged.
-    if(storing)
-    {
-      return;
-    }
-    else
-    {
-      // We are trying to retrieve and none of the keys was an upper bound.
-      // We could have a situation in which the time is greatest key + FPE.
-      // So we can check the key before the end and see if it matches time, else we have an error.
-      lower_bound_it = std::prev(lower_bound_it);
-    }
-  }
-  else if(lower_bound_it == stored_solutions.begin()) // At the beginning, so we cant go back any further
-  {
-    stored_sols = stored_solutions.begin();
-    return;
-  }
-  else // A decremented iterator, to perform the sandwich test for the key closest to time
-  {
-    lower_bound_it_decremented = std::prev(lower_bound_it);
-  }
-
-  // Set the stored sols iterator as per the key which is within TOLERANCE of time
-  if(std::abs(lower_bound_it->first - time) < TOLERANCE)
-  {
-    stored_sols = lower_bound_it;
-  }
-  else if(std::abs(lower_bound_it_decremented->first - time) < TOLERANCE)
-  {
-    stored_sols = lower_bound_it_decremented;
-  }
-  else
-  {
-    if(storing) // If we are storing, this is fine, we need to create a new entry, so just return
-    {
-      return;
-    }
-    else // If we are not storing, then we expected to find something but didnt, so we have a problem
-    {
-      libmesh_error_msg("Failed to set stored solutions iterator to a valid value.");
-    }
-  }
-
 }
 
-// This functions saves all the 'projection-worthy' system vectors for
+// This functions saves all the projected system vectors for
 // future use
 void MemorySolutionHistory::store(bool /* is_adjoint_solve */, Real time)
 {
   this->find_stored_entry(time, true);
 
   // In an empty history we create the first entry
-  if (stored_solutions.begin() == stored_solutions.end())
+  if (stored_data.begin() == stored_data.end())
     {
-      stored_solutions[time] = map_type();
-      stored_sols = stored_solutions.begin();
+      stored_data[time] = libmesh_make_unique<MemoryHistoryData>(_system);
+      stored_datum = stored_data.begin();
     }
 
   // If we're past the end we can create a new entry
-  if (time - stored_sols->first > TOLERANCE )
+  if (time - stored_datum->first > TOLERANCE )
     {
 #ifndef NDEBUG
-      ++stored_sols;
-      libmesh_assert (stored_sols == stored_solutions.end());
+      ++stored_datum;
+      libmesh_assert (stored_datum == stored_data.end());
 #endif
-      stored_solutions[time] = map_type();
-      stored_sols = stored_solutions.end();
-      --stored_sols;
+      stored_data[time] = libmesh_make_unique<MemoryHistoryData>(_system);
+      stored_datum = stored_data.end();
+      --stored_datum;
     }
 
   // If we're before the beginning we can create a new entry
-  else if (stored_sols->first - time > TOLERANCE)
+  else if (stored_datum->first - time > TOLERANCE)
     {
-      libmesh_assert (stored_sols == stored_solutions.begin());
-      stored_solutions[time] = map_type();
-      stored_sols = stored_solutions.begin();
+      libmesh_assert (stored_datum == stored_data.begin());
+      stored_data[time] = libmesh_make_unique<MemoryHistoryData>(_system);
+      stored_datum = stored_data.begin();
     }
 
   // We don't support inserting entries elsewhere
-  libmesh_assert(std::abs(stored_sols->first - time) < TOLERANCE);
+  libmesh_assert(std::abs(stored_datum->first - time) < TOLERANCE);
 
-  // Map of stored vectors for this solution step
-  std::map<std::string, std::unique_ptr<NumericVector<Number>>> & saved_vectors = stored_sols->second;
-
-  // Loop over all the system vectors
-  for (System::vectors_iterator vec     = _system.vectors_begin(),
-                                vec_end = _system.vectors_end();
-       vec != vec_end; ++vec)
-    {
-      // The name of this vector
-      const std::string & vec_name = vec->first;
-
-      // If we haven't seen this vector before or if we have and
-      // want to overwrite it
-      if ((overwrite_previously_stored || !saved_vectors.count(vec_name)) &&
-          // and if we think it's worth preserving
-          _system.vector_preservation(vec_name))
-        {
-          // Then we save it.
-          saved_vectors[vec_name] = vec->second->clone();
-        }
-    }
-
-  // Of course, we will usually save the actual solution
-  std::string _solution("_solution");
-  if ((overwrite_previously_stored || !saved_vectors.count(_solution)) &&
-      // and if we think it's worth preserving
-      _system.project_solution_on_reinit())
-    saved_vectors[_solution] = _system.solution->clone();
+  // First we handle the case of the initial data, this is the only case in which
+  // stored_data will have size one
+  if(stored_data.size() == 1)
+  {
+    // The initial data should only be stored once.
+    (stored_datum->second)->store_initial_solution();
+  }
+  else if((stored_datum->second)->get_previously_stored() == false) // If we are not at the initial time, we are either creating a new entry or overwriting an existing one
+  {
+    (stored_datum->second)->store_primal_solution(stored_datum);
+  }
+  else // We are overwriting an existing history data
+  {
+    (stored_datum->second)->rewrite_stored_solution();
+  }
 }
 
 void MemorySolutionHistory::retrieve(bool is_adjoint_solve, Real time)
 {
   this->find_stored_entry(time, false);
 
-  // To set the deltat while using adaptive timestepping, we will utilize
-  // consecutive time entries in the stored solutions iterator
-  Real _current_time = stored_sols->first;
-
-  // If we are solving the adjoint, we are moving backwards, so decrement time
-  // else we are moving forwards, so increment time
+  // If we are solving the adjoint, the timestep we need to move to the past step
+  // is the one taken at that step to get to the current time.
+  // At the initial time, be ready for the primal time march again.
   if(is_adjoint_solve)
   {
-    stored_solutions_iterator stored_sols_decrement_time = stored_sols;
-
-    // Recovering deltats needs two different entries from the the
-    // stored solutions map
-    if(stored_sols_decrement_time != stored_solutions.begin())
+    if( stored_datum != stored_data.begin() )
     {
-      stored_sols_decrement_time--;
+      stored_data_iterator stored_datum_past = stored_datum;
+      stored_datum_past--;
 
-      Real _decremented_time = stored_sols_decrement_time->first;
-
-      try
-      {
-        dynamic_cast<DifferentiableSystem &>(_system).deltat = _current_time - _decremented_time;
-      }
-      catch(const std::bad_cast& e)
-      {
-        // For a non-diff system, only fixed time step sizes are supported as of now.
-      }
+      _system.deltat = (stored_datum_past->second)->get_deltat_at();
+    }
+    else
+    {
+      _system.deltat = (stored_datum->second)->get_deltat_at();
     }
   }
   else
   {
-    stored_solutions_iterator stored_sols_increment_time = stored_sols;
-
-    // Recovering deltats needs two different entries from the the
-    // stored solutions map
-    if(stored_sols_increment_time != std::prev(stored_solutions.end()) )
+    if( stored_datum != std::prev(stored_data.end()) )
+      _system.deltat = (stored_datum->second)->get_deltat_at();
+    else
     {
-      stored_sols_increment_time++;
+      stored_data_iterator stored_datum_past = stored_datum;
+      stored_datum_past--;
 
-      Real _incremented_time = stored_sols_increment_time->first;
-
-      try
-      {
-        dynamic_cast<DifferentiableSystem &>(_system).deltat = _incremented_time - _current_time;
-      }
-      catch(const std::bad_cast& e)
-      {
-        // For a non-diff system, only fixed time step sizes are supported as of now.
-      }
+      _system.deltat = (stored_datum_past->second)->get_deltat_at();
     }
+
   }
 
   // Get the time at which we are recovering the solution vectors
-  Real recovery_time = stored_sols->first;
+  Real recovery_time = stored_datum->first;
 
   // Print out what time we are recovering vectors at
   //    libMesh::out << "Recovering solution vectors at time: " <<
@@ -228,7 +128,7 @@ void MemorySolutionHistory::retrieve(bool is_adjoint_solve, Real time)
 
   // Do we not have a solution for this time?  Then
   // there's nothing to do.
-  if (stored_sols == stored_solutions.end() ||
+  if (stored_datum == stored_data.end() ||
       std::abs(recovery_time - time) > TOLERANCE)
     {
       //libMesh::out << "No more solutions to recover ! We are at time t = " <<
@@ -236,56 +136,11 @@ void MemorySolutionHistory::retrieve(bool is_adjoint_solve, Real time)
       return;
     }
 
-  // Get the saved vectors at this timestep
-  map_type & saved_vectors = stored_sols->second;
-
-  map_type::iterator vec = saved_vectors.begin();
-  map_type::iterator vec_end = saved_vectors.end();
-
-  // Loop over all the saved vectors
-  for (; vec != vec_end; ++vec)
-    {
-      // The name of this vector
-      const std::string & vec_name = vec->first;
-
-      // Get the vec_name entry in the saved vectors map and set the
-      // current system vec[vec_name] entry to it
-      if (vec_name != "_solution")
-        _system.get_vector(vec_name) = *(vec->second);
-    }
-
-  // Of course, we will *always* have to get the actual solution
-  std::string _solution("_solution");
-  *(_system.solution) = *(saved_vectors[_solution]);
+  (stored_datum->second)->retrieve_primal_solution();
 
   // We need to call update to put system in a consistent state
   // with the solution that was read in
   _system.update();
-}
-
-void MemorySolutionHistory::erase(Real time)
-{
-  // We cant erase the stored_sols iterator which is used in other places
-  // So save its current value for the future
-  stored_solutions_iterator stored_sols_last = stored_sols;
-
-  // This will map the stored_sols iterator to the current time
-  this->find_stored_entry(time, false);
-
-  // map::erase behaviour is undefined if the iterator is pointing
-  // to a non-existent element.
-  libmesh_assert(stored_sols != stored_solutions.end());
-
-  // We want to keep using the stored_sols iterator, so we have to create
-  // a new one to erase the concerned entry
-  stored_solutions_iterator stored_sols_copy = stored_sols;
-
-  // If we're asking to erase the entry at stored_sols, then move stored_sols somewhere safer first
-  if(stored_sols == stored_sols_last)
-    stored_sols--;
-
-  stored_solutions.erase(stored_sols_copy);
-
 }
 
 }

--- a/src/solvers/no_solution_history.C
+++ b/src/solvers/no_solution_history.C
@@ -32,10 +32,4 @@ void NoSolutionHistory::retrieve(bool /* is_adjoint_solve */, Real /* time */)
   libmesh_not_implemented();
 }
 
-void NoSolutionHistory::erase(Real /* time */)
-{
-  // Nothing was stored, so nothing can be erased
-  libmesh_not_implemented();
-}
-
 }

--- a/src/solvers/solution_history.C
+++ b/src/solvers/solution_history.C
@@ -1,0 +1,121 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2020 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#include "libmesh/solution_history.h"
+#include <cmath>
+#include <iterator>
+
+namespace libMesh
+{
+ // This function finds, if it can, the entry where we're supposed to
+ // be storing data, leaves stored_datum unchanged if it cant find an entry
+ // with the key corresponding to time.
+ void SolutionHistory::find_stored_entry(Real time, bool storing)
+ {
+  if (stored_data.begin() == stored_data.end())
+    return;
+
+  // We will use the map::lower_bound operation to find the key which
+  // is the least upper bound among all existing keys for time.
+  // (key before map::lower_bound) < time < map::lower_bound, one of these
+  // should be within TOLERANCE of time (unless we are creating a new map entry)
+  // If the lower bound iterator points to:
+  // begin -> we are looking for the solution at the initial time
+  // end -> we are creating a new entry
+  // anything else, we are looking for an existing entry
+  stored_data_iterator lower_bound_it = stored_data.lower_bound(time);
+
+  // For the key right before the lower bound
+  stored_data_iterator lower_bound_it_decremented;
+
+  // If we are at end, we could be creating a new entry (depends on the storing bool), return
+  // Otherwise, get a decremented iterator for the sandwich test
+  if(lower_bound_it == stored_data.end())
+  {
+    // If we are storing and lower_bound_it points to stored_data.end(), we assume
+    // that this is a brand new entry in the map. We leave stored_datum unchanged.
+    if(storing)
+    {
+      return;
+    }
+    else
+    {
+      // We are trying to retrieve and none of the keys was an upper bound.
+      // We could have a situation in which the time is greatest key + FPE.
+      // So we can check the key before the end and see if it matches time, else we have an error.
+      lower_bound_it = std::prev(lower_bound_it);
+    }
+  }
+  else if(lower_bound_it == stored_data.begin()) // At the beginning, so we cant go back any further
+  {
+    stored_datum = stored_data.begin();
+    return;
+  }
+  else // A decremented iterator, to perform the sandwich test for the key closest to time
+  {
+    lower_bound_it_decremented = std::prev(lower_bound_it);
+  }
+
+  // Set the stored sols iterator as per the key which is within TOLERANCE of time
+  if(std::abs(lower_bound_it->first - time) < TOLERANCE)
+  {
+    stored_datum = lower_bound_it;
+  }
+  else if(std::abs(lower_bound_it_decremented->first - time) < TOLERANCE)
+  {
+    stored_datum = lower_bound_it_decremented;
+  }
+  else // Neither of the two candidate keys matched our time
+  {
+    if(storing) // If we are storing, this is fine, we need to create a new entry, so just return
+    {
+      return;
+    }
+    else // If we are not storing, then we expected to find something but didnt, so we have a problem
+    {
+      libmesh_error_msg("Failed to set stored solutions iterator to a valid value.");
+    }
+  }
+ }
+
+ void SolutionHistory::erase(Real time)
+ {
+  // We cant erase the stored_datum iterator which is used in other places
+  // So save its current value for the future
+  stored_data_iterator stored_datum_last = stored_datum;
+  //std::map<Real, unsigned int>::iterator timeTotimestamp_iterator_last = timeTotimestamp_iterator;
+
+  // This will map the stored_datum iterator to the current time
+  this->find_stored_entry(time, false);
+
+  // map::erase behaviour is undefined if the iterator is pointing
+  // to a non-existent element.
+  libmesh_assert(stored_datum != stored_data.end());
+
+  // We want to keep using the stored_datum iterator, so we have to create
+  // a new one to erase the concerned entry
+  stored_data_iterator stored_datum_copy = stored_datum;
+
+  // If we're asking to erase the entry at stored_datum, then move stored_datum somewhere safer first
+  if(stored_datum == stored_datum_last)
+    stored_datum--;
+
+  stored_data.erase(stored_datum_copy);
+ }
+
+}
+// End namespace libMesh

--- a/src/solvers/twostep_time_solver.C
+++ b/src/solvers/twostep_time_solver.C
@@ -124,6 +124,9 @@ void TwostepTimeSolver::solve()
       // Attempt the 'half timestep solve'
       core_time_solver->solve();
 
+      // If we successfully completed the solve, let the time solver know the deltat used
+      this->last_deltat = _system.deltat;
+
       // Increment system.time, and save the half solution to solution history
       core_time_solver->advance_timestep();
 


### PR DESCRIPTION
SolutionHistory derived classes were maintaining history with ad hoc maps from time to timestamps and filenames or vectors. To maintain a consistent, less error prone history and ensure a clean interface between SolutionHistory and MeshHistory (later PR):
1) A single map is now maintained by the SolutionHistory base class. 
2) This map takes time to the new HistoryData type objects.

HistoryData derived classes (currently File and Memory) interface between SolutionHistory and the disk or memory. SolutionHistory interfaces between TimeSolver and HistoryData.  In the future, whenever a combined Solution and MeshHistory is being maintained, HistoryData will allow us to maintain a convenient interface between MeshHistory and SolutionHistory.

The PR also includes fixes to TimeSolver handling of initial conditions, and adjoint examples 5 and 7.