### PR TITLE
Enable EIM using POD

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex4/eim.in
+++ b/examples/reduced_basis/reduced_basis_ex4/eim.in
@@ -11,4 +11,4 @@ deterministic_training = true # Are the training points generated randomly or de
 
 n_training_samples = 25       # The number of parameters in training set (must be square for the 2-parameter deterministic case)
 
-best_fit_type = projection # Choose which algorithm to use in the EIM greedy (either "projection" or "eim")
+best_fit_type = pod # Choose which algorithm to use in the EIM greedy (either "projection", "eim", or "pod")

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -149,7 +149,7 @@ int main (int argc, char ** argv)
 
         // Perform the EIM Greedy and write out the data
         eim_construction.initialize_eim_construction();
-        eim_construction.train_eim_approximation();
+        eim_construction.train_eim_approximation_with_POD();
 
         RBDataSerialization::RBEIMEvaluationSerialization rb_eim_eval_writer(eim_rb_eval);
         rb_eim_eval_writer.write_to_file("rb_eim_eval.bin");

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -149,7 +149,7 @@ int main (int argc, char ** argv)
 
         // Perform the EIM Greedy and write out the data
         eim_construction.initialize_eim_construction();
-        eim_construction.train_eim_approximation_with_POD();
+        eim_construction.train_eim_approximation();
 
         RBDataSerialization::RBEIMEvaluationSerialization rb_eim_eval_writer(eim_rb_eval);
         rb_eim_eval_writer.write_to_file("rb_eim_eval.bin");

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -146,10 +146,16 @@ public:
   virtual void print_info();
 
   /**
-   * Generate the EIM approximation for the specified parametrized function.
-   * Return the final tolerance from the training algorithm.
+   * Generate the EIM approximation for the specified parametrized function
+   * using the Greedy Algorithm. Return the final tolerance.
    */
   Real train_eim_approximation();
+
+  /**
+   * Generate the EIM approximation for the specified parametrized function
+   * using Proper Orthogonal Decomposition (POD). Return the final tolerance.
+   */
+  void train_eim_approximation_with_POD();
 
   /**
    * Build a vector of ElemAssembly objects that accesses the basis
@@ -316,6 +322,17 @@ private:
    * Add a new basis function to the EIM approximation.
    */
   void enrich_eim_approximation(unsigned int training_index);
+
+  /**
+   * Implementation of enrich_eim_approximation() for the case of element sides.
+   */
+  void enrich_eim_approximation_on_sides(const SideQpDataMap & interior_pf);
+
+  /**
+   * Implementation of enrich_eim_approximation() for the case of element interiors.
+   */
+  void enrich_eim_approximation_on_interiors(const QpDataMap & interior_pf,
+                                             const std::vector<std::vector<Number>> & interior_pf_obs_values);
 
   /**
    * Update the matrices used in training the EIM approximation.

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -154,14 +154,18 @@ public:
   /**
    * Generate the EIM approximation for the specified parametrized function
    * using the Greedy Algorithm. Return the final tolerance.
+   * Method is virtual so that behavior can be specialized further in
+   * subclasses, if needed.
    */
-  Real train_eim_approximation_with_greedy();
+  virtual Real train_eim_approximation_with_greedy();
 
   /**
    * Generate the EIM approximation for the specified parametrized function
    * using Proper Orthogonal Decomposition (POD). Return the final tolerance.
+   * Method is virtual so that behavior can be specialized further in
+   * subclasses, if needed.
    */
-  Real train_eim_approximation_with_POD();
+  virtual Real train_eim_approximation_with_POD();
 
   /**
    * Build a vector of ElemAssembly objects that accesses the basis

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -54,7 +54,7 @@ class RBEIMConstruction : public RBConstructionBase<System>
 {
 public:
 
-  enum BEST_FIT_TYPE { PROJECTION_BEST_FIT, EIM_BEST_FIT };
+  enum BEST_FIT_TYPE { PROJECTION_BEST_FIT, EIM_BEST_FIT, POD_BEST_FIT };
 
   /**
    * Constructor.  Optionally initializes required
@@ -147,15 +147,21 @@ public:
 
   /**
    * Generate the EIM approximation for the specified parametrized function
-   * using the Greedy Algorithm. Return the final tolerance.
+   * using either POD or the Greedy Algorithm. Return the final tolerance.
    */
   Real train_eim_approximation();
 
   /**
    * Generate the EIM approximation for the specified parametrized function
+   * using the Greedy Algorithm. Return the final tolerance.
+   */
+  Real train_eim_approximation_with_greedy();
+
+  /**
+   * Generate the EIM approximation for the specified parametrized function
    * using Proper Orthogonal Decomposition (POD). Return the final tolerance.
    */
-  void train_eim_approximation_with_POD();
+  Real train_eim_approximation_with_POD();
 
   /**
    * Build a vector of ElemAssembly objects that accesses the basis

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -1558,7 +1558,7 @@ void RBEIMConstruction::enrich_eim_approximation(unsigned int training_index)
       std::vector<std::vector<Number>> new_bf_obs_vals;
       if (has_obs_vals)
         new_bf_obs_vals = _parametrized_functions_for_training_obs_values[training_index];
-      
+
       enrich_eim_approximation_on_interiors(_local_parametrized_functions_for_training[training_index],
                                             new_bf_obs_vals);
     }


### PR DESCRIPTION
This is equivalent to the "Discrete Empirical Interpolation Method", which is described in the literature. In some cases (mainly with relatively few parameters) the POD-based approach can be more efficient than the Greedy approach, so it is good to have both options.