### PR TITLE
Preconditioner reuse in petsc_nonlinear_solver

### DIFF
--- a/include/solvers/nonlinear_solver.h
+++ b/include/solvers/nonlinear_solver.h
@@ -350,6 +350,16 @@ public:
   bool converged;
 
   /**
+   * Whether we should reuse the linear preconditioner
+   */
+  bool reuse_preconditioner;
+
+  /**
+   * Number of linear iterations to retain the preconditioner
+   */
+  unsigned int reuse_preconditioner_max_its;
+
+  /**
    * Set the solver configuration object.
    */
   void set_solver_configuration(SolverConfiguration & solver_configuration);
@@ -415,6 +425,8 @@ NonlinearSolver<T>::NonlinearSolver (sys_type & s) :
   initial_linear_tolerance(0),
   minimum_linear_tolerance(0),
   converged(false),
+  reuse_preconditioner(false),
+  reuse_preconditioner_max_its(0),
   _system(s),
   _is_initialized (false),
   _preconditioner (nullptr),

--- a/include/solvers/nonlinear_solver.h
+++ b/include/solvers/nonlinear_solver.h
@@ -350,21 +350,42 @@ public:
   bool converged;
 
   /**
-   * Whether we should reuse the linear preconditioner
-   */
-  bool reuse_preconditioner;
-
-  /**
-   * Number of linear iterations to retain the preconditioner
-   */
-  unsigned int reuse_preconditioner_max_its;
-
-  /**
    * Set the solver configuration object.
    */
   void set_solver_configuration(SolverConfiguration & solver_configuration);
 
+  /**
+   *  Get the reuse_preconditioner flag
+   */
+  virtual bool reuse_preconditioner() const;
+
+  /**
+   *  Set the reuse preconditioner flag
+   */
+  virtual void set_reuse_preconditioner(bool reuse);
+
+  /**
+   *  Get the reuse_preconditioner_max_its parameter
+   */
+  virtual unsigned int reuse_preconditioner_max_its() const;
+
+  /**
+   *  Set the reuse_preconditioner_max_its parameter
+   */
+  virtual void set_reuse_preconditioner_max_its(unsigned int i);
+
+
 protected:
+  /**
+   * Whether we should reuse the linear preconditioner
+   */
+  bool _reuse_preconditioner;
+
+  /**
+   * Number of linear iterations to retain the preconditioner
+   */
+  unsigned int _reuse_preconditioner_max_its;
+
   /**
    * A reference to the system we are solving.
    */
@@ -425,8 +446,8 @@ NonlinearSolver<T>::NonlinearSolver (sys_type & s) :
   initial_linear_tolerance(0),
   minimum_linear_tolerance(0),
   converged(false),
-  reuse_preconditioner(false),
-  reuse_preconditioner_max_its(0),
+  _reuse_preconditioner(false),
+  _reuse_preconditioner_max_its(0),
   _system(s),
   _is_initialized (false),
   _preconditioner (nullptr),

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -93,7 +93,7 @@ public:
   /**
    * Destructor.
    */
-  ~PetscNonlinearSolver () = default;
+  ~PetscNonlinearSolver ();
 
   /**
    * Release all memory and clear data structures.

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -47,6 +47,7 @@ class ResidualContext;
 // need access to these most of the time as they are used internally by this object.
 extern "C"
 {
+  PetscErrorCode libmesh_petsc_recalculate_monitor(SNES snes, PetscInt it, PetscReal norm, void* mctx);
   PetscErrorCode libmesh_petsc_snes_monitor (SNES, PetscInt its, PetscReal fnorm, void *);
   PetscErrorCode libmesh_petsc_snes_residual (SNES, Vec x, Vec r, void * ctx);
   PetscErrorCode libmesh_petsc_snes_fd_residual (SNES, Vec x, Vec r, void * ctx);
@@ -201,6 +202,11 @@ public:
    */
   std::unique_ptr<ComputeLineSearchObject> linesearch_object;
 
+  /**
+    * Setup the default monitor if required
+    */
+  void setup_default_monitor();
+
 protected:
 
   /**
@@ -261,6 +267,11 @@ protected:
    */
   bool _computing_base_vector;
 
