### PR TITLE
fix vector-index out of range

### DIFF
--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -288,8 +288,8 @@ Real InfHex::quality (const ElemQuality q) const
         std::vector<Real> edge_ratios(2);
 
         // Bottom
-        edge_ratios[8] = std::min(d01, d23) / std::max(d01, d23);
-        edge_ratios[9] = std::min(d03, d12) / std::max(d03, d12);
+        edge_ratios[0] = std::min(d01, d23) / std::max(d01, d23);
+        edge_ratios[1] = std::min(d03, d12) / std::max(d03, d12);
 
         return *(std::min_element(edge_ratios.begin(), edge_ratios.end())) ;
 


### PR DESCRIPTION
I have another micro-patch:
I don't understand the context here in more detail, so I am not fully sure that this is the correct fix.
But at least now we don't write out of bounds.