### PR TITLE
Lock against concurrent read-write/write-write in Vector::add/insert/set

### DIFF
--- a/contrib/bin/test_installed_examples.sh
+++ b/contrib/bin/test_installed_examples.sh
@@ -63,7 +63,7 @@ function test_example()
     printf '%s' "Testing example installation $exdir ... " > $stdout
     cd $examples_install_path/$exdir
 
-    if $CXX $installed_CXXFLAGS *.C -o $app_to_link $installed_LIBS > $errlog 2>&1 ; then
+    if $CXX $installed_CXXFLAGS $CXXFLAGS *.C -o $app_to_link $installed_LIBS > $errlog 2>&1 ; then
         # See color codes above.  We:
         # .) skip to column 65
         # .) print [ in white
@@ -76,7 +76,7 @@ function test_example()
         # See comment above for OK status
         printf '\e[65G\e[1;37m[\e[1;31m%s\e[1;37m]\e[m\e[m\n' " FAILED " >> $stdout
 	echo "Compile line:"  >> $stdout
-	echo $CXX $installed_CXXFLAGS *.C -o $app_to_link $installed_LIBS >> $stdout
+	echo $CXX $installed_CXXFLAGS $CXXFLAGS *.C -o $app_to_link $installed_LIBS >> $stdout
 	echo ""  >> $stdout
 	echo "Output:"  >> $stdout
 	cat $errlog  >> $stdout

--- a/contrib/bin/test_installed_headers.sh
+++ b/contrib/bin/test_installed_headers.sh
@@ -80,7 +80,7 @@ function test_header()
     echo "int foo () { return 0; }" >> $source_file
 
     #echo $CXX $test_CXXFLAGS $source_file -o $app_file
-    if $CXX $test_CXXFLAGS $source_file -c -o $object_file >$errlog 2>&1 ; then
+    if $CXX $test_CXXFLAGS $CXXFLAGS $source_file -c -o $object_file >$errlog 2>&1 ; then
         # See color codes above.  We:
         # .) skip to column 65
         # .) print [ in white
@@ -96,7 +96,7 @@ function test_header()
         cat $source_file  >> $stdout
         echo ""  >> $stdout
         echo "Command line:" >> $stdout
-        echo $CXX $test_CXXFLAGS $source_file -c -o $object_file  >> $stdout
+        echo $CXX $test_CXXFLAGS $CXXFLAGS $source_file -c -o $object_file  >> $stdout
         echo ""  >> $stdout
         echo "Output:" >> $stdout
         cat $errlog >> $stdout

--- a/include/numerics/distributed_vector.h
+++ b/include/numerics/distributed_vector.h
@@ -33,6 +33,7 @@
 #include <vector>
 #include <algorithm>
 #include <limits>
