### PR TITLE
Use string_view, std::move(string) where appropriate.

### DIFF
--- a/include/base/variable.h
+++ b/include/base/variable.h
@@ -56,12 +56,12 @@ public:
    * all subdomains.
    */
   Variable (System * sys,
-            const std::string & var_name,
+            std::string var_name,
             const unsigned int var_number,
             const unsigned int first_scalar_num,
             const FEType & var_type) :
     _sys(sys),
-    _name(var_name),
+    _name(std::move(var_name)),
     _active_subdomains(),
     _number(var_number),
     _first_scalar_number(first_scalar_num),
@@ -73,13 +73,13 @@ public:
    * indices for which this variable is active.
    */
   Variable (System * sys,
-            const std::string & var_name,
+            std::string var_name,
             const unsigned int var_number,
             const unsigned int first_scalar_num,
             const FEType & var_type,
             const std::set<subdomain_id_type> & var_active_subdomains) :
     _sys(sys),
-    _name(var_name),
+    _name(std::move(var_name)),
     _active_subdomains(var_active_subdomains),
     _number(var_number),
     _first_scalar_number(first_scalar_num),
@@ -190,7 +190,7 @@ public:
    * all subdomains.
    */
   VariableGroup (System * sys,
-                 const std::vector<std::string> & var_names,
+                 std::vector<std::string> var_names,
                  const unsigned int var_number,
                  const unsigned int first_scalar_num,
                  const FEType & var_type) :
@@ -199,7 +199,7 @@ public:
               var_number,
               first_scalar_num,
               var_type),
-    _names(var_names)
+    _names(std::move(var_names))
   {}
 
 
@@ -208,7 +208,7 @@ public:
    * indices for which this variable is active.
    */
   VariableGroup (System * sys,
-                 const std::vector<std::string> & var_names,
+                 std::vector<std::string> var_names,
                  const unsigned int var_number,
                  const unsigned int first_scalar_num,
                  const FEType & var_type,
@@ -220,7 +220,7 @@ public:
               first_scalar_num,
               var_type,
               var_active_subdomains),
-    _names(var_names)
+    _names(std::move(var_names))
   {}
 
   /**

--- a/include/base/variable.h
+++ b/include/base/variable.h
@@ -297,8 +297,8 @@ public:
    * a very limited window of opportunity - after the user specifies variables
    * but before the system is initialized.
    */
-  void append (const std::string & var_name)
-  { _names.push_back (var_name); }
+  void append (std::string var_name)
+  { _names.push_back (std::move(var_name)); }
 
 protected:
   std::vector<std::string> _names;

--- a/include/error_estimation/exact_solution.h
+++ b/include/error_estimation/exact_solution.h
@@ -197,8 +197,8 @@ public:
    * any value.  For that you need to call the l2_error(), h1_error()
    * or h2_error() functions respectively.
    */
-  void compute_error(const std::string & sys_name,
-                     const std::string & unknown_name);
+  void compute_error(std::string_view sys_name,
+                     std::string_view unknown_name);
 
   /**
    * \returns The integrated L2 error for the system \p sys_name for the
@@ -207,8 +207,8 @@ public:
    * \note No error computations are actually performed, you must call
    * \p compute_error() for that.
    */
-  Real l2_error(const std::string & sys_name,
-                const std::string & unknown_name);
+  Real l2_error(std::string_view sys_name,
+                std::string_view unknown_name);
 
   /**
    * \returns The integrated L1 error for the system \p sys_name for
@@ -217,8 +217,8 @@ public:
    * \note No error computations are actually performed, you must call
    * \p compute_error() for that.
    */
-  Real l1_error(const std::string & sys_name,
-                const std::string & unknown_name);
+  Real l1_error(std::string_view sys_name,
+                std::string_view unknown_name);
 
   /**
    * \returns The L_INF error for the system \p sys_name for
@@ -232,8 +232,8 @@ public:
    * compute it, we take the max of the absolute value of the error
    * over all the quadrature points.
    */
-  Real l_inf_error(const std::string & sys_name,
-                   const std::string & unknown_name);
+  Real l_inf_error(std::string_view sys_name,
+                   std::string_view unknown_name);
 
   /**
    * \returns The H1 error for the system \p sys_name for the unknown
@@ -242,8 +242,8 @@ public:
    * \note No error computations are actually performed, you must call
    * \p compute_error() for that.
    */
-  Real h1_error(const std::string & sys_name,
-                const std::string & unknown_name);
+  Real h1_error(std::string_view sys_name,
+                std::string_view unknown_name);
 
   /**
    * \returns The H(curl) error for the system \p sys_name for the
@@ -255,8 +255,8 @@ public:
    * \note This is only valid for vector-valued elements. An error is
    * thrown if requested for scalar-valued elements.
    */
-  Real hcurl_error(const std::string & sys_name,
-                   const std::string & unknown_name);
+  Real hcurl_error(std::string_view sys_name,
+                   std::string_view unknown_name);
 
   /**
    * \returns The H(div) error for the system \p sys_name for the
@@ -268,8 +268,8 @@ public:
    * \note This is only valid for vector-valued elements. An error is
    * thrown if requested for scalar-valued elements.
    */
-  Real hdiv_error(const std::string & sys_name,
-                  const std::string & unknown_name);
+  Real hdiv_error(std::string_view sys_name,
+                  std::string_view unknown_name);
 
   /**
    * \returns The H2 error for the system \p sys_name for the unknown
@@ -278,8 +278,8 @@ public:
    * \note No error computations are actually performed, you must call
    * \p compute_error() for that.
    */
-  Real h2_error(const std::string & sys_name,
-                const std::string & unknown_name);
+  Real h2_error(std::string_view sys_name,
+                std::string_view unknown_name);
 
   /**
    * \returns The error in the requested norm for the system \p
@@ -291,8 +291,8 @@ public:
    * \note The result is not exact, but an approximation based on the
    * chosen quadrature rule.
    */
-  Real error_norm(const std::string & sys_name,
-                  const std::string & unknown_name,
+  Real error_norm(std::string_view sys_name,
+                  std::string_view unknown_name,
                   const FEMNormType & norm);
 private:
 
@@ -303,8 +303,8 @@ private:
    * solving for several unknowns in several systems.
    */
   template<typename OutputShape>
-  void _compute_error(const std::string & sys_name,
-                      const std::string & unknown_name,
+  void _compute_error(std::string_view sys_name,
+                      std::string_view unknown_name,
                       std::vector<Real> & error_vals);
 
   /**
@@ -313,8 +313,8 @@ private:
    *
    * \returns A reference to the proper vector for storing the values.
    */
-  std::vector<Real> & _check_inputs(const std::string & sys_name,
-                                    const std::string & unknown_name);
+  std::vector<Real> & _check_inputs(std::string_view sys_name,
+                                    std::string_view unknown_name);
 
   /**
    * User-provided functors which compute the exact value of the
@@ -342,7 +342,8 @@ private:
    * The name of the unknown is
    * the key for the map.
    */
-  typedef std::map<std::string, std::vector<Real>> SystemErrorMap;
+  typedef std::map<std::string, std::vector<Real>, std::less<>>
+    SystemErrorMap;
 
   /**
    * A map of SystemErrorMaps, which contains entries
@@ -350,7 +351,7 @@ private:
    * This is required, since it is possible for two
    * systems to have unknowns with the *same name*.
    */
-  std::map<std::string, SystemErrorMap> _errors;
+  std::map<std::string, SystemErrorMap, std::less<>> _errors;
 
   /**
    * Constant reference to the \p EquationSystems object

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -824,7 +824,7 @@ public:
    * \returns The id of the named boundary if it exists, \p invalid_id
    * otherwise.
    */
-  boundary_id_type get_id_by_name(const std::string & name) const;
+  boundary_id_type get_id_by_name(std::string_view name) const;
 
   /**
    * \returns A writable reference to the sideset name map.

--- a/include/mesh/ensight_io.h
+++ b/include/mesh/ensight_io.h
@@ -75,8 +75,8 @@ public:
    * least once, otherwise only the Mesh will be written out.
    */
   void add_scalar (const std::string & system,
-                   const std::string & scalar_description,
-                   const std::string & s);
+                   std::string_view scalar_description,
+                   std::string_view s);
 
   /**
    * Tell the EnsightIO interface that the variables (u,v) constitute
@@ -86,9 +86,9 @@ public:
    * the same system.
    */
   void add_vector (const std::string & system,
-                   const std::string & vec_description,
-                   const std::string & u,
-                   const std::string & v);
+                   std::string_view vec_description,
+                   std::string u,
+                   std::string v);
 
   /**
    * Tell the EnsightIO interface that the variables (u, v, w)
@@ -98,10 +98,10 @@ public:
    * FEType, and must be defined in the same system.
    */
   void add_vector (const std::string & system,
-                   const std::string & vec_description,
-                   const std::string & u,
-                   const std::string & v,
-                   const std::string & w);
+                   std::string_view vec_description,
+                   std::string u,
+                   std::string v,
+                   std::string w);
   /**
    * Calls write_ascii() and write_case().
    * Writes case, mesh, and solution files named:
@@ -142,8 +142,8 @@ private:
   // private methods
   // write solution in ascii format file
   void write_ascii (Real time = 0);
-  void write_scalar_ascii (const std::string & sys, const std::string & var);
-  void write_vector_ascii (const std::string & sys, const std::vector<std::string> & vec, const std::string & var_name);
+  void write_scalar_ascii (std::string_view sys, std::string_view var);
+  void write_vector_ascii (std::string_view sys, const std::vector<std::string> & vec, std::string_view var_name);
   void write_solution_ascii ();
   void write_geometry_ascii ();
   void write_case();

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -539,14 +539,14 @@ public:
    * Prints the message defined in \p msg. Can be turned off if
    * verbosity is set to 0.
    */
