### PR TITLE
Fixes + workarounds for GCC 11 warnings, runtime error

### DIFF
--- a/configure
+++ b/configure
@@ -6997,6 +6997,22 @@ fi
                     ACSM_GXX_VERSION_STRING=`($CXX -v 2>&1) | grep "gcc version"`
 
           case "$ACSM_GXX_VERSION_STRING" in #(
+  *gcc\ version\ 11.*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-11.x >>>" >&5
+$as_echo "<<< C++ compiler is gcc-11.x >>>" >&6; }
+                                         ACSM_GXX_VERSION=gcc11 ;; #(
+  *gcc\ version\ 10.*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-10.x >>>" >&5
+$as_echo "<<< C++ compiler is gcc-10.x >>>" >&6; }
+                                         ACSM_GXX_VERSION=gcc10 ;; #(
+  *gcc\ version\ 9.*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-9.x >>>" >&5
+$as_echo "<<< C++ compiler is gcc-9.x >>>" >&6; }
+                                         ACSM_GXX_VERSION=gcc9 ;; #(
+  *gcc\ version\ 8.*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-8.x >>>" >&5
+$as_echo "<<< C++ compiler is gcc-8.x >>>" >&6; }
+                                         ACSM_GXX_VERSION=gcc8 ;; #(
   *gcc\ version\ 7.*) :
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-7.x >>>" >&5
 $as_echo "<<< C++ compiler is gcc-7.x >>>" >&6; }
@@ -24757,16 +24773,25 @@ fi
   # First the flags for gcc compilers
   if test "$GXX" = "yes" && test "x$ACSM_REAL_GXX" != "x"; then :
 
-          ACSM_CXXFLAGS_OPT="$ACSM_CXXFLAGS_OPT -O2 -felide-constructors -funroll-loops -fstrict-aliasing -Wdisabled-optimization"
+          ACSM_CXXFLAGS_OPT="$ACSM_CXXFLAGS_OPT -O2 -felide-constructors -fstrict-aliasing -Wdisabled-optimization"
                     ACSM_CXXFLAGS_DEVEL="$ACSM_CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused"
-          ACSM_CXXFLAGS_DEVEL="$ACSM_CXXFLAGS_DEVEL -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -funroll-loops -fstrict-aliasing -Woverloaded-virtual -Wdisabled-optimization"
+          ACSM_CXXFLAGS_DEVEL="$ACSM_CXXFLAGS_DEVEL -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -fstrict-aliasing -Woverloaded-virtual -Wdisabled-optimization"
           ACSM_CXXFLAGS_DBG="$ACSM_CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Woverloaded-virtual"
           ACSM_NODEPRECATEDFLAG="-Wno-deprecated"
 
-          ACSM_CFLAGS_OPT="-O2 -funroll-loops -fstrict-aliasing"
-          ACSM_CFLAGS_DEVEL="$ACSM_CFLAGS_OPT -g -Wimplicit -funroll-loops -fstrict-aliasing"
+          ACSM_CFLAGS_OPT="-O2 -fstrict-aliasing"
+          ACSM_CFLAGS_DEVEL="$ACSM_CFLAGS_OPT -g -Wimplicit -fstrict-aliasing"
           ACSM_CFLAGS_DBG="-g -Wimplicit"
           ACSM_ASSEMBLY_FLAGS="$ACSM_ASSEMBLY_FLAGS -fverbose-asm"
+
+                    if test "x$ACSM_GXX_VERSION" != "xgcc11"; then :
+
+                  ACSM_CXXFLAGS_OPT="$ACSM_CXXFLAGS_OPT -funroll-loops"
+                  ACSM_CXXFLAGS_DEVEL="$ACSM_CXXFLAGS_DEVEL -funroll-loops"
+                  ACSM_CFLAGS_OPT="$ACSM_CFLAGS_OPT -funroll-loops"
+                  ACSM_CFLAGS_DEVEL="$ACSM_CFLAGS_DEVEL -funroll-loops"
+
+fi
 
                               ACSM_PARANOID_FLAGS="-Wall -Wextra -Wcast-align -Wcast-qual -Wdisabled-optimization -Wformat=2"
           ACSM_PARANOID_FLAGS="$ACSM_PARANOID_FLAGS -Wformat-nonliteral -Wformat-security -Wformat-y2k"

--- a/include/base/reference_counter.h
+++ b/include/base/reference_counter.h
@@ -76,7 +76,7 @@ public:
   /**
    * Prints the reference information, by default to \p libMesh::out.
    */
-  static void print_info (std::ostream & out = libMesh::out);
+  static void print_info (std::ostream & out_stream = libMesh::out);
 
   /**
    * Prints the number of outstanding (created, but not yet

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -781,12 +781,12 @@ public:
   /**
    * Prints the boundary information data structure.
    */
-  void print_info (std::ostream & out=libMesh::out) const;
+  void print_info (std::ostream & out_stream=libMesh::out) const;
 
   /**
    * Prints a summary of the boundary information.
    */
-  void print_summary (std::ostream & out=libMesh::out) const;
+  void print_summary (std::ostream & out_stream=libMesh::out) const;
 
   /**
    * \returns A reference for getting an optional name for a sideset.

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -169,7 +169,7 @@ public:
   /**
    * Prints the nodal information, by default to \p libMesh::out.
    */
-  void print_nodes(std::ostream & out = libMesh::out);
+  void print_nodes(std::ostream & out_stream = libMesh::out);
 
   /**
    * Reads information for all of the blocks in the \p ExodusII mesh

--- a/include/mesh/mesh_smoother_laplace.h
+++ b/include/mesh/mesh_smoother_laplace.h
@@ -84,7 +84,7 @@ public:
    * Mainly for debugging, this function will print
    * out the connectivity graph which has been created.
    */