+  /**
+    * Whether we've triggered the preconditioner reuse
+    */
+  bool _setup_reuse;
+
 private:
   friend ResidualContext libmesh_petsc_snes_residual_helper (SNES snes, Vec x, void * ctx);
   friend PetscErrorCode libmesh_petsc_snes_residual (SNES snes, Vec x, Vec r, void * ctx);
@@ -268,8 +279,6 @@ private:
   friend PetscErrorCode libmesh_petsc_snes_mffd_residual (SNES snes, Vec x, Vec r, void * ctx);
   friend PetscErrorCode libmesh_petsc_snes_jacobian (SNES snes, Vec x, Mat jac, Mat pc, void * ctx);
 };
-
-
 
 } // namespace libMesh
 

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -282,6 +282,11 @@ protected:
     */
   bool _setup_reuse;
 
+  /**
+   *  Persistent storage for the maximum iterations
+   */
+  unsigned int _max_its;
+
 private:
   friend ResidualContext libmesh_petsc_snes_residual_helper (SNES snes, Vec x, void * ctx);
   friend PetscErrorCode libmesh_petsc_snes_residual (SNES snes, Vec x, Vec r, void * ctx);

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -93,7 +93,7 @@ public:
   /**
    * Destructor.
    */
-  ~PetscNonlinearSolver ();
+  ~PetscNonlinearSolver () = default;
 
   /**
    * Release all memory and clear data structures.

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -207,6 +207,16 @@ public:
     */
   void setup_default_monitor();
 
