### PR TITLE
Remove long-deprecated overload MeshTools::find_boundary_nodes()

### DIFF
--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -124,15 +124,6 @@ void build_nodes_to_elem_map (const MeshBase & mesh,
 //    */
 //   void all_tri (MeshBase & mesh);
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-/**
- * Fills the vector "on_boundary" with flags that tell whether each node
- * is on the domain boundary (true)) or not (false).
- */
-void find_boundary_nodes (const MeshBase & mesh,
-                          std::vector<bool> & on_boundary);
-#endif
-
 /**
  * Returns a std::set containing Node IDs for all of the boundary nodes
  */

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -348,32 +348,6 @@ void MeshTools::build_nodes_to_elem_map (const MeshBase & mesh,
 
 
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-void MeshTools::find_boundary_nodes (const MeshBase & mesh,
-                                     std::vector<bool> & on_boundary)
-{
-  libmesh_deprecated();
-
-  // Resize the vector which holds boundary nodes and fill with false.
-  on_boundary.resize(mesh.max_node_id());
-  std::fill(on_boundary.begin(),
-            on_boundary.end(),
-            false);
-
-  // Loop over elements, find those on boundary, and
-  // mark them as true in on_boundary.
-  for (const auto & elem : mesh.active_element_ptr_range())
-    for (auto s : elem->side_index_range())
-      if (elem->neighbor_ptr(s) == nullptr) // on the boundary
-        {
-          const auto nodes_on_side = elem->nodes_on_side(s);
-
-          for (auto & node_id : nodes_on_side)
-            on_boundary[node_id] = true;
-        }
-}
-#endif
-
 std::unordered_set<dof_id_type>
 MeshTools::find_boundary_nodes(const MeshBase & mesh)
 {


### PR DESCRIPTION
The deprecated version built a vector<bool> which was n_nodes() in
length. This does not scale well, so it was deprecated a while ago in
favor of a version that returns a std::unordered_set.