### PR TITLE
Add a VTK check before trying to write out a VTK file

### DIFF
--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -1023,11 +1023,13 @@ public:
       exii.write("exodus_file_mapping_out.e");
     }
 
+#ifdef LIBMESH_HAVE_VTK
     {
       VTKIO vtkout(mesh);
 
       vtkout.write("vtk_file_mapping_out.pvtu");
     }
+#endif
   }
 
   void testExodusFileMappingsPlateWithHole ()


### PR DESCRIPTION
Hopefully it is enough to just check if VTK is available and not a specific version.
Presumably, with older versions of VTK this will still provide a sanity check that exodus files with BEX don't crash when writing out to VTK.