### PR TITLE
Optionally use system provided netcdf

### DIFF
--- a/m4/libmesh_optional_packages.m4
+++ b/m4/libmesh_optional_packages.m4
@@ -720,7 +720,15 @@ AM_CONDITIONAL(LIBMESH_ENABLE_HDF5, test x$enablehdf5 = xyes)
 # --------------------------------------------------------------
 CONFIGURE_NETCDF
 AS_IF([test $enablenetcdf = yes],
-      [libmesh_contrib_INCLUDES="$NETCDF_INCLUDE $libmesh_contrib_INCLUDES"])
+      [
+          AS_IF([test x$netcdfversion = xsystem],
+                [
+                  libmesh_optional_INCLUDES="$NETCDF_CFLAGS $libmesh_optional_INCLUDES"
+                  libmesh_optional_LIBS="$NETCDF_LIBS $libmesh_optional_LIBS"
+                ],
+                [
+                  libmesh_contrib_INCLUDES="$NETCDF_INCLUDE $libmesh_contrib_INCLUDES"])
+      ])
 
 AM_CONDITIONAL(LIBMESH_ENABLE_NETCDF,    test x$enablenetcdf  = xyes)
 AM_CONDITIONAL(LIBMESH_ENABLE_NETCDF_V4, test x$netcdfversion = x4)

--- a/m4/netcdf.m4
+++ b/m4/netcdf.m4
@@ -7,6 +7,8 @@ AC_DEFUN([CONFIGURE_NETCDF],
                 AS_HELP_STRING([--disable-netcdf],
                                [build without netCDF binary I/O]),
                 [AS_CASE("${enableval}",
+                  [system],     [enablenetcdf=yes
+                                 netcdfversion=system],
                   [yes|new|v4], [enablenetcdf=yes
                                  netcdfversion=4],
                   [old|v3],     [enablenetcdf=yes
@@ -27,6 +29,8 @@ AC_DEFUN([CONFIGURE_NETCDF],
         ])
 
   AS_CASE("${netcdfversion}",
+          [system], [PKG_CHECK_MODULES([NETCDF], [netcdf >= 4.2])],
+
           [3], [
                  dnl We shouldn't get here, see if test above.
                  AC_MSG_ERROR([>>> Error: netCDF3 is no longer distributed with libMesh <<<])


### PR DESCRIPTION
Detect a system wide installed netcdf using pkgconfig and use it, in
case --enable-netcdf=system is specified.

Fixes #1542.