### PR TITLE
Add helper for building element sides that minimizes construction

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
+++ b/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
@@ -54,6 +54,7 @@
 #include "libmesh/string_to_enum.h"
 #include "libmesh/exact_solution.h"
 #include "libmesh/enum_solver_package.h"
+#include "libmesh/elem_side_builder.h"
 //#define QORDER TWENTYSIXTH
 
 // Bring in everything from the libMesh namespace
@@ -234,6 +235,12 @@ void assemble_ellipticdg(EquationSystems & es,
   // The global system matrix
   SparseMatrix<Number> & matrix = ellipticdg_system.get_system_matrix();
 
+  // We need to compute element side volumes, which requires obtaining
+  // a side element. Instead of constructing a new side every time,
+  // we leverage the ElemSideBuilder which can produce element sides
+  // and only allocates memory for each unique element side type.
+  ElemSideBuilder side_builder;
+
   // Now we will loop over all the elements in the mesh.  We will
   // compute first the element interior matrix and right-hand-side contribution
   // and then the element and neighbors boundary matrix contributions.
@@ -277,13 +284,13 @@ void assemble_ellipticdg(EquationSystems & es,
         {
           if (elem->neighbor_ptr(side) == nullptr)
             {
-              // Pointer to the element face
+              // Reinit the side
               fe_elem_face->reinit(elem, side);
 
-              std::unique_ptr<const Elem> elem_side (elem->build_side_ptr(side));
               // h element dimension to compute the interior penalty penalty parameter
+              const auto side_volume = side_builder(*elem, side).volume();
               const unsigned int elem_b_order = static_cast<unsigned int> (fe_elem_face->get_order());
-              const Real h_elem = elem->volume()/elem_side->volume() * 1./pow(elem_b_order, 2.);
+              const Real h_elem = elem->volume()/side_volume * 1./pow(elem_b_order, 2.);
 
               for (unsigned int qp=0; qp<qface.n_points(); qp++)
                 {
@@ -337,14 +344,13 @@ void assemble_ellipticdg(EquationSystems & es,
                    (elem_id < neighbor_id)) ||
                   (neighbor->level() < elem->level()))
                 {
-                  // Pointer to the element side
-                  std::unique_ptr<const Elem> elem_side (elem->build_side_ptr(side));
+                  const Elem & elem_side = side_builder(*elem, side);
 
                   // h dimension to compute the interior penalty penalty parameter
                   const unsigned int elem_b_order = static_cast<unsigned int>(fe_elem_face->get_order());
                   const unsigned int neighbor_b_order = static_cast<unsigned int>(fe_neighbor_face->get_order());
                   const double side_order = (elem_b_order + neighbor_b_order)/2.;
-                  const Real h_elem = (elem->volume()/elem_side->volume()) * 1./pow(side_order,2.);
+                  const Real h_elem = (elem->volume()/elem_side.volume()) * 1./pow(side_order,2.);
 
                   // The quadrature point locations on the neighbor side
                   std::vector<Point> qface_neighbor_point;
@@ -362,7 +368,7 @@ void assemble_ellipticdg(EquationSystems & es,
                   unsigned int side_neighbor = neighbor->which_neighbor_am_i(elem);
                   if (refinement_type == "p")
                     fe_neighbor_face->side_map (neighbor,
-                                                elem_side.get(),
+                                                &elem_side,
                                                 side_neighbor,
                                                 qface.get_points(),
                                                 qface_neighbor_point);

--- a/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
+++ b/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
@@ -56,6 +56,7 @@
 #include "libmesh/rb_data_deserialization.h"
 #include "libmesh/enum_solver_package.h"
 #include "libmesh/enum_solver_type.h"
+#include "libmesh/elem_side_builder.h"
 
 // local includes
 #include "rb_classes.h"
@@ -165,13 +166,16 @@ int main(int argc, char ** argv)
       // for now we'll add our required sidesets manually for our BEXT
       // file.
 
+      // To avoid extraneous allocation when obtaining element side vertex averages
+      ElemSideBuilder side_builder;
+
       // Each processor should know about each boundary condition it can
       // see, so we loop over all elements, not just local elements.
       for (const auto & elem : mesh.element_ptr_range())
         for (auto side : elem->side_index_range())
           if (!elem->neighbor_ptr(side))
             {
-              Point side_center = elem->build_side_ptr(side)->vertex_average();
+              const Point side_center = side_builder(*elem, side).vertex_average();
               // Yes, BOUNDARY_ID_MIN_X is a weird ID to use at
               // min(z), but we got an IGA cantilever mesh with the
               // lever arm in the z direction
@@ -542,4 +546,3 @@ void compute_stresses(EquationSystems & es)
 }
 
 #endif // LIBMESH_ENABLE_DIRICHLET
-

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -733,6 +733,7 @@ include_HEADERS = \
         geom/elem_internal.h \
         geom/elem_quality.h \
         geom/elem_range.h \
+        geom/elem_side_builder.h \
         geom/face.h \
         geom/face_inf_quad.h \
         geom/face_inf_quad4.h \

--- a/include/geom/cell_hex.h
+++ b/include/geom/cell_hex.h
@@ -172,6 +172,11 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 24; }
 
+  /**
+   * This maps each edge to the sides that contain said edge.
+   */
+  static const unsigned int edge_sides_map[12][2];
+
 protected:
 
   /**

--- a/include/geom/cell_hex20.h
+++ b/include/geom/cell_hex20.h
@@ -241,6 +241,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/cell_hex20.h
+++ b/include/geom/cell_hex20.h
@@ -230,11 +230,6 @@ public:
   static const unsigned int edge_nodes_map[num_edges][nodes_per_edge];
 
   /**
-   * This maps each edge to the sides that contain said edge.
-   */
-  static const unsigned int edge_sides_map[num_edges][2];
-
-  /**
    * A specialization for computing the volume of a Hex20.
    */
   virtual Real volume () const override;

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -246,11 +246,6 @@ public:
   static const unsigned int edge_nodes_map[num_edges][nodes_per_edge];
 
   /**
-   * This maps each edge to the sides that contain said edge.
-   */
-  static const unsigned int edge_sides_map[num_edges][2];
-
-  /**
    * A specialization for computing the volume of a Hex27.
    */
   virtual Real volume () const override;

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -259,6 +259,8 @@ public:
 
   unsigned int center_node_on_side(const unsigned short side) const override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
 

--- a/include/geom/cell_hex8.h
+++ b/include/geom/cell_hex8.h
@@ -180,11 +180,6 @@ public:
   static const unsigned int edge_nodes_map[num_edges][nodes_per_edge];
 
   /**
-   * This maps each edge to the sides that contain said edge.
-   */
-  static const unsigned int edge_sides_map[num_edges][2];
-
-  /**
    * Class static helper function that computes the centroid of a
    * hexahedral region from a set of input points which are assumed to
    * be in the standard "Hex8" ordering, possibly with some duplicates

--- a/include/geom/cell_hex8.h
+++ b/include/geom/cell_hex8.h
@@ -216,6 +216,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/cell_inf_hex.h
+++ b/include/geom/cell_inf_hex.h
@@ -187,6 +187,11 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 4; }
 
+  /**
+   * This maps each edge to the sides that contain said edge.
+   */
+  static const unsigned int edge_sides_map[8][2];
+
 protected:
 
   /**

--- a/include/geom/cell_inf_hex16.h
+++ b/include/geom/cell_inf_hex16.h
@@ -232,11 +232,6 @@ public:
    */
   static const unsigned int edge_nodes_map[num_edges][nodes_per_edge];
 
-  /**
-   * This maps each edge to the sides that contain said edge.
-   */
-  static const unsigned int edge_sides_map[num_edges][2];
-
   virtual void permute(unsigned int perm_num) override final;
 
   ElemType side_type (const unsigned int s) const override final;

--- a/include/geom/cell_inf_hex16.h
+++ b/include/geom/cell_inf_hex16.h
@@ -239,6 +239,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -247,11 +247,6 @@ public:
    */
   static const unsigned int edge_nodes_map[num_edges][nodes_per_edge];
 
-  /**
-   * This maps each edge to the sides that contain said edge.
-   */
-  static const unsigned int edge_sides_map[num_edges][2];
-
   virtual void permute(unsigned int perm_num) override final;
 
   ElemType side_type (const unsigned int s) const override final;

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -254,6 +254,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/cell_inf_hex8.h
+++ b/include/geom/cell_inf_hex8.h
@@ -182,11 +182,6 @@ public:
    */
   static const unsigned int edge_nodes_map[num_edges][nodes_per_edge];
 
-  /**
-   * This maps each edge to the sides that contain said edge.
-   */
-  static const unsigned int edge_sides_map[num_edges][2];
-
   virtual void permute(unsigned int perm_num) override final;
 
   ElemType side_type (const unsigned int s) const override final;

--- a/include/geom/cell_inf_hex8.h
+++ b/include/geom/cell_inf_hex8.h
@@ -189,6 +189,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/cell_inf_prism.h
+++ b/include/geom/cell_inf_prism.h
@@ -169,6 +169,13 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 3; }
 
+  std::vector<unsigned int> sides_on_edge(const unsigned int e) const override final;
+
+  /**
+   * This maps each edge to the sides that contain said edge.
+   */
+  static const unsigned int edge_sides_map[6][2];
+
 protected:
 
   /**

--- a/include/geom/cell_inf_prism12.h
+++ b/include/geom/cell_inf_prism12.h
@@ -117,8 +117,6 @@ public:
 
   virtual std::vector<unsigned int> nodes_on_edge(const unsigned int e) const override;
 
-  virtual std::vector<unsigned int> sides_on_edge(const unsigned int e) const override;
-
   /**
    * \returns \p true if the specified (local) node number is on the
    * specified edge.
@@ -221,11 +219,6 @@ public:
    * element node numbers.
    */
   static const unsigned int edge_nodes_map[num_edges][nodes_per_edge];
-
-  /**
-   * This maps each edge to the sides that contain said edge.
-   */
-  static const unsigned int edge_sides_map[num_edges][2];
 
   virtual void permute(unsigned int perm_num) override final;
 

--- a/include/geom/cell_inf_prism12.h
+++ b/include/geom/cell_inf_prism12.h
@@ -229,6 +229,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/cell_inf_prism6.h
+++ b/include/geom/cell_inf_prism6.h
@@ -113,8 +113,6 @@ public:
 
   virtual std::vector<unsigned int> nodes_on_edge(const unsigned int e) const override;
 
-  virtual std::vector<unsigned int> sides_on_edge(const unsigned int e) const override;
-
   /**
    * \returns \p true if the specified (local) node number is on the
    * specified edge.
@@ -182,11 +180,6 @@ public:
    * element node numbers.
    */
   static const unsigned int edge_nodes_map[num_edges][nodes_per_edge];
-
-  /**
-   * This maps each edge to the sides that contain said edge.
-   */
-  static const unsigned int edge_sides_map[num_edges][2];
 
   virtual void permute(unsigned int perm_num) override final;
 

--- a/include/geom/cell_inf_prism6.h
+++ b/include/geom/cell_inf_prism6.h
@@ -190,6 +190,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/cell_prism.h
+++ b/include/geom/cell_prism.h
@@ -151,6 +151,11 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 6; }
 
+  /**
+   * This maps each edge to the sides that contain said edge.
+   */
+  static const unsigned int edge_sides_map[9][2];
+
 protected:
 
   /**

--- a/include/geom/cell_prism15.h
+++ b/include/geom/cell_prism15.h
@@ -235,11 +235,6 @@ public:
   static const unsigned int edge_nodes_map[num_edges][nodes_per_edge];
 
   /**
-   * This maps each edge to the sides that contain said edge.
-   */
-  static const unsigned int edge_sides_map[num_edges][2];
-
-  /**
    * A specialization for computing the volume of a Prism15.
    */
   virtual Real volume () const override;

--- a/include/geom/cell_prism15.h
+++ b/include/geom/cell_prism15.h
@@ -246,6 +246,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -264,6 +264,8 @@ public:
 
   unsigned int center_node_on_side(const unsigned short side) const override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -251,11 +251,6 @@ public:
   static const unsigned int edge_nodes_map[num_edges][nodes_per_edge];
 
   /**
-   * This maps each edge to the sides that contain said edge.
-   */
-  static const unsigned int edge_sides_map[num_edges][2];
-
-  /**
    * A specialization for computing the volume of a Prism18.
    */
   virtual Real volume () const override;

--- a/include/geom/cell_prism6.h
+++ b/include/geom/cell_prism6.h
@@ -206,6 +206,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/cell_prism6.h
+++ b/include/geom/cell_prism6.h
@@ -184,11 +184,6 @@ public:
   static const unsigned int edge_nodes_map[num_edges][nodes_per_edge];
 
   /**
-   * This maps each edge to the sides that contain said edge.
-   */
-  static const unsigned int edge_sides_map[num_edges][2];
-
-  /**
    * An Optimized numerical quadrature approach for computing the
    * centroid of the Prism6.
    */

--- a/include/geom/cell_pyramid.h
+++ b/include/geom/cell_pyramid.h
@@ -175,6 +175,11 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 4; }
 
+  /**
+   * This maps each edge to the sides that contain said edge.
+   */
+  static const unsigned int edge_sides_map[8][2];
+
 protected:
 
   /**

--- a/include/geom/cell_pyramid13.h
+++ b/include/geom/cell_pyramid13.h
@@ -234,6 +234,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/cell_pyramid13.h
+++ b/include/geom/cell_pyramid13.h
@@ -223,11 +223,6 @@ public:
   static const unsigned int edge_nodes_map[num_edges][nodes_per_edge];
 
   /**
-   * This maps each edge to the sides that contain said edge.
-   */
-  static const unsigned int edge_sides_map[num_edges][2];
-
-  /**
    * Specialization for computing the volume of a Pyramid13.
    */
   virtual Real volume () const override;

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -242,11 +242,6 @@ public:
   static const unsigned int edge_nodes_map[num_edges][nodes_per_edge];
 
   /**
-   * This maps each edge to the sides that contain said edge.
-   */
-  static const unsigned int edge_sides_map[num_edges][2];
-
-  /**
    * Specialization for computing the volume of a Pyramid14.
    */
   virtual Real volume () const override;

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -255,6 +255,8 @@ public:
 
   unsigned int center_node_on_side(const unsigned short side) const override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/cell_pyramid5.h
+++ b/include/geom/cell_pyramid5.h
@@ -177,11 +177,6 @@ public:
   static const unsigned int edge_nodes_map[num_edges][nodes_per_edge];
 
   /**
-   * This maps each edge to the sides that contain said edge.
-   */
-  static const unsigned int edge_sides_map[num_edges][2];
-
-  /**
    * We compute the centroid of the Pyramid by treating it as a
    * degenerate Hex8 element.
    */

--- a/include/geom/cell_pyramid5.h
+++ b/include/geom/cell_pyramid5.h
@@ -199,6 +199,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/cell_tet.h
+++ b/include/geom/cell_tet.h
@@ -196,6 +196,11 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 12; }
 
+  /**
+   * This maps each edge to the sides that contain said edge.
+   */
+  static const unsigned int edge_sides_map[6][2];
+
 protected:
 
   /**

--- a/include/geom/cell_tet10.h
+++ b/include/geom/cell_tet10.h
@@ -242,6 +242,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/cell_tet10.h
+++ b/include/geom/cell_tet10.h
@@ -231,11 +231,6 @@ public:
   static const unsigned int edge_nodes_map[num_edges][nodes_per_edge];
 
   /**
-   * This maps each edge to the sides that contain said edge.
-   */
-  static const unsigned int edge_sides_map[num_edges][2];
-
-  /**
    * A specialization for computing the volume of a Tet10.
    */
   virtual Real volume () const override;

--- a/include/geom/cell_tet14.h
+++ b/include/geom/cell_tet14.h
@@ -242,6 +242,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 #ifdef LIBMESH_ENABLE_AMR
   virtual
   const std::vector<std::pair<unsigned char, unsigned char>> &

--- a/include/geom/cell_tet14.h
+++ b/include/geom/cell_tet14.h
@@ -235,11 +235,6 @@ public:
    */
   static const unsigned int edge_nodes_map[num_edges][nodes_per_edge];
 
-  /**
-   * This maps each edge to the sides that contain said edge.
-   */
-  static const unsigned int edge_sides_map[num_edges][2];
-
   virtual void permute(unsigned int perm_num) override final;
 
   ElemType side_type (const unsigned int s) const override final;

--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -249,6 +249,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -202,11 +202,6 @@ public:
   static const unsigned int edge_nodes_map[num_edges][nodes_per_edge];
 
   /**
-   * This maps each edge to the sides that contain said edge.
-   */
-  static const unsigned int edge_sides_map[num_edges][2];
-
-  /**
    * The centroid of a 4-node tetrahedron is simply given by the
    * average of its vertex positions.
    */

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -194,6 +194,8 @@ public:
 
   unsigned int center_node_on_side(const unsigned short side) const override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -636,6 +636,11 @@ public:
   virtual unsigned int n_sides () const = 0;
 
   /**
+   * \returns The type of element for side \p s.
+   */
+  virtual ElemType side_type (const unsigned int s) const = 0;
+
+  /**
    * \returns An integer range from 0 up to (but not including)
    * the number of sides this element has.
    */

--- a/include/geom/elem_side_builder.h
+++ b/include/geom/elem_side_builder.h
@@ -1,0 +1,68 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2021 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#ifndef LIBMESH_ELEM_SIDE_BUILDER_H
+#define LIBMESH_ELEM_SIDE_BUILDER_H
+
+#include "libmesh/elem.h"
+
+namespace libMesh
+{
+
+/**
+ * Helper for building element sides that minimizes the construction
+ * of new elements.
+ *
+ * The building of element side pointers has the option to pass an
+ * existing constructed element to avoid extraneous allocation.
+ * If the element that is passed is of the correct type, the
+ * build is done in place, that is, the nodes and subdomain are
+ * done in place.
+ *
+ * This tool contains a cache with an entry per element type.
+ * When a side is requested, the cached element of the desired
+ * type is utilized. On first request of a side of a specific
+ * type, the desired element is constructed. On all subsequent
+ * calls for a side of the same type, the cached element is
+ * used and the necessary members (nodes and subdomain)
+ * are changed in place.
+ *
+ * NOTE: This tool is meant for on-the-fly use. Because
+ * the cache is changed on each call, the references obtained
+ * from previous calls should be considered invalid.
+ */
+class ElemSideBuilder
+{
+public:
+  /**
+   * \returns an element side for side \p s of element \p elem.
+   */
+  ///@{
+  Elem & operator()(Elem & elem, const unsigned int s);
+  const Elem & operator()(const Elem & elem, const unsigned int s);
+  ///@}
+
+private:
+  /// Element cache for building sides; indexed by ElemType
+  std::vector<std::unique_ptr<Elem>> _cached_elems;
+};
+
+} // namespace libMesh
+
+#endif // LIBMESH_ELEM_SIDE_BUILDER_H

--- a/include/geom/face_inf_quad4.h
+++ b/include/geom/face_inf_quad4.h
@@ -160,6 +160,7 @@ public:
    */
   static const unsigned int side_nodes_map[num_sides][nodes_per_side];
 
+  ElemType side_type (const unsigned int s) const override final;
 
 protected:
 

--- a/include/geom/face_inf_quad6.h
+++ b/include/geom/face_inf_quad6.h
@@ -196,7 +196,7 @@ public:
    */
   static const unsigned int side_nodes_map[num_sides][nodes_per_side];
 
-
+  ElemType side_type (const unsigned int s) const override final;
 
 protected:
 

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -174,6 +174,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/face_quad8.h
+++ b/include/geom/face_quad8.h
@@ -213,6 +213,8 @@ public:
 
   unsigned int center_node_on_side(const unsigned short side) const override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/face_quad9.h
+++ b/include/geom/face_quad9.h
@@ -220,6 +220,8 @@ public:
 
   unsigned int center_node_on_side(const unsigned short side) const override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -199,6 +199,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/face_tri6.h
+++ b/include/geom/face_tri6.h
@@ -223,6 +223,8 @@ public:
 
   unsigned int center_node_on_side(const unsigned short side) const override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/face_tri7.h
+++ b/include/geom/face_tri7.h
@@ -229,6 +229,8 @@ public:
 
   unsigned int center_node_on_side(const unsigned short side) const override final;
 
+  ElemType side_type (const unsigned int s) const override final;
+
 protected:
 
   /**

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -256,6 +256,12 @@ public:
 
   virtual void permute(unsigned int) override final { libmesh_error(); }
 
+  virtual ElemType side_type (const unsigned int) const override
+  {
+    libmesh_not_implemented();
+    return INVALID_ELEM;
+  }
+
 protected:
 
   /**

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -233,6 +233,12 @@ public:
   virtual unsigned int center_node_on_side(const unsigned short) const override
   { libmesh_error(); return invalid_uint; }
 
+  virtual ElemType side_type (const unsigned int) const override
+  {
+    libmesh_not_implemented();
+    return INVALID_ELEM;
+  }
+
 protected:
 
   /**

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -142,6 +142,7 @@ include_HEADERS =  \
         geom/elem_internal.h \
         geom/elem_quality.h \
         geom/elem_range.h \
+        geom/elem_side_builder.h \
         geom/face.h \
         geom/face_inf_quad.h \
         geom/face_inf_quad4.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -132,6 +132,7 @@ BUILT_SOURCES = \
         elem_internal.h \
         elem_quality.h \
         elem_range.h \
+        elem_side_builder.h \
         face.h \
         face_inf_quad.h \
         face_inf_quad4.h \
@@ -948,6 +949,9 @@ elem_quality.h: $(top_srcdir)/include/geom/elem_quality.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 elem_range.h: $(top_srcdir)/include/geom/elem_range.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+elem_side_builder.h: $(top_srcdir)/include/geom/elem_side_builder.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 face.h: $(top_srcdir)/include/geom/face.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -548,18 +548,18 @@ BUILT_SOURCES = auto_ptr.h default_coupling.h dirichlet_boundaries.h \
 	cell_tet10.h cell_tet14.h cell_tet4.h compare_elems_by_level.h \
 	edge.h edge_edge2.h edge_edge3.h edge_edge4.h edge_inf_edge2.h \
 	elem.h elem_cutter.h elem_hash.h elem_internal.h \
-	elem_quality.h elem_range.h face.h face_inf_quad.h \
-	face_inf_quad4.h face_inf_quad6.h face_quad.h face_quad4.h \
-	face_quad4_shell.h face_quad8.h face_quad8_shell.h \
-	face_quad9.h face_tri.h face_tri3.h face_tri3_shell.h \
-	face_tri3_subdivision.h face_tri6.h face_tri7.h node.h \
-	node_elem.h node_range.h plane.h point.h reference_elem.h \
-	remote_elem.h side.h sphere.h stored_range.h surface.h \
-	abaqus_io.h boundary_info.h boundary_mesh.h checkpoint_io.h \
-	distributed_mesh.h dyna_io.h ensight_io.h exodusII_io.h \
-	exodusII_io_helper.h exodus_header_info.h fro_io.h gmsh_io.h \
-	gmv_io.h gnuplot_io.h inf_elem_builder.h matlab_io.h \
-	medit_io.h mesh.h mesh_base.h mesh_communication.h \
+	elem_quality.h elem_range.h elem_side_builder.h face.h \
+	face_inf_quad.h face_inf_quad4.h face_inf_quad6.h face_quad.h \
+	face_quad4.h face_quad4_shell.h face_quad8.h \
+	face_quad8_shell.h face_quad9.h face_tri.h face_tri3.h \
+	face_tri3_shell.h face_tri3_subdivision.h face_tri6.h \
+	face_tri7.h node.h node_elem.h node_range.h plane.h point.h \
+	reference_elem.h remote_elem.h side.h sphere.h stored_range.h \
+	surface.h abaqus_io.h boundary_info.h boundary_mesh.h \
+	checkpoint_io.h distributed_mesh.h dyna_io.h ensight_io.h \
+	exodusII_io.h exodusII_io_helper.h exodus_header_info.h \
+	fro_io.h gmsh_io.h gmv_io.h gnuplot_io.h inf_elem_builder.h \
+	matlab_io.h medit_io.h mesh.h mesh_base.h mesh_communication.h \
 	mesh_function.h mesh_generation.h mesh_input.h \
 	mesh_inserter_iterator.h mesh_modification.h mesh_output.h \
 	mesh_refinement.h mesh_serializer.h mesh_smoother.h \
@@ -1287,6 +1287,9 @@ elem_quality.h: $(top_srcdir)/include/geom/elem_quality.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 elem_range.h: $(top_srcdir)/include/geom/elem_range.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+elem_side_builder.h: $(top_srcdir)/include/geom/elem_side_builder.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 face.h: $(top_srcdir)/include/geom/face.h

--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -68,7 +68,21 @@ const Real Hex::_master_points[27][3] =
     {0, 0, 1}
   };
 
-
+const unsigned int Hex::edge_sides_map[12][2] =
+  {
+    {0, 1}, // Edge 0
+    {0, 2}, // Edge 1
+    {0, 3}, // Edge 2
+    {0, 4}, // Edge 3
+    {1, 4}, // Edge 4
+    {1, 2}, // Edge 5
+    {2, 3}, // Edge 6
+    {3, 4}, // Edge 7
+    {1, 5}, // Edge 8
+    {2, 5}, // Edge 9
+    {3, 5}, // Edge 10
+    {4, 5}  // Edge 11
+  };
 
 
 // ------------------------------------------------------------
@@ -156,15 +170,16 @@ bool Hex::is_edge_on_side(const unsigned int e,
   libmesh_assert_less (e, this->n_edges());
   libmesh_assert_less (s, this->n_sides());
 
-  return (Hex8::edge_sides_map[e][0] == s ||
-          Hex8::edge_sides_map[e][1] == s);
+  return (edge_sides_map[e][0] == s || edge_sides_map[e][1] == s);
 }
 
 
 
 std::vector<unsigned int> Hex::sides_on_edge(const unsigned int e) const
 {
-  return {Hex8::edge_sides_map[e][0], Hex8::edge_sides_map[e][1]};
+  libmesh_assert_less(e, this->n_edges());
+
+  return {edge_sides_map[e][0], edge_sides_map[e][1]};
 }
 
 

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -776,4 +776,13 @@ Hex20::permute(unsigned int perm_num)
   }
 }
 
+
+ElemType
+Hex20::side_type (const unsigned int libmesh_dbg_var(s)) const
+{
+  libmesh_assert_less (s, 6);
+  return QUAD8;
+}
+
+
 } // namespace libMesh

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -64,22 +64,6 @@ const unsigned int Hex20::edge_nodes_map[Hex20::num_edges][Hex20::nodes_per_edge
     {4, 7, 19}  // Edge 11
   };
 
-const unsigned int Hex20::edge_sides_map[Hex20::num_edges][2] =
-  {
-    {0, 1}, // Edge 0
-    {0, 2}, // Edge 1
-    {0, 3}, // Edge 2
-    {0, 4}, // Edge 3
-    {1, 4}, // Edge 4
-    {1, 2}, // Edge 5
-    {2, 3}, // Edge 6
-    {3, 4}, // Edge 7
-    {1, 5}, // Edge 8
-    {2, 5}, // Edge 9
-    {3, 5}, // Edge 10
-    {4, 5}  // Edge 11
-  };
-
 // ------------------------------------------------------------
 // Hex20 class member functions
 

--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -1273,4 +1273,12 @@ unsigned int Hex27::center_node_on_side(const unsigned short side) const
 }
 
 
+ElemType
+Hex27::side_type (const unsigned int libmesh_dbg_var(s)) const
+{
+  libmesh_assert_less (s, 6);
+  return QUAD9;
+}
+
+
 } // namespace libMesh

--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -64,22 +64,6 @@ const unsigned int Hex27::edge_nodes_map[Hex27::num_edges][Hex27::nodes_per_edge
     {4, 7, 19}  // Edge 11
   };
 
-const unsigned int Hex27::edge_sides_map[Hex27::num_edges][2] =
-  {
-    {0, 1}, // Edge 0
-    {0, 2}, // Edge 1
-    {0, 3}, // Edge 2
-    {0, 4}, // Edge 3
-    {1, 4}, // Edge 4
-    {1, 2}, // Edge 5
-    {2, 3}, // Edge 6
-    {3, 4}, // Edge 7
-    {1, 5}, // Edge 8
-    {2, 5}, // Edge 9
-    {3, 5}, // Edge 10
-    {4, 5}  // Edge 11
-  };
-
 // ------------------------------------------------------------
 // Hex27 class member functions
 

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -530,4 +530,12 @@ Hex8::permute(unsigned int perm_num)
 }
 
 
+ElemType
+Hex8::side_type (const unsigned int libmesh_dbg_var(s)) const
+{
+  libmesh_assert_less (s, 6);
+  return QUAD4;
+}
+
+
 } // namespace libMesh

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -69,22 +69,6 @@ const unsigned int Hex8::edge_nodes_map[Hex8::num_edges][Hex8::nodes_per_edge] =
     {4, 7}  // Edge 11
   };
 
-const unsigned int Hex8::edge_sides_map[Hex8::num_edges][2] =
-  {
-    {0, 1}, // Edge 0
-    {0, 2}, // Edge 1
-    {0, 3}, // Edge 2
-    {0, 4}, // Edge 3
-    {1, 4}, // Edge 4
-    {1, 2}, // Edge 5
-    {2, 3}, // Edge 6
-    {3, 4}, // Edge 7
-    {1, 5}, // Edge 8
-    {2, 5}, // Edge 9
-    {3, 5}, // Edge 10
-    {4, 5}  // Edge 11
-  };
-
 // ------------------------------------------------------------
 // Hex8 class member functions
 

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -66,7 +66,17 @@ const Real InfHex::_master_points[18][3] =
     {0, 0, 1}
   };
 
-
+const unsigned int InfHex::edge_sides_map[8][2] =
+  {
+    {0, 1}, // Edge 0
+    {0, 2}, // Edge 1
+    {0, 3}, // Edge 2
+    {0, 4}, // Edge 3
+    {1, 4}, // Edge 4
+    {1, 2}, // Edge 5
+    {2, 3}, // Edge 6
+    {3, 4}  // Edge 7
+  };
 
 
 
@@ -222,15 +232,16 @@ bool InfHex::is_edge_on_side (const unsigned int e,
   libmesh_assert_less (e, this->n_edges());
   libmesh_assert_less (s, this->n_sides());
 
-  return (InfHex8::edge_sides_map[e][0] == s ||
-          InfHex8::edge_sides_map[e][1] == s);
+  return (edge_sides_map[e][0] == s || edge_sides_map[e][1] == s);
 }
 
 
 
 std::vector<unsigned int> InfHex::sides_on_edge(const unsigned int e) const
 {
-  return {InfHex8::edge_sides_map[e][0], InfHex8::edge_sides_map[e][1]};
+  libmesh_assert_less(e, this->n_edges());
+
+  return {edge_sides_map[e][0], edge_sides_map[e][1]};
 }
 
 

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -64,18 +64,6 @@ const unsigned int InfHex16::edge_nodes_map[InfHex16::num_edges][InfHex16::nodes
     {3, 7, 99}  // Edge 7
   };
 
-const unsigned int InfHex16::edge_sides_map[InfHex16::num_edges][2] =
-  {
-    {0, 1}, // Edge 0
-    {1, 2}, // Edge 1
-    {0, 3}, // Edge 2
-    {0, 4}, // Edge 3
-    {1, 4}, // Edge 4
-    {1, 2}, // Edge 5
-    {2, 3}, // Edge 6
-    {3, 4}  // Edge 7
-  };
-
 // ------------------------------------------------------------
 // InfHex16 class member functions
 

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -547,6 +547,17 @@ InfHex16::permute(unsigned int perm_num)
     }
 }
 
+
+ElemType
+InfHex16::side_type (const unsigned int s) const
+{
+  libmesh_assert_less (s, 5);
+  if (s == 0)
+    return QUAD8;
+  return INFQUAD6;
+}
+
+
 } // namespace libMesh
 
 #endif  // ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -664,6 +664,17 @@ InfHex18::permute(unsigned int perm_num)
     }
 }
 
+
+ElemType
+InfHex18::side_type (const unsigned int s) const
+{
+  libmesh_assert_less (s, 5);
+  if (s == 0)
+    return QUAD9;
+  return INFQUAD6;
+}
+
+
 } // namespace libMesh
 
 #endif // ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -64,18 +64,6 @@ const unsigned int InfHex18::edge_nodes_map[InfHex18::num_edges][InfHex18::nodes
     {3, 7, 99}  // Edge 7
   };
 
-const unsigned int InfHex18::edge_sides_map[InfHex18::num_edges][2] =
-  {
-    {0, 1}, // Edge 0
-    {1, 2}, // Edge 1
-    {0, 3}, // Edge 2
-    {0, 4}, // Edge 3
-    {1, 4}, // Edge 4
-    {1, 2}, // Edge 5
-    {2, 3}, // Edge 6
-    {3, 4}  // Edge 7
-  };
-
 // ------------------------------------------------------------
 // InfHex18 class member functions
 

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -64,19 +64,6 @@ const unsigned int InfHex8::edge_nodes_map[InfHex8::num_edges][InfHex8::nodes_pe
     {3, 7}  // Edge 7
   };
 
-const unsigned int InfHex8::edge_sides_map[InfHex8::num_edges][2] =
-  {
-    {0, 1}, // Edge 0
-    {1, 2}, // Edge 1
-    {0, 3}, // Edge 2
-    {0, 4}, // Edge 3
-    {1, 4}, // Edge 4
-    {1, 2}, // Edge 5
-    {2, 3}, // Edge 6
-    {3, 4}  // Edge 7
-  };
-
-
 // ------------------------------------------------------------
 // InfHex8 class member functions
 

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -397,6 +397,16 @@ InfHex8::permute(unsigned int perm_num)
 }
 
 
+ElemType
+InfHex8::side_type (const unsigned int s) const
+{
+  libmesh_assert_less (s, 5);
+  if (s == 0)
+    return QUAD4;
+  return INFQUAD4;
+}
+
+
 } // namespace libMesh
 
 #endif // ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS

--- a/src/geom/cell_inf_prism.C
+++ b/src/geom/cell_inf_prism.C
@@ -54,7 +54,15 @@ const Real InfPrism::_master_points[12][3] =
     {0, .5, 1}
   };
 
-
+const unsigned int InfPrism::edge_sides_map[6][2] =
+  {
+    {0, 1}, // Edge 0
+    {0, 2}, // Edge 1
+    {0, 3}, // Edge 2
+    {1, 3}, // Edge 3
+    {1, 2}, // Edge 4
+    {2, 3}  // Edge 5
+  };
 
 // ------------------------------------------------------------
 // InfPrism class member functions
@@ -208,8 +216,7 @@ bool InfPrism::is_edge_on_side (const unsigned int e,
   libmesh_assert_less (e, this->n_edges());
   libmesh_assert_less (s, this->n_sides());
 
-  return (InfPrism6::edge_sides_map[e][0] == s ||
-          InfPrism6::edge_sides_map[e][1] == s);
+  return (edge_sides_map[e][0] == s || edge_sides_map[e][1] == s);
 }
 
 bool InfPrism::contains_point (const Point & p, Real tol) const
@@ -288,6 +295,12 @@ bool InfPrism::contains_point (const Point & p, Real tol) const
   return FEInterface::on_reference_element(mapped_point, this->type(), tol);
 }
 
+std::vector<unsigned>
+InfPrism::sides_on_edge(const unsigned int e) const
+{
+  libmesh_assert_less(e, n_edges());
+  return {std::begin(edge_sides_map[e]), std::end(edge_sides_map[e])};
+}
 
 } // namespace libMesh
 

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -60,17 +60,6 @@ const unsigned int InfPrism12::edge_nodes_map[InfPrism12::num_edges][InfPrism12:
     {2, 5, 99}  // Side 5
   };
 
-const unsigned int InfPrism12::edge_sides_map[InfPrism12::num_edges][2] =
-  {
-    {0, 1}, // Edge 0
-    {0, 2}, // Edge 1
-    {0, 3}, // Edge 2
-    {1, 3}, // Edge 3
-    {1, 2}, // Edge 4
-    {2, 3}  // Edge 5
-  };
-
-
 // ------------------------------------------------------------
 // InfPrism12 class member functions
 
@@ -119,13 +108,6 @@ InfPrism12::nodes_on_edge(const unsigned int e) const
   libmesh_assert_less(e, n_edges());
   auto trim = (e < 3) ? 0 : 1;
   return {std::begin(edge_nodes_map[e]), std::end(edge_nodes_map[e]) - trim};
-}
-
-std::vector<unsigned>
-InfPrism12::sides_on_edge(const unsigned int e) const
-{
-  libmesh_assert_less(e, n_edges());
-  return {std::begin(edge_sides_map[e]), std::end(edge_sides_map[e])};
 }
 
 bool InfPrism12::is_node_on_edge(const unsigned int n,

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -582,6 +582,16 @@ InfPrism12::permute(unsigned int perm_num)
 }
 
 
+ElemType
+InfPrism12::side_type (const unsigned int s) const
+{
+  libmesh_assert_less (s, 4);
+  if (s == 0)
+    return TRI6;
+  return INFQUAD6;
+}
+
+
 } // namespace libMesh
 
 #endif // ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS

--- a/src/geom/cell_inf_prism6.C
+++ b/src/geom/cell_inf_prism6.C
@@ -62,16 +62,6 @@ const unsigned int InfPrism6::edge_nodes_map[InfPrism6::num_edges][InfPrism6::no
     {2, 5}  // Edge 5
   };
 
-const unsigned int InfPrism6::edge_sides_map[InfPrism6::num_edges][2] =
-  {
-    {0, 1}, // Edge 0
-    {0, 2}, // Edge 1
-    {0, 3}, // Edge 2
-    {1, 3}, // Edge 3
-    {1, 2}, // Edge 4
-    {2, 3}  // Edge 5
-  };
-
 // ------------------------------------------------------------
 // InfPrism6 class member functions
 
@@ -116,13 +106,6 @@ InfPrism6::nodes_on_edge(const unsigned int e) const
 {
   libmesh_assert_less(e, n_edges());
   return {std::begin(edge_nodes_map[e]), std::end(edge_nodes_map[e])};
-}
-
-std::vector<unsigned>
-InfPrism6::sides_on_edge(const unsigned int e) const
-{
-  libmesh_assert_less(e, n_edges());
-  return {std::begin(edge_sides_map[e]), std::end(edge_sides_map[e])};
 }
 
 bool InfPrism6::is_node_on_edge(const unsigned int n,

--- a/src/geom/cell_inf_prism6.C
+++ b/src/geom/cell_inf_prism6.C
@@ -386,6 +386,16 @@ InfPrism6::permute(unsigned int perm_num)
     }
 }
 
+
+ElemType
+InfPrism6::side_type (const unsigned int s) const
+{
+  libmesh_assert_less (s, 4);
+  if (s == 0)
+    return TRI3;
+  return INFQUAD4;
+}
+
 } // namespace libMesh
 
 #endif  // ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS

--- a/src/geom/cell_prism.C
+++ b/src/geom/cell_prism.C
@@ -55,8 +55,18 @@ const Real Prism::_master_points[18][3] =
     {0, 0.5, 0}
   };
 
-
-
+const unsigned int Prism::edge_sides_map[9][2] =
+  {
+    {0, 1}, // Edge 0
+    {0, 2}, // Edge 1
+    {0, 3}, // Edge 2
+    {1, 3}, // Edge 3
+    {1, 2}, // Edge 4
+    {2, 3}, // Edge 5
+    {1, 4}, // Edge 6
+    {2, 4}, // Edge 7
+    {3, 4}  // Edge 8
+  };
 
 // ------------------------------------------------------------
 // Prism class member functions
@@ -213,15 +223,16 @@ bool Prism::is_edge_on_side(const unsigned int e,
   libmesh_assert_less (e, this->n_edges());
   libmesh_assert_less (s, this->n_sides());
 
-  return (Prism6::edge_sides_map[e][0] == s ||
-          Prism6::edge_sides_map[e][1] == s);
+  return (edge_sides_map[e][0] == s || edge_sides_map[e][1] == s);
 }
 
 
 
 std::vector<unsigned int> Prism::sides_on_edge(const unsigned int e) const
 {
-  return {Prism6::edge_sides_map[e][0], Prism6::edge_sides_map[e][1]};
+  libmesh_assert_less(e, this->n_edges());
+
+  return {edge_sides_map[e][0], edge_sides_map[e][1]};
 }
 
 

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -61,19 +61,6 @@ const unsigned int Prism15::edge_nodes_map[Prism15::num_edges][Prism15::nodes_pe
     {3, 5, 14}  // Edge 8
   };
 
-const unsigned int Prism15::edge_sides_map[Prism15::num_edges][2] =
-  {
-    {0, 1}, // Edge 0
-    {0, 2}, // Edge 1
-    {0, 3}, // Edge 2
-    {1, 3}, // Edge 3
-    {1, 2}, // Edge 4
-    {2, 3}, // Edge 5
-    {1, 4}, // Edge 6
-    {2, 4}, // Edge 7
-    {3, 4}  // Edge 8
-  };
-
 // ------------------------------------------------------------
 // Prism15 class member functions
 

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -777,4 +777,13 @@ Prism15::permute(unsigned int perm_num)
 }
 
 
+ElemType
+Prism15::side_type (const unsigned int s) const
+{
+  libmesh_assert_less (s, 5);
+  if (s == 0 || s == 4)
+    return TRI6;
+  return QUAD8;
+}
+
 } // namespace libMesh

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -62,19 +62,6 @@ const unsigned int Prism18::edge_nodes_map[Prism18::num_edges][Prism18::nodes_pe
     {3, 5, 14}  // Edge 8
   };
 
-const unsigned int Prism18::edge_sides_map[Prism18::num_edges][2] =
-  {
-    {0, 1}, // Edge 0
-    {0, 2}, // Edge 1
-    {0, 3}, // Edge 2
-    {1, 3}, // Edge 3
-    {1, 2}, // Edge 4
-    {2, 3}, // Edge 5
-    {1, 4}, // Edge 6
-    {2, 4}, // Edge 7
-    {3, 4}  // Edge 8
-  };
-
 // ------------------------------------------------------------
 // Prism18 class member functions
 

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -1047,4 +1047,14 @@ unsigned int Prism18::center_node_on_side(const unsigned short side) const
 }
 
 
+ElemType
+Prism18::side_type (const unsigned int s) const
+{
+  libmesh_assert_less (s, 5);
+  if (s == 0 || s == 4)
+    return TRI6;
+  return QUAD9;
+}
+
+
 } // namespace libMesh

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -145,19 +145,6 @@ const unsigned int Prism6::edge_nodes_map[Prism6::num_edges][Prism6::nodes_per_e
     {3, 5}  // Edge 8
   };
 
-const unsigned int Prism6::edge_sides_map[Prism6::num_edges][2] =
-  {
-    {0, 1}, // Edge 0
-    {0, 2}, // Edge 1
-    {0, 3}, // Edge 2
-    {1, 3}, // Edge 3
-    {1, 2}, // Edge 4
-    {2, 3}, // Edge 5
-    {1, 4}, // Edge 6
-    {2, 4}, // Edge 7
-    {3, 4}  // Edge 8
-  };
-
 // ------------------------------------------------------------
 // Prism6 class member functions
 

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -530,6 +530,16 @@ Prism6::permute(unsigned int perm_num)
 
 }
 
+
+ElemType
+Prism6::side_type (const unsigned int s) const
+{
+  libmesh_assert_less (s, 5);
+  if (s == 0 || s == 4)
+    return TRI3;
+  return QUAD4;
+}
+
 } // namespace libMesh
 
 namespace // anonymous

--- a/src/geom/cell_pyramid.C
+++ b/src/geom/cell_pyramid.C
@@ -50,8 +50,17 @@ const Real Pyramid::_master_points[14][3] =
     {0, 0, 0}
   };
 
-
-
+const unsigned int Pyramid::edge_sides_map[8][2] =
+  {
+    {0, 4}, // Edge 0
+    {1, 4}, // Edge 1
+    {2, 4}, // Edge 2
+    {3, 4}, // Edge 3
+    {0, 3}, // Edge 4
+    {0, 1}, // Edge 5
+    {1, 2}, // Edge 6
+    {2, 3}  // Edge 7
+  };
 
 // ------------------------------------------------------------
 // Pyramid class member functions
@@ -208,15 +217,15 @@ bool Pyramid::is_edge_on_side(const unsigned int e,
   libmesh_assert_less (e, this->n_edges());
   libmesh_assert_less (s, this->n_sides());
 
-  return (Pyramid5::edge_sides_map[e][0] == s ||
-          Pyramid5::edge_sides_map[e][1] == s);
+  return (edge_sides_map[e][0] == s || edge_sides_map[e][1] == s);
 }
 
 
 
 std::vector<unsigned int> Pyramid::sides_on_edge(const unsigned int e) const
 {
-  return {Pyramid5::edge_sides_map[e][0], Pyramid5::edge_sides_map[e][1]};
+  libmesh_assert_less (e, this->n_edges());
+  return {edge_sides_map[e][0], edge_sides_map[e][1]};
 }
 
 

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -61,18 +61,6 @@ const unsigned int Pyramid13::edge_nodes_map[Pyramid13::num_edges][Pyramid13::no
     {3, 4, 12}  // Edge 7
   };
 
-const unsigned int Pyramid13::edge_sides_map[Pyramid13::num_edges][2] =
-  {
-    {0, 4}, // Edge 0
-    {1, 4}, // Edge 1
-    {2, 4}, // Edge 2
-    {3, 4}, // Edge 3
-    {0, 3}, // Edge 4
-    {0, 1}, // Edge 5
-    {1, 2}, // Edge 6
-    {2, 3}  // Edge 7
-  };
-
 // ------------------------------------------------------------
 // Pyramid13 class member functions
 

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -727,4 +727,13 @@ void Pyramid13::permute(unsigned int perm_num)
 }
 
 
+ElemType Pyramid13::side_type (const unsigned int s) const
+{
+  libmesh_assert_less (s, 5);
+  if (s < 4)
+    return TRI6;
+  return QUAD8;
+}
+
+
 } // namespace libMesh

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -781,4 +781,13 @@ unsigned int Pyramid14::center_node_on_side(const unsigned short side) const
 }
 
 
+ElemType Pyramid14::side_type (const unsigned int s) const
+{
+  libmesh_assert_less (s, 5);
+  if (s < 4)
+    return TRI6;
+  return QUAD9;
+}
+
+
 } // namespace libMesh

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -61,18 +61,6 @@ const unsigned int Pyramid14::edge_nodes_map[Pyramid14::num_edges][Pyramid14::no
     {3, 4, 12}  // Edge 7
   };
 
-const unsigned int Pyramid14::edge_sides_map[Pyramid14::num_edges][2] =
-  {
-    {0, 4}, // Edge 0
-    {1, 4}, // Edge 1
-    {2, 4}, // Edge 2
-    {3, 4}, // Edge 3
-    {0, 3}, // Edge 4
-    {0, 1}, // Edge 5
-    {1, 2}, // Edge 6
-    {2, 3}  // Edge 7
-  };
-
 // ------------------------------------------------------------
 // Pyramid14 class member functions
 

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -335,5 +335,13 @@ void Pyramid5::permute(unsigned int perm_num)
     }
 }
 
+ElemType Pyramid5::side_type (const unsigned int s) const
+{
+  libmesh_assert_less (s, 5);
+  if (s < 4)
+    return TRI3;
+  return QUAD4;
+}
+
 
 } // namespace libMesh

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -62,19 +62,6 @@ const unsigned int Pyramid5::edge_nodes_map[Pyramid5::num_edges][Pyramid5::nodes
     {3, 4}  // Edge 7
   };
 
-const unsigned int Pyramid5::edge_sides_map[Pyramid5::num_edges][2] =
-  {
-    {0, 4}, // Edge 0
-    {1, 4}, // Edge 1
-    {2, 4}, // Edge 2
-    {3, 4}, // Edge 3
-    {0, 3}, // Edge 4
-    {0, 1}, // Edge 5
-    {1, 2}, // Edge 6
-    {2, 3}  // Edge 7
-  };
-
-
 // ------------------------------------------------------------
 // Pyramid5 class member functions
 

--- a/src/geom/cell_tet.C
+++ b/src/geom/cell_tet.C
@@ -46,8 +46,15 @@ const Real Tet::_master_points[10][3] =
     {0, 0.5, 0.5}
   };
 
-
-
+const unsigned int Tet::edge_sides_map[6][2] =
+  {
+    {0, 1}, // Edge 0
+    {0, 2}, // Edge 1
+    {0, 3}, // Edge 2
+    {1, 3}, // Edge 3
+    {1, 2}, // Edge 4
+    {2, 3}  // Edge 5
+  };
 
 // ------------------------------------------------------------
 // Tet class member functions
@@ -200,15 +207,15 @@ bool Tet::is_edge_on_side(const unsigned int e,
   libmesh_assert_less (e, this->n_edges());
   libmesh_assert_less (s, this->n_sides());
 
-  return (Tet4::edge_sides_map[e][0] == s ||
-          Tet4::edge_sides_map[e][1] == s);
+  return (edge_sides_map[e][0] == s || edge_sides_map[e][1] == s);
 }
 
 
 
 std::vector<unsigned int> Tet::sides_on_edge(const unsigned int e) const
 {
-  return {Tet4::edge_sides_map[e][0], Tet4::edge_sides_map[e][1]};
+  libmesh_assert_less (e, this->n_edges());
+  return {edge_sides_map[e][0], edge_sides_map[e][1]};
 }
 
 

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -56,17 +56,6 @@ const unsigned int Tet10::edge_nodes_map[Tet10::num_edges][Tet10::nodes_per_edge
     {2, 3, 9}  // Edge 5
   };
 
-const unsigned int Tet10::edge_sides_map[Tet10::num_edges][2] =
-  {
-    {0, 1}, // Edge 0
-    {0, 2}, // Edge 1
-    {0, 3}, // Edge 2
-    {1, 3}, // Edge 3
-    {1, 2}, // Edge 4
-    {2, 3}  // Edge 5
-  };
-
-
 // ------------------------------------------------------------
 // Tet10 class member functions
 

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -886,5 +886,11 @@ void Tet10::permute(unsigned int perm_num)
 }
 
 
+ElemType Tet10::side_type (const unsigned int libmesh_dbg_var(s)) const
+{
+  libmesh_assert_less (s, 4);
+  return TRI6;
+}
+
 
 } // namespace libMesh

--- a/src/geom/cell_tet14.C
+++ b/src/geom/cell_tet14.C
@@ -895,5 +895,11 @@ void Tet14::permute(unsigned int perm_num)
 }
 
 
+ElemType Tet14::side_type (const unsigned int libmesh_dbg_var(s)) const
+{
+  libmesh_assert_less (s, 4);
+  return TRI7;
+}
+
 
 } // namespace libMesh

--- a/src/geom/cell_tet14.C
+++ b/src/geom/cell_tet14.C
@@ -62,17 +62,6 @@ const unsigned int Tet14::edge_nodes_map[Tet14::num_edges][Tet14::nodes_per_edge
     {2, 3, 9}  // Edge 5
   };
 
-const unsigned int Tet14::edge_sides_map[Tet14::num_edges][2] =
-  {
-    {0, 1}, // Edge 0
-    {0, 2}, // Edge 1
-    {0, 3}, // Edge 2
-    {1, 3}, // Edge 3
-    {1, 2}, // Edge 4
-    {2, 3}  // Edge 5
-  };
-
-
 // ------------------------------------------------------------
 // Tet14 class member functions
 

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -57,16 +57,6 @@ const unsigned int Tet4::edge_nodes_map[Tet4::num_edges][Tet4::nodes_per_edge] =
     {2, 3}  // Edge 5
   };
 
-const unsigned int Tet4::edge_sides_map[Tet4::num_edges][2] =
-  {
-    {0, 1}, // Edge 0
-    {0, 2}, // Edge 1
-    {0, 3}, // Edge 2
-    {1, 3}, // Edge 3
-    {1, 2}, // Edge 4
-    {2, 3}  // Edge 5
-  };
-
 // ------------------------------------------------------------
 // Tet4 class member functions
 

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -621,4 +621,11 @@ void Tet4::permute(unsigned int perm_num)
 }
 
 
+ElemType Tet4::side_type (const unsigned int libmesh_dbg_var(s)) const
+{
+  libmesh_assert_less (s, 4);
+  return TRI3;
+}
+
+
 } // namespace libMesh

--- a/src/geom/edge.C
+++ b/src/geom/edge.C
@@ -141,4 +141,10 @@ unsigned int Edge::center_node_on_side(const unsigned short side) const
   return side;
 }
 
+ElemType Edge::side_type (const unsigned int libmesh_dbg_var(s)) const
+{
+  libmesh_assert_less (s, 2);
+  return NODEELEM;
+}
+
 } // namespace libMesh

--- a/src/geom/elem_side_builder.C
+++ b/src/geom/elem_side_builder.C
@@ -1,0 +1,43 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2021 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#include "libmesh/elem_side_builder.h"
+
+namespace libMesh
+{
+
+Elem &
+ElemSideBuilder::operator()(Elem & elem, const unsigned int s)
+{
+  libmesh_assert_less(s, elem.n_sides());
+  const std::size_t type_index = static_cast<std::size_t>(elem.side_type(s));
+  if (type_index >= _cached_elems.size())
+    _cached_elems.resize(type_index + 1);
+  std::unique_ptr<Elem> & side_elem = _cached_elems[type_index];
+  elem.build_side_ptr(side_elem, s);
+  return *side_elem;
+}
+
+const Elem &
+ElemSideBuilder::operator()(const Elem & elem, const unsigned int s)
+{
+  return (*this)(const_cast<Elem &>(elem), s);
+}
+
+} // namespace libMesh

--- a/src/geom/face_inf_quad4.C
+++ b/src/geom/face_inf_quad4.C
@@ -302,6 +302,17 @@ void InfQuad4::connectivity(const unsigned int libmesh_dbg_var(sf),
     }
 }
 
+
+ElemType
+InfQuad4::side_type (const unsigned int s) const
+{
+  libmesh_assert_less (s, 3);
+  if (s == 0)
+    return EDGE2;
+  return INFEDGE2;
+}
+
+
 } // namespace libMesh
 
 

--- a/src/geom/face_inf_quad6.C
+++ b/src/geom/face_inf_quad6.C
@@ -363,9 +363,18 @@ InfQuad6::second_order_child_vertex (const unsigned int n) const
     (0, 2*n-7);
 }
 
+
+ElemType
+InfQuad6::side_type (const unsigned int s) const
+{
+  libmesh_assert_less (s, 3);
+  if (s == 0)
+    return EDGE3;
+  return INFEDGE2;
+}
+
+
 } // namespace libMesh
-
-
 
 
 #endif // ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -369,4 +369,10 @@ void Quad4::permute(unsigned int perm_num)
 }
 
 
+ElemType Quad4::side_type (const unsigned int libmesh_dbg_var(s)) const
+{
+  libmesh_assert_less (s, 4);
+  return EDGE2;
+}
+
 } // namespace libMesh

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -513,4 +513,12 @@ unsigned int Quad8::center_node_on_side(const unsigned short side) const
 }
 
 
+
+ElemType Quad8::side_type (const unsigned int libmesh_dbg_var(s)) const
+{
+  libmesh_assert_less (s, 4);
+  return EDGE3;
+}
+
+
 } // namespace libMesh

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -528,4 +528,11 @@ unsigned int Quad9::center_node_on_side(const unsigned short side) const
 }
 
 
+ElemType Quad9::side_type (const unsigned int libmesh_dbg_var(s)) const
+{
+  libmesh_assert_less (s, 4);
+  return EDGE3;
+}
+
+
 } // namespace libMesh

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -274,5 +274,11 @@ void Tri3::permute(unsigned int perm_num)
     }
 }
 
+ElemType
+Tri3::side_type (const unsigned int libmesh_dbg_var(s)) const
+{
+  libmesh_assert_less (s, 3);
+  return EDGE2;
+}
 
 } // namespace libMesh

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -495,4 +495,12 @@ unsigned int Tri6::center_node_on_side(const unsigned short side) const
 }
 
 
+ElemType
+Tri6::side_type (const unsigned int libmesh_dbg_var(s)) const
+{
+  libmesh_assert_less (s, 3);
+  return EDGE3;
+}
+
+
 } // namespace libMesh

--- a/src/geom/face_tri7.C
+++ b/src/geom/face_tri7.C
@@ -508,4 +508,12 @@ unsigned int Tri7::center_node_on_side(const unsigned short side) const
 }
 
 
+ElemType
+Tri7::side_type (const unsigned int libmesh_dbg_var(s)) const
+{
+  libmesh_assert_less (s, 3);
+  return EDGE3;
+}
+
+
 } // namespace libMesh

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -153,6 +153,7 @@ libmesh_SOURCES =  \
         src/geom/elem_cutter.C \
         src/geom/elem_quality.C \
         src/geom/elem_refinement.C \
+        src/geom/elem_side_builder.C \
         src/geom/face.C \
         src/geom/face_inf_quad.C \
         src/geom/face_inf_quad4.C \

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -29,6 +29,7 @@
 #include "libmesh/partitioner.h"
 #include "libmesh/remote_elem.h"
 #include "libmesh/unstructured_mesh.h"
+#include "libmesh/elem_side_builder.h"
 
 // TIMPI includes
 #include "timpi/parallel_sync.h"
@@ -362,8 +363,10 @@ void BoundaryInfo::get_side_and_node_maps (UnstructuredMesh & boundary_mesh,
   node_id_map.clear();
   side_id_map.clear();
 
+  // For building element sides without extraneous allocation
+  ElemSideBuilder side_builder;
   // Pull objects out of the loop to reduce heap operations
-  std::unique_ptr<const Elem> interior_parent_side;
+  const Elem * interior_parent_side;
 
   for (const auto & boundary_elem : boundary_mesh.active_element_ptr_range())
     {
@@ -375,7 +378,7 @@ void BoundaryInfo::get_side_and_node_maps (UnstructuredMesh & boundary_mesh,
       bool found_matching_sides = false;
       for (auto side : interior_parent->side_index_range())
         {
-          interior_parent->build_side_ptr(interior_parent_side, side);
+          interior_parent_side = &side_builder(*interior_parent, side);
           Real va_distance = (boundary_elem->vertex_average() - interior_parent_side->vertex_average()).norm();
 
           if (va_distance < (tolerance * boundary_elem->hmin()))
@@ -1778,8 +1781,10 @@ BoundaryInfo::build_node_list_from_side_list()
   std::unordered_map<processor_id_type, set_type> nodes_to_push;
   std::unordered_map<processor_id_type, vec_type> node_vecs_to_push;
 
+  // For avoiding extraneous element side construction
+  ElemSideBuilder side_builder;
   // Pull objects out of the loop to reduce heap operations
-  std::unique_ptr<const Elem> side;
+  const Elem * side;
 
   // Loop over the side list
   for (const auto & pr : _boundary_side_id)
@@ -1798,7 +1803,7 @@ BoundaryInfo::build_node_list_from_side_list()
 
       for (const auto & cur_elem : family)
         {
-          cur_elem->build_side_ptr(side, pr.second.first);
+          side = &side_builder(*cur_elem, pr.second.first);
 
           // Add each node node on the side with the side's boundary id
           for (auto i : side->node_index_range())
@@ -2008,13 +2013,15 @@ void BoundaryInfo::build_side_list_from_node_list()
       return;
     }
 
+  // For avoiding extraneous element side construction
+  ElemSideBuilder side_builder;
   // Pull objects out of the loop to reduce heap operations
-  std::unique_ptr<const Elem> side_elem;
+  const Elem * side_elem;
 
   for (const auto & elem : _mesh->active_element_ptr_range())
     for (auto side : elem->side_index_range())
       {
-        elem->build_side_ptr(side_elem, side);
+        side_elem = &side_builder(*elem, side);
 
         // map from nodeset_id to count for that ID
         std::map<boundary_id_type, unsigned> nodesets_node_count;
@@ -2496,8 +2503,10 @@ void BoundaryInfo::_find_id_maps(const std::set<boundary_id_type> & requested_bo
     next_node_id = first_free_node_id + this->processor_id(),
     next_elem_id = first_free_elem_id + this->processor_id();
 
+  // For avoiding extraneous element side construction
+  ElemSideBuilder side_builder;
   // Pull objects out of the loop to reduce heap operations
-  std::unique_ptr<const Elem> side;
+  const Elem * side;
 
   // We'll pass through the mesh once first to build
   // the maps and count boundary nodes and elements.
@@ -2603,7 +2612,7 @@ void BoundaryInfo::_find_id_maps(const std::set<boundary_id_type> & requested_bo
                   next_elem_id += this->n_processors() + 1;
                 }
 
-              elem->build_side_ptr(side, s);
+              side = &side_builder(*elem, s);
               for (auto n : side->node_index_range())
                 {
                   const Node & node = side->node_ref(n);

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -44,6 +44,7 @@
 #include "libmesh/enum_to_string.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
 #include "libmesh/point_locator_nanoflann.h"
+#include "libmesh/elem_side_builder.h"
 
 namespace libMesh
 {
@@ -910,6 +911,7 @@ std::string MeshBase::get_info(const unsigned int verbosity /* = 0 */, const boo
         std::set<dof_id_type> node_ids;
         BoundingBox bbox;
       };
