### PR TITLE
Clang-tidy cleanup

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -2164,13 +2164,13 @@ Elem::Elem(const unsigned int nn,
   // Initialize the neighbors/parent data structure
   // _elemlinks = new Elem *[ns+1];
 
-  if (_elemlinks)
-    {
-      _elemlinks[0] = p;
+  // We now require that we get allocated data from a subclass
+  libmesh_assert (_elemlinks);
 
-      for (unsigned int n=1; n<ns+1; n++)
-        _elemlinks[n] = nullptr;
-    }
+  _elemlinks[0] = p;
+
+  for (unsigned int n=1; n<ns+1; n++)
+    _elemlinks[n] = nullptr;
 
   // Optionally initialize data from the parent
   if (this->parent() != nullptr)

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -145,21 +145,21 @@ public:
    * \returns \p true if all elements and nodes of the mesh
    * exist on the current processor, \p false otherwise
    */
-  virtual bool is_serial () const override
+  virtual bool is_serial () const override final
   { return _is_serial; }
 
   /**
    * \returns \p true if all elements and nodes of the mesh
    * exist on the processor 0, \p false otherwise
    */
-  virtual bool is_serial_on_zero () const override
+  virtual bool is_serial_on_zero () const override final
   { return _is_serial || _is_serial_on_proc_0; }
 
   /**
    * Asserts that not all elements and nodes of the mesh necessarily
    * exist on the current processor.
    */
-  virtual void set_distributed () override
+  virtual void set_distributed () override final
   { _is_serial = false;
     _is_serial_on_proc_0 = false; }
 
@@ -167,7 +167,7 @@ public:
    * \returns \p true if new elements and nodes can and should be
    * created in synchronization on all processors, \p false otherwise
    */
-  virtual bool is_replicated () const override
+  virtual bool is_replicated () const override final
   { return false; }
 
   /**
@@ -255,13 +255,13 @@ public:
   const std::set<Elem *> & extra_ghost_elems() const { return _extra_ghost_elems; }
 
   // Cached methods that can be called in serial
-  virtual dof_id_type n_nodes () const override { return _n_nodes; }
-  virtual dof_id_type max_node_id () const override { return _max_node_id; }
-  virtual void reserve_nodes (const dof_id_type) override {}
-  virtual dof_id_type n_elem () const override { return _n_elem; }
-  virtual dof_id_type n_active_elem () const override;
-  virtual dof_id_type max_elem_id () const override { return _max_elem_id; }
-  virtual void reserve_elem (const dof_id_type) override {}
+  virtual dof_id_type n_nodes () const override final { return _n_nodes; }
+  virtual dof_id_type max_node_id () const override final { return _max_node_id; }
+  virtual void reserve_nodes (const dof_id_type) override final {}
+  virtual dof_id_type n_elem () const override final { return _n_elem; }
+  virtual dof_id_type n_active_elem () const override final;
+  virtual dof_id_type max_elem_id () const override final { return _max_elem_id; }
+  virtual void reserve_elem (const dof_id_type) override final {}
 
   // Parallel only method to update the caches
   virtual void update_parallel_id_counts () override;
@@ -277,34 +277,34 @@ public:
   virtual void set_next_unique_id(unique_id_type id) override;
 #endif
 
-  virtual const Point & point (const dof_id_type i) const override;
+  virtual const Point & point (const dof_id_type i) const override final;
 
-  virtual const Node * node_ptr (const dof_id_type i) const override;
-  virtual Node * node_ptr (const dof_id_type i) override;
+  virtual const Node * node_ptr (const dof_id_type i) const override final;
+  virtual Node * node_ptr (const dof_id_type i) override final;
 
-  virtual const Node * query_node_ptr (const dof_id_type i) const override;
-  virtual Node * query_node_ptr (const dof_id_type i) override;
+  virtual const Node * query_node_ptr (const dof_id_type i) const override final;
+  virtual Node * query_node_ptr (const dof_id_type i) override final;
 
-  virtual const Elem * elem_ptr (const dof_id_type i) const override;
-  virtual Elem * elem_ptr (const dof_id_type i) override;
+  virtual const Elem * elem_ptr (const dof_id_type i) const override final;
+  virtual Elem * elem_ptr (const dof_id_type i) override final;
 
-  virtual const Elem * query_elem_ptr (const dof_id_type i) const override;
-  virtual Elem * query_elem_ptr (const dof_id_type i) override;
+  virtual const Elem * query_elem_ptr (const dof_id_type i) const override final;
+  virtual Elem * query_elem_ptr (const dof_id_type i) override final;
 
   /**
    * functions for adding /deleting nodes elements.
    */
   virtual Node * add_point (const Point & p,
                             const dof_id_type id = DofObject::invalid_id,
-                            const processor_id_type proc_id = DofObject::invalid_processor_id) override;
-  virtual Node * add_node (Node * n) override;
-  virtual Node * add_node (std::unique_ptr<Node> n) override;
+                            const processor_id_type proc_id = DofObject::invalid_processor_id) override final;
+  virtual Node * add_node (Node * n) override final;
+  virtual Node * add_node (std::unique_ptr<Node> n) override final;
 
   /**
    * Calls add_node().
    */
-  virtual Node * insert_node(Node * n) override;
-  virtual Node * insert_node(std::unique_ptr<Node> n) override;
+  virtual Node * insert_node(Node * n) override final;
+  virtual Node * insert_node(std::unique_ptr<Node> n) override final;
 
   /**
    * Takes ownership of node \p n on this partition of a distributed
@@ -312,16 +312,16 @@ public:
    * well as changing n.id() and moving it in the mesh's internal
    * container to give it a new authoritative id.
    */
-  virtual void own_node (Node & n) override;
+  virtual void own_node (Node & n) override final;
 
-  virtual void delete_node (Node * n) override;
-  virtual void renumber_node (dof_id_type old_id, dof_id_type new_id) override;
-  virtual Elem * add_elem (Elem * e) override;
-  virtual Elem * add_elem (std::unique_ptr<Elem> e) override;
-  virtual Elem * insert_elem (Elem * e) override;
-  virtual Elem * insert_elem (std::unique_ptr<Elem> e) override;
-  virtual void delete_elem (Elem * e) override;
-  virtual void renumber_elem (dof_id_type old_id, dof_id_type new_id) override;
+  virtual void delete_node (Node * n) override final;
+  virtual void renumber_node (dof_id_type old_id, dof_id_type new_id) override final;
+  virtual Elem * add_elem (Elem * e) override final;
+  virtual Elem * add_elem (std::unique_ptr<Elem> e) override final;
+  virtual Elem * insert_elem (Elem * e) override final;
+  virtual Elem * insert_elem (std::unique_ptr<Elem> e) override final;
+  virtual void delete_elem (Elem * e) override final;
+  virtual void renumber_elem (dof_id_type old_id, dof_id_type new_id) override final;
 
   /**
    * There is no reason for a user to ever call this function.
@@ -335,275 +335,275 @@ public:
   /**
    * Elem iterator accessor functions.
    */
-  virtual element_iterator elements_begin () override;
-  virtual element_iterator elements_end () override;
-  virtual const_element_iterator elements_begin() const override;
-  virtual const_element_iterator elements_end() const override;
-  virtual SimpleRange<element_iterator> element_ptr_range() override { return {elements_begin(), elements_end()}; }
-  virtual SimpleRange<const_element_iterator> element_ptr_range() const override { return {elements_begin(), elements_end()}; }
+  virtual element_iterator elements_begin () override final;
+  virtual element_iterator elements_end () override final;
+  virtual const_element_iterator elements_begin() const override final;
+  virtual const_element_iterator elements_end() const override final;
+  virtual SimpleRange<element_iterator> element_ptr_range() override final { return {elements_begin(), elements_end()}; }
+  virtual SimpleRange<const_element_iterator> element_ptr_range() const override final { return {elements_begin(), elements_end()}; }
 
-  virtual element_iterator active_elements_begin () override;
-  virtual element_iterator active_elements_end () override;
-  virtual const_element_iterator active_elements_begin() const override;
-  virtual const_element_iterator active_elements_end() const override;
-  virtual SimpleRange<element_iterator> active_element_ptr_range() override { return {active_elements_begin(), active_elements_end()}; }
-  virtual SimpleRange<const_element_iterator> active_element_ptr_range() const override  { return {active_elements_begin(), active_elements_end()}; }
+  virtual element_iterator active_elements_begin () override final;
+  virtual element_iterator active_elements_end () override final;
+  virtual const_element_iterator active_elements_begin() const override final;
+  virtual const_element_iterator active_elements_end() const override final;
+  virtual SimpleRange<element_iterator> active_element_ptr_range() override final { return {active_elements_begin(), active_elements_end()}; }
+  virtual SimpleRange<const_element_iterator> active_element_ptr_range() const override final  { return {active_elements_begin(), active_elements_end()}; }
 
-  virtual element_iterator ancestor_elements_begin () override;
-  virtual element_iterator ancestor_elements_end () override;
-  virtual const_element_iterator ancestor_elements_begin() const override;
-  virtual const_element_iterator ancestor_elements_end() const override;
+  virtual element_iterator ancestor_elements_begin () override final;
+  virtual element_iterator ancestor_elements_end () override final;
+  virtual const_element_iterator ancestor_elements_begin() const override final;
+  virtual const_element_iterator ancestor_elements_end() const override final;
 
-  virtual element_iterator subactive_elements_begin () override;
-  virtual element_iterator subactive_elements_end () override;
-  virtual const_element_iterator subactive_elements_begin() const override;
-  virtual const_element_iterator subactive_elements_end() const override;
+  virtual element_iterator subactive_elements_begin () override final;
+  virtual element_iterator subactive_elements_end () override final;
+  virtual const_element_iterator subactive_elements_begin() const override final;
+  virtual const_element_iterator subactive_elements_end() const override final;
 
-  virtual element_iterator not_active_elements_begin () override;
-  virtual element_iterator not_active_elements_end () override;
-  virtual const_element_iterator not_active_elements_begin() const override;
-  virtual const_element_iterator not_active_elements_end() const override;
+  virtual element_iterator not_active_elements_begin () override final;
+  virtual element_iterator not_active_elements_end () override final;
+  virtual const_element_iterator not_active_elements_begin() const override final;
+  virtual const_element_iterator not_active_elements_end() const override final;
 
-  virtual element_iterator not_ancestor_elements_begin () override;
-  virtual element_iterator not_ancestor_elements_end () override;
-  virtual const_element_iterator not_ancestor_elements_begin() const override;
-  virtual const_element_iterator not_ancestor_elements_end() const override;
+  virtual element_iterator not_ancestor_elements_begin () override final;
+  virtual element_iterator not_ancestor_elements_end () override final;
+  virtual const_element_iterator not_ancestor_elements_begin() const override final;
+  virtual const_element_iterator not_ancestor_elements_end() const override final;
 
-  virtual element_iterator not_subactive_elements_begin () override;
-  virtual element_iterator not_subactive_elements_end () override;
-  virtual const_element_iterator not_subactive_elements_begin() const override;
-  virtual const_element_iterator not_subactive_elements_end() const override;
+  virtual element_iterator not_subactive_elements_begin () override final;
+  virtual element_iterator not_subactive_elements_end () override final;
+  virtual const_element_iterator not_subactive_elements_begin() const override final;
+  virtual const_element_iterator not_subactive_elements_end() const override final;
 
-  virtual element_iterator local_elements_begin () override;
-  virtual element_iterator local_elements_end () override;
-  virtual const_element_iterator local_elements_begin () const override;
-  virtual const_element_iterator local_elements_end () const override;
+  virtual element_iterator local_elements_begin () override final;
+  virtual element_iterator local_elements_end () override final;
+  virtual const_element_iterator local_elements_begin () const override final;
+  virtual const_element_iterator local_elements_end () const override final;
 
-  virtual element_iterator semilocal_elements_begin () override;
-  virtual element_iterator semilocal_elements_end () override;
-  virtual const_element_iterator semilocal_elements_begin () const override;
-  virtual const_element_iterator semilocal_elements_end () const override;
+  virtual element_iterator semilocal_elements_begin () override final;
+  virtual element_iterator semilocal_elements_end () override final;
+  virtual const_element_iterator semilocal_elements_begin () const override final;
+  virtual const_element_iterator semilocal_elements_end () const override final;
 
-  virtual element_iterator active_semilocal_elements_begin () override;
-  virtual element_iterator active_semilocal_elements_end () override;
-  virtual const_element_iterator active_semilocal_elements_begin () const override;
-  virtual const_element_iterator active_semilocal_elements_end () const override;
+  virtual element_iterator active_semilocal_elements_begin () override final;
+  virtual element_iterator active_semilocal_elements_end () override final;
+  virtual const_element_iterator active_semilocal_elements_begin () const override final;
+  virtual const_element_iterator active_semilocal_elements_end () const override final;
 
-  virtual element_iterator facelocal_elements_begin () override;
-  virtual element_iterator facelocal_elements_end () override;
-  virtual const_element_iterator facelocal_elements_begin () const override;
-  virtual const_element_iterator facelocal_elements_end () const override;
+  virtual element_iterator facelocal_elements_begin () override final;
+  virtual element_iterator facelocal_elements_end () override final;
+  virtual const_element_iterator facelocal_elements_begin () const override final;
+  virtual const_element_iterator facelocal_elements_end () const override final;
 
-  virtual element_iterator not_local_elements_begin () override;
-  virtual element_iterator not_local_elements_end () override;
-  virtual const_element_iterator not_local_elements_begin () const override;
-  virtual const_element_iterator not_local_elements_end () const override;
+  virtual element_iterator not_local_elements_begin () override final;
+  virtual element_iterator not_local_elements_end () override final;
+  virtual const_element_iterator not_local_elements_begin () const override final;
+  virtual const_element_iterator not_local_elements_end () const override final;
 
-  virtual element_iterator active_local_elements_begin () override;
-  virtual element_iterator active_local_elements_end () override;
-  virtual const_element_iterator active_local_elements_begin () const override;
-  virtual const_element_iterator active_local_elements_end () const override;
-  virtual SimpleRange<element_iterator> active_local_element_ptr_range() override { return {active_local_elements_begin(), active_local_elements_end()}; }
-  virtual SimpleRange<const_element_iterator> active_local_element_ptr_range() const override  { return {active_local_elements_begin(), active_local_elements_end()}; }
+  virtual element_iterator active_local_elements_begin () override final;
+  virtual element_iterator active_local_elements_end () override final;
+  virtual const_element_iterator active_local_elements_begin () const override final;
+  virtual const_element_iterator active_local_elements_end () const override final;
+  virtual SimpleRange<element_iterator> active_local_element_ptr_range() override final { return {active_local_elements_begin(), active_local_elements_end()}; }
+  virtual SimpleRange<const_element_iterator> active_local_element_ptr_range() const override final  { return {active_local_elements_begin(), active_local_elements_end()}; }
 
-  virtual element_iterator active_not_local_elements_begin () override;
-  virtual element_iterator active_not_local_elements_end () override;
-  virtual const_element_iterator active_not_local_elements_begin () const override;
-  virtual const_element_iterator active_not_local_elements_end () const override;
+  virtual element_iterator active_not_local_elements_begin () override final;
+  virtual element_iterator active_not_local_elements_end () override final;
+  virtual const_element_iterator active_not_local_elements_begin () const override final;
+  virtual const_element_iterator active_not_local_elements_end () const override final;
 
-  virtual element_iterator level_elements_begin (unsigned int level) override;
-  virtual element_iterator level_elements_end (unsigned int level) override;
-  virtual const_element_iterator level_elements_begin (unsigned int level) const override;
-  virtual const_element_iterator level_elements_end (unsigned int level) const override;
+  virtual element_iterator level_elements_begin (unsigned int level) override final;
+  virtual element_iterator level_elements_end (unsigned int level) override final;
+  virtual const_element_iterator level_elements_begin (unsigned int level) const override final;
+  virtual const_element_iterator level_elements_end (unsigned int level) const override final;
 
-  virtual element_iterator not_level_elements_begin (unsigned int level) override;
-  virtual element_iterator not_level_elements_end (unsigned int level) override;
-  virtual const_element_iterator not_level_elements_begin (unsigned int level) const override;
-  virtual const_element_iterator not_level_elements_end (unsigned int level) const override;
+  virtual element_iterator not_level_elements_begin (unsigned int level) override final;
+  virtual element_iterator not_level_elements_end (unsigned int level) override final;
+  virtual const_element_iterator not_level_elements_begin (unsigned int level) const override final;
+  virtual const_element_iterator not_level_elements_end (unsigned int level) const override final;
 
-  virtual element_iterator local_level_elements_begin (unsigned int level) override;
-  virtual element_iterator local_level_elements_end (unsigned int level) override;
-  virtual const_element_iterator local_level_elements_begin (unsigned int level) const override;
-  virtual const_element_iterator local_level_elements_end (unsigned int level) const override;
+  virtual element_iterator local_level_elements_begin (unsigned int level) override final;
+  virtual element_iterator local_level_elements_end (unsigned int level) override final;
+  virtual const_element_iterator local_level_elements_begin (unsigned int level) const override final;
+  virtual const_element_iterator local_level_elements_end (unsigned int level) const override final;
 
