### PR TITLE
Add MeshBase::all_second_order_range()

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -1200,8 +1200,9 @@ public:
   second_order_child_vertex (const unsigned int n) const;
 
   /**
-   * \returns The element type of the associated second-order element,
-   * or INVALID_ELEM for second-order or other elements that cannot be
+   * \returns The ElemType of the associated second-order element
+   * (which will be the same as the input if the input is already a
+   * second-order ElemType) or INVALID_ELEM for elements that cannot be
    * converted into higher order equivalents.
    *
    * For example, when \p this is a \p TET4, then \p TET10 is returned.

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1273,19 +1273,6 @@ public:
 
   /**
    * Converts a (conforming, non-refined) mesh with linear elements
-   * into a mesh with second-order elements.  For example, a mesh
-   * consisting of \p Tet4 will be converted to a mesh with \p Tet10
-   * etc.
-   *
-   * \note For some elements like \p Hex8 there exist two higher order
-   * equivalents, \p Hex20 and \p Hex27.  When \p full_ordered is \p
-   * true (default), then \p Hex27 is built.  Otherwise, \p Hex20 is
-   * built.  The same holds obviously for \p Quad4, \p Prism6, etc.
-   */
-  virtual void all_second_order (const bool full_ordered=true) = 0;
-
-  /**
-   * Converts a (conforming, non-refined) mesh with linear elements
    * into a mesh with "complete" order elements, i.e. elements which
    * can store degrees of freedom on any vertex, edge, or face.  For
    * example, a mesh consisting of \p Tet4 or \p Tet10 will be
@@ -1318,6 +1305,26 @@ public:
    */
   struct node_iterator;
   struct const_node_iterator;
+
+  /**
+   * Converts a set of this Mesh's elements defined by \p range from
+   * FIRST order to SECOND order. Must be called on conforming,
+   * non-refined meshes. For example, a mesh consisting of \p Tet4
+   * will be converted to a mesh with \p Tet10 etc.
+   *
+   * \note For some elements like \p Hex8 there exist two higher order
+   * equivalents, \p Hex20 and \p Hex27.  When \p full_ordered is \p
+   * true (default), then \p Hex27 is built.  Otherwise, \p Hex20 is
+   * built.  The same holds obviously for \p Quad4, \p Prism6, etc.
+   */
+  virtual void all_second_order_range(const SimpleRange<element_iterator> & range,
+                                      const bool full_ordered = true) = 0;
+
+  /**
+   * Calls the range-based version of this function with a range
+   * consisting of all elements in the mesh.
+   */
+  void all_second_order (const bool full_ordered = true);
 
   /**
    * In a few (very rare) cases, the user may have manually tagged the

--- a/include/mesh/unstructured_mesh.h
+++ b/include/mesh/unstructured_mesh.h
@@ -137,7 +137,8 @@ public:
    * true (default), then \p Hex27 is built.  Otherwise, \p Hex20 is
    * built.  The same holds obviously for \p Quad4, \p Prism6, etc.
    */
-  virtual void all_second_order (const bool full_ordered=true) override;
+  virtual void all_second_order_range (const SimpleRange<element_iterator> & range,
+                                       const bool full_ordered=true) override;
 
   /**
    * Converts a (conforming, non-refined) mesh with linear elements

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -1236,6 +1236,11 @@ void MeshBase::partition (const unsigned int n_parts)
     }
 }
 
+void MeshBase::all_second_order (const bool full_ordered)
+{
+  this->all_second_order_range(this->element_ptr_range(), full_ordered);
+}
+
 unsigned int MeshBase::recalculate_n_partitions()
 {
   // This requires an inspection on every processor

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -1221,12 +1221,14 @@ void UnstructuredMesh::all_first_order ()
 
 
 
-void UnstructuredMesh::all_second_order (const bool full_ordered)
+void
+UnstructuredMesh::all_second_order_range (const SimpleRange<element_iterator> & range,
+                                          const bool full_ordered)
 {
   // This function must be run on all processors at once
   parallel_object_only();
 
-  LOG_SCOPE("all_second_order()", "Mesh");
+  LOG_SCOPE("all_second_order_range()", "Mesh");
 
   /*
    * when the mesh is not prepared,
@@ -1252,8 +1254,8 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
    * than elements.
    */
   bool already_second_order = false;
-  if (this->elements_begin() != this->elements_end() &&
-      (*(this->elements_begin()))->default_order() != FIRST)
+  if (range.begin() != range.end() &&
+      (*(range.begin()))->default_order() != FIRST)
     already_second_order = true;
   this->comm().max(already_second_order);
   if (already_second_order)
