### PR TITLE
Fix unistd.h issues when building with MS VC

### DIFF
--- a/examples/adjoints/adjoints_ex3/output.C
+++ b/examples/adjoints/adjoints_ex3/output.C
@@ -1,7 +1,10 @@
 #include <fstream>
-#include <unistd.h>
 
 #include "libmesh/libmesh_common.h"
+
+#ifdef LIBMESH_HAVE_UNISTD_H
+#include <unistd.h> // needed for truncate()
+#endif
 
 #include "output.h"
 

--- a/examples/fem_system/fem_system_ex2/fem_system_ex2.C
+++ b/examples/fem_system/fem_system_ex2/fem_system_ex2.C
@@ -41,7 +41,6 @@
 #include <iostream>
 #include <sstream>
 #include <string>
-#include <unistd.h>
 
 using namespace libMesh;
 

--- a/src/apps/meshtool.C
+++ b/src/apps/meshtool.C
@@ -26,7 +26,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <string>
-#include <unistd.h>
 #include <vector>
 
 // Local Includes

--- a/src/base/print_trace.C
+++ b/src/base/print_trace.C
@@ -46,7 +46,9 @@
 #include "libmesh/print_trace.h"
 #include "libmesh/libmesh.h"
 
+#ifdef LIBMESH_HAVE_UNISTD_H
 #include <unistd.h>  // needed for getpid()
+#endif
 #include <fstream>
 #include <sstream>
 #include <string>

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -39,7 +39,6 @@
 #include <iostream>
 #include <iomanip>
 #include <cstdio>
-#include <unistd.h>
 #include <vector>
 #include <string>
 #include <cstring>

--- a/src/mesh/namebased_io.C
+++ b/src/mesh/namebased_io.C
@@ -46,8 +46,10 @@
 #include <iomanip>
 #include <fstream>
 #include <vector>
-#include <sys/types.h> // getpid
-#include <unistd.h>
+#ifdef LIBMESH_HAVE_UNISTD_H
+#include <sys/types.h>
+#include <unistd.h>  // for getpid()
+#endif
 
 
 namespace libMesh

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -38,10 +38,6 @@
 #include <iomanip>
 #include <unordered_map>
 
-// C includes
-#include <sys/types.h> // for pid_t
-#include <unistd.h>    // for getpid(), unlink()
-
 
 namespace {
 

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -31,7 +31,9 @@
 #include "libmesh/wrapped_petsc.h"
 
 // C++ includes
+#ifdef LIBMESH_HAVE_UNISTD_H
 #include <unistd.h> // mkstemp
+#endif
 #include <fstream>
 
 #ifdef LIBMESH_ENABLE_BLOCKED_STORAGE

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -55,7 +55,9 @@
 #include <sstream>
 #include <limits>
 #include <stdlib.h> // mkstemps on Linux
+#ifdef LIBMESH_HAVE_UNISTD_H
 #include <unistd.h> // mkstemps on MacOS
+#endif
 
 namespace libMesh
 {

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -36,7 +36,9 @@
 #include "capnp/serialize.h"
 
 // C++ includes
-#include <unistd.h>
+#ifdef LIBMESH_HAVE_UNISTD_H
+#include <unistd.h> // for close()
+#endif
 #include <iostream>
 #include <fstream>
 #include <fcntl.h>

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -39,7 +39,9 @@
 // C++ includes
 #include <iostream>
 #include <fstream>
-#include <unistd.h>
+#ifdef LIBMESH_HAVE_UNISTD_H
+#include <unistd.h> // for close()
+#endif
 #include <fcntl.h>
 
 namespace libMesh

--- a/src/utils/perf_log.C
+++ b/src/utils/perf_log.C
@@ -27,7 +27,9 @@
 #include <iomanip>
 #include <cstring>
 #include <ctime>
-#include <unistd.h>
+#ifdef LIBMESH_HAVE_UNISTD_H
+#include <unistd.h> // for getuid()
+#endif
 #include <sys/types.h>
 #include <vector>
 #include <sstream>

--- a/src/utils/utility.C
+++ b/src/utils/utility.C
@@ -21,10 +21,15 @@
 #include "libmesh/libmesh_logging.h"
 
 // System includes
-#include <sys/time.h>
+#ifdef LIBMESH_HAVE_SYS_STAT_H
 #include <sys/stat.h>
+#endif
+#ifdef LIBMESH_HAVE_SYS_TYPES_H
 #include <sys/types.h>
-#include <unistd.h>
+#endif
+#ifdef LIBMESH_HAVE_UNISTD_H
+#include <unistd.h> // for getuid(), getpid()
+#endif
 #include <sstream>
 
 #ifdef LIBMESH_HAVE_SYS_UTSNAME_H

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -23,7 +23,9 @@
 #include <sstream>
 #include <fstream>
 
+#ifdef LIBMESH_HAVE_UNISTD_H
 #include <unistd.h> // for getpid()
+#endif
 
 // Local includes
 #include "libmesh/xdr_cxx.h"


### PR DESCRIPTION
- Use LIBMESH_HAVE_UNISTD_H
- Remove unneeded #include's

This fixes the majority of MS VC build issues related to missing unistd.h