### PR TITLE
Always get sideset data indices

### DIFF
--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -3219,77 +3219,43 @@ ExodusII_IO_Helper::
 get_sideset_data_indices (const MeshBase & mesh,
                           std::map<BoundaryInfo::BCTuple, unsigned int> & bc_array_indices)
 {
-  // This reads the sideset variable names into the local
-  // sideset_var_names data structure.
-  this->read_var_names(SIDESET);
-
-  if (num_sideset_vars)
+  // Store the sideset data array indices.
+  //
+  // Note: we assume that read_sideset() has already been called
+  // for each sideset, so the required values in elem_list and
+  // side_list are already present.
+  int offset=0;
+  for (int ss=0; ss<num_side_sets; ++ss)
     {
-      // Read the sideset data truth table
-      std::vector<int> sset_var_tab(num_side_sets * num_sideset_vars);
-      ex_err = exII::ex_get_sset_var_tab
-        (ex_id,
-         num_side_sets,
-         num_sideset_vars,
-         sset_var_tab.data());
-      EX_CHECK_ERR(ex_err, "Error reading sideset variable truth table.");
-
-      // Store the sideset data array indices.
-      //
-      // Note: we assume that read_sideset() has already been called
-      // for each sideset, so the required values in elem_list and
-      // side_list are already present.
-      int offset=0;
-      for (int ss=0; ss<num_side_sets; ++ss)
+      offset += (ss > 0 ? num_sides_per_set[ss-1] : 0);
+      for (int i=0; i<num_sides_per_set[ss]; ++i)
         {
-          offset += (ss > 0 ? num_sides_per_set[ss-1] : 0);
-          for (int var=0; var<num_sideset_vars; ++var)
-            {
-              int is_present = sset_var_tab[num_sideset_vars*ss + var];
+          dof_id_type exodus_elem_id = elem_list[i + offset];
+          unsigned int exodus_side_id = side_list[i + offset];
 
-              if (is_present)
-                {
-                  // Note: we don't actually call exII::ex_get_sset_var() here because
-                  // we don't need the values. We only need the indices into that vector
-                  // for each (elem, side, boundary_id) tuple.
-                  for (int i=0; i<num_sides_per_set[ss]; ++i)
-                    {
-                      dof_id_type exodus_elem_id = elem_list[i + offset];
-                      unsigned int exodus_side_id = side_list[i + offset];
+          // FIXME: We should use exodus_elem_num_to_libmesh for this,
+          // but it apparently is never set up, so just
+          // subtract 1 from the Exodus elem id.
+          dof_id_type converted_elem_id = exodus_elem_id - 1;
 
-                      // FIXME: We should use exodus_elem_num_to_libmesh for this,
-                      // but it apparently is never set up, so just
-                      // subtract 1 from the Exodus elem id.
-                      dof_id_type converted_elem_id = exodus_elem_id - 1;
+          // Conversion operator for this Elem type
+          const auto & conv = get_conversion(mesh.elem_ptr(converted_elem_id)->type());
 
-                      // Map Exodus side id to libmesh side id.
-                      // Map from Exodus side ids to libmesh side ids.
-                      const auto & conv = get_conversion(mesh.elem_ptr(converted_elem_id)->type());
+          // Map from Exodus side id to libmesh side id.
+          // Note: the mapping is defined on 0-based indices, so subtract
+          // 1 before doing the mapping.
+          unsigned int converted_side_id = conv.get_side_map(exodus_side_id - 1);
 
-                      // Map from Exodus side id to libmesh side id.
-                      // Note: the mapping is defined on 0-based indices, so subtract
-                      // 1 before doing the mapping.
-                      unsigned int converted_side_id = conv.get_side_map(exodus_side_id - 1);
+          // Make a BCTuple key from the converted information.
+          BoundaryInfo::BCTuple key = std::make_tuple
+            (converted_elem_id,
+             converted_side_id,
+             ss_ids[ss]);
 
-                      // Make a BCTuple key from the converted information.
-                      BoundaryInfo::BCTuple key = std::make_tuple
-                        (converted_elem_id,
-                         converted_side_id,
-                         ss_ids[ss]);
-
-                      // Store (elem, side, b_id) tuple with corresponding array index
-                      bc_array_indices.emplace(key, cast_int<unsigned int>(i));
-                    } // end for (i)
-
-                  // We only need to get the indices once per sideset
-                  // (not once per variable defined on this sideset)
-                  // so we can break out of this var loop as soon as
-                  // any variable is_present.
-                  break; // out of var loop
-                } // end if (present)
-            } // end for (var)
-        } // end for (ss)
-    } // end if (num_sideset_vars)
+          // Store (elem, side, b_id) tuple with corresponding array index
+          bc_array_indices.emplace(key, cast_int<unsigned int>(i));
+        } // end for (i)
+    } // end for (ss)
 }
 
 

--- a/tests/mesh/write_sideset_data.C
+++ b/tests/mesh/write_sideset_data.C
@@ -59,61 +59,61 @@ public:
     std::vector<std::map<BoundaryInfo::BCTuple, Real>> bc_vals;
 
     if (write_vars)
