### PR TITLE
Allow proper constness for our MeshBase iterators

### DIFF
--- a/include/base/variant_filter_iterator.h
+++ b/include/base/variant_filter_iterator.h
@@ -46,7 +46,9 @@
  * \author John W. Peterson
  * \date 2004
  */
-template<class Predicate, class Type, class ReferenceType = Type &, class PointerType = Type *>
+template<class Predicate, class Type, class ReferenceType = Type &, class PointerType = Type *,
+                          class ConstType = const Type, class ConstReferenceType = const Type &,
+                          class ConstPointerType = const Type *>
 class variant_filter_iterator :
 #if defined(__GNUC__) && (__GNUC__ < 3)  && !defined(__INTEL_COMPILER)
   public std::forward_iterator<std::forward_iterator_tag, Type>
@@ -58,7 +60,8 @@ public:
   /**
    * Shortcut name for the fully-qualified typename.
    */
-  typedef variant_filter_iterator<Predicate, Type, ReferenceType, PointerType> Iterator;
+  typedef variant_filter_iterator<Predicate, Type, ReferenceType, PointerType,
+                                  ConstType, ConstReferenceType, ConstPointerType> Iterator;
 
 
 
@@ -87,7 +90,7 @@ public:
     virtual bool equal(const IterBase * other) const = 0;
 
     // typedef typename variant_filter_iterator<Predicate, Type, const Type &, const Type *>::IterBase const_IterBase;
-    typedef typename variant_filter_iterator<Predicate, Type const, Type const & , Type const *>::IterBase const_IterBase;
+    typedef typename variant_filter_iterator<Predicate, ConstType, ConstReferenceType, ConstPointerType>::IterBase const_IterBase;
 
     /**
      * Similar to the \p clone() function.
@@ -113,7 +116,7 @@ public:
     virtual bool operator()(const IterBase * in) const = 0;
 
     // typedef typename variant_filter_iterator<Predicate, Type, const Type &, const Type *>::PredBase const_PredBase;
-    typedef typename variant_filter_iterator<Predicate, Type const, Type const &, Type const *>::PredBase const_PredBase;
+    typedef typename variant_filter_iterator<Predicate, ConstType, ConstReferenceType, ConstPointerType>::PredBase const_PredBase;
 
     /**
      * Similar to the \p clone() function.
@@ -186,7 +189,7 @@ public:
        * Important typedef for const_iterators.  Notice the weird syntax!  Does it compile everywhere?
        */
       // typedef typename variant_filter_iterator<Predicate, Type, const Type &, const Type *>::template Iter<IterType> const_Iter;
-      typedef typename variant_filter_iterator<Predicate, Type const, Type const &,  Type const *>::template Iter<IterType> const_Iter;
+      typedef typename variant_filter_iterator<Predicate, ConstType, ConstReferenceType, ConstPointerType>::template Iter<IterType> const_Iter;
 
       typename IterBase::const_IterBase * copy =
         new const_Iter(iter_data);
@@ -284,7 +287,7 @@ public:
        * Important typedef for const_iterators.
        */
       //      typedef typename variant_filter_iterator<Predicate, Type, const Type &, const Type *>::template Pred<IterType, PredType> const_Pred;
-      typedef typename variant_filter_iterator<Predicate, Type const, Type const &,  Type const *>::template Pred<IterType, PredType> const_Pred;
+      typedef typename variant_filter_iterator<Predicate, ConstType, ConstReferenceType, ConstPointerType>::template Pred<IterType, PredType> const_Pred;
 
 
       typename PredBase::const_PredBase * copy =
@@ -401,8 +404,10 @@ public:
    * you have:
    * Type=int * const, ReferenceType=int * const & , PointerType=int * const *
    */
-  template <class OtherType, class OtherReferenceType, class OtherPointerType>
-  variant_filter_iterator (const variant_filter_iterator<Predicate, OtherType, OtherReferenceType, OtherPointerType> & rhs)
+  template <class OtherType, class OtherReferenceType, class OtherPointerType,
+            class OtherConstType, class OtherConstReferenceType, class OtherConstPointerType>
+  variant_filter_iterator (const variant_filter_iterator<Predicate, OtherType, OtherReferenceType, OtherPointerType,
+                                                         OtherConstType, OtherConstReferenceType, OtherConstPointerType> & rhs)
     : data (rhs.data != nullptr ? rhs.data->const_clone() : nullptr),
       end  (rhs.end  != nullptr ? rhs.end->const_clone()  : nullptr),
       pred (rhs.pred != nullptr ? rhs.pred->const_clone() : nullptr)
@@ -518,10 +523,13 @@ private:
 
 
 // op==
-template<class Predicate, class Type, class ReferenceType, class PointerType>
+template<class Predicate, class Type, class ReferenceType, class PointerType,
+         class OtherConstType, class OtherConstReferenceType, class OtherConstPointerType>
 inline
-bool operator==(const variant_filter_iterator<Predicate, Type, ReferenceType, PointerType> & x,
-                const variant_filter_iterator<Predicate, Type, ReferenceType, PointerType> & y)
+bool operator==(const variant_filter_iterator<Predicate, Type, ReferenceType, PointerType,
+                                              OtherConstType, OtherConstReferenceType, OtherConstPointerType> & x,
+                const variant_filter_iterator<Predicate, Type, ReferenceType, PointerType,
+                                              OtherConstType, OtherConstReferenceType, OtherConstPointerType> & y)
 {
   return x.equal(y);
 }
