### PR TITLE
set_hdf5_writing(bool) option

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -495,6 +495,14 @@ public:
 #endif
 
   /**
+   * Set to true (the default) to write files in an HDF5-based file
+   * format (when HDF5 is available), or to false to write files in
+   * the old NetCDF3-based format.  If HDF5 is unavailable, this
+   * setting does nothing.
+   */
+  void set_hdf5_writing(bool write_hdf5);
+
+  /**
    * This function factors out a bunch of code which is common to the
    * write_nodal_data() and write_nodal_data_discontinuous() functions
    */

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -471,6 +471,14 @@ public:
   void use_mesh_dimension_instead_of_spatial_dimension(bool val);
 
   /**
+   * Set to true (the default) to write files in an HDF5-based file
+   * format (when HDF5 is available), or to false to write files in
+   * the old NetCDF3-based format.  If HDF5 is unavailable, this
+   * setting does nothing.
+   */
+  void set_hdf5_writing(bool write_hdf5);
+
+  /**
    * Sets the value of _write_as_dimension.
    *
    * This directly controls the num_dim which is written to the Exodus
@@ -817,6 +825,10 @@ protected:
   // of the elements comprising the mesh) instead of the mesh's
   // spatial dimension, when writing.  By default this is false.
   bool _use_mesh_dimension_instead_of_spatial_dimension;
+
+  // If true, write an HDF5 file when available.  If false, write the
+  // old format.
+  bool _write_hdf5;
 
   // Set once the elem num map has been read
   int _end_elem_id;

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -2110,6 +2110,13 @@ ExodusII_IO_Helper & ExodusII_IO::get_exio_helper()
 }
 
 
+void ExodusII_IO::set_hdf5_writing(bool write_hdf5)
+{
+  exio_helper->set_hdf5_writing(write_hdf5);
+}
+
+
+
 // LIBMESH_HAVE_EXODUS_API is not defined, declare error() versions of functions...
 #else
 
@@ -2326,6 +2333,8 @@ const std::vector<std::string> & ExodusII_IO::get_global_var_names()
 {
   libmesh_error_msg("ERROR, ExodusII API is not defined.");
 }
+
+void ExodusII_IO::set_hdf5_writing(bool) {}
 
 #endif // LIBMESH_HAVE_EXODUS_API
 } // namespace libMesh

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -176,6 +176,7 @@ ExodusII_IO_Helper::ExodusII_IO_Helper(const ParallelObject & parent,
   _global_vars_initialized(false),
   _nodal_vars_initialized(false),
   _use_mesh_dimension_instead_of_spatial_dimension(false),
+  _write_hdf5(true),
   _end_elem_id(0),
   _write_as_dimension(0),
   _single_precision(single_precision)
@@ -1948,8 +1949,11 @@ void ExodusII_IO_Helper::create(std::string filename)
       // in a more modern NETCDF4-compatible format. For this file
       // type, "ncdump -k" will report "netCDF-4".
 #ifdef LIBMESH_HAVE_HDF5
-      mode |= EX_NETCDF4;
-      mode |= EX_NOCLASSIC;
+      if (this->_write_hdf5)
+        {
+          mode |= EX_NETCDF4;
+          mode |= EX_NOCLASSIC;
+        }
 #endif
 
       ex_id = exII::ex_create(filename.c_str(), mode, &comp_ws, &io_ws);
@@ -3855,6 +3859,13 @@ void ExodusII_IO_Helper::use_mesh_dimension_instead_of_spatial_dimension(bool va
 {
   _use_mesh_dimension_instead_of_spatial_dimension = val;
 }
+
+
+void ExodusII_IO_Helper::set_hdf5_writing(bool write_hdf5)
+{
+  _write_hdf5 = write_hdf5;
+}
+
 
 
 


### PR DESCRIPTION
We're going to want to turn this off in Moose, so users' new files will
be as portable as possible to other builds (including new gold
regression test files and including our --disable-hdf5 CI recipes).

We'll leave it on by default in libMesh for backwards compatibility;
anybody who went to the trouble of building with HDF5 manually probably
had a reason to want HDF5 output.