-  void message(const std::string & msg);
+  void message(std::string_view msg);
 
   /**
    * Prints the message defined in \p msg, and appends the number \p i
    * to the end of the message.  Useful for printing messages in
    * loops.  Can be turned off if verbosity is set to 0.
    */
-  void message(const std::string & msg, int i);
+  void message(std::string_view msg, int i);
 
   // File identification flag
   int ex_id;

--- a/include/mesh/gnuplot_io.h
+++ b/include/mesh/gnuplot_io.h
@@ -83,7 +83,7 @@ public:
   /**
    * Set title of plot
    */
-  void set_title(const std::string & title) { _title = title; }
+  void set_title(std::string title) { _title = std::move(title); }
 
   /**
    * Turn grid on or off.

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -782,7 +782,7 @@ public:
    * \returns The index number for the new datum, or for the existing
    * datum if one by the same name has already been added.
    */
-  unsigned int add_elem_integer(const std::string & name,
+  unsigned int add_elem_integer(std::string name,
                                 bool allocate_data = true,
                                 dof_id_type default_value = DofObject::invalid_id);
 
@@ -808,12 +808,12 @@ public:
    * \returns The index number for the named extra element integer
    * datum, which must have already been added.
    */
-  unsigned int get_elem_integer_index(const std::string & name) const;
+  unsigned int get_elem_integer_index(std::string_view name) const;
 
   /*
    * \returns Whether or not the mesh has an element integer with its name.
    */
-  bool has_elem_integer(const std::string & name) const;
+  bool has_elem_integer(std::string_view name) const;
 
   /*
    * \returns The name for the indexed extra element integer
@@ -904,7 +904,7 @@ public:
    * \returns The index number for the new datum, or for the existing
    * datum if one by the same name has already been added.
    */
-  unsigned int add_node_integer(const std::string & name,
+  unsigned int add_node_integer(std::string name,
                                 bool allocate_data = true,
                                 dof_id_type default_value = DofObject::invalid_id);
 
@@ -930,12 +930,12 @@ public:
    * \returns The index number for the named extra node integer
    * datum, which must have already been added.
    */
-  unsigned int get_node_integer_index(const std::string & name) const;
+  unsigned int get_node_integer_index(std::string_view name) const;
 
   /*
    * \returns Whether or not the mesh has a node integer with its name.
    */
-  bool has_node_integer(const std::string & name) const;
+  bool has_node_integer(std::string_view name) const;
 
   /*
    * \returns The name for the indexed extra node integer
@@ -1395,7 +1395,7 @@ public:
    * \returns The id of the named subdomain if it exists,
    * \p Elem::invalid_subdomain_id otherwise.
    */
-  subdomain_id_type get_id_by_name(const std::string & name) const;
+  subdomain_id_type get_id_by_name(std::string_view name) const;
 
   //
   // element_iterator accessors

--- a/include/mesh/mesh_tetgen_interface.h
+++ b/include/mesh/mesh_tetgen_interface.h
@@ -69,7 +69,7 @@ public:
   /**
    * Method to set switches to tetgen, allowing for different behaviours
    */
-  void set_switches(const std::string &);
+  void set_switches(std::string new_switches);
 
   /**
    * Method invokes TetGen library to compute a Delaunay tetrahedralization

--- a/include/mesh/mesh_tetgen_wrapper.h
+++ b/include/mesh/mesh_tetgen_wrapper.h
@@ -88,7 +88,7 @@ public:
    * -v Prints the version information.
    * -h Help: A brief instruction for using TetGen.
    */
-  void set_switches(const std::string & s);
+  void set_switches(std::string_view s);
 
   /**
    * Starts the triangulation.

--- a/include/mesh/namebased_io.h
+++ b/include/mesh/namebased_io.h
@@ -99,7 +99,7 @@ public:
 
   // Certain mesh formats can support parallel I/O, including the
   // "new" Xdr format and the Nemesis format.
-  bool is_parallel_file_format (const std::string & filename);
+  bool is_parallel_file_format (std::string_view filename);
 };
 
 
@@ -121,7 +121,7 @@ NameBasedIO::NameBasedIO (MeshBase & mesh) :
 
 inline
 bool
-NameBasedIO::is_parallel_file_format (const std::string & name)
+NameBasedIO::is_parallel_file_format (std::string_view name)
 {
   return ((name.rfind(".xda") < name.size()) ||
           (name.rfind(".xdr") < name.size()) ||

--- a/include/mesh/nemesis_io_helper.h
+++ b/include/mesh/nemesis_io_helper.h
@@ -371,7 +371,7 @@ public:
    * Given base_filename, foo.e, constructs the Nemesis filename
    * foo.e.X.Y, where X=n. CPUs and Y=processor ID
    */
-  std::string construct_nemesis_filename(const std::string & base_filename);
+  std::string construct_nemesis_filename(std::string_view base_filename);
 
   /**
    * Member data

--- a/include/numerics/parsed_fem_function.h
+++ b/include/numerics/parsed_fem_function.h
@@ -63,7 +63,7 @@ public:
    */
   explicit
   ParsedFEMFunction (const System & sys,
-                     const std::string & expression,
+                     std::string expression,
                      const std::vector<std::string> * additional_vars=nullptr,
                      const std::vector<Output> * initial_vals=nullptr);
 
@@ -84,7 +84,7 @@ public:
   /**
    * Re-parse with new expression.
    */
-  void reparse (const std::string & expression);
+  void reparse (std::string expression);
 
   virtual void init_context (const FEMContext & c) override;
 
@@ -114,7 +114,7 @@ public:
    * redefined within any subexpression, and if the inline variable
    * takes the same value within any subexpressions where it appears.
    */
-  Output get_inline_value(const std::string & inline_var_name) const;
+  Output get_inline_value(std::string_view inline_var_name) const;
 
   /**
    * Changes the value of an inline variable.
@@ -126,16 +126,16 @@ public:
    * \note Currently only works if the inline variable is not redefined
    * within any one subexpression.
    */
-  void set_inline_value(const std::string & inline_var_name,
+  void set_inline_value(std::string_view inline_var_name,
                         Output newval);
 
 protected:
   // Helper function for reparsing minor changes to expression
-  void partial_reparse (const std::string & expression);
+  void partial_reparse (std::string expression);
 
   // Helper function for parsing out variable names
-  std::size_t find_name (const std::string & varname,
-                         const std::string & expr) const;
+  std::size_t find_name (std::string_view varname,
+                         std::string_view expr) const;
 
   // Helper function for evaluating function arguments
   void eval_args(const FEMContext & c,
@@ -145,11 +145,11 @@ protected:
   // Evaluate the ith FunctionParser and check the result
 #ifdef LIBMESH_HAVE_FPARSER
   inline Output eval(FunctionParserBase<Output> & parser,
-                     const std::string & libmesh_dbg_var(function_name),
+                     std::string_view libmesh_dbg_var(function_name),
                      unsigned int libmesh_dbg_var(component_idx)) const;
 #else // LIBMESH_HAVE_FPARSER
   inline Output eval(char & libmesh_dbg_var(parser),
-                     const std::string & libmesh_dbg_var(function_name),
+                     std::string_view libmesh_dbg_var(function_name),
                      unsigned int libmesh_dbg_var(component_idx)) const;
 #endif
 
@@ -195,7 +195,7 @@ private:
 template <typename Output>
 inline
 ParsedFEMFunction<Output>::ParsedFEMFunction (const System & sys,
-                                              const std::string & expression,
+                                              std::string expression,
                                               const std::vector<std::string> * additional_vars,
                                               const std::vector<Output> * initial_vals) :
   _sys(sys),
@@ -213,7 +213,7 @@ ParsedFEMFunction<Output>::ParsedFEMFunction (const System & sys,
   _additional_vars (additional_vars ? *additional_vars : std::vector<std::string>()),
   _initial_vals (initial_vals ? *initial_vals : std::vector<Output>())
 {
-  this->reparse(expression);
+  this->reparse(std::move(expression));
 }
 
 
@@ -261,7 +261,7 @@ ParsedFEMFunction<Output>::operator= (const ParsedFEMFunction<Output> & other)
 template <typename Output>
 inline
 void
-ParsedFEMFunction<Output>::reparse (const std::string & expression)
+ParsedFEMFunction<Output>::reparse (std::string expression)
 {
   variables = "x";
 #if LIBMESH_DIM > 1
@@ -384,7 +384,7 @@ ParsedFEMFunction<Output>::reparse (const std::string & expression)
         (i < _initial_vals.size()) ? _initial_vals[i] : 0;
     }
 
-  this->partial_reparse(expression);
+  this->partial_reparse(std::move(expression));
 }
 
 template <typename Output>
@@ -478,7 +478,7 @@ ParsedFEMFunction<Output>::component (const FEMContext & c,
 template <typename Output>
 inline
 Output
-ParsedFEMFunction<Output>::get_inline_value(const std::string & inline_var_name) const
+ParsedFEMFunction<Output>::get_inline_value(std::string_view inline_var_name) const
 {
   libmesh_assert_greater (_subexpressions.size(), 0);
 
@@ -509,8 +509,8 @@ ParsedFEMFunction<Output>::get_inline_value(const std::string & inline_var_name)
       libmesh_assert_not_equal_to(end_assignment_i, std::string::npos);
 
       std::string new_subexpression =
-        subexpression.substr(0, end_assignment_i+1) +
-        inline_var_name;
+        subexpression.substr(0, end_assignment_i+1).
+         append(inline_var_name);
 
 #ifdef LIBMESH_HAVE_FPARSER
       // Parse and evaluate the new subexpression.
@@ -551,7 +551,7 @@ ParsedFEMFunction<Output>::get_inline_value(const std::string & inline_var_name)
 template <typename Output>
 inline
 void
-ParsedFEMFunction<Output>::set_inline_value (const std::string & inline_var_name,
+ParsedFEMFunction<Output>::set_inline_value (std::string_view inline_var_name,
                                              Output newval)
 {
   libmesh_assert_greater (_subexpressions.size(), 0);
@@ -617,9 +617,9 @@ ParsedFEMFunction<Output>::set_inline_value (const std::string & inline_var_name
 template <typename Output>
 inline
 void
-ParsedFEMFunction<Output>::partial_reparse (const std::string & expression)
+ParsedFEMFunction<Output>::partial_reparse (std::string expression)
 {
-  _expression = expression;
+  _expression = std::move(expression);
   _subexpressions.clear();
   parsers.clear();
 
@@ -629,15 +629,15 @@ ParsedFEMFunction<Output>::partial_reparse (const std::string & expression)
     {
       // If we're past the end of the string, we can't make any more
       // subparsers
-      if (nextstart >= expression.size())
+      if (nextstart >= _expression.size())
         break;
 
       // If we're at the start of a brace delimited section, then we
       // parse just that section:
-      if (expression[nextstart] == '{')
+      if (_expression[nextstart] == '{')
         {
           nextstart++;
-          end = expression.find('}', nextstart);
+          end = _expression.find('}', nextstart);
         }
       // otherwise we parse the whole thing
       else
@@ -646,7 +646,7 @@ ParsedFEMFunction<Output>::partial_reparse (const std::string & expression)
       // We either want the whole end of the string (end == npos) or
       // a substring in the middle.
       _subexpressions.push_back
-        (expression.substr(nextstart, (end == std::string::npos) ?
+        (_expression.substr(nextstart, (end == std::string::npos) ?
                            std::string::npos : end - nextstart));
 
       // fparser can crash on empty expressions
@@ -681,8 +681,8 @@ ParsedFEMFunction<Output>::partial_reparse (const std::string & expression)
 template <typename Output>
 inline
 std::size_t
-ParsedFEMFunction<Output>::find_name (const std::string & varname,
-                                      const std::string & expr) const
+ParsedFEMFunction<Output>::find_name (std::string_view varname,
+                                      std::string_view expr) const
 {
   const std::size_t namesize = varname.size();
   std::size_t varname_i = expr.find(varname);
@@ -837,7 +837,7 @@ template <typename Output>
 inline
 Output
 ParsedFEMFunction<Output>::eval (FunctionParserBase<Output> & parser,
-                                 const std::string & libmesh_dbg_var(function_name),
+                                 std::string_view libmesh_dbg_var(function_name),
                                  unsigned int libmesh_dbg_var(component_idx)) const
 {
 #ifndef NDEBUG
@@ -891,7 +891,7 @@ template <typename Output>
 inline
 Output
 ParsedFEMFunction<Output>::eval (char & /*parser*/,
-                                 const std::string & /*function_name*/,
+                                 std::string_view /*function_name*/,
                                  unsigned int /*component_idx*/) const
 {
   libmesh_error_msg("ERROR: This functionality requires fparser!");

--- a/include/numerics/parsed_fem_function_parameter.h
+++ b/include/numerics/parsed_fem_function_parameter.h
@@ -62,8 +62,8 @@ public:
    * remain at their previous values.
    */
   ParsedFEMFunctionParameter(ParsedFEMFunction<T> & func_ref,
-                             const std::string & param_name) :
-    _func(func_ref), _name(param_name) {}
+                             std::string param_name) :
+    _func(func_ref), _name(std::move(param_name)) {}
 
   /**
    * A simple reseater won't work with a parsed function.

--- a/include/numerics/parsed_function_parameter.h
+++ b/include/numerics/parsed_function_parameter.h
@@ -60,8 +60,8 @@ public:
    * remain at their previous values.
    */
   ParsedFunctionParameter(ParsedFunction<T> & func_ref,
-                          const std::string & param_name) :
-    _func(func_ref), _name(param_name) {}
+                          std::string param_name) :
+    _func(func_ref), _name(std::move(param_name)) {}
 
   /**
    * A simple reseater won't work with a parsed function

--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -95,7 +95,7 @@ public:
    * This function allocates memory, therefore a \p std::unique_ptr<QBase>
    * is returned so that the user does not accidentally leak it.
    */
-  static std::unique_ptr<QBase> build (const std::string & name,
+  static std::unique_ptr<QBase> build (std::string_view name,
                                        const unsigned int dim,
                                        const Order order=INVALID_ORDER);
 

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -45,6 +45,8 @@ enum FEMNormType : int;
 // C++ includes
 #include <cstddef>
 #include <set>
+#include <string>
+#include <string_view>
 #include <vector>
 #include <memory>
 
@@ -769,8 +771,8 @@ public:
   /**
    * Vector iterator typedefs.
    */
-  typedef std::map<std::string, std::unique_ptr<NumericVector<Number>>>::iterator       vectors_iterator;
-  typedef std::map<std::string, std::unique_ptr<NumericVector<Number>>>::const_iterator const_vectors_iterator;
+  typedef std::map<std::string, std::unique_ptr<NumericVector<Number>>, std::less<>>::iterator       vectors_iterator;
+  typedef std::map<std::string, std::unique_ptr<NumericVector<Number>>, std::less<>>::const_iterator const_vectors_iterator;
 
   /**
    * Beginning of vectors container
@@ -801,14 +803,14 @@ public:
    * reinit().  To zero them instead (more efficient), pass "false" as the
    * second argument
    */
-  NumericVector<Number> & add_vector (const std::string & vec_name,
+  NumericVector<Number> & add_vector (std::string_view vec_name,
                                       const bool projections=true,
                                       const ParallelType type = PARALLEL);
 
   /**
    * Removes the additional vector \p vec_name from this system
    */
-  void remove_vector(const std::string & vec_name);
+  void remove_vector(std::string_view vec_name);
 
   /**
    * Tells the System whether or not to project the solution vector onto new
@@ -822,19 +824,19 @@ public:
    * \returns \p true if this \p System has a vector associated with the
    * given name, \p false otherwise.
    */
-  bool have_vector (const std::string & vec_name) const;
+  bool have_vector (std::string_view vec_name) const;
 
   /**
    * \returns A const pointer to the vector if this \p System has a
    * vector associated with the given name, \p nullptr otherwise.
    */
-  const NumericVector<Number> * request_vector (const std::string & vec_name) const;
+  const NumericVector<Number> * request_vector (std::string_view vec_name) const;
 
   /**
    * \returns A pointer to the vector if this \p System has a
    * vector associated with the given name, \p nullptr otherwise.
    */
-  NumericVector<Number> * request_vector (const std::string & vec_name);
+  NumericVector<Number> * request_vector (std::string_view vec_name);
 
   /**
    * \returns A const pointer to this system's additional vector
@@ -855,14 +857,14 @@ public:
    * named \p vec_name.  Access is only granted when the vector is already
    * properly initialized.
    */
-  const NumericVector<Number> & get_vector (const std::string & vec_name) const;
+  const NumericVector<Number> & get_vector (std::string_view vec_name) const;
 
   /**
    * \returns A writable reference to this system's additional vector
    * named \p vec_name.  Access is only granted when the vector is already
    * properly initialized.
    */
-  NumericVector<Number> & get_vector (const std::string & vec_name);
+  NumericVector<Number> & get_vector (std::string_view vec_name);
 
   /**
    * \returns A const reference to this system's additional vector
@@ -906,7 +908,7 @@ public:
    * vec_name represents a solution from an adjoint (non-negative) or
    * the primal (-1) space.
    */
-  int vector_is_adjoint (const std::string & vec_name) const;
+  int vector_is_adjoint (std::string_view vec_name) const;
 
   /**
    * Allows one to set the boolean controlling whether the vector
@@ -920,7 +922,7 @@ public:
    * vec_name should be "preserved": projected to new meshes, saved,
    * etc.
    */
-  bool vector_preservation (const std::string & vec_name) const;
+  bool vector_preservation (std::string_view vec_name) const;
 
   /**
    * \returns A reference to one of the system's adjoint solution
@@ -1114,7 +1116,7 @@ public:
    *
    * \returns The index number for the new variable.
    */
-  unsigned int add_variable (const std::string & var,
+  unsigned int add_variable (std::string_view var,
                              const FEType & type,
                              const std::set<subdomain_id_type> * const active_subdomains = nullptr);
 
@@ -1125,7 +1127,7 @@ public:
    * \p nullptr (the default) or points to an empty set, then it will be assumed
    * that \p var has no subdomain restrictions
    */
-  unsigned int add_variable (const std::string & var,
+  unsigned int add_variable (std::string_view var,
                              const Order order = FIRST,
                              const FEFamily = LAGRANGE,
                              const std::set<subdomain_id_type> * const active_subdomains = nullptr);
@@ -1167,7 +1169,7 @@ public:
   /**
    * \returns \p true if a variable named \p var exists in this System
    */
-  bool has_variable(const std::string & var) const;
+  bool has_variable(std::string_view var) const;
 
   /**
    * \returns The name of variable \p i.
@@ -1178,7 +1180,7 @@ public:
    * \returns The variable number associated with
    * the user-specified variable named \p var.
    */
-  unsigned short int variable_number (const std::string & var) const;
+  unsigned short int variable_number (std::string_view var) const;
 
   /**
    * Fills \p all_variable_numbers with all the variable numbers for the
@@ -1196,7 +1198,7 @@ public:
    * Irony: currently our only non-scalar-valued variable type is
    * SCALAR.
    */
-  unsigned int variable_scalar_number (const std::string & var,
+  unsigned int variable_scalar_number (std::string_view var,
                                        unsigned int component) const;
 
   /**
@@ -1221,7 +1223,7 @@ public:
   /**
    * \returns The finite element type for variable \p var.
    */
-  const FEType & variable_type (const std::string & var) const;
+  const FEType & variable_type (std::string_view var) const;
 
   /**
    * \returns \p true when \p VariableGroup structures should be
@@ -1255,7 +1257,7 @@ public:
    * Reads the basic data header for this System.
    */
   void read_header (Xdr & io,
-                    const std::string & version,
+                    std::string_view version,
                     const bool read_header=true,
                     const bool read_additional_data=true,
                     const bool read_legacy_format=false);
@@ -1335,7 +1337,7 @@ public:
    * Writes the basic data header for this System.
    */
   void write_header (Xdr & io,
-                     const std::string & version,
+                     std::string_view version,
                      const bool write_additional_data) const;
 
   /**
@@ -1763,8 +1765,8 @@ public:
   /**
    * Matrix iterator typedefs.
    */
-  typedef std::map<std::string, std::unique_ptr<SparseMatrix<Number>>>::iterator        matrices_iterator;
-  typedef std::map<std::string, std::unique_ptr<SparseMatrix<Number>>>::const_iterator  const_matrices_iterator;
+  typedef std::map<std::string, std::unique_ptr<SparseMatrix<Number>>, std::less<>>::iterator        matrices_iterator;
+  typedef std::map<std::string, std::unique_ptr<SparseMatrix<Number>>, std::less<>>::const_iterator  const_matrices_iterator;
 
   /**
    * Adds the additional matrix \p mat_name to this system.  Only
@@ -1783,7 +1785,7 @@ public:
    * @param mat_build_type The matrix type to build
    *
    */
-  SparseMatrix<Number> & add_matrix (const std::string & mat_name,
+  SparseMatrix<Number> & add_matrix (std::string_view mat_name,
                                      ParallelType type = PARALLEL,
                                      MatrixBuildType mat_build_type = MatrixBuildType::AUTOMATIC);
 
@@ -1803,44 +1805,44 @@ public:
   * @param type The serial/parallel/ghosted type of the matrix
   */
   template <template <typename> class>
-  SparseMatrix<Number> & add_matrix (const std::string & mat_name, ParallelType = PARALLEL);
+  SparseMatrix<Number> & add_matrix (std::string_view mat_name, ParallelType = PARALLEL);
 
   /**
    * Removes the additional matrix \p mat_name from this system
    */
-  void remove_matrix(const std::string & mat_name);
+  void remove_matrix(std::string_view mat_name);
 
   /**
    * \returns \p true if this \p System has a matrix associated with the
    * given name, \p false otherwise.
    */
-  inline bool have_matrix (const std::string & mat_name) const { return _matrices.count(mat_name); };
+  inline bool have_matrix (std::string_view mat_name) const { return _matrices.count(mat_name); };
 
   /**
    * \returns A const pointer to this system's additional matrix
    * named \p mat_name, or \p nullptr if no matrix by that name
    * exists.
    */
-  const SparseMatrix<Number> * request_matrix (const std::string & mat_name) const;
+  const SparseMatrix<Number> * request_matrix (std::string_view mat_name) const;
 
   /**
    * \returns A writable pointer to this system's additional matrix
    * named \p mat_name, or \p nullptr if no matrix by that name
    * exists.
    */
-  SparseMatrix<Number> * request_matrix (const std::string & mat_name);
+  SparseMatrix<Number> * request_matrix (std::string_view mat_name);
 
   /**
    * \returns A const reference to this system's matrix
    * named \p mat_name.
    */
-  const SparseMatrix<Number> & get_matrix (const std::string & mat_name) const;
+  const SparseMatrix<Number> & get_matrix (std::string_view mat_name) const;
 
   /**
    * \returns A writable reference to this system's matrix
    * named \p mat_name.
    */
-  SparseMatrix<Number> & get_matrix (const std::string & mat_name);
+  SparseMatrix<Number> & get_matrix (std::string_view mat_name);
 
 
 protected:
@@ -2105,7 +2107,7 @@ private:
    * The variable numbers corresponding to user-specified
    * names, useful for name-based lookups.
    */
-  std::map<std::string, unsigned short int> _variable_numbers;
+  std::map<std::string, unsigned short int, std::less<>> _variable_numbers;
 
   /**
    * Flag stating if the system is active or not.
@@ -2118,34 +2120,34 @@ private:
    * vectors.  All the vectors in this map will be distributed
    * in the same way as the solution vector.
    */
-  std::map<std::string, std::unique_ptr<NumericVector<Number>>> _vectors;
+  std::map<std::string, std::unique_ptr<NumericVector<Number>>, std::less<>> _vectors;
 
   /**
    * Holds true if a vector by that name should be projected
    * onto a changed grid, false if it should be zeroed.
    */
-  std::map<std::string, bool> _vector_projections;
+  std::map<std::string, bool, std::less<>> _vector_projections;
 
   /**
    * Holds non-negative if a vector by that name should be projected
    * using adjoint constraints/BCs, -1 if primal
    */
-  std::map<std::string, int> _vector_is_adjoint;
+  std::map<std::string, int, std::less<>> _vector_is_adjoint;
 
   /**
    * Holds the type of a vector
    */
-  std::map<std::string, ParallelType> _vector_types;
+  std::map<std::string, ParallelType, std::less<>> _vector_types;
 
   /**
    * Some systems need an arbitrary number of matrices.
    */
-  std::map<std::string, std::unique_ptr<SparseMatrix<Number>>> _matrices;
+  std::map<std::string, std::unique_ptr<SparseMatrix<Number>>, std::less<>> _matrices;
 
   /**
    * Holds the types of the matrices
    */
-  std::map<std::string, ParallelType> _matrix_types;
+  std::map<std::string, ParallelType, std::less<>> _matrix_types;
 
   /**
    * \p false when additional matrices being added require initialization, \p true otherwise.
@@ -2367,7 +2369,7 @@ const std::string & System::variable_name (const unsigned int i) const
 
 inline
 unsigned int
-System::variable_scalar_number (const std::string & var,
+System::variable_scalar_number (std::string_view var,
                                 unsigned int component) const
 {
   return variable_scalar_number(this->variable_number(var), component);
@@ -2396,7 +2398,7 @@ const FEType & System::variable_type (const unsigned int i) const
 
 
 inline
-const FEType & System::variable_type (const std::string & var) const
+const FEType & System::variable_type (std::string_view var) const
 {
   return _variables[this->variable_number(var)].type();
 }
@@ -2428,7 +2430,7 @@ dof_id_type System::n_active_dofs() const
 
 
 inline
-bool System::have_vector (const std::string & vec_name) const
+bool System::have_vector (std::string_view vec_name) const
 {
   return (_vectors.count(vec_name));
 }
@@ -2557,12 +2559,13 @@ unsigned int System::n_matrices () const
 template <template <typename> class MatrixType>
 inline
 SparseMatrix<Number> &
-System::add_matrix (const std::string & mat_name,
+System::add_matrix (std::string_view mat_name,
                     const ParallelType type)
 {
   // Return the matrix if it is already there.
-  if (this->have_matrix(mat_name))
-    return *(_matrices[mat_name]);
+  auto it = this->_matrices.find(mat_name);
+  if (it != this->_matrices.end())
+    return *it->second;
 
   // Otherwise build the matrix to return.
   auto pr = _matrices.emplace(mat_name, std::make_unique<MatrixType<Number>>(this->comm()));

--- a/include/utils/parameters.h
+++ b/include/utils/parameters.h
@@ -99,14 +99,14 @@ public:
    * if a parameter of specified name exists regardless of its type.
    */
   template <typename T>
-  bool have_parameter (const std::string &) const;
+  bool have_parameter (std::string_view) const;
 
   /**
    * \returns A constant reference to the specified parameter
    * value.  Requires, of course, that the parameter exists.
    */
   template <typename T>
-  const T & get (const std::string &) const;
+  const T & get (std::string_view) const;
 
   /**
    * Inserts a new Parameter into the object but does not return
@@ -134,7 +134,7 @@ public:
   /**
    * Removes the specified parameter from the list, if it exists.
    */
-  void remove (const std::string &);
+  void remove (std::string_view);
 
   /**
    * \returns The total number of parameters.
@@ -270,7 +270,7 @@ protected:
   /**
    * Data structure to map names with values.
    */
-  std::map<std::string, Value *> _values;
+  std::map<std::string, Value *, std::less<>> _values;
 
 };
 
@@ -402,7 +402,7 @@ std::ostream & operator << (std::ostream & os, const Parameters & p)
 
 template <typename T>
 inline
-bool Parameters::have_parameter (const std::string & name) const
+bool Parameters::have_parameter (std::string_view name) const
 {
   Parameters::const_iterator it = _values.find(name);
 
@@ -421,7 +421,7 @@ bool Parameters::have_parameter (const std::string & name) const
 
 template <typename T>
 inline
-const T & Parameters::get (const std::string & name) const
+const T & Parameters::get (std::string_view name) const
 {
   if (!this->have_parameter<T>(name))
     {
@@ -471,7 +471,7 @@ T & Parameters::set (const std::string & name)
 }
 
 inline
-void Parameters::remove (const std::string & name)
+void Parameters::remove (std::string_view name)
 {
   Parameters::iterator it = _values.find(name);
 

--- a/include/utils/perf_log.h
+++ b/include/utils/perf_log.h
@@ -151,7 +151,7 @@ public:
    * disable logging.  You can use this flag to turn off
    * logging without touching any other code.
    */
-  PerfLog(const std::string & label_name="",
+  PerfLog(std::string label_name="",
           const bool log_events=true);
 
   /**

--- a/include/utils/string_to_enum.h
+++ b/include/utils/string_to_enum.h
@@ -40,6 +40,19 @@ namespace Utility
 template <typename T>
 T string_to_enum (const std::string & s);
 
+/**
+ * \returns the enumeration of type \p T which matches the string_view \p s.
+ */
+template <typename T>
+T string_to_enum (std::string_view s);
+
+/**
+ * \returns the enumeration of type \p T which matches the C-style
+ * string \p s.
+ */
+template <typename T>
+T string_to_enum (const char * s);
+
 } // namespace Utility
 } // namespace libMesh
 

--- a/include/utils/utility.h
+++ b/include/utils/utility.h
@@ -407,7 +407,7 @@ void deallocate (std::vector<T> & vec)
  * of complex data, and for  \p r_o_c = 1 the filename for the imaginary
  * part.
  */
-std::string complex_filename (const std::string & basename,
+std::string complex_filename (std::string basename,
                               unsigned int r_o_c=0);
 
 /**
@@ -433,7 +433,7 @@ int mkdir(const char* pathname);
  * This is a hack because we don't have a neat bz2/xz equivalent to
  * gzstreams.
  */
-std::string unzip_file (const std::string & name);
+std::string unzip_file (std::string_view name);
 
 
 /**

--- a/include/utils/xdr_cxx.h
+++ b/include/utils/xdr_cxx.h
@@ -74,7 +74,7 @@ public:
    * Constructor.  Takes the filename and the mode.
    * Valid modes are ENCODE, DECODE, READ, and WRITE.
    */
-  Xdr (const std::string & name="", const XdrMODE m=UNKNOWN);
+  Xdr (std::string name="", const XdrMODE m=UNKNOWN);
 
   /**
    * Destructor.  Closes the file if it is open.
@@ -84,7 +84,7 @@ public:
   /**
    * Opens the file.
    */
-  void open (const std::string & name);
+  void open (std::string name);
 
   /**
    * Closes the file if it is open.

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -216,8 +216,8 @@ void ExactSolution::attach_exact_hessian (unsigned int sys_num,
 }
 
 
-std::vector<Real> & ExactSolution::_check_inputs(const std::string & sys_name,
-                                                 const std::string & unknown_name)
+std::vector<Real> & ExactSolution::_check_inputs(std::string_view sys_name,
+                                                 std::string_view unknown_name)
 {
   // Return a reference to the proper error entry, or throw an error
   // if it doesn't exist.
@@ -227,8 +227,8 @@ std::vector<Real> & ExactSolution::_check_inputs(const std::string & sys_name,
 
 
 
-void ExactSolution::compute_error(const std::string & sys_name,
-                                  const std::string & unknown_name)
+void ExactSolution::compute_error(std::string_view sys_name,
+                                  std::string_view unknown_name)
 {
   // Check the inputs for validity, and get a reference
   // to the proper location to store the error
@@ -264,8 +264,8 @@ void ExactSolution::compute_error(const std::string & sys_name,
 
 
 
-Real ExactSolution::error_norm(const std::string & sys_name,
-                               const std::string & unknown_name,
+Real ExactSolution::error_norm(std::string_view sys_name,
+                               std::string_view unknown_name,
                                const FEMNormType & norm)
 {
   // Check the inputs for validity, and get a reference
@@ -333,8 +333,8 @@ Real ExactSolution::error_norm(const std::string & sys_name,
 
 
 
-Real ExactSolution::l2_error(const std::string & sys_name,
-                             const std::string & unknown_name)
+Real ExactSolution::l2_error(std::string_view sys_name,
+                             std::string_view unknown_name)
 {
 
   // Check the inputs for validity, and get a reference
@@ -353,8 +353,8 @@ Real ExactSolution::l2_error(const std::string & sys_name,
 
 
 
-Real ExactSolution::l1_error(const std::string & sys_name,
-                             const std::string & unknown_name)
+Real ExactSolution::l1_error(std::string_view sys_name,
+                             std::string_view unknown_name)
 {
 
   // Check the inputs for validity, and get a reference
@@ -373,8 +373,8 @@ Real ExactSolution::l1_error(const std::string & sys_name,
 
 
 
-Real ExactSolution::l_inf_error(const std::string & sys_name,
-                                const std::string & unknown_name)
+Real ExactSolution::l_inf_error(std::string_view sys_name,
+                                std::string_view unknown_name)
 {
 
   // Check the inputs for validity, and get a reference
@@ -393,8 +393,8 @@ Real ExactSolution::l_inf_error(const std::string & sys_name,
 
 
 
-Real ExactSolution::h1_error(const std::string & sys_name,
-                             const std::string & unknown_name)
+Real ExactSolution::h1_error(std::string_view sys_name,
+                             std::string_view unknown_name)
 {
   // If the user has supplied no exact derivative function, we
   // just integrate the H1 norm of the solution; i.e. its
@@ -410,23 +410,23 @@ Real ExactSolution::h1_error(const std::string & sys_name,
 }
 
 
-Real ExactSolution::hcurl_error(const std::string & sys_name,
-                                const std::string & unknown_name)
+Real ExactSolution::hcurl_error(std::string_view sys_name,
+                                std::string_view unknown_name)
 {
   return this->error_norm(sys_name,unknown_name,HCURL);
 }
 
 
-Real ExactSolution::hdiv_error(const std::string & sys_name,
-                               const std::string & unknown_name)
+Real ExactSolution::hdiv_error(std::string_view sys_name,
+                               std::string_view unknown_name)
 {
   return this->error_norm(sys_name,unknown_name,HDIV);
 }
 
 
 
-Real ExactSolution::h2_error(const std::string & sys_name,
-                             const std::string & unknown_name)
+Real ExactSolution::h2_error(std::string_view sys_name,
+                             std::string_view unknown_name)
 {
   // If the user has supplied no exact derivative functions, we
   // just integrate the H2 norm of the solution; i.e. its
@@ -448,8 +448,8 @@ Real ExactSolution::h2_error(const std::string & sys_name,
 
 
 template<typename OutputShape>
-void ExactSolution::_compute_error(const std::string & sys_name,
-                                   const std::string & unknown_name,
+void ExactSolution::_compute_error(std::string_view sys_name,
+                                   std::string_view unknown_name,
                                    std::vector<Real> & error_vals)
 {
   // Make sure we aren't "overconfigured"
@@ -828,7 +828,7 @@ void ExactSolution::_compute_error(const std::string & sys_name,
 }
 
 // Explicit instantiations of templated member functions
-template LIBMESH_EXPORT void ExactSolution::_compute_error<Real>(const std::string &, const std::string &, std::vector<Real> &);
-template LIBMESH_EXPORT void ExactSolution::_compute_error<RealGradient>(const std::string &, const std::string &, std::vector<Real> &);
+template LIBMESH_EXPORT void ExactSolution::_compute_error<Real>(std::string_view, std::string_view, std::vector<Real> &);
+template LIBMESH_EXPORT void ExactSolution::_compute_error<RealGradient>(std::string_view, std::string_view, std::vector<Real> &);
 
 } // namespace libMesh

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -2464,7 +2464,7 @@ std::string & BoundaryInfo::edgeset_name(boundary_id_type id)
   return _es_id_to_name[id];
 }
 
-boundary_id_type BoundaryInfo::get_id_by_name(const std::string & name) const
+boundary_id_type BoundaryInfo::get_id_by_name(std::string_view name) const
 {
   // Search sidesets
   for (const auto & pr : _ss_id_to_name)

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -84,7 +84,7 @@ void chunking(libMesh::processor_id_type size, libMesh::processor_id_type rank, 
     }
 }
 
-std::string extension(const std::string & s)
+std::string_view extension(std::string_view s)
 {
   auto pos = s.rfind(".");
   if (pos == std::string::npos)
@@ -100,16 +100,16 @@ std::string split_dir(const std::string & input_name, libMesh::processor_id_type
 
 std::string header_file(const std::string & input_name, libMesh::processor_id_type n_procs)
 {
-  return split_dir(input_name, n_procs) + "/header" + extension(input_name);
+  return (split_dir(input_name, n_procs) + "/header").append(extension(input_name));
 }
 
 std::string
 split_file(const std::string & input_name,
-                        libMesh::processor_id_type n_procs,
-                        libMesh::processor_id_type proc_id)
+           libMesh::processor_id_type n_procs,
+           libMesh::processor_id_type proc_id)
 {
-  return split_dir(input_name, n_procs) + "/split-" + std::to_string(n_procs) + "-" +
-         std::to_string(proc_id) + extension(input_name);
+  return (split_dir(input_name, n_procs) + "/split-" + std::to_string(n_procs) + "-" +
+         std::to_string(proc_id)).append(extension(input_name));
 }
 
 void make_dir(const std::string & input_name, libMesh::processor_id_type n_procs)

--- a/src/mesh/ensight_io.C
+++ b/src/mesh/ensight_io.C
@@ -80,9 +80,9 @@ EnsightIO::EnsightIO (const std::string & filename,
 
 
 void EnsightIO::add_vector (const std::string & system_name,
-                            const std::string & vec_description,
-                            const std::string & u,
-                            const std::string & v)
+                            std::string_view vec_description,
+                            std::string u,
+                            std::string v)
 {
   libmesh_assert (_equation_systems.has_system(system_name));
   libmesh_assert (_equation_systems.get_system(system_name).has_variable(u));
@@ -90,19 +90,19 @@ void EnsightIO::add_vector (const std::string & system_name,
 
   Vectors vec;
   vec.description = vec_description;
-  vec.components.push_back(u);
-  vec.components.push_back(v);
+  vec.components.push_back(std::move(u));
+  vec.components.push_back(std::move(v));
 
-  _system_vars_map[system_name].EnsightVectors.push_back(vec);
+  _system_vars_map[system_name].EnsightVectors.push_back(std::move(vec));
 }
 
 
 
 void EnsightIO::add_vector (const std::string & system_name,
-                            const std::string & vec_name,
-                            const std::string & u,
-                            const std::string & v,
-                            const std::string & w)
+                            std::string_view vec_name,
+                            std::string u,
+                            std::string v,
+                            std::string w)
 {
   libmesh_assert(_equation_systems.has_system(system_name));
   libmesh_assert(_equation_systems.get_system(system_name).has_variable(u));
@@ -111,17 +111,17 @@ void EnsightIO::add_vector (const std::string & system_name,
 
   Vectors vec;
   vec.description = vec_name;
-  vec.components.push_back(u);
-  vec.components.push_back(v);
-  vec.components.push_back(w);
-  _system_vars_map[system_name].EnsightVectors.push_back(vec);
+  vec.components.push_back(std::move(u));
+  vec.components.push_back(std::move(v));
+  vec.components.push_back(std::move(w));
+  _system_vars_map[system_name].EnsightVectors.push_back(std::move(vec));
 }
 
 
 
 void EnsightIO::add_scalar(const std::string & system_name,
-                           const std::string & scl_description,
-                           const std::string & s)
+                           std::string_view scl_description,
+                           std::string_view s)
 {
   libmesh_assert(_equation_systems.has_system(system_name));
   libmesh_assert(_equation_systems.get_system(system_name).has_variable(s));
@@ -130,7 +130,7 @@ void EnsightIO::add_scalar(const std::string & system_name,
   scl.description = scl_description;
   scl.scalar_name = s;
 
-  _system_vars_map[system_name].EnsightScalars.push_back(scl);
+  _system_vars_map[system_name].EnsightScalars.push_back(std::move(scl));
 }
 
 
@@ -333,8 +333,8 @@ void EnsightIO::write_solution_ascii()
 }
 
 
-void EnsightIO::write_scalar_ascii(const std::string & sys,
-                                   const std::string & var_name)
+void EnsightIO::write_scalar_ascii(std::string_view sys,
+                                   std::string_view var_name)
 {
   // Construct scalar variable filename
   std::ostringstream scl_file;
@@ -404,9 +404,9 @@ void EnsightIO::write_scalar_ascii(const std::string & sys,
 }
 
 
-void EnsightIO::write_vector_ascii(const std::string & sys,
+void EnsightIO::write_vector_ascii(std::string_view sys,
                                    const std::vector<std::string> & vec,
-                                   const std::string & var_name)
+                                   std::string_view var_name)
 {
   // Construct vector variable filename
   std::ostringstream vec_file;

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -516,14 +516,14 @@ const char * ExodusII_IO_Helper::get_elem_type() const
 
 
 
-void ExodusII_IO_Helper::message(const std::string & msg)
+void ExodusII_IO_Helper::message(std::string_view msg)
 {
   if (verbose) libMesh::out << msg << std::endl;
 }
 
 
 
-void ExodusII_IO_Helper::message(const std::string & msg, int i)
+void ExodusII_IO_Helper::message(std::string_view msg, int i)
 {
   if (verbose) libMesh::out << msg << i << "." << std::endl;
 }

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -235,7 +235,7 @@ void MeshBase::set_spatial_dimension(unsigned char d)
 
 
 
-unsigned int MeshBase::add_elem_integer(const std::string & name,
+unsigned int MeshBase::add_elem_integer(std::string name,
                                         bool allocate_data,
                                         dof_id_type default_value)
 {
@@ -249,7 +249,7 @@ unsigned int MeshBase::add_elem_integer(const std::string & name,
 
   libmesh_assert_equal_to(_elem_integer_names.size(),
                           _elem_integer_default_values.size());
-  _elem_integer_names.push_back(name);
+  _elem_integer_names.push_back(std::move(name));
   _elem_integer_default_values.push_back(default_value);
   if (allocate_data)
     this->size_elem_extra_integers();
@@ -301,7 +301,7 @@ std::vector<unsigned int> MeshBase::add_elem_integers(const std::vector<std::str
 
 
 
-unsigned int MeshBase::get_elem_integer_index(const std::string & name) const
+unsigned int MeshBase::get_elem_integer_index(std::string_view name) const
 {
   for (auto i : index_range(_elem_integer_names))
     if (_elem_integer_names[i] == name)
@@ -313,7 +313,7 @@ unsigned int MeshBase::get_elem_integer_index(const std::string & name) const
 
 
 
-bool MeshBase::has_elem_integer(const std::string & name) const
+bool MeshBase::has_elem_integer(std::string_view name) const
 {
   for (auto & entry : _elem_integer_names)
     if (entry == name)
@@ -324,7 +324,7 @@ bool MeshBase::has_elem_integer(const std::string & name) const
 
 
 
-unsigned int MeshBase::add_node_integer(const std::string & name,
+unsigned int MeshBase::add_node_integer(std::string name,
                                         bool allocate_data,
                                         dof_id_type default_value)
 {
@@ -338,7 +338,7 @@ unsigned int MeshBase::add_node_integer(const std::string & name,
 
   libmesh_assert_equal_to(_node_integer_names.size(),
                           _node_integer_default_values.size());
-  _node_integer_names.push_back(name);
+  _node_integer_names.push_back(std::move(name));
   _node_integer_default_values.push_back(default_value);
   if (allocate_data)
     this->size_node_extra_integers();
@@ -390,7 +390,7 @@ std::vector<unsigned int> MeshBase::add_node_integers(const std::vector<std::str
 
 
 
-unsigned int MeshBase::get_node_integer_index(const std::string & name) const
+unsigned int MeshBase::get_node_integer_index(std::string_view name) const
 {
   for (auto i : index_range(_node_integer_names))
     if (_node_integer_names[i] == name)
@@ -402,7 +402,7 @@ unsigned int MeshBase::get_node_integer_index(const std::string & name) const
 
 
 
-bool MeshBase::has_node_integer(const std::string & name) const
+bool MeshBase::has_node_integer(std::string_view name) const
 {
   for (auto & entry : _node_integer_names)
     if (entry == name)
@@ -1335,7 +1335,7 @@ const std::string & MeshBase::subdomain_name(subdomain_id_type id) const
 
 
 
-subdomain_id_type MeshBase::get_id_by_name(const std::string & name) const
+subdomain_id_type MeshBase::get_id_by_name(std::string_view name) const
 {
   // Linear search over the map values.
   std::map<subdomain_id_type, std::string>::const_iterator

--- a/src/mesh/mesh_tetgen_interface.C
+++ b/src/mesh/mesh_tetgen_interface.C
@@ -44,7 +44,7 @@ TetGenMeshInterface::TetGenMeshInterface (UnstructuredMesh & mesh) :
 {
 }
 
-void TetGenMeshInterface::set_switches(const std::string & switches)
+void TetGenMeshInterface::set_switches(std::string switches)
 {
   // set the tetgen switch manually:
   // p = tetrahedralizes a piecewise linear complex (see definition in user manual)
@@ -54,7 +54,7 @@ void TetGenMeshInterface::set_switches(const std::string & switches)
   // V = verbose output
   // for full list of options and their meaning: see the tetgen manual
   // (http://wias-berlin.de/software/tetgen/1.5/doc/manual/manual005.html)
-  _switches = switches;
+  _switches = std::move(switches);
 }
 
 

--- a/src/mesh/mesh_tetgen_wrapper.C
+++ b/src/mesh/mesh_tetgen_wrapper.C
@@ -150,7 +150,7 @@ void TetGenWrapper::allocate_pointlist(int numofpoints)
 
 
 
-void TetGenWrapper::set_switches(const std::string & s)
+void TetGenWrapper::set_switches(std::string_view s)
 {
   // A temporary buffer for passing to the C API, it requires
   // a char *, not a const char *...

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -2791,7 +2791,7 @@ void Nemesis_IO_Helper::read_var_names_impl(const char * var_type,
 
 
 
-std::string Nemesis_IO_Helper::construct_nemesis_filename(const std::string & base_filename)
+std::string Nemesis_IO_Helper::construct_nemesis_filename(std::string_view base_filename)
 {
   // Build a filename for this processor.  This code is cut-n-pasted from the read function
   // and should probably be put into a separate function...

--- a/src/quadrature/quadrature_build.C
+++ b/src/quadrature/quadrature_build.C
@@ -40,7 +40,7 @@ namespace libMesh
 
 
 //---------------------------------------------------------------
-std::unique_ptr<QBase> QBase::build (const std::string & type,
+std::unique_ptr<QBase> QBase::build (std::string_view type,
                                      const unsigned int _dim,
                                      const Order _order)
 {

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -333,8 +333,8 @@ void EquationSystems::update ()
 
 
 
-System & EquationSystems::add_system (const std::string & sys_type,
-                                      const std::string & name)
+System & EquationSystems::add_system (std::string_view sys_type,
+                                      std::string_view name)
 {
   // If the user already built a system with this name, we'll
   // trust them and we'll use it.  That way they can pre-add
@@ -564,8 +564,8 @@ void EquationSystems::build_variable_names (std::vector<std::string> & var_names
 
 
 void EquationSystems::build_solution_vector (std::vector<Number> &,
-                                             const std::string &,
-                                             const std::string &) const
+                                             std::string_view,
+                                             std::string_view) const
 {
   // TODO:[BSK] re-implement this from the method below
   libmesh_not_implemented();

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -96,7 +96,7 @@ namespace libMesh
 // ------------------------------------------------------------
 // System class implementation
 void System::read_header (Xdr & io,
-                          const std::string & version,
+                          std::string_view version,
                           const bool read_header_in,
                           const bool read_additional_data,
                           const bool read_legacy_format)
@@ -1301,7 +1301,7 @@ numeric_index_type System::read_serialized_vector (Xdr & io,
 
 
 void System::write_header (Xdr & io,
-                           const std::string & /* version is currently unused */,
+                           std::string_view /* version is currently unused */,
                            const bool write_additional_data) const
 {
   /**

--- a/src/utils/perf_log.C
+++ b/src/utils/perf_log.C
@@ -52,9 +52,9 @@ namespace libMesh
 bool PerfLog::called = false;
 
 
-PerfLog::PerfLog(const std::string & ln,
+PerfLog::PerfLog(std::string ln,
                  const bool le) :
-  label_name(ln),
+  label_name(std::move(ln)),
   log_events(le),
   summarize_logs(false),
   total_time(0.)

--- a/src/utils/string_to_enum.C
+++ b/src/utils/string_to_enum.C
@@ -668,7 +668,7 @@ namespace Utility {
 
 #define INSTANTIATE_STRING_TO_ENUM(ENUM_NAME,VAR_NAME)                  \
   template <>                                                           \
-  ENUM_NAME string_to_enum<ENUM_NAME> (const std::string & s)           \
+  ENUM_NAME string_to_enum<ENUM_NAME> (std::string_view s)              \
   {                                                                     \
     init_##VAR_NAME##_to_enum();                                        \
                                                                         \
@@ -677,10 +677,22 @@ namespace Utility {
                                                                         \
     if (!VAR_NAME##_to_enum.count(upper))                               \
       {                                                                 \
-        libmesh_error_msg("No " #ENUM_NAME " named " + s + " found.");  \
+        libmesh_error_msg("No " #ENUM_NAME " named " << s << " found.");  \
       }                                                                 \
                                                                         \
     return VAR_NAME##_to_enum[upper];                                   \
+  }                                                                     \
+                                                                        \
+  template <>                                                           \
+  ENUM_NAME string_to_enum<ENUM_NAME> (const std::string & s)           \
+  {                                                                     \
+    return string_to_enum<ENUM_NAME>(std::string_view(s));              \
+  }                                                                     \
+                                                                        \
+  template <>                                                           \
+  ENUM_NAME string_to_enum<ENUM_NAME> (const char * s)                  \
+  {                                                                     \
+    return string_to_enum<ENUM_NAME>(std::string_view(s));              \
   }                                                                     \
                                                                         \
   template <>                                                           \
@@ -693,6 +705,7 @@ namespace Utility {
                                                                         \
     return enum_to_##VAR_NAME [e];                                      \
   }
+
 
 
 INSTANTIATE_STRING_TO_ENUM(ElemType,elem_type)

--- a/src/utils/utility.C
+++ b/src/utils/utility.C
@@ -108,18 +108,16 @@ std::string Utility::system_info()
 
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS
 
-std::string Utility::complex_filename (const std::string & basename,
+std::string Utility::complex_filename (std::string basename,
                                        const unsigned int r_o_c)
 {
-  std::string name(basename);
-
   if (r_o_c == 0)
-    name.append(".real");
+    basename.append(".real");
 
   else
-    name.append(".imag");
+    basename.append(".imag");
 
-  return name;
+  return basename;
 }
 
 
@@ -155,12 +153,12 @@ int Utility::mkdir(const char* pathname) {
 }
 
 
-std::string Utility::unzip_file (const std::string & name)
+std::string Utility::unzip_file (std::string_view name)
 {
   std::ostringstream pid_suffix;
   pid_suffix << '_' << getpid();
 
-  std::string new_name = name;
+  std::string new_name { name };
   if (name.size() - name.rfind(".bz2") == 4)
     {
 #ifdef LIBMESH_HAVE_BZIP
@@ -168,7 +166,8 @@ std::string Utility::unzip_file (const std::string & name)
       new_name += pid_suffix.str();
       LOG_SCOPE("system(bunzip2)", "Utility");
       std::string system_string = "bunzip2 -f -k -c ";
-      system_string += name + " > " + new_name;
+      system_string.append(name);
+      system_string += " > " + new_name;
       if (std::system(system_string.c_str()))
         libmesh_file_error(system_string);
 #else
@@ -182,7 +181,8 @@ std::string Utility::unzip_file (const std::string & name)
       new_name += pid_suffix.str();
       LOG_SCOPE("system(xz -d)", "Utility");
       std::string system_string = "xz -f -d -k -c ";
-      system_string += name + " > " + new_name;
+      system_string.append(name);
+      system_string += " > " + new_name;
       if (std::system(system_string.c_str()))
         libmesh_file_error(system_string);
 #else

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -45,7 +45,7 @@
 namespace {
 
 // Nasty hacks for reading/writing zipped files
-void bzip_file (const std::string & unzipped_name)
+void bzip_file (std::string_view unzipped_name)
 {
 #ifdef LIBMESH_HAVE_BZIP
   LOG_SCOPE("system(bzip2)", "XdrIO");
@@ -59,7 +59,7 @@ void bzip_file (const std::string & unzipped_name)
 #endif
 }
 
-void xzip_file (const std::string & unzipped_name)
+void xzip_file (std::string_view unzipped_name)
 {
 #ifdef LIBMESH_HAVE_XZ
   LOG_SCOPE("system(xz)", "XdrIO");
@@ -75,7 +75,7 @@ void xzip_file (const std::string & unzipped_name)
 
 
 // remove an unzipped file
-void remove_unzipped_file (const std::string & name)
+void remove_unzipped_file (std::string_view name)
 {
   std::ostringstream pid_suffix;
   pid_suffix << '_' << getpid();


### PR DESCRIPTION
Definitions of "appropriate" may vary.  In the one direction: I didn't get anywhere close to the "`const std::string &` parameters should all either be `string_view` or pass-by-value-then-move instead" advice.  In the other: we could scale down this PR or ditch it entirely; nothing we ever do with text is performance-critical (except PerfLog, ironically, and we fixed that quite a while ago).