### PR TITLE
Differentiate tasks for InFEM (InFEM::reinit)

### DIFF
--- a/include/fe/fe_base.h
+++ b/include/fe/fe_base.h
@@ -558,6 +558,7 @@ protected:
    * Determine which values are to be calculated, for both the FE
    * itself and for the FEMap.
    */
+  virtual_for_inffe
   void determine_calculations();
 
   /**

--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -559,19 +559,25 @@ public:
   { libmesh_assert(radial_qrule); return _n_total_qp; }
 
 
-
+  /**
+   * \returns the \p xyz spatial locations of the quadrature
+   * points on the element.
+   */
   virtual const std::vector<Point> & get_xyz () const override
-  { calculate_map = true; return xyz; }
+  { libmesh_assert(!calculations_started || calculate_xyz);
+    calculate_xyz = true; return xyz; }
 
   /**
-   * Please use \p get_JxWxdecay_sq() instead!
-   *
-   * The Jacobian cannot be computed for Infinite elements!
-   *
+   * \returns the Jacobian times quadrature weight.
+   * Due to the divergence with increasing radial distance, this quantity
+   * is numerically unstable.
+   * Thus, it is safer to use \p get_JxWxdecay_sq() instead!
    */
   virtual const std::vector<Real> & get_JxW () const override
   {
-      return this->JxW;
+    libmesh_assert(!calculations_started || calculate_jxw);
+    calculate_jxw = true;
+    return this->JxW;
   }
 
   /**
@@ -583,7 +589,8 @@ public:
    * applied to obtain well-defined quantities.
    */
   virtual const std::vector<Real> & get_JxWxdecay_sq () const override
-  { calculate_map = true; return this->JxWxdecay;}
+  { libmesh_assert(!calculations_started || calculate_map_scaled);
+    calculate_map_scaled = true; return this->JxWxdecay;}
 
 
   /**
@@ -597,8 +604,8 @@ public:
    * (i.e. by using \p get_Sobolev_weightxR_sq())
    **/
   virtual const std::vector<std::vector<OutputShape>> & get_phi_over_decayxR () const override
-  { libmesh_assert(!calculations_started || calculate_phi);
-    calculate_phi = true; return phixr; }
+  { libmesh_assert(!calculations_started || calculate_phi_scaled);
+    calculate_phi_scaled = true; return phixr; }
 
 
   /**
@@ -607,8 +614,8 @@ public:
    * See \p  get_phi_over_decayxR() for details.
    */
   virtual const std::vector<std::vector<OutputGradient>> & get_dphi_over_decayxR () const override
-  { libmesh_assert(!calculations_started || calculate_dphi);
-    calculate_dphi = calculate_dphiref = true; return dphixr; }
+  { libmesh_assert(!calculations_started || calculate_dphi_scaled);
+    calculate_dphi_scaled = true; return dphixr; }
 
 
   /**
@@ -619,8 +626,8 @@ public:
    * when divided by the decay function.
    */
   virtual const std::vector<std::vector<OutputGradient>> & get_dphi_over_decay () const override
-  { libmesh_assert(!calculations_started || calculate_dphi);
-    calculate_dphi = calculate_dphiref = true; return dphixr_sq; }
+  { libmesh_assert(!calculations_started || calculate_dphi_scaled);
+    calculate_dphi_scaled = true; return dphixr_sq; }
 
 
   /**
@@ -629,12 +636,16 @@ public:
    */
   virtual const std::vector<RealGradient> & get_dxyzdxi() const override
   { calculate_map = true; libmesh_not_implemented();}
+
+
   /**
    * \returns The element tangents in eta-direction at the quadrature
    * points.
    */
   virtual const std::vector<RealGradient> & get_dxyzdeta() const override
   { calculate_map = true; libmesh_not_implemented();}
+
+
   /**
    * \returns The element tangents in zeta-direction at the quadrature
    * points.
@@ -680,55 +691,81 @@ public:
    * matrix from physical to local coordinates.
    */
   virtual const std::vector<Real> & get_dxidx() const override
-  { calculate_map = true; return dxidx_map;}
+  {libmesh_assert(!calculations_started || calculate_map);
+    calculate_map = true; return dxidx_map;}
+
+
   /**
    * \returns The dxi/dy entry in the transformation
    * matrix from physical to local coordinates.
    */
   virtual const std::vector<Real> & get_dxidy() const override
-  { calculate_map = true; return dxidy_map;}
+  {libmesh_assert(!calculations_started || calculate_map);
+    calculate_map = true; return dxidy_map;}
+
+
   /**
    * \returns The dxi/dz entry in the transformation
    * matrix from physical to local coordinates.
    */
   virtual const std::vector<Real> & get_dxidz() const override
-  { calculate_map = true; return dxidz_map;}
+  { libmesh_assert(!calculations_started || calculate_map);
+    calculate_map = true; return dxidz_map;}
+
+
   /**
    * \returns The deta/dx entry in the transformation
    * matrix from physical to local coordinates.
    */
   virtual const std::vector<Real> & get_detadx() const override
-  { calculate_map = true; return detadx_map;}
+  { libmesh_assert(!calculations_started || calculate_map);
+    calculate_map = true; return detadx_map;}
+
+
   /**
    * \returns The deta/dy entry in the transformation
    * matrix from physical to local coordinates.
    */
   virtual const std::vector<Real> & get_detady() const override
-  { calculate_map = true; return detady_map;}
+  { libmesh_assert(!calculations_started || calculate_map);
+    calculate_map = true; return detady_map;}
+
+
   /**
    * \returns The deta/dx entry in the transformation
    * matrix from physical to local coordinates.
    */
   virtual const std::vector<Real> & get_detadz() const override
-  { calculate_map = true; return detadz_map;}
+  { libmesh_assert(!calculations_started || calculate_map);
+    calculate_map = true; return detadz_map;}
+
+
   /**
    * \returns The dzeta/dx entry in the transformation
    * matrix from physical to local coordinates.
    */
   virtual const std::vector<Real> & get_dzetadx() const override
-  { calculate_map = true; return dzetadx_map;}
+  { libmesh_assert(!calculations_started || calculate_map);
+    calculate_map = true; return dzetadx_map;}
+
+
   /**
    * \returns The dzeta/dy entry in the transformation
    * matrix from physical to local coordinates.
    */
   virtual const std::vector<Real> & get_dzetady() const override
-  { calculate_map = true; return dzetady_map;}
+  { libmesh_assert(!calculations_started || calculate_map);
+    calculate_map = true; return dzetady_map;}
+
+
   /**
    * \returns The dzeta/dz entry in the transformation
    * matrix from physical to local coordinates.
    */
   virtual const std::vector<Real> & get_dzetadz() const override
-  { calculate_map = true; return dzetadz_map;}
+  { libmesh_assert(!calculations_started || calculate_map);
+    calculate_map = true; return dzetadz_map;}
+
 
   /**
    * \returns The multiplicative weight at each quadrature point.
@@ -738,22 +775,34 @@ public:
    * variational form easily computable.
    */
   virtual const std::vector<Real> & get_Sobolev_weight() const override
-  { calculate_map = true; return weight; }
+  { libmesh_assert(!calculations_started || calculate_phi);
+    calculate_phi = true; return weight; }
+
+
+  /**
+   * \returns The first global derivative of the multiplicative
+   * weight at each quadrature point. See \p get_Sobolev_weight()
+   * for details.  In case of \p FE initialized to all zero.
+   */
+  virtual const std::vector<RealGradient> & get_Sobolev_dweight() const
+  {libmesh_assert(!calculations_started || calculate_dphi);
+    calculate_dphi = true; return dweight; }
+
 
 
   /**
    * \returns The tangent vectors for face integration.
    */
   virtual const std::vector<std::vector<Point>> & get_tangents() const override
-  { libmesh_assert(!calculations_started || calculate_dxyz);
-    calculate_dxyz = true; return tangents; }
+  { libmesh_assert(!calculations_started || calculate_map);
+    calculate_map = true; return tangents; }
 
   /**
    * \returns The outward pointing normal vectors for face integration.
    */
   virtual const std::vector<Point> & get_normals() const override
-  { libmesh_assert(!calculations_started || calculate_dxyz);
-    calculate_dxyz = true; return normals; }
+  { libmesh_assert(!calculations_started || calculate_map);
+    calculate_map = true; return normals; }
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   /**
@@ -769,7 +818,8 @@ public:
    *
    */
   virtual const std::vector<Real> & get_Sobolev_weightxR_sq() const override
-  { calculate_map = true; return weightxr_sq; }
+  { libmesh_assert(!calculations_started || calculate_phi_scaled);
+    calculate_phi_scaled = true; return weightxr_sq; }
 
 
   /**
@@ -779,7 +829,8 @@ public:
    *
    */
   virtual const std::vector<RealGradient> & get_Sobolev_dweightxR_sq() const override
-  { calculate_map = true; return dweightxr_sq; }
+  {libmesh_assert(!calculations_started || calculate_dphi_scaled);
+    calculate_dphi_scaled = true; return dweightxr_sq; }
 
 
 #ifdef LIBMESH_ENABLE_AMR
@@ -789,21 +840,19 @@ public:
    * non-conforming adapted meshes) corresponding to
    * variable number \p var_number, adapted to infinite elements.
    */
-static void inf_compute_constraints (DofConstraints & constraints,
-                                     DofMap & dof_map,
-                                     const unsigned int variable_number,
-                                     const Elem * child_elem);
+  static void inf_compute_constraints (DofConstraints & constraints,
+                                       DofMap & dof_map,
+                                       const unsigned int variable_number,
+                                       const Elem * child_elem);
 #endif
 
 #ifdef LIBMESH_ENABLE_NODE_CONSTRAINTS
   static void inf_compute_node_constraints (NodeConstraints & constraints,
-                                        const Elem * elem);
+                                            const Elem * elem);
 #endif
 
 
 protected:
-
-  mutable bool calculate_dxyz;
 
   // static members used by the workhorses
 
@@ -854,6 +903,12 @@ protected:
   { libmesh_not_implemented(); }
 
   /**
+   * Determine which values are to be calculated, for both the FE
+   * itself and for the FEMap.
+   */
+  virtual void determine_calculations() override;
+
+  /**
    * Some of the member data only depend on the radial part of the
    * infinite element.  The parts that only change when the radial
    * order changes, are initialized here.
@@ -888,11 +943,11 @@ protected:
    * still should be usable for children. Therefore, keep
    * it protected.
    */
