### PR TITLE
Optimize RATIONAL_BERNSTEIN evaluations for IGA problems

### DIFF
--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -1341,6 +1341,12 @@ Real rational_fe_shape_deriv(const Elem & elem,
                              const Point & p,
                              const bool add_p_level);
 
+Real rational_fe_shape_second_deriv(const Elem & elem,
+                                    const FEType underlying_fe_type,
+                                    const unsigned int i,
+                                    const unsigned int j,
+                                    const Point & p,
+                                    const bool add_p_level);
 } // namespace libMesh
 
 #define LIBMESH_DEFAULT_VECTORIZED_FE(MyDim, MyType) \

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -1328,7 +1328,7 @@ void rational_fe_weighted_shapes(const Elem * elem,
                                  const std::vector<Point> & p,
                                  const bool add_p_level);
 
-Real rational_fe_shape(const Elem * elem,
+Real rational_fe_shape(const Elem & elem,
                        const FEType underlying_fe_type,
                        const unsigned int i,
                        const Point & p,

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -173,7 +173,7 @@ public:
 
   /**
    * Fills \p v[i][qp] with the values of the \f$ i^{th} \f$
-   * shape functions, evaluated at points qp in p.  You must specify
+   * shape functions, evaluated at all points in p.  You must specify
    * element order directly.  \p v should already be the appropriate
    * size.
    *

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -597,6 +597,30 @@ protected:
                                     const Elem * e);
 
   /**
+   * Fills \p dphidxi (and in higher dimensions, eta/zeta) derivative
+   * values for all shape functions, evaluated at points qp in p.  You
+   * must specify element order directly.  \p Internal arrays should
+   * already be the appropriate size.
+   *
+   * On a p-refined element, \p o should be the base order of the
+   * element if \p add_p_level is left \p true, or can be the base
+   * order of the element if \p add_p_level is set to \p false.
+   */
+  void all_shape_derivs(const Elem * elem,
+                        const Order o,
+                        const std::vector<Point> & p,
+                        const bool add_p_level = true);
+
+  /**
+   * A default implementation for all_shape_derivs
+   */
+  void default_all_shape_derivs (const Elem * elem,
+                                 const Order o,
+                                 const std::vector<Point> & p,
+                                 const bool add_p_level = true);
+
+
+  /**
    * Init \p dual_phi and potentially \p dual_dphi, \p dual_d2phi
    */
   void init_dual_shape_functions(unsigned int n_shapes, unsigned int n_qp);
@@ -1334,6 +1358,17 @@ void FE<MyDim,MyType>::shape_derivs                  \
 {                                                    \
   FE<MyDim,MyType>::default_shape_derivs             \
     (elem,o,i,j,p,v,add_p_level);                    \
+}                                                    \
+                                                     \
+template<>                                           \
+void FE<MyDim,MyType>::all_shape_derivs              \
+  (const Elem * elem,                                \
+   const Order o,                                    \
+   const std::vector<Point> & p,                     \
+   const bool add_p_level)                           \
+{                                                    \
+  this->default_all_shape_derivs                     \
+    (elem,o,p,add_p_level);                          \
 }
 
 

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -1334,6 +1334,13 @@ Real rational_fe_shape(const Elem & elem,
                        const Point & p,
                        const bool add_p_level);
 
+Real rational_fe_shape_deriv(const Elem & elem,
+                             const FEType underlying_fe_type,
+                             const unsigned int i,
+                             const unsigned int j,
+                             const Point & p,
+                             const bool add_p_level);
+
 } // namespace libMesh
 
 #define LIBMESH_DEFAULT_VECTORIZED_FE(MyDim, MyType) \

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -1318,6 +1318,16 @@ fe_fdm_second_deriv(const Elem * elem,
                        const unsigned int, const unsigned int,
                        const Point &, const bool));
 
+/**
+ * Helper functions for rational basis functions.
+ */
+// shapes[i][j] is shape function phi_i at point p[j]
+void rational_fe_weighted_shapes(const Elem * elem,
+                                 FEType underlying_fe_type,
+                                 std::vector<std::vector<Real>> & shapes,
+                                 const std::vector<Point> & p,
+                                 const bool add_p_level);
+
 } // namespace libMesh
 
 #define LIBMESH_DEFAULT_VECTORIZED_FE(MyDim, MyType) \

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -1328,6 +1328,15 @@ void rational_fe_weighted_shapes(const Elem * elem,
                                  const std::vector<Point> & p,
                                  const bool add_p_level);
 
+// shapes[i][q] is shape function phi_i at point p[q]
+// derivs[j][i][q] is dphi_i/dxi_j at p[q]
+void rational_fe_weighted_shapes_derivs(const Elem * elem,
+                                        const FEType fe_type,
+                                        std::vector<std::vector<Real>> & shapes,
+                                        std::vector<std::vector<std::vector<Real>>> & derivs,
+                                        const std::vector<Point> & p,
+                                        const bool add_p_level);
+
 Real rational_fe_shape(const Elem & elem,
                        const FEType underlying_fe_type,
                        const unsigned int i,
@@ -1353,6 +1362,13 @@ void rational_all_shapes (const Elem & elem,
                           const std::vector<Point> & p,
                           std::vector<std::vector<Real>> & v,
                           const bool add_p_level);
+
+void rational_all_shape_derivs (const Elem & elem,
+                                const FEType underlying_fe_type,
+                                const std::vector<Point> & p,
+                                std::vector<std::vector<Real>> * comps[3],
+                                const bool add_p_level);
+
 } // namespace libMesh
 
 #define LIBMESH_DEFAULT_VECTORIZED_FE(MyDim, MyType) \

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -1323,10 +1323,16 @@ fe_fdm_second_deriv(const Elem * elem,
  */
 // shapes[i][j] is shape function phi_i at point p[j]
 void rational_fe_weighted_shapes(const Elem * elem,
-                                 FEType underlying_fe_type,
+                                 const FEType underlying_fe_type,
                                  std::vector<std::vector<Real>> & shapes,
                                  const std::vector<Point> & p,
                                  const bool add_p_level);
+
+Real rational_fe_shape(const Elem * elem,
+                       const FEType underlying_fe_type,
+                       const unsigned int i,
+                       const Point & p,
+                       const bool add_p_level);
 
 } // namespace libMesh
 

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -1347,6 +1347,12 @@ Real rational_fe_shape_second_deriv(const Elem & elem,
                                     const unsigned int j,
                                     const Point & p,
                                     const bool add_p_level);
