### PR TITLE
Clang fixes

### DIFF
--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -784,7 +784,7 @@ public:
    * weight at each quadrature point. See \p get_Sobolev_weight()
    * for details.  In case of \p FE initialized to all zero.
    */
-  virtual const std::vector<RealGradient> & get_Sobolev_dweight() const
+  virtual const std::vector<RealGradient> & get_Sobolev_dweight() const override
   {libmesh_assert(!calculations_started || calculate_dphi);
     calculate_dphi = true; return dweight; }
 

--- a/include/mesh/mesh_triangle_interface.h
+++ b/include/mesh/mesh_triangle_interface.h
@@ -53,7 +53,7 @@ public:
   /**
    * Empty destructor.
    */
-  ~TriangleInterface() = default;
+  virtual ~TriangleInterface() = default;
 
   /**
    * Internally, this calls Triangle's triangulate routine.

--- a/include/mesh/poly2tri_triangulator.h
+++ b/include/mesh/poly2tri_triangulator.h
@@ -53,7 +53,7 @@ public:
   /**
    * Empty destructor.
    */
-  ~Poly2TriTriangulator() = default;
+  virtual ~Poly2TriTriangulator() = default;
 
   /**
    * Internally, this calls the poly2tri triangulation code in a loop,

--- a/include/mesh/triangulator_interface.h
+++ b/include/mesh/triangulator_interface.h
@@ -58,7 +58,7 @@ public:
   /**
    * Empty destructor.
    */
-  ~TriangulatorInterface() = default;
+  virtual ~TriangulatorInterface() = default;
 
   /**
    * The TriangulationType is used with the general triangulate function

--- a/include/utils/mapvector.h
+++ b/include/utils/mapvector.h
@@ -53,8 +53,6 @@ public:
     veclike_iterator(const typename maptype::iterator & i)
       : it(i) {}
 
-    veclike_iterator(const veclike_iterator & i) = default;
-
     Val & operator*() const { return it->second; }
 
     index_t index() const { return it->first; }
@@ -86,9 +84,6 @@ public:
   public:
     const_veclike_iterator(const typename maptype::const_iterator & i)
       : it(i) {}
-
-    const_veclike_iterator(const const_veclike_iterator & i)
-      : it(i.it) {}
 
     const_veclike_iterator(const veclike_iterator & i)
       : it(i.it) {}

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -121,11 +121,13 @@ const std::vector<int> hex_inverse_edge_map =
   {
     // Reading Bezier Extraction from Exodus files requires ExodusII v8
 #if EX_API_VERS_NODOT < 800
+    libMesh::libmesh_ignore(elem_type_str);
     return false;
-#endif
+#else
     if (strlen(elem_type_str) <= 4)
       return false;
     return (std::string(elem_type_str, elem_type_str+4) == "BEX_");
+#endif
   }
 
 } // end anonymous namespace

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -860,9 +860,13 @@ void VariationalMeshSmoother::adp_renew(const Array2D<Real> & R,
     {
       for (dof_id_type i=0; i<_n_nodes; i++)
         {
+  // This was an unused variable since Derek's first import of
+  // Larisa's code!?  Could something have been miscopied?
+/*
           Real z = 0;
           for (unsigned j=0; j<_dim; j++)
             z += R[i][j];
+*/
 
           // adaptive function, node based
           afun[i] = 5*std::sin(R[i][0]);


### PR DESCRIPTION
These are the fixes for the clang warnings I encountered while investigating the gcc-9 problems with the iterators that were to fix the const-correctness problems that hit me while working on the new triangulator code.

(Darn, I forget, did I make the "old lady who swallowed a fly" joke last or did I link the "Hal fixing a light bulb" gif last?  I really need to find a third joke that's appropriate to these situations...)