-  virtual element_iterator local_not_level_elements_begin (unsigned int level) override;
-  virtual element_iterator local_not_level_elements_end (unsigned int level) override;
-  virtual const_element_iterator local_not_level_elements_begin (unsigned int level) const override;
-  virtual const_element_iterator local_not_level_elements_end (unsigned int level) const override;
+  virtual element_iterator local_not_level_elements_begin (unsigned int level) override final;
+  virtual element_iterator local_not_level_elements_end (unsigned int level) override final;
+  virtual const_element_iterator local_not_level_elements_begin (unsigned int level) const override final;
+  virtual const_element_iterator local_not_level_elements_end (unsigned int level) const override final;
 
-  virtual element_iterator pid_elements_begin (processor_id_type proc_id) override;
-  virtual element_iterator pid_elements_end (processor_id_type proc_id) override;
-  virtual const_element_iterator pid_elements_begin (processor_id_type proc_id) const override;
-  virtual const_element_iterator pid_elements_end (processor_id_type proc_id) const override;
+  virtual element_iterator pid_elements_begin (processor_id_type proc_id) override final;
+  virtual element_iterator pid_elements_end (processor_id_type proc_id) override final;
+  virtual const_element_iterator pid_elements_begin (processor_id_type proc_id) const override final;
+  virtual const_element_iterator pid_elements_end (processor_id_type proc_id) const override final;
 
-  virtual element_iterator type_elements_begin (ElemType type) override;
-  virtual element_iterator type_elements_end (ElemType type) override;
-  virtual const_element_iterator type_elements_begin (ElemType type) const override;
-  virtual const_element_iterator type_elements_end (ElemType type) const override;
+  virtual element_iterator type_elements_begin (ElemType type) override final;
+  virtual element_iterator type_elements_end (ElemType type) override final;
+  virtual const_element_iterator type_elements_begin (ElemType type) const override final;
+  virtual const_element_iterator type_elements_end (ElemType type) const override final;
 
-  virtual element_iterator active_type_elements_begin (ElemType type) override;
-  virtual element_iterator active_type_elements_end (ElemType type) override;
-  virtual const_element_iterator active_type_elements_begin (ElemType type) const override;
-  virtual const_element_iterator active_type_elements_end (ElemType type) const override;
+  virtual element_iterator active_type_elements_begin (ElemType type) override final;
+  virtual element_iterator active_type_elements_end (ElemType type) override final;
+  virtual const_element_iterator active_type_elements_begin (ElemType type) const override final;
+  virtual const_element_iterator active_type_elements_end (ElemType type) const override final;
 
-  virtual element_iterator active_pid_elements_begin (processor_id_type proc_id) override;
-  virtual element_iterator active_pid_elements_end (processor_id_type proc_id) override;
-  virtual const_element_iterator active_pid_elements_begin (processor_id_type proc_id) const override;
-  virtual const_element_iterator active_pid_elements_end (processor_id_type proc_id) const override;
+  virtual element_iterator active_pid_elements_begin (processor_id_type proc_id) override final;
+  virtual element_iterator active_pid_elements_end (processor_id_type proc_id) override final;
+  virtual const_element_iterator active_pid_elements_begin (processor_id_type proc_id) const override final;
+  virtual const_element_iterator active_pid_elements_end (processor_id_type proc_id) const override final;
 
-  virtual element_iterator unpartitioned_elements_begin () override;
-  virtual element_iterator unpartitioned_elements_end () override;
-  virtual const_element_iterator unpartitioned_elements_begin () const override;
-  virtual const_element_iterator unpartitioned_elements_end () const override;
+  virtual element_iterator unpartitioned_elements_begin () override final;
+  virtual element_iterator unpartitioned_elements_end () override final;
+  virtual const_element_iterator unpartitioned_elements_begin () const override final;
+  virtual const_element_iterator unpartitioned_elements_end () const override final;
 
-  virtual element_iterator active_unpartitioned_elements_begin () override;
-  virtual element_iterator active_unpartitioned_elements_end () override;
-  virtual const_element_iterator active_unpartitioned_elements_begin () const override;
-  virtual const_element_iterator active_unpartitioned_elements_end () const override;
+  virtual element_iterator active_unpartitioned_elements_begin () override final;
+  virtual element_iterator active_unpartitioned_elements_end () override final;
+  virtual const_element_iterator active_unpartitioned_elements_begin () const override final;
+  virtual const_element_iterator active_unpartitioned_elements_end () const override final;
 
-  virtual element_iterator active_local_subdomain_elements_begin (subdomain_id_type subdomain_id) override;
-  virtual element_iterator active_local_subdomain_elements_end (subdomain_id_type subdomain_id) override;
-  virtual const_element_iterator active_local_subdomain_elements_begin (subdomain_id_type subdomain_id) const override;
-  virtual const_element_iterator active_local_subdomain_elements_end (subdomain_id_type subdomain_id) const override;
-  virtual SimpleRange<element_iterator> active_local_subdomain_elements_ptr_range(subdomain_id_type subdomain_id) override
+  virtual element_iterator active_local_subdomain_elements_begin (subdomain_id_type subdomain_id) override final;
+  virtual element_iterator active_local_subdomain_elements_end (subdomain_id_type subdomain_id) override final;
+  virtual const_element_iterator active_local_subdomain_elements_begin (subdomain_id_type subdomain_id) const override final;
+  virtual const_element_iterator active_local_subdomain_elements_end (subdomain_id_type subdomain_id) const override final;
+  virtual SimpleRange<element_iterator> active_local_subdomain_elements_ptr_range(subdomain_id_type subdomain_id) override final
   { return {active_local_subdomain_elements_begin(subdomain_id), active_local_subdomain_elements_end(subdomain_id)}; }
-  virtual SimpleRange<const_element_iterator> active_local_subdomain_elements_ptr_range(subdomain_id_type subdomain_id) const override
+  virtual SimpleRange<const_element_iterator> active_local_subdomain_elements_ptr_range(subdomain_id_type subdomain_id) const override final
   { return {active_local_subdomain_elements_begin(subdomain_id), active_local_subdomain_elements_end(subdomain_id)}; }
 
-  virtual element_iterator active_subdomain_elements_begin (subdomain_id_type subdomain_id) override;
-  virtual element_iterator active_subdomain_elements_end (subdomain_id_type subdomain_id) override;
-  virtual const_element_iterator active_subdomain_elements_begin (subdomain_id_type subdomain_id) const override;
-  virtual const_element_iterator active_subdomain_elements_end (subdomain_id_type subdomain_id) const override;
-  virtual SimpleRange<element_iterator> active_subdomain_elements_ptr_range(subdomain_id_type subdomain_id) override
+  virtual element_iterator active_subdomain_elements_begin (subdomain_id_type subdomain_id) override final;
+  virtual element_iterator active_subdomain_elements_end (subdomain_id_type subdomain_id) override final;
+  virtual const_element_iterator active_subdomain_elements_begin (subdomain_id_type subdomain_id) const override final;
+  virtual const_element_iterator active_subdomain_elements_end (subdomain_id_type subdomain_id) const override final;
+  virtual SimpleRange<element_iterator> active_subdomain_elements_ptr_range(subdomain_id_type subdomain_id) override final
   { return {active_subdomain_elements_begin(subdomain_id), active_subdomain_elements_end(subdomain_id)}; }
-  virtual SimpleRange<const_element_iterator> active_subdomain_elements_ptr_range(subdomain_id_type subdomain_id) const override
+  virtual SimpleRange<const_element_iterator> active_subdomain_elements_ptr_range(subdomain_id_type subdomain_id) const override final
   { return {active_subdomain_elements_begin(subdomain_id), active_subdomain_elements_end(subdomain_id)}; }
 
-  virtual element_iterator active_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) override;
-  virtual element_iterator active_subdomain_set_elements_end (std::set<subdomain_id_type> ss) override;
-  virtual const_element_iterator active_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) const override;
-  virtual const_element_iterator active_subdomain_set_elements_end (std::set<subdomain_id_type> ss) const override;
-  virtual SimpleRange<element_iterator> active_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) override
+  virtual element_iterator active_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) override final;
+  virtual element_iterator active_subdomain_set_elements_end (std::set<subdomain_id_type> ss) override final;
+  virtual const_element_iterator active_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) const override final;
+  virtual const_element_iterator active_subdomain_set_elements_end (std::set<subdomain_id_type> ss) const override final;
+  virtual SimpleRange<element_iterator> active_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) override final
   { return {active_subdomain_set_elements_begin(ss), active_subdomain_set_elements_end(ss)}; }
-  virtual SimpleRange<const_element_iterator> active_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) const override
+  virtual SimpleRange<const_element_iterator> active_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) const override final
   { return {active_subdomain_set_elements_begin(ss), active_subdomain_set_elements_end(ss)}; }
 
-  virtual element_iterator active_local_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) override;
-  virtual element_iterator active_local_subdomain_set_elements_end (std::set<subdomain_id_type> ss) override;
-  virtual const_element_iterator active_local_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) const override;
-  virtual const_element_iterator active_local_subdomain_set_elements_end (std::set<subdomain_id_type> ss) const override;
-  virtual SimpleRange<element_iterator> active_local_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) override
+  virtual element_iterator active_local_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) override final;
+  virtual element_iterator active_local_subdomain_set_elements_end (std::set<subdomain_id_type> ss) override final;
+  virtual const_element_iterator active_local_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) const override final;
+  virtual const_element_iterator active_local_subdomain_set_elements_end (std::set<subdomain_id_type> ss) const override final;
+  virtual SimpleRange<element_iterator> active_local_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) override final
   { return {active_local_subdomain_set_elements_begin(ss), active_local_subdomain_set_elements_end(ss)}; }
-  virtual SimpleRange<const_element_iterator> active_local_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) const override
+  virtual SimpleRange<const_element_iterator> active_local_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) const override final
   { return {active_local_subdomain_set_elements_begin(ss), active_local_subdomain_set_elements_end(ss)}; }
 
-  virtual element_iterator ghost_elements_begin () override;
-  virtual element_iterator ghost_elements_end () override;
-  virtual const_element_iterator ghost_elements_begin () const override;
-  virtual const_element_iterator ghost_elements_end () const override;
+  virtual element_iterator ghost_elements_begin () override final;
+  virtual element_iterator ghost_elements_end () override final;
+  virtual const_element_iterator ghost_elements_begin () const override final;
+  virtual const_element_iterator ghost_elements_end () const override final;
 
   virtual element_iterator
   evaluable_elements_begin (const DofMap & dof_map,
-                            unsigned int var_num = libMesh::invalid_uint) override;
+                            unsigned int var_num = libMesh::invalid_uint) override final;
 
   virtual element_iterator
   evaluable_elements_end (const DofMap & dof_map,
-                          unsigned int var_num = libMesh::invalid_uint) override;
+                          unsigned int var_num = libMesh::invalid_uint) override final;
 
   virtual const_element_iterator
   evaluable_elements_begin (const DofMap & dof_map,
-                            unsigned int var_num = libMesh::invalid_uint) const override;
+                            unsigned int var_num = libMesh::invalid_uint) const override final;
 
   virtual const_element_iterator
   evaluable_elements_end (const DofMap & dof_map,
-                          unsigned int var_num = libMesh::invalid_uint) const override;
+                          unsigned int var_num = libMesh::invalid_uint) const override final;
 
   virtual element_iterator
-  multi_evaluable_elements_begin (std::vector<const DofMap *> dof_maps) override;
+  multi_evaluable_elements_begin (std::vector<const DofMap *> dof_maps) override final;
 
   virtual element_iterator
-  multi_evaluable_elements_end (std::vector<const DofMap *> dof_maps) override;
+  multi_evaluable_elements_end (std::vector<const DofMap *> dof_maps) override final;
 
   virtual const_element_iterator
-  multi_evaluable_elements_begin (std::vector<const DofMap *> dof_maps) const override;
+  multi_evaluable_elements_begin (std::vector<const DofMap *> dof_maps) const override final;
 
   virtual const_element_iterator
-  multi_evaluable_elements_end (std::vector<const DofMap *> dof_maps) const override;
+  multi_evaluable_elements_end (std::vector<const DofMap *> dof_maps) const override final;
 
 #ifdef LIBMESH_ENABLE_AMR
-  virtual element_iterator flagged_elements_begin (unsigned char rflag) override;
-  virtual element_iterator flagged_elements_end (unsigned char rflag) override;
-  virtual const_element_iterator flagged_elements_begin (unsigned char rflag) const override;
-  virtual const_element_iterator flagged_elements_end (unsigned char rflag) const override;
+  virtual element_iterator flagged_elements_begin (unsigned char rflag) override final;
+  virtual element_iterator flagged_elements_end (unsigned char rflag) override final;
+  virtual const_element_iterator flagged_elements_begin (unsigned char rflag) const override final;
+  virtual const_element_iterator flagged_elements_end (unsigned char rflag) const override final;
 
   virtual element_iterator flagged_pid_elements_begin (unsigned char rflag,
-                                                       processor_id_type pid) override;
+                                                       processor_id_type pid) override final;
   virtual element_iterator flagged_pid_elements_end (unsigned char rflag,
-                                                     processor_id_type pid) override;
+                                                     processor_id_type pid) override final;
   virtual const_element_iterator flagged_pid_elements_begin (unsigned char rflag,
-                                                             processor_id_type pid) const override;
+                                                             processor_id_type pid) const override final;
   virtual const_element_iterator flagged_pid_elements_end (unsigned char rflag,
-                                                           processor_id_type pid) const override;
+                                                           processor_id_type pid) const override final;
 #endif // LIBMESH_ENABLE_AMR
 
   /**
    * Node iterator accessor functions.
    */
-  virtual node_iterator nodes_begin () override;
-  virtual node_iterator nodes_end () override;
-  virtual const_node_iterator nodes_begin () const override;
-  virtual const_node_iterator nodes_end () const override;
-  virtual SimpleRange<node_iterator> node_ptr_range() override { return {nodes_begin(), nodes_end()}; }
-  virtual SimpleRange<const_node_iterator> node_ptr_range() const override { return {nodes_begin(), nodes_end()}; }
+  virtual node_iterator nodes_begin () override final;
+  virtual node_iterator nodes_end () override final;
+  virtual const_node_iterator nodes_begin () const override final;
+  virtual const_node_iterator nodes_end () const override final;
+  virtual SimpleRange<node_iterator> node_ptr_range() override final { return {nodes_begin(), nodes_end()}; }
+  virtual SimpleRange<const_node_iterator> node_ptr_range() const override final { return {nodes_begin(), nodes_end()}; }
 
-  virtual node_iterator active_nodes_begin () override;
-  virtual node_iterator active_nodes_end () override;
-  virtual const_node_iterator active_nodes_begin () const override;
-  virtual const_node_iterator active_nodes_end () const override;
+  virtual node_iterator active_nodes_begin () override final;
+  virtual node_iterator active_nodes_end () override final;
+  virtual const_node_iterator active_nodes_begin () const override final;
+  virtual const_node_iterator active_nodes_end () const override final;
 
-  virtual node_iterator local_nodes_begin () override;
-  virtual node_iterator local_nodes_end () override;
-  virtual const_node_iterator local_nodes_begin () const override;
-  virtual const_node_iterator local_nodes_end () const override;
-  virtual SimpleRange<node_iterator> local_node_ptr_range() override { return {local_nodes_begin(), local_nodes_end()}; }
-  virtual SimpleRange<const_node_iterator> local_node_ptr_range() const override { return {local_nodes_begin(), local_nodes_end()}; }
+  virtual node_iterator local_nodes_begin () override final;
+  virtual node_iterator local_nodes_end () override final;
+  virtual const_node_iterator local_nodes_begin () const override final;
+  virtual const_node_iterator local_nodes_end () const override final;
+  virtual SimpleRange<node_iterator> local_node_ptr_range() override final { return {local_nodes_begin(), local_nodes_end()}; }
+  virtual SimpleRange<const_node_iterator> local_node_ptr_range() const override final { return {local_nodes_begin(), local_nodes_end()}; }
 
-  virtual node_iterator pid_nodes_begin (processor_id_type proc_id) override;
-  virtual node_iterator pid_nodes_end (processor_id_type proc_id) override;
-  virtual const_node_iterator pid_nodes_begin (processor_id_type proc_id) const override;
-  virtual const_node_iterator pid_nodes_end (processor_id_type proc_id) const override;
+  virtual node_iterator pid_nodes_begin (processor_id_type proc_id) override final;
+  virtual node_iterator pid_nodes_end (processor_id_type proc_id) override final;
+  virtual const_node_iterator pid_nodes_begin (processor_id_type proc_id) const override final;
+  virtual const_node_iterator pid_nodes_end (processor_id_type proc_id) const override final;
 
-  virtual node_iterator bid_nodes_begin (boundary_id_type bndry_id) override;
-  virtual node_iterator bid_nodes_end (boundary_id_type bndry_id) override;
-  virtual const_node_iterator bid_nodes_begin (boundary_id_type bndry_id) const override;
-  virtual const_node_iterator bid_nodes_end (boundary_id_type bndry_id) const override;
+  virtual node_iterator bid_nodes_begin (boundary_id_type bndry_id) override final;
+  virtual node_iterator bid_nodes_end (boundary_id_type bndry_id) override final;
+  virtual const_node_iterator bid_nodes_begin (boundary_id_type bndry_id) const override final;
+  virtual const_node_iterator bid_nodes_end (boundary_id_type bndry_id) const override final;
 
