### PR TITLE
Detect PETSc HDF5 when --enable-hdf5

### DIFF
--- a/configure
+++ b/configure
@@ -54563,8 +54563,24 @@ fi
 
 
 # --------------------------------------------------------------
-# HDF5 -- enabled by default
+# HDF5 -- disabled by default
 # --------------------------------------------------------------
+
+# PETSc configure can --download-hdf5, and that's a really convenient
+# feature for users ... but libMesh --enable-hdf5 will only detect it
+# if we add PETSc include and lib directory flags *here*; if we wait
+# until build time it's too late.
+
+ac_PETSCHDF5_save_CPPFLAGS="$CPPFLAGS"
+ac_PETSCHDF5_save_LDFLAGS="$LDFLAGS"
+
+if test "x$enablepetsc" != "xno"; then :
+
+        CPPFLAGS="$PETSCINCLUDEDIRS $CPPFLAGS"
+        LDFLAGS="$PETSCLINKLIBS $LDFLAGS"
+
+fi
+
 
   # Check whether --enable-hdf5 was given.
 if test "${enable_hdf5+set}" = set; then :
@@ -54928,6 +54944,10 @@ $as_echo "<<< Configuring library with HDF5 support >>>" >&6; }
 fi
 
 fi
+
+
+CPPFLAGS="$ac_PETSCHDF5_save_CPPFLAGS"
+LDFLAGS="$ac_PETSCHDF5_save_LDFLAGS"
 
 if test $enablehdf5 = yes; then :
 
@@ -56493,10 +56513,30 @@ fi
 # additional arguments to be passed to those packages, do that here.
 # Specifically, we append libmesh_subpackage_arguments to ac_configure_args
 # before AC_OUTPUT recurses into our subpackages
+
+# We need our netcdf subpackage to be able to use whatever HDF5 we've
+# detected.  That means using whatever $HDF5_CPPFLAGS and $HDF5_LIBS
+# we've determined work - but if we're using PETSc it also means
+# passing along PETSc's directories in case we want to link to a
+# --download-hdf5 build there.
+SUB_CPPFLAGS="$CPPFLAGS"
+SUB_LIBS="$LIBS"
+if test $enablehdf5 = yes; then :
+
+       SUB_CPPFLAGS="$HDF5_CPPFLAGS $SUB_CPPFLAGS"
+       SUB_LIBS="$HDF5_LIBS $SUB_LIBS"
+       if test "x$enablepetsc" != "xno"; then :
+
+              SUB_CPPFLAGS="$PETSCINCLUDEDIRS $SUB_CPPFLAGS"
+              SUB_LIBS="$PETSCLINKLIBS $SUB_LIBS"
+
+fi
+fi
+
 if test "x$enablenested" = "xyes"; then :
 
         ac_configure_args_SAVE="$ac_configure_args"
