### PR TITLE
Deprecate non-std:: is_sorted, iota

### DIFF
--- a/include/base/sparsity_pattern.h
+++ b/include/base/sparsity_pattern.h
@@ -25,8 +25,9 @@
 #include "libmesh/parallel_object.h"
 
 // C++ includes
-#include <vector>
+#include <algorithm> // is_sorted
 #include <unordered_set>
+#include <vector>
 
 namespace libMesh
 {
@@ -283,18 +284,7 @@ void SparsityPattern::sort_row (const BidirectionalIterator begin,
 
   // Assure the algorithm worked if we are in DEBUG mode
 #ifdef DEBUG
-  {
-    // SGI STL extension!
-    // libmesh_assert (std::is_sorted(begin,end));
-
-    BidirectionalIterator
-      prev  = begin,
-      first = begin;
-
-    for (++first; first != end; prev=first, ++first)
-      if (*first < *prev)
-        libmesh_assert(false);
-  }
+  libmesh_assert (std::is_sorted(begin,end));
 #endif
 
   // Make sure the two ranges did not contain any common elements

--- a/include/parallel/parallel_conversion_utils.h
+++ b/include/parallel/parallel_conversion_utils.h
@@ -43,23 +43,18 @@ namespace Utils {
 /**
  * \returns \p true if the vector \p v is sorted, \p false otherwise.
  *
- * Requires O(N) comparisons, where N is the length of the vector.
  * This was implemented because std::is_sorted() was an STL extension
  * at the time.
  */
+#ifdef LIBMESH_ENABLE_DEPRECATED
 template <typename KeyType>
 inline
 bool is_sorted (const std::vector<KeyType> & v)
 {
-  if (v.empty())
-    return true;
-
-  for (auto i : IntRange<std::size_t>(1, v.size()))
-    if (v[i] < v[i-1])
-      return false;
-
-  return true;
+  libmesh_deprecated();
+  return std::is_sorted(v.begin(), v.end());
 }
+#endif // LIBMESH_ENABLE_DEPRECATED
 
 /**
  * A utility function which converts whatever \p KeyType is to

--- a/include/utils/utility.h
+++ b/include/utils/utility.h
@@ -25,7 +25,7 @@
 // System includes
 #include <string>
 #include <vector>
-#include <algorithm> // for std::lower_bound
+#include <algorithm> // is_sorted, lower_bound
 
 namespace libMesh
 {
@@ -194,12 +194,11 @@ vector_at(const Vector & vec,
   return vec[i];
 }
 
+
+#ifdef LIBMESH_ENABLE_DEPRECATED
 /**
- * \p Utility::iota is a duplication of the SGI STL extension
- * \p std::iota.  It simply assigns sequentially increasing values
- * to a range. That is, it assigns \p value to \p *first, \p value + 1
- * to \p *(first + 1) and so on. In general, each iterator \p i in the
- * range [first, last) is assigned \p value + (i - \p first).
+ * Utility::iota was created back when std::iota was just an
+ * SGI STL extension.
  */
 template <typename ForwardIter, typename T>
 void iota (ForwardIter first, ForwardIter last, T value)
@@ -216,58 +215,16 @@ void iota (ForwardIter first, ForwardIter last, T value)
 
 
 /**
- * Utility::is_sorted mimics the behavior of the SGI STL extension
- * std::is_sorted.  Checks to see if the range [first,last) is
- * sorted in non-decreasing order, ie. for each "i" in
- * [first,last) *i <= *(i+1).
+ * Utility::is_sorted was created back when std::is_sorted was just an
+ * SGI STL extension.
  */
 template<class InputIterator >
 bool is_sorted(InputIterator first, InputIterator last)
 {
-  if (first == last)
-    return true;
-
-  // "prev" always points to the entry just to the left of "first"
-  //  [-    -    -    -    -    -]
-  //   ^    ^
-  // prev first
-  //
-  //  [-    -    -    -    -    -]
-  //        ^    ^
-  //      prev first
-  //
-  //  [-    -    -    -    -    -]
-  //             ^    ^
-  //           prev first
-  InputIterator prev( first );
-  for (++first; first != last; ++prev, ++first)
-    if (*first < *prev)    // Note: this is the same as *prev > *first,
-      return false;        // but we only require op< to be defined.
-
-  // If we haven't returned yet, it's sorted!
-  return true;
-
-
-  // A one-liner version using adjacent_find.  This doesn't work for
-  // C-style arrays, since their pointers do not have a value_type.
-  //
-  // Works by checking to see if adjacent entries satisfy *i >
-  // *(i+1) and returns the first one which does.  If "last" is
-  // returned, no such pair was found, and therefore the range must
-  // be in non-decreasing order.
-  //
-  // return (last ==
-  // std::adjacent_find(first, last,
-  // std::greater<typename InputIterator::value_type >()));
-
-  // A second one-linear attempt.  This one checks for a **strictly
-  // increasing** (no duplicate entries) range.  Also doesn't work
-  // with C-style arrays.
-  //
-  // return (last ==
-  // std::adjacent_find(first, last,
-  // std::not2(std::less<typename InputIterator::value_type>())));
+  libmesh_deprecated();
+  return std::is_sorted(first, last);
 }
+#endif // LIBMESH_ENABLE_DEPRECATED
 
 
 /**

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -26,7 +26,7 @@
 #include "libmesh/nemesis_io_helper.h"
 #include "libmesh/node.h"
 #include "libmesh/parallel.h"
-#include "libmesh/utility.h" // is_sorted, deallocate
+#include "libmesh/utility.h" // deallocate
 #include "libmesh/boundary_info.h"
 #include "libmesh/mesh_communication.h"
 #include "libmesh/fe_type.h"

--- a/src/parallel/parallel_bin_sorter.C
+++ b/src/parallel/parallel_bin_sorter.C
@@ -17,7 +17,7 @@
 
 
 // C++ includes
-#include <algorithm>  // std::lower_bound
+#include <algorithm>  // is_sorted, lower_bound
 
 // Local includes
 #include "libmesh/libmesh_common.h"
@@ -40,13 +40,7 @@ BinSorter<KeyType,IdxType>::BinSorter (const Parallel::Communicator & comm_in,
   ParallelObject(comm_in),
   data(d)
 {
-  // Assume (& libmesh_assert) we are working with a sorted range
-
-  // Ah...  is_sorted is an STL extension!
-  //libmesh_assert (std::is_sorted (data.begin(), data.end()));
-
-  // Home-grown is_sorted
-  libmesh_assert (Parallel::Utils::is_sorted (data));
+  libmesh_assert (std::is_sorted (data.begin(), data.end()));
 }
 
 

--- a/src/parallel/parallel_histogram.C
+++ b/src/parallel/parallel_histogram.C
@@ -17,7 +17,7 @@
 
 
 // C++ includes
-#include <algorithm>  // std::lower_bound
+#include <algorithm>  // is_sorted, lower_bound
 
 // Local includes
 #include "libmesh/parallel_histogram.h"
@@ -37,7 +37,7 @@ Histogram<KeyType,IdxType>::Histogram (const Parallel::Communicator & comm_in,
   ParallelObject(comm_in),
   data(d)
 {
-  libmesh_assert (Parallel::Utils::is_sorted (data));
+  libmesh_assert (std::is_sorted (data.begin(), data.end()));
 }
 
 


### PR DESCRIPTION
Those have been available since C++11, they're not just SGI extensions
anymore.