### PR TITLE
Free all the attributes we retrieve with ex_get_attributes

### DIFF
--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1175,9 +1175,6 @@ void ExodusII_IO_Helper::read_elem_in_block(int block)
               const int * as_int = static_cast<int *>(attr.values);
               std::copy(as_int, as_int+attr.value_count, bex_elem_degrees.begin());
 
-              // ex_get_attributes did a values=calloc(); free() is our job.
-              if (attr.values)
-                free(attr.values);
 
               // Right now Bezier extraction elements aren't possible
               // for p>2 and aren't useful for p<2, and we don't
@@ -1189,6 +1186,9 @@ void ExodusII_IO_Helper::read_elem_in_block(int block)
                 libmesh_assert_equal_to(bex_elem_degrees[d], 2);
 #endif
             }
+            // ex_get_attributes did a values=calloc(); free() is our job.
+            if (attr.values)
+              free(attr.values);
         }
     }
 


### PR DESCRIPTION
Previously we only freed the attribute corresponding to bex_elem_degrees