### PR TITLE
ExodusII_IO::write_nodeset_data() should take const refs

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -358,8 +358,8 @@ public:
   void
   write_nodeset_data (int timestep,
                       const std::vector<std::string> & var_names,
-                      std::vector<std::set<boundary_id_type>> & node_boundary_ids,
-                      std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> & bc_vals);
+                      const std::vector<std::set<boundary_id_type>> & node_boundary_ids,
+                      const std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> & bc_vals);
 
   /**
    * Read all the nodeset data at a particular timestep. TODO:

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -375,7 +375,7 @@ public:
   write_nodeset_data (int timestep,
                       const std::vector<std::string> & var_names,
                       const std::vector<std::set<boundary_id_type>> & node_boundary_ids,
-                      std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> & bc_vals);
+                      const std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> & bc_vals);
 
   /**
    * Read nodeset variables, if any, into the provided data structures.

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1876,8 +1876,8 @@ void
 ExodusII_IO::
 write_nodeset_data (int timestep,
                     const std::vector<std::string> & var_names,
-                    std::vector<std::set<boundary_id_type>> & node_boundary_ids,
-                    std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> & bc_vals)
+                    const std::vector<std::set<boundary_id_type>> & node_boundary_ids,
+                    const std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> & bc_vals)
 {
   libmesh_error_msg_if(!exio_helper->opened_for_writing,
                        "ERROR, ExodusII file must be opened for writing "

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -3301,7 +3301,7 @@ void ExodusII_IO_Helper::
 write_nodeset_data (int timestep,
                     const std::vector<std::string> & var_names,
                     const std::vector<std::set<boundary_id_type>> & node_boundary_ids,
-                    std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> & bc_vals)
+                    const std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> & bc_vals)
 {
   if ((_run_only_on_proc0) && (this->processor_id() != 0))
     return;


### PR DESCRIPTION
This was a copy/paste issue from the "read" version of this function,
which takes non-const args. It now matches ExodusII_IO::write_sideset_data()
more closely.