### PR TITLE
Refactor unsteady adjoint operation order

### DIFF
--- a/src/solvers/twostep_time_solver.C
+++ b/src/solvers/twostep_time_solver.C
@@ -295,10 +295,6 @@ void TwostepTimeSolver::solve()
 
 std::pair<unsigned int, Real> TwostepTimeSolver::adjoint_solve (const QoISet & qoi_indices)
 {
-  // The adjoint timestepping mirrors the scheme used for the forward problem
-  // So the deltat, once set by solution history, will not be changed
-  Real old_time = _system.time;
-
   // Take the first adjoint 'half timestep'
   core_time_solver->adjoint_solve(qoi_indices);
 
@@ -308,18 +304,25 @@ std::pair<unsigned int, Real> TwostepTimeSolver::adjoint_solve (const QoISet & q
   // Adjoint advance the timestep
   core_time_solver->adjoint_advance_timestep();
 
+ // We have to contend with the fact that the delta_t set by SolutionHistory will not be the
+ // delta_t for the adjoint solve. At time t_i, the adjoint solve uses the same delta_t
+ // as the primal solve, pulling the adjoint solution from t_i+1 to t_i.
+ // FSH however sets delta_t to the value which takes us from t_i to t_i-1.
+ // Therefore use the last_deltat for the solve and reset system delta_t after the solve.
+  Real temp_deltat = _system.deltat;
+  _system.deltat = last_deltat;
+
   // The second half timestep
   std::pair<unsigned int, Real> full_adjoint_output = core_time_solver->adjoint_solve(qoi_indices);
 
-  // Record the sub step deltat we used for the last adjoint solve.
+  // Record the sub step deltat we used for the last adjoint solve and reset the system deltat to the
+  // value set by SolutionHistory.
   last_deltat = _system.deltat;
+  _system.deltat = temp_deltat;
 
   // Record the total size of the last timestep, for a 2StepTS, this is
   // simply twice the deltat for each sub(half) step.
   this->completed_timestep_size = 2.0*_system.deltat;
-
-  // Reset the system.time
-  _system.time = old_time;
 
   return full_adjoint_output;
 }

--- a/src/solvers/unsteady_solver.C
+++ b/src/solvers/unsteady_solver.C
@@ -217,31 +217,17 @@ std::pair<unsigned int, Real> UnsteadySolver::adjoint_solve(const QoISet & qoi_i
 
 void UnsteadySolver::adjoint_advance_timestep ()
 {
-  // All calls to adjoint_advance_timestep are made in the user's
-  // code. This first call is made immediately after the adjoint initial conditions
-  // are set. This is in the user code outside the adjoint time loop.
-  if (!first_adjoint_step)
-    {
-      // The adjoint system has been solved. We need to store the adjoint solution and
-      // load the primal solutions for the next time instance (t - delta_ti).
-      _system.time -= _system.deltat;
-    }
-  else
-    {
-      // The first adjoint step simply saves the given adjoint initial condition
-      // So there is a store, but no solve, no actual timestep, so no need to change system time
-      first_adjoint_step = false;
-    }
+  // Call the store function to store the adjoint we have computed (or
+  // for first_adjoint_step, the adjoint initial condition) in this
+  // time step for the time instance.
+  solution_history->store(true, _system.time);
+
+  _system.time -= _system.deltat;
 
   // Retrieve the primal solution vectors at this new (or for
   // first_adjoint_step, initial) time instance. These provide the
   // data to solve the adjoint problem for the next time instance.
   solution_history->retrieve(true, _system.time);
-
-  // Call the store function to store the adjoint we have computed (or
-  // for first_adjoint_step, the adjoint initial condition) in this
-  // time step for the time instance.
-  solution_history->store(true, _system.time);
 
   // Dont forget to localize the old_nonlinear_solution !
   _system.get_vector("_old_nonlinear_solution").localize


### PR DESCRIPTION
Earlier implementations of adjoint_advance_timestep() assumed a fixed mesh. With unsteady AMR, we need to make changes to the operation order in adjoint_advance_timestep() to ensure that a consistent state of mesh and solution is maintained. 

We now store the current adjoint and mesh, decrement the time, retrieve the mesh and primal for the next adjoint calculation, solve and cycle.