### PR TITLE
ExodusII::write_added_sides()

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -140,6 +140,8 @@ public:
    */
   void write_added_sides (bool val);
 
+  virtual bool get_add_sides () override;
+
   /**
    * \returns An array containing the timesteps in the file.
    */

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -129,6 +129,18 @@ public:
   void write_complex_magnitude (bool val);
 
   /**
+   * By default, we only write out the elements physically stored in
+   * the mesh.  If we have any SIDE_DISCONTINUOUS variables, however,
+   * we cannot easily output them on elements with sides that share
+   * vertices (and in 3D, edges).  We can set this flag to instead
+   * create extra "side elements" on which to visualize such
+   * variables.
+   *
+   * By default this flag is set to false.
+   */
+  void write_added_sides (bool val);
+
+  /**
    * \returns An array containing the timesteps in the file.
    */
   const std::vector<Real> & get_time_steps();

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -116,6 +116,12 @@ public:
   const char * get_elem_type() const;
 
   /**
+   * Sets whether or not to write extra "side" elements.  This is useful for
+   * plotting SIDE_DISCONTINUOUS data.
+   */
+  void set_add_sides(bool add_sides);
+
+  /**
    * Opens an \p ExodusII mesh file named \p filename.  If
    * read_only==true, the file will be opened with the EX_READ flag,
    * otherwise it will be opened with the EX_WRITE flag.
@@ -888,6 +894,11 @@ protected:
 protected:
 
   /**
+   * Set to true iff we want to write separate "side" elements too.
+   */
+  bool _add_sides = false;
+
+  /**
    * read_var_names() dispatches to this function.  We need to
    * override it slightly for Nemesis.
    */
@@ -1119,6 +1130,10 @@ private:
   size_t table_size;
 };
 
+
+inline void ExodusII_IO_Helper::set_add_sides(bool add_sides) {
+  _add_sides = add_sides;
+}
 
 
 inline int ExodusII_IO_Helper::end_elem_id() const {

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -907,11 +907,6 @@ protected:
 protected:
 
   /**
-   * Set to true iff we want to write separate "side" elements too.
-   */
-  bool _add_sides = false;
-
-  /**
    * read_var_names() dispatches to this function.  We need to
    * override it slightly for Nemesis.
    */
@@ -920,6 +915,11 @@ protected:
                                    std::vector<std::string> & result);
 
 private:
+
+  /**
+   * Set to true iff we want to write separate "side" elements too.
+   */
+  bool _add_sides = false;
 
   /**
    * write_var_names() dispatches to this function.

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -803,6 +803,14 @@ public:
   const ExodusII_IO_Helper::Conversion &
   get_conversion(std::string type_str) const;
 
+  /*
+   * Returns true iff the given side of the given element is *not*
+   * added to output from that element, because it is considered to be
+   * redundant with respect to the same data added from the
+   * neighboring element sharing that side.
+   */
+  static bool redundant_added_side(const Elem & elem, unsigned int side);
+
 protected:
   /**
    * When appending: during initialization, check that variable names

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -121,6 +121,8 @@ public:
    */
   void set_add_sides(bool add_sides);
 
+  bool get_add_sides();
+
   /**
    * Opens an \p ExodusII mesh file named \p filename.  If
    * read_only==true, the file will be opened with the EX_READ flag,
@@ -1144,6 +1146,11 @@ private:
 
 inline void ExodusII_IO_Helper::set_add_sides(bool add_sides) {
   _add_sides = add_sides;
+}
+
+
+inline bool ExodusII_IO_Helper::get_add_sides() {
+  return _add_sides;
 }
 
 

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -305,9 +305,20 @@ public:
 
   /**
    * Writes the elements contained in "mesh". FIXME: This only works
-   * for Meshes having a single type of element!
+   * for Meshes having a single type of element in each subdomain!
+   *
+   * If \p use_discontinuous is true, we break apart elements, so that
+   * shared nodes on faces/edges/vertices can take different values
+   * from different elements.  This is useful for plotting
+   * discontinuous underlying variables
+   *
+   * If \p _add_sides is true, we also output side elements, so that
+   * shared nodes on edges/vertices can take different values from
+   * different elements.  This is useful for plotting
+   * SIDE_DISCONTINUOUS representing e.g. inter-element fluxes.
    */