+
+void rational_all_shapes (const Elem & elem,
+                          const FEType underlying_fe_type,
+                          const std::vector<Point> & p,
+                          std::vector<std::vector<Real>> & v,
+                          const bool add_p_level);
 } // namespace libMesh
 
 #define LIBMESH_DEFAULT_VECTORIZED_FE(MyDim, MyType) \

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -598,9 +598,9 @@ protected:
 
   /**
    * Fills \p dphidxi (and in higher dimensions, eta/zeta) derivative
-   * values for all shape functions, evaluated at points qp in p.  You
-   * must specify element order directly.  \p Internal arrays should
-   * already be the appropriate size.
+   * values for all shape functions, evaluated at all points in p.
+   * You must specify element order directly.  \p Internal arrays
+   * should already be the appropriate size.
    *
    * On a p-refined element, \p o should be the base order of the
    * element if \p add_p_level is left \p true, or can be the base

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -571,6 +571,19 @@ public:
                           const Point & p);
 
   /**
+   * Fills \p dphi with the derivatives of the \f$ i^{th} \f$ shape
+   * function at point \p p in direction \p j.
+   */
+  template<typename OutputType>
+  static void shape_derivs(const FEType & fe_t,
+                           const Elem * elem,
+                           const unsigned int i,
+                           const unsigned int j,
+                           const std::vector<Point> & p,
+                           std::vector<OutputType> & dphi,
+                           const bool add_p_level = true);
+
+  /**
    * Typedef for pointer to a function that returns FE shape function derivative values.
    * The \p p_level() of the passed-in \p elem is accounted for internally when
    * the \p add_p_level flag is set to true. For more information, see fe.h.

--- a/include/fe/fe_macro.h
+++ b/include/fe/fe_macro.h
@@ -49,7 +49,8 @@
   template void         FE<2,SUBDIVISION>::reinit(const Elem *,const std::vector<Point> * const,const std::vector<Real> * const); \
   template void         FE<2,SUBDIVISION>::init_base_shape_functions(const std::vector<Point> &, const Elem *); \
   template void         FE<2,SUBDIVISION>::init_shape_functions(const std::vector<Point> &, const Elem *); \
-  template void         FE<2,SUBDIVISION>::init_dual_shape_functions(unsigned int, unsigned int)
+  template void         FE<2,SUBDIVISION>::init_dual_shape_functions(unsigned int, unsigned int); \
+  template void         FE<2,SUBDIVISION>::default_all_shape_derivs (const Elem * elem, const Order o, const std::vector<Point> & p, const bool add_p_level)
 
 #else // LIBMESH_ENABLE_INFINITE_ELEMENTS
 
@@ -60,7 +61,8 @@
   template unsigned int FE<2,SUBDIVISION>::n_quadrature_points () const; \
   template void         FE<2,SUBDIVISION>::reinit(const Elem *,const std::vector<Point> * const,const std::vector<Real> * const); \
   template void         FE<2,SUBDIVISION>::init_shape_functions(const std::vector<Point> &, const Elem *); \
-  template void         FE<2,SUBDIVISION>::init_dual_shape_functions(unsigned int, unsigned int)
+  template void         FE<2,SUBDIVISION>::init_dual_shape_functions(unsigned int, unsigned int); \
+  template void         FE<2,SUBDIVISION>::default_all_shape_derivs (const Elem * elem, const Order o, const std::vector<Point> & p, const bool add_p_level)
 
 #endif // LIBMESH_ENABLE_INFINITE_ELEMENTS
 

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -1061,6 +1061,36 @@ Real rational_fe_shape_second_deriv(const Elem & elem,
 #endif // LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 
+void rational_all_shapes (const Elem & elem,
+                          const FEType underlying_fe_type,
+                          const std::vector<Point> & p,
+                          std::vector<std::vector<Real>> & v,
+                          const bool add_p_level)
+{
+  std::vector<std::vector<Real>> shapes;
+
+  rational_fe_weighted_shapes(&elem, underlying_fe_type, shapes, p,
+                              add_p_level);
+
+  std::vector<Real> shape_sums(p.size(), 0);
+
+  for (auto i : index_range(v))
+    {
+      libmesh_assert_equal_to ( p.size(), shapes[i].size() );
+      for (auto j : index_range(p))
+        shape_sums[j] += shapes[i][j];
+    }
+
+  for (auto i : index_range(v))
+    {
+      libmesh_assert_equal_to ( p.size(), v[i].size() );
+      for (auto j : index_range(v[i]))
+        v[i][j] = shapes[i][j] / shape_sums[j];
+    }
+}
+
+
+
 template
 Real fe_fdm_deriv<Real>(const Elem *, const Order, const unsigned int,
                         const unsigned int, const Point &, const bool,

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -835,7 +835,7 @@ fe_fdm_second_deriv(const Elem * elem,
 
 
 void rational_fe_weighted_shapes(const Elem * elem,
-                                 FEType underlying_fe_type,
+                                 const FEType underlying_fe_type,
                                  std::vector<std::vector<Real>> & shapes,
                                  const std::vector<Point> & p,
                                  const bool add_p_level)
@@ -869,6 +869,42 @@ void rational_fe_weighted_shapes(const Elem * elem,
       for (auto & s : shapes_i)
         s *= node_weights[i];
     }
+}
+
+
+Real rational_fe_shape(const Elem * elem,
+                       const FEType underlying_fe_type,
+                       const unsigned int i,
+                       const Point & p,
+                       const bool add_p_level)
+{
+  libmesh_assert(elem);
+
+  int extra_order = add_p_level * elem->p_level();
+
+  const unsigned int n_sf =
+    FEInterface::n_shape_functions(underlying_fe_type, extra_order, elem);
+
+  libmesh_assert_equal_to (n_sf, elem->n_nodes());
+
+  std::vector<Real> node_weights(n_sf);
+
+  const unsigned char datum_index = elem->mapping_data();
+
+  Real weighted_shape_i = 0, weighted_sum = 0;
+
+  for (unsigned int sf=0; sf<n_sf; sf++)
+    {
+      Real node_weight =
+        elem->node_ref(sf).get_extra_datum<Real>(datum_index);
+      Real weighted_shape = node_weight *
+        FEInterface::shape(underlying_fe_type, extra_order, elem, sf, p);
+      weighted_sum += weighted_shape;
+      if (sf == i)
+        weighted_shape_i = weighted_shape;
+    }
+
+  return weighted_shape_i / weighted_sum;
 }
 
 

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -834,6 +834,44 @@ fe_fdm_second_deriv(const Elem * elem,
 }
 
 
+void rational_fe_weighted_shapes(const Elem * elem,
+                                 FEType underlying_fe_type,
+                                 std::vector<std::vector<Real>> & shapes,
+                                 const std::vector<Point> & p,
+                                 const bool add_p_level)
+{
+  const int extra_order = add_p_level * elem->p_level();
+
+  const int dim = elem->dim();
+
+  const unsigned int n_sf =
+    FEInterface::n_shape_functions(underlying_fe_type, extra_order,
+                                   elem);
+
+  libmesh_assert_equal_to (n_sf, elem->n_nodes());
+
+  std::vector<Real> node_weights(n_sf);
+
+  const unsigned char datum_index = elem->mapping_data();
+  for (unsigned int n=0; n<n_sf; n++)
+    node_weights[n] =
+      elem->node_ref(n).get_extra_datum<Real>(datum_index);
+
+  const std::size_t n_p = p.size();
+
+  shapes.resize(n_sf);
+  for (unsigned int i=0; i != n_sf; ++i)
+    {
+      auto & shapes_i = shapes[i];
+      shapes_i.resize(n_p, 0);
+      FEInterface::shapes(dim, underlying_fe_type, elem, i, p,
+                          shapes_i, add_p_level);
+      for (auto & s : shapes_i)
+        s *= node_weights[i];
+    }
+}
+
+
 template
 Real fe_fdm_deriv<Real>(const Elem *, const Order, const unsigned int,
                         const unsigned int, const Point &, const bool,

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -872,33 +872,31 @@ void rational_fe_weighted_shapes(const Elem * elem,
 }
 
 
-Real rational_fe_shape(const Elem * elem,
+Real rational_fe_shape(const Elem & elem,
                        const FEType underlying_fe_type,
                        const unsigned int i,
                        const Point & p,
                        const bool add_p_level)
 {
-  libmesh_assert(elem);
-
-  int extra_order = add_p_level * elem->p_level();
+  int extra_order = add_p_level * elem.p_level();
 
   const unsigned int n_sf =
-    FEInterface::n_shape_functions(underlying_fe_type, extra_order, elem);
+    FEInterface::n_shape_functions(underlying_fe_type, extra_order, &elem);
 
-  libmesh_assert_equal_to (n_sf, elem->n_nodes());
+  libmesh_assert_equal_to (n_sf, elem.n_nodes());
 
   std::vector<Real> node_weights(n_sf);
 
-  const unsigned char datum_index = elem->mapping_data();
+  const unsigned char datum_index = elem.mapping_data();
 
   Real weighted_shape_i = 0, weighted_sum = 0;
 
   for (unsigned int sf=0; sf<n_sf; sf++)
     {
       Real node_weight =
-        elem->node_ref(sf).get_extra_datum<Real>(datum_index);
+        elem.node_ref(sf).get_extra_datum<Real>(datum_index);
       Real weighted_shape = node_weight *
-        FEInterface::shape(underlying_fe_type, extra_order, elem, sf, p);
+        FEInterface::shape(underlying_fe_type, extra_order, &elem, sf, p);
       weighted_sum += weighted_shape;
       if (sf == i)
         weighted_shape_i = weighted_shape;

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -1677,6 +1677,74 @@ Real FEInterface::shape_deriv(const FEType & fe_t,
 
 
 
+template<>
+void FEInterface::shape_derivs<Real>(const FEType & fe_t,
+                                     const Elem * elem,
+                                     const unsigned int i,
+                                     const unsigned int j,
+                                     const std::vector<Point> & p,
+                                     std::vector<Real> & dphi,
+                                     const bool add_p_level)
+{
+  const Order o = fe_t.order;
+
+  switch(elem->dim())
+    {
+    case 0:
+      fe_scalar_vec_error_switch(0, shape_derivs(elem,o,i,j,p,dphi,add_p_level), , ; break;);
+      break;
+    case 1:
+      fe_scalar_vec_error_switch(1, shape_derivs(elem,o,i,j,p,dphi,add_p_level), , ; break;);
+      break;
+    case 2:
+      fe_scalar_vec_error_switch(2, shape_derivs(elem,o,i,j,p,dphi,add_p_level), , ; break;);
+      break;
+    case 3:
+      fe_scalar_vec_error_switch(3, shape_derivs(elem,o,i,j,p,dphi,add_p_level), , ; break;);
+      break;
+    default:
+      libmesh_error_msg("Invalid dimension = " << elem->dim());
+    }
+
+  return;
+}
+
+
+
+template<>
+void FEInterface::shape_derivs<RealGradient>(const FEType & fe_t,
+                                             const Elem * elem,
+                                             const unsigned int i,
+                                             const unsigned int j,
+                                             const std::vector<Point> & p,
+                                             std::vector<RealGradient> & dphi,
+                                             const bool add_p_level)
+{
+  const Order o = fe_t.order;
+
+  switch(elem->dim())
+    {
+    case 0:
+      fe_vector_scalar_error_switch(0, shape_derivs(elem,o,i,j,p,dphi,add_p_level), , ; break;);
+      break;
+    case 1:
+      fe_vector_scalar_error_switch(1, shape_derivs(elem,o,i,j,p,dphi,add_p_level), , ; break;);
+      break;
+    case 2:
+      fe_vector_scalar_error_switch(2, shape_derivs(elem,o,i,j,p,dphi,add_p_level), , ; break;);
+      break;
+    case 3:
+      fe_vector_scalar_error_switch(3, shape_derivs(elem,o,i,j,p,dphi,add_p_level), , ; break;);
+      break;
+    default:
+      libmesh_error_msg("Invalid dimension = " << elem->dim());
+    }
+
+  return;
+}
+
+
+
 FEInterface::shape_deriv_ptr
 FEInterface::shape_deriv_function(const unsigned int dim,
                                   const FEType & fe_t,

--- a/src/fe/fe_rational_shape_1D.C
+++ b/src/fe/fe_rational_shape_1D.C
@@ -47,10 +47,12 @@ Real FE<1,RATIONAL_BERNSTEIN>::shape(const Elem * elem,
                                      const Point & p,
                                      const bool add_p_level)
 {
+  libmesh_assert(elem);
+
   // FEType object for the non-rational basis underlying this one
   FEType fe_type(order, _underlying_fe_family);
 
-  return rational_fe_shape(elem, fe_type, i, p, add_p_level);
+  return rational_fe_shape(*elem, fe_type, i, p, add_p_level);
 }
 
 

--- a/src/fe/fe_rational_shape_1D.C
+++ b/src/fe/fe_rational_shape_1D.C
@@ -32,40 +32,6 @@ using namespace libMesh;
 
 static const FEFamily _underlying_fe_family = BERNSTEIN;
 
-// shapes[i][j] is shape function phi_i at point p[j]
-void weighted_shapes(const Elem * elem,
-                     FEType fe_type,
-                     std::vector<std::vector<Real>> & shapes,
-                     const std::vector<Point> & p,
-                     const bool add_p_level)
-{
-  const int extra_order = add_p_level * elem->p_level();
-
-  const unsigned int n_sf =
-    FEInterface::n_shape_functions(fe_type, extra_order, elem);
-
-  libmesh_assert_equal_to (n_sf, elem->n_nodes());
-
-  std::vector<Real> node_weights(n_sf);
-
-  const unsigned char datum_index = elem->mapping_data();
-  for (unsigned int n=0; n<n_sf; n++)
-    node_weights[n] =
-      elem->node_ref(n).get_extra_datum<Real>(datum_index);
-
-  const std::size_t n_p = p.size();
-
-  shapes.resize(n_sf);
-  for (unsigned int i=0; i != n_sf; ++i)
-    {
-      auto & shapes_i = shapes[i];
-      shapes_i.resize(n_p, 0);
-      FEInterface::shapes(1, fe_type, elem, i, p, shapes_i, add_p_level);
-      for (auto & s : shapes_i)
-        s *= node_weights[i];
-    }
-}
-
 } // anonymous namespace
 
 
@@ -343,7 +309,7 @@ void FE<1,RATIONAL_BERNSTEIN>::all_shapes
 
   FEType fe_type(o, _underlying_fe_family);
 
-  weighted_shapes(elem, fe_type, shapes, p, add_p_level);
+  rational_fe_weighted_shapes(elem, fe_type, shapes, p, add_p_level);
 
   std::vector<Real> shape_sums(p.size(), 0);
 

--- a/src/fe/fe_rational_shape_1D.C
+++ b/src/fe/fe_rational_shape_1D.C
@@ -197,34 +197,9 @@ void FE<1,RATIONAL_BERNSTEIN>::all_shapes
    std::vector<std::vector<OutputShape>> & v,
    const bool add_p_level)
 {
-  std::vector<std::vector<Real>> shapes;
+  FEType underlying_fe_type(o, _underlying_fe_family);
 
-  FEType fe_type(o, _underlying_fe_family);
-
-  rational_fe_weighted_shapes(elem, fe_type, shapes, p, add_p_level);
-
-  std::vector<Real> shape_sums(p.size(), 0);
-
-  for (auto i : index_range(v))
-    {
-      libmesh_assert_equal_to ( p.size(), shapes[i].size() );
-      for (auto j : index_range(p))
-        shape_sums[j] += shapes[i][j];
-    }
-
-  for (auto i : index_range(v))
-    {
-      libmesh_assert_equal_to ( p.size(), v[i].size() );
-      for (auto j : index_range(v[i]))
-        {
-          v[i][j] = shapes[i][j] / shape_sums[j];
-
-#ifdef DEBUG
-          Real old_shape = FE<1,RATIONAL_BERNSTEIN>::shape (elem, o, i, p[j], add_p_level);
-          libmesh_assert(std::abs(v[i][j] - old_shape) < TOLERANCE*TOLERANCE);
-#endif
-        }
-    }
+  rational_all_shapes(*elem, underlying_fe_type, p, v, add_p_level);
 }
 
 

--- a/src/fe/fe_rational_shape_1D.C
+++ b/src/fe/fe_rational_shape_1D.C
@@ -226,16 +226,13 @@ FE<1,RATIONAL_BERNSTEIN>::all_shape_derivs (const Elem * elem,
                                             const std::vector<Point> & p,
                                             const bool add_p_level)
 {
-  std::vector<std::vector<OutputShape>> * comps[3]
+  FEType underlying_fe_type(o, _underlying_fe_family);
+
+  std::vector<std::vector<Real>> * comps[3]
     { &this->dphidxi, &this->dphideta, &this->dphidzeta };
-  for (unsigned int d=0; d != 1; ++d)
-    {
-      libmesh_assert_equal_to(comps[d]->size(), elem->n_nodes());
-      auto & comps_d = *comps[d];
-      for (auto i : index_range(comps_d))
-        FE<1,RATIONAL_BERNSTEIN>::shape_derivs
-          (elem,o,i,d,p,comps_d[i],add_p_level);
-    }
+
+  rational_all_shape_derivs (*elem, underlying_fe_type, p,
+                             comps, add_p_level);
 }
 
 

--- a/src/fe/fe_rational_shape_1D.C
+++ b/src/fe/fe_rational_shape_1D.C
@@ -47,38 +47,10 @@ Real FE<1,RATIONAL_BERNSTEIN>::shape(const Elem * elem,
                                      const Point & p,
                                      const bool add_p_level)
 {
-  libmesh_assert(elem);
-
-  int extra_order = add_p_level * elem->p_level();
-
-  // FEType object to be passed to various FEInterface functions below.
+  // FEType object for the non-rational basis underlying this one
   FEType fe_type(order, _underlying_fe_family);
 
-  const unsigned int n_sf =
-    FEInterface::n_shape_functions(fe_type, extra_order, elem);
-
-  const unsigned int n_nodes = elem->n_nodes();
-  libmesh_assert_equal_to (n_sf, n_nodes);
-
-  std::vector<Real> node_weights(n_nodes);
-
-  const unsigned char datum_index = elem->mapping_data();
-  for (unsigned int n=0; n<n_nodes; n++)
-    node_weights[n] =
-      elem->node_ref(n).get_extra_datum<Real>(datum_index);
-
-  Real weighted_shape_i = 0, weighted_sum = 0;
-
-  for (unsigned int sf=0; sf<n_sf; sf++)
-    {
-      Real weighted_shape = node_weights[sf] *
-        FEInterface::shape(fe_type, extra_order, elem, sf, p);
-      weighted_sum += weighted_shape;
-      if (sf == i)
-        weighted_shape_i = weighted_shape;
-    }
-
-  return weighted_shape_i / weighted_sum;
+  return rational_fe_shape(elem, fe_type, i, p, add_p_level);
 }
 
 

--- a/src/fe/fe_rational_shape_1D.C
+++ b/src/fe/fe_rational_shape_1D.C
@@ -131,62 +131,17 @@ template <>
 Real FE<1,RATIONAL_BERNSTEIN>::shape_second_deriv(const Elem * elem,
                                                   const Order order,
                                                   const unsigned int i,
-                                                  const unsigned int libmesh_dbg_var(j),
+                                                  const unsigned int j,
                                                   const Point & p,
                                                   const bool add_p_level)
 {
-  // Don't need to switch on j.  1D shape functions
-  // depend on xi only!
-  libmesh_assert_equal_to (j, 0);
-
   libmesh_assert(elem);
 
-  int extra_order = add_p_level * elem->p_level();
-
   // FEType object to be passed to various FEInterface functions below.
-  FEType fe_type(order, _underlying_fe_family);
+  FEType underlying_fe_type(order, _underlying_fe_family);
 
-  const unsigned int n_sf =
-    FEInterface::n_shape_functions(fe_type, extra_order, elem);
-
-  const unsigned int n_nodes = elem->n_nodes();
-  libmesh_assert_equal_to (n_sf, n_nodes);
-
-  std::vector<Real> node_weights(n_nodes);
-
-  const unsigned char datum_index = elem->mapping_data();
-  for (unsigned int n=0; n<n_nodes; n++)
-    node_weights[n] =
-      elem->node_ref(n).get_extra_datum<Real>(datum_index);
-
-  Real weighted_shape_i = 0, weighted_sum = 0,
-       weighted_grad_i = 0, weighted_grad_sum = 0,
-       weighted_hess_i = 0, weighted_hess_sum = 0;
-
-  for (unsigned int sf=0; sf<n_sf; sf++)
-    {
-      Real weighted_shape = node_weights[sf] *
-        FEInterface::shape(fe_type, extra_order, elem, sf, p);
-      Real weighted_grad = node_weights[sf] *
-        FEInterface::shape_deriv(fe_type, extra_order, elem, sf, 0, p);
-      Real weighted_hess = node_weights[sf] *
-        FEInterface::shape_second_deriv(fe_type, extra_order, elem, sf, 0, p);
-      weighted_sum += weighted_shape;
-      weighted_grad_sum += weighted_grad;
-      weighted_hess_sum += weighted_hess;
-      if (sf == i)
-        {
-          weighted_shape_i = weighted_shape;
-          weighted_grad_i = weighted_grad;
-          weighted_hess_i = weighted_hess;
-        }
-    }
-
-  return (weighted_sum * weighted_sum *
-          (weighted_sum * weighted_hess_i - weighted_shape_i * weighted_hess_sum) -
-          (weighted_sum * weighted_grad_i - weighted_shape_i * weighted_grad_sum) *
-          2 * weighted_sum * weighted_grad_sum) /
-         (weighted_sum * weighted_sum * weighted_sum * weighted_sum);
+  return rational_fe_shape_second_deriv(*elem, underlying_fe_type, i,
+                                        j, p, add_p_level);
 }
 
 

--- a/src/fe/fe_rational_shape_1D.C
+++ b/src/fe/fe_rational_shape_1D.C
@@ -84,53 +84,16 @@ template <>
 Real FE<1,RATIONAL_BERNSTEIN>::shape_deriv(const Elem * elem,
                                            const Order order,
                                            const unsigned int i,
-                                           const unsigned int libmesh_dbg_var(j),
+                                           const unsigned int j,
                                            const Point & p,
                                            const bool add_p_level)
 {
-  // only d()/dxi in 1D!
-  libmesh_assert_equal_to (j, 0);
-
   libmesh_assert(elem);
 
-  int extra_order = add_p_level * elem->p_level();
+  FEType underlying_fe_type(order, _underlying_fe_family);
 
-  // FEType object to be passed to various FEInterface functions below.
-  FEType fe_type(order, _underlying_fe_family);
-
-  const unsigned int n_sf =
-    FEInterface::n_shape_functions(fe_type, extra_order, elem);
-
-  const unsigned int n_nodes = elem->n_nodes();
-  libmesh_assert_equal_to (n_sf, n_nodes);
-
-  std::vector<Real> node_weights(n_nodes);
-
-  const unsigned char datum_index = elem->mapping_data();
-  for (unsigned int n=0; n<n_nodes; n++)
-    node_weights[n] =
-      elem->node_ref(n).get_extra_datum<Real>(datum_index);
-
-  Real weighted_shape_i = 0, weighted_sum = 0,
-       weighted_grad_i = 0, weighted_grad_sum = 0;
-
-  for (unsigned int sf=0; sf<n_sf; sf++)
-    {
-      Real weighted_shape = node_weights[sf] *
-        FEInterface::shape(fe_type, extra_order, elem, sf, p);
-      Real weighted_grad = node_weights[sf] *
-        FEInterface::shape_deriv(fe_type, extra_order, elem, sf, 0, p);
-      weighted_sum += weighted_shape;
-      weighted_grad_sum += weighted_grad;
-      if (sf == i)
-        {
-          weighted_shape_i = weighted_shape;
-          weighted_grad_i = weighted_grad;
-        }
-    }
-
-  return (weighted_sum * weighted_grad_i - weighted_shape_i * weighted_grad_sum) /
-         weighted_sum / weighted_sum;
+  return rational_fe_shape_deriv(*elem, underlying_fe_type, i, j, p,
+                                 add_p_level);
 }
 
 

--- a/src/fe/fe_rational_shape_1D.C
+++ b/src/fe/fe_rational_shape_1D.C
@@ -386,6 +386,26 @@ void FE<1,RATIONAL_BERNSTEIN>::shape_derivs
 }
 
 
+template <>
+void
+FE<1,RATIONAL_BERNSTEIN>::all_shape_derivs (const Elem * elem,
+                                            const Order o,
+                                            const std::vector<Point> & p,
+                                            const bool add_p_level)
+{
+  std::vector<std::vector<OutputShape>> * comps[3]
+    { &this->dphidxi, &this->dphideta, &this->dphidzeta };
+  for (unsigned int d=0; d != 1; ++d)
+    {
+      libmesh_assert_equal_to(comps[d]->size(), elem->n_nodes());
+      auto & comps_d = *comps[d];
+      for (auto i : index_range(comps_d))
+        FE<1,RATIONAL_BERNSTEIN>::shape_derivs
+          (elem,o,i,d,p,comps_d[i],add_p_level);
+    }
+}
+
+
 } // namespace libMesh
 
 

--- a/src/fe/fe_rational_shape_2D.C
+++ b/src/fe/fe_rational_shape_2D.C
@@ -409,6 +409,25 @@ void FE<2,RATIONAL_BERNSTEIN>::shape_derivs
 }
 
 
+template <>
+void
+FE<2,RATIONAL_BERNSTEIN>::all_shape_derivs (const Elem * elem,
+                                            const Order o,
+                                            const std::vector<Point> & p,
+                                            const bool add_p_level)
+{
+  std::vector<std::vector<OutputShape>> * comps[3]
+    { &this->dphidxi, &this->dphideta, &this->dphidzeta };
+  for (unsigned int d=0; d != 2; ++d)
+    {
+      libmesh_assert_equal_to(comps[d]->size(), elem->n_nodes());
+      auto & comps_d = *comps[d];
+      for (auto i : index_range(comps_d))
+        FE<2,RATIONAL_BERNSTEIN>::shape_derivs
+          (elem,o,i,d,p,comps_d[i],add_p_level);
+    }
+}
+
 
 } // namespace libMesh
 

--- a/src/fe/fe_rational_shape_2D.C
+++ b/src/fe/fe_rational_shape_2D.C
@@ -30,40 +30,6 @@ using namespace libMesh;
 
 static const FEFamily _underlying_fe_family = BERNSTEIN;
 
-// shapes[i][j] is shape function phi_i at point p[j]
-void weighted_shapes(const Elem * elem,
-                     FEType fe_type,
-                     std::vector<std::vector<Real>> & shapes,
-                     const std::vector<Point> & p,
-                     const bool add_p_level)
-{
-  const int extra_order = add_p_level * elem->p_level();
-
-  const unsigned int n_sf =
-    FEInterface::n_shape_functions(fe_type, extra_order, elem);
-
-  libmesh_assert_equal_to (n_sf, elem->n_nodes());
-
-  std::vector<Real> node_weights(n_sf);
-
-  const unsigned char datum_index = elem->mapping_data();
-  for (unsigned int n=0; n<n_sf; n++)
-    node_weights[n] =
-      elem->node_ref(n).get_extra_datum<Real>(datum_index);
-
-  const std::size_t n_p = p.size();
-
-  shapes.resize(n_sf);
-  for (unsigned int i=0; i != n_sf; ++i)
-    {
-      auto & shapes_i = shapes[i];
-      shapes_i.resize(n_p, 0);
-      FEInterface::shapes(2, fe_type, elem, i, p, shapes_i, add_p_level);
-      for (auto & s : shapes_i)
-        s *= node_weights[i];
-    }
-}
-
 } // anonymous namespace
 
 
@@ -366,7 +332,7 @@ void FE<2,RATIONAL_BERNSTEIN>::all_shapes
 
   FEType fe_type(o, _underlying_fe_family);
 
-  weighted_shapes(elem, fe_type, shapes, p, add_p_level);
+  rational_fe_weighted_shapes(elem, fe_type, shapes, p, add_p_level);
 
   std::vector<Real> shape_sums(p.size(), 0);
 

--- a/src/fe/fe_rational_shape_2D.C
+++ b/src/fe/fe_rational_shape_2D.C
@@ -134,86 +134,13 @@ Real FE<2,RATIONAL_BERNSTEIN>::shape_second_deriv(const Elem * elem,
                                                   const Point & p,
                                                   const bool add_p_level)
 {
-  unsigned int j1, j2;
-  switch (j)
-    {
-    case 0:
-      // j = 0 ==> d^2 phi / dxi^2
-      j1 = j2 = 0;
-      break;
-    case 1:
-      // j = 1 ==> d^2 phi / dxi deta
-      j1 = 0;
-      j2 = 1;
-      break;
-    case 2:
-      // j = 2 ==> d^2 phi / deta^2
-      j1 = j2 = 1;
-      break;
-    default:
-      libmesh_error();
-    }
-
   libmesh_assert(elem);
 
-  int extra_order = add_p_level * elem->p_level();
-
   // FEType object to be passed to various FEInterface functions below.
-  FEType fe_type(order, _underlying_fe_family);
+  FEType underlying_fe_type(order, _underlying_fe_family);
 
-  const unsigned int n_sf =
-    FEInterface::n_shape_functions(fe_type, extra_order, elem);
-
-  const unsigned int n_nodes = elem->n_nodes();
-  libmesh_assert_equal_to (n_sf, n_nodes);
-
-  std::vector<Real> node_weights(n_nodes);
-
-  const unsigned char datum_index = elem->mapping_data();
-  for (unsigned int n=0; n<n_nodes; n++)
-    node_weights[n] =
-      elem->node_ref(n).get_extra_datum<Real>(datum_index);
-
-  Real weighted_shape_i = 0, weighted_sum = 0,
-       weighted_grada_i = 0, weighted_grada_sum = 0,
-       weighted_gradb_i = 0, weighted_gradb_sum = 0,
-       weighted_hess_i = 0, weighted_hess_sum = 0;
-
-  for (unsigned int sf=0; sf<n_sf; sf++)
-    {
-      Real weighted_shape = node_weights[sf] *
-        FEInterface::shape(fe_type, extra_order, elem, sf, p);
-      Real weighted_grada = node_weights[sf] *
-        FEInterface::shape_deriv(fe_type, extra_order, elem, sf, j1, p);
-      Real weighted_hess = node_weights[sf] *
-        FEInterface::shape_second_deriv(fe_type, extra_order, elem, sf, j, p);
-      weighted_sum += weighted_shape;
-      weighted_grada_sum += weighted_grada;
-      Real weighted_gradb = weighted_grada;
-      if (j1 != j2)
-        {
-          weighted_gradb = (j1 == j2) ? weighted_grada :
-            node_weights[sf] *
-            FEInterface::shape_deriv(fe_type, extra_order, elem, sf, j2, p);
-          weighted_grada_sum += weighted_grada;
-        }
-      weighted_hess_sum += weighted_hess;
-      if (sf == i)
-        {
-          weighted_shape_i = weighted_shape;
-          weighted_grada_i = weighted_grada;
-          weighted_gradb_i = weighted_gradb;
-          weighted_hess_i = weighted_hess;
-        }
-    }
-
-  if (j1 == j2)
-    weighted_gradb_sum = weighted_grada_sum;
-
-  return (weighted_sum * weighted_hess_i - weighted_grada_i * weighted_gradb_sum -
-          weighted_shape_i * weighted_hess_sum - weighted_gradb_i * weighted_grada_sum +
-          2 * weighted_grada_sum * weighted_shape_i * weighted_gradb_sum / weighted_sum) /
-         weighted_sum / weighted_sum;
+  return rational_fe_shape_second_deriv(*elem, underlying_fe_type, i,
+                                        j, p, add_p_level);
 }
 
 

--- a/src/fe/fe_rational_shape_2D.C
+++ b/src/fe/fe_rational_shape_2D.C
@@ -67,6 +67,7 @@ void weighted_shapes(const Elem * elem,
 } // anonymous namespace
 
 
+
 namespace libMesh
 {
 
@@ -339,8 +340,6 @@ Real FE<2,RATIONAL_BERNSTEIN>::shape_second_deriv(const FEType fet,
 #endif
 
 
-// LIBMESH_DEFAULT_VECTORIZED_FE(2, RATIONAL_BERNSTEIN)
-
 template<>
 void FE<2,RATIONAL_BERNSTEIN>::shapes
   (const Elem * elem,
@@ -350,7 +349,6 @@ void FE<2,RATIONAL_BERNSTEIN>::shapes
    std::vector<OutputShape> & vi,
    const bool add_p_level)
 {
-//  FE<2,RATIONAL_BERNSTEIN>::default_shapes(elem,o,i,p,vi,add_p_level);
   libmesh_assert_equal_to(p.size(), vi.size());
   for (auto j : index_range(vi))
     vi[j] = FE<2,RATIONAL_BERNSTEIN>::shape (elem, o, i, p[j], add_p_level);

--- a/src/fe/fe_rational_shape_2D.C
+++ b/src/fe/fe_rational_shape_2D.C
@@ -45,10 +45,12 @@ Real FE<2,RATIONAL_BERNSTEIN>::shape(const Elem * elem,
                                      const Point & p,
                                      const bool add_p_level)
 {
+  libmesh_assert(elem);
+
   // FEType object for the non-rational basis underlying this one
   FEType fe_type(order, _underlying_fe_family);
 
-  return rational_fe_shape(elem, fe_type, i, p, add_p_level);
+  return rational_fe_shape(*elem, fe_type, i, p, add_p_level);
 }
 
 

--- a/src/fe/fe_rational_shape_2D.C
+++ b/src/fe/fe_rational_shape_2D.C
@@ -89,44 +89,10 @@ Real FE<2,RATIONAL_BERNSTEIN>::shape_deriv(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  int extra_order = add_p_level * elem->p_level();
+  FEType underlying_fe_type(order, _underlying_fe_family);
 
-  // FEType object to be passed to various FEInterface functions below.
-  FEType fe_type(order, _underlying_fe_family);
-
-  const unsigned int n_sf =
-    FEInterface::n_shape_functions(fe_type, extra_order, elem);
-
-  const unsigned int n_nodes = elem->n_nodes();
-  libmesh_assert_equal_to (n_sf, n_nodes);
-
-  std::vector<Real> node_weights(n_nodes);
-
-  const unsigned char datum_index = elem->mapping_data();
-  for (unsigned int n=0; n<n_nodes; n++)
-    node_weights[n] =
-      elem->node_ref(n).get_extra_datum<Real>(datum_index);
-
-  Real weighted_shape_i = 0, weighted_sum = 0,
-       weighted_grad_i = 0, weighted_grad_sum = 0;
-
-  for (unsigned int sf=0; sf<n_sf; sf++)
-    {
-      Real weighted_shape = node_weights[sf] *
-        FEInterface::shape(fe_type, extra_order, elem, sf, p);
-      Real weighted_grad = node_weights[sf] *
-        FEInterface::shape_deriv(fe_type, extra_order, elem, sf, j, p);
-      weighted_sum += weighted_shape;
-      weighted_grad_sum += weighted_grad;
-      if (sf == i)
-        {
-          weighted_shape_i = weighted_shape;
-          weighted_grad_i = weighted_grad;
-        }
-    }
-
-  return (weighted_sum * weighted_grad_i - weighted_shape_i * weighted_grad_sum) /
-         weighted_sum / weighted_sum;
+  return rational_fe_shape_deriv(*elem, underlying_fe_type, i, j, p,
+                                 add_p_level);
 }
 
 

--- a/src/fe/fe_rational_shape_2D.C
+++ b/src/fe/fe_rational_shape_2D.C
@@ -26,15 +26,49 @@
 
 
 namespace {
-static const libMesh::FEFamily _underlying_fe_family = libMesh::BERNSTEIN;
+using namespace libMesh;
+
+static const FEFamily _underlying_fe_family = BERNSTEIN;
+
+// shapes[i][j] is shape function phi_i at point p[j]
+void weighted_shapes(const Elem * elem,
+                     FEType fe_type,
+                     std::vector<std::vector<Real>> & shapes,
+                     const std::vector<Point> & p,
+                     const bool add_p_level)
+{
+  const int extra_order = add_p_level * elem->p_level();
+
+  const unsigned int n_sf =
+    FEInterface::n_shape_functions(fe_type, extra_order, elem);
+
+  libmesh_assert_equal_to (n_sf, elem->n_nodes());
+
+  std::vector<Real> node_weights(n_sf);
+
+  const unsigned char datum_index = elem->mapping_data();
+  for (unsigned int n=0; n<n_sf; n++)
+    node_weights[n] =
+      elem->node_ref(n).get_extra_datum<Real>(datum_index);
+
+  const std::size_t n_p = p.size();
+
+  shapes.resize(n_sf);
+  for (unsigned int i=0; i != n_sf; ++i)
+    {
+      auto & shapes_i = shapes[i];
+      shapes_i.resize(n_p, 0);
+      FEInterface::shapes(2, fe_type, elem, i, p, shapes_i, add_p_level);
+      for (auto & s : shapes_i)
+        s *= node_weights[i];
+    }
 }
+
+} // anonymous namespace
 
 
 namespace libMesh
 {
-
-
-LIBMESH_DEFAULT_VECTORIZED_FE(2,RATIONAL_BERNSTEIN)
 
 
 template <>
@@ -303,6 +337,80 @@ Real FE<2,RATIONAL_BERNSTEIN>::shape_second_deriv(const FEType fet,
 
 
 #endif
+
+
+// LIBMESH_DEFAULT_VECTORIZED_FE(2, RATIONAL_BERNSTEIN)
+
+template<>
+void FE<2,RATIONAL_BERNSTEIN>::shapes
+  (const Elem * elem,
+   const Order o,
+   const unsigned int i,
+   const std::vector<Point> & p,
+   std::vector<OutputShape> & vi,
+   const bool add_p_level)
+{
+//  FE<2,RATIONAL_BERNSTEIN>::default_shapes(elem,o,i,p,vi,add_p_level);
+  libmesh_assert_equal_to(p.size(), vi.size());
+  for (auto j : index_range(vi))
+    vi[j] = FE<2,RATIONAL_BERNSTEIN>::shape (elem, o, i, p[j], add_p_level);
+}
+
+template<>
+void FE<2,RATIONAL_BERNSTEIN>::all_shapes
+  (const Elem * elem,
+   const Order o,
+   const std::vector<Point> & p,
+   std::vector<std::vector<OutputShape>> & v,
+   const bool add_p_level)
+{
+  std::vector<std::vector<Real>> shapes;
+
+  FEType fe_type(o, _underlying_fe_family);
+
+  weighted_shapes(elem, fe_type, shapes, p, add_p_level);
+
+  std::vector<Real> shape_sums(p.size(), 0);
+
+  for (auto i : index_range(v))
+    {
+      libmesh_assert_equal_to ( p.size(), shapes[i].size() );
+      for (auto j : index_range(p))
+        shape_sums[j] += shapes[i][j];
+    }
+
+  for (auto i : index_range(v))
+    {
+      libmesh_assert_equal_to ( p.size(), v[i].size() );
+      for (auto j : index_range(v[i]))
+        {
+          v[i][j] = shapes[i][j] / shape_sums[j];
+
+#ifdef DEBUG
+          Real old_shape = FE<2,RATIONAL_BERNSTEIN>::shape (elem, o, i, p[j], add_p_level);
+          libmesh_assert(std::abs(v[i][j] - old_shape) < TOLERANCE*TOLERANCE);
+#endif
+        }
+    }
+}
+
+
+template<>
+void FE<2,RATIONAL_BERNSTEIN>::shape_derivs
+  (const Elem * elem,
+   const Order o,
+   const unsigned int i,
+   const unsigned int j,
+   const std::vector<Point> & p,
+   std::vector<OutputShape> & v,
+   const bool add_p_level)
+{
+  libmesh_assert_equal_to(p.size(), v.size());
+  for (auto vi : index_range(v))
+    v[vi] = FE<2,RATIONAL_BERNSTEIN>::shape_deriv (elem, o, i, j, p[vi], add_p_level);
+}
+
+
 
 } // namespace libMesh
 

--- a/src/fe/fe_rational_shape_2D.C
+++ b/src/fe/fe_rational_shape_2D.C
@@ -45,38 +45,10 @@ Real FE<2,RATIONAL_BERNSTEIN>::shape(const Elem * elem,
                                      const Point & p,
                                      const bool add_p_level)
 {
-  libmesh_assert(elem);
-
-  int extra_order = add_p_level * elem->p_level();
-
-  // FEType object to be passed to various FEInterface functions below.
+  // FEType object for the non-rational basis underlying this one
   FEType fe_type(order, _underlying_fe_family);
 
-  const unsigned int n_sf =
-    FEInterface::n_shape_functions(fe_type, extra_order, elem);
-
-  const unsigned int n_nodes = elem->n_nodes();
-  libmesh_assert_equal_to (n_sf, n_nodes);
-
-  std::vector<Real> node_weights(n_nodes);
-
-  const unsigned char datum_index = elem->mapping_data();
-  for (unsigned int n=0; n<n_nodes; n++)
-    node_weights[n] =
-      elem->node_ref(n).get_extra_datum<Real>(datum_index);
-
-  Real weighted_shape_i = 0, weighted_sum = 0;
-
-  for (unsigned int sf=0; sf<n_sf; sf++)
-    {
-      Real weighted_shape = node_weights[sf] *
-        FEInterface::shape(fe_type, extra_order, elem, sf, p);
-      weighted_sum += weighted_shape;
-      if (sf == i)
-        weighted_shape_i = weighted_shape;
-    }
-
-  return weighted_shape_i / weighted_sum;
+  return rational_fe_shape(elem, fe_type, i, p, add_p_level);
 }
 
 

--- a/src/fe/fe_rational_shape_2D.C
+++ b/src/fe/fe_rational_shape_2D.C
@@ -195,34 +195,9 @@ void FE<2,RATIONAL_BERNSTEIN>::all_shapes
    std::vector<std::vector<OutputShape>> & v,
    const bool add_p_level)
 {
-  std::vector<std::vector<Real>> shapes;
+  FEType underlying_fe_type(o, _underlying_fe_family);
 
-  FEType fe_type(o, _underlying_fe_family);
-
-  rational_fe_weighted_shapes(elem, fe_type, shapes, p, add_p_level);
-
-  std::vector<Real> shape_sums(p.size(), 0);
-
-  for (auto i : index_range(v))
-    {
-      libmesh_assert_equal_to ( p.size(), shapes[i].size() );
-      for (auto j : index_range(p))
-        shape_sums[j] += shapes[i][j];
-    }
-
-  for (auto i : index_range(v))
-    {
-      libmesh_assert_equal_to ( p.size(), v[i].size() );
-      for (auto j : index_range(v[i]))
-        {
-          v[i][j] = shapes[i][j] / shape_sums[j];
-
-#ifdef DEBUG
-          Real old_shape = FE<2,RATIONAL_BERNSTEIN>::shape (elem, o, i, p[j], add_p_level);
-          libmesh_assert(std::abs(v[i][j] - old_shape) < TOLERANCE*TOLERANCE);
-#endif
-        }
-    }
+  rational_all_shapes(*elem, underlying_fe_type, p, v, add_p_level);
 }
 
 

--- a/src/fe/fe_rational_shape_2D.C
+++ b/src/fe/fe_rational_shape_2D.C
@@ -224,16 +224,13 @@ FE<2,RATIONAL_BERNSTEIN>::all_shape_derivs (const Elem * elem,
                                             const std::vector<Point> & p,
                                             const bool add_p_level)
 {
-  std::vector<std::vector<OutputShape>> * comps[3]
+  FEType underlying_fe_type(o, _underlying_fe_family);
+
+  std::vector<std::vector<Real>> * comps[3]
     { &this->dphidxi, &this->dphideta, &this->dphidzeta };
-  for (unsigned int d=0; d != 2; ++d)
-    {
-      libmesh_assert_equal_to(comps[d]->size(), elem->n_nodes());
-      auto & comps_d = *comps[d];
-      for (auto i : index_range(comps_d))
-        FE<2,RATIONAL_BERNSTEIN>::shape_derivs
-          (elem,o,i,d,p,comps_d[i],add_p_level);
-    }
+
+  rational_all_shape_derivs (*elem, underlying_fe_type, p,
+                             comps, add_p_level);
 }
 
 

--- a/src/fe/fe_rational_shape_3D.C
+++ b/src/fe/fe_rational_shape_3D.C
@@ -246,35 +246,9 @@ void FE<3,RATIONAL_BERNSTEIN>::all_shapes
    std::vector<std::vector<OutputShape>> & v,
    const bool add_p_level)
 {
-  std::vector<std::vector<Real>> shapes;
-
   FEType underlying_fe_type(o, _underlying_fe_family);
 
-  rational_fe_weighted_shapes(elem, underlying_fe_type, shapes, p,
-                              add_p_level);
-
-  std::vector<Real> shape_sums(p.size(), 0);
-
-  for (auto i : index_range(v))
-    {
-      libmesh_assert_equal_to ( p.size(), shapes[i].size() );
-      for (auto j : index_range(p))
-        shape_sums[j] += shapes[i][j];
-    }
-
-  for (auto i : index_range(v))
-    {
-      libmesh_assert_equal_to ( p.size(), v[i].size() );
-      for (auto j : index_range(v[i]))
-        {
-          v[i][j] = shapes[i][j] / shape_sums[j];
-
-#ifdef DEBUG
-          Real old_shape = FE<3,RATIONAL_BERNSTEIN>::shape (elem, o, i, p[j], add_p_level);
-          libmesh_assert(std::abs(v[i][j] - old_shape) < TOLERANCE*TOLERANCE);
-#endif
-        }
-    }
+  rational_all_shapes(*elem, underlying_fe_type, p, v, add_p_level);
 }
 
 

--- a/src/fe/fe_rational_shape_3D.C
+++ b/src/fe/fe_rational_shape_3D.C
@@ -30,40 +30,6 @@ using namespace libMesh;
 
 static const FEFamily _underlying_fe_family = BERNSTEIN;
 
-// shapes[i][q] is shape function phi_i at point p[q]
-void weighted_shapes(const Elem * elem,
-                     FEType fe_type,
-                     std::vector<std::vector<Real>> & shapes,
-                     const std::vector<Point> & p,
-                     const bool add_p_level)
-{
-  const int extra_order = add_p_level * elem->p_level();
-
-  const unsigned int n_sf =
-    FEInterface::n_shape_functions(fe_type, extra_order, elem);
-
-  libmesh_assert_equal_to (n_sf, elem->n_nodes());
-
-  std::vector<Real> node_weights(n_sf);
-
-  const unsigned char datum_index = elem->mapping_data();
-  for (unsigned int n=0; n<n_sf; n++)
-    node_weights[n] =
-      elem->node_ref(n).get_extra_datum<Real>(datum_index);
-
-  const std::size_t n_p = p.size();
-
-  shapes.resize(n_sf);
-  for (unsigned int i=0; i != n_sf; ++i)
-    {
-      auto & shapes_i = shapes[i];
-      shapes_i.resize(n_p, 0);
-      FEInterface::shapes(3, fe_type, elem, i, p, shapes_i, add_p_level);
-      for (auto & s : shapes_i)
-        s *= node_weights[i];
-    }
-}
-
 
 // shapes[i][q] is shape function phi_i at point p[q]
 // derivs[j][i][q] is dphi_i/dxi_j at p[q]
@@ -431,7 +397,8 @@ void FE<3,RATIONAL_BERNSTEIN>::all_shapes
 
   FEType underlying_fe_type(o, _underlying_fe_family);
 
-  weighted_shapes(elem, underlying_fe_type, shapes, p, add_p_level);
+  rational_fe_weighted_shapes(elem, underlying_fe_type, shapes, p,
+                              add_p_level);
 
   std::vector<Real> shape_sums(p.size(), 0);
 

--- a/src/fe/fe_rational_shape_3D.C
+++ b/src/fe/fe_rational_shape_3D.C
@@ -185,100 +185,13 @@ Real FE<3,RATIONAL_BERNSTEIN>::shape_second_deriv(const Elem * elem,
                                                   const Point & p,
                                                   const bool add_p_level)
 {
-  unsigned int j1, j2;
-  switch (j)
-    {
-    case 0:
-      // j = 0 ==> d^2 phi / dxi^2
-      j1 = j2 = 0;
-      break;
-    case 1:
-      // j = 1 ==> d^2 phi / dxi deta
-      j1 = 0;
-      j2 = 1;
-      break;
-    case 2:
-      // j = 2 ==> d^2 phi / deta^2
-      j1 = j2 = 1;
-      break;
-    case 3:
-      // j = 3 ==> d^2 phi / dxi dzeta
-      j1 = 0;
-      j2 = 2;
-      break;
-    case 4:
-      // j = 4 ==> d^2 phi / deta dzeta
-      j1 = 1;
-      j2 = 2;
-      break;
-    case 5:
-      // j = 5 ==> d^2 phi / dzeta^2
-      j1 = j2 = 2;
-      break;
-    default:
-      libmesh_error();
-    }
-
   libmesh_assert(elem);
 
-  int extra_order = add_p_level * elem->p_level();
-
   // FEType object to be passed to various FEInterface functions below.
-  FEType fe_type(order, _underlying_fe_family);
+  FEType underlying_fe_type(order, _underlying_fe_family);
 
-  const unsigned int n_sf =
-    FEInterface::n_shape_functions(fe_type, extra_order, elem);
-
-  const unsigned int n_nodes = elem->n_nodes();
-  libmesh_assert_equal_to (n_sf, n_nodes);
-
-  std::vector<Real> node_weights(n_nodes);
-
-  const unsigned char datum_index = elem->mapping_data();
-  for (unsigned int n=0; n<n_nodes; n++)
-    node_weights[n] =
-      elem->node_ref(n).get_extra_datum<Real>(datum_index);
-
-  Real weighted_shape_i = 0, weighted_sum = 0,
-       weighted_grada_i = 0, weighted_grada_sum = 0,
-       weighted_gradb_i = 0, weighted_gradb_sum = 0,
-       weighted_hess_i = 0, weighted_hess_sum = 0;
-
-  for (unsigned int sf=0; sf<n_sf; sf++)
-    {
-      Real weighted_shape = node_weights[sf] *
-        FEInterface::shape(fe_type, extra_order, elem, sf, p);
-      Real weighted_grada = node_weights[sf] *
-        FEInterface::shape_deriv(fe_type, extra_order, elem, sf, j1, p);
-      Real weighted_hess = node_weights[sf] *
-        FEInterface::shape_second_deriv(fe_type, extra_order, elem, sf, j, p);
-      weighted_sum += weighted_shape;
-      weighted_grada_sum += weighted_grada;
-      Real weighted_gradb = weighted_grada;
-      if (j1 != j2)
-        {
-          weighted_gradb = (j1 == j2) ? weighted_grada :
-            node_weights[sf] *
-            FEInterface::shape_deriv(fe_type, extra_order, elem, sf, j2, p);
-          weighted_grada_sum += weighted_grada;
-        }
-      weighted_hess_sum += weighted_hess;
-      if (sf == i)
-        {
-          weighted_shape_i = weighted_shape;
-          weighted_grada_i = weighted_grada;
-          weighted_gradb_i = weighted_gradb;
-          weighted_hess_i = weighted_hess;
-        }
-    }
-
-  if (j1 == j2)
-    weighted_gradb_sum = weighted_grada_sum;
-
-  return (weighted_sum * weighted_hess_i - weighted_grada_i * weighted_gradb_sum -
-          weighted_shape_i * weighted_hess_sum - weighted_gradb_i * weighted_grada_sum +
-          2 * weighted_grada_sum * weighted_shape_i * weighted_gradb_sum / weighted_sum) /
-         weighted_sum / weighted_sum;
+  return rational_fe_shape_second_deriv(*elem, underlying_fe_type, i,
+                                        j, p, add_p_level);
 }
 
 

--- a/src/fe/fe_rational_shape_3D.C
+++ b/src/fe/fe_rational_shape_3D.C
@@ -100,10 +100,12 @@ Real FE<3,RATIONAL_BERNSTEIN>::shape(const Elem * elem,
                                      const Point & p,
                                      const bool add_p_level)
 {
+  libmesh_assert(elem);
+
   // FEType object for the non-rational basis underlying this one
   FEType fe_type(order, _underlying_fe_family);
 
-  return rational_fe_shape(elem, fe_type, i, p, add_p_level);
+  return rational_fe_shape(*elem, fe_type, i, p, add_p_level);
 }
 
 

--- a/src/fe/fe_rational_shape_3D.C
+++ b/src/fe/fe_rational_shape_3D.C
@@ -30,61 +30,6 @@ using namespace libMesh;
 
 static const FEFamily _underlying_fe_family = BERNSTEIN;
 
-
-// shapes[i][q] is shape function phi_i at point p[q]
-// derivs[j][i][q] is dphi_i/dxi_j at p[q]
-void weighted_shapes_derivs(const Elem * elem,
-                            FEType fe_type,
-                            std::vector<std::vector<Real>> & shapes,
-                            std::vector<std::vector<std::vector<Real>>> & derivs,
-                            const std::vector<Point> & p,
-                            const bool add_p_level)
-{
-  const int extra_order = add_p_level * elem->p_level();
-  constexpr int dim = 3;
-
-  const unsigned int n_sf =
-    FEInterface::n_shape_functions(fe_type, extra_order, elem);
-
-  libmesh_assert_equal_to (n_sf, elem->n_nodes());
-
-  libmesh_assert_equal_to (dim, derivs.size());
-  for (unsigned int d = 0; d != dim; ++d)
-    derivs[d].resize(n_sf);
-
-  std::vector<Real> node_weights(n_sf);
-
-  const unsigned char datum_index = elem->mapping_data();
-  for (unsigned int n=0; n<n_sf; n++)
-    node_weights[n] =
-      elem->node_ref(n).get_extra_datum<Real>(datum_index);
-
-  const std::size_t n_p = p.size();
-
-  shapes.resize(n_sf);
-  for (unsigned int i=0; i != n_sf; ++i)
-    {
-      auto & shapes_i = shapes[i];
-
-      shapes_i.resize(n_p, 0);
-
-      FEInterface::shapes(dim, fe_type, elem, i, p, shapes_i, add_p_level);
-      for (auto & s : shapes_i)
-        s *= node_weights[i];
-
-      for (unsigned int d = 0; d != dim; ++d)
-        {
-          auto & derivs_di = derivs[d][i];
-          derivs_di.resize(n_p);
-          FEInterface::shape_derivs(fe_type, elem, i, d, p,
-                                    derivs_di, add_p_level);
-          for (auto & dip : derivs_di)
-            dip *= node_weights[i];
-        }
-    }
-}
-
-
 } // anonymous namespace
 
 
@@ -275,57 +220,13 @@ FE<3,RATIONAL_BERNSTEIN>::all_shape_derivs (const Elem * elem,
                                             const std::vector<Point> & p,
                                             const bool add_p_level)
 {
-  constexpr int my_dim = 3;
-
-  std::vector<std::vector<Real>> shapes;
-  std::vector<std::vector<std::vector<Real>>> derivs(my_dim);
   FEType underlying_fe_type(o, _underlying_fe_family);
 
-  weighted_shapes_derivs(elem, underlying_fe_type, shapes, derivs, p,
-                         add_p_level);
-
-  std::vector<Real> shape_sums(p.size(), 0);
-  std::vector<std::vector<Real>> shape_deriv_sums(my_dim);
-  for (int d=0; d != my_dim; ++d)
-    shape_deriv_sums[d].resize(p.size());
-
-  for (auto i : index_range(shapes))
-    {
-      libmesh_assert_equal_to ( p.size(), shapes[i].size() );
-      for (auto j : index_range(p))
-        shape_sums[j] += shapes[i][j];
-
-      for (int d=0; d != my_dim; ++d)
-        for (auto j : index_range(p))
-          shape_deriv_sums[d][j] += derivs[d][i][j];
-    }
-
-
-  std::vector<std::vector<OutputShape>> * comps[my_dim]
+  std::vector<std::vector<Real>> * comps[3]
     { &this->dphidxi, &this->dphideta, &this->dphidzeta };
-  for (unsigned int d=0; d != my_dim; ++d)
-    {
-      auto & comps_d = *comps[d];
-      libmesh_assert_equal_to(comps_d.size(), elem->n_nodes());
 
-      for (auto i : index_range(comps_d))
-        {
-          auto & comps_di = comps_d[i];
-          auto & derivs_di = derivs[d][i];
-
-          for (auto j : index_range(comps_di))
-            {
-              comps_di[j] = (shape_sums[j] * derivs_di[j] -
-                shapes[i][j] * shape_deriv_sums[d][j]) /
-                shape_sums[j] / shape_sums[j];
-
-#ifdef DEBUG
-              Real old_deriv = FE<3,RATIONAL_BERNSTEIN>::shape_deriv (elem, o, i, d, p[j], add_p_level);
-              libmesh_assert(std::abs(comps_di[j] - old_deriv) < TOLERANCE*TOLERANCE);
-#endif
-            }
-        }
-    }
+  rational_all_shape_derivs (*elem, underlying_fe_type, p,
+                             comps, add_p_level);
 }
 
 

--- a/src/fe/fe_rational_shape_3D.C
+++ b/src/fe/fe_rational_shape_3D.C
@@ -142,44 +142,10 @@ Real FE<3,RATIONAL_BERNSTEIN>::shape_deriv(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  int extra_order = add_p_level * elem->p_level();
+  FEType underlying_fe_type(order, _underlying_fe_family);
 
-  // FEType object to be passed to various FEInterface functions below.
-  FEType fe_type(order, _underlying_fe_family);
-
-  const unsigned int n_sf =
-    FEInterface::n_shape_functions(fe_type, extra_order, elem);
-
-  const unsigned int n_nodes = elem->n_nodes();
-  libmesh_assert_equal_to (n_sf, n_nodes);
-
-  std::vector<Real> node_weights(n_nodes);
-
-  const unsigned char datum_index = elem->mapping_data();
-  for (unsigned int n=0; n<n_nodes; n++)
-    node_weights[n] =
-      elem->node_ref(n).get_extra_datum<Real>(datum_index);
-
-  Real weighted_shape_i = 0, weighted_sum = 0,
-       weighted_grad_i = 0, weighted_grad_sum = 0;
-
-  for (unsigned int sf=0; sf<n_sf; sf++)
-    {
-      Real weighted_shape = node_weights[sf] *
-        FEInterface::shape(fe_type, extra_order, elem, sf, p);
-      Real weighted_grad = node_weights[sf] *
-        FEInterface::shape_deriv(fe_type, extra_order, elem, sf, j, p);
-      weighted_sum += weighted_shape;
-      weighted_grad_sum += weighted_grad;
-      if (sf == i)
-        {
-          weighted_shape_i = weighted_shape;
-          weighted_grad_i = weighted_grad;
-        }
-    }
-
-  return (weighted_sum * weighted_grad_i - weighted_shape_i * weighted_grad_sum) /
-         weighted_sum / weighted_sum;
+  return rational_fe_shape_deriv(*elem, underlying_fe_type, i, j, p,
+                                 add_p_level);
 }
 
 

--- a/src/fe/fe_rational_shape_3D.C
+++ b/src/fe/fe_rational_shape_3D.C
@@ -100,38 +100,10 @@ Real FE<3,RATIONAL_BERNSTEIN>::shape(const Elem * elem,
                                      const Point & p,
                                      const bool add_p_level)
 {
-  libmesh_assert(elem);
-
-  int extra_order = add_p_level * elem->p_level();
-
-  // FEType object to be passed to various FEInterface functions below.
+  // FEType object for the non-rational basis underlying this one
   FEType fe_type(order, _underlying_fe_family);
 
-  const unsigned int n_sf =
-    FEInterface::n_shape_functions(fe_type, extra_order, elem);
-
-  const unsigned int n_nodes = elem->n_nodes();
-  libmesh_assert_equal_to (n_sf, n_nodes);
-
-  std::vector<Real> node_weights(n_nodes);
-
-  const unsigned char datum_index = elem->mapping_data();
-  for (unsigned int n=0; n<n_nodes; n++)
-    node_weights[n] =
-      elem->node_ref(n).get_extra_datum<Real>(datum_index);
-
-  Real weighted_shape_i = 0, weighted_sum = 0;
-
-  for (unsigned int sf=0; sf<n_sf; sf++)
-    {
-      Real weighted_shape = node_weights[sf] *
-        FEInterface::shape(fe_type, extra_order, elem, sf, p);
-      weighted_sum += weighted_shape;
-      if (sf == i)
-        weighted_shape_i = weighted_shape;
-    }
-
-  return weighted_shape_i / weighted_sum;
+  return rational_fe_shape(elem, fe_type, i, p, add_p_level);
 }
 
 

--- a/src/fe/fe_rational_shape_3D.C
+++ b/src/fe/fe_rational_shape_3D.C
@@ -26,15 +26,50 @@
 
 
 namespace {
-static const libMesh::FEFamily _underlying_fe_family = libMesh::BERNSTEIN;
+using namespace libMesh;
+
+static const FEFamily _underlying_fe_family = BERNSTEIN;
+
+// shapes[i][j] is shape function phi_i at point p[j]
+void weighted_shapes(const Elem * elem,
+                     FEType fe_type,
+                     std::vector<std::vector<Real>> & shapes,
+                     const std::vector<Point> & p,
+                     const bool add_p_level)
+{
+  const int extra_order = add_p_level * elem->p_level();
+
+  const unsigned int n_sf =
+    FEInterface::n_shape_functions(fe_type, extra_order, elem);
+
+  libmesh_assert_equal_to (n_sf, elem->n_nodes());
+
+  std::vector<Real> node_weights(n_sf);
+
+  const unsigned char datum_index = elem->mapping_data();
+  for (unsigned int n=0; n<n_sf; n++)
+    node_weights[n] =
+      elem->node_ref(n).get_extra_datum<Real>(datum_index);
+
+  const std::size_t n_p = p.size();
+
+  shapes.resize(n_sf);
+  for (unsigned int i=0; i != n_sf; ++i)
+    {
+      auto & shapes_i = shapes[i];
+      shapes_i.resize(n_p, 0);
+      FEInterface::shapes(3, fe_type, elem, i, p, shapes_i, add_p_level);
+      for (auto & s : shapes_i)
+        s *= node_weights[i];
+    }
 }
+
+} // anonymous namespace
+
 
 
 namespace libMesh
 {
-
-
-LIBMESH_DEFAULT_VECTORIZED_FE(3,RATIONAL_BERNSTEIN)
 
 
 template <>
@@ -312,8 +347,80 @@ Real FE<3,RATIONAL_BERNSTEIN>::shape_second_deriv(const FEType fet,
 }
 
 
-
 #endif
+
+
+template<>
+void FE<3,RATIONAL_BERNSTEIN>::shapes
+  (const Elem * elem,
+   const Order o,
+   const unsigned int i,
+   const std::vector<Point> & p,
+   std::vector<OutputShape> & vi,
+   const bool add_p_level)
+{
+  libmesh_assert_equal_to(p.size(), vi.size());
+  for (auto j : index_range(vi))
+    vi[j] = FE<3,RATIONAL_BERNSTEIN>::shape (elem, o, i, p[j], add_p_level);
+}
+
+template<>
+void FE<3,RATIONAL_BERNSTEIN>::all_shapes
+  (const Elem * elem,
+   const Order o,
+   const std::vector<Point> & p,
+   std::vector<std::vector<OutputShape>> & v,
+   const bool add_p_level)
+{
+  std::vector<std::vector<Real>> shapes;
+
+  FEType fe_type(o, _underlying_fe_family);
+
+  weighted_shapes(elem, fe_type, shapes, p, add_p_level);
+
+  std::vector<Real> shape_sums(p.size(), 0);
+
+  for (auto i : index_range(v))
+    {
+      libmesh_assert_equal_to ( p.size(), shapes[i].size() );
+      for (auto j : index_range(p))
+        shape_sums[j] += shapes[i][j];
+    }
+
+  for (auto i : index_range(v))
+    {
+      libmesh_assert_equal_to ( p.size(), v[i].size() );
+      for (auto j : index_range(v[i]))
+        {
+          v[i][j] = shapes[i][j] / shape_sums[j];
+
+#ifdef DEBUG
+          Real old_shape = FE<3,RATIONAL_BERNSTEIN>::shape (elem, o, i, p[j], add_p_level);
+          libmesh_assert(std::abs(v[i][j] - old_shape) < TOLERANCE*TOLERANCE);
+#endif
+        }
+    }
+}
+
+
+template<>
+void FE<3,RATIONAL_BERNSTEIN>::shape_derivs
+  (const Elem * elem,
+   const Order o,
+   const unsigned int i,
+   const unsigned int j,
+   const std::vector<Point> & p,
+   std::vector<OutputShape> & v,
+   const bool add_p_level)
+{
+  libmesh_assert_equal_to(p.size(), v.size());
+  for (auto vi : index_range(v))
+    v[vi] = FE<3,RATIONAL_BERNSTEIN>::shape_deriv (elem, o, i, j, p[vi], add_p_level);
+}
+
+
+
+
 
 } // namespace libMesh
 

--- a/src/fe/fe_rational_shape_3D.C
+++ b/src/fe/fe_rational_shape_3D.C
@@ -419,7 +419,24 @@ void FE<3,RATIONAL_BERNSTEIN>::shape_derivs
 }
 
 
-
+template <>
+void
+FE<3,RATIONAL_BERNSTEIN>::all_shape_derivs (const Elem * elem,
+                                            const Order o,
+                                            const std::vector<Point> & p,
+                                            const bool add_p_level)
+{
+  std::vector<std::vector<OutputShape>> * comps[3]
+    { &this->dphidxi, &this->dphideta, &this->dphidzeta };
+  for (unsigned int d=0; d != 3; ++d)
+    {
+      libmesh_assert_equal_to(comps[d]->size(), elem->n_nodes());
+      auto & comps_d = *comps[d];
+      for (auto i : index_range(comps_d))
+        FE<3,RATIONAL_BERNSTEIN>::shape_derivs
+          (elem,o,i,d,p,comps_d[i],add_p_level);
+    }
+}
 
 
 } // namespace libMesh


### PR DESCRIPTION
This shaves 30% or 40% off a typical 3D IGA simulation for me, and although I don't think our other FE types have any such low-hanging fruit, a couple of the newly refactored APIs here might eventually also let us shave a few more FLOPs from anything like LAGRANGE that we might especially want to optimize further.