### PR TITLE
Modern C++ parameter passing

### DIFF
--- a/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
+++ b/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
@@ -271,11 +271,9 @@ int main(int argc, char ** argv)
   system.attach_assemble_function (assemble_laplace);
 
   // Add Dirichlet boundary conditions
-  std::set<boundary_id_type> all_bdys { 0 };
-
   WrappedFunction<Number> exact_val(system, exact_solution);
   WrappedFunction<Gradient> exact_grad(system, exact_derivative);
-  DirichletBoundary exact_bc(all_bdys, all_vars, exact_val, exact_grad);
+  DirichletBoundary exact_bc({0} , all_vars, exact_val, exact_grad);
   system.get_dof_map().add_dirichlet_boundary(exact_bc);
 
   // Initialize the data structures for the equation system.

--- a/examples/adjoints/adjoints_ex1/adjoints_ex1.C
+++ b/examples/adjoints/adjoints_ex1/adjoints_ex1.C
@@ -214,7 +214,7 @@ void set_system_parameters(LaplaceSystem & system,
 #ifdef LIBMESH_ENABLE_AMR
 
 std::unique_ptr<MeshRefinement> build_mesh_refinement(MeshBase & mesh,
-                                                      FEMParameters & param)
+                                                      const FEMParameters & param)
 {
   MeshRefinement * mesh_refinement = new MeshRefinement(mesh);
   mesh_refinement->coarsen_by_parents() = true;
@@ -236,8 +236,8 @@ std::unique_ptr<MeshRefinement> build_mesh_refinement(MeshBase & mesh,
 // forward and adjoint weights. The H1 seminorm component of the error is used
 // as dictated by the weak form the Laplace equation.
 
-std::unique_ptr<ErrorEstimator> build_error_estimator(FEMParameters & param,
-                                                      QoISet & qois)
+std::unique_ptr<ErrorEstimator> build_error_estimator(const FEMParameters & param,
+                                                      const QoISet & qois)
 {
   if (param.indicator_type == "kelly")
     {

--- a/examples/adjoints/adjoints_ex1/adjoints_ex1.C
+++ b/examples/adjoints/adjoints_ex1/adjoints_ex1.C
@@ -417,11 +417,8 @@ int main (int argc, char ** argv)
         // Declare a QoISet object, we need this object to set weights for our QoI error contributions
         QoISet qois;
 
-        // Declare a qoi_indices vector, each index will correspond to a QoI
-        std::vector<unsigned int> qoi_indices;
-        qoi_indices.push_back(0);
-        qoi_indices.push_back(1);
-        qois.add_indices(qoi_indices);
+        // Each index will correspond to a QoI
+        qois.add_indices({0,1});
 
         // Set weights for each index, these will weight the contribution of each QoI in the final error
         // estimate to be used for flagging elements for refinement

--- a/examples/adjoints/adjoints_ex2/adjoints_ex2.C
+++ b/examples/adjoints/adjoints_ex2/adjoints_ex2.C
@@ -335,9 +335,7 @@ int main (int argc, char ** argv)
 
   QoISet qois;
 
-  std::vector<unsigned int> qoi_indices;
-  qoi_indices.push_back(0);
-  qois.add_indices(qoi_indices);
+  qois.add_indices({0});
 
   qois.set_weight(0, 0.5);
 

--- a/examples/adjoints/adjoints_ex3/coupled_system.C
+++ b/examples/adjoints/adjoints_ex3/coupled_system.C
@@ -122,8 +122,6 @@ void CoupledSystem::init_data ()
 
   // Set Dirichlet boundary conditions
   const boundary_id_type left_inlet_id = 0;
-  std::set<boundary_id_type> left_inlet_bdy;
-  left_inlet_bdy.insert(left_inlet_id);
 
   const boundary_id_type right_inlet_id = 1;
   std::set<boundary_id_type> right_inlet_bdy;
@@ -134,14 +132,6 @@ void CoupledSystem::init_data ()
   outlets_bdy.insert(outlets_id);
 
   const boundary_id_type wall_id = 3;
-  std::set<boundary_id_type> wall_bdy;
-  wall_bdy.insert(wall_id);
-
-  // The uv identifier for the setting the inlet and wall velocity boundary conditions
-  std::vector<unsigned int> uv(1, u_var);
-  uv.push_back(v_var);
-  // The C_only identifier for setting the concentrations at the inlets
-  std::vector<unsigned int> C_only(1, C_var);
 
   // The zero and constant functions
   ZeroFunction<Number> zero;
@@ -156,21 +146,21 @@ void CoupledSystem::init_data ()
 #ifdef LIBMESH_ENABLE_DIRICHLET
   // On the walls we will apply the no slip and no penetration boundary condition, u=0, v=0
   this->get_dof_map().add_dirichlet_boundary
-    (DirichletBoundary (wall_bdy, uv, &zero));
+    (DirichletBoundary ({wall_id}, {u_var,v_var}, &zero));
 
   // On the inlet (left), we apply parabolic inflow boundary conditions for the velocity, u = - (y-2)*(y-3), v=0
   // and set C = 1
   this->get_dof_map().add_dirichlet_boundary
-    (DirichletBoundary (left_inlet_bdy, uv, &inflow_left));
+    (DirichletBoundary ({left_inlet_id}, {u_var,v_var}, &inflow_left));
   this->get_dof_map().add_dirichlet_boundary
-    (DirichletBoundary (left_inlet_bdy, C_only, &one));
+    (DirichletBoundary ({left_inlet_id}, {C_var}, &one));
 
   // On the inlet (right), we apply parabolic inflow boundary conditions for the velocity, u = (y-2)*(y-3), v=0
   // and set C = 0
   this->get_dof_map().add_dirichlet_boundary
-    (DirichletBoundary (right_inlet_bdy, uv, &inflow_right));
+    (DirichletBoundary (right_inlet_bdy, {u_var,v_var}, &inflow_right));
   this->get_dof_map().add_dirichlet_boundary
-    (DirichletBoundary (right_inlet_bdy, C_only, &zero));
+    (DirichletBoundary (right_inlet_bdy, {C_var}, &zero));
 #endif // LIBMESH_ENABLE_DIRICHLET
 
   // Note that the remaining boundary conditions are the natural boundary conditions for the concentration

--- a/examples/adjoints/adjoints_ex4/adjoints_ex4.C
+++ b/examples/adjoints/adjoints_ex4/adjoints_ex4.C
@@ -347,10 +347,7 @@ int main (int argc, char** argv)
         QoISet qois;
 
         // Declare a qoi_indices vector, each index will correspond to a QoI
-        std::vector<unsigned int> qoi_indices;
-        qoi_indices.push_back(0);
-        qoi_indices.push_back(1);
-        qois.add_indices(qoi_indices);
+        qois.add_indices({0,1});
 
         // Set weights for each index, these will weight the contribution of each QoI in the final error
         // estimate to be used for flagging elements for refinement
@@ -514,11 +511,7 @@ int main (int argc, char** argv)
         NumericVector<Number> & primal_solution = *system.solution;
 
         QoISet qois;
-        std::vector<unsigned int> qoi_indices;
-
-        qoi_indices.push_back(0);
-        qoi_indices.push_back(1);
-        qois.add_indices(qoi_indices);
+        qois.add_indices({0,1});
 
         qois.set_weight(0, 0.5);
         qois.set_weight(1, 0.5);

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -633,9 +633,7 @@ int main (int argc, char ** argv)
       // Prepare the quantities we need to pass to TimeSolver::integrate_adjoint_sensitivity
       QoISet qois;
 
-      std::vector<unsigned int> qoi_indices;
-      qoi_indices.push_back(0);
-      qois.add_indices(qoi_indices);
+      qois.add_indices({0});
       qois.set_weight(0, 1.0);
 
       // A SensitivityData object

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -292,9 +292,8 @@ void set_system_parameters(HeatSystem &system, FEMParameters &param)
     {
       boundary_id_type b = i->first;
       FunctionBase<Number> *f = i->second;
-      std::set<boundary_id_type> bdys; bdys.insert(b);
 
-      system.get_dof_map().add_dirichlet_boundary(DirichletBoundary(bdys,
+      system.get_dof_map().add_dirichlet_boundary(DirichletBoundary({b},
                                                                     param.dirichlet_condition_variables[b],
                                                                     f));
 

--- a/examples/adjoints/adjoints_ex5/heatsystem.C
+++ b/examples/adjoints/adjoints_ex5/heatsystem.C
@@ -56,18 +56,13 @@ void HeatSystem::init_data ()
   // The temperature is evolving, with a first order time derivative
   this->time_evolving(T_var, 1);
 
-  const boundary_id_type all_ids[4] = {0, 1, 2, 3};
-  std::set<boundary_id_type> all_bdys(all_ids, all_ids+(2*2));
-
-  std::vector<unsigned int> T_only(1, T_var);
-
   ZeroFunction<Number> zero;
 
 #ifdef LIBMESH_ENABLE_DIRICHLET
   // Most DirichletBoundary users will want to supply a "locally
   // indexed" functor
   this->get_dof_map().add_dirichlet_boundary
-    (DirichletBoundary (all_bdys, T_only, zero,
+    (DirichletBoundary ({0,1,2,3}, {T_var}, zero,
                         LOCAL_VARIABLE_ORDER));
 #endif
 

--- a/examples/adjoints/adjoints_ex6/adjoints_ex6.C
+++ b/examples/adjoints/adjoints_ex6/adjoints_ex6.C
@@ -319,10 +319,8 @@ int main (int argc, char ** argv)
         // Declare a QoISet object, we need this object to set weights for our QoI error contributions
         QoISet qois;
 
-        // Declare a qoi_indices vector, each index will correspond to a QoI
-        std::vector<unsigned int> qoi_indices;
-        qoi_indices.push_back(0);
-        qois.add_indices(qoi_indices);
+        // Each index will correspond to a QoI
+        qois.add_indices({0});
 
         // Set weights for each index, these will weight the contribution of each QoI in the final error
         // estimate to be used for flagging elements for refinement

--- a/examples/adjoints/adjoints_ex6/poisson.C
+++ b/examples/adjoints/adjoints_ex6/poisson.C
@@ -71,26 +71,17 @@ void PoissonSystem::init_data ()
 #ifdef LIBMESH_ENABLE_DIRICHLET
   // Now we will set the Dirichlet boundary conditions
 
-  // Get boundary ids for all the boundaries
-  const boundary_id_type all_bdry_id[4] = {0, 1, 2, 3};
-  std::set<boundary_id_type> all_bdy(all_bdry_id, all_bdry_id+4);
-
   // For the adjoint problem, we will only set the bottom boundary to a non-zero value
   const boundary_id_type bottom_bdry_id = 0;
-  std::set<boundary_id_type> bottom_bdry;
-  bottom_bdry.insert(bottom_bdry_id);
-
-  // The T_only identifier for setting the boundary conditions for T
-  std::vector<unsigned int> T_only(1, T_var);
 
   // The zero function pointer for the primal all bdry bcs
   ZeroFunction<Number> zero;
   // Boundary function for bottom bdry adjoint condition
   BdyFunction bottom_adjoint(T_var);
 
-  this->get_dof_map().add_dirichlet_boundary(DirichletBoundary (all_bdy, T_only, &zero));
+  this->get_dof_map().add_dirichlet_boundary(DirichletBoundary ({0,1,2,3}, {T_var}, &zero));
 
-  this->get_dof_map().add_adjoint_dirichlet_boundary(DirichletBoundary (bottom_bdry, T_only, &bottom_adjoint), 0);
+  this->get_dof_map().add_adjoint_dirichlet_boundary(DirichletBoundary ({bottom_bdry_id}, {T_var}, &bottom_adjoint), 0);
 #endif // LIBMESH_ENABLE_DIRICHLET
 
   // Do the parent's initialization after variables are defined

--- a/examples/adjoints/adjoints_ex7/adjoints_ex7.C
+++ b/examples/adjoints/adjoints_ex7/adjoints_ex7.C
@@ -253,9 +253,8 @@ void set_system_parameters(HeatSystem &system, FEMParameters &param)
     {
       boundary_id_type b = i->first;
       FunctionBase<Number> *f = i->second;
-      std::set<boundary_id_type> bdys; bdys.insert(b);
 
-      system.get_dof_map().add_dirichlet_boundary(DirichletBoundary(bdys,
+      system.get_dof_map().add_dirichlet_boundary(DirichletBoundary({b},
                                                                     param.dirichlet_condition_variables[b],
                                                                     f));
 

--- a/examples/adjoints/adjoints_ex7/adjoints_ex7.C
+++ b/examples/adjoints/adjoints_ex7/adjoints_ex7.C
@@ -707,10 +707,7 @@ int main (int argc, char ** argv)
       // the Backward-Euler (theta = 0.5) time integration method.
       QoISet qois;
 
-      std::vector<unsigned int> qoi_indices;
-      qoi_indices.push_back(0);
-      qoi_indices.push_back(1);
-      qois.add_indices(qoi_indices);
+      qois.add_indices({0,1});
       qois.set_weight(0, 0.5);
       qois.set_weight(1, 0.5);
 

--- a/examples/adjoints/adjoints_ex7/heatsystem.C
+++ b/examples/adjoints/adjoints_ex7/heatsystem.C
@@ -50,11 +50,6 @@ void HeatSystem::init_data ()
   // The temperature is evolving, with a first order time derivative
   this->time_evolving(0, 1);
 
-  const boundary_id_type all_ids[4] = {0, 1, 2, 3};
-  std::set<boundary_id_type> all_bdys(all_ids, all_ids+(4));
-
-  std::vector<unsigned int> T_only(1, 0);
-
   ZeroFunction<Number> zero;
 
   ConstFunction<Number> one(1.0);
@@ -63,12 +58,12 @@ void HeatSystem::init_data ()
   // Most DirichletBoundary users will want to supply a "locally
   // indexed" functor
   this->get_dof_map().add_dirichlet_boundary
-    (DirichletBoundary (all_bdys, T_only, one,
+    (DirichletBoundary ({0,1,2,3}, { /* T_var = */ 0 }, one,
                         LOCAL_VARIABLE_ORDER));
 #endif
 
-  this->get_dof_map().add_adjoint_dirichlet_boundary(DirichletBoundary (all_bdys, T_only, &zero), 0);
-  this->get_dof_map().add_adjoint_dirichlet_boundary(DirichletBoundary (all_bdys, T_only, &zero), 1);
+  this->get_dof_map().add_adjoint_dirichlet_boundary(DirichletBoundary ({0,1,2,3}, {0}, &zero), 0);
+  this->get_dof_map().add_adjoint_dirichlet_boundary(DirichletBoundary ({0,1,2,3}, {0}, &zero), 1);
 
   FEMSystem::init_data();
 }

--- a/examples/adjoints/adjoints_ex7/sigma_physics.C
+++ b/examples/adjoints/adjoints_ex7/sigma_physics.C
@@ -47,21 +47,16 @@ void SigmaPhysics::init_data (System & sys)
   // The temperature is evolving, with a first order time derivative
   this->time_evolving(T_var, 1);
 
-  const boundary_id_type all_ids[4] = {0, 1, 2, 3};
-  std::set<boundary_id_type> all_bdys(all_ids, all_ids+(4));
-
-  std::vector<unsigned int> T_only(1, T_var);
-
   ZeroFunction<Number> zero;
 
   ConstFunction<Number> one(1.0);
 
   // Dirichlet boundary conditions for the primal.
-  sys.get_dof_map().add_dirichlet_boundary(DirichletBoundary (all_bdys, T_only, &one));
+  sys.get_dof_map().add_dirichlet_boundary(DirichletBoundary ({0,1,2,3}, {T_var}, &one));
 
   // Set adjoint boundary conditions.
-  sys.get_dof_map().add_adjoint_dirichlet_boundary(DirichletBoundary (all_bdys, T_only, &zero), 0);
-  sys.get_dof_map().add_adjoint_dirichlet_boundary(DirichletBoundary (all_bdys, T_only, &zero), 1);
+  sys.get_dof_map().add_adjoint_dirichlet_boundary(DirichletBoundary ({0,1,2,3}, {T_var}, &zero), 0);
+  sys.get_dof_map().add_adjoint_dirichlet_boundary(DirichletBoundary ({0,1,2,3}, {T_var}, &zero), 1);
 
 }
 

--- a/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
+++ b/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
@@ -211,18 +211,12 @@ int main (int argc, char ** argv)
   eigen_system.get_eigen_solver().set_position_of_spectrum(0., TARGET_REAL);
 
   {
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(BOUNDARY_ID);
-
-    std::vector<unsigned int> variables;
-    variables.push_back(0);
-
     ZeroFunction<> zf;
 
 #ifdef LIBMESH_ENABLE_DIRICHLET
     // Most DirichletBoundary users will want to supply a "locally
     // indexed" functor
-    DirichletBoundary dirichlet_bc(boundary_ids, variables, zf,
+    DirichletBoundary dirichlet_bc({BOUNDARY_ID}, {0}, zf,
                                    LOCAL_VARIABLE_ORDER);
 
     eigen_system.get_dof_map().add_dirichlet_boundary(dirichlet_bc);

--- a/examples/fem_system/fem_system_ex1/naviersystem.C
+++ b/examples/fem_system/fem_system_ex1/naviersystem.C
@@ -132,8 +132,7 @@ void NavierSystem::init_data ()
 #ifdef LIBMESH_ENABLE_DIRICHLET
   const boundary_id_type top_id = (dim==3) ? 5 : 2;
 
-  std::set<boundary_id_type> top_bdys;
-  top_bdys.insert(top_id);
+  std::set<boundary_id_type> top_bdys { top_id };
 
   const boundary_id_type all_ids[6] = {0, 1, 2, 3, 4, 5};
   std::set<boundary_id_type> all_bdys(all_ids, all_ids+(dim*2));
@@ -141,14 +140,7 @@ void NavierSystem::init_data ()
   std::set<boundary_id_type> nontop_bdys = all_bdys;
   nontop_bdys.erase(top_id);
 
-  std::vector<unsigned int> u_only(1, u_var);
-  std::vector<unsigned int> vw(1, v_var), uvw(1, u_var);
-  uvw.push_back(v_var);
-  if (dim == 3)
-    {
-      vw.push_back(w_var);
-      uvw.push_back(w_var);
-    }
+  std::vector<unsigned int> uvw {u_var, v_var, w_var};
 
   ZeroFunction<Number> zero;
   ConstFunction<Number> one(1);
@@ -156,9 +148,9 @@ void NavierSystem::init_data ()
   if (application == 0)
     {
       this->get_dof_map().add_dirichlet_boundary
-        (DirichletBoundary (top_bdys, u_only, &one));
+        (DirichletBoundary (top_bdys, {u_var}, &one));
       this->get_dof_map().add_dirichlet_boundary
-        (DirichletBoundary (top_bdys, vw, &zero));
+        (DirichletBoundary (top_bdys, {v_var,w_var}, &zero));
       this->get_dof_map().add_dirichlet_boundary
         (DirichletBoundary (nontop_bdys, uvw, &zero));
     }

--- a/examples/fem_system/fem_system_ex3/elasticity_system.C
+++ b/examples/fem_system/fem_system_ex3/elasticity_system.C
@@ -78,10 +78,7 @@ void ElasticitySystem::init_data()
   if (all_boundary_ids.count(fixed_v_boundary_id))
     dirichlet_v_boundary_ids.insert(fixed_v_boundary_id);
 
-  std::vector<unsigned int> variables, u_variable, v_variable;
-  u_variable.push_back(_u_var);
-  v_variable.push_back(_v_var);
-  variables.push_back(_u_var);
+  std::vector<unsigned int> variables {_u_var};
   if (_dim > 1)
     variables.push_back(_v_var);
   if (_dim > 2)
@@ -98,7 +95,7 @@ void ElasticitySystem::init_data()
   if (!dirichlet_u_boundary_ids.empty())
     {
       DirichletBoundary dirichlet_u_bc(dirichlet_u_boundary_ids,
-                                       u_variable, zf,
+                                       {_u_var}, zf,
                                        LOCAL_VARIABLE_ORDER);
       this->get_dof_map().add_dirichlet_boundary(dirichlet_u_bc);
     }
@@ -106,7 +103,7 @@ void ElasticitySystem::init_data()
   if (!dirichlet_v_boundary_ids.empty())
     {
       DirichletBoundary dirichlet_v_bc(dirichlet_v_boundary_ids,
-                                       v_variable, zf,
+                                       {_v_var}, zf,
                                        LOCAL_VARIABLE_ORDER);
       this->get_dof_map().add_dirichlet_boundary(dirichlet_v_bc);
     }

--- a/examples/fem_system/fem_system_ex4/heatsystem.C
+++ b/examples/fem_system/fem_system_ex4/heatsystem.C
@@ -28,13 +28,12 @@ void HeatSystem::init_data ()
   const boundary_id_type yplus_id = (dim == 3) ? 3 : 2;
   nonyplus_bdys.erase(yplus_id);
 
-  std::vector<unsigned int> T_only(1, T_var);
   ZeroFunction<Number> zero;
 
   // Most DirichletBoundary users will want to supply a "locally
   // indexed" functor
   this->get_dof_map().add_dirichlet_boundary
-    (DirichletBoundary (nonyplus_bdys, T_only, zero, LOCAL_VARIABLE_ORDER));
+    (DirichletBoundary (nonyplus_bdys, {T_var}, zero, LOCAL_VARIABLE_ORDER));
 #endif // LIBMESH_ENABLE_DIRICHLET
 
   // Do the parent's initialization after variables are defined

--- a/examples/introduction/introduction_ex4/introduction_ex4.C
+++ b/examples/introduction/introduction_ex4/introduction_ex4.C
@@ -263,10 +263,6 @@ int main (int argc, char ** argv)
       boundary_ids.insert(5);
     }
 
-  // Create a vector storing the variable numbers which the BC applies to
-  std::vector<unsigned int> variables(1);
-  variables[0] = u_var;
-
   // Create an AnalyticFunction object that we use to project the BC
   // This function just calls the function exact_solution via exact_solution_wrapper
   AnalyticFunction<> exact_solution_object(exact_solution_wrapper);
@@ -278,7 +274,7 @@ int main (int argc, char ** argv)
   // though, we have only one variable, so system- and local-
   // orderings are the same.
   DirichletBoundary dirichlet_bc
-    (boundary_ids, variables, exact_solution_object);
+    (boundary_ids, {u_var}, exact_solution_object);
 
   // We must add the Dirichlet boundary condition _before_
   // we call equation_systems.init()

--- a/examples/introduction/introduction_ex5/introduction_ex5.C
+++ b/examples/introduction/introduction_ex5/introduction_ex5.C
@@ -161,19 +161,8 @@ int main (int argc, char ** argv)
 
   // Indicate which boundary IDs we impose the BC on
   // We either build a line, a square or a cube, and
-  // here we indicate the boundaries IDs in each case
-  std::set<boundary_id_type> boundary_ids;
-  // the dim==1 mesh has two boundaries with IDs 0 and 1
-  boundary_ids.insert(0);
-  boundary_ids.insert(1);
-  boundary_ids.insert(2);
-  boundary_ids.insert(3);
-  boundary_ids.insert(4);
-  boundary_ids.insert(5);
-
-  // Create a vector storing the variable numbers which the BC applies to
-  std::vector<unsigned int> variables(1);
-  variables[0] = u_var;
+  // here we indicate boundaries covering each case
+  std::set<boundary_id_type> boundary_ids {0,1,2,3,4,5};
 
   // Create an AnalyticFunction object that we use to project the BC
   // This function just calls the function exact_solution via exact_solution_wrapper
@@ -186,7 +175,7 @@ int main (int argc, char ** argv)
   // though, we have only one variable, so system- and local-
   // orderings are the same.
   DirichletBoundary dirichlet_bc
-    (boundary_ids, variables, exact_solution_object);
+    (boundary_ids, {u_var}, exact_solution_object);
 
   // We must add the Dirichlet boundary condition _before_
   // we call equation_systems.init()

--- a/examples/miscellaneous/miscellaneous_ex10/miscellaneous_ex10.C
+++ b/examples/miscellaneous/miscellaneous_ex10/miscellaneous_ex10.C
@@ -189,20 +189,13 @@ void assemble_and_solve(MeshBase & mesh,
 
   system.attach_assemble_function (assemble_poisson);
 
-  // the cube has boundaries IDs 0, 1, 2, 3, 4 and 5
-  std::set<boundary_id_type> boundary_ids;
-  for (int j = 0; j<6; ++j)
-    boundary_ids.insert(j);
-
-  // Create a vector storing the variable numbers which the BC applies to
-  std::vector<unsigned int> variables(1);
-  variables[0] = u_var;
-
   ZeroFunction<> zf;
+
+  // the cube has boundaries IDs 0, 1, 2, 3, 4 and 5
 
   // Most DirichletBoundary users will want to supply a "locally
   // indexed" functor
-  DirichletBoundary dirichlet_bc(boundary_ids, variables, zf,
+  DirichletBoundary dirichlet_bc({0,1,2,3,4,5}, {u_var}, zf,
                                  LOCAL_VARIABLE_ORDER);
   system.get_dof_map().add_dirichlet_boundary(dirichlet_bc);
 #endif // LIBMESH_ENABLE_DIRICHLET

--- a/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
+++ b/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
@@ -202,60 +202,34 @@ int main (int argc, char ** argv)
   // Other edges have symmetric boundary conditions.
 
 #ifdef LIBMESH_ENABLE_DIRICHLET
+  ZeroFunction<> zf;
+
   // AB w, theta_x, theta_y
-  {
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(7);
-    unsigned int variables[] = {2, 3, 4};
-    ZeroFunction<> zf;
 
-    // Most DirichletBoundary users will want to supply a "locally
-    // indexed" functor
-    DirichletBoundary dirichlet_bc
-      (boundary_ids,
-       std::vector<unsigned int>(variables, variables+3), zf,
-       LOCAL_VARIABLE_ORDER);
-    system.get_dof_map().add_dirichlet_boundary(dirichlet_bc);
-  }
+  // Most DirichletBoundary users will want to supply a "locally
+  // indexed" functor
+  DirichletBoundary dirichlet_bc1
+    (/*boundary_ids =*/{7},/*variables =*/{2,3,4}, zf,
+     LOCAL_VARIABLE_ORDER);
+  system.get_dof_map().add_dirichlet_boundary(dirichlet_bc1);
+
   // BC v, theta_x, theta_z
-  {
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(8);
-    unsigned int variables[] = {1, 3, 5};
-    ZeroFunction<> zf;
+  DirichletBoundary dirichlet_bc2
+    (/*boundary_ids =*/{8}, /*variables =*/{1,3,5}, zf,
+     LOCAL_VARIABLE_ORDER);
+  system.get_dof_map().add_dirichlet_boundary(dirichlet_bc2);
 
-    DirichletBoundary dirichlet_bc
-      (boundary_ids,
-       std::vector<unsigned int>(variables, variables+3), zf,
-       LOCAL_VARIABLE_ORDER);
-    system.get_dof_map().add_dirichlet_boundary(dirichlet_bc);
-  }
   // CD u, theta_y, theta_z
-  {
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(9);
-    unsigned int variables[] = {0, 4, 5};
-    ZeroFunction<> zf;
+  DirichletBoundary dirichlet_bc3
+    (/*boundary_ids =*/{9}, /*variables =*/{0,4,5}, zf,
+     LOCAL_VARIABLE_ORDER);
+  system.get_dof_map().add_dirichlet_boundary(dirichlet_bc3);
 
-    DirichletBoundary dirichlet_bc
-      (boundary_ids,
-       std::vector<unsigned int>(variables, variables+3), zf,
-       LOCAL_VARIABLE_ORDER);
-    system.get_dof_map().add_dirichlet_boundary(dirichlet_bc);
-  }
   // AD u, w, theta_y
-  {
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(10);
-    unsigned int variables[] = {0, 2, 4};
-    ZeroFunction<> zf;
-
-    DirichletBoundary dirichlet_bc
-      (boundary_ids,
-       std::vector<unsigned int>(variables, variables+3), zf,
-       LOCAL_VARIABLE_ORDER);
-    system.get_dof_map().add_dirichlet_boundary(dirichlet_bc);
-  }
+  DirichletBoundary dirichlet_bc4
+    (/*boundary_ids =*/{10}, /*variables =*/{0,2,4}, zf,
+     LOCAL_VARIABLE_ORDER);
+  system.get_dof_map().add_dirichlet_boundary(dirichlet_bc4);
 #endif // LIBMESH_ENABLE_DIRICHLET
 
   // Initialize the data structures for the equation system.

--- a/examples/miscellaneous/miscellaneous_ex13/miscellaneous_ex13.C
+++ b/examples/miscellaneous/miscellaneous_ex13/miscellaneous_ex13.C
@@ -191,55 +191,39 @@ int main (int argc, char ** argv)
 #ifdef LIBMESH_ENABLE_DIRICHLET
   // AB w, theta_x, theta_y
   {
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(7);
-    unsigned int variables[] = {2, 3, 4};
     ZeroFunction<> zf;
 
     // Most DirichletBoundary users will want to supply a "locally
     // indexed" functor
     DirichletBoundary dirichlet_bc
-      (boundary_ids,
-       std::vector<unsigned int>(variables, variables+3), zf,
+      (/*boundary_ids =*/{7},/*variables =*/{2,3,4}, zf,
        LOCAL_VARIABLE_ORDER);
     system.get_dof_map().add_dirichlet_boundary(dirichlet_bc);
   }
   // BC v, theta_x, theta_z
   {
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(8);
-    unsigned int variables[] = {1, 3, 5};
     ZeroFunction<> zf;
 
     DirichletBoundary dirichlet_bc
-      (boundary_ids,
-       std::vector<unsigned int>(variables, variables+3), zf,
+      (/*boundary_ids =*/{8}, /*variables =*/{1,3,5}, zf,
        LOCAL_VARIABLE_ORDER);
     system.get_dof_map().add_dirichlet_boundary(dirichlet_bc);
   }
   // CD u, theta_y, theta_z
   {
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(9);
-    unsigned int variables[] = {0, 4, 5};
     ZeroFunction<> zf;
 
     DirichletBoundary dirichlet_bc
-      (boundary_ids,
-       std::vector<unsigned int>(variables, variables+3), zf,
+      (/*boundary_ids =*/{9}, /*variables =*/{0,4,5}, zf,
        LOCAL_VARIABLE_ORDER);
     system.get_dof_map().add_dirichlet_boundary(dirichlet_bc);
   }
   // AD u, w, theta_y
   {
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(10);
-    unsigned int variables[] = {0, 2, 4};
     ZeroFunction<> zf;
 
     DirichletBoundary dirichlet_bc
-      (boundary_ids,
-       std::vector<unsigned int>(variables, variables+3), zf,
+      (/*boundary_ids =*/{10}, /*variables =*/{0,2,4}, zf,
        LOCAL_VARIABLE_ORDER);
     system.get_dof_map().add_dirichlet_boundary(dirichlet_bc);
   }

--- a/examples/miscellaneous/miscellaneous_ex8/miscellaneous_ex8.C
+++ b/examples/miscellaneous/miscellaneous_ex8/miscellaneous_ex8.C
@@ -142,10 +142,7 @@ int main(int argc, char ** argv)
     {
       std::vector<Point>       tgt_pts;
       std::vector<Number>      tgt_data_idi, tgt_data_rbi;
-      std::vector<std::string> field_vars;
-
-      field_vars.push_back("u");
-      field_vars.push_back("v");
+      std::vector<std::string> field_vars {"u", "v"};
 
       InverseDistanceInterpolation<3> idi (init.comm(),
                                            /* n_interp_pts = */ 8,
@@ -276,9 +273,7 @@ int main(int argc, char ** argv)
 
       std::vector<Point> & src_pts  (idi.get_source_points());
       std::vector<Number> & src_vals (idi.get_source_vals());
-      std::vector<std::string> field_vars;
-      field_vars.push_back("Cp");
-      idi.set_field_variables(field_vars);
+      idi.set_field_variables({"Cp"});
 
       // We now will loop over every node in the source mesh
       // and add it to a source point list, along with the solution
@@ -288,7 +283,7 @@ int main(int argc, char ** argv)
           src_vals.push_back(sys_a.current_solution(node->dof_number(0, 0, 0)));
         }
 
-      rbi.set_field_variables(field_vars);
+      rbi.set_field_variables({"Cp"});
       rbi.get_source_points() = idi.get_source_points();
       rbi.get_source_vals()   = idi.get_source_vals();
 

--- a/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
+++ b/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
@@ -133,15 +133,11 @@ int main (int argc, char ** argv)
 
 #ifdef LIBMESH_ENABLE_DIRICHLET
   // Impose zero Dirichlet boundary condition on MAX_Z_BOUNDARY
-  std::set<boundary_id_type> boundary_ids;
-  boundary_ids.insert(MAX_Z_BOUNDARY);
-  std::vector<unsigned int> variables;
-  variables.push_back(0);
   ZeroFunction<> zf;
 
   // Most DirichletBoundary users will want to supply a "locally
   // indexed" functor
-  DirichletBoundary dirichlet_bc(boundary_ids, variables, zf,
+  DirichletBoundary dirichlet_bc({MAX_Z_BOUNDARY}, {0}, zf,
                                  LOCAL_VARIABLE_ORDER);
   system.get_dof_map().add_dirichlet_boundary(dirichlet_bc);
 #endif // LIBMESH_ENABLE_DIRICHLET

--- a/examples/optimization/optimization_ex1/optimization_ex1.C
+++ b/examples/optimization/optimization_ex1/optimization_ex1.C
@@ -334,18 +334,11 @@ int main (int argc, char ** argv)
 
   // Apply Dirichlet constraints. This will be used to apply constraints
   // to the objective function, gradient and Hessian.
-  std::set<boundary_id_type> boundary_ids;
-  boundary_ids.insert(0);
-  boundary_ids.insert(1);
-  boundary_ids.insert(2);
-  boundary_ids.insert(3);
-  std::vector<unsigned int> variables;
-  variables.push_back(u_var);
   ZeroFunction<> zf;
 
   // Most DirichletBoundary users will want to supply a "locally
   // indexed" functor
-  DirichletBoundary dirichlet_bc(boundary_ids, variables, zf,
+  DirichletBoundary dirichlet_bc({0,1,2,3}, {u_var}, zf,
                                  LOCAL_VARIABLE_ORDER);
   system.get_dof_map().add_dirichlet_boundary(dirichlet_bc);
 #endif // LIBMESH_ENABLE_DIRICHLET

--- a/examples/reduced_basis/reduced_basis_ex4/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex4/rb_classes.h
@@ -91,10 +91,7 @@ public:
 
     // Set the Dirichlet boundary IDs
     // and the Dirichlet boundary variable numbers
-    dirichlet_bc->b.insert(0);
-    dirichlet_bc->b.insert(1);
-    dirichlet_bc->b.insert(2);
-    dirichlet_bc->b.insert(3);
+    dirichlet_bc->b = {0,1,2,3};
     dirichlet_bc->variables.push_back(u_var);
 
     // Attach dirichlet_bc (must do this _before_ Parent::init_data)

--- a/examples/reduced_basis/reduced_basis_ex6/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex6/rb_classes.h
@@ -109,8 +109,7 @@ public:
 
     // Set the Dirichlet boundary IDs
     // and the Dirichlet boundary variable numbers
-    dirichlet_bc->b.insert(0);
-    dirichlet_bc->b.insert(5);
+    dirichlet_bc->b = {0,5};
     dirichlet_bc->variables.push_back(u_var);
 
     // Attach dirichlet_bc (must do this _before_ Parent::init_data)

--- a/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
+++ b/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
@@ -687,45 +687,16 @@ void set_lid_driven_bcs(TransientLinearImplicitSystem & system)
   // Get a convenient reference to the System's DofMap
   DofMap & dof_map = system.get_dof_map();
 
-  {
-    // u=v=0 on bottom, left, right
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(0);
-    boundary_ids.insert(1);
-    boundary_ids.insert(3);
-
-    std::vector<unsigned int> variables;
-    variables.push_back(u_var);
-    variables.push_back(v_var);
-
-    dof_map.add_dirichlet_boundary(DirichletBoundary(boundary_ids,
-                                                     variables,
-                                                     ZeroFunction<Number>()));
-  }
-  {
-    // u=1 on top
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(2);
-
-    std::vector<unsigned int> variables;
-    variables.push_back(u_var);
-
-    dof_map.add_dirichlet_boundary(DirichletBoundary(boundary_ids,
-                                                     variables,
-                                                     ConstFunction<Number>(1.)));
-  }
-  {
-    // v=0 on top
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(2);
-
-    std::vector<unsigned int> variables;
-    variables.push_back(v_var);
-
-    dof_map.add_dirichlet_boundary(DirichletBoundary(boundary_ids,
-                                                     variables,
-                                                     ZeroFunction<Number>()));
-  }
+  // u=v=0 on bottom, left, right
+  dof_map.add_dirichlet_boundary(DirichletBoundary({0,1,3},
+                                                   {u_var, v_var},
+                                                   ZeroFunction<Number>()));
+  // u=1 on top
+  dof_map.add_dirichlet_boundary(DirichletBoundary({2}, {u_var},
+                                                   ConstFunction<Number>(1.)));
+  // v=0 on top
+  dof_map.add_dirichlet_boundary(DirichletBoundary({2}, {v_var},
+                                                   ZeroFunction<Number>()));
 #endif // LIBMESH_ENABLE_DIRICHLET
 }
 
@@ -745,70 +716,35 @@ void set_stagnation_bcs(TransientLinearImplicitSystem & system)
   // Get a convenient reference to the System's DofMap
   DofMap & dof_map = system.get_dof_map();
 
+  // u=v=0 on bottom (boundary 0)
+  dof_map.add_dirichlet_boundary(DirichletBoundary({0}, {u_var, v_var},
+                                                   ZeroFunction<Number>()));
+  // u=0 on left (boundary 3) (symmetry)
+  dof_map.add_dirichlet_boundary(DirichletBoundary({3}, {u_var},
+                                                   ZeroFunction<Number>()));
   {
-    // u=v=0 on bottom
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(0);
-
-    std::vector<unsigned int> variables;
-    variables.push_back(u_var);
-    variables.push_back(v_var);
-
-    dof_map.add_dirichlet_boundary(DirichletBoundary(boundary_ids,
-                                                     variables,
-                                                     ZeroFunction<Number>()));
-  }
-  {
-    // u=0 on left (symmetry)
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(3);
-
-    std::vector<unsigned int> variables;
-    variables.push_back(u_var);
-
-    dof_map.add_dirichlet_boundary(DirichletBoundary(boundary_ids,
-                                                     variables,
-                                                     ZeroFunction<Number>()));
-  }
-  {
-    // u = k*x on top
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(2);
-
-    std::vector<unsigned int> variables;
-    variables.push_back(u_var);
+    // u = k*x on top (boundary 2)
 
     // Set up ParsedFunction parameters
-    std::vector<std::string> additional_vars;
-    additional_vars.push_back("k");
-    std::vector<Number> initial_vals;
-    initial_vals.push_back(1.);
+    std::vector<std::string> additional_vars {"k"};
+    std::vector<Number> initial_vals {1.};
 
-    dof_map.add_dirichlet_boundary(DirichletBoundary(boundary_ids,
-                                                     variables,
+    dof_map.add_dirichlet_boundary(DirichletBoundary({2}, {u_var},
                                                      ParsedFunction<Number>("k*x",
                                                                             &additional_vars,
                                                                             &initial_vals)));
   }
   {
-    // v = -k*y on top
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(2);
-
-    std::vector<unsigned int> variables;
-    variables.push_back(v_var);
+    // v = -k*y on top (boundary 2)
 
     // Set up ParsedFunction parameters
-    std::vector<std::string> additional_vars;
-    additional_vars.push_back("k");
-    std::vector<Number> initial_vals;
-    initial_vals.push_back(1.);
+    std::vector<std::string> additional_vars {"k"};
+    std::vector<Number> initial_vals {1.};
 
     // Note: we have to specify LOCAL_VARIABLE_ORDER here, since we're
     // using a ParsedFunction to set the value of v_var, which is
     // actually the second variable in the system.
-    dof_map.add_dirichlet_boundary(DirichletBoundary(boundary_ids,
-                                                     variables,
+    dof_map.add_dirichlet_boundary(DirichletBoundary({2}, {v_var},
                                                      ParsedFunction<Number>("-k*y",
                                                                             &additional_vars,
                                                                             &initial_vals),

--- a/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
+++ b/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
@@ -679,45 +679,15 @@ void set_lid_driven_bcs(TransientLinearImplicitSystem & system)
   // Get a convenient reference to the System's DofMap
   DofMap & dof_map = system.get_dof_map();
 
-  {
-    // u=v=0 on bottom, left, right
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(0);
-    boundary_ids.insert(1);
-    boundary_ids.insert(3);
-
-    std::vector<unsigned int> variables;
-    variables.push_back(u_var);
-    variables.push_back(v_var);
-
-    dof_map.add_dirichlet_boundary(DirichletBoundary(boundary_ids,
-                                                     variables,
-                                                     ZeroFunction<Number>()));
-  }
-  {
-    // u=1 on top
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(2);
-
-    std::vector<unsigned int> variables;
-    variables.push_back(u_var);
-
-    dof_map.add_dirichlet_boundary(DirichletBoundary(boundary_ids,
-                                                     variables,
-                                                     ConstFunction<Number>(1.)));
-  }
-  {
-    // v=0 on top
-    std::set<boundary_id_type> boundary_ids;
-    boundary_ids.insert(2);
-
-    std::vector<unsigned int> variables;
-    variables.push_back(v_var);
-
-    dof_map.add_dirichlet_boundary(DirichletBoundary(boundary_ids,
-                                                     variables,
-                                                     ZeroFunction<Number>()));
-  }
+  // u=v=0 on bottom, left, right (boundaries 0,1,3)
+  dof_map.add_dirichlet_boundary(DirichletBoundary({0,1,3}, {u_var, v_var},
+                                                   ZeroFunction<Number>()));
+  // u=1 on top (boundary 2)
+  dof_map.add_dirichlet_boundary(DirichletBoundary({2}, {u_var},
+                                                   ConstFunction<Number>(1.)));
+  // v=0 on top
+  dof_map.add_dirichlet_boundary(DirichletBoundary({2}, {v_var},
+                                                   ZeroFunction<Number>()));
 #else
   libmesh_ignore(system);
 #endif

--- a/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
+++ b/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
@@ -130,22 +130,16 @@ int main (int argc, char ** argv)
   unsigned int u_var = system.add_variable("u", SECOND, LAGRANGE);
   unsigned int v_var = system.add_variable("v", SECOND, LAGRANGE);
 
-  // Construct a Dirichlet boundary condition object
-  // We impose a "clamped" boundary condition on the
-  // "left" boundary, i.e. bc_id = 3
-  std::set<boundary_id_type> boundary_ids;
-  boundary_ids.insert(3);
-
-  // Create a vector storing the variable numbers which the BC applies to
-  std::vector<unsigned int> variables(2);
-  variables[0] = u_var; variables[1] = v_var;
-
   // Create a ZeroFunction to initialize dirichlet_bc
   ZeroFunction<> zf;
 
+  // Construct a Dirichlet boundary condition object
+  // We impose a "clamped" boundary condition on the
+  // "left" boundary, i.e. bc_id = 3
+
   // Most DirichletBoundary users will want to supply a "locally
   // indexed" functor
-  DirichletBoundary dirichlet_bc(boundary_ids, variables, zf,
+  DirichletBoundary dirichlet_bc({3}, {u_var, v_var}, zf,
                                  LOCAL_VARIABLE_ORDER);
 
   // We must add the Dirichlet boundary condition _before_

--- a/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
+++ b/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
@@ -138,23 +138,16 @@ int main (int argc, char ** argv)
 
   system.attach_assemble_function (assemble_elasticity);
 
-  // Construct a Dirichlet boundary condition object
-  // We impose a "clamped" boundary condition on the
-  // "left" boundary, i.e. bc_id = 3
-  std::set<boundary_id_type> boundary_ids;
-  boundary_ids.insert(3);
-
-  // Create a vector storing the variable numbers which the BC applies to
-  std::vector<unsigned int> variables(2);
-  variables[0] = u_var;
-  variables[1] = v_var;
-
   // Create a ZeroFunction to initialize dirichlet_bc
   ZeroFunction<> zf;
 
+  // Construct a Dirichlet boundary condition object
+  // We impose a "clamped" boundary condition on the
+  // "left" boundary, i.e. bc_id = 3
+
   // Most DirichletBoundary users will want to supply a "locally
   // indexed" functor
-  DirichletBoundary dirichlet_bc(boundary_ids, variables, zf,
+  DirichletBoundary dirichlet_bc({3}, {u_var, v_var}, zf,
                                  LOCAL_VARIABLE_ORDER);
 
   // We must add the Dirichlet boundary condition _before_

--- a/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
+++ b/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
@@ -544,23 +544,14 @@ int main (int argc, char ** argv)
   unsigned int v_var = system.add_variable("v", FIRST, LAGRANGE);
   unsigned int w_var = system.add_variable("w", FIRST, LAGRANGE);
 
-  std::set<boundary_id_type> boundary_ids;
-  boundary_ids.insert(BOUNDARY_ID_MIN_X);
-  boundary_ids.insert(NODE_BOUNDARY_ID);
-  boundary_ids.insert(EDGE_BOUNDARY_ID);
-
-  // Create a vector storing the variable numbers which the BC applies to
-  std::vector<unsigned int> variables;
-  variables.push_back(u_var);
-  variables.push_back(v_var);
-  variables.push_back(w_var);
-
   // Create a ZeroFunction to initialize dirichlet_bc
   ZeroFunction<> zf;
 
   // Most DirichletBoundary users will want to supply a "locally
   // indexed" functor
-  DirichletBoundary dirichlet_bc(boundary_ids, variables, zf,
+  DirichletBoundary dirichlet_bc({BOUNDARY_ID_MIN_X, NODE_BOUNDARY_ID,
+                                 EDGE_BOUNDARY_ID},
+                                 {u_var, v_var, w_var}, zf,
                                  LOCAL_VARIABLE_ORDER);
 
   // We must add the Dirichlet boundary condition _before_

--- a/examples/systems_of_equations/systems_of_equations_ex7/systems_of_equations_ex7.C
+++ b/examples/systems_of_equations/systems_of_equations_ex7/systems_of_equations_ex7.C
@@ -601,25 +601,16 @@ int main (int argc, char ** argv)
   equation_systems.parameters.set<Real>("forcing_magnitude") = forcing_magnitude;
 
 #ifdef LIBMESH_ENABLE_DIRICHLET
-  // Attach Dirichlet boundary conditions
-  std::set<boundary_id_type> clamped_boundaries;
-  clamped_boundaries.insert(BOUNDARY_ID_MIN_X);
-
-  std::vector<unsigned int> uvw;
-  uvw.push_back(u_var);
-  uvw.push_back(v_var);
-  uvw.push_back(w_var);
-
+  // Attach Dirichlet (Clamped) boundary conditions
   ZeroFunction<Number> zero;
 
   // Most DirichletBoundary users will want to supply a "locally
   // indexed" functor
   system.get_dof_map().add_dirichlet_boundary
-    (DirichletBoundary (clamped_boundaries, uvw, zero,
-                        LOCAL_VARIABLE_ORDER));
-#else
-  libmesh_ignore(u_var, v_var, w_var);
+    (DirichletBoundary ({BOUNDARY_ID_MIN_X}, {u_var, v_var, w_var},
+                        zero, LOCAL_VARIABLE_ORDER));
 #endif // LIBMESH_ENABLE_DIRICHLET
+  libmesh_ignore(u_var, v_var, w_var);
 
   equation_systems.init();
   equation_systems.print_info();

--- a/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.C
@@ -157,54 +157,26 @@ int main (int argc, char ** argv)
   equation_systems.parameters.set<Real>("poisson_ratio") = poisson_ratio;
 
 #ifdef LIBMESH_ENABLE_DIRICHLET
-  // Attach Dirichlet boundary conditions
-  {
-    std::set<boundary_id_type> clamped_boundaries;
-    clamped_boundaries.insert(MIN_Z_BOUNDARY);
+  // Attach Dirichlet (Clamped) boundary conditions
+  ZeroFunction<Number> zero;
 
-    std::vector<unsigned int> uvw;
-    uvw.push_back(u_var);
-    uvw.push_back(v_var);
-    uvw.push_back(w_var);
+  // Most DirichletBoundary users will want to supply a "locally
+  // indexed" functor
+  system.get_dof_map().add_dirichlet_boundary
+    (DirichletBoundary ({MIN_Z_BOUNDARY}, {u_var, v_var, w_var},
+                        zero, LOCAL_VARIABLE_ORDER));
 
-    ZeroFunction<Number> zero;
+  system.get_dof_map().add_dirichlet_boundary
+    (DirichletBoundary ({MAX_Z_BOUNDARY}, {u_var, v_var}, zero,
+                        LOCAL_VARIABLE_ORDER));
 
-    // Most DirichletBoundary users will want to supply a "locally
-    // indexed" functor
-    system.get_dof_map().add_dirichlet_boundary
-      (DirichletBoundary (clamped_boundaries, uvw, zero,
-                          LOCAL_VARIABLE_ORDER));
-  }
-  {
-    std::set<boundary_id_type> clamped_boundaries;
-    clamped_boundaries.insert(MAX_Z_BOUNDARY);
+  ConstFunction<Number> neg_one(-1.);
 
-    std::vector<unsigned int> uv;
-    uv.push_back(u_var);
-    uv.push_back(v_var);
-
-    ZeroFunction<Number> zero;
-
-    system.get_dof_map().add_dirichlet_boundary
-      (DirichletBoundary (clamped_boundaries, uv, zero,
-                          LOCAL_VARIABLE_ORDER));
-  }
-  {
-    std::set<boundary_id_type> clamped_boundaries;
-    clamped_boundaries.insert(MAX_Z_BOUNDARY);
-
-    std::vector<unsigned int> w;
-    w.push_back(w_var);
-
-    ConstFunction<Number> neg_one(-1.);
-
-    system.get_dof_map().add_dirichlet_boundary
-      (DirichletBoundary (clamped_boundaries, w, neg_one,
-                          LOCAL_VARIABLE_ORDER));
-  }
-#else
-  libmesh_ignore(u_var, v_var, w_var);
+  system.get_dof_map().add_dirichlet_boundary
+    (DirichletBoundary ({MAX_Z_BOUNDARY}, {w_var}, neg_one,
+                        LOCAL_VARIABLE_ORDER));
 #endif // LIBMESH_ENABLE_DIRICHLET
+  libmesh_ignore(u_var, v_var, w_var);
 
   le.initialize_contact_load_paths();
 

--- a/examples/systems_of_equations/systems_of_equations_ex9/systems_of_equations_ex9.C
+++ b/examples/systems_of_equations/systems_of_equations_ex9/systems_of_equations_ex9.C
@@ -429,17 +429,10 @@ int main (int argc, char ** argv)
   LinearElasticity le(equation_systems);
   system.attach_assemble_object(le);
 
-  std::vector<unsigned int> variables;
-  variables.push_back(u_var);
-  variables.push_back(v_var);
-  variables.push_back(w_var);
   ZeroFunction<> zf;
-  std::set<boundary_id_type> clamped_boundary_ids;
-  clamped_boundary_ids.insert(300);
-  clamped_boundary_ids.insert(400);
 
 #ifdef LIBMESH_ENABLE_DIRICHLET
-  DirichletBoundary clamped_bc(clamped_boundary_ids, variables, zf);
+  DirichletBoundary clamped_bc({300,400}, {u_var,v_var,w_var}, zf);
   system.get_dof_map().add_dirichlet_boundary(clamped_bc);
 #endif
 

--- a/examples/vector_fe/vector_fe_ex2/laplace_system.C
+++ b/examples/vector_fe/vector_fe_ex2/laplace_system.C
@@ -64,12 +64,6 @@ void LaplaceSystem::init_data ()
 void LaplaceSystem::init_dirichlet_bcs()
 {
 #ifdef LIBMESH_ENABLE_DIRICHLET
-  const boundary_id_type all_ids[6] = {0, 1, 2, 3, 4, 5};
-  std::set<boundary_id_type> boundary_ids(all_ids, all_ids+6);
-
-  std::vector<unsigned int> vars;
-  vars.push_back(u_var);
-
   // Note that for vector-valued variables, it is assumed each
   // component is stored contiguously.  For 2-D elements in 3-D space,
   // only two components should be returned.
@@ -81,7 +75,7 @@ void LaplaceSystem::init_dirichlet_bcs()
   // though, we have only one (vector-valued!) variable, so system-
   // and local- orderings are the same.
   this->get_dof_map().add_dirichlet_boundary
-    (libMesh::DirichletBoundary(boundary_ids, vars, func));
+    (libMesh::DirichletBoundary({0,1,2,3,4,5}, {u_var}, func));
 #endif // LIBMESH_ENABLE_DIRICHLET
 }
 

--- a/include/base/dirichlet_boundaries.h
+++ b/include/base/dirichlet_boundaries.h
@@ -93,8 +93,8 @@ public:
    * Constructor for a system-variable-order boundary using
    * pointers-to-functors.
    */
-  DirichletBoundary(const std::set<boundary_id_type> & b_in,
-                    const std::vector<unsigned int> & variables_in,
+  DirichletBoundary(std::set<boundary_id_type> b_in,
+                    std::vector<unsigned int> variables_in,
                     const FunctionBase<Number> * f_in,
                     const FunctionBase<Gradient> * g_in = nullptr);
 
@@ -104,8 +104,8 @@ public:
    * Defaults to system variable indexing for backwards compatibility,
    * but most users will prefer local indexing.
    */
-  DirichletBoundary(const std::set<boundary_id_type> & b_in,
-                    const std::vector<unsigned int> & variables_in,
+  DirichletBoundary(std::set<boundary_id_type> b_in,
+                    std::vector<unsigned int> variables_in,
                     const FunctionBase<Number> & f_in,
                     VariableIndexing type = SYSTEM_VARIABLE_ORDER);
 
@@ -116,8 +116,8 @@ public:
    * Defaults to system variable indexing for backwards compatibility,
    * but most users will prefer local indexing.
    */
-  DirichletBoundary(const std::set<boundary_id_type> & b_in,
-                    const std::vector<unsigned int> & variables_in,
+  DirichletBoundary(std::set<boundary_id_type> b_in,
+                    std::vector<unsigned int> variables_in,
                     const FunctionBase<Number> & f_in,
                     const FunctionBase<Gradient> & g_in,
                     VariableIndexing type = SYSTEM_VARIABLE_ORDER);
@@ -126,8 +126,8 @@ public:
    * Constructor for a system-variable-order boundary from
    * pointers-to-fem-functors.
    */
-  DirichletBoundary(const std::set<boundary_id_type> & b_in,
-                    const std::vector<unsigned int> & variables_in,
+  DirichletBoundary(std::set<boundary_id_type> b_in,
+                    std::vector<unsigned int> variables_in,
                     const System & f_sys_in,
                     const FEMFunctionBase<Number> * f_in,
                     const FEMFunctionBase<Gradient> * g_in = nullptr);
@@ -139,8 +139,8 @@ public:
    * Defaults to system variable indexing for backwards compatibility,
    * but most users will prefer local indexing.
    */
-  DirichletBoundary(const std::set<boundary_id_type> & b_in,
-                    const std::vector<unsigned int> & variables_in,
+  DirichletBoundary(std::set<boundary_id_type> b_in,
+                    std::vector<unsigned int> variables_in,
                     const System & f_sys_in,
                     const FEMFunctionBase<Number> & f_in,
                     VariableIndexing type = SYSTEM_VARIABLE_ORDER);
@@ -152,8 +152,8 @@ public:
    * Defaults to system variable indexing for backwards compatibility,
    * but most users will prefer local indexing.
    */
-  DirichletBoundary(const std::set<boundary_id_type> & b_in,
-                    const std::vector<unsigned int> & variables_in,
+  DirichletBoundary(std::set<boundary_id_type> b_in,
+                    std::vector<unsigned int> variables_in,
                     const System & f_sys_in,
                     const FEMFunctionBase<Number> & f_in,
                     const FEMFunctionBase<Gradient> & g_in,

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -567,7 +567,7 @@ public:
    * Add a group of unknowns of order \p order and finite element type
    * \p type to the system of equations.
    */
-  void add_variable_group (const VariableGroup & var_group);
+  void add_variable_group (VariableGroup var_group);
 
   /**
    * Specify whether or not we perform an extra (opt-mode enabled) check

--- a/include/base/variable.h
+++ b/include/base/variable.h
@@ -87,6 +87,14 @@ public:
   {}
 
   /**
+   * Standard constructors.
+   */
+  Variable (const Variable &) = default;
+  Variable & operator= (const Variable &) = default;
+  Variable (Variable &&) = default;
+  Variable & operator= (Variable &&) = default;
+
+  /**
    * \returns true iff the \p other Variable has the same
    * characteristics and system numbering as this one.
    */
@@ -222,6 +230,14 @@ public:
               var_active_subdomains),
     _names(std::move(var_names))
   {}
+
+  /**
+   * Standard constructors.
+   */
+  VariableGroup (const VariableGroup &) = default;
+  VariableGroup & operator= (const VariableGroup &) = default;
+  VariableGroup (VariableGroup &&) = default;
+  VariableGroup & operator= (VariableGroup &&) = default;
 
   /**
    * \returns true iff the \p other VariableGroup has exactly the same

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -261,7 +261,7 @@ public:
    * and simply specify the element dimensions manually, which is why this
    * setter exists.
    */
-  void set_elem_dimensions(const std::set<unsigned char> & elem_dims);
+  void set_elem_dimensions(std::set<unsigned char> elem_dims);
 
   /**
    * \returns The "spatial dimension" of the mesh.

--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -67,7 +67,7 @@ public:
   MeshFunction (const EquationSystems & eqn_systems,
                 const NumericVector<Number> & vec,
                 const DofMap & dof_map,
-                const std::vector<unsigned int> & vars,
+                std::vector<unsigned int> vars,
                 const FunctionBase<Number> * master=nullptr);
 
   /**

--- a/include/mesh/mesh_triangle_holes.h
+++ b/include/mesh/mesh_triangle_holes.h
@@ -198,11 +198,11 @@ public:
    * and a reference to a vector of Points defining the hole.
    */
   ArbitraryHole(const Point & center,
-                const std::vector<Point> & points);
+                std::vector<Point> points);
 
   ArbitraryHole(const Point & center,
-                const std::vector<Point> & points,
-                const std::vector<unsigned int> & segment_indices);
+                std::vector<Point> points,
+                std::vector<unsigned int> segment_indices);
 
   /**
    * We can also construct an ArbitraryHole which just copies

--- a/include/numerics/composite_fem_function.h
+++ b/include/numerics/composite_fem_function.h
@@ -71,14 +71,13 @@ public:
    * (*this)(index_map[i]) will return f(i).
    */
   void attach_subfunction (const FEMFunctionBase<Output> & f,
-                           const std::vector<unsigned int> & index_map)
+                           std::vector<unsigned int> index_map)
   {
     const unsigned int subfunction_index =
       cast_int<unsigned int>(subfunctions.size());
     libmesh_assert_equal_to(subfunctions.size(), index_maps.size());
 
     subfunctions.push_back(f.clone());
-    index_maps.push_back(index_map);
 
     unsigned int max_index =
       *std::max_element(index_map.begin(), index_map.end());
@@ -98,6 +97,8 @@ public:
         reverse_index_map[index_map[j]] =
           std::make_pair(subfunction_index, j);
       }
+
+    index_maps.push_back(std::move(index_map));
   }
 
   virtual Output operator() (const FEMContext & c,

--- a/include/numerics/composite_function.h
+++ b/include/numerics/composite_function.h
@@ -80,14 +80,13 @@ public:
    * (*this)(x, t)(index_map[i]) will return f(x, t)(i).
    */
   void attach_subfunction (const FunctionBase<Output> & f,
-                           const std::vector<unsigned int> & index_map)
+                           std::vector<unsigned int> index_map)
   {
     const unsigned int subfunction_index =
       cast_int<unsigned int>(subfunctions.size());
     libmesh_assert_equal_to(subfunctions.size(), index_maps.size());
 
     subfunctions.push_back(f.clone());
-    index_maps.push_back(index_map);
 
     unsigned int max_index =
       *std::max_element(index_map.begin(), index_map.end());
@@ -121,6 +120,8 @@ public:
     // just added determines the time-dependence.
     else if (!this->_is_time_dependent)
       this->_is_time_dependent = (subfunctions.back())->is_time_dependent();
+
+    index_maps.push_back(std::move(index_map));
   }
 
   virtual Output operator() (const Point & p,

--- a/include/partitioning/sfc_partitioner.h
+++ b/include/partitioning/sfc_partitioner.h
@@ -72,12 +72,12 @@ public:
    * Sets the type of space-filling curve to use.  Valid types are
    * "Hilbert" (the default) and "Morton".
    */
-  void set_sfc_type (const std::string & sfc_type)
+  void set_sfc_type (std::string sfc_type)
   {
     libmesh_assert ((sfc_type == "Hilbert") ||
                     (sfc_type == "Morton"));
 
-    _sfc_type = sfc_type;
+    _sfc_type = std::move(sfc_type);
   }
 
   /**

--- a/include/solution_transfer/meshfree_interpolation.h
+++ b/include/solution_transfer/meshfree_interpolation.h
@@ -107,8 +107,8 @@ public:
    * Defines the field variable(s) we are responsible for,
    * and importantly their assumed ordering.
    */
-  void set_field_variables (const std::vector<std::string> & names)
-  { _names = names; }
+  void set_field_variables (std::vector<std::string> names)
+  { _names = std::move(names); }
 
   /**
    *\returns The field variables as a read-only reference.

--- a/include/systems/qoi_set.h
+++ b/include/systems/qoi_set.h
@@ -108,8 +108,8 @@ public:
    * \p indices[q] is true"
    */
   explicit
-  QoISet(const std::vector<bool> & indices) :
-    _indices(indices), _weights() {}
+  QoISet(std::vector<bool> indices) :
+    _indices(std::move(indices)), _weights() {}
 
   /**
    * Constructor-from-vector: "calculate the listed QoIs", "give every

--- a/include/systems/system_norm.h
+++ b/include/systems/system_norm.h
@@ -75,7 +75,7 @@ public:
    * n-vector of the norms in each variable.
    */
   explicit
-  SystemNorm(const std::vector<FEMNormType> & norms);
+  SystemNorm(std::vector<FEMNormType> norms);
 
   /**
    * Constructor, for weighted sobolev norms on systems with multiple
@@ -84,7 +84,7 @@ public:
    * For a system with n variables, the final norm will be the l2 norm of the
    * n-vector of the norms in each variable, each multiplied by weight.
    */
-  SystemNorm(const std::vector<FEMNormType> & norms,
+  SystemNorm(std::vector<FEMNormType> norms,
              std::vector<Real> & weights);
 
   /**
@@ -94,7 +94,7 @@ public:
    * For a system with n variables, the final norm computed will be of the form
    * norm_u^T*R*norm_z where R is a scaling matrix
    */
-  SystemNorm(const std::vector<FEMNormType> & norms,
+  SystemNorm(std::vector<FEMNormType> norms,
              std::vector<std::vector<Real>> & weights);
 
   /**

--- a/src/apps/meshdiff.C
+++ b/src/apps/meshdiff.C
@@ -157,7 +157,7 @@ int main(int argc, char ** argv)
 
           MeshFunction coarse_solution
             (coarse_es, *coarse_sys.solution,
-             coarse_sys.get_dof_map(), var_remapping);
+             coarse_sys.get_dof_map(), std::move(var_remapping));
           coarse_solution.init();
           const DenseVector<Number> oom_value(fine_sys.n_vars(), 0);
           coarse_solution.enable_out_of_mesh_mode(oom_value);

--- a/src/base/dirichlet_boundary.C
+++ b/src/base/dirichlet_boundary.C
@@ -33,12 +33,12 @@ namespace libMesh
 {
 
 DirichletBoundary::
-DirichletBoundary(const std::set<boundary_id_type> & b_in,
-                  const std::vector<unsigned int> & variables_in,
+DirichletBoundary(std::set<boundary_id_type> b_in,
+                  std::vector<unsigned int> variables_in,
                   const FunctionBase<Number> * f_in,
                   const FunctionBase<Gradient> * g_in) :
-  b(b_in),
-  variables(variables_in),
+  b(std::move(b_in)),
+  variables(std::move(variables_in)),
   f(f_in ? f_in->clone() : nullptr),
   g(g_in ? g_in->clone() : nullptr),
   f_system(nullptr),
@@ -52,19 +52,19 @@ DirichletBoundary(const std::set<boundary_id_type> & b_in,
 
 
 DirichletBoundary::
-DirichletBoundary(const std::set<boundary_id_type> & b_in,
-                  const std::vector<unsigned int> & variables_in,
+DirichletBoundary(std::set<boundary_id_type> b_in,
+                  std::vector<unsigned int> variables_in,
                   const FunctionBase<Number> & f_in,
                   VariableIndexing type) :
-  b(b_in),
-  variables(variables_in),
+  b(std::move(b_in)),
+  variables(std::move(variables_in)),
   f_system(nullptr),
   jacobian_tolerance(0.)
 {
   if (type == LOCAL_VARIABLE_ORDER)
     {
       auto c = std::make_unique<CompositeFunction<Number>>();
-      c->attach_subfunction(f_in, variables_in);
+      c->attach_subfunction(f_in, variables);
       f = std::move(c);
     }
   else
@@ -75,24 +75,24 @@ DirichletBoundary(const std::set<boundary_id_type> & b_in,
 
 
 DirichletBoundary::
-DirichletBoundary(const std::set<boundary_id_type> & b_in,
-                  const std::vector<unsigned int> & variables_in,
+DirichletBoundary(std::set<boundary_id_type> b_in,
+                  std::vector<unsigned int> variables_in,
                   const FunctionBase<Number> & f_in,
                   const FunctionBase<Gradient> & g_in,
                   VariableIndexing type) :
-  b(b_in),
-  variables(variables_in),
+  b(std::move(b_in)),
+  variables(std::move(variables_in)),
   f_system(nullptr),
   jacobian_tolerance(0.)
 {
   if (type == LOCAL_VARIABLE_ORDER)
     {
       auto cf = std::make_unique<CompositeFunction<Number>>();
-      cf->attach_subfunction(f_in, variables_in);
+      cf->attach_subfunction(f_in, variables);
       f = std::move(cf);
 
       auto cg = std::make_unique<CompositeFunction<Gradient>>();
-      cg->attach_subfunction(g_in, variables_in);
+      cg->attach_subfunction(g_in, variables);
       g = std::move(cg);
     }
   else
@@ -107,13 +107,13 @@ DirichletBoundary(const std::set<boundary_id_type> & b_in,
 
 
 DirichletBoundary::
-DirichletBoundary(const std::set<boundary_id_type> & b_in,
-                  const std::vector<unsigned int> & variables_in,
+DirichletBoundary(std::set<boundary_id_type> b_in,
+                  std::vector<unsigned int> variables_in,
                   const System & f_sys_in,
                   const FEMFunctionBase<Number> * f_in,
                   const FEMFunctionBase<Gradient> * g_in) :
-  b(b_in),
-  variables(variables_in),
+  b(std::move(b_in)),
+  variables(std::move(variables_in)),
   f_fem(f_in ? f_in->clone() : nullptr),
   g_fem(g_in ? g_in->clone() : nullptr),
   f_system(&f_sys_in),
@@ -124,20 +124,20 @@ DirichletBoundary(const std::set<boundary_id_type> & b_in,
 
 
 DirichletBoundary::
-DirichletBoundary(const std::set<boundary_id_type> & b_in,
-                  const std::vector<unsigned int> & variables_in,
+DirichletBoundary(std::set<boundary_id_type> b_in,
+                  std::vector<unsigned int> variables_in,
                   const System & f_sys_in,
                   const FEMFunctionBase<Number> & f_in,
                   VariableIndexing type) :
-  b(b_in),
-  variables(variables_in),
+  b(std::move(b_in)),
+  variables(std::move(variables_in)),
   f_system(&f_sys_in),
   jacobian_tolerance(0.)
 {
   if (type == LOCAL_VARIABLE_ORDER)
     {
       auto c = std::make_unique<CompositeFEMFunction<Number>>();
-      c->attach_subfunction(f_in, variables_in);
+      c->attach_subfunction(f_in, variables);
       f_fem = std::move(c);
     }
   else
@@ -146,25 +146,25 @@ DirichletBoundary(const std::set<boundary_id_type> & b_in,
 
 
 DirichletBoundary::
-DirichletBoundary(const std::set<boundary_id_type> & b_in,
-                  const std::vector<unsigned int> & variables_in,
+DirichletBoundary(std::set<boundary_id_type> b_in,
+                  std::vector<unsigned int> variables_in,
                   const System & f_sys_in,
                   const FEMFunctionBase<Number> & f_in,
                   const FEMFunctionBase<Gradient> & g_in,
                   VariableIndexing type) :
-  b(b_in),
-  variables(variables_in),
+  b(std::move(b_in)),
+  variables(std::move(variables_in)),
   f_system(&f_sys_in),
   jacobian_tolerance(0.)
 {
   if (type == LOCAL_VARIABLE_ORDER)
     {
       auto cf = std::make_unique<CompositeFEMFunction<Number>>();
-      cf->attach_subfunction(f_in, variables_in);
+      cf->attach_subfunction(f_in, variables);
       f_fem = std::move(cf);
 
       auto cg = std::make_unique<CompositeFEMFunction<Gradient>>();
-      cg->attach_subfunction(g_in, variables_in);
+      cg->attach_subfunction(g_in, variables);
       g_fem = std::move(cg);
     }
   else

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -252,14 +252,14 @@ void DofMap::set_error_on_constraint_loop(bool error_on_constraint_loop)
 
 
 
-void DofMap::add_variable_group (const VariableGroup & var_group)
+void DofMap::add_variable_group (VariableGroup var_group)
 {
   // Ensure that we are not duplicating an existing entry in _variable_groups
   if (std::find(_variable_groups.begin(), _variable_groups.end(), var_group) == _variable_groups.end())
   {
    const unsigned int vg = cast_int<unsigned int>(_variable_groups.size());
 
-   _variable_groups.push_back(var_group);
+   _variable_groups.push_back(std::move(var_group));
 
     VariableGroup & new_var_group = _variable_groups.back();
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -203,7 +203,7 @@ unsigned int MeshBase::mesh_dimension() const
 
 
 
-void MeshBase::set_elem_dimensions(const std::set<unsigned char> & elem_dims)
+void MeshBase::set_elem_dimensions(std::set<unsigned char> elem_dims)
 {
 #ifdef DEBUG
   // In debug mode, we call cache_elem_data() and then make sure
@@ -215,7 +215,7 @@ void MeshBase::set_elem_dimensions(const std::set<unsigned char> & elem_dims)
                      "Specified element dimensions does not match true element dimensions!");
 #endif
 
-  _elem_dims = elem_dims;
+  _elem_dims = std::move(elem_dims);
 }
 
 unsigned int MeshBase::spatial_dimension () const

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -42,14 +42,14 @@ namespace libMesh
 MeshFunction::MeshFunction (const EquationSystems & eqn_systems,
                             const NumericVector<Number> & vec,
                             const DofMap & dof_map,
-                            const std::vector<unsigned int> & vars,
+                            std::vector<unsigned int> vars,
                             const FunctionBase<Number> * master) :
   FunctionBase<Number> (master),
   ParallelObject       (eqn_systems),
   _eqn_systems         (eqn_systems),
   _vector              (vec),
   _dof_map             (dof_map),
-  _system_vars         (vars),
+  _system_vars         (std::move(vars)),
   _out_of_mesh_mode    (false)
 {
 }

--- a/src/mesh/mesh_triangle_holes.C
+++ b/src/mesh/mesh_triangle_holes.C
@@ -120,20 +120,20 @@ Point TriangulatorInterface::AffineHole::transform(const Point & p) const
 // ArbitraryHole member functions
 //
 TriangulatorInterface::ArbitraryHole::ArbitraryHole(const Point & center,
-                                                    const std::vector<Point> & points)
+                                                    std::vector<Point> points)
   : _center(center),
-    _points(points)
+    _points(std::move(points))
 {
   _segment_indices.push_back(0);
-  _segment_indices.push_back(points.size());
+  _segment_indices.push_back(_points.size());
 }
 
 TriangulatorInterface::ArbitraryHole::ArbitraryHole(const Point & center,
-                                                    const std::vector<Point> & points,
-                                                    const std::vector<unsigned int> & segment_indices)
+                                                    std::vector<Point> points,
+                                                    std::vector<unsigned int> segment_indices)
   : _center(center),
-    _points(points),
-    _segment_indices(segment_indices)
+    _points(std::move(points)),
+    _segment_indices(std::move(segment_indices))
 {}
 
 TriangulatorInterface::ArbitraryHole::ArbitraryHole(const Hole & orig)

--- a/src/systems/system_norm.C
+++ b/src/systems/system_norm.C
@@ -36,17 +36,18 @@ SystemNorm::SystemNorm(const FEMNormType & t) :
 }
 
 
-SystemNorm::SystemNorm(const std::vector<FEMNormType> & norms) :
-  _norms(norms), _weights(1, 1.0), _weights_sq(1, 1.0)
+SystemNorm::SystemNorm(std::vector<FEMNormType> norms) :
+  _norms(std::move(norms)), _weights(1, 1.0), _weights_sq(1, 1.0)
 {
   if (_norms.empty())
     _norms.push_back(DISCRETE_L2);
 }
 
 
-SystemNorm::SystemNorm(const std::vector<FEMNormType> & norms,
+SystemNorm::SystemNorm(std::vector<FEMNormType> norms,
                        std::vector<Real> & weights) :
-  _norms(norms), _weights(weights), _weights_sq(_weights.size(), 0.0)
+  _norms(std::move(norms)), _weights(weights),
+  _weights_sq(_weights.size(), 0.0)
 {
   if (_norms.empty())
     _norms.push_back(DISCRETE_L2);
@@ -61,9 +62,9 @@ SystemNorm::SystemNorm(const std::vector<FEMNormType> & norms,
       _weights_sq[i] = _weights[i] * _weights[i];
 }
 
-SystemNorm::SystemNorm(const std::vector<FEMNormType> & norms,
+SystemNorm::SystemNorm(std::vector<FEMNormType> norms,
                        std::vector<std::vector<Real>> & weights):
-  _norms(norms),
+  _norms(std::move(norms)),
   _weights(weights.size()),
   _weights_sq(weights.size()),
   _off_diagonal_weights(weights)

--- a/tests/mesh/mesh_function.C
+++ b/tests/mesh/mesh_function.C
@@ -89,11 +89,10 @@ public:
     es.init();
     sys.project_solution(trilinear_function, nullptr, es.parameters);
 
-    const std::vector<unsigned int> variables(1,u_var);
     MeshFunction mesh_function (sys.get_equation_systems(),
                                 *sys.current_local_solution,
                                 sys.get_dof_map(),
-                                variables);
+                                {u_var});
 
     // Checkerboard pattern
     const std::set<subdomain_id_type> sbdids1 {0,2,11,13,20,22,31,33};
@@ -189,9 +188,10 @@ public:
     sys.solution->localize(*mesh_function_vector,
                            sys.get_dof_map().get_send_list());
 
+
     // So the MeshFunction knows which variables to compute values for.
-    std::vector<unsigned int> variables(1);
-    variables[0] = u_var;
+    // std::make_unique doesn't like if we try to use {u_var} in-place?
+    std::vector<unsigned int> variables {u_var};
 
     auto mesh_function =
       std::make_unique<MeshFunction>(sys.get_equation_systems(),

--- a/tests/mesh/mesh_function.C
+++ b/tests/mesh/mesh_function.C
@@ -92,7 +92,7 @@ public:
     MeshFunction mesh_function (sys.get_equation_systems(),
                                 *sys.current_local_solution,
                                 sys.get_dof_map(),
-                                {u_var});
+                                u_var);
 
     // Checkerboard pattern
     const std::set<subdomain_id_type> sbdids1 {0,2,11,13,20,22,31,33};


### PR DESCRIPTION
This is a mix of:

1) more of the pass-by-value-then-move trick for taking copies.  I wasn't able to find any place this would be a big deal for performance, but in the course of looking I found:

2) a bunch places where we can pass braced initializer lists directly rather than laboriously constructing a named std:: container and passing that.

I like the results, but nothing in this PR is critical and everything in it is debatable.