### PR TITLE
Mapping fixes, optimizations

### DIFF
--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -507,6 +507,16 @@ public:
                          std::vector<Point> &       reference_points) override;
 
   /**
+   * Computes the reference space quadrature points on the side of
+   * an element based on the edge quadrature points.
+   */
+  virtual void edge_map (const Elem * elem,
+                         const Elem * edge,
+                         const unsigned int e,
+                         const std::vector<Point> & reference_edge_points,
+                         std::vector<Point> &       reference_points);
+
+  /**
    * Provides the class with the quadrature rule, which provides the
    * locations (on a reference element) where the shape functions are
    * to be calculated.

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -660,7 +660,7 @@ protected:
    */
   ElemType last_side;
 
-  unsigned int last_edge;
+  ElemType last_edge;
 };
 
 

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -2523,6 +2523,7 @@ Elem::simple_build_side_ptr (const unsigned int i,
     face->set_parent(nullptr);
   face->set_interior_parent(this);
 
+  face->set_mapping_type(this->mapping_type());
   face->subdomain_id() = this->subdomain_id();
 #ifdef LIBMESH_ENABLE_AMR
   face->set_p_level(this->p_level());
@@ -2550,6 +2551,7 @@ Elem::simple_build_side_ptr (std::unique_ptr<Elem> & side,
   else
     {
       side->subdomain_id() = this->subdomain_id();
+      side->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
       side->set_p_level(this->p_level());
 #endif
@@ -2624,6 +2626,7 @@ Elem::simple_build_edge_ptr (const unsigned int i)
     edge->set_node(n) = this->node_ptr(Subclass::edge_nodes_map[i][n]);
 
   edge->set_interior_parent(this);
+  edge->set_mapping_type(this->mapping_type());
   edge->subdomain_id() = this->subdomain_id();
 #ifdef LIBMESH_ENABLE_AMR
   edge->set_p_level(this->p_level());
@@ -2651,6 +2654,7 @@ Elem::simple_build_edge_ptr (std::unique_ptr<Elem> & edge,
     }
   else
     {
+      edge->set_mapping_type(this->mapping_type());
       edge->subdomain_id() = this->subdomain_id();
 #ifdef LIBMESH_ENABLE_AMR
       edge->set_p_level(this->p_level());

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -48,7 +48,7 @@ template <unsigned int Dim, FEFamily T>
 FE<Dim,T>::FE (const FEType & fet) :
   FEGenericBase<typename FEOutputType<T>::type> (Dim,fet),
   last_side(INVALID_ELEM),
-  last_edge(libMesh::invalid_uint)
+  last_edge(INVALID_ELEM)
 {
   // Sanity check.  Make sure the
   // Family specified in the template instantiation

--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -62,52 +62,37 @@ namespace libMesh
   }
 
 // 0D error instantiations
-#define ERRORS_IN_0D(_type) \
+#define LIBMESH_ERRORS_IN_LOW_D(_type) \
 REINIT_ERROR(0, _type, reinit)      { libmesh_error_msg("ERROR: Cannot reinit 0D " #_type " elements!"); } \
 REINIT_ERROR(0, _type, edge_reinit) { libmesh_error_msg("ERROR: Cannot edge_reinit 0D " #_type " elements!"); } \
-SIDEMAP_ERROR(0, _type, side_map)   { libmesh_error_msg("ERROR: Cannot side_map 0D " #_type " elements!"); }
+SIDEMAP_ERROR(0, _type, side_map)   { libmesh_error_msg("ERROR: Cannot side_map 0D " #_type " elements!"); } \
+SIDEMAP_ERROR(0, _type, edge_map)   { libmesh_error_msg("ERROR: Cannot edge_map 0D " #_type " elements!"); } \
+REINIT_ERROR(1, _type, edge_reinit) { libmesh_error_msg("ERROR: Cannot edge_reinit 1D " #_type " elements!"); } \
+SIDEMAP_ERROR(1, _type, edge_map)   { libmesh_error_msg("ERROR: Cannot edge_map 1D " #_type " elements!"); }
 
-ERRORS_IN_0D(CLOUGH)
-ERRORS_IN_0D(HERMITE)
-ERRORS_IN_0D(HIERARCHIC)
-ERRORS_IN_0D(L2_HIERARCHIC)
-ERRORS_IN_0D(SIDE_HIERARCHIC)
-ERRORS_IN_0D(LAGRANGE)
-ERRORS_IN_0D(L2_LAGRANGE)
-ERRORS_IN_0D(LAGRANGE_VEC)
-ERRORS_IN_0D(MONOMIAL)
-ERRORS_IN_0D(MONOMIAL_VEC)
-ERRORS_IN_0D(NEDELEC_ONE)
-ERRORS_IN_0D(SCALAR)
-ERRORS_IN_0D(XYZ)
+LIBMESH_ERRORS_IN_LOW_D(CLOUGH)
+LIBMESH_ERRORS_IN_LOW_D(HERMITE)
+LIBMESH_ERRORS_IN_LOW_D(HIERARCHIC)
+LIBMESH_ERRORS_IN_LOW_D(L2_HIERARCHIC)
+LIBMESH_ERRORS_IN_LOW_D(SIDE_HIERARCHIC)
+LIBMESH_ERRORS_IN_LOW_D(LAGRANGE)
+LIBMESH_ERRORS_IN_LOW_D(L2_LAGRANGE)
+LIBMESH_ERRORS_IN_LOW_D(LAGRANGE_VEC)
+LIBMESH_ERRORS_IN_LOW_D(MONOMIAL)
+LIBMESH_ERRORS_IN_LOW_D(MONOMIAL_VEC)
+LIBMESH_ERRORS_IN_LOW_D(NEDELEC_ONE)
+LIBMESH_ERRORS_IN_LOW_D(SCALAR)
+LIBMESH_ERRORS_IN_LOW_D(XYZ)
 
 #ifdef LIBMESH_ENABLE_HIGHER_ORDER_SHAPES
-ERRORS_IN_0D(BERNSTEIN)
-ERRORS_IN_0D(SZABAB)
-ERRORS_IN_0D(RATIONAL_BERNSTEIN)
+LIBMESH_ERRORS_IN_LOW_D(BERNSTEIN)
+LIBMESH_ERRORS_IN_LOW_D(SZABAB)
+LIBMESH_ERRORS_IN_LOW_D(RATIONAL_BERNSTEIN)
 #endif
 
-// 1D error instantiations
-REINIT_ERROR(1, CLOUGH, edge_reinit)        { libmesh_error_msg("ERROR: Cannot edge_reinit 1D CLOUGH elements!"); }
-REINIT_ERROR(1, HERMITE, edge_reinit)       { libmesh_error_msg("ERROR: Cannot edge_reinit 1D HERMITE elements!"); }
-REINIT_ERROR(1, HIERARCHIC, edge_reinit)    { libmesh_error_msg("ERROR: Cannot edge_reinit 1D HIERARCHIC elements!"); }
-REINIT_ERROR(1, L2_HIERARCHIC, edge_reinit) { libmesh_error_msg("ERROR: Cannot edge_reinit 1D L2_HIERARCHIC elements!"); }
-REINIT_ERROR(1, SIDE_HIERARCHIC, edge_reinit) { libmesh_error_msg("ERROR: Cannot edge_reinit 1D SIDE_HIERARCHIC elements!"); }
-REINIT_ERROR(1, LAGRANGE, edge_reinit)      { libmesh_error_msg("ERROR: Cannot edge_reinit 1D LAGRANGE elements!"); }
-REINIT_ERROR(1, LAGRANGE_VEC, edge_reinit)  { libmesh_error_msg("ERROR: Cannot edge_reinit 1D LAGRANGE_VEC elements!"); }
-REINIT_ERROR(1, L2_LAGRANGE, edge_reinit)   { libmesh_error_msg("ERROR: Cannot edge_reinit 1D L2_LAGRANGE elements!"); }
-REINIT_ERROR(1, XYZ, edge_reinit)           { libmesh_error_msg("ERROR: Cannot edge_reinit 1D XYZ elements!"); }
-REINIT_ERROR(1, MONOMIAL, edge_reinit)      { libmesh_error_msg("ERROR: Cannot edge_reinit 1D MONOMIAL elements!"); }
-REINIT_ERROR(1, MONOMIAL_VEC, edge_reinit)      { libmesh_error_msg("ERROR: Cannot edge_reinit 1D MONOMIAL_VEC elements!"); }
-REINIT_ERROR(1, SCALAR, edge_reinit)        { libmesh_error_msg("ERROR: Cannot edge_reinit 1D SCALAR elements!"); }
+// Special error instantiations
 REINIT_ERROR(1, NEDELEC_ONE, reinit)        { libmesh_error_msg("ERROR: Cannot reinit 1D NEDELEC_ONE elements!"); }
-REINIT_ERROR(1, NEDELEC_ONE, edge_reinit)   { libmesh_error_msg("ERROR: Cannot edge_reinit 1D NEDELEC_ONE elements!"); }
 SIDEMAP_ERROR(1, NEDELEC_ONE, side_map)     { libmesh_error_msg("ERROR: Cannot side_map 1D NEDELEC_ONE elements!"); }
-#ifdef LIBMESH_ENABLE_HIGHER_ORDER_SHAPES
-REINIT_ERROR(1, BERNSTEIN, edge_reinit)     { libmesh_error_msg("ERROR: Cannot edge_reinit 1D BERNSTEIN elements!"); }
-REINIT_ERROR(1, SZABAB, edge_reinit)        { libmesh_error_msg("ERROR: Cannot edge_reinit 1D SZABAB elements!"); }
-REINIT_ERROR(1, RATIONAL_BERNSTEIN, edge_reinit) { libmesh_error_msg("ERROR: Cannot edge_reinit 1D RATIONAL_BERNSTEIN elements!"); }
-#endif
 
 
 //-------------------------------------------------------
@@ -242,7 +227,7 @@ void FE<Dim,T>::reinit(const Elem * elem,
 template <unsigned int Dim, FEFamily T>
 void FE<Dim,T>::edge_reinit(const Elem * elem,
                             const unsigned int e,
-                            const Real tolerance,
+                            const Real /* tolerance */,
                             const std::vector<Point> * const pts,
                             const std::vector<Real> * const weights)
 {
@@ -321,8 +306,14 @@ void FE<Dim,T>::edge_reinit(const Elem * elem,
 
   // Find where the integration points are located on the
   // full element.
+  const std::vector<Point> * ref_qp;
+  if (pts != nullptr)
+    ref_qp = pts;
+  else
+    ref_qp = & this->qrule->get_points();
+
   std::vector<Point> qp;
-  FEMap::inverse_map (Dim, elem, this->_fe_map->get_xyz(), qp, tolerance);
+  this->edge_map(elem, edge.get(), e, *ref_qp, qp);
 
   // compute the shape function and derivative values
   // at the points qp
@@ -381,6 +372,55 @@ void FE<Dim,T>::side_map (const Elem * elem,
         reference_points[p].add_scaled (side_node, psi_map[i][p]);
     }
 }
+
+template <unsigned int Dim, FEFamily T>
+void FE<Dim,T>::edge_map (const Elem * elem,
+                          const Elem * edge,
+                          const unsigned int e,
+                          const std::vector<Point> & reference_edge_points,
+                          std::vector<Point> &       reference_points)
+{
+  // We're calculating mappings - we need at least first order info
+  this->calculate_phi = true;
+  this->determine_calculations();
+
+  unsigned int edge_p_level = elem->p_level();
+
+  if (edge->type() != last_edge ||
+      edge_p_level != this->_p_level ||
+      !this->shapes_on_quadrature)
+    {
+      // Set the element type
+      this->elem_type = elem->type();
+      this->_p_level = edge_p_level;
+
+      // Set the last_edge
+      last_edge = edge->type();
+
+      // Initialize the edge shape functions
+      this->_fe_map->template init_edge_shape_functions<Dim>(reference_edge_points, edge);
+    }
+
+  const unsigned int n_points =
+    cast_int<unsigned int>(reference_edge_points.size());
+  reference_points.resize(n_points);
+  for (unsigned int i = 0; i < n_points; i++)
+    reference_points[i].zero();
+
+  std::vector<Point> refspace_nodes;
+  this->get_refspace_nodes(elem->type(), refspace_nodes);
+
+  const std::vector<std::vector<Real>> & psi_map = this->_fe_map->get_psi();
+
+  // sum over the nodes
+  for (auto i : index_range(psi_map))
+    {
+      const Point & edge_node = refspace_nodes[elem->local_edge_node(e,i)];
+      for (unsigned int p=0; p<n_points; p++)
+        reference_points[p].add_scaled (edge_node, psi_map[i][p]);
+    }
+}
+
 
 template<unsigned int Dim>
 void FEMap::init_face_shape_functions(const std::vector<Point> & qp,
@@ -1076,9 +1116,11 @@ template void FE<1,_type>::reinit(Elem const *, unsigned int, Real, const std::v
 template void FE<1,_type>::side_map(Elem const *, Elem const *, const unsigned int, const std::vector<Point> &, std::vector<Point> &); \
 template void FE<2,_type>::reinit(Elem const *, unsigned int, Real, const std::vector<Point> * const, const std::vector<Real> * const); \
 template void FE<2,_type>::side_map(Elem const *, Elem const *, const unsigned int, const std::vector<Point> &, std::vector<Point> &); \
+template void FE<2,_type>::edge_map(Elem const *, Elem const *, const unsigned int, const std::vector<Point> &, std::vector<Point> &); \
 template void FE<2,_type>::edge_reinit(Elem const *, unsigned int, Real, const std::vector<Point> * const, const std::vector<Real> * const); \
 template void FE<3,_type>::reinit(Elem const *, unsigned int, Real, const std::vector<Point> * const, const std::vector<Real> * const); \
 template void FE<3,_type>::side_map(Elem const *, Elem const *, const unsigned int, const std::vector<Point> &, std::vector<Point> &); \
+template void FE<3,_type>::edge_map(Elem const *, Elem const *, const unsigned int, const std::vector<Point> &, std::vector<Point> &); \
 template void FE<3,_type>::edge_reinit(Elem const *, unsigned int, Real, const std::vector<Point> * const, const std::vector<Real> * const)
 
 REINIT_AND_SIDE_MAPS(LAGRANGE);
@@ -1101,12 +1143,15 @@ REINIT_AND_SIDE_MAPS(RATIONAL_BERNSTEIN);
 #endif
 
 template void FE<2,SUBDIVISION>::reinit(Elem const *, unsigned int, Real, const std::vector<Point> * const, const std::vector<Real> * const);
+template void FE<2,SUBDIVISION>::edge_map(Elem const *, Elem const *, const unsigned int, const std::vector<Point> &, std::vector<Point> &);
 template void FE<2,NEDELEC_ONE>::reinit(Elem const *, unsigned int, Real, const std::vector<Point> * const, const std::vector<Real> * const);
 template void FE<2,NEDELEC_ONE>::side_map(Elem const *, Elem const *, const unsigned int, const std::vector<Point> &, std::vector<Point> &);
+template void FE<2,NEDELEC_ONE>::edge_map(Elem const *, Elem const *, const unsigned int, const std::vector<Point> &, std::vector<Point> &);
 template void FE<2,NEDELEC_ONE>::edge_reinit(Elem const *, unsigned int, Real, const std::vector<Point> * const, const std::vector<Real> * const);
 
 template void FE<3,NEDELEC_ONE>::reinit(Elem const *, unsigned int, Real, const std::vector<Point> * const, const std::vector<Real> * const);
 template void FE<3,NEDELEC_ONE>::side_map(Elem const *, Elem const *, const unsigned int, const std::vector<Point> &, std::vector<Point> &);
+template void FE<3,NEDELEC_ONE>::edge_map(Elem const *, Elem const *, const unsigned int, const std::vector<Point> &, std::vector<Point> &);
 template void FE<3,NEDELEC_ONE>::edge_reinit(Elem const *, unsigned int, Real, const std::vector<Point> * const, const std::vector<Real> * const);
 
 // Intel 9.1 complained it needed this in devel mode.

--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -295,7 +295,7 @@ void FE<Dim,T>::edge_reinit(const Elem * elem,
 
       // We might not need to reinitialize the shape functions
       if ((this->get_type() != elem->type())                   ||
-          (edge->type() != static_cast<int>(last_edge))        || // Comparison between enum and unsigned, cast the unsigned to int
+          (edge->type() != last_edge)                          ||
           this->shapes_need_reinit()                           ||
           !this->shapes_on_quadrature)
         {

--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -368,12 +368,6 @@ void FE<Dim,T>::side_map (const Elem * elem,
   for (unsigned int i = 0; i < n_points; i++)
     reference_points[i].zero();
 
-  std::vector<unsigned int> elem_nodes_map;
-  elem_nodes_map.resize(side->n_nodes());
-  for (auto j : side->node_index_range())
-    for (auto i : elem->node_index_range())
-      if (side->node_id(j) == elem->node_id(i))
-        elem_nodes_map[j] = i;
   std::vector<Point> refspace_nodes;
   this->get_refspace_nodes(elem->type(), refspace_nodes);
 
@@ -382,7 +376,7 @@ void FE<Dim,T>::side_map (const Elem * elem,
   // sum over the nodes
   for (auto i : index_range(psi_map))
     {
-      const Point & side_node = refspace_nodes[elem_nodes_map[i]];
+      const Point & side_node = refspace_nodes[elem->local_side_node(s,i)];
       for (unsigned int p=0; p<n_points; p++)
         reference_points[p].add_scaled (side_node, psi_map[i][p]);
     }

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -251,6 +251,7 @@ std::unique_ptr<Elem> InfHex16::build_side_ptr (const unsigned int i,
   face->set_interior_parent(this);
 
   face->subdomain_id() = this->subdomain_id();
+  face->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   face->set_p_level(this->p_level());
 #endif
@@ -298,6 +299,7 @@ void InfHex16::build_side_ptr (std::unique_ptr<Elem> & side,
     }
 
   side->subdomain_id() = this->subdomain_id();
+  side->set_mapping_type(this->mapping_type());
 
   // Set the nodes
   for (auto n : side->node_index_range())
@@ -357,6 +359,7 @@ void InfHex16::build_edge_ptr (std::unique_ptr<Elem> & edge,
     }
 
   edge->subdomain_id() = this->subdomain_id();
+  edge->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   edge->set_p_level(this->p_level());
 #endif

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -271,6 +271,7 @@ std::unique_ptr<Elem> InfHex18::build_side_ptr (const unsigned int i,
   face->set_interior_parent(this);
 
   face->subdomain_id() = this->subdomain_id();
+  face->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   face->set_p_level(this->p_level());
 #endif
@@ -318,6 +319,7 @@ void InfHex18::build_side_ptr (std::unique_ptr<Elem> & side,
     }
 
   side->subdomain_id() = this->subdomain_id();
+  side->set_mapping_type(this->mapping_type());
 
   // Set the nodes
   for (auto n : side->node_index_range())
@@ -377,6 +379,7 @@ void InfHex18::build_edge_ptr (std::unique_ptr<Elem> & edge,
     }
 
   edge->subdomain_id() = this->subdomain_id();
+  edge->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   edge->set_p_level(this->p_level());
 #endif

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -213,6 +213,7 @@ std::unique_ptr<Elem> InfHex8::build_side_ptr (const unsigned int i,
   face->set_interior_parent(this);
 
   face->subdomain_id() = this->subdomain_id();
+  face->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   face->set_p_level(this->p_level());
 #endif
@@ -280,6 +281,7 @@ void InfHex8::build_edge_ptr (std::unique_ptr<Elem> & edge,
     }
 
   edge->subdomain_id() = this->subdomain_id();
+  edge->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   edge->set_p_level(this->p_level());
 #endif

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -241,6 +241,7 @@ std::unique_ptr<Elem> InfPrism12::build_side_ptr (const unsigned int i,
   face->set_interior_parent(this);
 
   face->subdomain_id() = this->subdomain_id();
+  face->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   face->set_p_level(this->p_level());
 #endif
@@ -283,6 +284,7 @@ void InfPrism12::build_side_ptr (std::unique_ptr<Elem> & side,
     }
 
   side->subdomain_id() = this->subdomain_id();
+  side->set_mapping_type(this->mapping_type());
 
   // Set the nodes
   for (auto n : side->node_index_range())
@@ -340,6 +342,7 @@ void InfPrism12::build_edge_ptr (std::unique_ptr<Elem> & edge,
     }
 
   edge->subdomain_id() = this->subdomain_id();
+  edge->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   edge->set_p_level(this->p_level());
 #endif

--- a/src/geom/cell_inf_prism6.C
+++ b/src/geom/cell_inf_prism6.C
@@ -212,6 +212,7 @@ std::unique_ptr<Elem> InfPrism6::build_side_ptr (const unsigned int i,
   face->set_interior_parent(this);
 
   face->subdomain_id() = this->subdomain_id();
+  face->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   face->set_p_level(this->p_level());
 #endif
@@ -276,6 +277,7 @@ void InfPrism6::build_edge_ptr (std::unique_ptr<Elem> & edge,
     }
 
   edge->subdomain_id() = this->subdomain_id();
+  edge->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   edge->set_p_level(this->p_level());
 #endif

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -262,6 +262,7 @@ std::unique_ptr<Elem> Prism15::build_side_ptr (const unsigned int i,
   face->set_interior_parent(this);
 
   face->subdomain_id() = this->subdomain_id();
+  face->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   face->set_p_level(this->p_level());
 #endif
@@ -305,6 +306,7 @@ void Prism15::build_side_ptr (std::unique_ptr<Elem> & side,
     }
 
   side->subdomain_id() = this->subdomain_id();
+  side->set_mapping_type(this->mapping_type());
 
   // Set the nodes
   for (auto n : side->node_index_range())

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -301,6 +301,7 @@ std::unique_ptr<Elem> Prism18::build_side_ptr (const unsigned int i,
   face->set_interior_parent(this);
 
   face->subdomain_id() = this->subdomain_id();
+  face->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   face->set_p_level(this->p_level());
 #endif
@@ -345,6 +346,7 @@ void Prism18::build_side_ptr (std::unique_ptr<Elem> & side,
     }
 
   side->subdomain_id() = this->subdomain_id();
+  side->set_mapping_type(this->mapping_type());
 
   // Set the nodes
   for (auto n : side->node_index_range())

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -297,6 +297,7 @@ std::unique_ptr<Elem> Prism6::build_side_ptr (const unsigned int i,
   face->set_interior_parent(this);
 
   face->subdomain_id() = this->subdomain_id();
+  face->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   face->set_p_level(this->p_level());
 #endif

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -245,6 +245,7 @@ std::unique_ptr<Elem> Pyramid13::build_side_ptr (const unsigned int i, bool prox
   face->set_interior_parent(this);
 
   face->subdomain_id() = this->subdomain_id();
+  face->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   face->set_p_level(this->p_level());
 #endif
@@ -287,6 +288,7 @@ void Pyramid13::build_side_ptr (std::unique_ptr<Elem> & side,
     }
 
   side->subdomain_id() = this->subdomain_id();
+  side->set_mapping_type(this->mapping_type());
 
   // Set the nodes
   for (auto n : side->node_index_range())

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -272,6 +272,7 @@ std::unique_ptr<Elem> Pyramid14::build_side_ptr (const unsigned int i, bool prox
   face->set_interior_parent(this);
 
   face->subdomain_id() = this->subdomain_id();
+  face->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   face->set_p_level(this->p_level());
 #endif
@@ -314,6 +315,7 @@ void Pyramid14::build_side_ptr (std::unique_ptr<Elem> & side,
     }
 
   side->subdomain_id() = this->subdomain_id();
+  side->set_mapping_type(this->mapping_type());
 
   // Set the nodes
   for (auto n : side->node_index_range())

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -211,6 +211,7 @@ std::unique_ptr<Elem> Pyramid5::build_side_ptr (const unsigned int i,
   face->set_interior_parent(this);
 
   face->subdomain_id() = this->subdomain_id();
+  face->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   face->set_p_level(this->p_level());
 #endif

--- a/src/geom/edge.C
+++ b/src/geom/edge.C
@@ -61,6 +61,7 @@ void Edge::side_ptr (std::unique_ptr<Elem> & side,
   else
     {
       side->subdomain_id() = this->subdomain_id();
+      side->set_mapping_type(this->mapping_type());
 
       side->set_node(0) = this->node_ptr(i);
     }

--- a/src/geom/face_inf_quad4.C
+++ b/src/geom/face_inf_quad4.C
@@ -253,6 +253,7 @@ std::unique_ptr<Elem> InfQuad4::build_side_ptr (const unsigned int i,
   edge->set_interior_parent(this);
 
   edge->subdomain_id() = this->subdomain_id();
+  edge->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   edge->set_p_level(this->p_level());
 #endif

--- a/src/geom/face_inf_quad6.C
+++ b/src/geom/face_inf_quad6.C
@@ -233,6 +233,7 @@ std::unique_ptr<Elem> InfQuad6::build_side_ptr (const unsigned int i,
   edge->set_interior_parent(this);
 
   edge->subdomain_id() = this->subdomain_id();
+  edge->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   edge->set_p_level(this->p_level());
 #endif
@@ -278,6 +279,7 @@ void InfQuad6::build_side_ptr (std::unique_ptr<Elem> & side,
     }
 
   side->subdomain_id() = this->subdomain_id();
+  side->set_mapping_type(this->mapping_type());
 #ifdef LIBMESH_ENABLE_AMR
   side->set_p_level(this->p_level());
 #endif

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -888,6 +888,9 @@ public:
 
     sys.project_solution(sin_x_plus_cos_y, nullptr, es.parameters);
 
+    // Make this easy to tweak in the future
+    const double my_tolerance = TOLERANCE;
+
     // Calculate some norms, skipping the spline points, and compare
     // to regression standard values
     std::set<unsigned int> skip_dimensions {0};
@@ -895,20 +898,20 @@ public:
       sys.calculate_norm(*sys.solution, 0, L2, &skip_dimensions);
 //    std::cout.precision(16);
 //    std::cout << "L2_norm = " << L2_norm << std::endl;
-    LIBMESH_ASSERT_FP_EQUAL(L2_norm, expected_norms[0], TOLERANCE);
+    LIBMESH_ASSERT_FP_EQUAL(L2_norm, expected_norms[0], my_tolerance);
     const Real Linf_norm =
       sys.calculate_norm(*sys.solution, 0, L_INF, &skip_dimensions);
 //    std::cout << "Linf_norm = " << Linf_norm << std::endl;
-    LIBMESH_ASSERT_FP_EQUAL(Linf_norm, expected_norms[1], TOLERANCE);
+    LIBMESH_ASSERT_FP_EQUAL(Linf_norm, expected_norms[1], my_tolerance);
     const Real H1_norm =
       sys.calculate_norm(*sys.solution, 0, H1_SEMINORM, &skip_dimensions);
 //    std::cout << "H1_norm = " << H1_norm << std::endl;
-    LIBMESH_ASSERT_FP_EQUAL(H1_norm, expected_norms[2], TOLERANCE);
+    LIBMESH_ASSERT_FP_EQUAL(H1_norm, expected_norms[2], my_tolerance);
     const Real W1inf_norm =
       sys.calculate_norm(*sys.solution, 0, W1_INF_SEMINORM, &skip_dimensions);
 //    std::cout << "W1inf_norm = " << W1inf_norm << std::endl;
     // W1_inf seems more sensitive to FP error...
-    LIBMESH_ASSERT_FP_EQUAL(W1inf_norm, expected_norms[3], 10*TOLERANCE);
+    LIBMESH_ASSERT_FP_EQUAL(W1inf_norm, expected_norms[3], 10*my_tolerance);
   }
 
   void testDynaFileMappings (const std::string & filename, std::array<Real, 4> expected_norms)

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -945,8 +945,8 @@ public:
   {
     testDynaFileMappings("meshes/BlockWithHole_Patch9.bxt.gz",
     // Regression values for sin_x_plus_cos_y
-                         {3.226125496262302, 1.97405596521291,
-                          2.533759662135491, 1.413785069495184});
+                         {3.22612556930183, 1.97405365384733,
+                          2.53376235803176, 1.41374070517223});
   }
 
   void testDynaFileMappingsPlateWithHole ()
@@ -961,8 +961,8 @@ public:
   {
     testDynaFileMappings("meshes/PressurizedCyl3d_Patch1_8Elem.bxt.gz",
     // Regression values for sin_x_plus_cos_y
-                         {0.9636130896326653, 1.823294442918401,
-                          0.7080084233124895, 1.314114853940283});
+                         {0.963612880188165, 1.82329452603503,
+                          0.707998701597943, 1.31399222566683});
   }
 
   void testExodusFileMappings (const std::string & filename, std::array<Real, 4> expected_norms)
@@ -1016,8 +1016,8 @@ public:
   void testExodusFileMappingsCyl3d ()
   {
     testExodusFileMappings("meshes/PressurizedCyl3d_Patch1_8Elem.e",
-                           {0.9636130896326653, 1.823294442918401,
-                            0.7080084233124895, 1.314114853940283});
+                           {0.963612880188165, 1.82329452603503,
+                            0.707998701597943, 1.31399222566683});
   }
 };
 


### PR DESCRIPTION
The edge_map fix here seems to be just what I needed to fix initial condition projections on a complex IsoGeometric Analysis mesh, and it should generally be faster and less FP-error prone in other edge reinit uses too.