-  virtual node_iterator bnd_nodes_begin () override;
-  virtual node_iterator bnd_nodes_end () override;
-  virtual const_node_iterator bnd_nodes_begin () const override;
-  virtual const_node_iterator bnd_nodes_end () const override;
+  virtual node_iterator bnd_nodes_begin () override final;
+  virtual node_iterator bnd_nodes_end () override final;
+  virtual const_node_iterator bnd_nodes_begin () const override final;
+  virtual const_node_iterator bnd_nodes_end () const override final;
 
   virtual node_iterator
   evaluable_nodes_begin (const DofMap & dof_map,
-                         unsigned int var_num = libMesh::invalid_uint) override;
+                         unsigned int var_num = libMesh::invalid_uint) override final;
   virtual node_iterator
   evaluable_nodes_end (const DofMap & dof_map,
-                       unsigned int var_num = libMesh::invalid_uint) override;
+                       unsigned int var_num = libMesh::invalid_uint) override final;
   virtual const_node_iterator
   evaluable_nodes_begin (const DofMap & dof_map,
-                         unsigned int var_num = libMesh::invalid_uint) const override;
+                         unsigned int var_num = libMesh::invalid_uint) const override final;
   virtual const_node_iterator
   evaluable_nodes_end (const DofMap & dof_map,
-                       unsigned int var_num = libMesh::invalid_uint) const override;
+                       unsigned int var_num = libMesh::invalid_uint) const override final;
 
   virtual node_iterator
-  multi_evaluable_nodes_begin (std::vector<const DofMap *> dof_maps) override;
+  multi_evaluable_nodes_begin (std::vector<const DofMap *> dof_maps) override final;
   virtual node_iterator
-  multi_evaluable_nodes_end (std::vector<const DofMap *> dof_maps) override;
+  multi_evaluable_nodes_end (std::vector<const DofMap *> dof_maps) override final;
   virtual const_node_iterator
-  multi_evaluable_nodes_begin (std::vector<const DofMap *> dof_maps) const override;
+  multi_evaluable_nodes_begin (std::vector<const DofMap *> dof_maps) const override final;
   virtual const_node_iterator
-  multi_evaluable_nodes_end (std::vector<const DofMap *> dof_maps) const override;
+  multi_evaluable_nodes_end (std::vector<const DofMap *> dof_maps) const override final;
 
 protected:
 

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -119,61 +119,61 @@ public:
    */
   virtual void renumber_nodes_and_elements () override;
 
-  virtual dof_id_type n_nodes () const override
+  virtual dof_id_type n_nodes () const override final
   { return _n_nodes; }
 
-  virtual dof_id_type parallel_n_nodes () const override
+  virtual dof_id_type parallel_n_nodes () const override final
   { return _n_nodes; }
 
-  virtual dof_id_type max_node_id () const override
+  virtual dof_id_type max_node_id () const override final
   { return cast_int<dof_id_type>(_nodes.size()); }
 
-  virtual void reserve_nodes (const dof_id_type nn) override
+  virtual void reserve_nodes (const dof_id_type nn) override final
   { _nodes.reserve (nn); }
 
-  virtual dof_id_type n_elem () const override
+  virtual dof_id_type n_elem () const override final
   { return _n_elem; }
 
-  virtual dof_id_type parallel_n_elem () const override
+  virtual dof_id_type parallel_n_elem () const override final
   { return _n_elem; }
 
-  virtual dof_id_type n_active_elem () const override;
+  virtual dof_id_type n_active_elem () const override final;
 
-  virtual dof_id_type max_elem_id () const override
+  virtual dof_id_type max_elem_id () const override final
   { return cast_int<dof_id_type>(_elements.size()); }
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
-  virtual unique_id_type parallel_max_unique_id () const override;
-  virtual void set_next_unique_id(unique_id_type id) override;
+  virtual unique_id_type parallel_max_unique_id () const override final;
+  virtual void set_next_unique_id(unique_id_type id) override final;
 #endif
 
-  virtual void reserve_elem (const dof_id_type ne) override
+  virtual void reserve_elem (const dof_id_type ne) override final
   { _elements.reserve (ne); }
 
   virtual void update_parallel_id_counts () override;
 
-  virtual const Point & point (const dof_id_type i) const override;
+  virtual const Point & point (const dof_id_type i) const override final;
 
-  virtual const Node * node_ptr (const dof_id_type i) const override;
-  virtual Node * node_ptr (const dof_id_type i) override;
+  virtual const Node * node_ptr (const dof_id_type i) const override final;
+  virtual Node * node_ptr (const dof_id_type i) override final;
 
-  virtual const Node * query_node_ptr (const dof_id_type i) const override;
-  virtual Node * query_node_ptr (const dof_id_type i) override;
+  virtual const Node * query_node_ptr (const dof_id_type i) const override final;
+  virtual Node * query_node_ptr (const dof_id_type i) override final;
 
-  virtual const Elem * elem_ptr (const dof_id_type i) const override;
-  virtual Elem * elem_ptr (const dof_id_type i) override;
+  virtual const Elem * elem_ptr (const dof_id_type i) const override final;
+  virtual Elem * elem_ptr (const dof_id_type i) override final;
 
-  virtual const Elem * query_elem_ptr (const dof_id_type i) const override;
-  virtual Elem * query_elem_ptr (const dof_id_type i) override;
+  virtual const Elem * query_elem_ptr (const dof_id_type i) const override final;
+  virtual Elem * query_elem_ptr (const dof_id_type i) override final;
 
   /**
    * functions for adding /deleting nodes elements.
    */
   virtual Node * add_point (const Point & p,
                             const dof_id_type id = DofObject::invalid_id,
-                            const processor_id_type proc_id = DofObject::invalid_processor_id) override;
-  virtual Node * add_node (Node * n) override;
-  virtual Node * add_node (std::unique_ptr<Node> n) override;
+                            const processor_id_type proc_id = DofObject::invalid_processor_id) override final;
+  virtual Node * add_node (Node * n) override final;
+  virtual Node * add_node (std::unique_ptr<Node> n) override final;
 
   /**
    * Insert \p Node \p n into the Mesh at a location consistent with
@@ -186,17 +186,17 @@ public:
    * which is only capable of appending nodes at the end of the nodes
    * storage.
    */
-  virtual Node * insert_node(Node * n) override;
-  virtual Node * insert_node(std::unique_ptr<Node> n) override;
+  virtual Node * insert_node(Node * n) override final;
+  virtual Node * insert_node(std::unique_ptr<Node> n) override final;
 
-  virtual void delete_node (Node * n) override;
-  virtual void renumber_node (dof_id_type old_id, dof_id_type new_id) override;
-  virtual Elem * add_elem (Elem * e) override;
-  virtual Elem * add_elem (std::unique_ptr<Elem> e) override;
-  virtual Elem * insert_elem (Elem * e) override;
-  virtual Elem * insert_elem (std::unique_ptr<Elem> e) override;
-  virtual void delete_elem (Elem * e) override;
-  virtual void renumber_elem (dof_id_type old_id, dof_id_type new_id) override;
+  virtual void delete_node (Node * n) override final;
+  virtual void renumber_node (dof_id_type old_id, dof_id_type new_id) override final;
+  virtual Elem * add_elem (Elem * e) override final;
+  virtual Elem * add_elem (std::unique_ptr<Elem> e) override final;
+  virtual Elem * insert_elem (Elem * e) override final;
+  virtual Elem * insert_elem (std::unique_ptr<Elem> e) override final;
+  virtual void delete_elem (Elem * e) override final;
+  virtual void renumber_elem (dof_id_type old_id, dof_id_type new_id) override final;
 
   /**
    * There is no reason for a user to ever call this function.
@@ -282,275 +282,275 @@ public:
   /**
    * Elem iterator accessor functions.
    */
-  virtual element_iterator elements_begin () override;
-  virtual element_iterator elements_end () override;
-  virtual const_element_iterator elements_begin() const override;
-  virtual const_element_iterator elements_end() const override;
-  virtual SimpleRange<element_iterator> element_ptr_range() override { return {elements_begin(), elements_end()}; }
-  virtual SimpleRange<const_element_iterator> element_ptr_range() const override  { return {elements_begin(), elements_end()}; }
+  virtual element_iterator elements_begin () override final;
+  virtual element_iterator elements_end () override final;
+  virtual const_element_iterator elements_begin() const override final;
+  virtual const_element_iterator elements_end() const override final;
+  virtual SimpleRange<element_iterator> element_ptr_range() override final { return {elements_begin(), elements_end()}; }
+  virtual SimpleRange<const_element_iterator> element_ptr_range() const override final  { return {elements_begin(), elements_end()}; }
 
-  virtual element_iterator active_elements_begin () override;
-  virtual element_iterator active_elements_end () override;
-  virtual const_element_iterator active_elements_begin() const override;
-  virtual const_element_iterator active_elements_end() const override;
-  virtual SimpleRange<element_iterator> active_element_ptr_range() override { return {active_elements_begin(), active_elements_end()}; }
-  virtual SimpleRange<const_element_iterator> active_element_ptr_range() const override  { return {active_elements_begin(), active_elements_end()}; }
+  virtual element_iterator active_elements_begin () override final;
+  virtual element_iterator active_elements_end () override final;
+  virtual const_element_iterator active_elements_begin() const override final;
+  virtual const_element_iterator active_elements_end() const override final;
+  virtual SimpleRange<element_iterator> active_element_ptr_range() override final { return {active_elements_begin(), active_elements_end()}; }
+  virtual SimpleRange<const_element_iterator> active_element_ptr_range() const override final  { return {active_elements_begin(), active_elements_end()}; }
 
-  virtual element_iterator ancestor_elements_begin () override;
-  virtual element_iterator ancestor_elements_end () override;
-  virtual const_element_iterator ancestor_elements_begin() const override;
-  virtual const_element_iterator ancestor_elements_end() const override;
+  virtual element_iterator ancestor_elements_begin () override final;
+  virtual element_iterator ancestor_elements_end () override final;
+  virtual const_element_iterator ancestor_elements_begin() const override final;
+  virtual const_element_iterator ancestor_elements_end() const override final;
 
-  virtual element_iterator subactive_elements_begin () override;
-  virtual element_iterator subactive_elements_end () override;
-  virtual const_element_iterator subactive_elements_begin() const override;
-  virtual const_element_iterator subactive_elements_end() const override;
+  virtual element_iterator subactive_elements_begin () override final;
+  virtual element_iterator subactive_elements_end () override final;
+  virtual const_element_iterator subactive_elements_begin() const override final;
+  virtual const_element_iterator subactive_elements_end() const override final;
 
-  virtual element_iterator not_active_elements_begin () override;
-  virtual element_iterator not_active_elements_end () override;
-  virtual const_element_iterator not_active_elements_begin() const override;
-  virtual const_element_iterator not_active_elements_end() const override;
+  virtual element_iterator not_active_elements_begin () override final;
+  virtual element_iterator not_active_elements_end () override final;
+  virtual const_element_iterator not_active_elements_begin() const override final;
+  virtual const_element_iterator not_active_elements_end() const override final;
 
-  virtual element_iterator not_ancestor_elements_begin () override;
-  virtual element_iterator not_ancestor_elements_end () override;
-  virtual const_element_iterator not_ancestor_elements_begin() const override;
-  virtual const_element_iterator not_ancestor_elements_end() const override;
+  virtual element_iterator not_ancestor_elements_begin () override final;
+  virtual element_iterator not_ancestor_elements_end () override final;
+  virtual const_element_iterator not_ancestor_elements_begin() const override final;
+  virtual const_element_iterator not_ancestor_elements_end() const override final;
 
-  virtual element_iterator not_subactive_elements_begin () override;
-  virtual element_iterator not_subactive_elements_end () override;
-  virtual const_element_iterator not_subactive_elements_begin() const override;
-  virtual const_element_iterator not_subactive_elements_end() const override;
+  virtual element_iterator not_subactive_elements_begin () override final;
+  virtual element_iterator not_subactive_elements_end () override final;
+  virtual const_element_iterator not_subactive_elements_begin() const override final;
+  virtual const_element_iterator not_subactive_elements_end() const override final;
 
-  virtual element_iterator local_elements_begin () override;
-  virtual element_iterator local_elements_end () override;
-  virtual const_element_iterator local_elements_begin () const override;
-  virtual const_element_iterator local_elements_end () const override;
+  virtual element_iterator local_elements_begin () override final;
+  virtual element_iterator local_elements_end () override final;
+  virtual const_element_iterator local_elements_begin () const override final;
+  virtual const_element_iterator local_elements_end () const override final;
 
-  virtual element_iterator semilocal_elements_begin () override;
-  virtual element_iterator semilocal_elements_end () override;
-  virtual const_element_iterator semilocal_elements_begin () const override;
-  virtual const_element_iterator semilocal_elements_end () const override;
+  virtual element_iterator semilocal_elements_begin () override final;
+  virtual element_iterator semilocal_elements_end () override final;
+  virtual const_element_iterator semilocal_elements_begin () const override final;
+  virtual const_element_iterator semilocal_elements_end () const override final;
 
-  virtual element_iterator active_semilocal_elements_begin () override;
-  virtual element_iterator active_semilocal_elements_end () override;
-  virtual const_element_iterator active_semilocal_elements_begin () const override;
-  virtual const_element_iterator active_semilocal_elements_end () const override;
+  virtual element_iterator active_semilocal_elements_begin () override final;
+  virtual element_iterator active_semilocal_elements_end () override final;
+  virtual const_element_iterator active_semilocal_elements_begin () const override final;
+  virtual const_element_iterator active_semilocal_elements_end () const override final;
 
-  virtual element_iterator facelocal_elements_begin () override;
-  virtual element_iterator facelocal_elements_end () override;
-  virtual const_element_iterator facelocal_elements_begin () const override;
-  virtual const_element_iterator facelocal_elements_end () const override;
+  virtual element_iterator facelocal_elements_begin () override final;
+  virtual element_iterator facelocal_elements_end () override final;
+  virtual const_element_iterator facelocal_elements_begin () const override final;
+  virtual const_element_iterator facelocal_elements_end () const override final;
 
-  virtual element_iterator not_local_elements_begin () override;
-  virtual element_iterator not_local_elements_end () override;
-  virtual const_element_iterator not_local_elements_begin () const override;
-  virtual const_element_iterator not_local_elements_end () const override;
+  virtual element_iterator not_local_elements_begin () override final;
+  virtual element_iterator not_local_elements_end () override final;
+  virtual const_element_iterator not_local_elements_begin () const override final;
+  virtual const_element_iterator not_local_elements_end () const override final;
 
-  virtual element_iterator active_local_elements_begin () override;
-  virtual element_iterator active_local_elements_end () override;
-  virtual const_element_iterator active_local_elements_begin () const override;
-  virtual const_element_iterator active_local_elements_end () const override;
-  virtual SimpleRange<element_iterator> active_local_element_ptr_range() override { return {active_local_elements_begin(), active_local_elements_end()}; }
-  virtual SimpleRange<const_element_iterator> active_local_element_ptr_range() const override  { return {active_local_elements_begin(), active_local_elements_end()}; }
+  virtual element_iterator active_local_elements_begin () override final;
+  virtual element_iterator active_local_elements_end () override final;
+  virtual const_element_iterator active_local_elements_begin () const override final;
+  virtual const_element_iterator active_local_elements_end () const override final;
+  virtual SimpleRange<element_iterator> active_local_element_ptr_range() override final { return {active_local_elements_begin(), active_local_elements_end()}; }
+  virtual SimpleRange<const_element_iterator> active_local_element_ptr_range() const override final  { return {active_local_elements_begin(), active_local_elements_end()}; }
 
-  virtual element_iterator active_not_local_elements_begin () override;
-  virtual element_iterator active_not_local_elements_end () override;
-  virtual const_element_iterator active_not_local_elements_begin () const override;
-  virtual const_element_iterator active_not_local_elements_end () const override;
+  virtual element_iterator active_not_local_elements_begin () override final;
+  virtual element_iterator active_not_local_elements_end () override final;
+  virtual const_element_iterator active_not_local_elements_begin () const override final;
+  virtual const_element_iterator active_not_local_elements_end () const override final;
 
-  virtual element_iterator level_elements_begin (unsigned int level) override;
-  virtual element_iterator level_elements_end (unsigned int level) override;
-  virtual const_element_iterator level_elements_begin (unsigned int level) const override;
-  virtual const_element_iterator level_elements_end (unsigned int level) const override;
+  virtual element_iterator level_elements_begin (unsigned int level) override final;
+  virtual element_iterator level_elements_end (unsigned int level) override final;
+  virtual const_element_iterator level_elements_begin (unsigned int level) const override final;
+  virtual const_element_iterator level_elements_end (unsigned int level) const override final;
 
-  virtual element_iterator not_level_elements_begin (unsigned int level) override;
-  virtual element_iterator not_level_elements_end (unsigned int level) override;
-  virtual const_element_iterator not_level_elements_begin (unsigned int level) const override;
-  virtual const_element_iterator not_level_elements_end (unsigned int level) const override;
+  virtual element_iterator not_level_elements_begin (unsigned int level) override final;
+  virtual element_iterator not_level_elements_end (unsigned int level) override final;
+  virtual const_element_iterator not_level_elements_begin (unsigned int level) const override final;
+  virtual const_element_iterator not_level_elements_end (unsigned int level) const override final;
 
