### PR TITLE
Fixes up deprecation warnings in custom iterators due to C++17

### DIFF
--- a/include/base/variant_filter_iterator.h
+++ b/include/base/variant_filter_iterator.h
@@ -49,14 +49,15 @@
 template<class Predicate, class Type, class ReferenceType = Type &, class PointerType = Type *,
                           class ConstType = const Type, class ConstReferenceType = const Type &,
                           class ConstPointerType = const Type *>
-class variant_filter_iterator :
-#if defined(__GNUC__) && (__GNUC__ < 3)  && !defined(__INTEL_COMPILER)
-  public std::forward_iterator<std::forward_iterator_tag, Type>
-#else
-  public std::iterator<std::forward_iterator_tag,  Type>
-#endif
+class variant_filter_iterator
 {
 public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = Type;
+  using difference_type = std::ptrdiff_t;
+  using pointer = PointerType;
+  using reference = ReferenceType;
+
   /**
    * Shortcut name for the fully-qualified typename.
    */

--- a/include/mesh/mesh_inserter_iterator.h
+++ b/include/mesh/mesh_inserter_iterator.h
@@ -47,8 +47,13 @@ class Point;
  */
 template <typename T>
 struct mesh_inserter_iterator
-  : std::iterator<std::output_iterator_tag, T>
 {
+  using iterator_category = std::output_iterator_tag;
+  using value_type = T;
+  using difference_type = std::ptrdiff_t;
+  using pointer = T*;
+  using reference = T&;
+
   mesh_inserter_iterator (MeshBase & m) : mesh(m) {}
 
   void operator=(Elem * e) { mesh.add_elem(e); }


### PR DESCRIPTION
The following warning was experienced in idaholab/moose#20580 now that we have moved to a conda-forge provided mpich, though I am unsure how this wasn't experienced before when we started C++17 testing:

```
./include/libmesh/variant_filter_iterator.h:56:15: warning: 'iterator<std::forward_iterator_tag, libMesh::Node *>' is deprecated [-Wdeprecated-declarations]
  public std::iterator<std::forward_iterator_tag,  Type>
              ^
./include/libmesh/mesh_base.h:2166:27: note: in instantiation of template class 'variant_filter_iterator<libMesh::Predicates::multi_predicate, libMesh::Node *>' requested here
MeshBase::node_iterator : MeshBase::node_filter_iter
                          ^
/Users/icenct/miniconda3/envs/test/bin/../include/c++/v1/__iterator/iterator.h:27:29: note: 'iterator<std::forward_iterator_tag, libMesh::Node *>' has been explicitly marked deprecated here
struct _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 iterator
                            ^
/Users/icenct/miniconda3/envs/test/bin/../include/c++/v1/__config:1016:39: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
#  define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
                                      ^
/Users/icenct/miniconda3/envs/test/bin/../include/c++/v1/__config:993:48: note: expanded from macro '_LIBCPP_DEPRECATED'
#    define _LIBCPP_DEPRECATED __attribute__ ((deprecated))
```

We treat warnings as errors in end user testing, so I made a possible fix for it. I also saw similar warnings for `mesh_inserter_iterator.h`, so my fix was applied there as well. 

If there is a cleaner or more desirable way to do this, I welcome any comments 😄 

Tagging @roystgnr and @lindsayad 