### PR TITLE
Add --enable-hdf5-required option to configure

### DIFF
--- a/configure
+++ b/configure
@@ -1272,6 +1272,7 @@ enable_curl
 with_curl_include
 with_curl_lib
 enable_hdf5
+enable_hdf5_required
 with_hdf5
 enable_netcdf
 enable_exodus
@@ -2064,8 +2065,9 @@ Optional Features:
   --enable-capnp-required Error if Cap'n Proto support is not detected by
                           configure
   --enable-curl           link against libcurl, for using the cURL API
-  --enable-hdf5           build libmesh with HDF5 support, the selected HDF5
-                          must be compatible with contrib/netcdf
+  --enable-hdf5           build with HDF5 support; the selected HDF5 must be
+                          compatible with our netcdf
+  --enable-hdf5-required  Error if HDF5 is not detected by configure
   --disable-netcdf        build without netCDF binary I/O
   --disable-exodus        build without ExodusII API support
   --enable-exodus-fortran build with ExodusII Fortran API support
@@ -54522,6 +54524,22 @@ else
 fi
 
 
+                # Check whether --enable-hdf5-required was given.
+if test "${enable_hdf5_required+set}" = set; then :
+  enableval=$enable_hdf5_required; case "${enableval}" in #(
+  yes) :
+    hdf5required=yes ;; #(
+  no) :
+    hdf5required=no ;; #(
+  *) :
+    as_fn_error $? "bad value ${enableval} for --enable-hdf5-required" "$LINENO" 5 ;;
+esac
+else
+  hdf5required=no
+fi
+
+
+
   if test "x$enablehdf5" = "xyes"; then :
 
 
@@ -54554,7 +54572,7 @@ fi
 
 
 
-is_package_required=no
+is_package_required=$hdf5required
 
 if test "x${with_hdf5}" != "xno"; then :
 

--- a/m4/hdf5.m4
+++ b/m4/hdf5.m4
@@ -12,9 +12,26 @@ AC_DEFUN([CONFIGURE_HDF5],
                          [AC_MSG_ERROR(bad value ${enableval} for --enable-hdf5)])],
                 [enablehdf5=no])
 
+  dnl Setting --enable-hdf5-required causes an error to be emitted during
+  dnl configure if HDF5 is not successfully detected. This is useful for app
+  dnl codes which require HDF5 (like IsoGeometric Analysis simulations
+  dnl using Exodus IGA meshes), since it prevents situations where
+  dnl libmesh is accidentally built without HDF5 support (which may
+  dnl take a very long time), and then the read fails at runtime,
+  dnl requiring you to redo everything.
+  AC_ARG_ENABLE(hdf5-required,
+                AS_HELP_STRING([--enable-hdf5-required],
+                               [Error if HDF5 is not detected by configure]),
+                [AS_CASE("${enableval}",
+                         [yes], [hdf5required=yes],
+                         [no],  [hdf5required=no],
+                         [AC_MSG_ERROR(bad value ${enableval} for --enable-hdf5-required)])],
+                [hdf5required=no])
+
+
   AS_IF([test "x$enablehdf5" = "xyes"],
         [
-          AX_PATH_HDF5(1.8.0,no)
+          AX_PATH_HDF5(1.8.0,$hdf5required)
           AS_IF([test "x$HAVE_HDF5" = "x0"],
                 [
                   enablehdf5=no

--- a/m4/hdf5.m4
+++ b/m4/hdf5.m4
@@ -5,7 +5,7 @@ AC_DEFUN([CONFIGURE_HDF5],
 [
   AC_ARG_ENABLE(hdf5,
                 AS_HELP_STRING([--enable-hdf5],
-                               [build libmesh with HDF5 support, the selected HDF5 must be compatible with contrib/netcdf]),
+                               [build with HDF5 support; the selected HDF5 must be compatible with our netcdf]),
                 [AS_CASE("${enableval}",
                          [yes], [enablehdf5=yes],
                          [no],  [enablehdf5=no],


### PR DESCRIPTION
This should be helpful for making sure we're not missing out on HDF5
when running automated build scripts