### PR TITLE
More robust Packing of trivially-copyable classes

### DIFF
--- a/include/geom/point.h
+++ b/include/geom/point.h
@@ -50,14 +50,12 @@ public:
   {}
 
   /**
-   * Copy-constructor.
+   * Trivial copy-constructor.
    */
-  Point (const Point & p) :
-    TypeVector<Real> (p)
-  {}
+  Point (const Point & p) = default;
 
   /**
-   * Copy-constructor.
+   * Copy-constructor from non-point Typevector.
    */
   Point (const TypeVector<Real> & p) :
     TypeVector<Real> (p)

--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -168,9 +168,14 @@ public:
   TypeVector (const TypeVector<T2> & p);
 
   /**
+   * Copy-constructor for the trivial case.
+   */
+  TypeVector (const TypeVector & p) = default;
+
+  /**
    * Destructor.
    */
-  ~TypeVector ();
+  ~TypeVector () = default;
 
   /**
    * Assign to this vector without creating a temporary.
@@ -554,14 +559,6 @@ TypeVector<T>::TypeVector (const TypeVector<T2> & p)
   // copy the nodes from vector p to me
   for (unsigned int i=0; i<LIBMESH_DIM; i++)
     _coords[i] = p._coords[i];
-}
-
-
-
-template <typename T>
-inline
-TypeVector<T>::~TypeVector ()
-{
 }
 
 

--- a/src/geom/point.C
+++ b/src/geom/point.C
@@ -18,13 +18,15 @@
 
 
 
-// C++ includes
-
 // Local includes
-// #include "libmesh/point.h"
+#include "libmesh/point.h"
+
+// C++ includes
+#include <type_traits> // std::is_trivially_copyable
 
 
-
+static_assert(std::is_trivially_copyable<libMesh::TypeVector<libMesh::Point>>::value,
+              "Someone made Point non-TriviallyCopyable");
 
 // ------------------------------------------------------------
 // Point class member functions

--- a/src/numerics/type_vector.C
+++ b/src/numerics/type_vector.C
@@ -18,12 +18,22 @@
 
 
 
+// Local includes
+#include "libmesh/type_vector.h"
+
 // C++ includes
 #include <iostream>
 #include <iomanip> // for std::setw, std::setiosflags
+#include <type_traits> // std::is_trivially_copyable
 
-// Local includes
-#include "libmesh/type_vector.h"
+
+static_assert(std::is_trivially_copyable<libMesh::TypeVector<libMesh::Real>>::value,
+              "Someone made TypeVector non-TriviallyCopyable");
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+static_assert(std::is_trivially_copyable<libMesh::TypeVector<libMesh::Complex>>::value,
+              "Someone made TypeVector non-TriviallyCopyable");
+#endif
+
 
 namespace libMesh
 {

--- a/tests/parallel/parallel_point_test.C
+++ b/tests/parallel/parallel_point_test.C
@@ -125,7 +125,7 @@ public:
     for (auto p : make_range(comm_size))
       {
         CPPUNIT_ASSERT_EQUAL(vals[p*2].size(), std::size_t(1));
-        CPPUNIT_ASSERT_EQUAL(Real(p+1), vals[p*2][0](0));
+        CPPUNIT_ASSERT_EQUAL(Real(p+1), libmesh_real(vals[p*2][0](0)));
       }
   }
 

--- a/tests/parallel/parallel_point_test.C
+++ b/tests/parallel/parallel_point_test.C
@@ -1,3 +1,4 @@
+#include <libmesh/int_range.h>
 #include <libmesh/parallel.h>
 #include <libmesh/parallel_algebra.h>
 
@@ -15,6 +16,8 @@ public:
   CPPUNIT_TEST( testAllGatherPoint );
   CPPUNIT_TEST( testAllGatherPairPointPoint );
   CPPUNIT_TEST( testAllGatherPairRealPoint );
+  CPPUNIT_TEST( testMapUnionGradient );
+  CPPUNIT_TEST( testMapUnionPoint );
 #endif
 
   CPPUNIT_TEST( testBroadcastVectorValueInt );
@@ -101,6 +104,42 @@ public:
       }
   }
 
+
+
+  template <typename VecType>
+  void testMapUnionVec()
+  {
+    // std::map<processor_id_type , std::vector<Point>> vals;
+    std::map<processor_id_type , std::vector<VecType>> vals;
+
+    const processor_id_type myrank = TestCommWorld->rank();
+
+    vals[myrank*2].resize(1);
+    vals[myrank*2][0](0) = myrank+1;
+
+    TestCommWorld->set_union(vals);
+
+    const processor_id_type comm_size = TestCommWorld->size();
+
+    CPPUNIT_ASSERT_EQUAL(vals.size(), std::size_t(comm_size));
+    for (auto p : make_range(comm_size))
+      {
+        CPPUNIT_ASSERT_EQUAL(vals[p*2].size(), std::size_t(1));
+        CPPUNIT_ASSERT_EQUAL(Real(p+1), vals[p*2][0](0));
+      }
+  }
+
+
+  void testMapUnionGradient()
+  {
+    testMapUnionVec<Gradient>();
+  }
+
+
+  void testMapUnionPoint()
+  {
+    testMapUnionVec<Point>();
+  }
 
 
   template <typename T>


### PR DESCRIPTION
This updates TIMPI to avoid gcc overzealous warnings about memcpy with trivially-copyable-but-not-trivial classes, updates a couple of our classes to trivially-copyable status, and adds unit tests for the result.

This fixes #3157 for me.