-  virtual element_iterator local_level_elements_begin (unsigned int level) override;
-  virtual element_iterator local_level_elements_end (unsigned int level) override;
-  virtual const_element_iterator local_level_elements_begin (unsigned int level) const override;
-  virtual const_element_iterator local_level_elements_end (unsigned int level) const override;
+  virtual element_iterator local_level_elements_begin (unsigned int level) override final;
+  virtual element_iterator local_level_elements_end (unsigned int level) override final;
+  virtual const_element_iterator local_level_elements_begin (unsigned int level) const override final;
+  virtual const_element_iterator local_level_elements_end (unsigned int level) const override final;
 
-  virtual element_iterator local_not_level_elements_begin (unsigned int level) override;
-  virtual element_iterator local_not_level_elements_end (unsigned int level) override;
-  virtual const_element_iterator local_not_level_elements_begin (unsigned int level) const override;
-  virtual const_element_iterator local_not_level_elements_end (unsigned int level) const override;
+  virtual element_iterator local_not_level_elements_begin (unsigned int level) override final;
+  virtual element_iterator local_not_level_elements_end (unsigned int level) override final;
+  virtual const_element_iterator local_not_level_elements_begin (unsigned int level) const override final;
+  virtual const_element_iterator local_not_level_elements_end (unsigned int level) const override final;
 
-  virtual element_iterator pid_elements_begin (processor_id_type proc_id) override;
-  virtual element_iterator pid_elements_end (processor_id_type proc_id) override;
-  virtual const_element_iterator pid_elements_begin (processor_id_type proc_id) const override;
-  virtual const_element_iterator pid_elements_end (processor_id_type proc_id) const override;
+  virtual element_iterator pid_elements_begin (processor_id_type proc_id) override final;
+  virtual element_iterator pid_elements_end (processor_id_type proc_id) override final;
+  virtual const_element_iterator pid_elements_begin (processor_id_type proc_id) const override final;
+  virtual const_element_iterator pid_elements_end (processor_id_type proc_id) const override final;
 
-  virtual element_iterator type_elements_begin (ElemType type) override;
-  virtual element_iterator type_elements_end (ElemType type) override;
-  virtual const_element_iterator type_elements_begin (ElemType type) const override;
-  virtual const_element_iterator type_elements_end (ElemType type) const override;
+  virtual element_iterator type_elements_begin (ElemType type) override final;
+  virtual element_iterator type_elements_end (ElemType type) override final;
+  virtual const_element_iterator type_elements_begin (ElemType type) const override final;
+  virtual const_element_iterator type_elements_end (ElemType type) const override final;
 
-  virtual element_iterator active_type_elements_begin (ElemType type) override;
-  virtual element_iterator active_type_elements_end (ElemType type) override;
-  virtual const_element_iterator active_type_elements_begin (ElemType type) const override;
-  virtual const_element_iterator active_type_elements_end (ElemType type) const override;
+  virtual element_iterator active_type_elements_begin (ElemType type) override final;
+  virtual element_iterator active_type_elements_end (ElemType type) override final;
+  virtual const_element_iterator active_type_elements_begin (ElemType type) const override final;
+  virtual const_element_iterator active_type_elements_end (ElemType type) const override final;
 
-  virtual element_iterator active_pid_elements_begin (processor_id_type proc_id) override;
-  virtual element_iterator active_pid_elements_end (processor_id_type proc_id) override;
-  virtual const_element_iterator active_pid_elements_begin (processor_id_type proc_id) const override;
-  virtual const_element_iterator active_pid_elements_end (processor_id_type proc_id) const override;
+  virtual element_iterator active_pid_elements_begin (processor_id_type proc_id) override final;
+  virtual element_iterator active_pid_elements_end (processor_id_type proc_id) override final;
+  virtual const_element_iterator active_pid_elements_begin (processor_id_type proc_id) const override final;
+  virtual const_element_iterator active_pid_elements_end (processor_id_type proc_id) const override final;
 
-  virtual element_iterator unpartitioned_elements_begin () override;
-  virtual element_iterator unpartitioned_elements_end () override;
-  virtual const_element_iterator unpartitioned_elements_begin () const override;
-  virtual const_element_iterator unpartitioned_elements_end () const override;
+  virtual element_iterator unpartitioned_elements_begin () override final;
+  virtual element_iterator unpartitioned_elements_end () override final;
+  virtual const_element_iterator unpartitioned_elements_begin () const override final;
+  virtual const_element_iterator unpartitioned_elements_end () const override final;
 
-  virtual element_iterator active_unpartitioned_elements_begin () override;
-  virtual element_iterator active_unpartitioned_elements_end () override;
-  virtual const_element_iterator active_unpartitioned_elements_begin () const override;
-  virtual const_element_iterator active_unpartitioned_elements_end () const override;
+  virtual element_iterator active_unpartitioned_elements_begin () override final;
+  virtual element_iterator active_unpartitioned_elements_end () override final;
+  virtual const_element_iterator active_unpartitioned_elements_begin () const override final;
+  virtual const_element_iterator active_unpartitioned_elements_end () const override final;
 
-  virtual element_iterator active_local_subdomain_elements_begin (subdomain_id_type subdomain_id) override;
-  virtual element_iterator active_local_subdomain_elements_end (subdomain_id_type subdomain_id) override;
-  virtual const_element_iterator active_local_subdomain_elements_begin (subdomain_id_type subdomain_id) const override;
-  virtual const_element_iterator active_local_subdomain_elements_end (subdomain_id_type subdomain_id) const override;
-  virtual SimpleRange<element_iterator> active_local_subdomain_elements_ptr_range(subdomain_id_type subdomain_id) override
+  virtual element_iterator active_local_subdomain_elements_begin (subdomain_id_type subdomain_id) override final;
+  virtual element_iterator active_local_subdomain_elements_end (subdomain_id_type subdomain_id) override final;
+  virtual const_element_iterator active_local_subdomain_elements_begin (subdomain_id_type subdomain_id) const override final;
+  virtual const_element_iterator active_local_subdomain_elements_end (subdomain_id_type subdomain_id) const override final;
+  virtual SimpleRange<element_iterator> active_local_subdomain_elements_ptr_range(subdomain_id_type subdomain_id) override final
   { return {active_local_subdomain_elements_begin(subdomain_id), active_local_subdomain_elements_end(subdomain_id)}; }
-  virtual SimpleRange<const_element_iterator> active_local_subdomain_elements_ptr_range(subdomain_id_type subdomain_id) const override
+  virtual SimpleRange<const_element_iterator> active_local_subdomain_elements_ptr_range(subdomain_id_type subdomain_id) const override final
   { return {active_local_subdomain_elements_begin(subdomain_id), active_local_subdomain_elements_end(subdomain_id)}; }
 
-  virtual element_iterator active_subdomain_elements_begin (subdomain_id_type subdomain_id) override;
-  virtual element_iterator active_subdomain_elements_end (subdomain_id_type subdomain_id) override;
-  virtual const_element_iterator active_subdomain_elements_begin (subdomain_id_type subdomain_id) const override;
-  virtual const_element_iterator active_subdomain_elements_end (subdomain_id_type subdomain_id) const override;
-  virtual SimpleRange<element_iterator> active_subdomain_elements_ptr_range(subdomain_id_type subdomain_id) override
+  virtual element_iterator active_subdomain_elements_begin (subdomain_id_type subdomain_id) override final;
+  virtual element_iterator active_subdomain_elements_end (subdomain_id_type subdomain_id) override final;
+  virtual const_element_iterator active_subdomain_elements_begin (subdomain_id_type subdomain_id) const override final;
+  virtual const_element_iterator active_subdomain_elements_end (subdomain_id_type subdomain_id) const override final;
+  virtual SimpleRange<element_iterator> active_subdomain_elements_ptr_range(subdomain_id_type subdomain_id) override final
   { return {active_subdomain_elements_begin(subdomain_id), active_subdomain_elements_end(subdomain_id)}; }
-  virtual SimpleRange<const_element_iterator> active_subdomain_elements_ptr_range(subdomain_id_type subdomain_id) const override
+  virtual SimpleRange<const_element_iterator> active_subdomain_elements_ptr_range(subdomain_id_type subdomain_id) const override final
   { return {active_subdomain_elements_begin(subdomain_id), active_subdomain_elements_end(subdomain_id)}; }
 
-  virtual element_iterator active_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) override;
-  virtual element_iterator active_subdomain_set_elements_end (std::set<subdomain_id_type> ss) override;
-  virtual const_element_iterator active_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) const override;
-  virtual const_element_iterator active_subdomain_set_elements_end (std::set<subdomain_id_type> ss) const override;
-  virtual SimpleRange<element_iterator> active_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) override
+  virtual element_iterator active_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) override final;
+  virtual element_iterator active_subdomain_set_elements_end (std::set<subdomain_id_type> ss) override final;
+  virtual const_element_iterator active_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) const override final;
+  virtual const_element_iterator active_subdomain_set_elements_end (std::set<subdomain_id_type> ss) const override final;
+  virtual SimpleRange<element_iterator> active_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) override final
   { return {active_subdomain_set_elements_begin(ss), active_subdomain_set_elements_end(ss)}; }
-  virtual SimpleRange<const_element_iterator> active_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) const override
+  virtual SimpleRange<const_element_iterator> active_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) const override final
   { return {active_subdomain_set_elements_begin(ss), active_subdomain_set_elements_end(ss)}; }
 
-  virtual element_iterator active_local_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) override;
-  virtual element_iterator active_local_subdomain_set_elements_end (std::set<subdomain_id_type> ss) override;
-  virtual const_element_iterator active_local_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) const override;
-  virtual const_element_iterator active_local_subdomain_set_elements_end (std::set<subdomain_id_type> ss) const override;
-  virtual SimpleRange<element_iterator> active_local_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) override
+  virtual element_iterator active_local_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) override final;
+  virtual element_iterator active_local_subdomain_set_elements_end (std::set<subdomain_id_type> ss) override final;
+  virtual const_element_iterator active_local_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) const override final;
+  virtual const_element_iterator active_local_subdomain_set_elements_end (std::set<subdomain_id_type> ss) const override final;
+  virtual SimpleRange<element_iterator> active_local_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) override final
   { return {active_local_subdomain_set_elements_begin(ss), active_local_subdomain_set_elements_end(ss)}; }
-  virtual SimpleRange<const_element_iterator> active_local_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) const override
+  virtual SimpleRange<const_element_iterator> active_local_subdomain_set_elements_ptr_range(std::set<subdomain_id_type> ss) const override final
   { return {active_local_subdomain_set_elements_begin(ss), active_local_subdomain_set_elements_end(ss)}; }
 
-  virtual element_iterator ghost_elements_begin () override;
-  virtual element_iterator ghost_elements_end () override;
-  virtual const_element_iterator ghost_elements_begin () const override;
-  virtual const_element_iterator ghost_elements_end () const override;
+  virtual element_iterator ghost_elements_begin () override final;
+  virtual element_iterator ghost_elements_end () override final;
+  virtual const_element_iterator ghost_elements_begin () const override final;
+  virtual const_element_iterator ghost_elements_end () const override final;
 
   virtual element_iterator
   evaluable_elements_begin (const DofMap & dof_map,
-                            unsigned int var_num = libMesh::invalid_uint) override;
+                            unsigned int var_num = libMesh::invalid_uint) override final;
 
   virtual element_iterator
   evaluable_elements_end (const DofMap & dof_map,
-                          unsigned int var_num = libMesh::invalid_uint) override;
+                          unsigned int var_num = libMesh::invalid_uint) override final;
 
   virtual const_element_iterator
   evaluable_elements_begin (const DofMap & dof_map,
-                            unsigned int var_num = libMesh::invalid_uint) const override;
+                            unsigned int var_num = libMesh::invalid_uint) const override final;
 
   virtual const_element_iterator
   evaluable_elements_end (const DofMap & dof_map,
-                          unsigned int var_num = libMesh::invalid_uint) const override;
+                          unsigned int var_num = libMesh::invalid_uint) const override final;
 
   virtual element_iterator
-  multi_evaluable_elements_begin (std::vector<const DofMap *> dof_maps) override;
+  multi_evaluable_elements_begin (std::vector<const DofMap *> dof_maps) override final;
 
   virtual element_iterator
-  multi_evaluable_elements_end (std::vector<const DofMap *> dof_maps) override;
+  multi_evaluable_elements_end (std::vector<const DofMap *> dof_maps) override final;
 
   virtual const_element_iterator
-  multi_evaluable_elements_begin (std::vector<const DofMap *> dof_maps) const override;
+  multi_evaluable_elements_begin (std::vector<const DofMap *> dof_maps) const override final;
 
   virtual const_element_iterator
-  multi_evaluable_elements_end (std::vector<const DofMap *> dof_maps) const override;
+  multi_evaluable_elements_end (std::vector<const DofMap *> dof_maps) const override final;
 
 #ifdef LIBMESH_ENABLE_AMR
-  virtual element_iterator flagged_elements_begin (unsigned char rflag) override;
-  virtual element_iterator flagged_elements_end (unsigned char rflag) override;
-  virtual const_element_iterator flagged_elements_begin (unsigned char rflag) const override;
-  virtual const_element_iterator flagged_elements_end (unsigned char rflag) const override;
+  virtual element_iterator flagged_elements_begin (unsigned char rflag) override final;
+  virtual element_iterator flagged_elements_end (unsigned char rflag) override final;
+  virtual const_element_iterator flagged_elements_begin (unsigned char rflag) const override final;
+  virtual const_element_iterator flagged_elements_end (unsigned char rflag) const override final;
 
   virtual element_iterator flagged_pid_elements_begin (unsigned char rflag,
-                                                       processor_id_type pid) override;
+                                                       processor_id_type pid) override final;
   virtual element_iterator flagged_pid_elements_end (unsigned char rflag,
-                                                     processor_id_type pid) override;
+                                                     processor_id_type pid) override final;
   virtual const_element_iterator flagged_pid_elements_begin (unsigned char rflag,
-                                                             processor_id_type pid) const override;
+                                                             processor_id_type pid) const override final;
   virtual const_element_iterator flagged_pid_elements_end (unsigned char rflag,
-                                                           processor_id_type pid) const override;
+                                                           processor_id_type pid) const override final;
 #endif // LIBMESH_ENABLE_AMR
 
   /**
    * Node iterator accessor functions.
    */
-  virtual node_iterator nodes_begin () override;
-  virtual node_iterator nodes_end () override;
-  virtual const_node_iterator nodes_begin () const override;
-  virtual const_node_iterator nodes_end () const override;
-  virtual SimpleRange<node_iterator> node_ptr_range() override { return {nodes_begin(), nodes_end()}; }
-  virtual SimpleRange<const_node_iterator> node_ptr_range() const override { return {nodes_begin(), nodes_end()}; }
+  virtual node_iterator nodes_begin () override final;
+  virtual node_iterator nodes_end () override final;
+  virtual const_node_iterator nodes_begin () const override final;
+  virtual const_node_iterator nodes_end () const override final;
+  virtual SimpleRange<node_iterator> node_ptr_range() override final { return {nodes_begin(), nodes_end()}; }
+  virtual SimpleRange<const_node_iterator> node_ptr_range() const override final { return {nodes_begin(), nodes_end()}; }
 
-  virtual node_iterator active_nodes_begin () override;
-  virtual node_iterator active_nodes_end () override;
-  virtual const_node_iterator active_nodes_begin () const override;
-  virtual const_node_iterator active_nodes_end () const override;
+  virtual node_iterator active_nodes_begin () override final;
+  virtual node_iterator active_nodes_end () override final;
+  virtual const_node_iterator active_nodes_begin () const override final;
+  virtual const_node_iterator active_nodes_end () const override final;
 
-  virtual node_iterator local_nodes_begin () override;
-  virtual node_iterator local_nodes_end () override;
-  virtual const_node_iterator local_nodes_begin () const override;
-  virtual const_node_iterator local_nodes_end () const override;
-  virtual SimpleRange<node_iterator> local_node_ptr_range() override { return {local_nodes_begin(), local_nodes_end()}; }
-  virtual SimpleRange<const_node_iterator> local_node_ptr_range() const override { return {local_nodes_begin(), local_nodes_end()}; }
+  virtual node_iterator local_nodes_begin () override final;
+  virtual node_iterator local_nodes_end () override final;
+  virtual const_node_iterator local_nodes_begin () const override final;
+  virtual const_node_iterator local_nodes_end () const override final;
+  virtual SimpleRange<node_iterator> local_node_ptr_range() override final { return {local_nodes_begin(), local_nodes_end()}; }
+  virtual SimpleRange<const_node_iterator> local_node_ptr_range() const override final { return {local_nodes_begin(), local_nodes_end()}; }
 
-  virtual node_iterator pid_nodes_begin (processor_id_type proc_id) override;
-  virtual node_iterator pid_nodes_end (processor_id_type proc_id) override;
-  virtual const_node_iterator pid_nodes_begin (processor_id_type proc_id) const override;
-  virtual const_node_iterator pid_nodes_end (processor_id_type proc_id) const override;
+  virtual node_iterator pid_nodes_begin (processor_id_type proc_id) override final;
+  virtual node_iterator pid_nodes_end (processor_id_type proc_id) override final;
+  virtual const_node_iterator pid_nodes_begin (processor_id_type proc_id) const override final;
+  virtual const_node_iterator pid_nodes_end (processor_id_type proc_id) const override final;
 