+#include <mutex>
 
 namespace libMesh
 {
@@ -576,6 +577,7 @@ void DistributedVector<T>::set (const numeric_index_type i, const T value)
   libmesh_assert_less (i, size());
   libmesh_assert_less (i-first_local_index(), local_size());
 
+  std::scoped_lock lock(this->_numeric_vector_mutex);
   _values[i - _first_local_index] = value;
 
 
@@ -595,6 +597,7 @@ void DistributedVector<T>::add (const numeric_index_type i, const T value)
   libmesh_assert_less (i, size());
   libmesh_assert_less (i-first_local_index(), local_size());
 
+  std::scoped_lock lock(this->_numeric_vector_mutex);
   _values[i - _first_local_index] += value;
 
 

--- a/include/numerics/eigen_sparse_vector.h
+++ b/include/numerics/eigen_sparse_vector.h
@@ -33,6 +33,7 @@
 
 // C++ includes
 #include <limits>
+#include <mutex>
 
 namespace libMesh
 {
@@ -481,6 +482,7 @@ void EigenSparseVector<T>::set (const numeric_index_type i, const T value)
   libmesh_assert (this->initialized());
   libmesh_assert_less (i, this->size());
 
+  std::scoped_lock lock(this->_numeric_vector_mutex);
   _vec[static_cast<eigen_idx_type>(i)] = value;
 
   this->_is_closed = false;
@@ -495,6 +497,7 @@ void EigenSparseVector<T>::add (const numeric_index_type i, const T value)
   libmesh_assert (this->initialized());
   libmesh_assert_less (i, this->size());
 
+  std::scoped_lock lock(this->_numeric_vector_mutex);
   _vec[static_cast<eigen_idx_type>(i)] += value;
 
   this->_is_closed = false;

--- a/include/numerics/laspack_vector.h
+++ b/include/numerics/laspack_vector.h
@@ -37,6 +37,7 @@
 // C++ includes
 #include <cstdio> // for std::sprintf
 #include <limits>
+#include <mutex>
 
 namespace libMesh
 {
@@ -501,6 +502,7 @@ void LaspackVector<T>::set (const numeric_index_type i, const T value)
   libmesh_assert (this->initialized());
   libmesh_assert_less (i, this->size());
 
+  std::scoped_lock lock(this->_numeric_vector_mutex);
   V_SetCmp (&_vec, i+1, value);
 
 #ifndef NDEBUG
@@ -517,6 +519,7 @@ void LaspackVector<T>::add (const numeric_index_type i, const T value)
   libmesh_assert (this->initialized());
   libmesh_assert_less (i, this->size());
 
+  std::scoped_lock lock(this->_numeric_vector_mutex);
   V_AddCmp (&_vec, i+1, value);
 
 #ifndef NDEBUG

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -45,6 +45,7 @@ enum SolverPackage : int;
 #include <set>
 #include <vector>
 #include <memory>
+#include <mutex>
 
 namespace libMesh
 {
@@ -434,12 +435,14 @@ public:
   virtual void conjugate() = 0;
 
   /**
-   * Sets v(i) = \p value.
+   * Sets v(i) = \p value. Note that library implementations of this method are
+   * thread safe, e.g. we will lock \p _numeric_vector_mutex before writing to the vector
    */
   virtual void set (const numeric_index_type i, const T value) = 0;
 
   /**
-   * Adds \p value to each entry of the vector.
+   * Adds \p value to the vector entry specified by \p i. Note that library implementations of this
+   * method are thread safe, e.g. we will lock \p _numeric_vector_mutex before writing to the vector
    */
   virtual void add (const numeric_index_type i, const T value) = 0;
 
@@ -467,7 +470,8 @@ public:
    * Computes \f$ \vec{u} \leftarrow \vec{u} + \vec{v} \f$,
    * where \p v is a pointer and each \p dof_indices[i] specifies where
    * to add value \p v[i].  This should be overridden in subclasses
-   * for efficiency.
+   * for efficiency. Note that library implementations of this
+   * method are thread safe
    */
   virtual void add_vector (const T * v,
                            const std::vector<numeric_index_type> & dof_indices);
@@ -475,7 +479,8 @@ public:
   /**
    * Computes \f$ \vec{u} \leftarrow \vec{u} + \vec{v} \f$,
    * where \p v is a std::vector and each \p dof_indices[i] specifies
-   * where to add value \p v[i].
+   * where to add value \p v[i]. This method is guaranteed to be thread safe as long as library
+   * implementations of \p NumericVector are used
    */
   void add_vector (const std::vector<T> & v,
                    const std::vector<numeric_index_type> & dof_indices);
@@ -483,15 +488,17 @@ public:
   /**
    * Computes \f$ \vec{u} \leftarrow \vec{u} + \vec{v} \f$,
    * where \p v is a NumericVector and each \p dof_indices[i]
-   * specifies where to add value \p v(i).
+   * specifies where to add value \p v(i). This method is
+   * guaranteed to be thread-safe as long as library implementations of \p NumericVector are used
    */
-  virtual void add_vector (const NumericVector<T> & v,
-                           const std::vector<numeric_index_type> & dof_indices);
+  void add_vector (const NumericVector<T> & v,
+                   const std::vector<numeric_index_type> & dof_indices);
 
   /**
    * Computes \f$ \vec{u} \leftarrow \vec{u} + \vec{v} \f$,
    * where \p v is a DenseVector and each \p dof_indices[i] specifies
-   * where to add value \p v(i).
+   * where to add value \p v(i). This method is guaranteed to be thread safe as long as library
+   * implementations of \p NumericVector are used
    */
   void add_vector (const DenseVector<T> & v,
                    const std::vector<numeric_index_type> & dof_indices);
@@ -521,31 +528,36 @@ public:
                                      const SparseMatrix<T> & A) = 0;
 
   /**
-   * Inserts the entries of \p v in *this at the locations specified by \p v.
+   * Inserts the entries of \p v in *this at the locations specified by \p v. Note that library
+   * implementations of this method are thread safe
    */
   virtual void insert (const T * v,
                        const std::vector<numeric_index_type> & dof_indices);
 
   /**
-   * Inserts the entries of \p v in *this at the locations specified by \p v.
+   * Inserts the entries of \p v in *this at the locations specified by \p v. This method is
+   * guaranteed to be thread-safe as long as library implementations of \p NumericVector are used
    */
   void insert (const std::vector<T> & v,
                const std::vector<numeric_index_type> & dof_indices);
 
   /**
-   * Inserts the entries of \p v in *this at the locations specified by \p v.
+   * Inserts the entries of \p v in *this at the locations specified by \p v. This method is
+   * guaranteed to be thread-safe as long as library implementations of \p NumericVector are used
    */
-  virtual void insert (const NumericVector<T> & v,
-                       const std::vector<numeric_index_type> & dof_indices);
+  void insert (const NumericVector<T> & v,
+               const std::vector<numeric_index_type> & dof_indices);
 
   /**
-   * Inserts the entries of \p v in *this at the locations specified by \p v.
+   * Inserts the entries of \p v in *this at the locations specified by \p v. This method is
+   * guaranteed to be thread-safe as long as library implementations of \p NumericVector are used
    */
   void insert (const DenseVector<T> & v,
                const std::vector<numeric_index_type> & dof_indices);
 
   /**
-   * Inserts the entries of \p v in *this at the locations specified by \p v.
+   * Inserts the entries of \p v in *this at the locations specified by \p v. This method is
+   * guaranteed to be thread-safe as long as library implementations of \p NumericVector are used
    */
   void insert (const DenseSubVector<T> & v,
                const std::vector<numeric_index_type> & dof_indices);

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -748,6 +748,11 @@ protected:
    * Type of vector.
    */
   ParallelType _type;
+
+  /**
+   * Mutex for performing thread-safe operations
+   */
+  std::mutex _numeric_vector_mutex;
 };
 
 

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -413,7 +413,7 @@ private:
    * object to keep down thread contention when reading from multiple
    * PetscVectors simultaneously
    */
-  mutable std::mutex _petsc_vector_mutex;
+  mutable Threads::spin_mutex _petsc_vector_mutex;
 
   /**
    * Queries the array (and the local form if the vector is ghosted)

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -413,7 +413,7 @@ private:
    * object to keep down thread contention when reading from multiple
    * PetscVectors simultaneously
    */
-  mutable std::mutex _petsc_vector_mutex;
+  mutable std::mutex _petsc_get_restore_array_mutex;
 
   /**
    * Queries the array (and the local form if the vector is ghosted)

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -413,7 +413,7 @@ private:
    * object to keep down thread contention when reading from multiple
    * PetscVectors simultaneously
    */
-  mutable Threads::spin_mutex _petsc_vector_mutex;
+  mutable std::mutex _petsc_vector_mutex;
 
   /**
    * Queries the array (and the local form if the vector is ghosted)

--- a/include/numerics/trilinos_epetra_vector.h
+++ b/include/numerics/trilinos_epetra_vector.h
@@ -41,6 +41,7 @@
 #include <cstddef>
 #include <vector>
 #include <limits>
+#include <mutex>
 
 // Forward declarations
 class Epetra_IntSerialDenseVector;

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -147,7 +147,7 @@ void PetscVector<T>::set (const numeric_index_type i, const T value)
   PetscInt i_val = static_cast<PetscInt>(i);
   PetscScalar petsc_value = PS(value);
 
-  std::scoped_lock lock(_petsc_vector_mutex);
+  std::scoped_lock lock(_numeric_vector_mutex);
   ierr = VecSetValues (_vec, 1, &i_val, &petsc_value, INSERT_VALUES);
   LIBMESH_CHKERR(ierr);
 
@@ -190,7 +190,7 @@ void PetscVector<T>::add (const numeric_index_type i, const T value)
   PetscInt i_val = static_cast<PetscInt>(i);
   PetscScalar petsc_value = PS(value);
 
-  std::scoped_lock lock(_petsc_vector_mutex);
+  std::scoped_lock lock(_numeric_vector_mutex);
   ierr = VecSetValues (_vec, 1, &i_val, &petsc_value, ADD_VALUES);
   LIBMESH_CHKERR(ierr);
 
@@ -213,7 +213,7 @@ void PetscVector<T>::add_vector (const T * v,
   const PetscInt * i_val = reinterpret_cast<const PetscInt *>(dof_indices.data());
   const PetscScalar * petsc_value = pPS(v);
 
-  std::scoped_lock lock(_petsc_vector_mutex);
+  std::scoped_lock lock(_numeric_vector_mutex);
   ierr = VecSetValues (_vec, cast_int<PetscInt>(dof_indices.size()),
                        i_val, petsc_value, ADD_VALUES);
   LIBMESH_CHKERR(ierr);
@@ -365,7 +365,7 @@ void PetscVector<T>::insert (const T * v,
 
   PetscErrorCode ierr=0;
   PetscInt * idx_values = numeric_petsc_cast(dof_indices.data());
-  std::scoped_lock lock(_petsc_vector_mutex);
+  std::scoped_lock lock(_numeric_vector_mutex);
   ierr = VecSetValues (_vec, cast_int<PetscInt>(dof_indices.size()),
                        idx_values, pPS(v), INSERT_VALUES);
   LIBMESH_CHKERR(ierr);
@@ -1171,7 +1171,7 @@ void PetscVector<T>::_get_array(bool read_only) const
 
   if (!initially_array_is_present)
     {
-      std::scoped_lock do_once_lock(_petsc_vector_mutex);
+      std::scoped_lock lock(_petsc_vector_mutex);
       if (!_array_is_present.load(std::memory_order_relaxed))
         {
           PetscErrorCode ierr=0;

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -147,6 +147,7 @@ void PetscVector<T>::set (const numeric_index_type i, const T value)
   PetscInt i_val = static_cast<PetscInt>(i);
   PetscScalar petsc_value = PS(value);
 
+  std::scoped_lock lock(_petsc_vector_mutex);
   ierr = VecSetValues (_vec, 1, &i_val, &petsc_value, INSERT_VALUES);
   LIBMESH_CHKERR(ierr);
 
@@ -189,7 +190,7 @@ void PetscVector<T>::add (const numeric_index_type i, const T value)
   PetscInt i_val = static_cast<PetscInt>(i);
   PetscScalar petsc_value = PS(value);
 
-  Threads::spin_mutex::scoped_lock lock(_petsc_vector_mutex);
+  std::scoped_lock lock(_petsc_vector_mutex);
   ierr = VecSetValues (_vec, 1, &i_val, &petsc_value, ADD_VALUES);
   LIBMESH_CHKERR(ierr);
 
@@ -212,7 +213,7 @@ void PetscVector<T>::add_vector (const T * v,
   const PetscInt * i_val = reinterpret_cast<const PetscInt *>(dof_indices.data());
   const PetscScalar * petsc_value = pPS(v);
 
-  Threads::spin_mutex::scoped_lock lock(_petsc_vector_mutex);
+  std::scoped_lock lock(_petsc_vector_mutex);
   ierr = VecSetValues (_vec, cast_int<PetscInt>(dof_indices.size()),
                        i_val, petsc_value, ADD_VALUES);
   LIBMESH_CHKERR(ierr);
@@ -364,6 +365,7 @@ void PetscVector<T>::insert (const T * v,
 
   PetscErrorCode ierr=0;
   PetscInt * idx_values = numeric_petsc_cast(dof_indices.data());
+  std::scoped_lock lock(_petsc_vector_mutex);
   ierr = VecSetValues (_vec, cast_int<PetscInt>(dof_indices.size()),
                        idx_values, pPS(v), INSERT_VALUES);
   LIBMESH_CHKERR(ierr);
@@ -1169,7 +1171,7 @@ void PetscVector<T>::_get_array(bool read_only) const
 
   if (!initially_array_is_present)
     {
-      Threads::spin_mutex::scoped_lock do_once_lock(_petsc_vector_mutex);
+      std::scoped_lock do_once_lock(_petsc_vector_mutex);
       if (!_array_is_present.load(std::memory_order_relaxed))
         {
           PetscErrorCode ierr=0;
@@ -1234,7 +1236,7 @@ void PetscVector<T>::_restore_array() const
   libmesh_assert (this->initialized());
   if (_array_is_present.load(std::memory_order_acquire))
     {
-      Threads::spin_mutex::scoped_lock lock(_petsc_vector_mutex);
+      std::scoped_lock lock(_petsc_vector_mutex);
       if (_array_is_present.load(std::memory_order_relaxed))
         {
           PetscErrorCode ierr=0;

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -147,7 +147,7 @@ void PetscVector<T>::set (const numeric_index_type i, const T value)
   PetscInt i_val = static_cast<PetscInt>(i);
   PetscScalar petsc_value = PS(value);
 
-  std::scoped_lock lock(_numeric_vector_mutex);
+  std::scoped_lock lock(this->_numeric_vector_mutex);
   ierr = VecSetValues (_vec, 1, &i_val, &petsc_value, INSERT_VALUES);
   LIBMESH_CHKERR(ierr);
 
@@ -190,7 +190,7 @@ void PetscVector<T>::add (const numeric_index_type i, const T value)
   PetscInt i_val = static_cast<PetscInt>(i);
   PetscScalar petsc_value = PS(value);
 
-  std::scoped_lock lock(_numeric_vector_mutex);
+  std::scoped_lock lock(this->_numeric_vector_mutex);
   ierr = VecSetValues (_vec, 1, &i_val, &petsc_value, ADD_VALUES);
   LIBMESH_CHKERR(ierr);
 
@@ -213,7 +213,7 @@ void PetscVector<T>::add_vector (const T * v,
   const PetscInt * i_val = reinterpret_cast<const PetscInt *>(dof_indices.data());
   const PetscScalar * petsc_value = pPS(v);
 
-  std::scoped_lock lock(_numeric_vector_mutex);
+  std::scoped_lock lock(this->_numeric_vector_mutex);
   ierr = VecSetValues (_vec, cast_int<PetscInt>(dof_indices.size()),
                        i_val, petsc_value, ADD_VALUES);
   LIBMESH_CHKERR(ierr);
@@ -365,7 +365,7 @@ void PetscVector<T>::insert (const T * v,
 
   PetscErrorCode ierr=0;
   PetscInt * idx_values = numeric_petsc_cast(dof_indices.data());
-  std::scoped_lock lock(_numeric_vector_mutex);
+  std::scoped_lock lock(this->_numeric_vector_mutex);
   ierr = VecSetValues (_vec, cast_int<PetscInt>(dof_indices.size()),
                        idx_values, pPS(v), INSERT_VALUES);
   LIBMESH_CHKERR(ierr);
@@ -1171,7 +1171,7 @@ void PetscVector<T>::_get_array(bool read_only) const
 
   if (!initially_array_is_present)
     {
-      std::scoped_lock lock(_petsc_vector_mutex);
+      std::scoped_lock lock(_petsc_get_restore_array_mutex);
       if (!_array_is_present.load(std::memory_order_relaxed))
         {
           PetscErrorCode ierr=0;
@@ -1236,7 +1236,7 @@ void PetscVector<T>::_restore_array() const
   libmesh_assert (this->initialized());
   if (_array_is_present.load(std::memory_order_acquire))
     {
-      std::scoped_lock lock(_petsc_vector_mutex);
+      std::scoped_lock lock(_petsc_get_restore_array_mutex);
       if (_array_is_present.load(std::memory_order_relaxed))
         {
           PetscErrorCode ierr=0;

--- a/src/numerics/trilinos_epetra_vector.C
+++ b/src/numerics/trilinos_epetra_vector.C
@@ -166,6 +166,7 @@ void EpetraVector<T>::set (const numeric_index_type i_in, const T value_in)
 
   libmesh_assert_less (i_in, this->size());
 
+  std::scoped_lock lock(this->_numeric_vector_mutex);
   ReplaceGlobalValues(1, &i, &value);
 
   this->_is_closed = false;
@@ -217,6 +218,7 @@ void EpetraVector<T>::add (const numeric_index_type i_in, const T value_in)
 
   libmesh_assert_less (i_in, this->size());
 
+  std::scoped_lock lock(this->_numeric_vector_mutex);
   SumIntoGlobalValues(1, &i, &value);
 
   this->_is_closed = false;
@@ -230,6 +232,7 @@ void EpetraVector<T>::add_vector (const T * v,
 {
   libmesh_assert_equal_to (sizeof(numeric_index_type), sizeof(int));
 
+  std::scoped_lock lock(this->_numeric_vector_mutex);
   SumIntoGlobalValues (cast_int<numeric_index_type>(dof_indices.size()),
                        numeric_trilinos_cast(dof_indices.data()),
                        const_cast<T *>(v));
@@ -303,9 +306,11 @@ void EpetraVector<T>::insert (const T * v,
 {
   libmesh_assert_equal_to (sizeof(numeric_index_type), sizeof(int));
 
+  std::scoped_lock lock(this->_numeric_vector_mutex);
   ReplaceGlobalValues (cast_int<numeric_index_type>(dof_indices.size()),
                        numeric_trilinos_cast(dof_indices.data()),
                        const_cast<T *>(v));
+  this->_is_closed = false;
 }
 
 

--- a/tests/numerics/numeric_vector_test.h
+++ b/tests/numerics/numeric_vector_test.h
@@ -67,6 +67,28 @@ public:
       for (libMesh::dof_id_type n=first; n != last; n++)
         v.set (n, static_cast<libMesh::Number>(n));
       v.close();
+      for (libMesh::dof_id_type n=first; n != last; n++)
+        v.add (n, static_cast<libMesh::Number>(n));
+      v.close();
+
+      if (!to_one)
+        v.localize(l);
+      else
+        v.localize_to_one(l,root_pid);
+
+      if (!to_one || my_comm->rank() == root_pid)
+        // Yes I really mean v.size()
+        for (libMesh::dof_id_type i=0; i<v.size(); i++)
+          LIBMESH_ASSERT_FP_EQUAL(2.*libMesh::libmesh_real(i),
+                                  libMesh::libmesh_real(l[i]),
+                                  libMesh::TOLERANCE*libMesh::TOLERANCE);
+
+      for (libMesh::dof_id_type n=first; n != last; n++)
+      {
+        const auto value = static_cast<libMesh::Number>(n);
+        v.insert (&value, std::vector<libMesh::numeric_index_type>({n}));
+      }
+      v.close();
 
       if (!to_one)
         v.localize(l);


### PR DESCRIPTION
A couple other minor changes
- Use `Threads::spin_mutex` instead of `std::mutex` to help address
  @dschwen's concerns about being thread-model agnostic
- Similarly `Threads::spin_mutex::scoped_lock` in place of
  `std::lock_guard<std::mutex>`
- In `_restore_array` use the same pattern as `_get_array`. We were
  actually using memory sequential ordering here before. Going to `release`
  and `acquire` is actually less heavy-weight

The changes here fix the thread errors on the failing moose test
`geomsearch/3d_moving_penetration_smoothing.disjoint/pl_test3nnstt` when
run with threads on https://civet.inl.gov/job/963721/ for #3170. I've also
seen that thread failure crop on another libmesh PR recently (I think it
was my own). That test currently has thread errors because the racing adds
are protected by translation unit local mutexes ... and the mutexes are in
different translation units (Postprocessor unity build vs. UserObject unity build). 
This is a demonstration that users cannot really
be trusted to write thread-safe code, or that they can get races from places
they wouldn't necessarily expect to compete