### PR TITLE
fix error in non-deprecated variant

### DIFF
--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -493,6 +493,9 @@ void FEMap::compute_single_point_map(const unsigned int dim,
   libmesh_assert(!compute_second_derivatives);
 #endif
 
+  // this parameter is only accounted for if LIBMESH_DIM==2.
+  libmesh_ignore(compute_second_derivatives);
+
   if (calculate_xyz)
     libmesh_assert_equal_to(phi_map.size(), elem_nodes.size());
 

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -355,15 +355,23 @@ void InfFE<Dim, T_radial, T_map>::determine_calculations()
         }
     }
 #else //LIBMESH_ENABLE_DEPRECATED
+  // ANSI C does not allow to embed the preprocessor-statement into the assert, so we
+  // make two statements, just different by 'calculate_d2phi'.
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+  libmesh_assert (this->calculate_nothing || this->calculate_d2phi ||
+                  this->calculate_phi || this->calculate_dphi ||
+                  this->calculate_phi_scaled || this->calculate_dphi_scaled ||
+                  this->calculate_xyz || this->calculate_jxw ||
+                  this->calculate_map_scaled || this->calculate_map ||
+                  this->calculate_curl_phi || this->calculate_div_phi);
+#else
   libmesh_assert (this->calculate_nothing ||
                   this->calculate_phi || this->calculate_dphi ||
-                  !this->calculate_phi_scaled && !this->calculate_dphi_scaled &&
-                  !this->calculate_xyz && !this->calculate_jxw &&
-                  !this->calculate_map_scaled && !this->calculate_map &&
-#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
-                  this->calculate_d2phi ||
+                  this->calculate_phi_scaled || this->calculate_dphi_scaled ||
+                  this->calculate_xyz || this->calculate_jxw ||
+                  this->calculate_map_scaled || this->calculate_map ||
+                  this->calculate_curl_phi || this->calculate_div_phi);
 #endif
-                  this->calculate_curl_phi || this->calculate_div_phi)
 #endif // LIBMESH_ENABLE_DEPRECATED
 
   // set further terms necessary to do the requested task


### PR DESCRIPTION
As @roystgnr pointed out, I introduced an error in #3138   (see [here](https://github.com/libMesh/libmesh/pull/3138#discussion_r804124045) ), which is fixed here.

I also caught an unused second-derivative quantity; I think, its previous uses were removed/refactored somehow?

Best regards