-    {
-    // Get list of all (elem, side, id) tuples
-    std::vector<BoundaryInfo::BCTuple> all_bc_tuples =
-      mesh.get_boundary_info().build_side_list();
-
-    // Data structures to be passed to ExodusII_IO::write_sideset_data
-    var_names = {"var1", "var2", "var3"};
-    side_ids =
       {
-        {0, 2}, // var1 is defined on sidesets 0 and 2
-        {1, 3}, // var2 is defined on sidesets 1 and 3
-        {4}     // var3 is only defined on the empty sideset 4
-      };
+        // Get list of all (elem, side, id) tuples
+        std::vector<BoundaryInfo::BCTuple> all_bc_tuples =
+          mesh.get_boundary_info().build_side_list();
 
-    // Data structure mapping (elem, side, id) tuples to Real values that
-    // will be passed to Exodus.
-    bc_vals.resize(var_names.size());
-
-    // For each var_names[i], construct bc_vals[i]
-    for (unsigned int i=0; i<var_names.size(); ++i)
-      {
-        // const auto & var_name = var_names[i];
-        auto & vals = bc_vals[i];
-
-        for (const auto & t : all_bc_tuples)
+        // Data structures to be passed to ExodusII_IO::write_sideset_data
+        var_names = {"var1", "var2", "var3"};
+        side_ids =
           {
-            // dof_id_type elem_id = std::get<0>(t);
-            // unsigned int side_id = std::get<1>(t);
-            boundary_id_type b_id = std::get<2>(t);
+            {0, 2}, // var1 is defined on sidesets 0 and 2
+            {1, 3}, // var2 is defined on sidesets 1 and 3
+            {4}     // var3 is only defined on the empty sideset 4
+          };
 
-            if (side_ids[i].count(b_id))
+        // Data structure mapping (elem, side, id) tuples to Real values that
+        // will be passed to Exodus.
+        bc_vals.resize(var_names.size());
+
+        // For each var_names[i], construct bc_vals[i]
+        for (unsigned int i=0; i<var_names.size(); ++i)
+          {
+            // const auto & var_name = var_names[i];
+            auto & vals = bc_vals[i];
+
+            for (const auto & t : all_bc_tuples)
               {
-                // Compute a value. This could in theory depend on
-                // var_name, elem_id, side_id, and/or b_id.
-                Real val = static_cast<Real>(b_id);
+                // dof_id_type elem_id = std::get<0>(t);
+                // unsigned int side_id = std::get<1>(t);
+                boundary_id_type b_id = std::get<2>(t);
 
-                // Insert into the vals map.
-                vals.emplace(t, val);
+                if (side_ids[i].count(b_id))
+                  {
+                    // Compute a value. This could in theory depend on
+                    // var_name, elem_id, side_id, and/or b_id.
+                    Real val = static_cast<Real>(b_id);
+
+                    // Insert into the vals map.
+                    vals.emplace(t, val);
+                  }
               }
-          }
 
-        // If we have a distributed mesh, write_sideset_data wants our
-        // ghost data too; we'll just serialize everything here.
-        if (!mesh.is_serial())
-          TestCommWorld->set_union(vals);
+            // If we have a distributed mesh, write_sideset_data wants our
+            // ghost data too; we'll just serialize everything here.
+            if (!mesh.is_serial())
+              TestCommWorld->set_union(vals);
 
-      } // done constructing bc_vals
+          } // done constructing bc_vals
 
-    // We write the file in the ExodusII format.
-    {
-      IOClass writer(mesh);
-      writer.write(filename);
-      writer.write_sideset_data (/*timestep=*/1, var_names, side_ids, bc_vals);
-    }
-    } // if (write_vars)
+        // We write the file in the ExodusII format.
+        {
+          IOClass writer(mesh);
+          writer.write(filename);
+          writer.write_sideset_data (/*timestep=*/1, var_names, side_ids, bc_vals);
+        }
+      } // if (write_vars)
 
     // Make sure that the writing is done before the reading starts.
     TestCommWorld->barrier();
@@ -124,18 +124,18 @@ public:
     reader.read(filename);
 
     if (write_vars)
-    {
-    std::vector<std::string> read_in_var_names;
-    std::vector<std::set<boundary_id_type>> read_in_side_ids;
-    std::vector<std::map<BoundaryInfo::BCTuple, Real>> read_in_bc_vals;
-    reader.read_sideset_data
-      (/*timestep=*/1, read_in_var_names, read_in_side_ids, read_in_bc_vals);
+      {
+        std::vector<std::string> read_in_var_names;
+        std::vector<std::set<boundary_id_type>> read_in_side_ids;
+        std::vector<std::map<BoundaryInfo::BCTuple, Real>> read_in_bc_vals;
+        reader.read_sideset_data
+          (/*timestep=*/1, read_in_var_names, read_in_side_ids, read_in_bc_vals);
 
-    // Assert that we got back out what we put in.
-    CPPUNIT_ASSERT(read_in_var_names == var_names);
-    CPPUNIT_ASSERT(read_in_side_ids == side_ids);
-    CPPUNIT_ASSERT(read_in_bc_vals == bc_vals);
-    } // if (write_vars)
+        // Assert that we got back out what we put in.
+        CPPUNIT_ASSERT(read_in_var_names == var_names);
+        CPPUNIT_ASSERT(read_in_side_ids == side_ids);
+        CPPUNIT_ASSERT(read_in_bc_vals == bc_vals);
+      } // if (write_vars)
 
     // Also check that the flat indices match those in the file
     std::map<BoundaryInfo::BCTuple, unsigned int> bc_array_indices;


### PR DESCRIPTION
Previously we only read the sideset data indices when there were sideset variables present, but I need to update this behavior so that sideset indices are read regardless of whether or not there are sideset variables present. So it does basically the same thing as before, but might read a bit more information now in some cases. This is a slight modification of a relatively new function, so I doubt it affects any existing code. I also added a unit test which reuses the code for an existing unit test for simplicity.