+  /**
+   * Getter for preconditioner reuse
+   */
+  virtual bool reuse_preconditioner() const override;
+
+  /**
+   *  Getter for the maximum iterations flag for preconditioner reuse
+   */
+  virtual unsigned int reuse_preconditioner_max_its() const override;
+
 protected:
 
   /**

--- a/src/solvers/nonlinear_solver.C
+++ b/src/solvers/nonlinear_solver.C
@@ -84,6 +84,29 @@ void NonlinearSolver<T>::set_solver_configuration(SolverConfiguration & solver_c
   _solver_configuration = &solver_configuration;
 }
 
+template <typename T>
+bool NonlinearSolver<T>::reuse_preconditioner() const
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+void NonlinearSolver<T>::set_reuse_preconditioner(bool reuse)
+{
+  _reuse_preconditioner = reuse;
+}
+
+template <typename T>
+unsigned int NonlinearSolver<T>::reuse_preconditioner_max_its() const
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+void NonlinearSolver<T>::set_reuse_preconditioner_max_its(unsigned int i)
+{
+  _reuse_preconditioner_max_its = i;
+}
 
 //------------------------------------------------------------------
 // Explicit instantiations

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -649,6 +649,12 @@ PetscNonlinearSolver<T>::PetscNonlinearSolver (sys_type & system_in) :
 }
 
 
+
+template <typename T>
+PetscNonlinearSolver<T>::~PetscNonlinearSolver () = default;
+
+
+
 template <typename T>
 void PetscNonlinearSolver<T>::clear ()
 {

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -105,6 +105,33 @@ libmesh_petsc_snes_residual_helper (SNES snes, Vec x, void * ctx)
 // Give them an obscure name to avoid namespace pollution.
 extern "C"
 {
+  // -----------------------------------------------------------------
+  // this function monitors the nonlinear solve and checks to see
+  // if we want to recalculate the preconditioner.  It only gets
+  // added to the SNES instance if we're reusing the preconditioner
+  PetscErrorCode
+  libmesh_petsc_recalculate_monitor(SNES snes, PetscInt, PetscReal, void* mctx)
+  {
+    unsigned int * max_iters = (unsigned int *) mctx;
+    PetscErrorCode ierr = 0;
+
+    KSP ksp;
+    ierr = SNESGetKSP(snes, &ksp);
+    LIBMESH_CHKERR(ierr);
+
+    PetscInt niter;
+    ierr = KSPGetIterationNumber(ksp, &niter);
+    LIBMESH_CHKERR(ierr);
+
+    if (niter > *max_iters)
+    {
+      // -2 is a magic number for "recalculate next time you need it
+      // and then not again"
+      ierr = SNESSetLagPreconditioner(snes, -2);
+      LIBMESH_CHKERR(ierr);
+    }
+    return 0;
+  }
 
   //-------------------------------------------------------------------
   // this function is called by PETSc at the end of each nonlinear step
@@ -615,15 +642,22 @@ PetscNonlinearSolver<T>::PetscNonlinearSolver (sys_type & system_in) :
   _zero_out_jacobian(true),
   _default_monitor(true),
   _snesmf_reuse_base(true),
-  _computing_base_vector(true)
+  _computing_base_vector(true),
+  _setup_reuse(false)
 {
 }
 
 
 
 template <typename T>
-PetscNonlinearSolver<T>::~PetscNonlinearSolver () = default;
-
+PetscNonlinearSolver<T>::~PetscNonlinearSolver ()
+{
+  // Take care of the SNES instance, if it was allocated
+  if (_snes)
+    {
+    _snes.destroy();
+    }
+}
 
 
 template <typename T>
@@ -633,8 +667,15 @@ void PetscNonlinearSolver<T>::clear ()
     {
       this->_is_initialized = false;
 
-      // Calls custom deleter
-      _snes.destroy();
+      // If we don't need the preconditioner next time
+      // retain the original behavior of clearing the data
+      // between solves.
+      if (!(this->reuse_preconditioner))
+        {
+        PetscErrorCode ierr=0;
+        ierr = SNESReset(_snes);
+        LIBMESH_CHKERR(ierr);
+        }
 
       // Reset the nonlinear iteration counter.  This information is only relevant
       // *during* the solve().  After the solve is completed it should return to
@@ -655,8 +696,15 @@ void PetscNonlinearSolver<T>::init (const char * name)
 
       PetscErrorCode ierr=0;
 
-      ierr = SNESCreate(this->comm().get(), _snes.get());
-      LIBMESH_CHKERR(ierr);
+      // Make only if we don't already have a retained snes
+      // hanging around from the last solve
+      if (!_snes) {
+        ierr = SNESCreate(this->comm().get(), _snes.get());
+        LIBMESH_CHKERR(ierr);
+      }
+
+      // I believe all of the following can be safely repeated
+      // even on an old snes instance from the last solve
 
       if (name)
         {
@@ -680,12 +728,7 @@ void PetscNonlinearSolver<T>::init (const char * name)
         // SNES now owns the reference to dm.
       }
 
-      if (_default_monitor)
-        {
-          ierr = SNESMonitorSet (_snes, libmesh_petsc_snes_monitor,
-                                 this, PETSC_NULL);
-          LIBMESH_CHKERR(ierr);
-        }
+      setup_default_monitor();
 
       // If the SolverConfiguration object is provided, use it to set
       // options during solver initialization.
@@ -729,7 +772,6 @@ void PetscNonlinearSolver<T>::init (const char * name)
       LIBMESH_CHKERR(ierr);
     }
 }
-
 
 
 template <typename T>
@@ -815,6 +857,7 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  pre_in,  // System Preconditi
   LOG_SCOPE("solve()", "PetscNonlinearSolver");
   this->init ();
 
+
   // Make sure the data passed in are really of Petsc types
   PetscMatrix<T> * pre = cast_ptr<PetscMatrix<T> *>(&pre_in);
   PetscVector<T> * x   = cast_ptr<PetscVector<T> *>(&x_in);
@@ -824,6 +867,40 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  pre_in,  // System Preconditi
   PetscInt n_iterations =0;
   // Should actually be a PetscReal, but I don't know which version of PETSc first introduced PetscReal
   Real final_residual_norm=0.;
+
+  // We don't want to do this twice because it resets
+  // SNESSetLagPreconditioner
+  if ((this->reuse_preconditioner) && (!_setup_reuse))
+    {
+      _setup_reuse = true;
+      ierr = SNESSetLagPreconditionerPersists(_snes, PETSC_TRUE);
+      LIBMESH_CHKERR(ierr);
+      // According to the PETSC 3.16.5 docs -2 is a magic number which
+      // means "recalculate the next time you need it and then not again"
+      ierr = SNESSetLagPreconditioner(_snes, -2);
+      LIBMESH_CHKERR(ierr);
+      // Add in our callback which will trigger recalculating
+      // the preconditioner when we hit reuse_preconditioner_max_its
+      ierr = SNESMonitorSet(_snes, &libmesh_petsc_recalculate_monitor,
+                            (void*)
+                            &(this->reuse_preconditioner_max_its),
+                            NULL);
+      LIBMESH_CHKERR(ierr);
+    }
+  else if (!(this->reuse_preconditioner))
+    // This covers the case where it was enabled but was then disabled
+    {
+      ierr = SNESSetLagPreconditionerPersists(_snes, PETSC_FALSE);
+      LIBMESH_CHKERR(ierr);
+      if (_setup_reuse)
+        {
+          _setup_reuse = false;
+          ierr = SNESMonitorCancel(_snes);
+          LIBMESH_CHKERR(ierr);
+          // Readd default monitor
+          setup_default_monitor();
+        }
+    }
 
   ierr = SNESSetFunction (_snes, r->vec(), libmesh_petsc_snes_residual, this);
   LIBMESH_CHKERR(ierr);
@@ -998,6 +1075,7 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  pre_in,  // System Preconditi
   //Based on Petsc 2.3.3 documentation all diverged reasons are negative
   this->converged = (_reason >= 0);
 
+  // Reset data structure
   this->clear();
 
   // return the # of its. and the final residual norm.
@@ -1034,6 +1112,17 @@ template <typename T>
 int PetscNonlinearSolver<T>::get_total_linear_iterations()
 {
   return _n_linear_iterations;
+}
+
+template <typename T>
+void PetscNonlinearSolver<T>::setup_default_monitor()
+{
+  if (_default_monitor)
+    {
+      PetscErrorCode ierr = SNESMonitorSet (_snes, libmesh_petsc_snes_monitor,
+                                            this, PETSC_NULL);
+      LIBMESH_CHKERR(ierr);
+    }
 }
 
 

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -649,18 +649,6 @@ PetscNonlinearSolver<T>::PetscNonlinearSolver (sys_type & system_in) :
 }
 
 
-
-template <typename T>
-PetscNonlinearSolver<T>::~PetscNonlinearSolver ()
-{
-  // Take care of the SNES instance, if it was allocated
-  if (_snes)
-    {
-    _snes.destroy();
-    }
-}
-
-
 template <typename T>
 void PetscNonlinearSolver<T>::clear ()
 {

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -643,7 +643,8 @@ PetscNonlinearSolver<T>::PetscNonlinearSolver (sys_type & system_in) :
   _default_monitor(true),
   _snesmf_reuse_base(true),
   _computing_base_vector(true),
-  _setup_reuse(false)
+  _setup_reuse(false),
+  _max_its(0)
 {
 }
 
@@ -882,10 +883,10 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  pre_in,  // System Preconditi
       LIBMESH_CHKERR(ierr);
       // Add in our callback which will trigger recalculating
       // the preconditioner when we hit reuse_preconditioner_max_its
-      unsigned int max_its = reuse_preconditioner_max_its();
+      _max_its = reuse_preconditioner_max_its();
       ierr = SNESMonitorSet(_snes, &libmesh_petsc_recalculate_monitor,
                             (void*)
-                            &max_its,
+                            &_max_its,
                             NULL);
       LIBMESH_CHKERR(ierr);
     }

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -672,9 +672,10 @@ void PetscNonlinearSolver<T>::clear ()
       // between solves.
       if (!(this->reuse_preconditioner))
         {
-        PetscErrorCode ierr=0;
-        ierr = SNESReset(_snes);
-        LIBMESH_CHKERR(ierr);
+        // SNESReset really ought to work but replacing destory() with
+        // SNESReset causes a very slight change in behavior that
+        // manifests as two failed MOOSE tests...
+        _snes.destroy();
         }
 
       // Reset the nonlinear iteration counter.  This information is only relevant

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -670,7 +670,7 @@ void PetscNonlinearSolver<T>::clear ()
       // If we don't need the preconditioner next time
       // retain the original behavior of clearing the data
       // between solves.
-      if (!(this->reuse_preconditioner))
+      if (!(reuse_preconditioner()))
         {
         // SNESReset really ought to work but replacing destory() with
         // SNESReset causes a very slight change in behavior that
@@ -871,7 +871,7 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  pre_in,  // System Preconditi
 
   // We don't want to do this twice because it resets
   // SNESSetLagPreconditioner
-  if ((this->reuse_preconditioner) && (!_setup_reuse))
+  if ((reuse_preconditioner()) && (!_setup_reuse))
     {
       _setup_reuse = true;
       ierr = SNESSetLagPreconditionerPersists(_snes, PETSC_TRUE);
@@ -882,13 +882,14 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  pre_in,  // System Preconditi
       LIBMESH_CHKERR(ierr);
       // Add in our callback which will trigger recalculating
       // the preconditioner when we hit reuse_preconditioner_max_its
+      unsigned int max_its = reuse_preconditioner_max_its();
       ierr = SNESMonitorSet(_snes, &libmesh_petsc_recalculate_monitor,
                             (void*)
-                            &(this->reuse_preconditioner_max_its),
+                            &max_its,
                             NULL);
       LIBMESH_CHKERR(ierr);
     }
-  else if (!(this->reuse_preconditioner))
+  else if (!(reuse_preconditioner()))
     // This covers the case where it was enabled but was then disabled
     {
       ierr = SNESSetLagPreconditionerPersists(_snes, PETSC_FALSE);
@@ -1124,6 +1125,18 @@ void PetscNonlinearSolver<T>::setup_default_monitor()
                                             this, PETSC_NULL);
       LIBMESH_CHKERR(ierr);
     }
+}
+
+template <typename T>
+bool PetscNonlinearSolver<T>::reuse_preconditioner() const
+{
+  return this->_reuse_preconditioner;
+}
+
+template <typename T>
+unsigned int PetscNonlinearSolver<T>::reuse_preconditioner_max_its() const
+{
+  return this->_reuse_preconditioner_max_its;
 }
 
 

--- a/src/systems/nonlinear_implicit_system.C
+++ b/src/systems/nonlinear_implicit_system.C
@@ -148,8 +148,8 @@ void NonlinearImplicitSystem::set_solver_parameters ()
   nonlinear_solver->max_linear_iterations = maxlinearits;
   nonlinear_solver->initial_linear_tolerance = linear_tol;
   nonlinear_solver->minimum_linear_tolerance = linear_min_tol;
-  nonlinear_solver->reuse_preconditioner =  reuse_preconditioner;
-  nonlinear_solver->reuse_preconditioner_max_its = reuse_preconditioner_max_its;
+  nonlinear_solver->set_reuse_preconditioner(reuse_preconditioner);
+  nonlinear_solver->set_reuse_preconditioner_max_its(reuse_preconditioner_max_its);
 
   if (diff_solver.get())
     {

--- a/src/systems/nonlinear_implicit_system.C
+++ b/src/systems/nonlinear_implicit_system.C
@@ -52,6 +52,9 @@ NonlinearImplicitSystem::NonlinearImplicitSystem (EquationSystems & es,
   es.parameters.set<Real>("nonlinear solver divergence tolerance") = 1e+4;
   es.parameters.set<Real>("nonlinear solver absolute step tolerance") = 1e-8;
   es.parameters.set<Real>("nonlinear solver relative step tolerance") = 1e-8;
+
+  es.parameters.set<bool>("reuse preconditioner") = false;
+  es.parameters.set<unsigned int>("reuse preconditioner maximum iterations") = 1;
 }
 
 
@@ -129,6 +132,11 @@ void NonlinearImplicitSystem::set_solver_parameters ()
   const double linear_min_tol =
     double(es.parameters.get<Real>("linear solver minimum tolerance"));
 
+  const bool reuse_preconditioner =
+      es.parameters.get<bool>("reuse preconditioner");
+  const unsigned int reuse_preconditioner_max_its =
+      es.parameters.get<unsigned int>("reuse preconditioner maximum iterations");
+
   // Set all the parameters on the NonlinearSolver
   nonlinear_solver->max_nonlinear_iterations = maxits;
   nonlinear_solver->max_function_evaluations = maxfuncs;
@@ -140,6 +148,8 @@ void NonlinearImplicitSystem::set_solver_parameters ()
   nonlinear_solver->max_linear_iterations = maxlinearits;
   nonlinear_solver->initial_linear_tolerance = linear_tol;
   nonlinear_solver->minimum_linear_tolerance = linear_min_tol;
+  nonlinear_solver->reuse_preconditioner =  reuse_preconditioner;
+  nonlinear_solver->reuse_preconditioner_max_its = reuse_preconditioner_max_its;
 
   if (diff_solver.get())
     {


### PR DESCRIPTION
This alters the logic used in PetscNonlinearSolver to:

1. Not free the SNES instance between solves
2. Use SNESReset by default in between solves
3. Add two new options "reuse preconditioner" and "reuse preconditioner maximum iterations" to support preconditioner reuse during and across nonlinear solves.

This PR would close  issue #3209