### PR TITLE
Add ExodusII_IO::get_nodeset_data_indices()

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -373,6 +373,20 @@ public:
                      std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> & bc_vals);
 
   /**
+   * Similar to read_nodeset_data(), but instead of creating one
+   * std::map per nodeset per variable, creates a single map of
+   * (node_id, boundary_id) tuples, and stores the exo file array indices
+   * for any/all nodeset variables on that nodeset (they are all the
+   * same). In cases where there are hundreds of nodeset variables on
+   * a single nodeset, it is more efficient to store the array indices
+   * in a quickly searchable data structure than to repeat the
+   * indexing once per variable as is done in the read_nodeset_data()
+   * case.
+   */
+  void
+  get_nodeset_data_indices (std::map<BoundaryInfo::NodeBCTuple, unsigned int> & bc_array_indices);
+
+  /**
    * Set the elemental variables in the Exodus file to be read into extra
    * element integers. The names of these elemental variables will be used to
    * name the extra element integers.

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -387,6 +387,16 @@ public:
                      std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> & bc_vals);
 
   /**
+   * Similar to read_nodeset_data(), but instead of creating one
+   * std::map per nodeset per variable, creates a single map of
+   * (node_id, boundary_id) tuples, and stores the exo file array
+   * indexing for any/all nodeset variables on that nodeset (they are
+   * all the same).
+   */
+  void
+  get_nodeset_data_indices (std::map<BoundaryInfo::NodeBCTuple, unsigned int> & bc_array_indices);
+
+  /**
    * Writes the vector of values to the element variables.
    *
    * The 'values' vector is assumed to be in the order:

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1863,6 +1863,17 @@ get_sideset_data_indices (std::map<BoundaryInfo::BCTuple, unsigned int> & bc_arr
 
 void
 ExodusII_IO::
+get_nodeset_data_indices (std::map<BoundaryInfo::NodeBCTuple, unsigned int> & bc_array_indices)
+{
+  libmesh_error_msg_if(!exio_helper->opened_for_reading,
+                       "ERROR, ExodusII file must be opened for reading "
+                       "before calling ExodusII_IO::get_nodeset_data_indices()!");
+
+  exio_helper->get_nodeset_data_indices(bc_array_indices);
+}
+
+void
+ExodusII_IO::
 write_nodeset_data (int timestep,
                     const std::vector<std::string> & var_names,
                     std::vector<std::set<boundary_id_type>> & node_boundary_ids,

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -3491,6 +3491,79 @@ read_nodeset_data (int timestep,
 
 
 
+void
+ExodusII_IO_Helper::
+get_nodeset_data_indices (std::map<BoundaryInfo::NodeBCTuple, unsigned int> & bc_array_indices)
+{
+  // This reads the nodeset variable names into the local
+  // nodeset_var_names data structure.
+  this->read_var_names(NODESET);
+
+  if (num_nodeset_vars)
+    {
+      // Read the nodeset data truth table
+      std::vector<int> nset_var_tab(num_node_sets * num_nodeset_vars);
+      ex_err = exII::ex_get_nset_var_tab
+        (ex_id,
+         num_node_sets,
+         num_nodeset_vars,
+         nset_var_tab.data());
+      EX_CHECK_ERR(ex_err, "Error reading nodeset variable truth table.");
+
+      // Read the nodeset data.
+      //
+      // Note: we assume that the functions
+      // 1.) this->read_nodeset_info() and
+      // 2.) this->read_all_nodesets()
+      // have already been called, so that we already know e.g. how
+      // many nodes are in each set, their ids, etc.
+      int offset=0;
+      for (int ns=0; ns<num_node_sets; ++ns)
+        {
+          offset += (ns > 0 ? num_nodes_per_set[ns-1] : 0);
+          for (int var=0; var<num_nodeset_vars; ++var)
+            {
+              int is_present = nset_var_tab[num_nodeset_vars*ns + var];
+
+              if (is_present)
+                {
+                  // Note: we don't actually call exII::ex_get_nset_var() here because
+                  // we don't need the values. We only need the indices into that vector
+                  // for each (node_id, boundary_id) tuple.
+                  for (int i=0; i<num_nodes_per_set[ns]; ++i)
+                    {
+                      // The read_all_nodesets() function now reads all the node ids into the
+                      // node_sets_node_list vector, which is of length "total_nodes_in_all_sets"
+                      // The old read_nodset() function is no longer called as far as I can tell,
+                      // and should probably be removed? The "offset" that we are using only
+                      // depends on the current nodeset index and the num_nodes_per_set vector,
+                      // which gets filled in by the call to read_all_nodesets().
+                      dof_id_type exodus_node_id = node_sets_node_list[i + offset];
+
+                      // FIXME: We should use exodus_node_num_to_libmesh for this,
+                      // but it apparently is never set up, so just
+                      // subtract 1 from the Exodus node id.
+                      dof_id_type converted_node_id = exodus_node_id - 1;
+
+                      // Make a NodeBCTuple key from the converted information.
+                      BoundaryInfo::NodeBCTuple key = std::make_tuple
+                        (converted_node_id, nodeset_ids[ns]);
+
+                      // Store the array index of this (node, b_id) tuple
+                      bc_array_indices.emplace(key, cast_int<unsigned int>(i));
+                    } // end for (i)
+
+                  // We only need to get the indices once per nodeset
+                  // (not once per variable defined on this nodeset)
+                  // so we can break out of this var loop as soon as
+                  // any variable is_present.
+                  break; // out of var loop
+                } // end if (present)
+            } // end for (var)
+        } // end for (ns)
+    } // end if (num_nodeset_vars)
+}
+
 void ExodusII_IO_Helper::write_element_values
 (const MeshBase & mesh,
  const std::vector<Real> & values,

--- a/tests/mesh/write_nodeset_data.C
+++ b/tests/mesh/write_nodeset_data.C
@@ -7,6 +7,7 @@
 #include "libmesh/parallel.h" // set_union
 #include "libmesh/string_to_enum.h"
 #include "libmesh/boundary_info.h"
+#include "libmesh/utility.h" // libmesh_map_find
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"
@@ -124,6 +125,60 @@ public:
     CPPUNIT_ASSERT(read_in_var_names == var_names);
     CPPUNIT_ASSERT(read_in_node_boundary_ids == node_boundary_ids);
     CPPUNIT_ASSERT(read_in_bc_vals == bc_vals);
+
+    // Also check that the flat indices match those in the file
+    std::map<BoundaryInfo::NodeBCTuple, unsigned int> bc_array_indices;
+    reader.get_nodeset_data_indices(bc_array_indices);
+
+    // Debugging
+    // for (const auto & pr : bc_array_indices)
+    //   {
+    //     const auto & t = pr.first;
+    //     const auto & node_id = std::get<0>(t);
+    //     const auto & boundary_id = std::get<1>(t);
+    //     libMesh::out << "(node, boundary_id) = "
+    //                  << "(" << node_id << ", " << boundary_id << ")"
+    //                  << " is at array index " << pr.second
+    //                  << std::endl;
+    //   }
+
+    // For this test case, the nodeset arrays are ordered as follows:
+    // ns_prop1 = 0, 1, 2, 3, 4 ;
+    // ns_names = "bottom", "right", "top", "left", "empty" ;
+    //
+    // Exodus (1-based) node ids
+    // node_ns1 = 1, 2, 3, 4, 5, 6 ;
+    // node_ns2 = 6, 12, 18, 24, 30, 36 ;
+    // node_ns3 = 31, 32, 33, 34, 35, 36 ;
+    // node_ns4 = 1, 7, 13, 19, 25, 31 ;
+
+    // Check the node ids in the "bottom" nodeset, which contains the
+    // first six nodes in order.
+    for (unsigned int i=0; i<6; ++i)
+      CPPUNIT_ASSERT_EQUAL
+        (static_cast<unsigned int>(i),
+         libmesh_map_find(bc_array_indices, std::make_tuple(/*node_id=*/cast_int<dof_id_type>(i), /*b_id=*/0)));
+
+    // Check the node ids in the "right" sideset, which contains every
+    // 6th node starting from 5, i.e. 5, 11, 17
+    for (unsigned int i=0; i<6; ++i)
+      CPPUNIT_ASSERT_EQUAL
+        (static_cast<unsigned int>(i),
+         libmesh_map_find(bc_array_indices, std::make_tuple(/*node_id=*/cast_int<dof_id_type>(6*i + 5), /*b_id=*/1)));
+
+    // Check the node ids in the "top" sideset, which contains the last
+    // six nodes in order.
+    for (unsigned int i=0; i<6; ++i)
+      CPPUNIT_ASSERT_EQUAL
+        (static_cast<unsigned int>(i),
+         libmesh_map_find(bc_array_indices, std::make_tuple(/*node_id=*/cast_int<dof_id_type>(30 + i), /*b_id=*/2)));
+
+    // Check the node ids in the "left" sideset, which contains every
+    // 6th node starting from 0, i.e. 0, 6, 12
+    for (unsigned int i=0; i<6; ++i)
+      CPPUNIT_ASSERT_EQUAL
+        (static_cast<unsigned int>(i),
+         libmesh_map_find(bc_array_indices, std::make_tuple(/*node_id=*/cast_int<dof_id_type>(6*i), /*b_id=*/3)));
   }
 
   void testWriteExodus()


### PR DESCRIPTION
This PR adds analogous support for reading nodeset variable array indices that PR #3050 added for reading sideset variable indices. To complete this approach, we would also need to add ExodusII_IO APIs for extracting the sideset/nodeset data arrays themselves from the exo file s as well, but I don't need that capability at the moment, so it will remain as future work for now. Also adds a unit test of the new capability.