@@ -529,10 +537,13 @@ bool operator==(const variant_filter_iterator<Predicate, Type, ReferenceType, Po
 
 
 // op!=
-template<class Predicate, class Type, class ReferenceType, class PointerType>
+template<class Predicate, class Type, class ReferenceType, class PointerType,
+         class OtherConstType, class OtherConstReferenceType, class OtherConstPointerType>
 inline
-bool operator!=(const variant_filter_iterator<Predicate, Type, ReferenceType, PointerType> & x,
-                const variant_filter_iterator<Predicate, Type, ReferenceType, PointerType> & y)
+bool operator!=(const variant_filter_iterator<Predicate, Type, ReferenceType, PointerType,
+                                              OtherConstType, OtherConstReferenceType, OtherConstPointerType> & x,
+                const variant_filter_iterator<Predicate, Type, ReferenceType, PointerType,
+                                              OtherConstType, OtherConstReferenceType, OtherConstPointerType> & y)
 {
   return !(x == y);
 }

--- a/include/base/variant_filter_iterator.h
+++ b/include/base/variant_filter_iterator.h
@@ -202,7 +202,7 @@ public:
      */
     virtual ReferenceType operator*() const override
     {
-      return * iter_data;
+      return * this->iter_ptr();
     }
 
     /**
@@ -237,6 +237,15 @@ public:
      * This is the iterator passed by the user.
      */
     IterType iter_data;
+  private:
+    /**
+     * This seems to work around a bug in g++ prior to version 10 and
+     * clang++ prior to version 10
+     */
+    PointerType iter_ptr () const
+    {
+      return &*iter_data;
+    }
   };
 
 

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -2066,14 +2066,21 @@ protected:
  * The definition of the element_iterator struct.
  */
 struct
-MeshBase::element_iterator : variant_filter_iterator<MeshBase::Predicate, Elem *>
+MeshBase::element_iterator : variant_filter_iterator<MeshBase::Predicate,
+                                                     Elem * const,
+                                                     Elem * const &,
+                                                     Elem * const *,
+                                                     const Elem * const,
+                                                     const Elem * const &,
+                                                     const Elem * const *>
 {
   // Templated forwarding ctor -- forwards to appropriate variant_filter_iterator ctor
   template <typename PredType, typename IterType>
   element_iterator (const IterType & d,
                     const IterType & e,
                     const PredType & p ) :
-    variant_filter_iterator<MeshBase::Predicate, Elem *>(d,e,p) {}
+    variant_filter_iterator<MeshBase::Predicate, Elem * const, Elem * const &, Elem * const *,
+                            const Elem * const, const Elem * const &, const Elem * const *>(d,e,p)  {}
 };
 
 
@@ -2085,9 +2092,9 @@ MeshBase::element_iterator : variant_filter_iterator<MeshBase::Predicate, Elem *
  */
 struct
 MeshBase::const_element_iterator : variant_filter_iterator<MeshBase::Predicate,
-                                                           Elem * const,
-                                                           Elem * const &,
-                                                           Elem * const *>
+                                                           const Elem * const,
+                                                           const Elem * const &,
+                                                           const Elem * const *>
 {
   /**
    * Templated forwarding ctor -- forwards to appropriate variant_filter_iterator ctor.
@@ -2096,7 +2103,7 @@ MeshBase::const_element_iterator : variant_filter_iterator<MeshBase::Predicate,
   const_element_iterator (const IterType & d,
                           const IterType & e,
                           const PredType & p ) :
-    variant_filter_iterator<MeshBase::Predicate, Elem * const, Elem * const &, Elem * const *>(d,e,p)  {}
+    variant_filter_iterator<MeshBase::Predicate, const Elem * const, const Elem * const &, const Elem * const *>(d,e,p)  {}
 
   /**
    * The conversion-to-const ctor.  Takes a regular iterator and calls the appropriate
@@ -2105,7 +2112,7 @@ MeshBase::const_element_iterator : variant_filter_iterator<MeshBase::Predicate,
    * \note This one is \e not templated!
    */
   const_element_iterator (const MeshBase::element_iterator & rhs) :
-    variant_filter_iterator<Predicate, Elem * const, Elem * const &, Elem * const *>(rhs) {}
+    variant_filter_iterator<Predicate, const Elem * const, const Elem * const &, const Elem * const *>(rhs) {}
 };
 
 

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -2050,6 +2050,54 @@ protected:
    * it can directly broadcast *_integer_names
    */
   friend class MeshCommunication;
