### PR TITLE
Poly2tri updates

### DIFF
--- a/include/mesh/poly2tri_triangulator.h
+++ b/include/mesh/poly2tri_triangulator.h
@@ -32,6 +32,9 @@
 namespace libMesh
 {
 
+// Forward Declarations
+class Elem;
+
 /**
  * A C++ interface between LibMesh and the poly2tri library, with
  * custom code for Steiner point insertion.
@@ -59,9 +62,10 @@ public:
                          DofObject::invalid_id);
 
   /**
-   * Empty destructor.
+   * Empty destructor.  Defaulted in the .C so we can forward declare
+   * unique_ptr contents.
    */
-  virtual ~Poly2TriTriangulator() = default;
+  virtual ~Poly2TriTriangulator();
 
   /**
    * Internally, this calls the poly2tri triangulation code in a loop,
@@ -69,6 +73,20 @@ public:
    * quality.
    */
   virtual void triangulate() override;
+
+  /**
+   * Set a function giving desired triangle area as a function of
+   * position.  Set this to nullptr to disable position-dependent area
+   * constraint (falling back on desired_area()).
+   */
+  virtual void set_desired_area_function (FunctionBase<Real> * desired);
+
+  /**
+   * Get the function giving desired triangle area as a function of
+   * position, or \p nullptr if no such function has been set.
+   */
+  virtual FunctionBase<Real> * get_desired_area_function ();
+
 
 protected:
   /**
@@ -81,6 +99,12 @@ protected:
    * existing trangulation.  Returns true iff new points were added.
    */
   bool insert_refinement_points();
+
+  /**
+   * Returns true if the given element ought to be refined according
+   * to current criteria.
+   */
+  bool should_refine_elem(Elem & elem);
 
 private:
 
@@ -99,6 +123,11 @@ private:
    * Keep track of how many mesh nodes are boundary nodes.
    */
   dof_id_type _n_boundary_nodes;
+
+  /**
+   * Location-dependent area requirements
+   */
+  std::unique_ptr<FunctionBase<Real>> _desired_area_func;
 };
 
 } // namespace libMesh

--- a/include/mesh/triangulator_interface.h
+++ b/include/mesh/triangulator_interface.h
@@ -42,6 +42,7 @@ namespace libMesh
 
 // Forward Declarations
 class UnstructuredMesh;
