### PR TITLE
MeshTools::clear_spline_nodes() support

### DIFF
--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -366,6 +366,16 @@ void find_hanging_nodes_and_parents(const MeshBase & mesh,
  */
 void correct_node_proc_ids(MeshBase &);
 
+/**
+ * Remove spline node (for IsoGeometric Analysis meshes) elements
+ * and nodes and constraints from the mesh.  This should be done
+ * after the mesh is read but before the constraints are used by
+ * System initialization.  The result is a mesh and solution space
+ * with lower required continuity and more unconstrained degrees of
+ * freedom, but with fewer total degrees of freedom and far fewer
+ * constraint equations.
+ */
+void clear_spline_nodes(MeshBase &);
 
 #ifdef DEBUG
 /**

--- a/src/mesh/dyna_io.C
+++ b/src/mesh/dyna_io.C
@@ -22,6 +22,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/dyna_io.h"
 #include "libmesh/mesh_base.h"
+#include "libmesh/mesh_tools.h"
 #include "libmesh/int_range.h"
 #include "libmesh/utility.h"
 
@@ -729,7 +730,7 @@ void DynaIO::read_mesh(std::istream & in)
     }
 
   if (!_keep_spline_nodes)
-    this->clear_spline_nodes();
+    MeshTools::clear_spline_nodes(MeshInput<MeshBase>::mesh());
 }
 
 
@@ -742,32 +743,9 @@ void DynaIO::add_spline_constraints(DofMap &,
 
 void DynaIO::clear_spline_nodes()
 {
-  MeshBase & mesh = MeshInput<MeshBase>::mesh();
+  libmesh_deprecated();
 
-  auto & constraint_rows = mesh.get_constraint_rows();
-
-  std::vector<Elem *> nodeelem_to_delete;
-
-  for (auto & elem : mesh.element_ptr_range())
-    if (elem->type() == NODEELEM)
-      nodeelem_to_delete.push_back(elem);
-
-  // All our constraint_rows ought to be for spline constraints we're
-  // about to get rid of.
-#ifndef NDEBUG
-  for (auto & node_row : constraint_rows)
-    for (auto pr : node_row.second)
-      libmesh_assert(pr.first.first->type() == NODEELEM);
-#endif
-
-  constraint_rows.clear();
-
-  for (Elem * elem : nodeelem_to_delete)
-    {
-      Node * node = elem->node_ptr(0);
-      mesh.delete_elem(elem);
-      mesh.delete_node(node);
-    }
+  MeshTools::clear_spline_nodes(MeshInput<MeshBase>::mesh());
 }
 
 

--- a/src/mesh/dyna_io.C
+++ b/src/mesh/dyna_io.C
@@ -302,7 +302,9 @@ void DynaIO::read_mesh(std::istream & in)
             spline_node_ptrs.resize(n_spline_nodes);
             spline_weights.resize(n_spline_nodes);
 
-            if (weight_control_flag)
+            // Even if we have w=1.0, we still want RATIONAL_BERNSTEIN
+            // elements!
+            // if (weight_control_flag)
               {
                 // If we ever add more nodes that aren't in this file,
                 // merge this mesh with a non-spline mesh, etc., 1.0

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1173,6 +1173,41 @@ void MeshTools::find_hanging_nodes_and_parents(const MeshBase & mesh,
 
 
 
+void MeshTools::clear_spline_nodes(MeshBase & mesh)
+{
+  std::vector<Elem *> nodeelem_to_delete;
+
+  for (auto & elem : mesh.element_ptr_range())
+    if (elem->type() == NODEELEM &&
+        elem->mapping_type() == RATIONAL_BERNSTEIN_MAP)
+      nodeelem_to_delete.push_back(elem);
+
+  auto & constraint_rows = mesh.get_constraint_rows();
+
+  // All our constraint_rows ought to be for spline constraints we're
+  // about to get rid of.
+#ifndef NDEBUG
+  for (auto & node_row : constraint_rows)
+    for (auto pr : node_row.second)
+      {
+        const Elem * elem = pr.first.first;
+        libmesh_assert(elem->type() == NODEELEM);
+        libmesh_assert(elem->mapping_type() == RATIONAL_BERNSTEIN_MAP);
+      }
+#endif
+
+  constraint_rows.clear();
+
+  for (Elem * elem : nodeelem_to_delete)
+    {
+      Node * node = elem->node_ptr(0);
+      mesh.delete_elem(elem);
+      mesh.delete_node(node);
+    }
+}
+
+
+
 #ifdef DEBUG
 void MeshTools::libmesh_assert_equal_n_systems (const MeshBase & mesh)
 {

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -713,14 +713,6 @@ public:
   {
     auto locator = mesh.sub_point_locator();
 
-    // A multiblock Exodus file will have a subdomain for each block;
-    // we stick the nodeelem subdomain at the end.
-    const subdomain_id_type nodeelems = mesh.n_subdomains()-1;
-    const std::set<subdomain_id_type> nodeelem_subdomain { nodeelems };
-    std::set<subdomain_id_type> manifold_subdomain;
-    for (auto i : make_range(nodeelems))
-      manifold_subdomain.insert(i);
-
     for (auto & elem : mesh.element_ptr_range())
       {
         Point master_pt = {}; // center, for tensor product elements
@@ -746,11 +738,9 @@ public:
 
         CPPUNIT_ASSERT(elem->contains_point(physical_pt));
 
-        const std::set<subdomain_id_type> * sbd_set =
-          (elem->type() == NODEELEM) ?
-          &nodeelem_subdomain : &manifold_subdomain;
+        std::set<subdomain_id_type> my_subdomain { elem->subdomain_id() };
 
-        const Elem * located_elem = (*locator)(physical_pt, sbd_set);
+        const Elem * located_elem = (*locator)(physical_pt, &my_subdomain);
 
         CPPUNIT_ASSERT(located_elem == elem);
       }


### PR DESCRIPTION
It's becoming clear to me that we need to support condensed linear systems, or *some* sort of better solver support for systems with tons of constraint equations ... but in the meantime we can sometimes work around the problem by avoiding creating tons of constraint equations.  Factoring that support out of the DynaIO IGA code lets us invoke it for Exodus IGA files too.