+      ElemSideBuilder side_builder;
       std::map<boundary_id_type, SidesetInfo> sideset_info_map;
       for (const auto & pair : this->get_boundary_info().get_sideset_map())
         {
@@ -921,21 +923,21 @@ std::string MeshBase::get_info(const unsigned int verbosity /* = 0 */, const boo
           SidesetInfo & info = sideset_info_map[id];
 
           const auto s = pair.second.first;
-          const auto side = elem->build_side_ptr(s);
+          const Elem & side = side_builder(*elem, s);
 
           ++info.num_sides;
-          info.side_elem_types.insert(side->type());
+          info.side_elem_types.insert(side.type());
           info.elem_types.insert(elem->type());
           info.elem_ids.insert(elem->id());
 
-          for (const Node & node : side->node_ref_range())
+          for (const Node & node : side.node_ref_range())
             if (include_object(node))
               info.node_ids.insert(node.id());
 
           if (verbosity > 1)
           {
-            info.volume += side->volume();
-            info.bbox.union_with(side->loose_bounding_box());
+            info.volume += side.volume();
+            info.bbox.union_with(side.loose_bounding_box());
           }
         }
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -366,9 +366,7 @@ void MeshTools::find_boundary_nodes (const MeshBase & mesh,
     for (auto s : elem->side_index_range())
       if (elem->neighbor_ptr(s) == nullptr) // on the boundary
         {
-          std::unique_ptr<const Elem> side = elem->build_side_ptr(s);
-
-          auto nodes_on_side = elem->nodes_on_side(s);
+          const auto nodes_on_side = elem->nodes_on_side(s);
 
           for (auto & node_id : nodes_on_side)
             on_boundary[node_id] = true;

--- a/tests/geom/elem_test.C
+++ b/tests/geom/elem_test.C
@@ -139,6 +139,13 @@ public:
             CPPUNIT_ASSERT_EQUAL(invalid_uint, elem->center_node_on_side(s));
         }
   }
+
+  void test_side_type()
+  {
+    for (const auto & elem : _mesh->active_local_element_ptr_range())
+      for (const auto s : elem->side_index_range())
+        CPPUNIT_ASSERT_EQUAL(elem->build_side_ptr(s)->type(), elem->side_type(s));
+  }
 };
 
 #define ELEMTEST                                \
