### PR TITLE
Fix "make coverage -j"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -706,6 +706,9 @@ lcov-reset:
 	$(lcov_bin)/lcov --directory . --zerocounters
 
 coverage: lcov-reset check lcov-report
+	$(MAKE) lcov-reset
+	$(MAKE) check
+	$(MAKE) lcov-report
 
 CLEANFILES += src/apps/*.gcda src/apps/*.gcno
 


### PR DESCRIPTION
This should have been an obvious race condition, but I guess I never triggered it before adding coverage support to TIMPI.