### PR TITLE
Return the 3x3 rotation matrix computed in MeshTools::Modification::rotate()

### DIFF
--- a/include/mesh/mesh_modification.h
+++ b/include/mesh/mesh_modification.h
@@ -23,6 +23,7 @@
 // Local Includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/id_types.h" // for boundary_id_type, subdomain_id_type
+#include "libmesh/tensor_value.h"
 
 namespace libMesh
 {
@@ -106,9 +107,11 @@ void translate (MeshBase & mesh,
  * Here the standard Euler angles are adopted
  * (http://mathworld.wolfram.com/EulerAngles.html)
  * The angles are in degrees (360 make a full circle)
+ * \returns the 3x3 rotation matrix implied by (phi, theta, psi)
  */
-void rotate (MeshBase & mesh,
-             const Real phi, const Real theta=0., const Real psi=0.);
+RealTensorValue
+rotate (MeshBase & mesh,
+        const Real phi, const Real theta=0., const Real psi=0.);
 
 /**
  * Scales the mesh.  The grid points are scaled in the


### PR DESCRIPTION
I ran into a situation where it would be helpful to have the rotation matrix computed internally to `MeshTools::Modification::rotate()` for use elsewhere, so I updated the code to return it. Technically this is an API change, but it shouldn't break any existing code since it previously returned void.




This may also be a slight optimization since previously we would recompute the same rotation matrix for every Node (unless the compiler was already smart enough to optimize that out).