### PR TITLE
Higher precision when printing assert failures

### DIFF
--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -301,14 +301,18 @@ extern bool warned_about_auto_ptr;
 #define libmesh_assert_equal_to_msg(expr1,expr2, msg)                   \
   do {                                                                  \
     if (!((expr1) == (expr2))) {                                        \
+      std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " == " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
+      libMesh::err.precision(oldp);                                     \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_not_equal_to_msg(expr1,expr2, msg)               \
   do {                                                                  \
     if (!((expr1) != (expr2))) {                                        \
+      std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " != " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
+      libMesh::err.precision(oldp);                                     \
       libmesh_error();                                                  \
     } } while (0)
 
@@ -319,28 +323,36 @@ extern bool warned_about_auto_ptr;
 #define libmesh_assert_less_msg(expr1,expr2, msg)                       \
   do {                                                                  \
     if (!((expr1) < (expr2))) {                                         \
+      std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " < " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
+      libMesh::err.precision(oldp);                                     \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_greater_msg(expr1,expr2, msg)                    \
   do {                                                                  \
     if (!((expr1) > (expr2))) {                                         \
+      std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " > " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
+      libMesh::err.precision(oldp);                                     \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_less_equal_msg(expr1,expr2, msg)                 \
   do {                                                                  \
     if (!((expr1) <= (expr2))) {                                        \
+      std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " <= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
+      libMesh::err.precision(oldp);                                     \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_greater_equal_msg(expr1,expr2, msg)              \
   do {                                                                  \
     if (!((expr1) >= (expr2))) {                                        \
+      std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " >= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
+      libMesh::err.precision(oldp);                                     \
       libmesh_error();                                                  \
     } } while (0)
 
@@ -369,28 +381,36 @@ struct casting_compare {
 #define libmesh_assert_less_msg(expr1,expr2, msg)                       \
   do {                                                                  \
     if (!libMesh::casting_compare<std::less>()(expr1, expr2)) {         \
+      std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " < " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
+      libMesh::err.precision(oldp);                                     \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_greater_msg(expr1,expr2, msg)                    \
   do {                                                                  \
     if (!libMesh::casting_compare<std::greater>()(expr1, expr2)) {      \
+      std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " > " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
+      libMesh::err.precision(oldp);                                     \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_less_equal_msg(expr1,expr2, msg)                 \
   do {                                                                  \
     if (!libMesh::casting_compare<std::less_equal>()(expr1, expr2)) {   \
+      std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " <= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
+      libMesh::err.precision(oldp);                                     \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_greater_equal_msg(expr1,expr2, msg)              \
   do {                                                                  \
     if (!libMesh::casting_compare<std::greater_equal>()(expr1, expr2)) { \
+      std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " >= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
+      libMesh::err.precision(oldp);                                     \
       libmesh_error();                                                  \
     } } while (0)
 


### PR DESCRIPTION
I managed to trigger a bug where doubles that I expected to be exactly
equal really did differ by an ulp, but increasing the precision here
was what I needed to ensure they weren't actually differing by a billion
ulps.