+
+
+  /**
+   * The original iterator classes weren't properly const-safe;
+   * relying on their const-incorrectness is now deprecated.
+   */
+#ifdef LIBMESH_ENABLE_DEPRECATED
+typedef variant_filter_iterator<MeshBase::Predicate, Elem *> elem_filter_iter;
+
+typedef variant_filter_iterator<MeshBase::Predicate,
+                                Elem * const,
+                                Elem * const &,
+                                Elem * const *> const_elem_filter_iter;
+
+typedef variant_filter_iterator<MeshBase::Predicate, Node *> node_filter_iter;
+
+typedef variant_filter_iterator<MeshBase::Predicate,
+                                Node * const,
+                                Node * const &,
+                                Node * const *> const_node_filter_iter;
+#else
+typedef variant_filter_iterator<MeshBase::Predicate,
+                                Elem * const,
+                                Elem * const &,
+                                Elem * const *,
+                                const Elem * const,
+                                const Elem * const &,
+                                const Elem * const *> elem_filter_iter;
+
+typedef variant_filter_iterator<MeshBase::Predicate,
+                                const Elem * const,
+                                const Elem * const &,
+                                const Elem * const *> const_elem_filter_iter;
+
+typedef variant_filter_iterator<MeshBase::Predicate,
+                                Node * const,
+                                Node * const &,
+                                Node * const *,
+                                const Node * const,
+                                const Node * const &,
+                                const Node * const *> node_filter_iter;
+
+typedef variant_filter_iterator<MeshBase::Predicate,
+                                const Node * const,
+                                const Node * const &,
+                                const Node * const *> const_node_filter_iter;
+#endif // LIBMESH_ENABLE_DEPRECATED
+
 };
 
 
@@ -2066,21 +2114,14 @@ protected:
  * The definition of the element_iterator struct.
  */
 struct
-MeshBase::element_iterator : variant_filter_iterator<MeshBase::Predicate,
-                                                     Elem * const,
-                                                     Elem * const &,
-                                                     Elem * const *,
-                                                     const Elem * const,
-                                                     const Elem * const &,
-                                                     const Elem * const *>
+MeshBase::element_iterator : MeshBase::elem_filter_iter
 {
   // Templated forwarding ctor -- forwards to appropriate variant_filter_iterator ctor
   template <typename PredType, typename IterType>
   element_iterator (const IterType & d,
                     const IterType & e,
                     const PredType & p ) :
-    variant_filter_iterator<MeshBase::Predicate, Elem * const, Elem * const &, Elem * const *,
-                            const Elem * const, const Elem * const &, const Elem * const *>(d,e,p)  {}
+    elem_filter_iter(d,e,p) {}
 };
 
 
@@ -2091,10 +2132,7 @@ MeshBase::element_iterator : variant_filter_iterator<MeshBase::Predicate,
  * iterator above, but also provides an additional conversion-to-const ctor.
  */
 struct
-MeshBase::const_element_iterator : variant_filter_iterator<MeshBase::Predicate,
-                                                           const Elem * const,
-                                                           const Elem * const &,
-                                                           const Elem * const *>
+MeshBase::const_element_iterator : MeshBase::const_elem_filter_iter
 {
   /**
    * Templated forwarding ctor -- forwards to appropriate variant_filter_iterator ctor.
@@ -2103,7 +2141,7 @@ MeshBase::const_element_iterator : variant_filter_iterator<MeshBase::Predicate,
   const_element_iterator (const IterType & d,
                           const IterType & e,
                           const PredType & p ) :
-    variant_filter_iterator<MeshBase::Predicate, const Elem * const, const Elem * const &, const Elem * const *>(d,e,p)  {}
+    const_elem_filter_iter(d,e,p)  {}
 
   /**
    * The conversion-to-const ctor.  Takes a regular iterator and calls the appropriate
@@ -2112,7 +2150,7 @@ MeshBase::const_element_iterator : variant_filter_iterator<MeshBase::Predicate,
    * \note This one is \e not templated!
    */
   const_element_iterator (const MeshBase::element_iterator & rhs) :
-    variant_filter_iterator<Predicate, const Elem * const, const Elem * const &, const Elem * const *>(rhs) {}
+    const_elem_filter_iter(rhs) {}
 };
 
 
@@ -2125,13 +2163,7 @@ MeshBase::const_element_iterator : variant_filter_iterator<MeshBase::Predicate,
  * The definition of the node_iterator struct.
  */
 struct