+template <typename Output> class FunctionBase;
 
 class TriangulatorInterface
 {
@@ -121,8 +122,32 @@ public:
   /**
    * Sets and/or gets the desired triangle area. Set to zero to disable
    * area constraint.
+   *
+   * If a \p desired_area_function is set, then \p desired_area()
+   * should be used to set a *minimum* desired area; this will reduce
+   * "false negatives" by suggesting how finely to sample \p
+   * desired_area_function inside large triangles, where ideally the
+   * \p desired_area_function will be satisfied in the triangle
+   * interior and not just at the triangle vertices.
    */
   Real & desired_area() {return _desired_area;}
+
+  /**
+   * Set a function giving desired triangle area as a function of
+   * position.  Set this to nullptr to disable position-dependent area
+   * constraint (falling back on desired_area()).
+   *
+   * This may not be implemented in all subclasses.
+   */
+  virtual void set_desired_area_function (FunctionBase<Real> *)
+  { libmesh_not_implemented(); }
+
+  /**
+   * Get the function giving desired triangle area as a function of
+   * position, or \p nullptr if no such function has been set.
+   */
+  virtual FunctionBase<Real> * get_desired_area_function ()
+  { return nullptr; }
 
   /**
    * Sets and/or gets the minimum desired angle. Set to zero to

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -790,13 +790,17 @@ bool Poly2TriTriangulator::insert_refinement_points()
                   checked_emplace(this_node->id(), next_node->id());
 
                   this_node = next_node;
+                  if (this_node->id() == this->segments.front().first)
+                    break;
+
                   it = next_boundary_node.find(*this_node);
                 }
             }
 
           // We expect a closed loop here
-          checked_emplace(this->segments.back().second,
-                          this->segments.front().first);
+          if (this->segments.back().second != this->segments.front().first)
+            checked_emplace(this->segments.back().second,
+                            this->segments.front().first);
         }
       else
         {

--- a/tests/mesh/libmesh_poly2tri.C
+++ b/tests/mesh/libmesh_poly2tri.C
@@ -13,6 +13,7 @@ public:
 
 #ifdef LIBMESH_HAVE_POLY2TRI
   CPPUNIT_TEST( testLibMeshPoly2Tri );
+  CPPUNIT_TEST( testLibMeshPoly2TriHole );
 #endif
 
   CPPUNIT_TEST_SUITE_END();
@@ -45,6 +46,47 @@ public:
     // it.
     CPPUNIT_ASSERT_EQUAL(tris.size(), std::size_t(3));
   }
+
+  void testLibMeshPoly2TriHole ()
+  {
+//    const double eps = 0;  // This (or negative eps) succeeds
+//    const double eps = 1e-12;  // This (or larger eps) succeeds
+    const double eps = 1e-15; // This gave EdgeEvent - null triangle with older Poly2Tri
+
+    std::vector<p2t::Point> outer_boundary
+      {{0,0},{0.5,eps},{1,0},{1-eps,0.836541},
+       {1,2},{.46,1.46+eps},{0,1},{eps,0.5}};
+
+    std::vector<p2t::Point *> api_shim(outer_boundary.size());
+    std::iota(api_shim.begin(), api_shim.end(), outer_boundary.data());
+
+    const double r2o4 = std::sqrt(2.)/4;
+    std::vector<p2t::Point> hole_boundary
+      {{0.5+r2o4,0.5},{0.5,0.5+r2o4},{0.5-r2o4,0.5},{0.5-eps,0.5-r2o4}};
+
+    std::vector<p2t::Point *> hole_shim(hole_boundary.size());
+    std::iota(hole_shim.begin(), hole_shim.end(), hole_boundary.data());
+
+    p2t::CDT cdt(api_shim);
+    cdt.AddHole(hole_shim);
+
+    std::vector<p2t::Point> interior_points
+      {{0.21,0.79},{0.21,0.21},{0.79,0.21}};
+    for (auto & p : interior_points)
+      cdt.AddPoint(&p);
+
+    cdt.Triangulate();
+
+    auto tris = cdt.GetTriangles();
+
+    std::cout << "With perturbation " << eps << " we got " << tris.size() << " triangles!" << std::endl;
+
+    // We mostly wanted to make sure this compiled, but might as well
+    // make sure it gave us the expected triangle count while we're at
+    // it.
+//    CPPUNIT_ASSERT_EQUAL(tris.size(), std::size_t(3));
+  }
+
 #endif
 };
 

--- a/tests/mesh/mesh_triangulation.C
+++ b/tests/mesh/mesh_triangulation.C
@@ -32,6 +32,8 @@ public:
   CPPUNIT_TEST( testPoly2TriRefined );
   CPPUNIT_TEST( testPoly2TriExtraRefined );
   CPPUNIT_TEST( testPoly2TriHolesRefined );
+  // This covers an old poly2tri collinearity-tolerance bug
+  CPPUNIT_TEST( testPoly2TriHolesExtraRefined );
 #endif
 
 #ifdef LIBMESH_HAVE_TRIANGLE
@@ -383,6 +385,15 @@ public:
     const std::vector<TriangulatorInterface::Hole*> holes { &diamond };
 
     testPoly2TriRefinementBase(&holes, 1.25, 13);
+  }
+
+  void testPoly2TriHolesExtraRefined()
+  {
+    // Add a diamond hole
+    TriangulatorInterface::PolygonHole diamond(Point(0.5,0.5), std::sqrt(2)/4, 4);
+    const std::vector<TriangulatorInterface::Hole*> holes { &diamond };
+
+    testPoly2TriRefinementBase(&holes, 1.25, 125, 0.01);
   }
 #endif // LIBMESH_HAVE_POLY2TRI
 

--- a/tests/mesh/mesh_triangulation.C
+++ b/tests/mesh/mesh_triangulation.C
@@ -382,7 +382,7 @@ public:
     TriangulatorInterface::PolygonHole diamond(Point(0.5,0.5), std::sqrt(2)/4, 4);
     const std::vector<TriangulatorInterface::Hole*> holes { &diamond };
 
-    testPoly2TriRefinementBase(&holes, 1.25, 8);
+    testPoly2TriRefinementBase(&holes, 1.25, 13);
   }
 #endif // LIBMESH_HAVE_POLY2TRI
 

--- a/tests/mesh/mesh_triangulation.C
+++ b/tests/mesh/mesh_triangulation.C
@@ -3,6 +3,7 @@
 #include <libmesh/mesh.h>
 #include <libmesh/mesh_triangle_holes.h>
 #include <libmesh/mesh_triangle_interface.h>
+#include <libmesh/parsed_function.h>
 #include <libmesh/point.h>
 #include <libmesh/poly2tri_triangulator.h>
 
@@ -34,6 +35,9 @@ public:
   CPPUNIT_TEST( testPoly2TriHolesRefined );
   // This covers an old poly2tri collinearity-tolerance bug
   CPPUNIT_TEST( testPoly2TriHolesExtraRefined );
+
+  CPPUNIT_TEST( testPoly2TriNonUniformRefined );
+  CPPUNIT_TEST( testPoly2TriHolesNonUniformRefined );
 #endif
 
 #ifdef LIBMESH_HAVE_TRIANGLE
@@ -322,7 +326,8 @@ public:
     (const std::vector<TriangulatorInterface::Hole*> * holes,
      Real expected_total_area,
      dof_id_type n_original_elem,
-     Real desired_area = 0.1)
+     Real desired_area = 0.1,
+     FunctionBase<Real> * area_func = nullptr)
   {
     Mesh mesh(*TestCommWorld);
     mesh.add_point(Point(0,0), 0);
@@ -342,6 +347,7 @@ public:
 
     // Try to insert points!
     triangulator.desired_area() = desired_area;
+    triangulator.set_desired_area_function(area_func);
     triangulator.minimum_angle() = 0;
     triangulator.smooth_after_generating() = false;
 
@@ -358,7 +364,16 @@ public:
         const Real my_area = elem->volume();
 
         // my_area <= desired_area, wow this macro ordering hurts
-        CPPUNIT_ASSERT_LESSEQUAL(desired_area, my_area);
+        if (desired_area != 0)
+          CPPUNIT_ASSERT_LESSEQUAL(desired_area, my_area);
+
+        if (area_func != nullptr)
+          for (auto v : make_range(elem->n_vertices()))
+            {
+              const Real local_desired_area =
+                (*area_func)(elem->point(v));
+              CPPUNIT_ASSERT_LESSEQUAL(local_desired_area, my_area);
+            }
 
         area += my_area;
       }
@@ -378,6 +393,12 @@ public:
     testPoly2TriRefinementBase(nullptr, 1.5, 150, 0.01);
   }
 
+  void testPoly2TriNonUniformRefined()
+  {
+    ParsedFunction<Real> var_area {"0.002*(1+2*x)*(1+2*y)"};
+    testPoly2TriRefinementBase(nullptr, 1.5, 150, 0, &var_area);
+  }
+
   void testPoly2TriHolesRefined()
   {
     // Add a diamond hole
@@ -395,6 +416,18 @@ public:
 
     testPoly2TriRefinementBase(&holes, 1.25, 125, 0.01);
   }
+
+  void testPoly2TriHolesNonUniformRefined()
+  {
+    // Add a diamond hole
+    TriangulatorInterface::PolygonHole diamond(Point(0.5,0.5), std::sqrt(2)/4, 4);
+    const std::vector<TriangulatorInterface::Hole*> holes { &diamond };
+
+    ParsedFunction<Real> var_area {"0.002*(0.25+2*x)*(0.25+2*y)"};
+    testPoly2TriRefinementBase(&holes, 1.25, 150, 0, &var_area);
+  }
+
+
 #endif // LIBMESH_HAVE_POLY2TRI
 
 };


### PR DESCRIPTION
This gets us:

A bugfix in poly2tri itself.  I don't think this hit any of the Moose mesh generator users yet, but it was dismayingly easy for me to trigger when I started refining triangulations.  I've currently got the new submodule branch hosted on my own fork, but will update to point to a master commit if/when my upstream PR (or an equivalent fix) makes it in.

A number of fixes in my refinement code.  Before it worked in most cases but was easy to break if I hammered on it hard enough; now I can generate millions of elements without problems.

Support for non-uniform refinement.  Non-uniform isotropic refinement was surprisingly easy once the underlying code was all working.  Anisotropic will be much harder.

Unit tests for all of the above.