### PR TITLE
memcpy warning fix in TypeNTensor

### DIFF
--- a/include/numerics/type_n_tensor.h
+++ b/include/numerics/type_n_tensor.h
@@ -61,6 +61,10 @@ public:
 
   TypeNTensor (const TypeTensor<T> &) : _coords(std::vector<T>(int_pow(LIBMESH_DIM, N))) {}
 
+  TypeNTensor (const TypeNTensor<N,T> &) : _coords(std::vector<T>(int_pow(LIBMESH_DIM, N))) {}
+
+  TypeNTensor & operator = (const TypeNTensor<N,T> &) { libmesh_not_implemented(); return *this; }
+
   operator TypeVector<T> () const { libmesh_not_implemented(); return 0; }
   operator VectorValue<T> () const { libmesh_not_implemented(); return 0; }
 


### PR DESCRIPTION
I'm not sure I understand why gcc 11 thinks the auto-generated functions
here might lead to memcpy-into-buffer-of-size-0, but this is a
compilation shim we should never be truly using anyway, so I won't
bother figuring out the details until we actually need rank-3+ tensors,
I'll just work around the problem.