-MeshBase::node_iterator : variant_filter_iterator<MeshBase::Predicate,
-                                                  Node * const,
-                                                  Node * const &,
-                                                  Node * const *,
-                                                  const Node * const,
-                                                  const Node * const &,
-                                                  const Node * const *>
+MeshBase::node_iterator : MeshBase::node_filter_iter
 {
   /**
    * Templated forwarding ctor -- forwards to appropriate variant_filter_iterator ctor.
@@ -2140,8 +2172,7 @@ MeshBase::node_iterator : variant_filter_iterator<MeshBase::Predicate,
   node_iterator (const IterType & d,
                  const IterType & e,
                  const PredType & p ) :
-    variant_filter_iterator<MeshBase::Predicate, Node * const, Node * const &, Node * const *,
-                            const Node * const, const Node * const &, const Node * const *>(d,e,p)  {}
+    node_filter_iter(d,e,p)  {}
 };
 
 
@@ -2152,10 +2183,7 @@ MeshBase::node_iterator : variant_filter_iterator<MeshBase::Predicate,
  * iterator above, but also provides an additional conversion-to-const ctor.
  */
 struct
-MeshBase::const_node_iterator : variant_filter_iterator<MeshBase::Predicate,
-                                                        const Node * const,
-                                                        const Node * const &,
-                                                        const Node * const *>
+MeshBase::const_node_iterator : MeshBase::const_node_filter_iter
 {
   /**
    * Templated forwarding ctor -- forwards to appropriate variant_filter_iterator ctor.
@@ -2164,7 +2192,7 @@ MeshBase::const_node_iterator : variant_filter_iterator<MeshBase::Predicate,
   const_node_iterator (const IterType & d,
                        const IterType & e,
                        const PredType & p ) :
-    variant_filter_iterator<MeshBase::Predicate, const Node * const, const Node * const &, const Node * const *>(d,e,p)  {}
+    const_node_filter_iter(d,e,p)  {}
 
   /**
    * The conversion-to-const ctor.  Takes a regular iterator and calls the appropriate
@@ -2173,7 +2201,7 @@ MeshBase::const_node_iterator : variant_filter_iterator<MeshBase::Predicate,
    * \note This one is *not* templated!
    */
   const_node_iterator (const MeshBase::node_iterator & rhs) :
-    variant_filter_iterator<Predicate, const Node * const, const Node * const &, const Node * const *>(rhs) {}
+    const_node_filter_iter(rhs) {}
 };
 
 

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -2118,7 +2118,13 @@ MeshBase::const_element_iterator : variant_filter_iterator<MeshBase::Predicate,
  * The definition of the node_iterator struct.
  */
 struct
-MeshBase::node_iterator : variant_filter_iterator<MeshBase::Predicate, Node *>
+MeshBase::node_iterator : variant_filter_iterator<MeshBase::Predicate,
+                                                  Node * const,
+                                                  Node * const &,
+                                                  Node * const *,
+                                                  const Node * const,
+                                                  const Node * const &,
+                                                  const Node * const *>
 {
   /**
    * Templated forwarding ctor -- forwards to appropriate variant_filter_iterator ctor.
@@ -2127,7 +2133,8 @@ MeshBase::node_iterator : variant_filter_iterator<MeshBase::Predicate, Node *>
   node_iterator (const IterType & d,
                  const IterType & e,
                  const PredType & p ) :
-    variant_filter_iterator<MeshBase::Predicate, Node *>(d,e,p) {}
+    variant_filter_iterator<MeshBase::Predicate, Node * const, Node * const &, Node * const *,
+                            const Node * const, const Node * const &, const Node * const *>(d,e,p)  {}
 };
 
 
@@ -2139,9 +2146,9 @@ MeshBase::node_iterator : variant_filter_iterator<MeshBase::Predicate, Node *>
  */
 struct
 MeshBase::const_node_iterator : variant_filter_iterator<MeshBase::Predicate,
-                                                        Node * const,
-                                                        Node * const &,
-                                                        Node * const *>
+                                                        const Node * const,
+                                                        const Node * const &,
+                                                        const Node * const *>
 {
   /**
    * Templated forwarding ctor -- forwards to appropriate variant_filter_iterator ctor.
@@ -2150,7 +2157,7 @@ MeshBase::const_node_iterator : variant_filter_iterator<MeshBase::Predicate,
   const_node_iterator (const IterType & d,
                        const IterType & e,
                        const PredType & p ) :
-    variant_filter_iterator<MeshBase::Predicate, Node * const, Node * const &, Node * const *>(d,e,p)  {}
+    variant_filter_iterator<MeshBase::Predicate, const Node * const, const Node * const &, const Node * const *>(d,e,p)  {}
 
   /**
    * The conversion-to-const ctor.  Takes a regular iterator and calls the appropriate
@@ -2159,7 +2166,7 @@ MeshBase::const_node_iterator : variant_filter_iterator<MeshBase::Predicate,
    * \note This one is *not* templated!
    */
   const_node_iterator (const MeshBase::node_iterator & rhs) :
-    variant_filter_iterator<Predicate, Node * const, Node * const &, Node * const *>(rhs) {}
+    variant_filter_iterator<Predicate, const Node * const, const Node * const &, const Node * const *>(rhs) {}
 };
 
 

--- a/include/parallel/parallel_elem.h
+++ b/include/parallel/parallel_elem.h
@@ -90,6 +90,62 @@ inline const Elem*
 Packing<const Elem*>::unpack(BufferIter in, Context * ctx)
 { return Packing<Elem*>::unpack(in, ctx); }
 
+
+template <>
+class Packing<Elem * const>
+{
+public:
+  typedef largest_id_type buffer_type;
+
+  template <typename OutputIter, typename Context>
+  static void pack(Elem * const & object,
+                   OutputIter data_out,
+                   const Context * context)
+  { return Packing<const Elem *>::pack(object, data_out, context); }
+
+  template <typename Context>
+  static unsigned int packable_size(Elem * const & object,
+                                    const Context * context)
+  { return Packing<const Elem*>::packable_size(object, context); }
+
+  template <typename BufferIter>
+  static unsigned int packed_size(BufferIter iter)
+  { return Packing<const Elem *>::packed_size(iter); }
+
+  template <typename BufferIter, typename Context>
+  static Elem * unpack(BufferIter in, Context * ctx)
+  { return Packing<Elem *>::unpack(in, ctx); }
+};
+
+
+template <>
+class Packing<const Elem * const>
+{
+public:
+  typedef largest_id_type buffer_type;
+
+  template <typename OutputIter, typename Context>
+  static void pack(Elem * const & object,
+                   OutputIter data_out,
+                   const Context * context)
+  { return Packing<const Elem *>::pack(object, data_out, context); }
+
+  template <typename Context>
+  static unsigned int packable_size(Elem * const & object,
+                                    const Context * context)
+  { return Packing<const Elem*>::packable_size(object, context); }
+
+  template <typename BufferIter>
+  static unsigned int packed_size(BufferIter iter)
+  { return Packing<const Elem *>::packed_size(iter); }
+
+  template <typename BufferIter, typename Context>
+  static Elem * unpack(BufferIter in, Context * ctx)
+  { return Packing<Elem *>::unpack(in, ctx); }
+};
+
+
+
 } // namespace Parallel
 } // namespace libMesh
 