-  virtual node_iterator bid_nodes_begin (boundary_id_type bndry_id) override;
-  virtual node_iterator bid_nodes_end (boundary_id_type bndry_id) override;
-  virtual const_node_iterator bid_nodes_begin (boundary_id_type bndry_id) const override;
-  virtual const_node_iterator bid_nodes_end (boundary_id_type bndry_id) const override;
+  virtual node_iterator bid_nodes_begin (boundary_id_type bndry_id) override final;
+  virtual node_iterator bid_nodes_end (boundary_id_type bndry_id) override final;
+  virtual const_node_iterator bid_nodes_begin (boundary_id_type bndry_id) const override final;
+  virtual const_node_iterator bid_nodes_end (boundary_id_type bndry_id) const override final;
 
-  virtual node_iterator bnd_nodes_begin () override;
-  virtual node_iterator bnd_nodes_end () override;
-  virtual const_node_iterator bnd_nodes_begin () const override;
-  virtual const_node_iterator bnd_nodes_end () const override;
+  virtual node_iterator bnd_nodes_begin () override final;
+  virtual node_iterator bnd_nodes_end () override final;
+  virtual const_node_iterator bnd_nodes_begin () const override final;
+  virtual const_node_iterator bnd_nodes_end () const override final;
 
   virtual node_iterator
   evaluable_nodes_begin (const DofMap & dof_map,
-                         unsigned int var_num = libMesh::invalid_uint) override;
+                         unsigned int var_num = libMesh::invalid_uint) override final;
   virtual node_iterator
   evaluable_nodes_end (const DofMap & dof_map,
-                       unsigned int var_num = libMesh::invalid_uint) override;
+                       unsigned int var_num = libMesh::invalid_uint) override final;
   virtual const_node_iterator
   evaluable_nodes_begin (const DofMap & dof_map,
-                         unsigned int var_num = libMesh::invalid_uint) const override;
+                         unsigned int var_num = libMesh::invalid_uint) const override final;
   virtual const_node_iterator
   evaluable_nodes_end (const DofMap & dof_map,
-                       unsigned int var_num = libMesh::invalid_uint) const override;
+                       unsigned int var_num = libMesh::invalid_uint) const override final;
 
   virtual node_iterator
-  multi_evaluable_nodes_begin (std::vector<const DofMap *> dof_maps) override;
+  multi_evaluable_nodes_begin (std::vector<const DofMap *> dof_maps) override final;
   virtual node_iterator
-  multi_evaluable_nodes_end (std::vector<const DofMap *> dof_maps) override;
+  multi_evaluable_nodes_end (std::vector<const DofMap *> dof_maps) override final;
   virtual const_node_iterator
-  multi_evaluable_nodes_begin (std::vector<const DofMap *> dof_maps) const override;
+  multi_evaluable_nodes_begin (std::vector<const DofMap *> dof_maps) const override final;
   virtual const_node_iterator
-  multi_evaluable_nodes_end (std::vector<const DofMap *> dof_maps) const override;
+  multi_evaluable_nodes_end (std::vector<const DofMap *> dof_maps) const override final;
 
 protected:
 

--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -113,7 +113,7 @@ public:
    * flag which may have been previously set.  This allows e.g. a new
    * LU decomposition to be computed while reusing the same storage.
    */
-  virtual void zero() override;
+  virtual void zero() override final;
 
   /**
    * Get submatrix with the smallest row and column indices and the submatrix size.
@@ -134,14 +134,14 @@ public:
                   const unsigned int j);
 
   virtual T el(const unsigned int i,
-               const unsigned int j) const override
+               const unsigned int j) const override final
   { return (*this)(i,j); }
 
   virtual T & el(const unsigned int i,
-                 const unsigned int j) override
+                 const unsigned int j) override final
   { return (*this)(i,j); }
 
-  virtual void left_multiply (const DenseMatrixBase<T> & M2) override;
+  virtual void left_multiply (const DenseMatrixBase<T> & M2) override final;
 
   /**
    * Left multiplies by the matrix \p M2 of different type
@@ -149,7 +149,7 @@ public:
   template <typename T2>
   void left_multiply (const DenseMatrixBase<T2> & M2);
 
-  virtual void right_multiply (const DenseMatrixBase<T> & M2) override;
+  virtual void right_multiply (const DenseMatrixBase<T> & M2) override final;
 
   /**
    * Right multiplies by the matrix \p M2 of different type

--- a/include/numerics/dense_submatrix.h
+++ b/include/numerics/dense_submatrix.h
@@ -73,7 +73,7 @@ public:
    */
   DenseMatrix<T> & parent () { return _parent_matrix; }
 
-  virtual void zero() override;
+  virtual void zero() override final;
 
   /**
    * \returns The \p (i,j) element of the submatrix.
@@ -88,16 +88,16 @@ public:
                   const unsigned int j);
 
   virtual T el(const unsigned int i,
-               const unsigned int j) const override
+               const unsigned int j) const override final
   { return (*this)(i,j); }
 
   virtual T & el(const unsigned int i,
-                 const unsigned int j) override
+                 const unsigned int j) override final
   { return (*this)(i,j); }
 
-  virtual void left_multiply (const DenseMatrixBase<T> & M2) override;
+  virtual void left_multiply (const DenseMatrixBase<T> & M2) override final;
 
-  virtual void right_multiply (const DenseMatrixBase<T> & M3) override;
+  virtual void right_multiply (const DenseMatrixBase<T> & M3) override final;
 
   /**
    * Changes the location of the submatrix in the parent matrix.

--- a/include/numerics/dense_subvector.h
+++ b/include/numerics/dense_subvector.h
@@ -68,7 +68,7 @@ public:
    */
   DenseVector<T> & parent () { return _parent_vector; }
 
-  virtual void zero() override;
+  virtual void zero() override final;
 
   /**
    * \returns The \p (i,j) element of the subvector as a const
@@ -81,16 +81,16 @@ public:
    */
   T & operator() (const unsigned int i);
 
-  virtual T el(const unsigned int i) const override
+  virtual T el(const unsigned int i) const override final
   { return (*this)(i); }
 
-  virtual T & el(const unsigned int i) override
+  virtual T & el(const unsigned int i) override final
   { return (*this)(i); }
 
-  virtual unsigned int size() const override
+  virtual unsigned int size() const override final
   { return _n; }
 
-  virtual bool empty() const override
+  virtual bool empty() const override final
   { return (_n == 0); }
 
   /**

--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -100,15 +100,15 @@ public:
   DenseVector & operator= (DenseVector &&) = default;
   virtual ~DenseVector() = default;
 
-  virtual unsigned int size() const override
+  virtual unsigned int size() const override final
   {
     return cast_int<unsigned int>(_val.size());
   }
 
-  virtual bool empty() const override
+  virtual bool empty() const override final
   { return _val.empty(); }
 
-  virtual void zero() override;
+  virtual void zero() override final;
 
   /**
    * \returns Entry \p i of the vector as a const reference.
@@ -120,10 +120,10 @@ public:
    */
   T & operator() (const unsigned int i);
 
-  virtual T el(const unsigned int i) const override
+  virtual T el(const unsigned int i) const override final
   { return (*this)(i); }
 
-  virtual T & el(const unsigned int i) override
+  virtual T & el(const unsigned int i) override final
   { return (*this)(i); }
 
   /**

--- a/include/numerics/raw_accessor.h
+++ b/include/numerics/raw_accessor.h
@@ -169,7 +169,7 @@ public:
 private:
   RawAccessor();
 
-  ScalarType dummy;
+  ScalarType dummy = 0;
 
   FieldType & _data;
   const unsigned int _dim;

--- a/include/parallel/parallel_object.h
+++ b/include/parallel/parallel_object.h
@@ -101,7 +101,12 @@ public:
    * \returns The number of processors in the group.
    */
   processor_id_type n_processors () const
-  { return cast_int<processor_id_type>(_communicator.size()); }
+  {
+    processor_id_type returnval =
+      cast_int<processor_id_type>(_communicator.size());
+    libmesh_assert(returnval); // We never have an empty comm
+    return returnval;
+  }
 
   /**
    * \returns The rank of this processor in the group.

--- a/include/partitioning/parmetis_helper.h
+++ b/include/partitioning/parmetis_helper.h
@@ -26,6 +26,8 @@
 
 #ifdef LIBMESH_HAVE_PARMETIS
 
+#include "libmesh/id_types.h"
+
 // Before we include a header wrapped in a namespace, we'd better make
 // sure none of its dependencies end up in that namespace
 #include <mpi.h>

--- a/include/solvers/linear_solver.h
+++ b/include/solvers/linear_solver.h
@@ -313,7 +313,7 @@ template <typename T>
 inline
 LinearSolver<T>::~LinearSolver ()
 {
-  this->clear ();
+  this->LinearSolver::clear ();
 }
 
 template <typename T>

--- a/include/solvers/nonlinear_solver.h
+++ b/include/solvers/nonlinear_solver.h
@@ -436,7 +436,7 @@ template <typename T>
 inline
 NonlinearSolver<T>::~NonlinearSolver ()
 {
-  this->clear ();
+  this->NonlinearSolver::clear ();
 }
 
 

--- a/include/utils/parameters.h
+++ b/include/utils/parameters.h
@@ -331,7 +331,7 @@ void Parameters::clear () // since this is inline we must define it
 inline
 Parameters & Parameters::operator= (const Parameters & source)
 {
-  this->clear();
+  this->Parameters::clear();
   *this += source;
 
   return *this;
@@ -361,7 +361,7 @@ Parameters::Parameters (const Parameters & p)
 inline
 Parameters::~Parameters ()
 {
-  this->clear ();
+  this->Parameters::clear ();
 }
 
 

--- a/include/utils/point_locator_nanoflann.h
+++ b/include/utils/point_locator_nanoflann.h
@@ -89,13 +89,13 @@ public:
   /**
    * Restore to PointLocator to a just-constructed state.
    */
-  virtual void clear() override;
+  virtual void clear() override final;
 
   /**
    * Initializes the locator, so that the \p operator() methods can
    * be used. This function allocates dynamic memory with "new".
    */
-  virtual void init() override;
+  virtual void init() override final;
 
   /**
    * Locates the element in which the point with global coordinates \p
@@ -103,7 +103,7 @@ public:
    * subdomains.
    */
   virtual const Elem * operator() (const Point & p,
-                                   const std::set<subdomain_id_type> * allowed_subdomains = nullptr) const override;
+                                   const std::set<subdomain_id_type> * allowed_subdomains = nullptr) const override final;
 
   /**
    * Locates a set of elements in proximity to the point with global
@@ -116,19 +116,19 @@ public:
    */
   virtual void operator() (const Point & p,
                            std::set<const Elem *> & candidate_elements,
-                           const std::set<subdomain_id_type> * allowed_subdomains = nullptr) const override;
+                           const std::set<subdomain_id_type> * allowed_subdomains = nullptr) const override final;
 
   /**
    * Enables out-of-mesh mode. In this mode, if a searched-for Point
    * is not contained in any element of the Mesh, return nullptr
    * instead of throwing an error. By default, this mode is off.
    */
-  virtual void enable_out_of_mesh_mode () override;
+  virtual void enable_out_of_mesh_mode () override final;
 
   /**
    * Disables out-of-mesh mode (default). See above.
    */
-  virtual void disable_out_of_mesh_mode () override;
+  virtual void disable_out_of_mesh_mode () override final;
 
   /**
    * Set/get the number of results returned by each Nanoflann

--- a/include/utils/point_locator_tree.h
+++ b/include/utils/point_locator_tree.h
@@ -84,7 +84,7 @@ public:
   /**
    * Clears the locator.  This function frees dynamic memory with "delete".
    */
-  virtual void clear() override;
+  virtual void clear() override final;
 
   /**
    * Initializes the locator, so that the \p operator() methods can
@@ -96,7 +96,7 @@ public:
    * Initializes the locator, so that the \p operator() methods can
    * be used.  This function allocates dynamic memory with "new".
    */
-  virtual void init() override;
+  virtual void init() override final;
 
   /**
    * Locates the element in which the point with global coordinates
@@ -106,7 +106,7 @@ public:
    * operator().
    */
   virtual const Elem * operator() (const Point & p,
-                                   const std::set<subdomain_id_type> * allowed_subdomains = nullptr) const override;
+                                   const std::set<subdomain_id_type> * allowed_subdomains = nullptr) const override final;
 
   /**
    * Locates a set of elements in proximity to the point with global coordinates
@@ -114,7 +114,7 @@ public:
    */
   virtual void operator() (const Point & p,
                            std::set<const Elem *> & candidate_elements,
-                           const std::set<subdomain_id_type> * allowed_subdomains = nullptr) const override;
+                           const std::set<subdomain_id_type> * allowed_subdomains = nullptr) const override final;
 
   /**
    * As a fallback option, it's helpful to be able to do a linear
@@ -144,14 +144,14 @@ public:
    * return nullptr instead of crashing.  Per default, this
    * mode is off.
    */
-  virtual void enable_out_of_mesh_mode () override;
+  virtual void enable_out_of_mesh_mode () override final;
 
   /**
    * Disables out-of-mesh mode (default).  If asked to find a point
    * that is contained in no mesh at all, the point locator will now
    * crash.
    */
