### PR TITLE
WIP: Add support for Bezier elements in VTK output.

### DIFF
--- a/include/mesh/vtk_io.h
+++ b/include/mesh/vtk_io.h
@@ -209,15 +209,15 @@ private:
   };
 
   /**
-   * ElementMaps object that is built statically and used by
+   * ElementMaps objects that are built statically and used by
    * all instances of this class.
    */
-  static ElementMaps _element_maps;
+  static std::map<ElemMappingType, ElementMaps> _element_maps;
 
   /**
-   * Static function used to construct the _element_maps struct.
+   * Static function used to construct _element_maps.
    */
-  static ElementMaps build_element_maps();
+  static std::map<ElemMappingType, ElementMaps> build_element_maps();
 
 #endif
 };

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -12,6 +12,7 @@
 #include <libmesh/dyna_io.h>
 #include <libmesh/exodusII_io.h>
 #include <libmesh/nemesis_io.h>
+#include <libmesh/vtk_io.h>
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"
@@ -1022,6 +1023,11 @@ public:
       exii.write("exodus_file_mapping_out.e");
     }
 
+    {
+      VTKIO vtkout(mesh);
+
+      vtkout.write("vtk_file_mapping_out.pvtu");
+    }
   }
 
   void testExodusFileMappingsPlateWithHole ()


### PR DESCRIPTION
VTK 9 added support for VTK_BEZIER_* elements.
This writes out those elements in the VTK output when available.

Start with a WIP to make sure this is how the libmesh folks want this done.

For verification, I just look at the result in paraview  with a tesselation. As @roystgnr said in #3152 , not sure how else to check it.

[PlateWithHole_Patch8_0.vtu.gz](https://github.com/libMesh/libmesh/files/8050965/PlateWithHole_Patch8_0.vtu.gz)

closes #3152
