### PR TITLE
Fix MS VC 2019 build

### DIFF
--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -193,19 +193,8 @@ void FEMContext::init_internal_data(const System & sys)
   // Reserve space for the FEAbstract and QBase objects for each
   // element dimension possibility (0,1,2,3)
 
-  // Below is a workaround for the ICC 19. The original code was:
-  //
-  // _element_fe.resize(4);
-  // _side_fe.resize(4);
-
-  _element_fe.clear();
-  for (int i=0; i<4; ++i)
-    _element_fe.push_back(std::map<FEType, std::unique_ptr<FEAbstract>>());
-
-  _side_fe.clear();
-  for (int i=0; i<4; ++i)
-    _side_fe.push_back(std::map<FEType, std::unique_ptr<FEAbstract>>());
-
+  _element_fe = std::vector<std::map<FEType, std::unique_ptr<FEAbstract>>>(4);
+  _side_fe = std::vector<std::map<FEType, std::unique_ptr<FEAbstract>>>(4);
   _element_fe_var.resize(4);
   _side_fe_var.resize(4);
 


### PR DESCRIPTION
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\xmemory(714): error C2280: 'std::pair<const libMesh::FEType,std::unique_ptr<libMesh::FEAbstract,std::default_delete<libMesh::FEAbstract>>>::pair(const std::pair<const libMesh::FEType,std::unique_ptr<libMesh::FEAbstract,std::default_delete<libMesh::FEAbstract>>> &)': attempting to reference a deleted function