@@ -1290,9 +1292,10 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
 #endif
 
   /*
-   * for speed-up of the \p add_point() method, we
+   * For speed-up of the \p add_point() method, we
    * can reserve memory.  Guess the number of additional
-   * nodes for different dimensions
+   * nodes based on the element spatial dimensions and the
+   * total number of nodes in the mesh as an upper bound.
    */
   switch (this->mesh_dimension())
     {
@@ -1361,7 +1364,7 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
    * them with an equivalent second-order element.  Don't
    * forget to delete the low-order element, or else it will leak!
    */
-  for (auto & lo_elem : element_ptr_range())
+  for (auto & lo_elem : range)
     {
       // make sure it is linear order
       libmesh_error_msg_if(lo_elem->default_order() != FIRST,

--- a/tests/mesh/all_second_order.C
+++ b/tests/mesh/all_second_order.C
@@ -1,7 +1,11 @@
+// libMesh includes
 #include <libmesh/libmesh.h>
 #include <libmesh/distributed_mesh.h>
+#include <libmesh/replicated_mesh.h>
 #include <libmesh/mesh_generation.h>
+#include <libmesh/edge_edge2.h>
 
+// cppunit includes
 #include "test_comm.h"
 #include "libmesh_cppunit.h"
 
@@ -13,6 +17,7 @@ public:
   LIBMESH_CPPUNIT_TEST_SUITE( AllSecondOrderTest );
 
   CPPUNIT_TEST( allSecondOrder );
+  CPPUNIT_TEST( allSecondOrderRange );
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -32,6 +37,34 @@ public:
     MeshTools::Generation::build_square(mesh, 2, 2);
 
     mesh.all_second_order();
+  }
+
+  void allSecondOrderRange()
+  {
+    ReplicatedMesh mesh(*TestCommWorld);
+
+    // Construct a single-element Quad4 mesh
+    MeshTools::Generation::build_square(mesh, /*nx=*/1, /*ny=*/1);
+
+    // Add extra nodes above the four original nodes
+    Point z_trans(0,0,1);
+    for (dof_id_type n=0; n<4; ++n)
+      mesh.add_point(mesh.point(n) + z_trans, /*id=*/4+n, /*proc_id=*/0);
+
+    // Construct Edge2 elements attached to Quad4 at individual points
+    // and in subdomain 1.
+    for (dof_id_type n=0; n<4; ++n)
+      {
+        Elem * elem = mesh.add_elem(new Edge2);
+        elem->set_node(0) = mesh.node_ptr(n);
+        elem->set_node(1) = mesh.node_ptr(n+4);
+        elem->subdomain_id() = 1;
+      }
+
+    // Convert only Edge2 elements (all elements in subdomain 1) to
+    // SECOND-order.
+    mesh.all_second_order_range(mesh.active_subdomain_elements_ptr_range(1),
+                                /*full_ordered=*/true);
   }
 };
 

--- a/tests/mesh/all_second_order.C
+++ b/tests/mesh/all_second_order.C
@@ -18,6 +18,7 @@ public:
 
   CPPUNIT_TEST( allSecondOrder );
   CPPUNIT_TEST( allSecondOrderRange );
+  CPPUNIT_TEST( allSecondOrderDoNothing );
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -78,6 +79,31 @@ public:
     // Make sure that the other elements are now Edge3s
     for (dof_id_type e=1; e<5; ++e)
       CPPUNIT_ASSERT_EQUAL(EDGE3, mesh.elem_ptr(e)->type());
+  }
+
+  void allSecondOrderDoNothing()
+  {
+    DistributedMesh mesh(*TestCommWorld, /*dim=*/2);
+
+    mesh.allow_remote_element_removal(false);
+
+    MeshTools::Generation::build_square(mesh,
+                                        /*nx=*/2, /*ny=*/2,
+                                        /*xmin=*/0., /*xmax=*/1.,
+                                        /*ymin=*/0., /*ymax=*/1.,
+                                        QUAD9);
+
+    // Test that all_second_order_range() correctly "does nothing" in
+    // parallel when passed ranges of local elements. Here we should
+    // hit one of the "early return" cases for this function.
+    mesh.all_second_order_range(mesh.active_local_element_ptr_range(),
+                                /*full_ordered=*/true);
+
+    // Make sure we still have the same number of elements
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(4), mesh.n_elem());
+
+    // Make sure we still have the same number of nodes
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(25), mesh.n_nodes());
   }
 };
 

--- a/tests/mesh/all_second_order.C
+++ b/tests/mesh/all_second_order.C
@@ -65,6 +65,19 @@ public:
     // SECOND-order.
     mesh.all_second_order_range(mesh.active_subdomain_elements_ptr_range(1),
                                 /*full_ordered=*/true);
+
+    // Make sure we still have the expected total number of elements
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(5), mesh.n_elem());
+
+    // Make sure we added the right number of nodes
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(12), mesh.n_nodes());
+
+    // Make sure that the type of the Quad4 is unchanged
+    CPPUNIT_ASSERT_EQUAL(QUAD4, mesh.elem_ptr(0)->type());
+
+    // Make sure that the other elements are now Edge3s
+    for (dof_id_type e=1; e<5; ++e)
+      CPPUNIT_ASSERT_EQUAL(EDGE3, mesh.elem_ptr(e)->type());
   }
 };
 


### PR DESCRIPTION
This generalizes the behavior of `MeshBase::all_second_order()` by allowing the user to pass in an iterator range of elements to be converted to `SECOND` order. The original `MeshBase::all_second_order()` function is now a shim that calls this function. 

Note: I considered the possibility of giving the new function the same name but that would have made it an overloaded virtual, which seems to always give warnings about "hidden" functions, so I decided to just avoid this by giving it a new name.

Refs #000