@@ -146,7 +153,8 @@ public:
   CPPUNIT_TEST( test_maps );                    \
   CPPUNIT_TEST( test_permute );                 \
   CPPUNIT_TEST( test_contains_point_node );     \
-  CPPUNIT_TEST( test_center_node_on_side );
+  CPPUNIT_TEST( test_center_node_on_side );     \
+  CPPUNIT_TEST( test_side_type );
 
 #define INSTANTIATE_ELEMTEST(elemtype)                          \
   class ElemTest_##elemtype : public ElemTest<elemtype> {       \

--- a/tests/geom/elem_test.C
+++ b/tests/geom/elem_test.C
@@ -5,6 +5,7 @@
 #include <libmesh/mesh.h>
 #include <libmesh/mesh_generation.h>
 #include <libmesh/elem_side_builder.h>
+#include <libmesh/auto_ptr.h>
 
 #include "libmesh_cppunit.h"
 
@@ -14,7 +15,7 @@ template <ElemType elem_type>
 class ElemTest : public CppUnit::TestCase {
 
 private:
-  Mesh * _mesh;
+  std::unique_ptr<Mesh> _mesh;
 
 public:
   void setUp()
@@ -22,23 +23,109 @@ public:
     const Real minpos = 1.5, maxpos = 5.5;
     const unsigned int N = 2;
 
-    _mesh = new Mesh(*TestCommWorld);
-    const std::unique_ptr<Elem> test_elem = Elem::build(elem_type);
-    const unsigned int dim = test_elem->dim();
-    const unsigned int use_y = dim > 1;
-    const unsigned int use_z = dim > 2;
+    _mesh = libmesh_make_unique<Mesh>(*TestCommWorld);
+    std::unique_ptr<Elem> test_elem = Elem::build(elem_type);
 
-    MeshTools::Generation::build_cube (*_mesh,
-                                       N, N*use_y, N*use_z,
-                                       minpos, maxpos,
-                                       minpos, use_y*maxpos,
-                                       minpos, use_z*maxpos,
-                                       elem_type);
-  }
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+#if LIBMESH_DIM > 1
+    if (test_elem->infinite())
+      {
+        _mesh->add_elem(std::move(test_elem));
 
-  void tearDown()
-  {
-    delete _mesh;
+        const auto add_point = [this](const unsigned int i,
+                                      const Real x,
+                                      const Real y,
+                                      const Real
+#if LIBMESH_DIM == 3
+                                      z
+#endif
+                                      )
+          {
+#if LIBMESH_DIM == 2
+            auto node = _mesh->add_point(Point(x, y), i);
+#else
+            auto node = _mesh->add_point(Point(x, y, z), i);
+#endif
+            _mesh->elem_ref(0).set_node(i) = node;
+          };
+
+        const Real halfpos = (minpos + maxpos) / 2.;
+
+        if (elem_type == INFQUAD4 || elem_type == INFQUAD6 ||
+            elem_type == INFHEX8 || elem_type == INFHEX16 || elem_type == INFHEX18)
+          {
+            add_point(0, minpos, minpos, minpos);
+            add_point(1, maxpos, minpos, minpos);
+            add_point(2, minpos, maxpos, minpos);
+            add_point(3, maxpos, maxpos, minpos);
+
+            if (elem_type == INFQUAD6)
+              {
+                add_point(4, halfpos, minpos, minpos);
+                add_point(5, halfpos, maxpos, minpos);
+              }
+          }
+        if (elem_type == INFHEX8 || elem_type == INFHEX16 || elem_type == INFHEX18)
+          {
+            add_point(4, minpos, minpos, maxpos);
+            add_point(5, maxpos, minpos, maxpos);
+            add_point(6, minpos, maxpos, maxpos);
+            add_point(7, maxpos, maxpos, maxpos);
+
+            if (elem_type == INFHEX16 || elem_type == INFHEX18)
+              {
+                add_point(8, halfpos, minpos, minpos);
+                add_point(9, maxpos, halfpos, minpos);
+                add_point(10, halfpos, maxpos, minpos);
+                add_point(11, minpos, halfpos, minpos);
+                add_point(12, halfpos, minpos, maxpos);
+                add_point(13, maxpos, halfpos, maxpos);
+                add_point(14, halfpos, maxpos, maxpos);
+                add_point(15, minpos, halfpos, maxpos);
+              }
+            if (elem_type == INFHEX18)
+              {
+                add_point(16, halfpos, halfpos, minpos);
+                add_point(17, halfpos, halfpos, maxpos);
+              }
+          }
+        if (elem_type == INFPRISM6 || elem_type == INFPRISM12)
+          {
+            add_point(0, minpos, minpos, minpos);
+            add_point(1, maxpos, minpos, minpos);
+            add_point(2, halfpos, maxpos, minpos);
+            add_point(3, minpos, minpos, maxpos);
+            add_point(4, maxpos, minpos, maxpos);
+            add_point(5, halfpos, maxpos, maxpos);
+
+            if (elem_type == INFPRISM12)
+              {
+                add_point(6, halfpos, minpos, minpos);
+                add_point(7, (halfpos + maxpos) / 2., halfpos, minpos);
+                add_point(8, (halfpos + minpos) / 2., halfpos, minpos);
+                add_point(9, halfpos, minpos, maxpos);
+                add_point(10, (halfpos + maxpos) / 2., halfpos, maxpos);
+                add_point(11, (halfpos + minpos) / 2., halfpos, maxpos);
+              }
+          }
+
+        _mesh->prepare_for_use();
+      }
+    else
+#endif
+#endif
+      {
+        const unsigned int dim = test_elem->dim();
+        const unsigned int use_y = dim > 1;
+        const unsigned int use_z = dim > 2;
+
+        MeshTools::Generation::build_cube (*_mesh,
+                                           N, N*use_y, N*use_z,
+                                           minpos, maxpos,
+                                           minpos, use_y*maxpos,
+                                           minpos, use_z*maxpos,
+                                           elem_type);
+      }
   }
 
   void test_bounding_box()