-        ac_configure_args="$ac_configure_args $libmesh_subpackage_arguments CXX='$CXX' CC='$CC' F77='$F77' FC='$FC' CPPFLAGS='$HDF5_CPPFLAGS $CPPFLAGS' LIBS='$HDF5_LIBS $LIBS'"
+        ac_configure_args="$ac_configure_args $libmesh_subpackage_arguments CXX='$CXX' CC='$CC' F77='$F77' FC='$FC' CPPFLAGS='$SUB_CPPFLAGS' LIBS='$SUB_LIBS'"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -453,10 +453,28 @@ AS_IF([test "x$enableexamples" = "xyes"],
 # additional arguments to be passed to those packages, do that here.
 # Specifically, we append libmesh_subpackage_arguments to ac_configure_args
 # before AC_OUTPUT recurses into our subpackages
+
+# We need our netcdf subpackage to be able to use whatever HDF5 we've
+# detected.  That means using whatever $HDF5_CPPFLAGS and $HDF5_LIBS
+# we've determined work - but if we're using PETSc it also means
+# passing along PETSc's directories in case we want to link to a
+# --download-hdf5 build there.
+SUB_CPPFLAGS="$CPPFLAGS"
+SUB_LIBS="$LIBS"
+AS_IF([test $enablehdf5 = yes],
+      [
+       SUB_CPPFLAGS="$HDF5_CPPFLAGS $SUB_CPPFLAGS"
+       SUB_LIBS="$HDF5_LIBS $SUB_LIBS"
+       AS_IF([test "x$enablepetsc" != "xno"],
+             [
+              SUB_CPPFLAGS="$PETSCINCLUDEDIRS $SUB_CPPFLAGS"
+              SUB_LIBS="$PETSCLINKLIBS $SUB_LIBS"
+             ])])
+
 AS_IF([test "x$enablenested" = "xyes"],
       [
         ac_configure_args_SAVE="$ac_configure_args"
-        ac_configure_args="$ac_configure_args $libmesh_subpackage_arguments CXX='$CXX' CC='$CC' F77='$F77' FC='$FC' CPPFLAGS='$HDF5_CPPFLAGS $CPPFLAGS' LIBS='$HDF5_LIBS $LIBS'"
+        ac_configure_args="$ac_configure_args $libmesh_subpackage_arguments CXX='$CXX' CC='$CC' F77='$F77' FC='$FC' CPPFLAGS='$SUB_CPPFLAGS' LIBS='$SUB_LIBS'"
       ])
 
 # Create output files. Also configures any subpackages

--- a/m4/libmesh_optional_packages.m4
+++ b/m4/libmesh_optional_packages.m4
@@ -681,7 +681,26 @@ AM_CONDITIONAL(LIBMESH_ENABLE_CURL, test x$enablecurl = xyes)
 # --------------------------------------------------------------
 # HDF5 -- disabled by default
 # --------------------------------------------------------------
+
+# PETSc configure can --download-hdf5, and that's a really convenient
+# feature for users ... but libMesh --enable-hdf5 will only detect it
+# if we add PETSc include and lib directory flags *here*; if we wait
+# until build time it's too late.
+
+ac_PETSCHDF5_save_CPPFLAGS="$CPPFLAGS"
+ac_PETSCHDF5_save_LDFLAGS="$LDFLAGS"
+
+AS_IF([test "x$enablepetsc" != "xno"],
+      [
+        CPPFLAGS="$PETSCINCLUDEDIRS $CPPFLAGS"
+        LDFLAGS="$PETSCLINKLIBS $LDFLAGS"
+      ])
+
 CONFIGURE_HDF5
+
+CPPFLAGS="$ac_PETSCHDF5_save_CPPFLAGS"
+LDFLAGS="$ac_PETSCHDF5_save_LDFLAGS"
+
 AS_IF([test $enablehdf5 = yes],
       [
         libmesh_optional_INCLUDES="$HDF5_CPPFLAGS $libmesh_optional_INCLUDES"

--- a/m4/libmesh_optional_packages.m4
+++ b/m4/libmesh_optional_packages.m4
@@ -679,7 +679,7 @@ AM_CONDITIONAL(LIBMESH_ENABLE_CURL, test x$enablecurl = xyes)
 
 
 # --------------------------------------------------------------
-# HDF5 -- enabled by default
+# HDF5 -- disabled by default
 # --------------------------------------------------------------
 CONFIGURE_HDF5
 AS_IF([test $enablehdf5 = yes],


### PR DESCRIPTION
See https://github.com/idaholab/moose/issues/20033#issuecomment-1012323604 for the discussion

This still doesn't turn on HDF5 when it's not explicitly enabled, but it makes it possible for us to enable it in configure scripts that will then be compatible with all of the basic "$HDF5_DIR is set" and "PETSc built HDF5" and "HDF5 is already in compiler include+lib paths" build scenarios.

In my test builds this is ... *mostly* enough.  `make check` in contrib/netcdf/v4 runs into [this API incompatibility](https://stackoverflow.com/questions/62157364/why-is-hdf5-giving-a-too-few-arguments-error-here) when I try to use the HDF5 1.12.0 that my petsc 3.15.0 tree downloaded for me - but the netcdf library itself built okay, and the HDF5-dependent bits of libMesh still work fine.  Hopefully this is something that was fixed in HDF5 1.12.1 (what I've been using previously), not something particular to PETSc's HDF5 configuration.