-  virtual void disable_out_of_mesh_mode () override;
+  virtual void disable_out_of_mesh_mode () override final;
 
   /**
    * Set the target bin size.

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -529,6 +529,7 @@ void ExactSolution::_compute_error(std::string_view sys_name,
 
   // Construct Quadrature rule based on default quadrature order
   const FEType & fe_type  = computed_dof_map.variable_type(var);
+  const auto field_type = FEInterface::field_type(fe_type);
 
   unsigned int n_vec_dim = FEInterface::n_vec_dim( mesh, fe_type );
 
@@ -617,7 +618,7 @@ void ExactSolution::_compute_error(std::string_view sys_name,
       // Only computed for vector-valued elements
       const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputDivergence>> * div_values = nullptr;
 
-      if (FEInterface::field_type(fe_type) == TYPE_VECTOR)
+      if (field_type == TYPE_VECTOR)
         {
           curl_values = &fe->get_curl_phi();
           div_values = &fe->get_div_phi();
@@ -629,7 +630,7 @@ void ExactSolution::_compute_error(std::string_view sys_name,
       const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputTensor>> *
         d2phi_values = nullptr;
 
-      if (FEInterface::field_type(fe_type) != TYPE_VECTOR)
+      if (field_type != TYPE_VECTOR)
         d2phi_values = &fe->get_d2phi();
 #endif
 
@@ -676,7 +677,7 @@ void ExactSolution::_compute_error(std::string_view sys_name,
               // Values from current solution.
               u_h      += phi_values[i][qp]*computed_system.current_solution  (dof_indices[i]);
               grad_u_h += dphi_values[i][qp]*computed_system.current_solution (dof_indices[i]);
-              if (FEInterface::field_type(fe_type) == TYPE_VECTOR)
+              if (field_type == TYPE_VECTOR)
                 {
                   curl_u_h += (*curl_values)[i][qp]*computed_system.current_solution (dof_indices[i]);
                   div_u_h += (*div_values)[i][qp]*computed_system.current_solution (dof_indices[i]);
@@ -742,7 +743,7 @@ void ExactSolution::_compute_error(std::string_view sys_name,
           error_vals[1] += JxW[qp]*grad_error.norm_sq();
 
 
-          if (FEInterface::field_type(fe_type) == TYPE_VECTOR)
+          if (field_type == TYPE_VECTOR)
             {
               // Compute the value of the error in the curl at this
               // quadrature point
@@ -789,7 +790,7 @@ void ExactSolution::_compute_error(std::string_view sys_name,
               //FIXME: This needs to be implemented to support rank 3 tensors
               //       which can't happen until type_n_tensor is fully implemented
               //       and a RawAccessor<TypeNTensor> is fully implemented
-              if (FEInterface::field_type(fe_type) == TYPE_VECTOR)
+              if (field_type == TYPE_VECTOR)
                 libmesh_not_implemented();
 
               for (unsigned int c = 0; c < n_vec_dim; c++)

--- a/src/error_estimation/patch_recovery_error_estimator.C
+++ b/src/error_estimation/patch_recovery_error_estimator.C
@@ -256,28 +256,29 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
       // Process each variable in the system using the current patch
       for (unsigned int var=0; var<n_vars; var++)
         {
+          const auto norm_type = error_estimator.error_norm.type(var);
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 #ifdef DEBUG
           bool is_valid_norm_type =
-            error_estimator.error_norm.type(var) == L2 ||
-            error_estimator.error_norm.type(var) == H1_SEMINORM ||
-            error_estimator.error_norm.type(var) == H2_SEMINORM ||
-            error_estimator.error_norm.type(var) == H1_X_SEMINORM ||
-            error_estimator.error_norm.type(var) == H1_Y_SEMINORM ||
-            error_estimator.error_norm.type(var) == H1_Z_SEMINORM ||
-            error_estimator.error_norm.type(var) == L_INF ||
-            error_estimator.error_norm.type(var) == W1_INF_SEMINORM ||
-            error_estimator.error_norm.type(var) == W2_INF_SEMINORM;
+            norm_type == L2 ||
+            norm_type == H1_SEMINORM ||
+            norm_type == H2_SEMINORM ||
+            norm_type == H1_X_SEMINORM ||
+            norm_type == H1_Y_SEMINORM ||
+            norm_type == H1_Z_SEMINORM ||
+            norm_type == L_INF ||
+            norm_type == W1_INF_SEMINORM ||
+            norm_type == W2_INF_SEMINORM;
           libmesh_assert (is_valid_norm_type);
 #endif // DEBUG
 #else
-          libmesh_assert (error_estimator.error_norm.type(var) == L2 ||
-                          error_estimator.error_norm.type(var) == L_INF ||
-                          error_estimator.error_norm.type(var) == H1_SEMINORM ||
-                          error_estimator.error_norm.type(var) == H1_X_SEMINORM ||
-                          error_estimator.error_norm.type(var) == H1_Y_SEMINORM ||
-                          error_estimator.error_norm.type(var) == H1_Z_SEMINORM ||
-                          error_estimator.error_norm.type(var) == W1_INF_SEMINORM);
+          libmesh_assert (norm_type == L2 ||
+                          norm_type == L_INF ||
+                          norm_type == H1_SEMINORM ||
+                          norm_type == H1_X_SEMINORM ||
+                          norm_type == H1_Y_SEMINORM ||
+                          norm_type == H1_Z_SEMINORM ||
+                          norm_type == W1_INF_SEMINORM);
 #endif
 
 
@@ -286,21 +287,21 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
             {
               // We can't mix L_inf and L_2 norms
               bool is_valid_norm_combo =
-                ((error_estimator.error_norm.type(var) == L2 ||
-                  error_estimator.error_norm.type(var) == H1_SEMINORM ||
-                  error_estimator.error_norm.type(var) == H1_X_SEMINORM ||
-                  error_estimator.error_norm.type(var) == H1_Y_SEMINORM ||
-                  error_estimator.error_norm.type(var) == H1_Z_SEMINORM ||
-                  error_estimator.error_norm.type(var) == H2_SEMINORM) &&
+                ((norm_type == L2 ||
+                  norm_type == H1_SEMINORM ||
+                  norm_type == H1_X_SEMINORM ||
+                  norm_type == H1_Y_SEMINORM ||
+                  norm_type == H1_Z_SEMINORM ||
+                  norm_type == H2_SEMINORM) &&
                  (error_estimator.error_norm.type(var-1) == L2 ||
                   error_estimator.error_norm.type(var-1) == H1_SEMINORM ||
                   error_estimator.error_norm.type(var-1) == H1_X_SEMINORM ||
                   error_estimator.error_norm.type(var-1) == H1_Y_SEMINORM ||
                   error_estimator.error_norm.type(var-1) == H1_Z_SEMINORM ||
                   error_estimator.error_norm.type(var-1) == H2_SEMINORM)) ||
-                ((error_estimator.error_norm.type(var) == L_INF ||
-                  error_estimator.error_norm.type(var) == W1_INF_SEMINORM ||
-                  error_estimator.error_norm.type(var) == W2_INF_SEMINORM) &&
+                ((norm_type == L_INF ||
+                  norm_type == W1_INF_SEMINORM ||
+                  norm_type == W2_INF_SEMINORM) &&
                  (error_estimator.error_norm.type(var-1) == L_INF ||
                   error_estimator.error_norm.type(var-1) == W1_INF_SEMINORM ||
                   error_estimator.error_norm.type(var-1) == W2_INF_SEMINORM));
@@ -339,23 +340,23 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
           // vector size later, then we'll need to get_phi whether we
           // plan to use it or not.
 #ifdef NDEBUG
-          if (error_estimator.error_norm.type(var) == L2 ||
-              error_estimator.error_norm.type(var) == L_INF)
+          if (norm_type == L2 ||
+              norm_type == L_INF)
 #endif
             phi = &(fe->get_phi());
 
           const std::vector<std::vector<RealGradient>> * dphi = nullptr;
-          if (error_estimator.error_norm.type(var) == H1_SEMINORM ||
-              error_estimator.error_norm.type(var) == H1_X_SEMINORM ||
-              error_estimator.error_norm.type(var) == H1_Y_SEMINORM ||
-              error_estimator.error_norm.type(var) == H1_Z_SEMINORM ||
-              error_estimator.error_norm.type(var) == W1_INF_SEMINORM)
+          if (norm_type == H1_SEMINORM ||
+              norm_type == H1_X_SEMINORM ||
+              norm_type == H1_Y_SEMINORM ||
+              norm_type == H1_Z_SEMINORM ||
+              norm_type == W1_INF_SEMINORM)
             dphi = &(fe->get_dphi());
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
           const std::vector<std::vector<RealTensor>> * d2phi = nullptr;
-          if (error_estimator.error_norm.type(var) == H2_SEMINORM ||
-              error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+          if (norm_type == H2_SEMINORM ||
+              norm_type == W2_INF_SEMINORM)
             d2phi = &(fe->get_d2phi());
 #endif
 
@@ -379,15 +380,15 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
           DenseMatrix<Number> Kp(matsize,matsize);
           DenseVector<Number> F,    Fx,     Fy,     Fz,     Fxy,     Fxz,     Fyz;
           DenseVector<Number> Pu_h, Pu_x_h, Pu_y_h, Pu_z_h, Pu_xy_h, Pu_xz_h, Pu_yz_h;
-          if (error_estimator.error_norm.type(var) == L2 ||
-              error_estimator.error_norm.type(var) == L_INF)
+          if (norm_type == L2 ||
+              norm_type == L_INF)
             {
               F.resize(matsize); Pu_h.resize(matsize);
             }
-          else if (error_estimator.error_norm.type(var) == H1_SEMINORM ||
-                   error_estimator.error_norm.type(var) == W1_INF_SEMINORM ||
-                   error_estimator.error_norm.type(var) == H2_SEMINORM ||
-                   error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+          else if (norm_type == H1_SEMINORM ||
+                   norm_type == W1_INF_SEMINORM ||
+                   norm_type == H2_SEMINORM ||
+                   norm_type == W2_INF_SEMINORM)
             {
               Fx.resize(matsize); Pu_x_h.resize(matsize); // stores xx in W2 cases
 #if LIBMESH_DIM > 1
@@ -397,24 +398,24 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
               Fz.resize(matsize); Pu_z_h.resize(matsize); // stores zz in W2 cases
 #endif
             }
-          else if (error_estimator.error_norm.type(var) == H1_X_SEMINORM)
+          else if (norm_type == H1_X_SEMINORM)
             {
               Fx.resize(matsize); Pu_x_h.resize(matsize); // Only need to compute the x gradient for the x component seminorm
             }
-          else if (error_estimator.error_norm.type(var) == H1_Y_SEMINORM)
+          else if (norm_type == H1_Y_SEMINORM)
             {
               libmesh_assert_greater (LIBMESH_DIM, 1);
               Fy.resize(matsize); Pu_y_h.resize(matsize); // Only need to compute the y gradient for the y component seminorm
             }
-          else if (error_estimator.error_norm.type(var) == H1_Z_SEMINORM)
+          else if (norm_type == H1_Z_SEMINORM)
             {
               libmesh_assert_greater (LIBMESH_DIM, 2);
               Fz.resize(matsize); Pu_z_h.resize(matsize); // Only need to compute the z gradient for the z component seminorm
             }
 
 #if LIBMESH_DIM > 1
-          if (error_estimator.error_norm.type(var) == H2_SEMINORM ||
-              error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+          if (norm_type == H2_SEMINORM ||
+              norm_type == W2_INF_SEMINORM)
             {
               Fxy.resize(matsize); Pu_xy_h.resize(matsize);
 #if LIBMESH_DIM > 2
@@ -456,8 +457,8 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                     for (unsigned int j=0; j<n; j++)
                       Kp(i,j) += JxW[qp]*psi[i]*psi[j];
 
-                  if (error_estimator.error_norm.type(var) == L2 ||
-                      error_estimator.error_norm.type(var) == L_INF)
+                  if (norm_type == L2 ||
+                      norm_type == L_INF)
                     {
                       // Compute the solution on the current patch element
                       // the quadrature point
@@ -471,8 +472,8 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                         F(i) += JxW[qp]*u_h*psi[i];
 
                     }
-                  else if (error_estimator.error_norm.type(var) == H1_SEMINORM ||
-                           error_estimator.error_norm.type(var) == W1_INF_SEMINORM)
+                  else if (norm_type == H1_SEMINORM ||
+                           norm_type == W1_INF_SEMINORM)
                     {
                       // Compute the gradient on the current patch element
                       // at the quadrature point
@@ -494,7 +495,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
 #endif
                         }
                     }
-                  else if (error_estimator.error_norm.type(var) == H1_X_SEMINORM)
+                  else if (norm_type == H1_X_SEMINORM)
                     {
                       // Compute the gradient on the current patch element
                       // at the quadrature point
@@ -511,7 +512,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                         }
                     }
 #if LIBMESH_DIM > 1
-                  else if (error_estimator.error_norm.type(var) == H1_Y_SEMINORM)
+                  else if (norm_type == H1_Y_SEMINORM)
                     {
                       // Compute the gradient on the current patch element
                       // at the quadrature point
@@ -529,7 +530,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                     }
 #endif // LIBMESH_DIM > 1
 #if LIBMESH_DIM > 2
-                  else if (error_estimator.error_norm.type(var) == H1_Z_SEMINORM)
+                  else if (norm_type == H1_Z_SEMINORM)
                     {
                       // Compute the gradient on the current patch element
                       // at the quadrature point
@@ -546,8 +547,8 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                         }
                     }
 #endif // LIBMESH_DIM > 2
-                  else if (error_estimator.error_norm.type(var) == H2_SEMINORM ||
-                           error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+                  else if (norm_type == H2_SEMINORM ||
+                           norm_type == W2_INF_SEMINORM)
                     {
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
                       // Compute the hessian on the current patch element
@@ -577,7 +578,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
 #endif
                     }
                   else
-                    libmesh_error_msg("Unsupported error norm type == " << Utility::enum_to_string(error_estimator.error_norm.type(var)));
+                    libmesh_error_msg("Unsupported error norm type == " << Utility::enum_to_string(norm_type));
                 } // end quadrature loop
             } // end patch loop
 
@@ -587,15 +588,15 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
           // Now we have fully assembled the projection system
           // for this patch.  Project the gradient components.
           // MAY NEED TO USE PARTIAL PIVOTING!
-          if (error_estimator.error_norm.type(var) == L2 ||
-              error_estimator.error_norm.type(var) == L_INF)
+          if (norm_type == L2 ||
+              norm_type == L_INF)
             {
               Kp.lu_solve(F, Pu_h);
             }
-          else if (error_estimator.error_norm.type(var) == H1_SEMINORM ||
-                   error_estimator.error_norm.type(var) == W1_INF_SEMINORM ||
-                   error_estimator.error_norm.type(var) == H2_SEMINORM ||
-                   error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+          else if (norm_type == H1_SEMINORM ||
+                   norm_type == W1_INF_SEMINORM ||
+                   norm_type == H2_SEMINORM ||
+                   norm_type == W2_INF_SEMINORM)
             {
               Kp.lu_solve (Fx, Pu_x_h);
 #if LIBMESH_DIM > 1
@@ -605,22 +606,22 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
               Kp.lu_solve (Fz, Pu_z_h);
 #endif
             }
-          else if (error_estimator.error_norm.type(var) == H1_X_SEMINORM)
+          else if (norm_type == H1_X_SEMINORM)
             {
               Kp.lu_solve (Fx, Pu_x_h);
             }
-          else if (error_estimator.error_norm.type(var) == H1_Y_SEMINORM)
+          else if (norm_type == H1_Y_SEMINORM)
             {
               Kp.lu_solve (Fy, Pu_y_h);
             }
-          else if (error_estimator.error_norm.type(var) == H1_Z_SEMINORM)
+          else if (norm_type == H1_Z_SEMINORM)
             {
               Kp.lu_solve (Fz, Pu_z_h);
             }
 
 #if LIBMESH_DIM > 1
-          if (error_estimator.error_norm.type(var) == H2_SEMINORM ||
-              error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+          if (norm_type == H2_SEMINORM ||
+              norm_type == W2_INF_SEMINORM)
             {
               Kp.lu_solve(Fxy, Pu_xy_h);
 #if LIBMESH_DIM > 2
@@ -704,8 +705,8 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
               // A quadrature rule for this element
               QGrid samprule (dim, qorder);
 
-              if (error_estimator.error_norm.type(var) == W1_INF_SEMINORM ||
-                  error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+              if (norm_type == W1_INF_SEMINORM ||
+                  norm_type == W2_INF_SEMINORM)
                 fe->attach_quadrature_rule (&samprule);
 
               // The number of points we will sample over
@@ -719,8 +720,8 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
 
                   std::vector<Number> temperr(6,0.0); // x,y,z or xx,yy,zz,xy,xz,yz
 
-                  if (error_estimator.error_norm.type(var) == L2 ||
-                      error_estimator.error_norm.type(var) == L_INF)
+                  if (norm_type == L2 ||
+                      norm_type == L_INF)
                     {
                       // Compute the value at the current sample point
                       Number u_h = libMesh::zero;
@@ -737,8 +738,8 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
 
                       temperr[0] -= u_h;
                     }
-                  else if (error_estimator.error_norm.type(var) == H1_SEMINORM ||
-                           error_estimator.error_norm.type(var) == W1_INF_SEMINORM)
+                  else if (norm_type == H1_SEMINORM ||
+                           norm_type == W1_INF_SEMINORM)
                     {
                       // Compute the gradient at the current sample point
                       Gradient grad_u_h;
@@ -768,7 +769,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                       temperr[2] -= grad_u_h(2);
 #endif
                     }
-                  else if (error_estimator.error_norm.type(var) == H1_X_SEMINORM)
+                  else if (norm_type == H1_X_SEMINORM)
                     {
                       // Compute the gradient at the current sample point
                       Gradient grad_u_h;
@@ -787,7 +788,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                       temperr[0] -= grad_u_h(0);
                     }
 #if LIBMESH_DIM > 1
-                  else if (error_estimator.error_norm.type(var) == H1_Y_SEMINORM)
+                  else if (norm_type == H1_Y_SEMINORM)
                     {
                       // Compute the gradient at the current sample point
                       Gradient grad_u_h;
@@ -807,7 +808,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                     }
 #endif // LIBMESH_DIM > 1
 #if LIBMESH_DIM > 2
-                  else if (error_estimator.error_norm.type(var) == H1_Z_SEMINORM)
+                  else if (norm_type == H1_Z_SEMINORM)
                     {
                       // Compute the gradient at the current sample point
                       Gradient grad_u_h;
@@ -826,8 +827,8 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                       temperr[2] -= grad_u_h(2);
                     }
 #endif // LIBMESH_DIM > 2
-                  else if (error_estimator.error_norm.type(var) == H2_SEMINORM ||
-                           error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+                  else if (norm_type == H2_SEMINORM ||
+                           norm_type == W2_INF_SEMINORM)
                     {
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
                       // Compute the Hessian at the current sample point
@@ -871,26 +872,26 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                   // LIBMESH_DIM < 3 cases a little bit with the exception
                   // of the W2 cases
 
-                  if (error_estimator.error_norm.type(var) == L_INF)
+                  if (norm_type == L_INF)
                     element_error = std::max(element_error, std::abs(temperr[0]));
-                  else if (error_estimator.error_norm.type(var) == W1_INF_SEMINORM)
+                  else if (norm_type == W1_INF_SEMINORM)
                     for (unsigned int i=0; i != LIBMESH_DIM; ++i)
                       element_error = std::max(element_error, std::abs(temperr[i]));
-                  else if (error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+                  else if (norm_type == W2_INF_SEMINORM)
                     for (unsigned int i=0; i != 6; ++i)
                       element_error = std::max(element_error, std::abs(temperr[i]));
-                  else if (error_estimator.error_norm.type(var) == L2)
+                  else if (norm_type == L2)
                     element_error += JxW[sp]*TensorTools::norm_sq(temperr[0]);
-                  else if (error_estimator.error_norm.type(var) == H1_SEMINORM)
+                  else if (norm_type == H1_SEMINORM)
                     for (unsigned int i=0; i != LIBMESH_DIM; ++i)
                       element_error += JxW[sp]*TensorTools::norm_sq(temperr[i]);
-                  else if (error_estimator.error_norm.type(var) == H1_X_SEMINORM)
+                  else if (norm_type == H1_X_SEMINORM)
                     element_error += JxW[sp]*TensorTools::norm_sq(temperr[0]);
-                  else if (error_estimator.error_norm.type(var) == H1_Y_SEMINORM)
+                  else if (norm_type == H1_Y_SEMINORM)
                     element_error += JxW[sp]*TensorTools::norm_sq(temperr[1]);
-                  else if (error_estimator.error_norm.type(var) == H1_Z_SEMINORM)
+                  else if (norm_type == H1_Z_SEMINORM)
                     element_error += JxW[sp]*TensorTools::norm_sq(temperr[2]);
-                  else if (error_estimator.error_norm.type(var) == H2_SEMINORM)
+                  else if (norm_type == H2_SEMINORM)
                     {
                       for (unsigned int i=0; i != LIBMESH_DIM; ++i)
                         element_error += JxW[sp]*TensorTools::norm_sq(temperr[i]);
@@ -901,19 +902,19 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
 
                 } // End loop over sample points
 
-              if (error_estimator.error_norm.type(var) == L_INF ||
-                  error_estimator.error_norm.type(var) == W1_INF_SEMINORM ||
-                  error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+              if (norm_type == L_INF ||
+                  norm_type == W1_INF_SEMINORM ||
+                  norm_type == W2_INF_SEMINORM)
                 new_error_per_cell[e] += error_estimator.error_norm.weight(var) * element_error;
-              else if (error_estimator.error_norm.type(var) == L2 ||
-                       error_estimator.error_norm.type(var) == H1_SEMINORM ||
-                       error_estimator.error_norm.type(var) == H1_X_SEMINORM ||
-                       error_estimator.error_norm.type(var) == H1_Y_SEMINORM ||
-                       error_estimator.error_norm.type(var) == H1_Z_SEMINORM ||
-                       error_estimator.error_norm.type(var) == H2_SEMINORM)
+              else if (norm_type == L2 ||
+                       norm_type == H1_SEMINORM ||
+                       norm_type == H1_X_SEMINORM ||
+                       norm_type == H1_Y_SEMINORM ||
+                       norm_type == H1_Z_SEMINORM ||
+                       norm_type == H2_SEMINORM)
                 new_error_per_cell[e] += error_estimator.error_norm.weight_sq(var) * element_error;
               else
-                libmesh_error_msg("Unsupported error norm type == " << Utility::enum_to_string(error_estimator.error_norm.type(var)));
+                libmesh_error_msg("Unsupported error norm type == " << Utility::enum_to_string(norm_type));
             }  // End (re) loop over patch elements
 
         } // end variables loop

--- a/src/error_estimation/weighted_patch_recovery_error_estimator.C
+++ b/src/error_estimation/weighted_patch_recovery_error_estimator.C
@@ -158,28 +158,29 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
       // Process each variable in the system using the current patch
       for (unsigned int var=0; var<n_vars; var++)
         {
+          const auto norm_type = error_estimator.error_norm.type(var);
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 #ifdef DEBUG
           bool is_valid_norm_type =
-            error_estimator.error_norm.type(var) == L2 ||
-            error_estimator.error_norm.type(var) == H1_SEMINORM ||
-            error_estimator.error_norm.type(var) == H2_SEMINORM ||
-            error_estimator.error_norm.type(var) == H1_X_SEMINORM ||
-            error_estimator.error_norm.type(var) == H1_Y_SEMINORM ||
-            error_estimator.error_norm.type(var) == H1_Z_SEMINORM ||
-            error_estimator.error_norm.type(var) == L_INF ||
-            error_estimator.error_norm.type(var) == W1_INF_SEMINORM ||
-            error_estimator.error_norm.type(var) == W2_INF_SEMINORM;
+            norm_type == L2 ||
+            norm_type == H1_SEMINORM ||
+            norm_type == H2_SEMINORM ||
+            norm_type == H1_X_SEMINORM ||
+            norm_type == H1_Y_SEMINORM ||
+            norm_type == H1_Z_SEMINORM ||
+            norm_type == L_INF ||
+            norm_type == W1_INF_SEMINORM ||
+            norm_type == W2_INF_SEMINORM;
           libmesh_assert (is_valid_norm_type);
 #endif // DEBUG
 #else
-          libmesh_assert (error_estimator.error_norm.type(var) == L2 ||
-                          error_estimator.error_norm.type(var) == L_INF ||
-                          error_estimator.error_norm.type(var) == H1_SEMINORM ||
-                          error_estimator.error_norm.type(var) == H1_X_SEMINORM ||
-                          error_estimator.error_norm.type(var) == H1_Y_SEMINORM ||
-                          error_estimator.error_norm.type(var) == H1_Z_SEMINORM ||
-                          error_estimator.error_norm.type(var) == W1_INF_SEMINORM);
+          libmesh_assert (norm_type == L2 ||
+                          norm_type == L_INF ||
+                          norm_type == H1_SEMINORM ||
+                          norm_type == H1_X_SEMINORM ||
+                          norm_type == H1_Y_SEMINORM ||
+                          norm_type == H1_Z_SEMINORM ||
+                          norm_type == W1_INF_SEMINORM);
 #endif
 
 #ifdef DEBUG
@@ -187,21 +188,21 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
             {
               // We can't mix L_inf and L_2 norms
               bool is_valid_norm_combo =
-                ((error_estimator.error_norm.type(var) == L2 ||
-                  error_estimator.error_norm.type(var) == H1_SEMINORM ||
-                  error_estimator.error_norm.type(var) == H1_X_SEMINORM ||
-                  error_estimator.error_norm.type(var) == H1_Y_SEMINORM ||
-                  error_estimator.error_norm.type(var) == H1_Z_SEMINORM ||
-                  error_estimator.error_norm.type(var) == H2_SEMINORM) &&
+                ((norm_type == L2 ||
+                  norm_type == H1_SEMINORM ||
+                  norm_type == H1_X_SEMINORM ||
+                  norm_type == H1_Y_SEMINORM ||
+                  norm_type == H1_Z_SEMINORM ||
+                  norm_type == H2_SEMINORM) &&
                  (error_estimator.error_norm.type(var-1) == L2 ||
                   error_estimator.error_norm.type(var-1) == H1_SEMINORM ||
                   error_estimator.error_norm.type(var-1) == H1_X_SEMINORM ||
                   error_estimator.error_norm.type(var-1) == H1_Y_SEMINORM ||
                   error_estimator.error_norm.type(var-1) == H1_Z_SEMINORM ||
                   error_estimator.error_norm.type(var-1) == H2_SEMINORM)) ||
-                ((error_estimator.error_norm.type(var) == L_INF ||
-                  error_estimator.error_norm.type(var) == W1_INF_SEMINORM ||
-                  error_estimator.error_norm.type(var) == W2_INF_SEMINORM) &&
+                ((norm_type == L_INF ||
+                  norm_type == W1_INF_SEMINORM ||
+                  norm_type == W2_INF_SEMINORM) &&
                  (error_estimator.error_norm.type(var-1) == L_INF ||
                   error_estimator.error_norm.type(var-1) == W1_INF_SEMINORM ||
                   error_estimator.error_norm.type(var-1) == W2_INF_SEMINORM));
@@ -240,23 +241,23 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
           // vector size later, then we'll need to get_phi whether we
           // plan to use it or not.
 #ifdef NDEBUG
-          if (error_estimator.error_norm.type(var) == L2 ||
-              error_estimator.error_norm.type(var) == L_INF)
+          if (norm_type == L2 ||
+              norm_type == L_INF)
 #endif
             phi = &(fe->get_phi());
 
           const std::vector<std::vector<RealGradient>> * dphi = nullptr;
-          if (error_estimator.error_norm.type(var) == H1_SEMINORM ||
-              error_estimator.error_norm.type(var) == H1_X_SEMINORM ||
-              error_estimator.error_norm.type(var) == H1_Y_SEMINORM ||
-              error_estimator.error_norm.type(var) == H1_Z_SEMINORM ||
-              error_estimator.error_norm.type(var) == W1_INF_SEMINORM)
+          if (norm_type == H1_SEMINORM ||
+              norm_type == H1_X_SEMINORM ||
+              norm_type == H1_Y_SEMINORM ||
+              norm_type == H1_Z_SEMINORM ||
+              norm_type == W1_INF_SEMINORM)
             dphi = &(fe->get_dphi());
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
           const std::vector<std::vector<RealTensor>> * d2phi = nullptr;
-          if (error_estimator.error_norm.type(var) == H2_SEMINORM ||
-              error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+          if (norm_type == H2_SEMINORM ||
+              norm_type == W2_INF_SEMINORM)
             d2phi = &(fe->get_d2phi());
 #endif
 
@@ -280,15 +281,15 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
           DenseMatrix<Number> Kp(matsize,matsize);
           DenseVector<Number> F,    Fx,     Fy,     Fz,     Fxy,     Fxz,     Fyz;
           DenseVector<Number> Pu_h, Pu_x_h, Pu_y_h, Pu_z_h, Pu_xy_h, Pu_xz_h, Pu_yz_h;
-          if (error_estimator.error_norm.type(var) == L2 ||
-              error_estimator.error_norm.type(var) == L_INF)
+          if (norm_type == L2 ||
+              norm_type == L_INF)
             {
               F.resize(matsize); Pu_h.resize(matsize);
             }
-          else if (error_estimator.error_norm.type(var) == H1_SEMINORM ||
-                   error_estimator.error_norm.type(var) == W1_INF_SEMINORM ||
-                   error_estimator.error_norm.type(var) == H2_SEMINORM ||
-                   error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+          else if (norm_type == H1_SEMINORM ||
+                   norm_type == W1_INF_SEMINORM ||
+                   norm_type == H2_SEMINORM ||
+                   norm_type == W2_INF_SEMINORM)
             {
               Fx.resize(matsize); Pu_x_h.resize(matsize); // stores xx in W2 cases
 #if LIBMESH_DIM > 1
@@ -298,24 +299,24 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
               Fz.resize(matsize); Pu_z_h.resize(matsize); // stores zz in W2 cases
 #endif
             }
-          else if (error_estimator.error_norm.type(var) == H1_X_SEMINORM)
+          else if (norm_type == H1_X_SEMINORM)
             {
               Fx.resize(matsize); Pu_x_h.resize(matsize); // Only need to compute the x gradient for the x component seminorm
             }
-          else if (error_estimator.error_norm.type(var) == H1_Y_SEMINORM)
+          else if (norm_type == H1_Y_SEMINORM)
             {
               libmesh_assert(LIBMESH_DIM > 1);
               Fy.resize(matsize); Pu_y_h.resize(matsize); // Only need to compute the y gradient for the y component seminorm
             }
-          else if (error_estimator.error_norm.type(var) == H1_Z_SEMINORM)
+          else if (norm_type == H1_Z_SEMINORM)
             {
               libmesh_assert(LIBMESH_DIM > 2);
               Fz.resize(matsize); Pu_z_h.resize(matsize); // Only need to compute the z gradient for the z component seminorm
             }
 
 #if LIBMESH_DIM > 1
-          if (error_estimator.error_norm.type(var) == H2_SEMINORM ||
-              error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+          if (norm_type == H2_SEMINORM ||
+              norm_type == W2_INF_SEMINORM)
             {
               Fxy.resize(matsize); Pu_xy_h.resize(matsize);
 #if LIBMESH_DIM > 2
@@ -358,8 +359,8 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                     for (unsigned int j=0; j<n; j++)
                       Kp(i,j) += JxW[qp]*psi[i]*psi[j];
 
-                  if (error_estimator.error_norm.type(var) == L2 ||
-                      error_estimator.error_norm.type(var) == L_INF)
+                  if (norm_type == L2 ||
+                      norm_type == L_INF)
                     {
                       // Compute the solution on the current patch element
                       // the quadrature point
@@ -373,8 +374,8 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                         F(i) = JxW[qp]*u_h*psi[i];
 
                     }
-                  else if (error_estimator.error_norm.type(var) == H1_SEMINORM ||
-                           error_estimator.error_norm.type(var) == W1_INF_SEMINORM)
+                  else if (norm_type == H1_SEMINORM ||
+                           norm_type == W1_INF_SEMINORM)
                     {
                       // Compute the gradient on the current patch element
                       // at the quadrature point
@@ -398,7 +399,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
 #endif
                         }
                     }
-                  else if (error_estimator.error_norm.type(var) == H1_X_SEMINORM)
+                  else if (norm_type == H1_X_SEMINORM)
                     {
                       // Compute the gradient on the current patch element
                       // at the quadrature point
@@ -417,7 +418,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                         }
                     }
 #if LIBMESH_DIM > 1
-                  else if (error_estimator.error_norm.type(var) == H1_Y_SEMINORM)
+                  else if (norm_type == H1_Y_SEMINORM)
                     {
                       // Compute the gradient on the current patch element
                       // at the quadrature point
@@ -437,7 +438,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                     }
 #endif // LIBMESH_DIM > 1
 #if LIBMESH_DIM > 2
-                  else if (error_estimator.error_norm.type(var) == H1_Z_SEMINORM)
+                  else if (norm_type == H1_Z_SEMINORM)
                     {
                       // Compute the gradient on the current patch element
                       // at the quadrature point
@@ -456,8 +457,8 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                         }
                     }
 #endif // LIBMESH_DIM > 2
-                  else if (error_estimator.error_norm.type(var) == H2_SEMINORM ||
-                           error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+                  else if (norm_type == H2_SEMINORM ||
+                           norm_type == W2_INF_SEMINORM)
                     {
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
                       // Compute the hessian on the current patch element
@@ -489,7 +490,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
 #endif
                     }
                   else
-                    libmesh_error_msg("Unsupported error norm type == " << Utility::enum_to_string(error_estimator.error_norm.type(var)));
+                    libmesh_error_msg("Unsupported error norm type == " << Utility::enum_to_string(norm_type));
                 } // end quadrature loop
             } // end patch loop
 
@@ -499,15 +500,15 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
           // Now we have fully assembled the projection system
           // for this patch.  Project the gradient components.
           // MAY NEED TO USE PARTIAL PIVOTING!
-          if (error_estimator.error_norm.type(var) == L2 ||
-              error_estimator.error_norm.type(var) == L_INF)
+          if (norm_type == L2 ||
+              norm_type == L_INF)
             {
               Kp.lu_solve(F, Pu_h);
             }
-          else if (error_estimator.error_norm.type(var) == H1_SEMINORM ||
-                   error_estimator.error_norm.type(var) == W1_INF_SEMINORM ||
-                   error_estimator.error_norm.type(var) == H2_SEMINORM ||
-                   error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+          else if (norm_type == H1_SEMINORM ||
+                   norm_type == W1_INF_SEMINORM ||
+                   norm_type == H2_SEMINORM ||
+                   norm_type == W2_INF_SEMINORM)
             {
               Kp.lu_solve (Fx, Pu_x_h);
 #if LIBMESH_DIM > 1
@@ -517,22 +518,22 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
               Kp.lu_solve (Fz, Pu_z_h);
 #endif
             }
-          else if (error_estimator.error_norm.type(var) == H1_X_SEMINORM)
+          else if (norm_type == H1_X_SEMINORM)
             {
               Kp.lu_solve (Fx, Pu_x_h);
             }
-          else if (error_estimator.error_norm.type(var) == H1_Y_SEMINORM)
+          else if (norm_type == H1_Y_SEMINORM)
             {
               Kp.lu_solve (Fy, Pu_y_h);
             }
-          else if (error_estimator.error_norm.type(var) == H1_Z_SEMINORM)
+          else if (norm_type == H1_Z_SEMINORM)
             {
               Kp.lu_solve (Fz, Pu_z_h);
             }
 
 #if LIBMESH_DIM > 1
-          if (error_estimator.error_norm.type(var) == H2_SEMINORM ||
-              error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+          if (norm_type == H2_SEMINORM ||
+              norm_type == W2_INF_SEMINORM)
             {
               Kp.lu_solve(Fxy, Pu_xy_h);
 #if LIBMESH_DIM > 2
@@ -624,8 +625,8 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
               // A quadrature rule for this element
               QGrid samprule (dim, qorder);
 
-              if (error_estimator.error_norm.type(var) == W1_INF_SEMINORM ||
-                  error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+              if (norm_type == W1_INF_SEMINORM ||
+                  norm_type == W2_INF_SEMINORM)
                 fe->attach_quadrature_rule (&samprule);
 
               // The number of points we will sample over
@@ -639,8 +640,8 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
 
                   std::vector<Number> temperr(6,0.0); // x,y,z or xx,yy,zz,xy,xz,yz
 
-                  if (error_estimator.error_norm.type(var) == L2 ||
-                      error_estimator.error_norm.type(var) == L_INF)
+                  if (norm_type == L2 ||
+                      norm_type == L_INF)
                     {
                       // Compute the value at the current sample point
                       Number u_h = libMesh::zero;
@@ -657,8 +658,8 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
 
                       temperr[0] -= u_h;
                     }
-                  else if (error_estimator.error_norm.type(var) == H1_SEMINORM ||
-                           error_estimator.error_norm.type(var) == W1_INF_SEMINORM)
+                  else if (norm_type == H1_SEMINORM ||
+                           norm_type == W1_INF_SEMINORM)
                     {
                       // Compute the gradient at the current sample point
                       Gradient grad_u_h;
@@ -688,7 +689,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                       temperr[2] -= grad_u_h(2);
 #endif
                     }
-                  else if (error_estimator.error_norm.type(var) == H1_X_SEMINORM)
+                  else if (norm_type == H1_X_SEMINORM)
                     {
                       // Compute the gradient at the current sample point
                       Gradient grad_u_h;
@@ -707,7 +708,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                       temperr[0] -= grad_u_h(0);
                     }
 #if LIBMESH_DIM > 1
-                  else if (error_estimator.error_norm.type(var) == H1_Y_SEMINORM)
+                  else if (norm_type == H1_Y_SEMINORM)
                     {
                       // Compute the gradient at the current sample point
                       Gradient grad_u_h;
@@ -727,7 +728,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                     }
 #endif // LIBMESH_DIM > 1
 #if LIBMESH_DIM > 2
-                  else if (error_estimator.error_norm.type(var) == H1_Z_SEMINORM)
+                  else if (norm_type == H1_Z_SEMINORM)
                     {
                       // Compute the gradient at the current sample point
                       Gradient grad_u_h;
@@ -746,8 +747,8 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                       temperr[2] -= grad_u_h(2);
                     }
 #endif // LIBMESH_DIM > 2
-                  else if (error_estimator.error_norm.type(var) == H2_SEMINORM ||
-                           error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+                  else if (norm_type == H2_SEMINORM ||
+                           norm_type == W2_INF_SEMINORM)
                     {
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
                       // Compute the Hessian at the current sample point
@@ -795,26 +796,26 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                   // LIBMESH_DIM < 3 cases a little bit with the exception
                   // of the W2 cases
 
-                  if (error_estimator.error_norm.type(var) == L_INF)
+                  if (norm_type == L_INF)
                     element_error = std::max(element_error, std::abs(weight*temperr[0]));
-                  else if (error_estimator.error_norm.type(var) == W1_INF_SEMINORM)
+                  else if (norm_type == W1_INF_SEMINORM)
                     for (unsigned int i=0; i != LIBMESH_DIM; ++i)
                       element_error = std::max(element_error, std::abs(weight*temperr[i]));
-                  else if (error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+                  else if (norm_type == W2_INF_SEMINORM)
                     for (unsigned int i=0; i != 6; ++i)
                       element_error = std::max(element_error, std::abs(weight*temperr[i]));
-                  else if (error_estimator.error_norm.type(var) == L2)
+                  else if (norm_type == L2)
                     element_error += JxW[sp]*TensorTools::norm_sq(weight*temperr[0]);
-                  else if (error_estimator.error_norm.type(var) == H1_SEMINORM)
+                  else if (norm_type == H1_SEMINORM)
                     for (unsigned int i=0; i != LIBMESH_DIM; ++i)
                       element_error += JxW[sp]*TensorTools::norm_sq(weight*temperr[i]);
-                  else if (error_estimator.error_norm.type(var) == H1_X_SEMINORM)
+                  else if (norm_type == H1_X_SEMINORM)
                     element_error += JxW[sp]*TensorTools::norm_sq(weight*temperr[0]);
-                  else if (error_estimator.error_norm.type(var) == H1_Y_SEMINORM)
+                  else if (norm_type == H1_Y_SEMINORM)
                     element_error += JxW[sp]*TensorTools::norm_sq(weight*temperr[1]);
-                  else if (error_estimator.error_norm.type(var) == H1_Z_SEMINORM)
+                  else if (norm_type == H1_Z_SEMINORM)
                     element_error += JxW[sp]*TensorTools::norm_sq(weight*temperr[2]);
-                  else if (error_estimator.error_norm.type(var) == H2_SEMINORM)
+                  else if (norm_type == H2_SEMINORM)
                     {
                       for (unsigned int i=0; i != LIBMESH_DIM; ++i)
                         element_error += JxW[sp]*TensorTools::norm_sq(weight*temperr[i]);
@@ -825,19 +826,19 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
 
                 } // End loop over sample points
 
-              if (error_estimator.error_norm.type(var) == L_INF ||
-                  error_estimator.error_norm.type(var) == W1_INF_SEMINORM ||
-                  error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
+              if (norm_type == L_INF ||
+                  norm_type == W1_INF_SEMINORM ||
+                  norm_type == W2_INF_SEMINORM)
                 new_error_per_cell[e] += error_estimator.error_norm.weight(var) * element_error;
-              else if (error_estimator.error_norm.type(var) == L2 ||
-                       error_estimator.error_norm.type(var) == H1_SEMINORM ||
-                       error_estimator.error_norm.type(var) == H1_X_SEMINORM ||
-                       error_estimator.error_norm.type(var) == H1_Y_SEMINORM ||
-                       error_estimator.error_norm.type(var) == H1_Z_SEMINORM ||
-                       error_estimator.error_norm.type(var) == H2_SEMINORM)
+              else if (norm_type == L2 ||
+                       norm_type == H1_SEMINORM ||
+                       norm_type == H1_X_SEMINORM ||
+                       norm_type == H1_Y_SEMINORM ||
+                       norm_type == H1_Z_SEMINORM ||
+                       norm_type == H2_SEMINORM)
                 new_error_per_cell[e] += error_estimator.error_norm.weight_sq(var) * element_error;
               else
-                libmesh_error_msg("Unsupported error norm type == " << Utility::enum_to_string(error_estimator.error_norm.type(var)));
+                libmesh_error_msg("Unsupported error norm type == " << Utility::enum_to_string(norm_type));
             }  // End (re) loop over patch elements
 
         } // end variables loop

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -305,7 +305,7 @@ void FE<Dim,T>::reinit(const Elem * elem,
         // for all the elements on the mortar segment mesh by setting `calculate_default_dual_coeff' = false
         // in MOOSE (in `Assembly::reinitDual`) and use the customized QRule for calculating the dual shape coefficients
         // This is to be improved in the future
-        if (this->calculate_default_dual_coeff)
+        if (elem && this->calculate_default_dual_coeff)
           this->reinit_default_dual_shape_coeffs(elem);
         // The dual shape functions relies on the customized shape functions
         // and the coefficient matrix, \p dual_coeff
@@ -339,6 +339,8 @@ void FE<Dim,T>::reinit_dual_shape_coeffs(const Elem * elem,
 template <unsigned int Dim, FEFamily T>
 void FE<Dim,T>::reinit_default_dual_shape_coeffs (const Elem * elem)
 {
+  libmesh_assert(elem);
+
   FEType default_fe_type(this->get_order(), T);
   QGauss default_qrule(elem->dim(), default_fe_type.default_quadrature_order());
   default_qrule.init(elem->type(), elem->p_level());

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -90,7 +90,7 @@ MeshBase & DistributedMesh::assign(MeshBase && other_mesh)
 
 DistributedMesh::~DistributedMesh ()
 {
-  this->clear();  // Free nodes and elements
+  this->DistributedMesh::clear();  // Free nodes and elements
 }
 
 
@@ -967,7 +967,7 @@ void DistributedMesh::clear ()
   // There is no need to remove them from
   // the BoundaryInfo data structure since we
   // already cleared it.
-  this->clear_elems();
+  this->DistributedMesh::clear_elems();
 
   for (auto & node : _nodes)
     delete node;

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -187,7 +187,7 @@ MeshBase& MeshBase::operator= (MeshBase && other_mesh)
 
 MeshBase::~MeshBase()
 {
-  this->clear();
+  this->MeshBase::clear();
 
   libmesh_exceptionless_assert (!libMesh::closed());
 }

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1118,9 +1118,8 @@ void MeshTools::find_hanging_nodes_and_parents(const MeshBase & mesh,
                   else // If it wasn't node1 then it must be node2!
                     hanging_node=node2;
 
-                  // Reset these for reuse
+                  // Reset for reuse
                   local_node1=0;
-                  local_node2=0;
 
                   // Find the first node that makes up the side in the neighbor (these should be the parent nodes)
                   while (!neigh->is_node_on_side(local_node1++,s_neigh)) { }

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -106,7 +106,7 @@ ReplicatedMesh::ReplicatedMesh (const Parallel::Communicator & comm_in,
 
 ReplicatedMesh::~ReplicatedMesh ()
 {
-  this->clear();  // Free nodes and elements
+  this->ReplicatedMesh::clear();  // Free nodes and elements
 }
 
 
@@ -707,7 +707,7 @@ void ReplicatedMesh::clear ()
   // There is no need to remove them from
   // the BoundaryInfo data structure since we
   // already cleared it.
-  this->clear_elems();
+  this->ReplicatedMesh::clear_elems();
 
   for (auto & node : _nodes)
     delete node;

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -1280,16 +1280,11 @@ UnstructuredMesh::all_second_order_range (const SimpleRange<element_iterator> & 
   /*
    * The maximum number of new second order nodes we might be adding,
    * for use when picking unique unique_id values later. This variable
-   * is not used unless unique ids are enabled, so libmesh_ignore() it
-   * to avoid warnings in that case.
+   * is not used unless unique ids are enabled.
    */
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
   unsigned int max_new_nodes_per_elem;
 
