### PR TITLE
Use get_unique_tag() for a few more MessageTags

### DIFF
--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1063,7 +1063,7 @@ void ExodusII_IO::copy_scalar_solution(System & system,
 #ifdef LIBMESH_HAVE_MPI
   if (this->n_processors() > 1)
   {
-    const Parallel::MessageTag tag(1);
+    const Parallel::MessageTag tag = this->comm().get_unique_tag(1);
     if (this->processor_id() == this->n_processors()-1)
       this->comm().receive(0, values_from_exodus, tag);
     if (this->processor_id() == 0)

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -2146,7 +2146,8 @@ unsigned int System::write_SCALAR_dofs (const NumericVector<Number> & vec,
 #ifdef LIBMESH_HAVE_MPI
   if (this->n_processors() > 1)
     {
-      const Parallel::MessageTag val_tag(1);
+      const Parallel::MessageTag val_tag =
+        this->comm().get_unique_tag(1);
 
       // Post the receive on processor 0
       if (this->processor_id() == 0)


### PR DESCRIPTION
Not sure how I missed these when upgrading others.

Still requesting the same magic numbers as before, by default, to avoid
causing any new conflicts with anyone else who is manually specifying
tag numbers.