-  void print_graph(std::ostream & out = libMesh::out) const;
+  void print_graph(std::ostream & out_stream = libMesh::out) const;
 
 private:
   /**

--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -444,7 +444,8 @@ public:
    * Unformatted print to the stream \p out.  Simply prints the elements
    * of the tensor separated by spaces and newlines.
    */
-  void write_unformatted (std::ostream & out, const bool newline = true) const;
+  void write_unformatted (std::ostream & out_stream,
+                          const bool newline = true) const;
 
 protected:
 

--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -436,7 +436,8 @@ public:
    * newline by default, however, this behavior can be controlled with
    * the \p newline parameter.
    */
-  void write_unformatted (std::ostream & out, const bool newline = true) const;
+  void write_unformatted (std::ostream & out_stream,
+                          const bool newline = true) const;
 
 protected:
 

--- a/include/utils/perfmon.h
+++ b/include/utils/perfmon.h
@@ -58,7 +58,8 @@ public:
 
   ~PerfMon ();
   void reset ();
-  double print (std::string msg="NULL", std::ostream & out = libMesh::out);
+  double print (std::string msg="NULL",
+                std::ostream & my_out = libMesh::out);
 
 private:
 

--- a/include/utils/tree_base.h
+++ b/include/utils/tree_base.h
@@ -83,12 +83,12 @@ public:
   /**
    * Prints the nodes.
    */
-  virtual void print_nodes(std::ostream & out=libMesh::out) const = 0;
+  virtual void print_nodes(std::ostream & out_stream=libMesh::out) const = 0;
 
   /**
    * Prints the nodes.
    */
-  virtual void print_elements(std::ostream & out=libMesh::out) const = 0;
+  virtual void print_elements(std::ostream & out_stream=libMesh::out) const = 0;
 
   /**
    * \returns The number of active bins.

--- a/include/utils/tree_node.h
+++ b/include/utils/tree_node.h
@@ -129,13 +129,13 @@ public:
    * Prints the contents of the node_numbers vector if we
    * are active.
    */
-  void print_nodes(std::ostream & out=libMesh::out) const;
+  void print_nodes(std::ostream & out_stream=libMesh::out) const;
 
   /**
    * Prints the contents of the elements set if we
    * are active.
    */
-  void print_elements(std::ostream & out=libMesh::out) const;
+  void print_elements(std::ostream & out_stream=libMesh::out) const;
 
   /**
    * Transforms node numbers to element pointers.

--- a/src/solvers/petscdmlibmeshimpl.C
+++ b/src/solvers/petscdmlibmeshimpl.C
@@ -907,7 +907,9 @@ static PetscErrorCode  DMSetUp_libMesh(DM dm)
     ierr = DMSNESSetFunction(dm, SNESFunction_DMlibMesh, (void *)dm); CHKERRQ(ierr);
     ierr = DMSNESSetJacobian(dm, SNESJacobian_DMlibMesh, (void *)dm); CHKERRQ(ierr);
     if (dlm->sys->nonlinear_solver->bounds || dlm->sys->nonlinear_solver->bounds_object)
-      ierr = DMSetVariableBounds(dm, DMVariableBounds_libMesh); CHKERRQ(ierr);
+      {
+        ierr = DMSetVariableBounds(dm, DMVariableBounds_libMesh); CHKERRQ(ierr);
+      }
   }
   else {
     /*

--- a/tests/parallel/parallel_test.C
+++ b/tests/parallel/parallel_test.C
@@ -151,18 +151,16 @@ public:
 
   void testBroadcast()
   {
-    std::vector<unsigned int> src(3), dest(3);
-
-    src[0]=0;
-    src[1]=1;
-    src[2]=2;
+    // Workaround for spurious warning from operator=
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100366
+    std::vector<unsigned int> src{0,1,2}, dest(3,0);
 
     if (TestCommWorld->rank() == 0)
       dest = src;
 
     TestCommWorld->broadcast(dest);
 
-    for (std::size_t i=0; i<src.size(); i++)
+    for (std::size_t i=0; i<3; i++)
       CPPUNIT_ASSERT_EQUAL( src[i] , dest[i] );
   }
 


### PR DESCRIPTION
The first two commits are fixes for sensible warnings that have become more zealous or more clever.  The third commit is a workaround for a buggy warning, which someone already reported in gcc bugzilla.

The fourth commit is a workaround for a buggy combination of optimization flags that somehow makes it possible for `std::stable_sort` to corrupt data.  I've added it to the Ubuntu bug database, and if I don't get much traction there I'll make sure it's replicable with a from-scratch gcc and I'll add it to gcc bugzilla too.

In the meantime, I recommend everyone learn from my mistakes: avoid Ubuntu 21.10 and avoid gcc 11.  Seriously: **makes it possible for `std::stable_sort` to corrupt data!**  This was a really picky bug to distill, and I can't seem to trigger any other assertion failures or segfaults so far when testing with this workaround, but until someone manages to figure out what went wrong it might be safest to steer clear of the risk of finding the next trigger.

If anyone happens to have a non-Ubuntu gcc 11 install handy, I'd love to know whether my failure case breaks for them too:

```
  std::vector<std::pair<std::tuple<double,double>,int>> testvec(1900, {{1,2},12345}); // 18- works
  std::stable_sort(testvec.begin(), testvec.end());

  for (auto & p : testvec)
    if (p.second != 12345)
      abort();
```

fails at runtime whenever compiled with the combination `-O2 -funroll-loops`.