-  virtual void write_elements(const MeshBase & mesh, bool use_discontinuous=false);
+  virtual void write_elements(const MeshBase & mesh,
+                              bool use_discontinuous=false);
 
   /**
    * Writes the sidesets contained in "mesh"

--- a/include/mesh/mesh_output.h
+++ b/include/mesh/mesh_output.h
@@ -165,6 +165,14 @@ protected:
 
 
   /**
+   * \returns Whether or not added sides are expected to be output,
+   * to plot SIDE_DISCONTINUOUS data.  Subclasses should override this
+   * if they are capable of plotting such data.
+   */
+  virtual bool get_add_sides() { return false; }
+
+
+  /**
    * Flag specifying whether this format is parallel-capable.
    * If this is false (default) I/O is only permitted when the mesh
    * has been serialized.

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -373,7 +373,11 @@ void ExodusII_IO::read (const std::string & fname)
           // Assign the current subdomain to this Elem
           uelem->subdomain_id() = static_cast<subdomain_id_type>(subdomain_id);
 
-          // Use the elem_num_map to obtain the ID of this element in the Exodus file
+          // Use the elem_num_map to obtain the ID of this element in
+          // the Exodus file.  Make sure we aren't reading garbage if
+          // the file is corrupt.
+          libmesh_error_msg_if(std::size_t(j) >= exio_helper->elem_num_map.size(),
+                               "Error: Trying to read Exodus file with more elements than elem_num_map entries.\n");
           int exodus_id = exio_helper->elem_num_map[j];
 
           // Assign this element the same ID it had in the Exodus

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -795,6 +795,11 @@ void ExodusII_IO::write_added_sides (bool val)
 }
 
 
+bool ExodusII_IO::get_add_sides ()
+{
+  return exio_helper->get_add_sides();
+}
+
 
 void ExodusII_IO::use_mesh_dimension_instead_of_spatial_dimension(bool val)
 {

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -785,6 +785,13 @@ void ExodusII_IO::write_complex_magnitude (bool val)
 
 
 
+void ExodusII_IO::write_added_sides (bool val)
+{
+  exio_helper->set_add_sides(val);
+}
+
+
+
 void ExodusII_IO::use_mesh_dimension_instead_of_spatial_dimension(bool val)
 {
   exio_helper->use_mesh_dimension_instead_of_spatial_dimension(val);

--- a/tests/mesh/write_vec_and_scalar.C
+++ b/tests/mesh/write_vec_and_scalar.C
@@ -118,9 +118,11 @@ public:
 #endif
         CPPUNIT_ASSERT_EQUAL(node->n_vars(0), 3*v2);
 
+        CPPUNIT_ASSERT_LESS(node_reordering.size(), std::size_t(node->id()));
         const dof_id_type gold_i_ux = node_reordering[node->id()] * 3;
         const dof_id_type gold_i_uy = gold_i_ux + 1;
         const dof_id_type gold_i_v  = gold_i_uy + 1;
+        CPPUNIT_ASSERT_LESS(gold_vector.size(), std::size_t(gold_i_v));
 
         LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,0,0))),
                                 gold_vector[gold_i_ux], tol);


### PR DESCRIPTION
We're going to want to let users visualize SIDE_DISCONTINUOUS variables, and that's a little tricky to do when we're outputting continuous meshes.  A workaround: output side elements for all sides of the mesh, so we can then output discontinuous side data on those.

This is the first half of that: output of the side elements, and a unit test for the same.  This probably isn't worth merging until the data output is also done, but I want to make sure our CI tests aren't unhappy with this.