@@ -57,7 +144,12 @@ public:
           {
             const Point & p = elem->point(n);
 
-            CPPUNIT_ASSERT(bbox.contains_point(p));
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+            if (!elem->infinite())
+#endif
+              {
+                CPPUNIT_ASSERT(bbox.contains_point(p));
+              }
 
             wide_bbox.union_with
               (BoundingBox(elem->point(n), elem->point(n)));
@@ -65,8 +157,13 @@ public:
 
         wide_bbox.scale(1. / 3.);
 
-        CPPUNIT_ASSERT(!bbox.contains_point(wide_bbox.min()));
-        CPPUNIT_ASSERT(!bbox.contains_point(wide_bbox.max()));
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+        if (!elem->infinite())
+#endif
+          {
+            CPPUNIT_ASSERT(!bbox.contains_point(wide_bbox.min()));
+            CPPUNIT_ASSERT(!bbox.contains_point(wide_bbox.max()));
+          }
       }
   }
 
@@ -96,27 +193,41 @@ public:
   void test_contains_point_node()
   {
     for (const auto & elem : _mesh->active_local_element_ptr_range())
-      for (const auto n : elem->node_index_range())
-#ifndef LIBMESH_ENABLE_EXCEPTIONS
-        // If this node has a singular Jacobian, we need exceptions in order
-        // to catch the failed inverse_map solve and return the singular
-        // master point. Therefore, if we don't have exceptions and we're
-        // at a singular node, we can't test this. As of the writing of
-        // this comment, this issue exists for only Pyramid elements at
-        // the apex.
-        if (elem->local_singular_node(elem->point(n), TOLERANCE*TOLERANCE) == invalid_uint)
+      {
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+        if (elem->infinite())
+          continue;
 #endif
-          CPPUNIT_ASSERT(elem->contains_point(elem->point(n)));
+
+        for (const auto n : elem->node_index_range())
+#ifndef LIBMESH_ENABLE_EXCEPTIONS
+          // If this node has a singular Jacobian, we need exceptions in order
+          // to catch the failed inverse_map solve and return the singular
+          // master point. Therefore, if we don't have exceptions and we're
+          // at a singular node, we can't test this. As of the writing of
+          // this comment, this issue exists for only Pyramid elements at
+          // the apex.
+          if (elem->local_singular_node(elem->point(n), TOLERANCE*TOLERANCE) == invalid_uint)
+#endif
+            CPPUNIT_ASSERT(elem->contains_point(elem->point(n)));
+      }
   }
 
   void test_permute()
   {
     for (const auto & elem : _mesh->active_local_element_ptr_range())
-      for (const auto p : IntRange<unsigned int>(0, elem->n_permutations()))
-        {
-          elem->permute(p);
-          CPPUNIT_ASSERT(elem->has_invertible_map());
-        }
+      {
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+        if (elem->infinite())
+          continue;
+#endif
+
+        for (const auto p : IntRange<unsigned int>(0, elem->n_permutations()))
+          {
+            elem->permute(p);
+            CPPUNIT_ASSERT(elem->has_invertible_map());
+          }
+      }
   }
 
   void test_center_node_on_side()