-   void compute_shape_functions(const Elem * inf_elem,
-                                const std::vector<Point> & base_qp,
-                                const std::vector<Point> & radial_qp);
+  void compute_shape_functions(const Elem * inf_elem,
+                               const std::vector<Point> & base_qp,
+                               const std::vector<Point> & radial_qp);
 
-   void compute_face_functions();
+  void compute_face_functions();
 
   /**
    * Use \p compute_shape_functions(const Elem*, const std::vector<Point> &, const std::vector<Point> &)
@@ -900,11 +955,38 @@ protected:
    */
   virtual void compute_shape_functions(const Elem *, const std::vector<Point> & ) override
   {
-     //FIXME: it seems this function cannot be left out because
-     // it is pure virtual in \p FEBase
-     libmesh_not_implemented();
+    //FIXME: it seems this function cannot be left out because
+    // it is pure virtual in \p FEBase
+    libmesh_not_implemented();
   }
 
+  /**
+   * Are we calculating scaled mapping functions?
+   */
+  mutable bool calculate_map_scaled;
+
+  /**
+   * Are we calculating scaled shape functions?
+   */
+  mutable bool calculate_phi_scaled;
+
+  /**
+   * Are we calculating scaled shape function gradients?
+   */
+  mutable bool calculate_dphi_scaled;
+
+
+  /**
+   * Are we calculating the positions of quadrature points?
+   */
+  mutable bool calculate_xyz;
+
+
+  /**
+   * Are we calculating the unscaled jacobian?
+   * We avoid it if not requested explicitly; this has the worst stability.
+   */
+  mutable bool calculate_jxw;
 
   // Miscellaneous static members
 

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -557,17 +557,23 @@ void FE<Dim,T>::init_shape_functions(const std::vector<Point> & qp,
   // returned
 
   {
-    this->weight.resize  (n_qp);
-    this->dweight.resize (n_qp);
-    this->dphase.resize  (n_qp);
-
-    for (unsigned int p=0; p<n_qp; p++)
+    if (this->calculate_phi || this->calculate_dphi)
       {
-        this->weight[p] = 1.;
-        this->dweight[p].zero();
-        this->dphase[p].zero();
+        this->weight.resize  (n_qp);
+        for (unsigned int p=0; p<n_qp; p++)
+          this->weight[p] = 1.;
       }
 
+    if (this->calculate_dphi)
+      {
+        this->dweight.resize (n_qp);
+        this->dphase.resize  (n_qp);
+        for (unsigned int p=0; p<n_qp; p++)
+          {
+            this->dweight[p].zero();
+            this->dphase[p].zero();
+          }
+      }
   }
 #endif // ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -1537,17 +1537,6 @@ FEGenericBase<OutputType>::compute_proj_constraints (DofConstraints & constraint
   if (!elem->active())
     return;
 
-#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
-   if (elem->infinite())
-   {
-      // this would require some generalisation:
-      //  - e.g. the 'my_fe'-object needs generalisation
-      //  - due to lack of one-to-one correspondence of DOFs and nodes,
-      //    this doesn't work easily.
-      libmesh_not_implemented();
-   }
-#endif
-
   const Variable & var = dof_map.variable(variable_number);
   const FEType & base_fe_type = var.type();
 
@@ -1561,6 +1550,17 @@ FEGenericBase<OutputType>::compute_proj_constraints (DofConstraints & constraint
     return;
   libmesh_assert (cont == C_ZERO || cont == C_ONE ||
                   cont == SIDE_DISCONTINUOUS);
+
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+   if (elem->infinite())
+   {
+      // this would require some generalisation:
+      //  - e.g. the 'my_fe'-object needs generalisation
+      //  - due to lack of one-to-one correspondence of DOFs and nodes,
+      //    this doesn't work easily.
+      libmesh_not_implemented();
+   }
+#endif
 
   std::unique_ptr<FEGenericBase<OutputShape>> neigh_fe
     (FEGenericBase<OutputShape>::build(Dim, base_fe_type));

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -30,20 +30,7 @@
 #include "libmesh/int_range.h"
 #include "libmesh/auto_ptr.h"
 #include "libmesh/type_tensor.h"
-
-
-namespace {
-  // Put this outside a templated class, so we only get 1 warning
-  // during our unit tests, not 1 warning for each of the zillion FE
-  // specializations we test.
-#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
-  void inffe_hessian_warning () {
-    libmesh_warning("Warning: Second derivatives for Infinite elements"
-                    << " are not yet implemented!"
-                    << std::endl);
-  }
-#endif
-}
+#include "libmesh/fe_interface.h"
 
 
 namespace libMesh
@@ -56,6 +43,11 @@ template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
 InfFE<Dim,T_radial,T_map>::InfFE (const FEType & fet) :
   FEBase       (Dim, fet),
 
+  calculate_map_scaled(false),
+  calculate_phi_scaled(false),
+  calculate_dphi_scaled(false),
+  calculate_xyz(false),
+  calculate_jxw(false),
   _n_total_approx_sf (0),
   _n_total_qp        (0),
 
@@ -133,14 +125,9 @@ void InfFE<Dim,T_radial,T_map>::reinit(const Elem * inf_elem,
   libmesh_assert(base_fe.get());
   libmesh_assert(inf_elem);
 
-  // I don't understand infinite elements well enough to risk
-  // calculating too little.  :-(  RHS
-  this->calculate_phi = this->calculate_dphi = this->calculate_dphiref = true;
-  this->get_xyz();
+  // checks for consistency of requested calculations,
+  // adds further quantities as needed.
   this->determine_calculations();
-  base_fe->calculate_phi = base_fe->calculate_dphi = base_fe->calculate_dphiref = true;
-  base_fe->get_xyz();
-  base_fe->determine_calculations();
 
   if (pts == nullptr)
     {
@@ -198,9 +185,10 @@ void InfFE<Dim,T_radial,T_map>::reinit(const Elem * inf_elem,
       if (update_base_elem_required)
         this->update_base_elem(inf_elem);
 
-      // initialize the shape functions in the base
-      base_fe->init_base_shape_functions(base_fe->qrule->get_points(),
-                                         base_elem.get());
+      if (calculate_phi_scaled || calculate_dphi_scaled || calculate_phi || calculate_dphi)
+        // initialize the shape functions in the base
+        base_fe->init_base_shape_functions(base_fe->qrule->get_points(),
+                                           base_elem.get());
 
       // compute the shape functions and map functions of base_fe
       // before using them later in compute_shape_functions.
@@ -305,16 +293,11 @@ void InfFE<Dim,T_radial,T_map>::reinit(const Elem * inf_elem,
       // update the base
       this->update_base_elem(inf_elem);
 
-      //FIXME: why not use :
-      //this->update_base_elem(inf_elem);
-      // -> it looks better to me though...
-
       // the finite element on the ifem base
       base_fe = FEBase::build(Dim-1, this->fe_type);
 
-      base_fe->calculate_phi = base_fe->calculate_dphi = base_fe->calculate_dphiref = true;
-      base_fe->get_xyz();
-      base_fe->determine_calculations();
+      // having a new base_fe, we need to redetermine the tasks...
+      this->determine_calculations();
 
       base_fe->reinit( base_elem.get(), &base_pts);
 
@@ -338,6 +321,78 @@ void InfFE<Dim,T_radial,T_map>::reinit(const Elem * inf_elem,
 }
 
 
+
+template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
+void InfFE<Dim, T_radial, T_map>::determine_calculations()
+{
+  this->calculations_started = true;
+
+  // If the user forgot to request anything, but we're enabling
+  // deprecated backwards compatibility, then we'll be safe and
+  // calculate everything.  If we haven't enable deprecated backwards
+  // compatibility then we'll scream and die.
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  if (!this->calculate_nothing &&
+      !this->calculate_phi && !this->calculate_dphi &&
+      !this->calculate_phi_scaled && !this->calculate_dphi_scaled &&
+      !this->calculate_xyz && !this->calculate_jxw &&
+      !this->calculate_map_scaled && !this->calculate_map &&
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+      !this->calculate_d2phi &&
+#endif
+      !this->calculate_curl_phi && !this->calculate_div_phi)
+    {
+      libmesh_deprecated();
+      this->calculate_phi = this->calculate_dphi = this->calculate_jxw = true;
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+      this->calculate_d2phi = true;
+#endif
+      this->calculate_phi_scaled = this->calculate_dphi_scaled = this->calculate_xyz = true;
+      if (FEInterface::field_type(fe_type.family) == TYPE_VECTOR)
+        {
+          this->calculate_curl_phi = true;
+          this->calculate_div_phi  = true;
+        }
+    }
+#else //LIBMESH_ENABLE_DEPRECATED
+  libmesh_assert (this->calculate_nothing ||
+                  this->calculate_phi || this->calculate_dphi ||
+                  !this->calculate_phi_scaled && !this->calculate_dphi_scaled &&
+                  !this->calculate_xyz && !this->calculate_jxw &&
+                  !this->calculate_map_scaled && !this->calculate_map &&
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+                  this->calculate_d2phi ||
+#endif
+                  this->calculate_curl_phi || this->calculate_div_phi)
+#endif // LIBMESH_ENABLE_DEPRECATED
+
+  // set further terms necessary to do the requested task
+  if (calculate_jxw)
+    this->calculate_map = true;
+  if (this->calculate_dphi)
+    this->calculate_map = true;
+  if (this->calculate_dphi_scaled)
+    this->calculate_map_scaled = true;
+  if (calculate_xyz && !calculate_map)
+    // if Cartesian positions were requested but the calculation of map
+    // was not triggered, we'll opt for the 'scaled' variant.
+    this->calculate_map_scaled = true;
+  base_fe->calculate_phi = this->calculate_phi || this->calculate_phi_scaled
+                       || this->calculate_dphi || this->calculate_dphi_scaled;
+  base_fe->calculate_dphi = this->calculate_dphi || this->calculate_dphi_scaled;
+  if (this->calculate_map || this->calculate_map_scaled)
+    {
+      base_fe->calculate_dphiref = true;
+      base_fe->get_xyz(); // trigger base_fe->fe_map to 'calculate_xyz'
+      base_fe->get_JxW(); //  trigger base_fe->fe_map to 'calculate_dxyz'
+    }
+  base_fe->determine_calculations();
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+  if (this->calculate_d2phi)
+    libmesh_not_implemented();
+#endif //LIBMESH_ENABLE_SECOND_DERIVATIVES
+}
 
 
 
@@ -364,37 +419,45 @@ init_radial_shape_functions(const Elem * libmesh_dbg_var(inf_elem),
     radial_pts ? *radial_pts : radial_qrule->get_points();
 
   // the radial polynomials (eval)
-  mode.resize      (n_radial_approx_shape_functions);
-  dmodedv.resize   (n_radial_approx_shape_functions);
-
-  // the (1-v)/2 weight
-  som.resize       (n_radial_qp);
-  dsomdv.resize    (n_radial_qp);
-
-
-  for (unsigned int i=0; i<n_radial_approx_shape_functions; ++i)
+  if (calculate_phi || calculate_dphi || calculate_phi_scaled || calculate_dphi_scaled)
     {
-      mode[i].resize    (n_radial_qp);
-      dmodedv[i].resize (n_radial_qp);
+      mode.resize      (n_radial_approx_shape_functions);
+      for (unsigned int i=0; i<n_radial_approx_shape_functions; ++i)
+        mode[i].resize (n_radial_qp);
+
+      // evaluate the mode shapes in radial direction at radial quadrature points
+      for (unsigned int i=0; i<n_radial_approx_shape_functions; ++i)
+        for (std::size_t p=0; p<n_radial_qp; ++p)
+          mode[i][p] = InfFE<Dim,T_radial,T_map>::eval (radial_qp[p](0), radial_approx_order, i);
     }
 
-
-  // compute scalar values at radial quadrature points
-  for (std::size_t p=0; p<n_radial_qp; ++p)
+  if (calculate_dphi || calculate_dphi_scaled)
     {
-      som[p] = InfFERadial::decay (Dim, radial_qp[p](0));
-      dsomdv[p] = InfFERadial::decay_deriv (Dim, radial_qp[p](0));
+      dmodedv.resize   (n_radial_approx_shape_functions);
+      for (unsigned int i=0; i<n_radial_approx_shape_functions; ++i)
+        dmodedv[i].resize (n_radial_qp);
+
+      // evaluate the mode shapes in radial direction at radial quadrature points
+      for (unsigned int i=0; i<n_radial_approx_shape_functions; ++i)
+        for (std::size_t p=0; p<n_radial_qp; ++p)
+          dmodedv[i][p] = InfFE<Dim,T_radial,T_map>::eval_deriv (radial_qp[p](0), radial_approx_order, i);
     }
 
-
-  // evaluate the mode shapes in radial direction at radial quadrature points
-  for (unsigned int i=0; i<n_radial_approx_shape_functions; ++i)
-    for (std::size_t p=0; p<n_radial_qp; ++p)
-      {
-        mode[i][p] = InfFE<Dim,T_radial,T_map>::eval (radial_qp[p](0), radial_approx_order, i);
-        dmodedv[i][p] = InfFE<Dim,T_radial,T_map>::eval_deriv (radial_qp[p](0), radial_approx_order, i);
-      }
-
+  // the (1-v)/2 weight.
+  if (calculate_phi || calculate_phi_scaled || calculate_dphi || calculate_dphi_scaled)
+    {
+      som.resize       (n_radial_qp);
+      // compute scalar values at radial quadrature points
+      for (std::size_t p=0; p<n_radial_qp; ++p)
+        som[p] = InfFERadial::decay (Dim, radial_qp[p](0));
+    }
+  if (calculate_dphi || calculate_dphi_scaled)
+    {
+      dsomdv.resize    (n_radial_qp);
+      // compute scalar values at radial quadrature points
+      for (std::size_t p=0; p<n_radial_qp; ++p)
+        dsomdv[p] = InfFERadial::decay_deriv (Dim, radial_qp[p](0));
+    }
 }
 
 
@@ -410,8 +473,14 @@ void InfFE<Dim,T_radial,T_map>::init_shape_functions(const std::vector<Point> & 
   LOG_SCOPE("init_shape_functions()", "InfFE");
 
   // fast access to some const ints for the radial data
-  const unsigned int n_radial_approx_sf  = cast_int<unsigned int>(mode.size());
-  const unsigned int n_radial_qp         = cast_int<unsigned int>(som.size());
+  const unsigned int n_radial_approx_sf  = InfFERadial::n_dofs(fe_type.radial_order);
+  const std::size_t  n_radial_qp         = radial_qp.size();
+#ifdef DEBUG
+  if (calculate_phi || calculate_dphi || calculate_phi_scaled || calculate_dphi_scaled)
+    libmesh_assert_equal_to(n_radial_approx_sf, mode.size());
+  if (calculate_phi || calculate_dphi || calculate_dphi_scaled)
+    libmesh_assert_equal_to(som.size(), n_radial_qp);
+#endif
 
 
   // initialize most of the quantities related to mapping
@@ -479,13 +548,19 @@ void InfFE<Dim,T_radial,T_map>::init_shape_functions(const std::vector<Point> & 
   // the weight, though, is only needed at the radial quadrature points, n_radial_qp.
   // but for a uniform interface to the protected data fields
   // the weight data field (which are accessible from the outside) are expanded to _n_total_qp.
-  weight.resize      (_n_total_qp);
-  weightxr_sq.resize (_n_total_qp);
-  dweightdv.resize   (n_radial_qp);
-  dweight.resize     (_n_total_qp);
-  dweightxr_sq.resize(_n_total_qp);
+  if (calculate_phi || calculate_dphi)
+    weight.resize      (_n_total_qp);
+  if (calculate_phi_scaled || calculate_dphi_scaled)
+    weightxr_sq.resize (_n_total_qp);
+  if (calculate_dphi || calculate_dphi_scaled)
+    dweightdv.resize   (n_radial_qp);
+  if (calculate_dphi)
+    dweight.resize     (_n_total_qp);
+  if (calculate_dphi_scaled)
+    dweightxr_sq.resize(_n_total_qp);
 
-  dphase.resize      (_n_total_qp);
+  if (calculate_dphi || calculate_dphi_scaled)
+    dphase.resize      (_n_total_qp);
 
   // this vector contains the integration weights for the combined quadrature rule
   // if no quadrature rules are given, use only ones.
@@ -494,120 +569,162 @@ void InfFE<Dim,T_radial,T_map>::init_shape_functions(const std::vector<Point> & 
   // InfFE's data fields phi, dphi, dphidx, phi_map etc hold the _total_
   // shape and mapping functions, respectively
   {
-    JxWxdecay.resize(_n_total_qp);
-    JxW.resize(_n_total_qp);
-    xyz.resize(_n_total_qp);
-    dxidx_map.resize(_n_total_qp);
-    dxidy_map.resize(_n_total_qp);
-    dxidz_map.resize(_n_total_qp);
-    detadx_map.resize(_n_total_qp);
-    detady_map.resize(_n_total_qp);
-    detadz_map.resize(_n_total_qp);
-    dzetadx_map.resize(_n_total_qp);
-    dzetady_map.resize(_n_total_qp);
-    dzetadz_map.resize(_n_total_qp);
-    dxidx_map_scaled.resize(_n_total_qp);
-    dxidy_map_scaled.resize(_n_total_qp);
-    dxidz_map_scaled.resize(_n_total_qp);
-    detadx_map_scaled.resize(_n_total_qp);
-    detady_map_scaled.resize(_n_total_qp);
-    detadz_map_scaled.resize(_n_total_qp);
-    dzetadx_map_scaled.resize(_n_total_qp);
-    dzetady_map_scaled.resize(_n_total_qp);
-    dzetadz_map_scaled.resize(_n_total_qp);
-
-    phi.resize     (_n_total_approx_sf);
-    dphi.resize    (_n_total_approx_sf);
-    dphidx.resize  (_n_total_approx_sf);
-    dphidy.resize  (_n_total_approx_sf);
-    dphidz.resize  (_n_total_approx_sf);
-    dphidxi.resize (_n_total_approx_sf);
-
-    phixr.resize    (_n_total_approx_sf);
-    dphixr.resize   (_n_total_approx_sf);
-    dphixr_sq.resize(_n_total_approx_sf);
-#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
-    inffe_hessian_warning();
-
-    d2phi.resize     (_n_total_approx_sf);
-    d2phidx2.resize  (_n_total_approx_sf);
-    d2phidxdy.resize (_n_total_approx_sf);
-    d2phidxdz.resize (_n_total_approx_sf);
-    d2phidy2.resize  (_n_total_approx_sf);
-    d2phidydz.resize (_n_total_approx_sf);
-    d2phidz2.resize  (_n_total_approx_sf);
-    d2phidxi2.resize (_n_total_approx_sf);
-
-    if (Dim > 1)
+    if (calculate_map_scaled)
+      JxWxdecay.resize(_n_total_qp);
+    if (calculate_jxw)
+      JxW.resize(_n_total_qp);
+    if (calculate_map_scaled || calculate_map)
       {
-        d2phidxideta.resize(_n_total_approx_sf);
-        d2phideta2.resize(_n_total_approx_sf);
+        xyz.resize(_n_total_qp);
+        dxidx_map_scaled.resize(_n_total_qp);
+        dxidy_map_scaled.resize(_n_total_qp);
+        dxidz_map_scaled.resize(_n_total_qp);
+        detadx_map_scaled.resize(_n_total_qp);
+        detady_map_scaled.resize(_n_total_qp);
+        detadz_map_scaled.resize(_n_total_qp);
+        dzetadx_map_scaled.resize(_n_total_qp);
+        dzetady_map_scaled.resize(_n_total_qp);
+        dzetadz_map_scaled.resize(_n_total_qp);
+      }
+    if (calculate_map)
+      {
+        dxidx_map.resize(_n_total_qp);
+        dxidy_map.resize(_n_total_qp);
+        dxidz_map.resize(_n_total_qp);
+        detadx_map.resize(_n_total_qp);
+        detady_map.resize(_n_total_qp);
+        detadz_map.resize(_n_total_qp);
+        dzetadx_map.resize(_n_total_qp);
+        dzetady_map.resize(_n_total_qp);
+        dzetadz_map.resize(_n_total_qp);
+      }
+    if (calculate_phi)
+      phi.resize     (_n_total_approx_sf);
+    if (calculate_phi_scaled)
+      phixr.resize    (_n_total_approx_sf);
+    if (calculate_dphi)
+      {
+        dphi.resize    (_n_total_approx_sf);
+        dphidx.resize  (_n_total_approx_sf);
+        dphidy.resize  (_n_total_approx_sf);
+        dphidz.resize  (_n_total_approx_sf);
       }
 
-    if (Dim > 2)
+    if (calculate_dphi_scaled)
       {
-        d2phidetadzeta.resize(_n_total_approx_sf);
-        d2phidxidzeta.resize(_n_total_approx_sf);
-        d2phidzeta2.resize(_n_total_approx_sf);
+        dphixr.resize   (_n_total_approx_sf);
+        dphixr_sq.resize(_n_total_approx_sf);
+      }
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
+    if (calculate_d2phi)
+      {
+        libmesh_not_implemented();
+        d2phi.resize     (_n_total_approx_sf);
+        d2phidx2.resize  (_n_total_approx_sf);
+        d2phidxdy.resize (_n_total_approx_sf);
+        d2phidxdz.resize (_n_total_approx_sf);
+        d2phidy2.resize  (_n_total_approx_sf);
+        d2phidydz.resize (_n_total_approx_sf);
+        d2phidz2.resize  (_n_total_approx_sf);
+        d2phidxi2.resize (_n_total_approx_sf);
+
+        if (Dim > 1)
+          {
+            d2phidxideta.resize(_n_total_approx_sf);
+            d2phideta2.resize(_n_total_approx_sf);
+          }
+
+        if (Dim > 2)
+          {
+            d2phidetadzeta.resize(_n_total_approx_sf);
+            d2phidxidzeta.resize(_n_total_approx_sf);
+            d2phidzeta2.resize(_n_total_approx_sf);
+          }
       }
 #endif // ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
-    if (Dim > 1)
-      dphideta.resize(_n_total_approx_sf);
+    if (calculate_dphi || calculate_dphi_scaled)
+      {
+        dphidxi.resize (_n_total_approx_sf);
 
-    if (Dim == 3)
-      dphidzeta.resize(_n_total_approx_sf);
+        if (Dim > 1)
+          dphideta.resize(_n_total_approx_sf);
+
+        if (Dim == 3)
+          dphidzeta.resize(_n_total_approx_sf);
+      }
 
   }
 
   // collect all the for loops, where inner vectors are
   // resized to the appropriate number of quadrature points
   {
-    for (unsigned int i=0; i<_n_total_approx_sf; ++i)
-      {
+    if (calculate_phi)
+      for (unsigned int i=0; i<_n_total_approx_sf; ++i)
         phi[i].resize         (_n_total_qp);
-        dphi[i].resize        (_n_total_qp);
-        dphidx[i].resize      (_n_total_qp);
-        dphidy[i].resize      (_n_total_qp);
-        dphidz[i].resize      (_n_total_qp);
-        dphidxi[i].resize     (_n_total_qp);
 
-        phixr[i].resize (_n_total_qp);
-        dphixr[i].resize(_n_total_qp);
-        dphixr_sq[i].resize(_n_total_qp);
+    if (calculate_dphi)
+      for (unsigned int i=0; i<_n_total_approx_sf; ++i)
+        {
+          dphi[i].resize        (_n_total_qp);
+          dphidx[i].resize      (_n_total_qp);
+          dphidy[i].resize      (_n_total_qp);
+          dphidz[i].resize      (_n_total_qp);
+        }
+
+    if (calculate_phi_scaled)
+      for (unsigned int i=0; i<_n_total_approx_sf; ++i)
+        {
+          phixr[i].resize (_n_total_qp);
+        }
+    if (calculate_dphi_scaled)
+      for (unsigned int i=0; i<_n_total_approx_sf; ++i)
+        {
+          dphixr[i].resize(_n_total_qp);
+          dphixr_sq[i].resize(_n_total_qp);
+        }
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
-        d2phi[i].resize       (_n_total_qp);
-        d2phidx2[i].resize    (_n_total_qp);
-        d2phidxdy[i].resize   (_n_total_qp);
-        d2phidxdz[i].resize   (_n_total_qp);
-        d2phidy2[i].resize    (_n_total_qp);
-        d2phidydz[i].resize   (_n_total_qp);
-        d2phidy2[i].resize    (_n_total_qp);
-        d2phidxi2[i].resize   (_n_total_qp);
+    if (calculate_d2phi)
+      for (unsigned int i=0; i<_n_total_approx_sf; ++i)
+        {
+          d2phi[i].resize       (_n_total_qp);
+          d2phidx2[i].resize    (_n_total_qp);
+          d2phidxdy[i].resize   (_n_total_qp);
+          d2phidxdz[i].resize   (_n_total_qp);
+          d2phidy2[i].resize    (_n_total_qp);
+          d2phidydz[i].resize   (_n_total_qp);
+          d2phidy2[i].resize    (_n_total_qp);
+          d2phidxi2[i].resize   (_n_total_qp);
 
-        if (Dim > 1)
-          {
-            d2phidxideta[i].resize   (_n_total_qp);
-            d2phideta2[i].resize     (_n_total_qp);
-          }
-        if (Dim > 2)
-          {
-            d2phidxidzeta[i].resize  (_n_total_qp);
-            d2phidetadzeta[i].resize (_n_total_qp);
-            d2phidzeta2[i].resize    (_n_total_qp);
-          }
+          if (Dim > 1)
+            {
+              d2phidxideta[i].resize   (_n_total_qp);
+              d2phideta2[i].resize     (_n_total_qp);
+            }
+          if (Dim > 2)
+            {
+              d2phidxidzeta[i].resize  (_n_total_qp);
+              d2phidetadzeta[i].resize (_n_total_qp);
+              d2phidzeta2[i].resize    (_n_total_qp);
+            }
+        }
 #endif // ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
-        if (Dim > 1)
-          dphideta[i].resize  (_n_total_qp);
+    if (calculate_dphi || calculate_dphi_scaled)
+      for (unsigned int i=0; i<_n_total_approx_sf; ++i)
+        {
+          dphidxi[i].resize     (_n_total_qp);
 
-        if (Dim == 3)
-          dphidzeta[i].resize (_n_total_qp);
+          if (Dim > 1)
+            dphideta[i].resize  (_n_total_qp);
 
-      }
+          if (Dim == 3)
+            dphidzeta[i].resize (_n_total_qp);
+
+        }
 
   }
-
   {
     // (a) compute scalar values at _all_ quadrature points  -- for uniform
     //     access from the outside to these fields
@@ -623,27 +740,23 @@ void InfFE<Dim,T_radial,T_map>::init_shape_functions(const std::vector<Point> & 
         libmesh_assert_equal_to (base_qw.size(), n_base_qp);
 
         for (unsigned int rp=0; rp<n_radial_qp; ++rp)
-          {
-            for (unsigned int bp=0; bp<n_base_qp; ++bp)
-              {
-                weight[bp + rp*n_base_qp] = InfFERadial::D(radial_qp[rp](0));
-                weightxr_sq[bp + rp*n_base_qp] = InfFERadial::Dxr_sq(radial_qp[rp](0));
-                _total_qrule_weights[bp + rp*n_base_qp] = radial_qw[rp] * base_qw[bp];
-              }
-            dweightdv[rp] = InfFERadial::D_deriv(radial_qp[rp](0));
-          }
+          for (unsigned int bp=0; bp<n_base_qp; ++bp)
+            _total_qrule_weights[bp + rp*n_base_qp] = radial_qw[rp] * base_qw[bp];
       }
-    else
+
+
+    for (unsigned int rp=0; rp<n_radial_qp; ++rp)
       {
-        for (unsigned int rp=0; rp<n_radial_qp; ++rp)
-          {
-            for (unsigned int bp=0; bp<n_base_qp; ++bp)
-              {
-                weight[bp + rp*n_base_qp] = InfFERadial::D(radial_qp[rp](0));
-                weightxr_sq[bp + rp*n_base_qp] = InfFERadial::Dxr_sq(radial_qp[rp](0));
-              }
-            dweightdv[rp] = InfFERadial::D_deriv(radial_qp[rp](0));
-          }
+        if (calculate_phi || calculate_dphi)
+          for (unsigned int bp=0; bp<n_base_qp; ++bp)
+            weight[bp + rp*n_base_qp] = InfFERadial::D(radial_qp[rp](0));
+
+        if ( calculate_phi_scaled)
+          for (unsigned int bp=0; bp<n_base_qp; ++bp)
+            weightxr_sq[bp + rp*n_base_qp] = InfFERadial::Dxr_sq(radial_qp[rp](0));
+
+        if ( calculate_dphi || calculate_dphi_scaled)
+          dweightdv[rp] = InfFERadial::D_deriv(radial_qp[rp](0));
       }
   }
 }
@@ -665,16 +778,25 @@ void InfFE<Dim,T_radial,T_map>::compute_shape_functions(const Elem * inf_elem,
   // Start logging the overall computation of shape functions
   LOG_SCOPE("compute_shape_functions()", "InfFE");
 
-  // these vectors are needed later; initialize here already to have access to
-  // n_base_qp etc.
-  const std::vector<std::vector<Real>> & S_map  = (base_fe->get_fe_map()).get_phi_map();
-
-  const unsigned int n_radial_qp = cast_int<unsigned int>(som.size());
-  const unsigned int n_base_qp = cast_int<unsigned int>(S_map[0].size());
+  //const unsigned int n_radial_qp = cast_int<unsigned int>(som.size());
+  //const unsigned int n_base_qp = cast_int<unsigned int>(S_map[0].size());
+  const std::size_t  n_radial_qp = radial_qp.size();
+  const unsigned int n_base_qp   = base_qp.size();
 
   libmesh_assert_equal_to (_n_total_qp, n_radial_qp*n_base_qp);
   libmesh_assert_equal_to (_n_total_qp, _total_qrule_weights.size());
 #ifdef DEBUG
+  if (som.size() > 0)
+    libmesh_assert_equal_to(n_radial_qp, som.size());
+
+  if (this->calculate_map || this->calculate_map_scaled)
+    {
+      // these vectors are needed later; initialize here already to have access to
+      // n_base_qp etc.
+      const std::vector<std::vector<Real>> & S_map  = (base_fe->get_fe_map()).get_phi_map();
+      if (S_map[0].size() > 0)
+        libmesh_assert_equal_to(n_base_qp, S_map[0].size());
+    }
   if (radial_qrule)
     libmesh_assert_equal_to(n_radial_qp, radial_qrule->n_points());
   if (base_qrule)
@@ -706,212 +828,293 @@ void InfFE<Dim,T_radial,T_map>::compute_shape_functions(const Elem * inf_elem,
       }
     case 3:
       {
+        std::vector<std::vector<Real>> S (0);
+        std::vector<std::vector<Real>> Ss(0);
+        std::vector<std::vector<Real>> St(0);
+
+        std::vector<Real> base_dxidx (0);
+        std::vector<Real> base_dxidy (0);
+        std::vector<Real> base_dxidz (0);
+        std::vector<Real> base_detadx(0);
+        std::vector<Real> base_detady(0);
+        std::vector<Real> base_detadz(0);
+
+        std::vector<Point> base_xyz (0);
+
+        if (calculate_phi  || calculate_phi_scaled ||
+            calculate_dphi || calculate_dphi_scaled)
+          S=base_fe->phi;
+
         // fast access to the approximation and mapping shapes of base_fe
-        const std::vector<std::vector<Real>> & Ss = base_fe->dphidxi;
-        const std::vector<std::vector<Real>> & St = base_fe->dphideta;
-        const std::vector<std::vector<Real>> & S  = base_fe->phi;
+        if (calculate_map || calculate_map_scaled)
+          {
+            Ss = base_fe->dphidxi;
+            St = base_fe->dphideta;
 
-        const std::vector<Real> & base_dxidx = base_fe->get_dxidx();
-        const std::vector<Real> & base_dxidy = base_fe->get_dxidy();
-        const std::vector<Real> & base_dxidz = base_fe->get_dxidz();
-        const std::vector<Real> & base_detadx = base_fe->get_detadx();
-        const std::vector<Real> & base_detady = base_fe->get_detady();
-        const std::vector<Real> & base_detadz = base_fe->get_detadz();
+            base_dxidx = base_fe->get_dxidx();
+            base_dxidy = base_fe->get_dxidy();
+            base_dxidz = base_fe->get_dxidz();
+            base_detadx = base_fe->get_detadx();
+            base_detady = base_fe->get_detady();
+            base_detadz = base_fe->get_detadz();
 
-        const std::vector<Point> & base_xyz = base_fe->get_xyz();
+            base_xyz = base_fe->get_xyz();
+          }
+
         ElemType base_type= base_elem->type();
 
-        libmesh_assert_equal_to (phi.size(), _n_total_approx_sf);
-        libmesh_assert_equal_to (dphidxi.size(), _n_total_approx_sf);
-        libmesh_assert_equal_to (dphideta.size(), _n_total_approx_sf);
-        libmesh_assert_equal_to (dphidzeta.size(), _n_total_approx_sf);
+#ifdef DEBUG
+        if (calculate_phi)
+          libmesh_assert_equal_to (phi.size(), _n_total_approx_sf);
+        if (calculate_dphi)
+          {
+            libmesh_assert_equal_to (dphidxi.size(), _n_total_approx_sf);
+            libmesh_assert_equal_to (dphideta.size(), _n_total_approx_sf);
+            libmesh_assert_equal_to (dphidzeta.size(), _n_total_approx_sf);
+          }
+#endif
 
         unsigned int tp=0; // total qp
         for (unsigned int rp=0; rp<n_radial_qp; ++rp)  // over radial qps
           for (unsigned int bp=0; bp<n_base_qp; ++bp)  // over base qps
 
             { // First compute the map from base element quantities to physical space:
-              xyz[tp] = InfFEMap::map(elem_dim, inf_elem, Point(base_qp[bp](0),base_qp[bp](1),radial_qp[rp](0)));
 
-              const Point r(xyz[tp]-origin);
-              const Real  a((base_xyz[bp]-origin).norm());
-              const Real  r_norm = r.norm();
-
-              // check that 'som' == a/r.
-              libmesh_assert_less(std::abs(som[rp] -a/r_norm) , 1e-7);
-              const Point unit_r(r/r_norm);
-
-
-              // They are used for computing the normal and do not correspond to the direction of eta and xi in this element:
-              // Due to the stretch of these axes in radial direction, they are deformed.
-              Point e_xi(base_dxidx[bp],
-                         base_dxidy[bp],
-                         base_dxidz[bp]);
-              Point e_eta(base_detadx[bp],
-                          base_detady[bp],
-                          base_detadz[bp]);
-
-              const RealGradient normal=e_eta.cross(e_xi).unit();
-
-              // grad a = a/r.norm() * grad_a_scaled
-              RealGradient grad_a_scaled=unit_r - normal/(normal*unit_r);
-
-              const Real  dxi_er=base_dxidx[bp]* unit_r(0) + base_dxidy[bp] *unit_r(1) + base_dxidz[bp] *unit_r(2);
-              const Real deta_er=base_detadx[bp]*unit_r(0) + base_detady[bp]*unit_r(1) + base_detadz[bp]*unit_r(2);
-
-              // in case of non-affine map, further terms need to be taken into account,
-              // involving \p e_eta and \p e_xi and thus recursive computation is needed
-              if (!base_elem->has_affine_map())
+              // initialize them with invalid value to not use them
+              // without setting them to the correct value before.
+              Point unit_r(NAN);
+              RealGradient grad_a_scaled(NAN);
+              Real a(NAN);
+              Real r_norm(NAN);
+              if (calculate_map || calculate_map_scaled)
                 {
-                  /**
-                   * The full form for 'a' is
-                   * a =  (r0*normal)/(normal*unit_r);
-                   * where r0 is some point on the base plane(!)
-                   * when the base element is not a plane, r0 and normal are functions of space.
-                   * Here, some approximation is used:
-                   */
+                  xyz[tp] = InfFEMap::map(elem_dim, inf_elem, Point(base_qp[bp](0),base_qp[bp](1),radial_qp[rp](0)));
 
-                  const unsigned int n_sf = base_elem->n_nodes();
-                  RealGradient tmp(0.,0.,0.);
-                  for (unsigned int i=0; i< n_sf; ++i)
+                  const Point r(xyz[tp]-origin);
+                  a=(base_xyz[bp]-origin).norm();
+                  r_norm = r.norm();
+
+                  // check that 'som' == a/r.
+                  libmesh_assert_less(std::abs(som[rp] -a/r_norm) , 1e-7);
+                  unit_r=(r/r_norm);
+
+                  // They are used for computing the normal and do not correspond to the direction of eta and xi in this element:
+                  // Due to the stretch of these axes in radial direction, they are deformed.
+                  Point e_xi(base_dxidx[bp],
+                             base_dxidy[bp],
+                             base_dxidz[bp]);
+                  Point e_eta(base_detadx[bp],
+                              base_detady[bp],
+                              base_detadz[bp]);
+
+                  const RealGradient normal=e_eta.cross(e_xi).unit();
+
+                  // grad a = a/r.norm() * grad_a_scaled
+                  grad_a_scaled=unit_r - normal/(normal*unit_r);
+
+                  const Real  dxi_er=base_dxidx[bp]* unit_r(0) + base_dxidy[bp] *unit_r(1) + base_dxidz[bp] *unit_r(2);
+                  const Real deta_er=base_detadx[bp]*unit_r(0) + base_detady[bp]*unit_r(1) + base_detadz[bp]*unit_r(2);
+
+                  // in case of non-affine map, further terms need to be taken into account,
+                  // involving \p e_eta and \p e_xi and thus recursive computation is needed
+                  if (!base_elem->has_affine_map())
                     {
-                      RealGradient dL_da_i = (FE<2,LAGRANGE>::shape_deriv(base_type,
-                                                                          base_elem->default_order(),
-                                                                          i, 0, base_qp[bp]) * e_xi
-                                              +FE<2,LAGRANGE>::shape_deriv(base_type,
-                                                                           base_elem->default_order(),
-                                                                           i, 1, base_qp[bp]) * e_eta);
+                      /**
+                       * The full form for 'a' is
+                       * a =  (r0*normal)/(normal*unit_r);
+                       * where r0 is some point on the base plane(!)
+                       * when the base element is not a plane, r0 and normal are functions of space.
+                       * Here, some approximation is used:
+                       */
 
-                      tmp += (base_elem->node_ref(i) -origin).norm()* dL_da_i;
+                      const unsigned int n_sf = base_elem->n_nodes();
+                      RealGradient tmp(0.,0.,0.);
+                      for (unsigned int i=0; i< n_sf; ++i)
+                        {
+                          RealGradient dL_da_i = (FE<2,LAGRANGE>::shape_deriv(base_type,
+                                                                              base_elem->default_order(),
+                                                                              i, 0, base_qp[bp]) * e_xi
+                                                  +FE<2,LAGRANGE>::shape_deriv(base_type,
+                                                                               base_elem->default_order(),
+                                                                               i, 1, base_qp[bp]) * e_eta);
+
+                          tmp += (base_elem->node_ref(i) -origin).norm()* dL_da_i;
+
+                        }
+                      libmesh_assert(tmp*unit_r < .95 ); // in a proper setup, tmp should have only a small radial component.
+                      grad_a_scaled = ( tmp - (tmp*unit_r)*unit_r ) / ( 1. - tmp*unit_r);
 
                     }
-                  libmesh_assert(tmp*unit_r < .95 ); // in a proper setup, tmp should have only a small radial component.
-                  grad_a_scaled = ( tmp - (tmp*unit_r)*unit_r ) / ( 1. - tmp*unit_r);
+
+                  // 'scale' = r/a
+                  dxidx_map_scaled[tp] = (grad_a_scaled(0) - unit_r(0))*dxi_er +base_dxidx[bp];
+                  dxidy_map_scaled[tp] = (grad_a_scaled(1) - unit_r(1))*dxi_er +base_dxidy[bp];
+                  dxidz_map_scaled[tp] = (grad_a_scaled(2) - unit_r(2))*dxi_er +base_dxidz[bp];
+
+                  // 'scale' = r/a
+                  detadx_map_scaled[tp] = (grad_a_scaled(0) - unit_r(0))*deta_er + base_detadx[bp];
+                  detady_map_scaled[tp] = (grad_a_scaled(1) - unit_r(1))*deta_er + base_detady[bp];
+                  detadz_map_scaled[tp] = (grad_a_scaled(2) - unit_r(2))*deta_er + base_detadz[bp];
+
+                  // 'scale' = (r/a)**2
+                  dzetadx_map_scaled[tp] =-2./a*(grad_a_scaled(0) - unit_r(0));
+                  dzetady_map_scaled[tp] =-2./a*(grad_a_scaled(1) - unit_r(1));
+                  dzetadz_map_scaled[tp] =-2./a*(grad_a_scaled(2) - unit_r(2));
 
                 }
 
-
-              dxidx_map_scaled[tp] = (grad_a_scaled(0) - unit_r(0))*dxi_er +base_dxidx[bp];
-              dxidy_map_scaled[tp] = (grad_a_scaled(1) - unit_r(1))*dxi_er +base_dxidy[bp];
-              dxidz_map_scaled[tp] = (grad_a_scaled(2) - unit_r(2))*dxi_er +base_dxidz[bp];
-              dxidx_map[tp] = a/r_norm * dxidx_map_scaled[tp];
-              dxidy_map[tp] = a/r_norm * dxidy_map_scaled[tp];
-              dxidz_map[tp] = a/r_norm * dxidz_map_scaled[tp];
-
-              detadx_map_scaled[tp] = (grad_a_scaled(0) - unit_r(0))*deta_er + base_detadx[bp];
-              detady_map_scaled[tp] = (grad_a_scaled(1) - unit_r(1))*deta_er + base_detady[bp];
-              detadz_map_scaled[tp] = (grad_a_scaled(2) - unit_r(2))*deta_er + base_detadz[bp];
-              detadx_map[tp] = a/r_norm * detadx_map_scaled[tp];
-              detady_map[tp] = a/r_norm * detady_map_scaled[tp];
-              detadz_map[tp] = a/r_norm * detadz_map_scaled[tp];
-
-              // dzetadx = dzetadr*dr/dx - 2/r * grad_a
-              //         = dzetadr*dr/dx - 2*a/r^2 * grad_a_scaled
-              dzetadx_map[tp] =-2.*a/(r_norm*r_norm)*(grad_a_scaled(0) - unit_r(0));
-              dzetady_map[tp] =-2.*a/(r_norm*r_norm)*(grad_a_scaled(1) - unit_r(1));
-              dzetadz_map[tp] =-2.*a/(r_norm*r_norm)*(grad_a_scaled(2) - unit_r(2));
-              dzetadx_map_scaled[tp] =-2./a*(grad_a_scaled(0) - unit_r(0));
-              dzetady_map_scaled[tp] =-2./a*(grad_a_scaled(1) - unit_r(1));
-              dzetadz_map_scaled[tp] =-2./a*(grad_a_scaled(2) - unit_r(2));
-
-              Real inv_jacxR_pow4 = (dxidx_map_scaled[tp]  *(  detady_map_scaled[tp]*dzetadz_map_scaled[tp]
-                                                            - dzetady_map_scaled[tp]* detadz_map_scaled[tp]) +
-                                     detadx_map_scaled[tp] *( dzetady_map_scaled[tp]*  dxidz_map_scaled[tp]
-                                                              - dxidy_map_scaled[tp]*dzetadz_map_scaled[tp]) +
-                                     dzetadx_map_scaled[tp]*(   dxidy_map_scaled[tp]* detadz_map_scaled[tp]
-                                                              -detady_map_scaled[tp]*  dxidz_map_scaled[tp]));
-
-              Real inv_jac = (  dxidx_map[tp]*( detady_map[tp]*dzetadz_map[tp]- dzetady_map[tp]*detadz_map[tp]) +
-                               detadx_map[tp]*(dzetady_map[tp]*  dxidz_map[tp]-  dxidy_map[tp]*dzetadz_map[tp]) +
-                              dzetadx_map[tp]*(  dxidy_map[tp]* detadz_map[tp]- detady_map[tp]*  dxidz_map[tp]));
-
-              if (inv_jacxR_pow4 <= 1e-7)
+              if (calculate_map)
                 {
-                  libmesh_error_msg("ERROR: negative inverse Jacobian " \
-                                    << inv_jacxR_pow4 \
-                                    << " at point " \
-                                    << xyz[tp] \
-                                    << " in element " \
-                                    << inf_elem->id());
-                }
+                  dxidx_map[tp] = a/r_norm * dxidx_map_scaled[tp];
+                  dxidy_map[tp] = a/r_norm * dxidy_map_scaled[tp];
+                  dxidz_map[tp] = a/r_norm * dxidz_map_scaled[tp];
 
-              JxWxdecay[tp] = _total_qrule_weights[tp]/inv_jacxR_pow4;
-              JxW[tp] = _total_qrule_weights[tp]/inv_jac;
+                  detadx_map[tp] = a/r_norm * detadx_map_scaled[tp];
+                  detady_map[tp] = a/r_norm * detady_map_scaled[tp];
+                  detadz_map[tp] = a/r_norm * detadz_map_scaled[tp];
+
+                  // dzetadx = dzetadr*dr/dx - 2/r * grad_a
+                  //         = dzetadr*dr/dx - 2*a/r^2 * grad_a_scaled
+                  dzetadx_map[tp] =-2.*a/(r_norm*r_norm)*(grad_a_scaled(0) - unit_r(0));
+                  dzetady_map[tp] =-2.*a/(r_norm*r_norm)*(grad_a_scaled(1) - unit_r(1));
+                  dzetadz_map[tp] =-2.*a/(r_norm*r_norm)*(grad_a_scaled(2) - unit_r(2));
+
+                  if (calculate_jxw)
+                    {
+                      Real inv_jac = (dxidx_map[tp]*( detady_map[tp]*dzetadz_map[tp]- dzetady_map[tp]*detadz_map[tp]) +
+                                      detadx_map[tp]*(dzetady_map[tp]* dxidz_map[tp]-  dxidy_map[tp]*dzetadz_map[tp]) +
+                                      dzetadx_map[tp]*( dxidy_map[tp]*detadz_map[tp]- detady_map[tp]*  dxidz_map[tp]));
+
+                      if (inv_jac <= 1e-10)
+                        {
+                          libmesh_error_msg("ERROR: negative inverse Jacobian " \
+                                            << inv_jac \
+                                            << " at point " \
+                                            << xyz[tp] \
+                                            << " in element " \
+                                            << inf_elem->id());
+                        }
+
+
+                      JxW[tp] = _total_qrule_weights[tp]/inv_jac;
+                    }
+
+                }
+              if (calculate_map_scaled)
+                {
+                  Real inv_jacxR_pow4 = (dxidx_map_scaled[tp]  *(  detady_map_scaled[tp]*dzetadz_map_scaled[tp]
+                                                                - dzetady_map_scaled[tp]* detadz_map_scaled[tp]) +
+                                         detadx_map_scaled[tp] *( dzetady_map_scaled[tp]*  dxidz_map_scaled[tp]
+                                                                - dxidy_map_scaled[tp]*dzetadz_map_scaled[tp]) +
+                                         dzetadx_map_scaled[tp]*( dxidy_map_scaled[tp]* detadz_map_scaled[tp]
+                                                                -detady_map_scaled[tp]*  dxidz_map_scaled[tp]));
+                  if (inv_jacxR_pow4 <= 1e-7)
+                    {
+                      libmesh_error_msg("ERROR: negative weighted inverse Jacobian " \
+                                        << inv_jacxR_pow4 \
+                                        << " at point " \
+                                        << xyz[tp] \
+                                        << " in element " \
+                                        << inf_elem->id());
+                    }
+
+                  JxWxdecay[tp] = _total_qrule_weights[tp]/inv_jacxR_pow4;
+                }
 
               // phase term mu(r)=i*k*(r-a).
               // skip i*k: it is added separately during matrix assembly.
-              dphase[tp] = unit_r - grad_a_scaled*a/r_norm;
 
-              dweight[tp](0) = dweightdv[rp] * dzetadx_map[tp];
-              dweight[tp](1) = dweightdv[rp] * dzetady_map[tp];
-              dweight[tp](2) = dweightdv[rp] * dzetadz_map[tp];
+              if (calculate_dphi || calculate_dphi_scaled)
+                dphase[tp] = unit_r - grad_a_scaled*a/r_norm;
 
-              dweightxr_sq[tp](0) = dweightdv[rp] * dzetadx_map_scaled[tp];
-              dweightxr_sq[tp](1) = dweightdv[rp] * dzetady_map_scaled[tp];
-              dweightxr_sq[tp](2) = dweightdv[rp] * dzetadz_map_scaled[tp];
-
-              // compute the shape-functions and derivative quantities:
-              for (auto i : index_range(phi))
+              if (calculate_dphi)
                 {
-
-                  // let the index vectors take care of selecting the appropriate base/radial shape
-                  unsigned int bi = _base_shape_index  [i];
-                  unsigned int ri = _radial_shape_index[i];
-                  phi      [i][tp] = S [bi][bp] * mode[ri][rp] * som[rp];
-                  phixr    [i][tp] = S [bi][bp] * mode[ri][rp];
-                  dphidxi  [i][tp] = Ss[bi][bp] * mode[ri][rp] * som[rp];
-                  dphideta [i][tp] = St[bi][bp] * mode[ri][rp] * som[rp];
-                  dphidzeta[i][tp] = S [bi][bp]
-                    * (dmodedv[ri][rp] * som[rp] + mode[ri][rp] * dsomdv[rp]);
-
-
-                  // dphi/dx    = (dphi/dxi)*(dxi/dx) + (dphi/deta)*(deta/dx) + (dphi/dzeta)*(dzeta/dx);
-                  dphi[i][tp](0) =
-                    dphidx[i][tp] = (dphidxi[i][tp]*dxidx_map[tp] +
-                                     dphideta[i][tp]*detadx_map[tp] +
-                                     dphidzeta[i][tp]*dzetadx_map[tp]);
-
-                  // dphi/dy    = (dphi/dxi)*(dxi/dy) + (dphi/deta)*(deta/dy) + (dphi/dzeta)*(dzeta/dy);
-                  dphi[i][tp](1) =
-                    dphidy[i][tp] = (dphidxi[i][tp]*dxidy_map[tp] +
-                                     dphideta[i][tp]*detady_map[tp] +
-                                     dphidzeta[i][tp]*dzetady_map[tp]);
-
-                  // dphi/dz    = (dphi/dxi)*(dxi/dz) + (dphi/deta)*(deta/dz) + (dphi/dzeta)*(dzeta/dz);
-                  dphi[i][tp](2) =
-                    dphidz[i][tp] = (dphidxi[i][tp]*dxidz_map[tp] +
-                                     dphideta[i][tp]*detadz_map[tp] +
-                                     dphidzeta[i][tp]*dzetadz_map[tp]);
-
-                  dphixr[i][tp](0)= (dphidxi[i][tp]*dxidx_map_scaled[tp] +
-                                     dphideta[i][tp]*detadx_map_scaled[tp] +
-                                     dphidzeta[i][tp]*dzetadx_map_scaled[tp]*som[rp]);
-
-                  dphixr[i][tp](1) = (dphidxi[i][tp]*dxidy_map_scaled[tp] +
-                                      dphideta[i][tp]*detady_map_scaled[tp] +
-                                      dphidzeta[i][tp]*dzetady_map_scaled[tp]*som[rp]);
-
-                  dphixr[i][tp](2) = (dphidxi[i][tp]*dxidz_map_scaled[tp] +
-                                      dphideta[i][tp]*detadz_map_scaled[tp] +
-                                      dphidzeta[i][tp]*dzetadz_map_scaled[tp]*som[rp]);
-
-                  const Real dphidxixr = Ss[bi][bp] * mode[ri][rp];
-                  const Real dphidetaxr= St[bi][bp] * mode[ri][rp];
-
-                  dphixr_sq[i][tp](0)= (dphidxixr*dxidx_map_scaled[tp] +
-                                        dphidetaxr*detadx_map_scaled[tp] +
-                                        dphidzeta[i][tp]*dzetadx_map_scaled[tp]);
-
-                  dphixr_sq[i][tp](1) = (dphidxixr*dxidy_map_scaled[tp] +
-                                         dphidetaxr*detady_map_scaled[tp] +
-                                         dphidzeta[i][tp]*dzetady_map_scaled[tp]);
-
-                  dphixr_sq[i][tp](2) = (dphidxixr*dxidz_map_scaled[tp] +
-                                         dphidetaxr*detadz_map_scaled[tp] +
-                                         dphidzeta[i][tp]*dzetadz_map_scaled[tp]);
-
+                  dweight[tp](0) = dweightdv[rp] * dzetadx_map[tp];
+                  dweight[tp](1) = dweightdv[rp] * dzetady_map[tp];
+                  dweight[tp](2) = dweightdv[rp] * dzetadz_map[tp];
+                }
+              if (calculate_dphi_scaled)
+                {
+                  dweightxr_sq[tp](0) = dweightdv[rp] * dzetadx_map_scaled[tp];
+                  dweightxr_sq[tp](1) = dweightdv[rp] * dzetady_map_scaled[tp];
+                  dweightxr_sq[tp](2) = dweightdv[rp] * dzetadz_map_scaled[tp];
                 }
 
+              if (calculate_phi || calculate_phi_scaled || calculate_dphi || calculate_dphi_scaled)
+                // compute the shape-functions and derivative quantities:
+                for (unsigned int i=0; i <_n_total_approx_sf ; ++i)
+                  {
+                    // let the index vectors take care of selecting the appropriate base/radial shape
+                    unsigned int bi = _base_shape_index  [i];
+                    unsigned int ri = _radial_shape_index[i];
+                    if (calculate_phi)
+                      phi      [i][tp] = S [bi][bp] * mode[ri][rp] * som[rp];
+
+                    if (calculate_phi_scaled)
+                      phixr    [i][tp] = S [bi][bp] * mode[ri][rp];
+
+                    if (calculate_dphi || calculate_dphi_scaled)
+                      {
+                        dphidxi  [i][tp] = Ss[bi][bp] * mode[ri][rp] * som[rp];
+                        dphideta [i][tp] = St[bi][bp] * mode[ri][rp] * som[rp];
+                        dphidzeta[i][tp] = S [bi][bp]
+                          * (dmodedv[ri][rp] * som[rp] + mode[ri][rp] * dsomdv[rp]);
+                      }
+
+                    if (calculate_dphi)
+                      {
+
+                        // dphi/dx    = (dphi/dxi)*(dxi/dx) + (dphi/deta)*(deta/dx) + (dphi/dzeta)*(dzeta/dx);
+                        dphi[i][tp](0) =
+                          dphidx[i][tp] = (dphidxi[i][tp]*dxidx_map[tp] +
+                                           dphideta[i][tp]*detadx_map[tp] +
+                                           dphidzeta[i][tp]*dzetadx_map[tp]);
+
+                        // dphi/dy    = (dphi/dxi)*(dxi/dy) + (dphi/deta)*(deta/dy) + (dphi/dzeta)*(dzeta/dy);
+                        dphi[i][tp](1) =
+                          dphidy[i][tp] = (dphidxi[i][tp]*dxidy_map[tp] +
+                                           dphideta[i][tp]*detady_map[tp] +
+                                           dphidzeta[i][tp]*dzetady_map[tp]);
+
+                        // dphi/dz    = (dphi/dxi)*(dxi/dz) + (dphi/deta)*(deta/dz) + (dphi/dzeta)*(dzeta/dz);
+                        dphi[i][tp](2) =
+                          dphidz[i][tp] = (dphidxi[i][tp]*dxidz_map[tp] +
+                                           dphideta[i][tp]*detadz_map[tp] +
+                                           dphidzeta[i][tp]*dzetadz_map[tp]);
+
+                      }
+                    if (calculate_dphi_scaled)
+                      { // we don't distinguish between the different levels of scaling here...
+
+                        dphixr[i][tp](0)= (dphidxi[i][tp]*dxidx_map_scaled[tp] +
+                                           dphideta[i][tp]*detadx_map_scaled[tp] +
+                                           dphidzeta[i][tp]*dzetadx_map_scaled[tp]*som[rp]);
+
+                        dphixr[i][tp](1) = (dphidxi[i][tp]*dxidy_map_scaled[tp] +
+                                            dphideta[i][tp]*detady_map_scaled[tp] +
+                                            dphidzeta[i][tp]*dzetady_map_scaled[tp]*som[rp]);
+
+                        dphixr[i][tp](2) = (dphidxi[i][tp]*dxidz_map_scaled[tp] +
+                                            dphideta[i][tp]*detadz_map_scaled[tp] +
+                                            dphidzeta[i][tp]*dzetadz_map_scaled[tp]*som[rp]);
+
+                        const Real dphidxixr = Ss[bi][bp] * mode[ri][rp];
+                        const Real dphidetaxr= St[bi][bp] * mode[ri][rp];
+
+                        dphixr_sq[i][tp](0)= (dphidxixr*dxidx_map_scaled[tp] +
+                                              dphidetaxr*detadx_map_scaled[tp] +
+                                              dphidzeta[i][tp]*dzetadx_map_scaled[tp]);
+
+                        dphixr_sq[i][tp](1) = (dphidxixr*dxidy_map_scaled[tp] +
+                                               dphidetaxr*detady_map_scaled[tp] +
+                                               dphidzeta[i][tp]*dzetady_map_scaled[tp]);
+
+                        dphixr_sq[i][tp](2) = (dphidxixr*dxidz_map_scaled[tp] +
+                                               dphidetaxr*detadz_map_scaled[tp] +
+                                               dphidzeta[i][tp]*dzetadz_map_scaled[tp]);
+                      }
+
+                  }
               tp++;
             }
 
@@ -928,6 +1131,8 @@ void InfFE<Dim,T_radial,T_map>::compute_shape_functions(const Elem * inf_elem,
 template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
 bool InfFE<Dim,T_radial,T_map>::shapes_need_reinit() const
 {
+  // We never call this.
+  libmesh_not_implemented();
   return false;
 }
 

--- a/src/fe/inf_fe_boundary.C
+++ b/src/fe/inf_fe_boundary.C
@@ -156,7 +156,7 @@ void InfFE<Dim,T_radial,T_base>::init_face_shape_functions(const std::vector<Poi
   // so update the fe_base.
   if (inf_side->infinite())
     {
-      base_fe = FEBase::build(1, this->fe_type);
+      base_fe = FEBase::build(Dim-2, this->fe_type);
       base_fe->attach_quadrature_rule(base_qrule.get());
     }
   else
@@ -165,21 +165,26 @@ void InfFE<Dim,T_radial,T_base>::init_face_shape_functions(const std::vector<Poi
       base_fe->attach_quadrature_rule(base_qrule.get());
     }
 
-  //before initializing, we should say what to compute:
-  base_fe->_fe_map->get_xyz();
-  base_fe->_fe_map->get_JxW();
+  if (this->calculate_map || this->calculate_map_scaled)
+    {
+      //before initializing, we should say what to compute:
+      base_fe->_fe_map->get_xyz();
+      base_fe->_fe_map->get_JxW();
+    }
 
-  // initialize the shape functions on the base
-  base_fe->init_base_shape_functions(base_fe->qrule->get_points(),
-                                     base_elem.get());
+  if (calculate_phi || calculate_dphi || calculate_phi_scaled || calculate_dphi_scaled)
+    // initialize the shape functions on the base
+    base_fe->init_base_shape_functions(base_fe->qrule->get_points(),
+                                       base_elem.get());
 
   // the number of quadrature points
-  const unsigned int n_radial_qp =
-    cast_int<unsigned int>(som.size());
+  const unsigned int n_radial_qp = radial_qrule->n_points();
   const unsigned int n_base_qp   = base_qrule->n_points();
   const unsigned int n_total_qp  = n_radial_qp * n_base_qp;
 
 #ifdef DEBUG
+  if (som.size() > 0)
+    libmesh_assert_equal_to(n_radial_qp, som.size());
   // when evaluating the base side, there should be only one radial point.
   if (!inf_side->infinite())
     libmesh_assert_equal_to (n_radial_qp, 1);
@@ -229,24 +234,28 @@ template <unsigned int Dim, FEFamily T_radial, InfMapType T_base>
 void InfFE<Dim,T_radial,T_base>::compute_face_functions()
 {
 
-  const unsigned int n_qp = cast_int<unsigned int>(_total_qrule_weights.size());
-  if (calculate_dxyz)
-    {
-      this->normals.resize(n_qp);
+  if (!calculate_map && !calculate_map_scaled)
+    return; // we didn't ask for any quantity computed here.
 
-      if (Dim > 1)
-        {
-          this->tangents.resize(n_qp);
-          for (unsigned int p=0; p<n_qp; ++p)
-            this->tangents[p].resize(LIBMESH_DIM-1);
-        }
-      else
-        {
-          libMesh::err << "tangents have no sense in 1-dimensional elements!"<<std::endl;
-          libmesh_error_msg("Exiting...");
-        }
+  const unsigned int n_qp = cast_int<unsigned int>(_total_qrule_weights.size());
+  this->normals.resize(n_qp);
+
+  if (Dim > 1)
+    {
+      this->tangents.resize(n_qp);
+      for (unsigned int p=0; p<n_qp; ++p)
+        this->tangents[p].resize(LIBMESH_DIM-1);
+    }
+  else
+    {
+      libMesh::err << "tangents have no sense in 1-dimensional elements!"<<std::endl;
+      libmesh_error_msg("Exiting...");
     }
 
+  // the dimension of base indicates which side we have:
+  // if base_dim == Dim -1 : base
+  //    base_dim == Dim -2 : one of the other sides.
+  unsigned int base_dim =base_fe->dim;
   // If we have no quadrature points, there's nothing else to do
   if (!n_qp)
     return;
@@ -261,67 +270,74 @@ void InfFE<Dim,T_radial,T_base>::compute_face_functions()
       }
     case 3:
       {
-        for (unsigned int p=0; p<n_qp; ++p)
-          {
+        // Below, we assume a 2D base, i.e. we compute the side s=0.
+        if (base_dim==Dim-1)
+          for (unsigned int p=0; p<n_qp; ++p)
+            {
+              //
+              // seeking dxyzdx, dxyzdeta means to compute
+              //        / dx/dxi    dy/dxi   dz/dxi \.
+              // J^-1= |                             |
+              //       \ dx/deta  dy/deta   dz/deta /.
+              // which is the psudo-inverse of J, i.e.
+              //
+              // J^-1 = (J^T J)^-1 J^T
+              //
+              // where J^T T is the 2x2 matrix 'g' used to compute the
+              // Jacobian determinant; thus
+              //
+              // J^-1 = ________1________   / g22  -g21 \  / dxi/dx  dxi/dy   dxi/dz \.
+              //        g11*g22 - g21*g12   \-g12  g11  /  \ deta/dx deta/dy deta/dz /.
+              const std::vector<Real> & base_dxidx = base_fe->get_dxidx();
+              const std::vector<Real> & base_dxidy = base_fe->get_dxidy();
+              const std::vector<Real> & base_dxidz = base_fe->get_dxidz();
+              const std::vector<Real> & base_detadx = base_fe->get_detadx();
+              const std::vector<Real> & base_detady = base_fe->get_detady();
+              const std::vector<Real> & base_detadz = base_fe->get_detadz();
 
-            if (calculate_dxyz)
-              {
-                //
-                // seeking dxyzdx, dxyzdeta means to compute
-                //        / dx/dxi    dy/dxi   dz/dxi \.
-                // J^-1= |                             |
-                //       \ dx/deta  dy/deta   dz/deta /.
-                // which is the psudo-inverse of J, i.e.
-                //
-                // J^-1 = (J^T J)^-1 J^T
-                //
-                // where J^T T is the 2x2 matrix 'g' used to compute the
-                // Jacobian determinant; thus
-                //
-                // J^-1 = ________1________   / g22  -g21 \  / dxi/dx  dxi/dy   dxi/dz \.
-                //        g11*g22 - g21*g12   \-g12  g11  /  \ deta/dx deta/dy deta/dz /.
-                const std::vector<Real> & base_dxidx = base_fe->get_dxidx();
-                const std::vector<Real> & base_dxidy = base_fe->get_dxidy();
-                const std::vector<Real> & base_dxidz = base_fe->get_dxidz();
-                const std::vector<Real> & base_detadx = base_fe->get_detadx();
-                const std::vector<Real> & base_detady = base_fe->get_detady();
-                const std::vector<Real> & base_detadz = base_fe->get_detadz();
+              const Real g11 = (base_dxidx[p]*base_dxidx[p] +
+                                base_dxidy[p]*base_dxidy[p] +
+                                base_dxidz[p]*base_dxidz[p]);
+              const Real g12 = (base_dxidx[p]*base_detadx[p] +
+                                base_dxidy[p]*base_detady[p] +
+                                base_dxidz[p]*base_detadz[p]);
+              const Real g21 = g12;
+              const Real g22 = (base_detadx[p]*base_detadx[p] +
+                                base_detady[p]*base_detady[p] +
+                                base_detadz[p]*base_detadz[p]);
 
-                const Real g11 = (base_dxidx[p]*base_dxidx[p] +
-                                  base_dxidy[p]*base_dxidy[p] +
-                                  base_dxidz[p]*base_dxidz[p]);
-                const Real g12 = (base_dxidx[p]*base_detadx[p] +
-                                  base_dxidy[p]*base_detady[p] +
-                                  base_dxidz[p]*base_detadz[p]);
-                const Real g21 = g12;
-                const Real g22 = (base_detadx[p]*base_detadx[p] +
-                                  base_detady[p]*base_detady[p] +
-                                  base_detadz[p]*base_detadz[p]);
+              const Real det = (g11*g22 - g12*g21);
 
-                // det is scaled by r^6
-                const Real det = (g11*g22 - g12*g21);
+              Point dxyzdxi_map((g22*base_dxidx[p]-g21*base_detadx[p])/det,
+                                (g22*base_dxidy[p]-g21*base_detady[p])/det,
+                                (g22*base_dxidz[p]-g21*base_detadz[p])/det);
 
-                // scaled by r^-3
-                Point dxyzdxi_map((g22*base_dxidx[p]-g21*base_detadx[p])/det,
-                                  (g22*base_dxidy[p]-g21*base_detady[p])/det,
-                                  (g22*base_dxidz[p]-g21*base_detadz[p])/det);
+              Point dxyzdeta_map((g11*base_detadx[p] - g12*base_dxidx[p])/det,
+                                 (g11*base_detady[p] - g12*base_dxidy[p])/det,
+                                 (g11*base_detadz[p] - g12*base_dxidz[p])/det);
 
-                Point dxyzdeta_map((g11*base_detadx[p] - g12*base_dxidx[p])/det,
-                                   (g11*base_detady[p] - g12*base_dxidy[p])/det,
-                                   (g11*base_detadz[p] - g12*base_dxidz[p])/det);
-                // scaled by r^-2
+              this->tangents[p][0] = dxyzdxi_map.unit();
 
-                this->tangents[p][0] = dxyzdxi_map.unit();
+              this->tangents[p][1] = (dxyzdeta_map - (dxyzdeta_map*tangents[p][0])*tangents[p][0] ).unit();
 
-                this->tangents[p][1] = (dxyzdeta_map - (dxyzdeta_map*tangents[p][0])*tangents[p][0] ).unit();
+              this->normals[p]     = tangents[p][0].cross(tangents[p][1]).unit();
+              // recompute JxW using the 2D Jacobian:
+              // Since we are at the base, there is no difference between scaled and unscaled jacobian
+              if (calculate_jxw)
+                this->JxW[p] = _total_qrule_weights[p]/std::sqrt(det);
 
-                this->normals[p]     = tangents[p][0].cross(tangents[p][1]).unit();
-                // recompute JxW using the 2D Jacobian:
+              if (calculate_map_scaled)
                 this->JxWxdecay[p] = _total_qrule_weights[p]/std::sqrt(det);
-                this->JxW[p] = JxWxdecay[p];
-              }
 
-
+            }
+        else if (base_dim == Dim -2)
+          {
+            libmesh_not_implemented();
+          }
+        else
+          {
+            // in this case something went completely wrong.
+            libmesh_not_implemented();
           }
         break;
       }

--- a/tests/fe/inf_fe_radial_test.C
+++ b/tests/fe/inf_fe_radial_test.C
@@ -557,6 +557,20 @@ public:
     const std::vector<std::vector<Real> >&         phi_w  = inf_fe->get_phi_over_decayxR();
     inf_fe->reinit(infinite_elem,&points);
 
+    // check that all quantities are sized correctly:
+    libmesh_assert_equal_to(q_point.size(), sob_w.size());
+    libmesh_assert_equal_to(q_point.size(), dsob_w.size());
+    libmesh_assert_equal_to(q_point.size(), sob_now.size());
+    libmesh_assert_equal_to(q_point.size(), dsob_now.size());
+    libmesh_assert_equal_to(q_point.size(), dphase.size());
+    libmesh_assert_equal_to(phi.size(), phi_w.size());
+    libmesh_assert_equal_to(phi.size(), dphi.size());
+    libmesh_assert_equal_to(phi.size(), dphi_w.size());
+    libmesh_assert_equal_to(q_point.size(), phi[0].size());
+    libmesh_assert_equal_to(q_point.size(), phi_w[0].size());
+    libmesh_assert_equal_to(q_point.size(), dphi[0].size());
+    libmesh_assert_equal_to(q_point.size(), dphi_w[0].size());
+
     for(unsigned int qp =0 ; qp < num_pt ; ++qp)
       {
         const Point dxyz(q_point[qp+num_pt]-q_point[qp]);


### PR DESCRIPTION
Finally I have adjusted the calculation of `InfFE`s to only compute the required quantities.
Since the overall structure of the calculation differs from the `FE`-variant, I have added some other `calculate_<something>`s:'

While I didn't see much sense in having a separate `calculate_dphiref` here, I made a distinction between `scaled` and unscaled sets, i.e. if the quantity itself is requested or if the `xdecay` or `overdecay` variant needs to be calculated.

Further, I added a separate `calculate_jxw`-flag because after restructuring one must test both the weighted and unweighted JxW for positiveness  (at least it makes sense). Testing the unweighted jacobian (`inv_jac <= 1e-10`) however often resulted in errors of my (otherwise working) application, so I'd like to avoid its computation as long as not explicitly requested.

`include/fe/inf_fe.h` from running `reindent.sh`; if you don't like it, let me know.

Best regards