### PR TITLE
Make use of std::condition_variable for _get_array

### DIFF
--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -1099,6 +1099,9 @@ void PetscVector<T>::get(const std::vector<numeric_index_type> & index,
 
   std::unique_lock<std::mutex> read_lock(_petsc_vector_mutex);
   _petsc_vector_cv.wait(read_lock, [this](){ return _array_is_present.load(); });
+  // When wait exits it means we've acquired and locked the mutex, but all we are doing now
+  // is reading, so it's safe to unlock and let other threads continue
+  read_lock.unlock();
   for (std::size_t i=0; i<num; i++)
     {
       const numeric_index_type local_index = this->map_global_to_local_index(index[i]);

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -51,10 +51,9 @@
 #include <unordered_map>
 #include <limits>
 
-#ifdef LIBMESH_HAVE_CXX11_THREAD
 #include <atomic>
 #include <mutex>
-#endif
+#include <condition_variable>
 
 namespace libMesh
 {
@@ -414,11 +413,20 @@ private:
    * object to keep down thread contention when reading frmo multiple
    * PetscVectors simultaneously
    */
-#ifdef LIBMESH_HAVE_CXX11_THREAD
   mutable std::mutex _petsc_vector_mutex;
-#else
-  mutable Threads::spin_mutex _petsc_vector_mutex;
-#endif
+
+  /**
+   * Condition variable for _get_array and _restore_array.  This is part of the
+   * object to keep down thread contention when reading frmo multiple
+   * PetscVectors simultaneously
+   */
+  mutable std::condition_variable _petsc_vector_cv;
+
+  /**
+   * Mutex that helps enforce a call_once idiom within a method, where
+   * once means call for only one thread
+   */
+  mutable std::mutex _petsc_vector_do_once_mutex;
 
   /**
    * Queries the array (and the local form if the vector is ghosted)
@@ -460,7 +468,7 @@ private:
   /**
    * Whether or not the data array is for read only access
    */
-  mutable bool _values_read_only;
+  mutable std::atomic<bool> _values_read_only;
 };
 
 
@@ -1089,6 +1097,8 @@ void PetscVector<T>::get(const std::vector<numeric_index_type> & index,
 
   const std::size_t num = index.size();
 
+  std::unique_lock<std::mutex> read_lock(_petsc_vector_mutex);
+  _petsc_vector_cv.wait(read_lock, [this](){ return _array_is_present.load(); });
   for (std::size_t i=0; i<num; i++)
     {
       const numeric_index_type local_index = this->map_global_to_local_index(index[i]);

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -410,14 +410,14 @@ private:
 
   /**
    * Mutex for _get_array and _restore_array.  This is part of the
-   * object to keep down thread contention when reading frmo multiple
+   * object to keep down thread contention when reading from multiple
    * PetscVectors simultaneously
    */
   mutable std::mutex _petsc_vector_mutex;
 
   /**
    * Condition variable for _get_array and _restore_array.  This is part of the
-   * object to keep down thread contention when reading frmo multiple
+   * object to keep down thread contention when reading from multiple
    * PetscVectors simultaneously
    */
   mutable std::condition_variable _petsc_vector_cv;

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -1151,12 +1151,6 @@ void PetscVector<T>::_get_array(bool read_only) const
 {
   libmesh_assert (this->initialized());
 
-#ifdef LIBMESH_HAVE_CXX11_THREAD
-  std::atomic_thread_fence(std::memory_order_acquire);
-#else
-  Threads::spin_mutex::scoped_lock lock(_petsc_vector_mutex);
-#endif
-
   // If the values have already been retrieved and we're currently
   // trying to get a non-read only view (ie read/write) and the
   // values are currently read only... then we need to restore
@@ -1171,11 +1165,10 @@ void PetscVector<T>::_get_array(bool read_only) const
 
   if (!_array_is_present)
     {
-#ifdef LIBMESH_HAVE_CXX11_THREAD
-      std::lock_guard<std::mutex> lock(_petsc_vector_mutex);
-#endif
+      std::lock_guard<std::mutex> do_once_lock(_petsc_vector_do_once_mutex);
       if (!_array_is_present)
         {
+          std::unique_lock<std::mutex> write_lock(_petsc_vector_mutex);
           PetscErrorCode ierr=0;
           if (this->type() != GHOSTED)
             {
@@ -1222,12 +1215,8 @@ void PetscVector<T>::_get_array(bool read_only) const
             _first = static_cast<numeric_index_type>(petsc_first);
             _last = static_cast<numeric_index_type>(petsc_last);
           }
-#ifdef LIBMESH_HAVE_CXX11_THREAD
-          std::atomic_thread_fence(std::memory_order_release);
-          _array_is_present.store(true, std::memory_order_relaxed);
-#else
           _array_is_present = true;
-#endif
+          _petsc_vector_cv.notify_all();
         }
     }
 }

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -1168,7 +1168,6 @@ void PetscVector<T>::_get_array(bool read_only) const
       std::lock_guard<std::mutex> do_once_lock(_petsc_vector_do_once_mutex);
       if (!_array_is_present)
         {
-          std::unique_lock<std::mutex> write_lock(_petsc_vector_mutex);
           PetscErrorCode ierr=0;
           if (this->type() != GHOSTED)
             {


### PR DESCRIPTION
I'll keep the below text for historical purposes. TLDR, initially I threw up a PR
that just locked at the top of `_get_array` in order to avoid helgrind errors. But
then I dove into this a bit more, and I think the new code keeps optimal performance
and eliminates helgrind errors.

### Original post

This removed all the helgrind errors coming out of the threaded element
loop in `system_projection.C`. By putting the lock at function scope as
opposed to contained within a `if (!_array_present)` scope, you ensure
that you don't let through any "reader" threads (e.g. threads that exit
this function and go onto read things like the global to local map and
finally the actual read array), while you have a writer thread. This
also makes this function much simpler to read I think. You will have
more lock contention with this change for sure (like a lot more), but
once threads get through the handful of lines under contention, they're
free to race off (reading) uncontested.

I recognize that letting reader threads through and the helgrind errors
associated with this are probably false positives, at least I'm 90% sure
they are false positives 100% of the time (because the only way that
`_array_is_present` can be `true`, which "lets a reader thread through",
is if a writer thread has already essentially made
it's way through `_get_array` ... unless two threads had two different
call stacks ... and if that was the case then the
function level lock in `_get_array` would also be insufficient to
prevent races). So if we don't want to go with this PR, then I
definitely understand. I just get tickled the wrong way by these
helgrind "errors". Maybe if we don't let this get merged, I can do some
helgrind development instead 😆 

Closes #3127