@@ -200,7 +311,12 @@ INSTANTIATE_ELEMTEST(TRI7);
 INSTANTIATE_ELEMTEST(QUAD4);
 INSTANTIATE_ELEMTEST(QUAD8);
 INSTANTIATE_ELEMTEST(QUAD9);
+
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+INSTANTIATE_ELEMTEST(INFQUAD4);
+INSTANTIATE_ELEMTEST(INFQUAD6);
 #endif
+#endif // LIBMESH_DIM > 1
 
 #if LIBMESH_DIM > 2
 INSTANTIATE_ELEMTEST(TET4);
@@ -218,4 +334,13 @@ INSTANTIATE_ELEMTEST(PRISM18);
 INSTANTIATE_ELEMTEST(PYRAMID5);
 INSTANTIATE_ELEMTEST(PYRAMID13);
 INSTANTIATE_ELEMTEST(PYRAMID14);
+
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+INSTANTIATE_ELEMTEST(INFHEX8);
+INSTANTIATE_ELEMTEST(INFHEX16);
+INSTANTIATE_ELEMTEST(INFHEX18);
+
+INSTANTIATE_ELEMTEST(INFPRISM6);
+INSTANTIATE_ELEMTEST(INFPRISM12);
 #endif
+#endif // LIBMESH_DIM > 2


### PR DESCRIPTION
The capability to pass in a possibly exiting element in the form of a `unique_ptr` to `Elem::build_side_ptr()` was added in the past. If the element that is passed in is of the correct type required to build a side, no new allocation is made and the necessary information is transferred in place. 

This helper, the `ElemSideBuilder`, stores a cache that is indexed by `ElemType` and "builds" element sides given an element and a side in a way that requires the construction of an element for a given type only once. With this also comes `Elem::side_type()`, which returns the `ElemType` of a given side and is needed for indexing into the cache in `ElemSideBuilder.`

Additionally, I used this new helper in a few places and also cleaned up some side building where appropriate.