--- a/include/parallel/parallel_ghost_sync.h
+++ b/include/parallel/parallel_ghost_sync.h
@@ -378,7 +378,7 @@ void sync_dofobject_data_by_id(const Communicator & comm,
 
   for (Iterator it = range_begin; it != range_end; ++it)
     {
-      DofObject * obj = *it;
+      const DofObject * obj = *it;
       libmesh_assert (obj);
 
       // We may want to pass Elem* or Node* to the check function, not
@@ -406,7 +406,7 @@ void sync_dofobject_data_by_id(const Communicator & comm,
 
   for (Iterator it = range_begin; it != range_end; ++it)
     {
-      DofObject * obj = *it;
+      const DofObject * obj = *it;
 
       if (!dofobj_check(*it))
         continue;

--- a/include/parallel/parallel_node.h
+++ b/include/parallel/parallel_node.h
@@ -91,6 +91,59 @@ Packing<const Node *>::unpack(BufferIter in, Context * ctx)
 { return Packing<Node *>::unpack(in, ctx); }
 
 
+template <>
+class Packing<Node * const>
+{
+public:
+  typedef largest_id_type buffer_type;
+
+  template <typename OutputIter, typename Context>
+  static void pack(Node * const & object,
+                   OutputIter data_out,
+                   const Context * context)
+  { return Packing<const Node *>::pack(object, data_out, context); }
+
+  template <typename Context>
+  static unsigned int packable_size(Node * const & object,
+                                    const Context * context)
+  { return Packing<const Node*>::packable_size(object, context); }
+
+  template <typename BufferIter>
+  static unsigned int packed_size(BufferIter iter)
+  { return Packing<const Node *>::packed_size(iter); }
+
+  template <typename BufferIter, typename Context>
+  static Node * unpack(BufferIter in, Context * ctx)
+  { return Packing<Node *>::unpack(in, ctx); }
+};
+
+
+template <>
+class Packing<const Node * const>
+{
+public:
+  typedef largest_id_type buffer_type;
+
+  template <typename OutputIter, typename Context>
+  static void pack(Node * const & object,
+                   OutputIter data_out,
+                   const Context * context)
+  { return Packing<const Node *>::pack(object, data_out, context); }
+
+  template <typename Context>
+  static unsigned int packable_size(Node * const & object,
+                                    const Context * context)
+  { return Packing<const Node*>::packable_size(object, context); }
+
+  template <typename BufferIter>
+  static unsigned int packed_size(BufferIter iter)
+  { return Packing<const Node *>::packed_size(iter); }
+
+  template <typename BufferIter, typename Context>
+  static Node * unpack(BufferIter in, Context * ctx)
+  { return Packing<Node *>::unpack(in, ctx); }
+};
+
 
 } // namespace Parallel
 } // namespace libMesh

--- a/include/partitioning/partitioner.h
+++ b/include/partitioning/partitioner.h
@@ -267,7 +267,7 @@ protected:
   /**
    * Assign the computed partitioning to the mesh.
    */
-  void assign_partitioning (const MeshBase & mesh, const std::vector<dof_id_type> & parts);
+  void assign_partitioning (MeshBase & mesh, const std::vector<dof_id_type> & parts);
 
   /**
    * The weights that might be used for partitioning.

--- a/include/utils/point_locator_nanoflann.h
+++ b/include/utils/point_locator_nanoflann.h
@@ -219,7 +219,7 @@ protected:
    * These are shared_ptrs to vectors since, if we are not the "master"
    * PointLocator, they need to point at the master's vectors instead.
    */
-  std::shared_ptr<std::vector<Elem *>> _elems;
+  std::shared_ptr<std::vector<const Elem *>> _elems;
   std::shared_ptr<std::vector<Point>> _point_cloud;
 
   // kd_tree will be initialized during init() and then automatically

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1126,7 +1126,7 @@ void DofMap::local_variable_indices(std::vector<dof_id_type> & idx,
           // First get any new nodal DOFS
           for (unsigned int n=0; n<n_nodes; n++)
             {
-              Node & node = elem->node_ref(n);
+              const Node & node = elem->node_ref(n);
 
               if (node.processor_id() != this->processor_id())
                 continue;

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -376,7 +376,7 @@ void CheckpointIO::write (const std::string & name)
 
   // We're going to sort elements by pid in one pass, to avoid sending
   // predicated iterators through the whole mesh N_p times
-  std::unordered_map<processor_id_type, std::vector<Elem *>> elements_on_pid;
+  std::unordered_map<processor_id_type, std::vector<const Elem *>> elements_on_pid;
 
   if (_parallel)
     {
@@ -445,18 +445,18 @@ void CheckpointIO::write (const std::string & name)
               if (elements_vec_it != elements_on_pid.end())
                 {
                   const auto & p_elements = elements_vec_it->second;
-                  Elem * const * elempp = p_elements.data();
-                  Elem * const * elemend = elempp + p_elements.size();
+                  const Elem * const * elempp = p_elements.data();
+                  const Elem * const * elemend = elempp + p_elements.size();
 
                   const MeshBase::const_element_iterator
                     pid_elements_begin = MeshBase::const_element_iterator
-                      (elempp, elemend, Predicates::NotNull<Elem * const *>()),
+                      (elempp, elemend, Predicates::NotNull<const Elem * const *>()),
                     pid_elements_end = MeshBase::const_element_iterator
-                      (elemend, elemend, Predicates::NotNull<Elem * const *>()),
+                      (elemend, elemend, Predicates::NotNull<const Elem * const *>()),
                     active_pid_elements_begin = MeshBase::const_element_iterator
-                      (elempp, elemend, Predicates::Active<Elem * const *>()),
+                      (elempp, elemend, Predicates::Active<const Elem * const *>()),
                     active_pid_elements_end = MeshBase::const_element_iterator
-                      (elemend, elemend, Predicates::Active<Elem * const *>());
+                      (elemend, elemend, Predicates::Active<const Elem * const *>());
 
                   query_ghosting_functors
                     (mesh, p, active_pid_elements_begin,

--- a/src/mesh/gmv_io.C
+++ b/src/mesh/gmv_io.C
@@ -686,7 +686,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                     {
                       std::unique_ptr<Elem> lo_elem = Elem::build(Elem::first_order_equivalent_type(elem->type()));
                       for (auto i : lo_elem->node_index_range())
-                        lo_elem->set_node(i) = elem->node_ptr(i);
+                        lo_elem->set_node(i) = const_cast<Node*>(elem->node_ptr(i));
                       lo_elem->connectivity(0, TECPLOT, conn);
                     }
                   for (const auto & idx : conn)
@@ -756,7 +756,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                     {
                       std::unique_ptr<Elem> lo_elem = Elem::build(Elem::first_order_equivalent_type(elem->type()));
                       for (auto i : lo_elem->node_index_range())
-                        lo_elem->set_node(i) = elem->node_ptr(i);
+                        lo_elem->set_node(i) = const_cast<Node*>(elem->node_ptr(i));
                       lo_elem->connectivity(0, TECPLOT, conn);
                       out_stream << "quad 4\n";
                       for (const auto & idx : conn)
@@ -773,7 +773,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                     {
                       std::unique_ptr<Elem> lo_elem = Elem::build(Elem::first_order_equivalent_type(elem->type()));
                       for (auto i : lo_elem->node_index_range())
-                        lo_elem->set_node(i) = elem->node_ptr(i);
+                        lo_elem->set_node(i) = const_cast<Node*>(elem->node_ptr(i));
                       lo_elem->connectivity(0, TECPLOT, conn);
                       out_stream << "tri 3\n";
                       for (unsigned int i=0; i<3; i++)
@@ -946,7 +946,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                 {
                   std::unique_ptr<Elem> lo_elem = Elem::build(Elem::first_order_equivalent_type(elem->type()));
                   for (auto i : lo_elem->node_index_range())
-                    lo_elem->set_node(i) = elem->node_ptr(i);
+                    lo_elem->set_node(i) = const_cast<Node*>(elem->node_ptr(i));
                   if ((lo_elem->type() == HEX8)
 #ifdef  LIBMESH_ENABLE_INFINITE_ELEMENTS
                       || (lo_elem->type() == HEX27)

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -393,9 +393,12 @@ void MeshCommunication::redistribute (DistributedMesh & mesh,
   std::vector<Parallel::Request>
     node_send_requests, element_send_requests;
 
+  // Be compatible with both deprecated and corrected MeshBase iterator types
+  typedef std::remove_const<MeshBase::const_element_iterator::value_type>::type nc_v_t;
+
   // We're going to sort elements-to-send by pid in one pass, to avoid
   // sending predicated iterators through the whole mesh N_p times
-  std::unordered_map<processor_id_type, std::vector<const Elem *>> send_to_pid;
+  std::unordered_map<processor_id_type, std::vector<nc_v_t>> send_to_pid;
 
   const MeshBase::const_element_iterator send_elems_begin =
 #ifdef LIBMESH_ENABLE_AMR
@@ -431,8 +434,12 @@ void MeshCommunication::redistribute (DistributedMesh & mesh,
 
       libmesh_assert(!p_elements.empty());
 
-      const Elem * const * elempp = p_elements.data();
-      const Elem * const * elemend = elempp + p_elements.size();
+      // Be compatible with both deprecated and
+      // corrected MeshBase iterator types
+      typedef MeshBase::const_element_iterator::value_type v_t;
+
+      v_t * elempp = p_elements.data();
+      v_t * elemend = elempp + p_elements.size();
 
 #ifndef LIBMESH_ENABLE_AMR
       // This parameter is not used when !LIBMESH_ENABLE_AMR.
@@ -442,11 +449,11 @@ void MeshCommunication::redistribute (DistributedMesh & mesh,
 
       MeshBase::const_element_iterator elem_it =
         MeshBase::const_element_iterator
-          (elempp, elemend, Predicates::NotNull<const Elem * const *>());
+          (elempp, elemend, Predicates::NotNull<v_t *>());
 
       const MeshBase::const_element_iterator elem_end =
         MeshBase::const_element_iterator
-          (elemend, elemend, Predicates::NotNull<const Elem * const *>());
+          (elemend, elemend, Predicates::NotNull<v_t *>());
 
       std::set<const Elem *, CompareElemIdsByLevel> elements_to_send;
 

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -395,7 +395,7 @@ void MeshCommunication::redistribute (DistributedMesh & mesh,
 
   // We're going to sort elements-to-send by pid in one pass, to avoid
   // sending predicated iterators through the whole mesh N_p times
-  std::unordered_map<processor_id_type, std::vector<Elem *>> send_to_pid;
+  std::unordered_map<processor_id_type, std::vector<const Elem *>> send_to_pid;
 
   const MeshBase::const_element_iterator send_elems_begin =
 #ifdef LIBMESH_ENABLE_AMR
@@ -431,8 +431,8 @@ void MeshCommunication::redistribute (DistributedMesh & mesh,
 
       libmesh_assert(!p_elements.empty());
 
-      Elem * const * elempp = p_elements.data();
-      Elem * const * elemend = elempp + p_elements.size();
+      const Elem * const * elempp = p_elements.data();
+      const Elem * const * elemend = elempp + p_elements.size();
 
 #ifndef LIBMESH_ENABLE_AMR
       // This parameter is not used when !LIBMESH_ENABLE_AMR.
@@ -442,11 +442,11 @@ void MeshCommunication::redistribute (DistributedMesh & mesh,
 
       MeshBase::const_element_iterator elem_it =
         MeshBase::const_element_iterator
-          (elempp, elemend, Predicates::NotNull<Elem * const *>());
+          (elempp, elemend, Predicates::NotNull<const Elem * const *>());
 
       const MeshBase::const_element_iterator elem_end =
         MeshBase::const_element_iterator
-          (elemend, elemend, Predicates::NotNull<Elem * const *>());
+          (elemend, elemend, Predicates::NotNull<const Elem * const *>());
 
       std::set<const Elem *, CompareElemIdsByLevel> elements_to_send;
 

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -610,12 +610,12 @@ void MeshCommunication::check_for_duplicate_global_indices (MeshBase & mesh) con
                   get_hilbert_coords(**nodej, bbox, jcoords);
                   libMesh::err <<
                     "node " << (*nodej)->id() << ", " <<
-                    *(Point *)(*nodej) << " has HilbertIndices " <<
+                    *(const Point *)(*nodej) << " has HilbertIndices " <<
                     node_keys[j] << std::endl;
                   get_hilbert_coords(**nodei, bbox, icoords);
                   libMesh::err <<
                     "node " << (*nodei)->id() << ", " <<
-                    *(Point *)(*nodei) << " has HilbertIndices " <<
+                    *(const Point *)(*nodei) << " has HilbertIndices " <<
                     node_keys[i] << std::endl;
                   libmesh_error_msg("Error: nodes with duplicate Hilbert keys!");
                 }

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -987,7 +987,7 @@ void ReplicatedMesh::stitching_helper (const ReplicatedMesh * other_mesh,
   std::map<dof_id_type, std::vector<dof_id_type>> node_to_elems_map;
 
   typedef dof_id_type                     key_type;
-  typedef std::pair<Elem *, unsigned char> val_type;
+  typedef std::pair<const Elem *, unsigned char> val_type;
   typedef std::pair<key_type, val_type>   key_val_pair;
   typedef std::unordered_multimap<key_type, val_type> map_type;
   // Mapping between all side keys in this mesh and elements+side numbers relevant to the boundary in this mesh as well.
@@ -1470,7 +1470,7 @@ void ReplicatedMesh::stitching_helper (const ReplicatedMesh * other_mesh,
                               while (bounds.first != bounds.second)
                                 {
                                   // Get the potential element
-                                  Elem * neighbor = bounds.first->second.first;
+                                  Elem * neighbor = const_cast<Elem *>(bounds.first->second.first);
 
                                   // Get the side for the neighboring element
                                   const unsigned int ns = bounds.first->second.second;

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -1014,7 +1014,7 @@ void ReplicatedMesh::stitching_helper (const ReplicatedMesh * other_mesh,
       std::set<dof_id_type> this_boundary_node_ids, other_boundary_node_ids;
 
       // Pull objects out of the loop to reduce heap operations
-      std::unique_ptr<Elem> side;
+      std::unique_ptr<const Elem> side;
 
       {
         // Make temporary fixed-size arrays for loop
@@ -1117,7 +1117,7 @@ void ReplicatedMesh::stitching_helper (const ReplicatedMesh * other_mesh,
 
                               if (std::find(bc_ids.begin(), bc_ids.end(), id_array[i]) != bc_ids.end())
                                 {
-                                  std::unique_ptr<Elem> edge (el->build_edge_ptr(edge_id));
+                                  std::unique_ptr<const Elem> edge (el->build_edge_ptr(edge_id));
                                   for (auto & n : edge->node_ref_range())
                                     set_array[i]->insert( n.id() );
 
@@ -1441,7 +1441,7 @@ void ReplicatedMesh::stitching_helper (const ReplicatedMesh * other_mesh,
       LOG_SCOPE("stitch_meshes neighbor fixes", "ReplicatedMesh");
 
       // Pull objects out of the loop to reduce heap operations
-      std::unique_ptr<Elem> my_side, their_side;
+      std::unique_ptr<const Elem> my_side, their_side;
 
       std::set<dof_id_type> fixed_elems;
       for (const auto & pr : node_to_elems_map)
@@ -1576,7 +1576,7 @@ ReplicatedMesh::get_disconnected_subdomains(std::vector<subdomain_id_type> * sub
 
   // a stack for visiting elements, make its capacity sufficiently large to avoid
   // memory allocation and deallocation when the vector size changes
-  std::vector<Elem *> list;
+  std::vector<const Elem *> list;
   list.reserve(n_elem());
 
   // counter of visited elements
@@ -1598,13 +1598,13 @@ ReplicatedMesh::get_disconnected_subdomains(std::vector<subdomain_id_type> * sub
     while (list.size() > 0)
     {
       // pop up an element
-      Elem * elem = list.back(); list.pop_back(); ++visited;
+      const Elem * elem = list.back(); list.pop_back(); ++visited;
 
       min_id = std::min(elem->id(), min_id);
 
       for (auto s : elem->side_index_range())
       {
-        Elem * neighbor = elem->neighbor_ptr(s);
+        const Elem * neighbor = elem->neighbor_ptr(s);
         if (neighbor != nullptr && (*subdomain_ids)[neighbor->id()] == Elem::invalid_subdomain_id)
         {
           // neighbor must be active

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -1237,7 +1237,7 @@ void Partitioner::build_graph (const MeshBase & mesh)
 
 }
 
-void Partitioner::assign_partitioning (const MeshBase & mesh, const std::vector<dof_id_type> & parts)
+void Partitioner::assign_partitioning (MeshBase & mesh, const std::vector<dof_id_type> & parts)
 {
   LOG_SCOPE("assign_partitioning()", "Partitioner");
 

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -1079,7 +1079,7 @@ void Partitioner::_find_global_index_by_pid_map(const MeshBase & mesh)
 
 void Partitioner::build_graph (const MeshBase & mesh)
 {
-  LOG_SCOPE("build_graph()", "ParmetisPartitioner");
+  LOG_SCOPE("build_graph()", "Partitioner");
 
   const dof_id_type n_active_local_elem  = mesh.n_active_local_elem();
   // If we have boundary elements in this mesh, we want to account for
@@ -1239,7 +1239,7 @@ void Partitioner::build_graph (const MeshBase & mesh)
 
 void Partitioner::assign_partitioning (const MeshBase & mesh, const std::vector<dof_id_type> & parts)
 {
-  LOG_SCOPE("assign_partitioning()", "ParmetisPartitioner");
+  LOG_SCOPE("assign_partitioning()", "Partitioner");
 
   // This function must be run on all processors at once
   libmesh_parallel_only(mesh.comm());

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -1136,7 +1136,7 @@ void Partitioner::build_graph (const MeshBase & mesh)
       std::vector<dof_id_type> & graph_row = _dual_graph[local_index];
 
       // Save this off to make it easy to index later
-      _local_id_to_elem[local_index] = elem;
+      _local_id_to_elem[local_index] = const_cast<Elem*>(elem);
 
       // Loop over the element's neighbors.  An element
       // adjacency corresponds to a face neighbor

--- a/src/utils/point_locator_nanoflann.C
+++ b/src/utils/point_locator_nanoflann.C
@@ -82,7 +82,7 @@ PointLocatorNanoflann::init ()
       // data structure with active, local element vertex averages.
       if (we_are_master)
         {
-          _elems = std::make_shared<std::vector<Elem *>>();
+          _elems = std::make_shared<std::vector<const Elem *>>();
           _point_cloud = std::make_shared<std::vector<Point>>();
 
           // Make the KD-Tree out of active element vertex averages.

--- a/tests/base/overlapping_coupling_test.C
+++ b/tests/base/overlapping_coupling_test.C
@@ -202,7 +202,7 @@ protected:
       }
   }
 
-  void assign_proc_id_subdomain( const MeshBase & mesh,
+  void assign_proc_id_subdomain( MeshBase & mesh,
                                  const subdomain_id_type sid,
                                  const dof_id_type blksize,
                                  const unsigned int n_parts,


### PR DESCRIPTION
In the middle of working on the triangulation code, I wrote a range for loop over `node_ptr_range()`, and out of habit I declared the loop variable `auto & node`, and then later in my first crack at the algorithm I decided to reuse the variable via `node = next_node` in a while loop ...

And of course this leaks memory and corrupts the mesh.  Fun, "you'll finally trigger an assert four hundred lines of code later" corruption.

With our current mesh iterators, a const MeshBase will give you iterators that allow users to change the underlying elements and nodes, and a non-const MeshBase will give you iterators that allow users to corrupt the Mesh's internal pointers!

This PR fixes that: a const MeshBase will now only give you const access to Elem and Node values, and while a non-const MeshBase will give you non-const access it will no longer let you change the MeshBase internal pointers.

This is a very far-reaching API change (see the fix commits in this PR, just for our internal code), so for now we'll only make the change when configured with `--disable-deprecated`).  Most of the fixes are straightforward and sensible.

There are a couple `const_cast` workarounds here, for code that either needs an API rework or code that's not heavily used enough to be worth more than a hack.

There's one `const_cast` that really worries me, though: I'd really appreciate it if @dknez or @jwpeterson find time to look at the "const_cast hack in mesh stitching", 98f2ea6 - that code has so much test coverage that I can't imagine there's an actual bug, but neither can I figure out how to make it properly const-correct.