### PR TITLE
Protect access to libMesh::cerr

### DIFF
--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -73,6 +73,12 @@
 
 namespace libMesh
 {
+namespace Threads
+{
+// For thread-safe error-messaging. Definitions in threads.h
+void lock_singleton_spin_mutex();
+void unlock_singleton_spin_mutex();
+}
 
 // A namespace for functions used in the bodies of the macros below.
 // The macros generally call these functions with __FILE__, __LINE__,
@@ -287,32 +293,37 @@ extern bool warned_about_auto_ptr;
 #define libmesh_assert_msg(asserted, msg)                               \
   do {                                                                  \
     if (!(asserted)) {                                                  \
-      libMesh::err << "Assertion `" #asserted "' failed." << std::endl; \
       libmesh_error_msg(msg);                                           \
     } } while (0)
 
 #define libmesh_exceptionless_assert_msg(asserted, msg)                 \
   do {                                                                  \
     if (!(asserted)) {                                                  \
+      libMesh::Threads::lock_singleton_spin_mutex();                    \
       libMesh::err << "Assertion `" #asserted "' failed." << std::endl; \
+      libMesh::Threads::unlock_singleton_spin_mutex();                  \
       libmesh_exceptionless_error();                                    \
     } } while (0)
 
 #define libmesh_assert_equal_to_msg(expr1,expr2, msg)                   \
   do {                                                                  \
     if (!((expr1) == (expr2))) {                                        \
+      libMesh::Threads::lock_singleton_spin_mutex();                    \
       std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " == " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libMesh::err.precision(oldp);                                     \
+      libMesh::Threads::unlock_singleton_spin_mutex();                  \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_not_equal_to_msg(expr1,expr2, msg)               \
   do {                                                                  \
     if (!((expr1) != (expr2))) {                                        \
+      libMesh::Threads::lock_singleton_spin_mutex();                    \
       std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " != " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libMesh::err.precision(oldp);                                     \
+      libMesh::Threads::unlock_singleton_spin_mutex();                  \
       libmesh_error();                                                  \
     } } while (0)
 
@@ -323,36 +334,44 @@ extern bool warned_about_auto_ptr;
 #define libmesh_assert_less_msg(expr1,expr2, msg)                       \
   do {                                                                  \
     if (!((expr1) < (expr2))) {                                         \
+      libMesh::Threads::lock_singleton_spin_mutex();                    \
       std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " < " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libMesh::err.precision(oldp);                                     \
+      libMesh::Threads::unlock_singleton_spin_mutex();                  \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_greater_msg(expr1,expr2, msg)                    \
   do {                                                                  \
     if (!((expr1) > (expr2))) {                                         \
+      libMesh::Threads::lock_singleton_spin_mutex();                    \
       std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " > " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libMesh::err.precision(oldp);                                     \
+      libMesh::Threads::unlock_singleton_spin_mutex();                  \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_less_equal_msg(expr1,expr2, msg)                 \
   do {                                                                  \
     if (!((expr1) <= (expr2))) {                                        \
+      libMesh::Threads::lock_singleton_spin_mutex();                    \
       std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " <= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libMesh::err.precision(oldp);                                     \
+      libMesh::Threads::unlock_singleton_spin_mutex();                  \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_greater_equal_msg(expr1,expr2, msg)              \
   do {                                                                  \
     if (!((expr1) >= (expr2))) {                                        \
+      libMesh::Threads::lock_singleton_spin_mutex();                    \
       std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " >= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libMesh::err.precision(oldp);                                     \
+      libMesh::Threads::unlock_singleton_spin_mutex();                  \
       libmesh_error();                                                  \
     } } while (0)
 
@@ -381,36 +400,44 @@ struct casting_compare {
 #define libmesh_assert_less_msg(expr1,expr2, msg)                       \
   do {                                                                  \
     if (!libMesh::casting_compare<std::less>()(expr1, expr2)) {         \
+      libMesh::Threads::lock_singleton_spin_mutex();                    \
       std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " < " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libMesh::err.precision(oldp);                                     \
+      libMesh::Threads::unlock_singleton_spin_mutex();                  \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_greater_msg(expr1,expr2, msg)                    \
   do {                                                                  \
     if (!libMesh::casting_compare<std::greater>()(expr1, expr2)) {      \
+      libMesh::Threads::lock_singleton_spin_mutex();                    \
       std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " > " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libMesh::err.precision(oldp);                                     \
+      libMesh::Threads::unlock_singleton_spin_mutex();                  \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_less_equal_msg(expr1,expr2, msg)                 \
   do {                                                                  \
     if (!libMesh::casting_compare<std::less_equal>()(expr1, expr2)) {   \
+      libMesh::Threads::lock_singleton_spin_mutex();                    \
       std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " <= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libMesh::err.precision(oldp);                                     \
+      libMesh::Threads::unlock_singleton_spin_mutex();                  \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_greater_equal_msg(expr1,expr2, msg)              \
   do {                                                                  \
     if (!libMesh::casting_compare<std::greater_equal>()(expr1, expr2)) { \
+      libMesh::Threads::lock_singleton_spin_mutex();                    \
       std::streamsize oldp = libMesh::err.precision(17);                \
       libMesh::err << "Assertion `" #expr1 " >= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libMesh::err.precision(oldp);                                     \
+      libMesh::Threads::unlock_singleton_spin_mutex();                  \
       libmesh_error();                                                  \
     } } while (0)
 
@@ -441,10 +468,12 @@ struct casting_compare {
 // throws a ConvergenceFailure exception
 #define libmesh_error_msg(msg)                                          \
   do {                                                                  \
+    libMesh::Threads::lock_singleton_spin_mutex();                      \
     libMesh::err << msg << std::endl;                                   \
     std::stringstream msg_stream;                                       \
     msg_stream << msg;                                                  \
     libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME); \
+    libMesh::Threads::unlock_singleton_spin_mutex();                    \
     LIBMESH_THROW(libMesh::LogicError(msg_stream.str()));               \
   } while (0)
 
@@ -458,9 +487,11 @@ struct casting_compare {
 
 #define libmesh_exceptionless_error_msg(msg)                            \
   do {                                                                  \
+    libMesh::Threads::lock_singleton_spin_mutex();                      \
     libMesh::err << msg << std::endl;                                   \
     libmesh_try { libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME); } \
     libmesh_catch (...) {}                                              \
+    libMesh::Threads::unlock_singleton_spin_mutex();                    \
     std::terminate();                                                   \
   } while (0)
 
@@ -468,8 +499,10 @@ struct casting_compare {
 
 #define libmesh_not_implemented_msg(msg)                                \
   do {                                                                  \
+    libMesh::Threads::lock_singleton_spin_mutex();                      \
     libMesh::err << msg << std::endl;                                   \
     libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME); \
+    libMesh::Threads::unlock_singleton_spin_mutex();                    \
     LIBMESH_THROW(libMesh::NotImplemented());                           \
   } while (0)
 
@@ -477,9 +510,11 @@ struct casting_compare {
 
 #define libmesh_file_error_msg(filename, msg)                           \
   do {                                                                  \
+    libMesh::Threads::lock_singleton_spin_mutex();                      \
     libMesh::err << "Error with file `" << filename << "'" << std::endl; \
     libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME); \
     libMesh::err << msg << std::endl;                                   \
+    libMesh::Threads::unlock_singleton_spin_mutex();                    \
     LIBMESH_THROW(libMesh::FileError(filename));                        \
   } while (0)
 

--- a/src/parallel/threads.C
+++ b/src/parallel/threads.C
@@ -23,11 +23,15 @@
 
 namespace libMesh
 {
-
+namespace Threads
+{
 //-------------------------------------------------------------------------
-// Threads:: object instantiation
-Threads::spin_mutex Threads::spin_mtx;
-Threads::recursive_mutex Threads::recursive_mtx;
-bool Threads::in_threads = false;
+// object instantiation
+spin_mutex spin_mtx;
+recursive_mutex recursive_mtx;
+bool in_threads = false;
 
+void lock_singleton_spin_mutex() { spin_mtx.lock(); }
+void unlock_singleton_spin_mutex() { spin_mtx.unlock(); }
+}
 } // namespace libMesh


### PR DESCRIPTION
The motivator for this is idaholab/moose#20326 which is a test that
catches singular matrix exceptions out of libMesh and then alters the
formulation to be less accurate in general but guaranteed to always be
nonsingular. Currently access to libMesh::cerr is not protected and this
can result in read/write data races, resulting in non-deterministic
failing of the MOOSE test