-#ifndef LIBMESH_ENABLE_UNIQUE_ID
-  libmesh_ignore(max_new_nodes_per_elem);
-#endif
-
-#ifdef LIBMESH_ENABLE_UNIQUE_ID
   unique_id_type max_unique_id = this->parallel_max_unique_id();
 #endif
 
@@ -1307,7 +1302,9 @@ UnstructuredMesh::all_second_order_range (const SimpleRange<element_iterator> & 
        * to Edge3.  Something like 1/2 of n_nodes() have
        * to be added
        */
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
       max_new_nodes_per_elem = 3 - 2;
+#endif
       this->reserve_nodes(static_cast<unsigned int>
                           (1.5*static_cast<double>(this->n_nodes())));
       break;
@@ -1317,7 +1314,9 @@ UnstructuredMesh::all_second_order_range (const SimpleRange<element_iterator> & 
        * in 2D, either refine from Tri3 to Tri6 (double the nodes)
        * or from Quad4 to Quad8 (again, double) or Quad9 (2.25 that much)
        */
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
       max_new_nodes_per_elem = 9 - 4;
+#endif
       this->reserve_nodes(static_cast<unsigned int>
                           (2*static_cast<double>(this->n_nodes())));
       break;
@@ -1330,7 +1329,9 @@ UnstructuredMesh::all_second_order_range (const SimpleRange<element_iterator> & 
        * quite some nodes, and since we do not want to overburden the memory by
        * a too conservative guess, use the lower bound
        */
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
       max_new_nodes_per_elem = 27 - 8;
+#endif
       this->reserve_nodes(static_cast<unsigned int>
                           (2.5*static_cast<double>(this->n_nodes())));
       break;

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -115,6 +115,8 @@ namespace libMesh
 #else
           PetscErrorCode (*refine)(DM,MPI_Comm,DM*) = nullptr;
           ierr = DMShellGetRefine(dm, &refine);
+          CHKERRQ(ierr);
+
           if (refine)
             {
               ierr = DMShellSetRefine(*subdm, refine);

--- a/src/solvers/petscdmlibmeshimpl.C
+++ b/src/solvers/petscdmlibmeshimpl.C
@@ -99,6 +99,7 @@ PetscErrorCode DMlibMeshSetSystem_libMesh(DM dm, NonlinearImplicitSystem & sys)
   PetscValidHeaderSpecific(dm,DM_CLASSID,1);
   PetscBool islibmesh;
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH,&islibmesh);
+  CHKERRQ(ierr);
   if (!islibmesh) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
 
   if (dm->setupcalled) SETERRQ(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONGSTATE, "Cannot reset the libMesh system after DM has been set up.");
@@ -176,6 +177,7 @@ PetscErrorCode DMlibMeshGetBlocks(DM dm, PetscInt * n, char *** blocknames)
   PetscValidHeaderSpecific(dm,DM_CLASSID,1);
   PetscBool islibmesh;
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH,&islibmesh);
+  CHKERRQ(ierr);
   if (!islibmesh) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
   PetscValidPointer(n,2);
@@ -201,6 +203,7 @@ PetscErrorCode DMlibMeshGetVariables(DM dm, PetscInt * n, char *** varnames)
   PetscBool islibmesh;
   PetscInt i;
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH,&islibmesh);
+  CHKERRQ(ierr);
   if (!islibmesh) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
   PetscValidPointer(n,2);
@@ -487,6 +490,7 @@ PetscErrorCode DMlibMeshCreateFieldDecompositionDM(DM dm, PetscInt dnumber, Pets
   PetscFunctionBegin;
   PetscValidHeaderSpecific(dm,DM_CLASSID,1);
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH,&islibmesh);
+  CHKERRQ(ierr);
   if (!islibmesh) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
   if (dnumber < 0) SETERRQ1(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Negative number %D of decomposition parts", dnumber);
   PetscValidPointer(ddm,5);
@@ -539,6 +543,7 @@ PetscErrorCode DMlibMeshCreateDomainDecompositionDM(DM dm, PetscInt dnumber, Pet
   PetscFunctionBegin;
   PetscValidHeaderSpecific(dm,DM_CLASSID,1);
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH,&islibmesh);
+  CHKERRQ(ierr);
   if (!islibmesh) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
   if (dnumber < 0) SETERRQ1(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Negative number %D of decomposition parts", dnumber);
   PetscValidPointer(ddm,5);

--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -59,7 +59,7 @@ SlepcEigenSolver<T>::SlepcEigenSolver (const Parallel::Communicator & comm_in) :
 template <typename T>
 SlepcEigenSolver<T>::~SlepcEigenSolver ()
 {
-  this->clear ();
+  this->SlepcEigenSolver::clear ();
 }
 
 

--- a/src/solvers/tao_optimization_solver.C
+++ b/src/solvers/tao_optimization_solver.C
@@ -421,7 +421,7 @@ TaoOptimizationSolver<T>::TaoOptimizationSolver (OptimizationSystem & system_in)
 template <typename T>
 TaoOptimizationSolver<T>::~TaoOptimizationSolver ()
 {
-  this->clear ();
+  this->TaoOptimizationSolver::clear ();
 }
 
 

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1231,20 +1231,16 @@ unsigned int System::add_variable (std::string_view var,
 
   libmesh_assert(!this->is_initialized());
 
-  // Optimize for VariableGroups here - if the user is adding multiple
-  // variables of the same FEType and subdomain restriction, catch
-  // that here and add them as members of the same VariableGroup.
-  //
-  // start by setting this flag to whatever the user has requested
-  // and then consider the conditions which should negate it.
-  bool should_be_in_vg = this->identify_variable_groups();
-
-  // No variable groups, nothing to add to
-  if (!this->n_variable_groups())
-    should_be_in_vg = false;
-
-  else
+  if (this->n_variable_groups())
     {
+      // Optimize for VariableGroups here - if the user is adding multiple
+      // variables of the same FEType and subdomain restriction, catch
+      // that here and add them as members of the same VariableGroup.
+      //
+      // start by setting this flag to whatever the user has requested
+      // and then consider the conditions which should negate it.
+      bool should_be_in_vg = this->identify_variable_groups();
+
       VariableGroup & vg(_variable_groups.back());
 
       // get a pointer to their subdomain restriction, if any.
@@ -1325,19 +1321,16 @@ unsigned int System::add_variables (const std::vector<std::string> & vars,
           libmesh_error_msg("ERROR: incompatible variable " << ovar << " has already been added for this system!");
         }
 
-  // Optimize for VariableGroups here - if the user is adding multiple
-  // variables of the same FEType and subdomain restriction, catch
-  // that here and add them as members of the same VariableGroup.
-  //
-  // start by setting this flag to whatever the user has requested
-  // and then consider the conditions which should negate it.
-  bool should_be_in_vg = this->identify_variable_groups();
-
-  // No variable groups, nothing to add to
-  if (!this->n_variable_groups())
-    should_be_in_vg = false;
-  else
+  if (this->n_variable_groups())
     {
+      // Optimize for VariableGroups here - if the user is adding multiple
+      // variables of the same FEType and subdomain restriction, catch
+      // that here and add them as members of the same VariableGroup.
+      //
+      // start by setting this flag to whatever the user has requested
+      // and then consider the conditions which should negate it.
+      bool should_be_in_vg = this->identify_variable_groups();
+
       VariableGroup & vg(_variable_groups.back());
 
       // get a pointer to their subdomain restriction, if any.

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -276,7 +276,7 @@ void System::read_header (Xdr & io,
       this->comm().broadcast(vec_name);
       if (io.version() >= LIBMESH_VERSION_ID(1,7,0))
         {
-          int vec_projection;
+          int vec_projection = 0;
           if (this->processor_id() == 0)
             io.data (vec_projection);
           this->comm().broadcast(vec_projection);

--- a/src/utils/perf_log.C
+++ b/src/utils/perf_log.C
@@ -111,8 +111,9 @@ void PerfLog::push (const std::string & label,
     label_c_str = non_temporary_strings[label];
   else
     {
-      char * newcopy = new char [label.size()+1];
-      strcpy(newcopy, label.c_str());
+      const std::size_t labelsizep1 = label.size()+1;
+      char * newcopy = new char [labelsizep1];
+      strncpy(newcopy, label.c_str(), labelsizep1);
       label_c_str = newcopy;
       non_temporary_strings[label] = label_c_str;
     }
@@ -121,8 +122,9 @@ void PerfLog::push (const std::string & label,
     header_c_str = non_temporary_strings[header];
   else
     {
-      char * newcopy = new char [header.size()+1];
-      strcpy(newcopy, header.c_str());
+      const std::size_t headersizep1 = header.size()+1;
+      char * newcopy = new char [headersizep1];
+      strncpy(newcopy, header.c_str(), headersizep1);
       header_c_str = newcopy;
       non_temporary_strings[header] = header_c_str;
     }

--- a/src/utils/perf_log.C
+++ b/src/utils/perf_log.C
@@ -113,7 +113,7 @@ void PerfLog::push (const std::string & label,
     {
       const std::size_t labelsizep1 = label.size()+1;
       char * newcopy = new char [labelsizep1];
-      strncpy(newcopy, label.c_str(), labelsizep1);
+      std::strncpy(newcopy, label.c_str(), labelsizep1);
       label_c_str = newcopy;
       non_temporary_strings[label] = label_c_str;
     }
@@ -124,7 +124,7 @@ void PerfLog::push (const std::string & label,
     {
       const std::size_t headersizep1 = header.size()+1;
       char * newcopy = new char [headersizep1];
-      strncpy(newcopy, header.c_str(), headersizep1);
+      std::strncpy(newcopy, header.c_str(), headersizep1);
       header_c_str = newcopy;
       non_temporary_strings[header] = header_c_str;
     }


### PR DESCRIPTION
Most of the fixes here are trivial performance improvements and/or slightly clearer code; the one serious bugfix I moved into #3223

Even the workarounds for false positives might be worth it in the long run.  Ever since I discovered that nothing less would do to catch "used a container after std::move" bugs, I've been thinking of getting a clang-tidy target into our Makefiles and CI recipes; it's annoying when there are false positives to ignore or work around, but #3223 alone has been worth the hassle.