### PR TITLE
Add support for element sets (elemsets) to MeshBase, Exodus

### DIFF
--- a/include/base/id_types.h
+++ b/include/base/id_types.h
@@ -158,6 +158,13 @@ typedef uint16_t largest_id_type;
 typedef uint8_t largest_id_type;
 #endif
 
+// elemset ids have something in common with both boundary ids and
+// subdomain ids, but are not used for exactly the purposes as
+// either. To try and avoid confusion, we define here a custom type
+// for elemset ids, but for simplicity we just typedef it to be the
+// same as whatever the subdomain_id_type is.
+typedef subdomain_id_type elemset_id_type;
+
 } // namespace libMesh
 
 #endif // LIBMESH_ID_TYPES_H

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -298,13 +298,13 @@ public:
   /**
    * Write elemsets with the specified ids and set ids.
    *
-   * \note An elemset is a concept which is related to but distinct
-   * from both elem blocks and sidesets/nodesets. Elems in an elemset
+   * \note An elemset is a concept which is related to (but distinct
+   * from) both elem blocks and sidesets/nodesets. Elems in an elemset
    * can be from multiple different blocks. In addition, one can
    * define an elemset variable, which is like an elemental variable
    * but exists only on the elements defined in the set.
    */
-  void write_elemsets(const std::map<boundary_id_type, std::vector<dof_id_type>> & elemsets);
+  void write_elemsets();
 
   /**
    * The Exodus format can also store values on sidesets. This can be

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -296,10 +296,10 @@ public:
                        const std::set<std::string> * system_names=nullptr);
 
   /**
-   * Write elemsets with the specified ids and set ids.
+   * Write elemsets stored on the Mesh to file.
    *
    * \note An elemset is a concept which is related to (but distinct
-   * from) both elem blocks and sidesets/nodesets. Elems in an elemset
+   * from) both elem blocks and sidesets/nodesets. Elements in an elemset
    * can be from multiple different blocks. In addition, one can
    * define an elemset variable, which is like an elemental variable
    * but exists only on the elements defined in the set.

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -296,6 +296,17 @@ public:
                        const std::set<std::string> * system_names=nullptr);
 
   /**
+   * Write elemsets with the specified ids and set ids.
+   *
+   * \note An elemset is a concept which is related to but distinct
+   * from both elem blocks and sidesets/nodesets. Elems in an elemset
+   * can be from multiple different blocks. In addition, one can
+   * define an elemset variable, which is like an elemental variable
+   * but exists only on the elements defined in the set.
+   */
+  void write_elemsets(const std::map<boundary_id_type, std::vector<dof_id_type>> & elemsets);
+
+  /**
    * The Exodus format can also store values on sidesets. This can be
    * thought of as an alternative to defining an elemental variable
    * field on lower-dimensional elements making up a part of the

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -252,6 +252,12 @@ public:
   void read_sideset(int id, int offset);
 
   /**
+   * Reads information about elemset \p id and inserts it into the
+   * global elemset array at the position \p offset.
+   */
+  void read_elemset(int id, int offset);
+
+  /**
    * New API that reads all nodesets simultaneously. This may be slightly
    * faster than reading them one at a time. Calls ex_get_concat_node_sets()
    * under the hood.
@@ -624,6 +630,9 @@ public:
   // Total number of elements in all side sets
   int num_elem_all_sidesets;
 
+  // Total number of elements in all elem sets
+  int num_elem_all_elemsets;
+
   // Vector of element block identification numbers
   std::vector<int> block_ids;
 
@@ -642,17 +651,23 @@ public:
   // Vector of the elemset IDs
   std::vector<int> elemset_ids;
 
-  // Number of sides (edges/faces) in current set
+  // Number of sides in each sideset
   std::vector<int> num_sides_per_set;
 
-  // Number of nodes in current set
+  // Number of nodes in each nodeset
   std::vector<int> num_nodes_per_set;
 
-  // Number of distribution factors per set
+  // Number of elems in each elemset
+  std::vector<int> num_elems_per_set;
+
+  // Number of distribution factors per sideset
   std::vector<int> num_df_per_set;
 
-  // Number of distribution factors per set
+  // Number of distribution factors per nodeset
   std::vector<int> num_node_df_per_set;
+
+  // Number of distribution factors per elemset
+  std::vector<int> num_elem_df_per_set;
 
   // Starting indices for each nodeset in the node_sets_node_list vector.
   // Used in the calls to ex_{put,get}_concat_node_sets().
@@ -678,6 +693,12 @@ public:
 
   // Side (face/edge) id number
   std::vector<int> id_list;
+
+  // List of element numbers in all elemsets
+  std::vector<int> elemset_list;
+
+  // List of elemset ids for all elements in elemsets
+  std::vector<int> elemset_id_list;
 
   // Optional mapping from internal [0,num_nodes) to arbitrary indices
   std::vector<int> node_num_map;

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -335,7 +335,7 @@ public:
   void write_timestep(int timestep, Real time);
 
   /**
-   * Writes one elemset per map entry to the exo file.
+   * Write elemsets stored on the Mesh to the exo file.
    */
   void write_elemsets(const MeshBase & mesh);
 

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -240,6 +240,12 @@ public:
   void read_nodeset_info();
 
   /**
+   * Reads information about all of the elemsets in the \p ExodusII
+   * mesh file.
+   */
+  void read_elemset_info();
+
+  /**
    * Reads information about sideset \p id and inserts it into the
    * global sideset array at the position \p offset.
    */
@@ -632,6 +638,9 @@ public:
 
   // Vector of the nodeset IDs
   std::vector<int> nodeset_ids;
+
+  // Vector of the elemset IDs
+  std::vector<int> elemset_ids;
 
   // Number of sides (edges/faces) in current set
   std::vector<int> num_sides_per_set;

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -335,6 +335,11 @@ public:
   void write_timestep(int timestep, Real time);
 
   /**
+   * Writes one elemset per map entry to the exo file.
+   */
+  void write_elemsets(const std::map<boundary_id_type, std::vector<dof_id_type>> & elemsets);
+
+  /**
    * Write sideset data for the requested timestep.
    */
   void

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -337,7 +337,7 @@ public:
   /**
    * Writes one elemset per map entry to the exo file.
    */
-  void write_elemsets(const std::map<boundary_id_type, std::vector<dof_id_type>> & elemsets);
+  void write_elemsets(const MeshBase & mesh);
 
   /**
    * Write sideset data for the requested timestep.
@@ -591,8 +591,11 @@ public:
   // Total number of node sets
   int & num_node_sets;
 
-  // Total number of element sets
+  // Total number of side sets
   int & num_side_sets;
+
+  // Total number of element sets
+  int & num_elem_sets;
 
   // Number of global variables
   int num_global_vars;

--- a/include/mesh/exodus_header_info.h
+++ b/include/mesh/exodus_header_info.h
@@ -57,19 +57,21 @@ public:
     // Pack individual integers into vector
     std::vector<int> buffer =
       {num_dim, num_elem, num_elem_blk, num_node_sets,
-       num_side_sets, num_edge_blk, num_edge};
+       num_side_sets, num_elem_sets, num_edge_blk, num_edge};
 
     // broadcast integers
     comm.broadcast(buffer);
 
     // unpack
-    num_dim       = buffer[0];
-    num_elem      = buffer[1];
-    num_elem_blk  = buffer[2];
-    num_node_sets = buffer[3];
-    num_side_sets = buffer[4];
-    num_edge_blk  = buffer[5];
-    num_edge      = buffer[6];
+    unsigned int ctr = 0;
+    num_dim       = buffer[ctr++];
+    num_elem      = buffer[ctr++];
+    num_elem_blk  = buffer[ctr++];
+    num_node_sets = buffer[ctr++];
+    num_side_sets = buffer[ctr++];
+    num_elem_sets = buffer[ctr++];
+    num_edge_blk  = buffer[ctr++];
+    num_edge      = buffer[ctr++];
   }
 
   std::vector<char> title;
@@ -79,6 +81,7 @@ public:
   int num_elem_blk;
   int num_node_sets;
   int num_side_sets;
+  int num_elem_sets;
   int num_edge_blk;
   int num_edge;
 };

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -283,7 +283,7 @@ public:
    * calling add_elemset_code(). If no such code/set is found, returns
    * the empty set or DofObject::invalid_id, respectively.
    */
-  std::set<subdomain_id_type> get_elemsets(dof_id_type elemset_code) const;
+  void get_elemsets(dof_id_type elemset_code, std::set<subdomain_id_type> & id_set_to_fill) const;
   dof_id_type get_elemset_code(const std::set<subdomain_id_type> & id_set) const;
 
   /**

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -271,6 +271,13 @@ public:
   void add_elemset_code(dof_id_type code, const std::set<subdomain_id_type> & id_set);
 
   /**
+   * Determines the number of unique elemset ids which have been added
+   * via add_elemset_code() calls by looping over the
+   * _elemset_codes_inverse_map and counting them.
+   */
+  unsigned int n_elemsets() const;
+
+  /**
    * Look up the element sets for a given elemset code and
    * vice-versa. The elemset must have been previously stored by
    * calling add_elemset_code(). If no such code/set is found, returns

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -268,7 +268,7 @@ public:
    * specified in \p id_set. Also sets up the inverse mapping, so that if one knows
    * all the element sets an Elem belongs to, one can look up the corresponding code.
    */
-  void add_elemset_code(dof_id_type code, const std::set<subdomain_id_type> & id_set);
+  void add_elemset_code(dof_id_type code, const std::set<elemset_id_type> & id_set);
 
   /**
    * Determines the number of unique elemset ids which have been added
@@ -283,8 +283,8 @@ public:
    * calling add_elemset_code(). If no such code/set is found, returns
    * the empty set or DofObject::invalid_id, respectively.
    */
-  void get_elemsets(dof_id_type elemset_code, std::set<subdomain_id_type> & id_set_to_fill) const;
-  dof_id_type get_elemset_code(const std::set<subdomain_id_type> & id_set) const;
+  void get_elemsets(dof_id_type elemset_code, std::set<elemset_id_type> & id_set_to_fill) const;
+  dof_id_type get_elemset_code(const std::set<elemset_id_type> & id_set) const;
 
   /**
    * \returns The "spatial dimension" of the mesh.
@@ -1975,8 +1975,7 @@ protected:
    * stored as an extra_integer (named "elemset_code") on all elements,
    * and extra_integers are of type dof_id_type. Elements which do not
    * belong to any set should be assigned an elemset code of DofObject::invalid_id.
-   * 2.) We use subdomain_id_type for the element set id type since
-   * element sets can be thought of as a generalization of the concept
+   * 2.) Element sets can be thought of as a generalization of the concept
    * of a subdomain. Subdomains have the following restrictions:
    *   a.) A given element can only belong to a single subdomain
    *   b.) When using Exodus file input/output, subdomains are (unfortunately)
@@ -1989,8 +1988,8 @@ protected:
    * with the one requirement that elements which belong to no sets
    * should have a set code of DofObject::invalid_id.
    */
-  std::map<dof_id_type, std::set<subdomain_id_type>> _elemset_codes;
-  std::map<std::set<subdomain_id_type>, dof_id_type> _elemset_codes_inverse_map;
+  std::map<dof_id_type, std::set<elemset_id_type>> _elemset_codes;
+  std::map<std::set<elemset_id_type>, dof_id_type> _elemset_codes_inverse_map;
 
   /**
    * The "spatial dimension" of the Mesh.  See the documentation for

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -264,11 +264,19 @@ public:
   void set_elem_dimensions(const std::set<unsigned char> & elem_dims);
 
   /**
+   * Typedef for the "set" container used to store elemset ids. The
+   * main requirements are that the entries be sorted and unique, so
+   * std::set works for this, but there may be more efficient
+   * alternatives.
+   */
+  typedef std::set<elemset_id_type> elemset_type;
+
+  /**
    * Tabulate a user-defined "code" for elements which belong to the element sets
    * specified in \p id_set. Also sets up the inverse mapping, so that if one knows
    * all the element sets an Elem belongs to, one can look up the corresponding code.
    */
-  void add_elemset_code(dof_id_type code, const std::set<elemset_id_type> & id_set);
+  void add_elemset_code(dof_id_type code, const MeshBase::elemset_type & id_set);
 
   /**
    * Determines the number of unique elemset ids which have been added
@@ -283,8 +291,8 @@ public:
    * calling add_elemset_code(). If no such code/set is found, returns
    * the empty set or DofObject::invalid_id, respectively.
    */
-  void get_elemsets(dof_id_type elemset_code, std::set<elemset_id_type> & id_set_to_fill) const;
-  dof_id_type get_elemset_code(const std::set<elemset_id_type> & id_set) const;
+  void get_elemsets(dof_id_type elemset_code, MeshBase::elemset_type & id_set_to_fill) const;
+  dof_id_type get_elemset_code(const MeshBase::elemset_type & id_set) const;
 
   /**
    * \returns The "spatial dimension" of the mesh.
@@ -1990,9 +1998,9 @@ protected:
    * 4.) We also keep a list of all the elemset ids which have been added in
    * order to support O(1) performance behavior in n_elemsets() calls.
    */
-  std::map<dof_id_type, std::set<elemset_id_type>> _elemset_codes;
-  std::map<std::set<elemset_id_type>, dof_id_type> _elemset_codes_inverse_map;
-  std::set<elemset_id_type> _all_elemset_ids;
+  std::map<dof_id_type, MeshBase::elemset_type> _elemset_codes;
+  std::map<MeshBase::elemset_type, dof_id_type> _elemset_codes_inverse_map;
+  MeshBase::elemset_type _all_elemset_ids;
 
   /**
    * The "spatial dimension" of the Mesh.  See the documentation for

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -276,7 +276,7 @@ public:
    * specified in \p id_set. Also sets up the inverse mapping, so that if one knows
    * all the element sets an Elem belongs to, one can look up the corresponding code.
    */
-  void add_elemset_code(dof_id_type code, const MeshBase::elemset_type & id_set);
+  void add_elemset_code(dof_id_type code, MeshBase::elemset_type id_set);
 
   /**
    * Determines the number of unique elemset ids which have been added

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1987,9 +1987,12 @@ protected:
    * automatically. The codes can basically be chosen arbitrarily,
    * with the one requirement that elements which belong to no sets
    * should have a set code of DofObject::invalid_id.
+   * 4.) We also keep a list of all the elemset ids which have been added in
+   * order to support O(1) performance behavior in n_elemsets() calls.
    */
   std::map<dof_id_type, std::set<elemset_id_type>> _elemset_codes;
   std::map<std::set<elemset_id_type>, dof_id_type> _elemset_codes_inverse_map;
+  std::set<elemset_id_type> _all_elemset_ids;
 
   /**
    * The "spatial dimension" of the Mesh.  See the documentation for

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -273,8 +273,24 @@ public:
 
   /**
    * Tabulate a user-defined "code" for elements which belong to the element sets
-   * specified in \p id_set. Also sets up the inverse mapping, so that if one knows
-   * all the element sets an Elem belongs to, one can look up the corresponding code.
+   * specified in \p id_set. For example, suppose that we have two elemsets A and
+   * B with the following Elem ids:
+   * Elemset A = {1, 3}
+   * Elemset B = {2, 3}
+   *
+   * This implies the following mapping from elem id to elemset id:
+   * Elem 1 -> {A}
+   * Elem 2 -> {B}
+   * Elem 3 -> {A,B}
+   *
+   * In this case, we would need to tabulate three different elemset codes, e.g.:
+   * 0 -> {A}
+   * 1 -> {B}
+   * 2 -> {A,B}
+   *
+   * Also sets up the inverse mapping, so that if one knows all the
+   * element sets an Elem belongs to, one can look up the
+   * corresponding elemset code.
    */
   void add_elemset_code(dof_id_type code, MeshBase::elemset_type id_set);
 
@@ -1998,7 +2014,7 @@ protected:
    * 4.) We also keep a list of all the elemset ids which have been added in
    * order to support O(1) performance behavior in n_elemsets() calls.
    */
-  std::map<dof_id_type, MeshBase::elemset_type> _elemset_codes;
+  std::map<dof_id_type, const MeshBase::elemset_type *> _elemset_codes;
   std::map<MeshBase::elemset_type, dof_id_type> _elemset_codes_inverse_map;
   MeshBase::elemset_type _all_elemset_ids;
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1811,13 +1811,14 @@ void ExodusII_IO::write_timestep (const std::string & fname,
 }
 
 
-void ExodusII_IO::write_elemsets(const std::map<boundary_id_type, std::vector<dof_id_type>> & elemsets)
+void ExodusII_IO::write_elemsets()
 {
   libmesh_error_msg_if(!exio_helper->opened_for_writing,
                        "ERROR, ExodusII file must be opened for writing "
                        "before calling ExodusII_IO::write_elemset()!");
 
-  exio_helper->write_elemsets(elemsets);
+  const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
+  exio_helper->write_elemsets(mesh);
 }
 
 void

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -704,7 +704,7 @@ void ExodusII_IO::read (const std::string & fname)
       {
         // Build map from Elem -> {elemsets}. This is needed only
         // temporarily to determine a unique set of elemset codes.
-        std::map<Elem *, std::set<elemset_id_type>> elem_to_elemsets;
+        std::map<Elem *, MeshBase::elemset_type> elem_to_elemsets;
         for (auto e : index_range(exio_helper->elemset_list))
           {
             // Follow standard (see sideset case above) approach for
@@ -727,7 +727,7 @@ void ExodusII_IO::read (const std::string & fname)
           }
 
         // Create a set of unique elemsets
-        std::set<std::set<elemset_id_type>> unique_elemsets;
+        std::set<MeshBase::elemset_type> unique_elemsets;
         for (const auto & pr : elem_to_elemsets)
           unique_elemsets.insert(pr.second);
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -676,6 +676,21 @@ void ExodusII_IO::read (const std::string & fname)
   // Read in elemset information and apply to Mesh elements if present
   {
     exio_helper->read_elemset_info();
+
+    // Mimic behavior of sideset case where we store all the set
+    // information in a single array with offsets.
+    int offset=0;
+    for (int i=0; i<exio_helper->num_elem_sets; i++)
+      {
+        // Compute new offset
+        offset += (i > 0 ? exio_helper->num_elems_per_set[i-1] : 0);
+        exio_helper->read_elemset (i, offset);
+
+        // TODO: add support for elemset names
+        // std::string elemset_name = exio_helper->get_elem_set_name(i);
+        // if (!elemset_name.empty())
+        //   mesh.get_boundary_info().elemset_name(cast_int<boundary_id_type>(exio_helper->get_elem_set_id(i))) = elemset_name;
+      }
   }
 
   // Read nodeset info

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -673,6 +673,11 @@ void ExodusII_IO::read (const std::string & fname)
       } // end for (elem_list)
   } // end read sideset info
 
+  // Read in elemset information and apply to Mesh elements if present
+  {
+    exio_helper->read_elemset_info();
+  }
+
   // Read nodeset info
   {
     // This fills in the following fields of the helper for later use:

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1811,6 +1811,14 @@ void ExodusII_IO::write_timestep (const std::string & fname,
 }
 
 
+void ExodusII_IO::write_elemsets(const std::map<boundary_id_type, std::vector<dof_id_type>> & elemsets)
+{
+  libmesh_error_msg_if(!exio_helper->opened_for_writing,
+                       "ERROR, ExodusII file must be opened for writing "
+                       "before calling ExodusII_IO::write_elemset()!");
+
+  exio_helper->write_elemsets(elemsets);
+}
 
 void
 ExodusII_IO::
@@ -2263,6 +2271,11 @@ void ExodusII_IO::write_timestep (const std::string &,
 }
 
 
+
+void ExodusII_IO::write_elemsets(const std::map<boundary_id_type, std::vector<dof_id_type>> &)
+{
+  libmesh_error_msg("ERROR, ExodusII API is not defined.");
+}
 
 void
 ExodusII_IO::

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -691,7 +691,71 @@ void ExodusII_IO::read (const std::string & fname)
         // if (!elemset_name.empty())
         //   mesh.get_boundary_info().elemset_name(cast_int<boundary_id_type>(exio_helper->get_elem_set_id(i))) = elemset_name;
       }
-  }
+
+    // Debugging: print the concatenated list of elemset ids
+    libMesh::out << "Concatenated list of elemset Elem ids (Exodus numbering):" << std::endl;
+    for (const auto & id : exio_helper->elemset_list)
+      libMesh::out << id << " ";
+    libMesh::out << std::endl;
+
+    // Next we need to assign the elemset ids to the mesh using the
+    // Elem's "extra_integers" support, if we have any.
+    if (exio_helper->num_elem_all_elemsets)
+      {
+        // Build map from Elem -> {elemsets}. This is needed only
+        // temporarily to determine a unique set of elemset codes.
+        std::map<Elem *, std::set<elemset_id_type>> elem_to_elemsets;
+        for (auto e : index_range(exio_helper->elemset_list))
+          {
+            // Follow standard (see sideset case above) approach for
+            // converting the ids stored in the elemset_list to
+            // libmesh Elem ids.
+            //
+            // TODO: this should be moved to a helper function so we
+            // don't duplicate the code.
+            dof_id_type libmesh_elem_id =
+              cast_int<dof_id_type>(exio_helper->elem_num_map[exio_helper->elemset_list[e] - 1] - 1);
+
+            // Get a pointer to this Elem
+            Elem * elem = mesh.elem_ptr(libmesh_elem_id);
+
+            // Debugging:
+            libMesh::out << "Elem " << elem->id() << " is in elemset " << exio_helper->elemset_id_list[e] << std::endl;
+
+            // Store elemset id in the map
+            elem_to_elemsets[elem].insert(exio_helper->elemset_id_list[e]);
+          }
+
+        // Create a set of unique elemsets
+        std::set<std::set<elemset_id_type>> unique_elemsets;
+        for (const auto & pr : elem_to_elemsets)
+          unique_elemsets.insert(pr.second);
+
+        // Debugging: print the unique elemsets
+        libMesh::out << "The set of unique elemsets which exist on the Mesh:" << std::endl;
+        for (const auto & s : unique_elemsets)
+          {
+            for (const auto & elemset_id : s)
+              libMesh::out << elemset_id << " ";
+            libMesh::out << std::endl;
+          }
+
+        // Enumerate the unique_elemsets and tell the mesh about them
+        dof_id_type code = 0;
+        for (const auto & s : unique_elemsets)
+          mesh.add_elemset_code(code++, s);
+
+        // Create storage for the extra integer on all Elems. Elems which
+        // are not in any set will use the default value of DofObject::invalid_id
+        unsigned int elemset_index =
+          mesh.add_elem_integer("elemset_code",
+                                /*allocate_data=*/true);
+
+        // Store the appropriate extra_integer value on all Elems that need it.
+        for (const auto & [elem, s] : elem_to_elemsets)
+          elem->set_extra_integer(elemset_index, mesh.get_elemset_code(s));
+      }
+  } // done reading elemset info
 
   // Read nodeset info
   {

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -693,10 +693,10 @@ void ExodusII_IO::read (const std::string & fname)
       }
 
     // Debugging: print the concatenated list of elemset ids
-    libMesh::out << "Concatenated list of elemset Elem ids (Exodus numbering):" << std::endl;
-    for (const auto & id : exio_helper->elemset_list)
-      libMesh::out << id << " ";
-    libMesh::out << std::endl;
+    // libMesh::out << "Concatenated list of elemset Elem ids (Exodus numbering):" << std::endl;
+    // for (const auto & id : exio_helper->elemset_list)
+    //   libMesh::out << id << " ";
+    // libMesh::out << std::endl;
 
     // Next we need to assign the elemset ids to the mesh using the
     // Elem's "extra_integers" support, if we have any.
@@ -720,7 +720,7 @@ void ExodusII_IO::read (const std::string & fname)
             Elem * elem = mesh.elem_ptr(libmesh_elem_id);
 
             // Debugging:
-            libMesh::out << "Elem " << elem->id() << " is in elemset " << exio_helper->elemset_id_list[e] << std::endl;
+            // libMesh::out << "Elem " << elem->id() << " is in elemset " << exio_helper->elemset_id_list[e] << std::endl;
 
             // Store elemset id in the map
             elem_to_elemsets[elem].insert(exio_helper->elemset_id_list[e]);
@@ -732,13 +732,13 @@ void ExodusII_IO::read (const std::string & fname)
           unique_elemsets.insert(pr.second);
 
         // Debugging: print the unique elemsets
-        libMesh::out << "The set of unique elemsets which exist on the Mesh:" << std::endl;
-        for (const auto & s : unique_elemsets)
-          {
-            for (const auto & elemset_id : s)
-              libMesh::out << elemset_id << " ";
-            libMesh::out << std::endl;
-          }
+        // libMesh::out << "The set of unique elemsets which exist on the Mesh:" << std::endl;
+        // for (const auto & s : unique_elemsets)
+        //   {
+        //     for (const auto & elemset_id : s)
+        //       libMesh::out << elemset_id << " ";
+        //     libMesh::out << std::endl;
+        //   }
 
         // Enumerate the unique_elemsets and tell the mesh about them
         dof_id_type code = 0;
@@ -1899,7 +1899,7 @@ void ExodusII_IO::write_elemsets()
 {
   libmesh_error_msg_if(!exio_helper->opened_for_writing,
                        "ERROR, ExodusII file must be opened for writing "
-                       "before calling ExodusII_IO::write_elemset()!");
+                       "before calling ExodusII_IO::write_elemsets()!");
 
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
   exio_helper->write_elemsets(mesh);

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -3014,13 +3014,13 @@ ExodusII_IO_Helper::write_elemsets(const MeshBase & mesh)
   // integer called "elemset_code" defined on it.
   if (mesh.has_elem_integer("elemset_code"))
     {
-      std::map<subdomain_id_type, std::vector<int>> exodus_elemsets;
+      std::map<elemset_id_type, std::vector<int>> exodus_elemsets;
 
       unsigned int elemset_index =
         mesh.get_elem_integer_index("elemset_code");
 
       // Catch ids returned from MeshBase::get_elemsets() calls
-      std::set<subdomain_id_type> set_ids;
+      std::set<elemset_id_type> set_ids;
       for (const auto & elem : mesh.element_ptr_range())
         {
           dof_id_type elemset_code =

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -2084,18 +2084,14 @@ void ExodusII_IO_Helper::initialize(std::string str_title, const MeshBase & mesh
   // extra_integers capability of Elems.
   if (mesh.has_elem_integer("elemset_code"))
     {
-      unsigned int elemset_index =
-        mesh.get_elem_integer_index("elemset_code");
+      // unsigned int elemset_index =
+      //   mesh.get_elem_integer_index("elemset_code");
 
       // Debugging
-      libMesh::out << "Mesh defines an elemset_code at index " << elemset_index << std::endl;
+      // libMesh::out << "Mesh defines an elemset_code at index " << elemset_index << std::endl;
 
-      // TODO: Add an API on the Mesh which returns the total number
-      // of element sets.  We can obtain this by looping over the
-      // _elemset_codes map stored on the Mesh and counting the number
-      // of unique elemset ids. For now we just hard-code this value
-      // for testing.
-      num_elem_sets = 2;
+      // Store the number of elemsets in the exo file header.
+      num_elem_sets = mesh.n_elemsets();
     }
 
   // Build an ex_init_params() structure that is to be passed to the

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1449,7 +1449,7 @@ void ExodusII_IO_Helper::read_nodeset_info()
       EX_CHECK_ERR(ex_err, "Error retrieving nodeset information.");
       message("All nodeset information retrieved successfully.");
 
-      // Resize appropriate data structures -- only do this once outnode the loop
+      // Resize appropriate data structures -- only do this once outside the loop
       num_nodes_per_set.resize(num_node_sets);
       num_node_df_per_set.resize(num_node_sets);
     }
@@ -1463,6 +1463,35 @@ void ExodusII_IO_Helper::read_nodeset_info()
       id_to_ns_names[nodeset_ids[i]] = name_buffer;
     }
   message("All node set names retrieved successfully.");
+}
+
+
+
+void ExodusII_IO_Helper::read_elemset_info()
+{
+  elemset_ids.resize(num_elem_sets);
+  if (num_elem_sets > 0)
+    {
+      ex_err = exII::ex_get_ids(ex_id,
+                                exII::EX_ELEM_SET,
+                                elemset_ids.data());
+      EX_CHECK_ERR(ex_err, "Error retrieving elemset information.");
+      message("All elemset information retrieved successfully.");
+
+      // Resize appropriate data structures -- only do this once outside the loop
+      // num_nodes_per_set.resize(num_elem_sets);
+      // num_node_df_per_set.resize(num_elem_sets);
+    }
+
+  char name_buffer[MAX_STR_LENGTH+1];
+  for (int i=0; i<num_elem_sets; ++i)
+    {
+      ex_err = exII::ex_get_name(ex_id, exII::EX_ELEM_SET,
+                                 elemset_ids[i], name_buffer);
+      EX_CHECK_ERR(ex_err, "Error getting node set name.");
+      id_to_ns_names[elemset_ids[i]] = name_buffer;
+    }
+  message("All elem set names retrieved successfully.");
 }
 
 

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -3104,7 +3104,7 @@ ExodusII_IO_Helper::write_elemsets(const MeshBase & mesh)
         mesh.get_elem_integer_index("elemset_code");
 
       // Catch ids returned from MeshBase::get_elemsets() calls
-      std::set<elemset_id_type> set_ids;
+      MeshBase::elemset_type set_ids;
       for (const auto & elem : mesh.element_ptr_range())
         {
           dof_id_type elemset_code =

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1492,7 +1492,7 @@ void ExodusII_IO_Helper::read_elemset_info()
       elemset_id_list.resize(num_elem_all_elemsets);
 
       // Debugging
-      libMesh::out << "num_elem_all_elemsets = " << num_elem_all_elemsets << std::endl;
+      // libMesh::out << "num_elem_all_elemsets = " << num_elem_all_elemsets << std::endl;
     }
 
   char name_buffer[MAX_STR_LENGTH+1];

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -3021,13 +3021,15 @@ ExodusII_IO_Helper::write_elemsets(const MeshBase & mesh)
       unsigned int elemset_index =
         mesh.get_elem_integer_index("elemset_code");
 
+      // Catch ids returned from MeshBase::get_elemsets() calls
+      std::set<subdomain_id_type> set_ids;
       for (const auto & elem : mesh.element_ptr_range())
         {
           dof_id_type elemset_code =
             elem->get_extra_integer(elemset_index);
 
-          // Look up which element set ids this elemset_code corresponds to.
-          std::set<subdomain_id_type> set_ids = mesh.get_elemsets(elemset_code);
+          // Look up which element set ids (if any) this elemset_code corresponds to.
+          mesh.get_elemsets(elemset_code, set_ids);
 
           // Debugging
           // libMesh::out << "elemset_code = " << elemset_code << std::endl;

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1558,8 +1558,7 @@ void ExodusII_IO_Helper::read_elemset(int id, int offset)
   libmesh_assert_less (id, elemset_ids.size());
   libmesh_assert_less (id, num_elems_per_set.size());
   libmesh_assert_less (id, num_elem_df_per_set.size());
-  // libmesh_assert_less_equal (offset, elem_list.size());
-  // libmesh_assert_less_equal (offset, side_list.size());
+  libmesh_assert_less_equal (offset, elemset_list.size());
 
   ex_err = exII::ex_get_set_param(ex_id,
                                   exII::EX_ELEM_SET,
@@ -1570,13 +1569,12 @@ void ExodusII_IO_Helper::read_elemset(int id, int offset)
   message("Parameters retrieved successfully for elemset: ", id);
 
 
-  // It's OK for offset==elem_list.size() as long as num_sides_per_set[id]==0
+  // It's OK for offset==elemset_list.size() as long as num_elems_per_set[id]==0
   // because in that case we don't actually read anything...
-// #ifdef DEBUG
-//   if (static_cast<unsigned int>(offset) == elem_list.size() ||
-//       static_cast<unsigned int>(offset) == side_list.size() )
-//     libmesh_assert_equal_to (num_elems_per_set[id], 0);
-// #endif
+  #ifdef DEBUG
+  if (static_cast<unsigned int>(offset) == elemset_list.size())
+    libmesh_assert_equal_to (num_elems_per_set[id], 0);
+  #endif
 
   // Don't call ex_get_set() unless there are actually elems there to get.
   // Exodus prints an annoying warning in DEBUG mode otherwise...

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -233,6 +233,14 @@ void MeshBase::add_elemset_code(dof_id_type code, const std::set<subdomain_id_ty
 
 
 
+unsigned int MeshBase::n_elemsets() const
+{
+  std::set<subdomain_id_type> all_elemset_ids;
+  for (const auto & pr : _elemset_codes_inverse_map)
+    all_elemset_ids.insert(pr.first.begin(), pr.first.end());
+  return all_elemset_ids.size();
+}
+
 std::set<subdomain_id_type> MeshBase::get_elemsets(dof_id_type elemset_code) const
 {
   auto it = _elemset_codes.find(elemset_code);

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -184,6 +184,17 @@ MeshBase& MeshBase::operator= (MeshBase && other_mesh)
   boundary_info = std::move(other_mesh.boundary_info);
   boundary_info->set_mesh(*this);
 
+#ifdef DEBUG
+  // Make sure that move assignment worked for pointers
+  for (const auto & [set, code] : _elemset_codes_inverse_map)
+    {
+      auto it = _elemset_codes.find(code);
+      libmesh_assert_msg(it != _elemset_codes.end(),
+                         "Elemset code " << code << " not found in _elmset_codes container.");
+      libmesh_assert_equal_to(it->second, &set);
+    }
+#endif
+
   // We're *not* really done at this point, but we have the problem
   // that some of our data movement might be expecting subclasses data
   // movement to happen first.  We'll let subclasses handle that by

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -226,6 +226,8 @@ void MeshBase::set_elem_dimensions(const std::set<unsigned char> & elem_dims)
 
 void MeshBase::add_elemset_code(dof_id_type code, MeshBase::elemset_type id_set)
 {
+  libmesh_experimental();
+
   // Populate inverse map, stealing id_set's resources
   auto [it1, inserted1] = _elemset_codes_inverse_map.emplace(std::move(id_set), code);
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -224,7 +224,7 @@ void MeshBase::set_elem_dimensions(const std::set<unsigned char> & elem_dims)
 
 
 
-void MeshBase::add_elemset_code(dof_id_type code, const std::set<elemset_id_type> & id_set)
+void MeshBase::add_elemset_code(dof_id_type code, const MeshBase::elemset_type & id_set)
 {
   // TODO: Throw an error if this code exists with a different set of ids
   _elemset_codes.emplace(code, id_set);
@@ -241,7 +241,7 @@ unsigned int MeshBase::n_elemsets() const
   return _all_elemset_ids.size();
 }
 
-void MeshBase::get_elemsets(dof_id_type elemset_code, std::set<elemset_id_type> & id_set_to_fill) const
+void MeshBase::get_elemsets(dof_id_type elemset_code, MeshBase::elemset_type & id_set_to_fill) const
 {
   // If we don't recognize this elemset_code, hand back an empty set
   id_set_to_fill.clear();
@@ -251,7 +251,7 @@ void MeshBase::get_elemsets(dof_id_type elemset_code, std::set<elemset_id_type> 
     id_set_to_fill = it->second;
 }
 
-dof_id_type MeshBase::get_elemset_code(const std::set<elemset_id_type> & id_set) const
+dof_id_type MeshBase::get_elemset_code(const MeshBase::elemset_type & id_set) const
 {
   auto it = _elemset_codes_inverse_map.find(id_set);
   return (it == _elemset_codes_inverse_map.end()) ? DofObject::invalid_id : it->second;

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -224,14 +224,15 @@ void MeshBase::set_elem_dimensions(const std::set<unsigned char> & elem_dims)
 
 
 
-void MeshBase::add_elemset_code(dof_id_type code, const MeshBase::elemset_type & id_set)
+void MeshBase::add_elemset_code(dof_id_type code, MeshBase::elemset_type id_set)
 {
   // TODO: Throw an error if this code exists with a different set of ids
-  _elemset_codes.emplace(code, id_set);
-  _elemset_codes_inverse_map.emplace(id_set, code);
+  _elemset_codes.emplace(code, id_set); // copy id_set
 
   // Keep track of all elemset ids ever added for O(1) n_elemsets() behavior
   _all_elemset_ids.insert(id_set.begin(), id_set.end());
+
+  _elemset_codes_inverse_map.emplace(std::move(id_set), code); // steal id_set
 }
 
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -226,8 +226,11 @@ void MeshBase::set_elem_dimensions(const std::set<unsigned char> & elem_dims)
 
 void MeshBase::add_elemset_code(dof_id_type code, MeshBase::elemset_type id_set)
 {
-  // TODO: Throw an error if this code exists with a different set of ids
-  _elemset_codes.emplace(code, id_set); // copy id_set
+  auto [it, inserted] = _elemset_codes.emplace(code, id_set); // copy id_set
+
+  // Throw an error if this code already exists with a different set of ids
+  libmesh_error_msg_if(!inserted && it->second != id_set,
+                       "The elemset code " << code << " already exists with a different id_set.");
 
   // Keep track of all elemset ids ever added for O(1) n_elemsets() behavior
   _all_elemset_ids.insert(id_set.begin(), id_set.end());

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -224,7 +224,7 @@ void MeshBase::set_elem_dimensions(const std::set<unsigned char> & elem_dims)
 
 
 
-void MeshBase::add_elemset_code(dof_id_type code, const std::set<subdomain_id_type> & id_set)
+void MeshBase::add_elemset_code(dof_id_type code, const std::set<elemset_id_type> & id_set)
 {
   // TODO: Throw an error if this code exists with a different set of ids
   _elemset_codes.emplace(code, id_set);
@@ -235,13 +235,13 @@ void MeshBase::add_elemset_code(dof_id_type code, const std::set<subdomain_id_ty
 
 unsigned int MeshBase::n_elemsets() const
 {
-  std::set<subdomain_id_type> all_elemset_ids;
+  std::set<elemset_id_type> all_elemset_ids;
   for (const auto & pr : _elemset_codes_inverse_map)
     all_elemset_ids.insert(pr.first.begin(), pr.first.end());
   return all_elemset_ids.size();
 }
 
-void MeshBase::get_elemsets(dof_id_type elemset_code, std::set<subdomain_id_type> & id_set_to_fill) const
+void MeshBase::get_elemsets(dof_id_type elemset_code, std::set<elemset_id_type> & id_set_to_fill) const
 {
   // If we don't recognize this elemset_code, hand back an empty set
   id_set_to_fill.clear();
@@ -251,7 +251,7 @@ void MeshBase::get_elemsets(dof_id_type elemset_code, std::set<subdomain_id_type
     id_set_to_fill = it->second;
 }
 
-dof_id_type MeshBase::get_elemset_code(const std::set<subdomain_id_type> & id_set) const
+dof_id_type MeshBase::get_elemset_code(const std::set<elemset_id_type> & id_set) const
 {
   auto it = _elemset_codes_inverse_map.find(id_set);
   return (it == _elemset_codes_inverse_map.end()) ? DofObject::invalid_id : it->second;

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -104,7 +104,6 @@ MeshBase::MeshBase (const MeshBase & other_mesh) :
   _skip_find_neighbors(other_mesh._skip_find_neighbors),
   _allow_remote_element_removal(other_mesh._allow_remote_element_removal),
   _elem_dims(other_mesh._elem_dims),
-  _elemset_codes(other_mesh._elemset_codes),
   _elemset_codes_inverse_map(other_mesh._elemset_codes_inverse_map),
   _spatial_dimension(other_mesh._spatial_dimension),
   _default_ghosting(std::make_unique<GhostPointNeighbors>(*this)),
@@ -143,6 +142,11 @@ MeshBase::MeshBase (const MeshBase & other_mesh) :
 
   if (other_mesh._partitioner.get())
     _partitioner = other_mesh._partitioner->clone();
+
+  // _elemset_codes stores pointers to entries in _elemset_codes_inverse_map,
+  // so it is not possible to simply copy it directly from other_mesh
+  for (const auto & [set, code] : _elemset_codes_inverse_map)
+    _elemset_codes.emplace(code, &set);
 }
 
 MeshBase& MeshBase::operator= (MeshBase && other_mesh)

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -241,10 +241,14 @@ unsigned int MeshBase::n_elemsets() const
   return all_elemset_ids.size();
 }
 
-std::set<subdomain_id_type> MeshBase::get_elemsets(dof_id_type elemset_code) const
+void MeshBase::get_elemsets(dof_id_type elemset_code, std::set<subdomain_id_type> & id_set_to_fill) const
 {
+  // If we don't recognize this elemset_code, hand back an empty set
+  id_set_to_fill.clear();
+
   auto it = _elemset_codes.find(elemset_code);
-  return (it == _elemset_codes.end()) ? std::set<subdomain_id_type>() : it->second;
+  if (it != _elemset_codes.end())
+    id_set_to_fill = it->second;
 }
 
 dof_id_type MeshBase::get_elemset_code(const std::set<subdomain_id_type> & id_set) const

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -229,16 +229,16 @@ void MeshBase::add_elemset_code(dof_id_type code, const std::set<elemset_id_type
   // TODO: Throw an error if this code exists with a different set of ids
   _elemset_codes.emplace(code, id_set);
   _elemset_codes_inverse_map.emplace(id_set, code);
+
+  // Keep track of all elemset ids ever added for O(1) n_elemsets() behavior
+  _all_elemset_ids.insert(id_set.begin(), id_set.end());
 }
 
 
 
 unsigned int MeshBase::n_elemsets() const
 {
-  std::set<elemset_id_type> all_elemset_ids;
-  for (const auto & pr : _elemset_codes_inverse_map)
-    all_elemset_ids.insert(pr.first.begin(), pr.first.end());
-  return all_elemset_ids.size();
+  return _all_elemset_ids.size();
 }
 
 void MeshBase::get_elemsets(dof_id_type elemset_code, std::set<elemset_id_type> & id_set_to_fill) const

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -76,6 +76,7 @@ unit_tests_sources = \
   mesh/slit_mesh_test.C \
   mesh/spatial_dimension_test.C \
   mesh/mapped_subdomain_partitioner_test.C \
+  mesh/write_elemset_data.C \
   mesh/write_sideset_data.C \
   mesh/write_nodeset_data.C \
   mesh/write_edgeset_data.C \
@@ -270,6 +271,7 @@ CLEANFILES = cube_mesh.xda \
 	     out.e \
 	     mesh_with_soln.e \
 	     elemental_from_nodal.e \
+             write_elemset_data.e \
              write_sideset_data.e \
              write_nodeset_data.e \
              write_edgeset_data.e \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -221,9 +221,9 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/libmesh_poly2tri.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
-	mesh/write_sideset_data.C mesh/write_nodeset_data.C \
-	mesh/write_edgeset_data.C mesh/write_vec_and_scalar.C \
-	numerics/composite_function_test.C \
+	mesh/write_elemset_data.C mesh/write_sideset_data.C \
+	mesh/write_nodeset_data.C mesh/write_edgeset_data.C \
+	mesh/write_vec_and_scalar.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -320,6 +320,7 @@ am__objects_3 = unit_tests_dbg-driver.$(OBJEXT) \
 	mesh/unit_tests_dbg-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-spatial_dimension_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.$(OBJEXT) \
+	mesh/unit_tests_dbg-write_elemset_data.$(OBJEXT) \
 	mesh/unit_tests_dbg-write_sideset_data.$(OBJEXT) \
 	mesh/unit_tests_dbg-write_nodeset_data.$(OBJEXT) \
 	mesh/unit_tests_dbg-write_edgeset_data.$(OBJEXT) \
@@ -403,9 +404,9 @@ am__unit_tests_devel_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/libmesh_poly2tri.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
-	mesh/write_sideset_data.C mesh/write_nodeset_data.C \
-	mesh/write_edgeset_data.C mesh/write_vec_and_scalar.C \
-	numerics/composite_function_test.C \
+	mesh/write_elemset_data.C mesh/write_sideset_data.C \
+	mesh/write_nodeset_data.C mesh/write_edgeset_data.C \
+	mesh/write_vec_and_scalar.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -500,6 +501,7 @@ am__objects_5 = unit_tests_devel-driver.$(OBJEXT) \
 	mesh/unit_tests_devel-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_devel-spatial_dimension_test.$(OBJEXT) \
 	mesh/unit_tests_devel-mapped_subdomain_partitioner_test.$(OBJEXT) \
+	mesh/unit_tests_devel-write_elemset_data.$(OBJEXT) \
 	mesh/unit_tests_devel-write_sideset_data.$(OBJEXT) \
 	mesh/unit_tests_devel-write_nodeset_data.$(OBJEXT) \
 	mesh/unit_tests_devel-write_edgeset_data.$(OBJEXT) \
@@ -579,9 +581,9 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/libmesh_poly2tri.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
-	mesh/write_sideset_data.C mesh/write_nodeset_data.C \
-	mesh/write_edgeset_data.C mesh/write_vec_and_scalar.C \
-	numerics/composite_function_test.C \
+	mesh/write_elemset_data.C mesh/write_sideset_data.C \
+	mesh/write_nodeset_data.C mesh/write_edgeset_data.C \
+	mesh/write_vec_and_scalar.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -676,6 +678,7 @@ am__objects_7 = unit_tests_oprof-driver.$(OBJEXT) \
 	mesh/unit_tests_oprof-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-spatial_dimension_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.$(OBJEXT) \
+	mesh/unit_tests_oprof-write_elemset_data.$(OBJEXT) \
 	mesh/unit_tests_oprof-write_sideset_data.$(OBJEXT) \
 	mesh/unit_tests_oprof-write_nodeset_data.$(OBJEXT) \
 	mesh/unit_tests_oprof-write_edgeset_data.$(OBJEXT) \
@@ -755,9 +758,9 @@ am__unit_tests_opt_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/libmesh_poly2tri.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
-	mesh/write_sideset_data.C mesh/write_nodeset_data.C \
-	mesh/write_edgeset_data.C mesh/write_vec_and_scalar.C \
-	numerics/composite_function_test.C \
+	mesh/write_elemset_data.C mesh/write_sideset_data.C \
+	mesh/write_nodeset_data.C mesh/write_edgeset_data.C \
+	mesh/write_vec_and_scalar.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -852,6 +855,7 @@ am__objects_9 = unit_tests_opt-driver.$(OBJEXT) \
 	mesh/unit_tests_opt-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_opt-spatial_dimension_test.$(OBJEXT) \
 	mesh/unit_tests_opt-mapped_subdomain_partitioner_test.$(OBJEXT) \
+	mesh/unit_tests_opt-write_elemset_data.$(OBJEXT) \
 	mesh/unit_tests_opt-write_sideset_data.$(OBJEXT) \
 	mesh/unit_tests_opt-write_nodeset_data.$(OBJEXT) \
 	mesh/unit_tests_opt-write_edgeset_data.$(OBJEXT) \
@@ -931,9 +935,9 @@ am__unit_tests_prof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/libmesh_poly2tri.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
-	mesh/write_sideset_data.C mesh/write_nodeset_data.C \
-	mesh/write_edgeset_data.C mesh/write_vec_and_scalar.C \
-	numerics/composite_function_test.C \
+	mesh/write_elemset_data.C mesh/write_sideset_data.C \
+	mesh/write_nodeset_data.C mesh/write_edgeset_data.C \
+	mesh/write_vec_and_scalar.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -1028,6 +1032,7 @@ am__objects_11 = unit_tests_prof-driver.$(OBJEXT) \
 	mesh/unit_tests_prof-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_prof-spatial_dimension_test.$(OBJEXT) \
 	mesh/unit_tests_prof-mapped_subdomain_partitioner_test.$(OBJEXT) \
+	mesh/unit_tests_prof-write_elemset_data.$(OBJEXT) \
 	mesh/unit_tests_prof-write_sideset_data.$(OBJEXT) \
 	mesh/unit_tests_prof-write_nodeset_data.$(OBJEXT) \
 	mesh/unit_tests_prof-write_edgeset_data.$(OBJEXT) \
@@ -1274,6 +1279,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-spatial_dimension_test.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-write_edgeset_data.Po \
+	mesh/$(DEPDIR)/unit_tests_dbg-write_elemset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-write_nodeset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-write_vec_and_scalar.Po \
@@ -1302,6 +1308,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-spatial_dimension_test.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-write_edgeset_data.Po \
+	mesh/$(DEPDIR)/unit_tests_devel-write_elemset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-write_nodeset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-write_vec_and_scalar.Po \
@@ -1330,6 +1337,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-spatial_dimension_test.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-write_edgeset_data.Po \
+	mesh/$(DEPDIR)/unit_tests_oprof-write_elemset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-write_nodeset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-write_vec_and_scalar.Po \
@@ -1358,6 +1366,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-spatial_dimension_test.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-write_edgeset_data.Po \
+	mesh/$(DEPDIR)/unit_tests_opt-write_elemset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-write_nodeset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-write_vec_and_scalar.Po \
@@ -1386,6 +1395,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-spatial_dimension_test.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-write_edgeset_data.Po \
+	mesh/$(DEPDIR)/unit_tests_prof-write_elemset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-write_nodeset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-write_vec_and_scalar.Po \
@@ -2067,9 +2077,9 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 	mesh/libmesh_poly2tri.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
-	mesh/write_sideset_data.C mesh/write_nodeset_data.C \
-	mesh/write_edgeset_data.C mesh/write_vec_and_scalar.C \
-	numerics/composite_function_test.C \
+	mesh/write_elemset_data.C mesh/write_sideset_data.C \
+	mesh/write_nodeset_data.C mesh/write_edgeset_data.C \
+	mesh/write_vec_and_scalar.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -2145,18 +2155,19 @@ data = meshes/1_quad.bxt.gz \
 @LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPT_MODE_TRUE@unit_tests_opt_DATA = $(data)
 @LIBMESH_ENABLE_CPPUNIT_TRUE@TESTS = run_unit_tests.sh
 CLEANFILES = cube_mesh.xda slit_mesh.xda slit_solution.xda out.e \
-	mesh_with_soln.e elemental_from_nodal.e write_sideset_data.e \
-	write_nodeset_data.e write_edgeset_data.e read_header_test.e \
-	output.dat periodic.e mesh.out.memory.moved.xda \
-	mesh.out.file.moved.xda repl_with_nodal_soln.nem.1.0 \
-	dist_with_elem_soln.e dist.e dist_with_nodal_soln.e \
-	dist_with_nodal_soln.nem.1.0 dist_with_elem_vec.e \
-	dist_with_single_elem.nem.1.0 dist_with_elem_soln.nem.1.0 \
-	rep.nem.1.0 repl_with_elem_soln.nem.1.0 \
-	repl_with_single_elem.nem.1.0 dist_with_elem_vec.nem.1.0 \
-	repl_with_elem_vec.nem.1.0 dist.nem.1.0 repl_with_elem_soln.e \
-	test_nemesis_read.nem.1.0 rep.e repl_with_nodal_soln.e \
-	repl_with_elem_vec.e $(am__append_12) $(am__append_13)
+	mesh_with_soln.e elemental_from_nodal.e write_elemset_data.e \
+	write_sideset_data.e write_nodeset_data.e write_edgeset_data.e \
+	read_header_test.e output.dat periodic.e \
+	mesh.out.memory.moved.xda mesh.out.file.moved.xda \
+	repl_with_nodal_soln.nem.1.0 dist_with_elem_soln.e dist.e \
+	dist_with_nodal_soln.e dist_with_nodal_soln.nem.1.0 \
+	dist_with_elem_vec.e dist_with_single_elem.nem.1.0 \
+	dist_with_elem_soln.nem.1.0 rep.nem.1.0 \
+	repl_with_elem_soln.nem.1.0 repl_with_single_elem.nem.1.0 \
+	dist_with_elem_vec.nem.1.0 repl_with_elem_vec.nem.1.0 \
+	dist.nem.1.0 repl_with_elem_soln.e test_nemesis_read.nem.1.0 \
+	rep.e repl_with_nodal_soln.e repl_with_elem_vec.e \
+	$(am__append_12) $(am__append_13)
 
 # need to link any data files for VPATH builds
 @LIBMESH_VPATH_BUILD_TRUE@BUILT_SOURCES = .linkstamp
@@ -2343,6 +2354,8 @@ mesh/unit_tests_dbg-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 mesh/unit_tests_dbg-spatial_dimension_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_dbg-write_elemset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-write_sideset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -2598,6 +2611,8 @@ mesh/unit_tests_devel-spatial_dimension_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-mapped_subdomain_partitioner_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_devel-write_elemset_data.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-write_sideset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-write_nodeset_data.$(OBJEXT):  \
@@ -2803,6 +2818,8 @@ mesh/unit_tests_oprof-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 mesh/unit_tests_oprof-spatial_dimension_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_oprof-write_elemset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-write_sideset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -3010,6 +3027,8 @@ mesh/unit_tests_opt-spatial_dimension_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-mapped_subdomain_partitioner_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_opt-write_elemset_data.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-write_sideset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-write_nodeset_data.$(OBJEXT):  \
@@ -3215,6 +3234,8 @@ mesh/unit_tests_prof-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 mesh/unit_tests_prof-spatial_dimension_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-mapped_subdomain_partitioner_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_prof-write_elemset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-write_sideset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -3515,6 +3536,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-spatial_dimension_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-write_edgeset_data.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-write_elemset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-write_nodeset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-write_vec_and_scalar.Po@am__quote@ # am--include-marker
@@ -3543,6 +3565,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-spatial_dimension_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-write_edgeset_data.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-write_elemset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-write_nodeset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-write_vec_and_scalar.Po@am__quote@ # am--include-marker
@@ -3571,6 +3594,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-spatial_dimension_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-write_edgeset_data.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-write_elemset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-write_nodeset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-write_vec_and_scalar.Po@am__quote@ # am--include-marker
@@ -3599,6 +3623,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-spatial_dimension_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-write_edgeset_data.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-write_elemset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-write_nodeset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-write_vec_and_scalar.Po@am__quote@ # am--include-marker
@@ -3627,6 +3652,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-spatial_dimension_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-write_edgeset_data.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-write_elemset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-write_nodeset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-write_vec_and_scalar.Po@am__quote@ # am--include-marker
@@ -4611,6 +4637,20 @@ mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.obj: mesh/mapped_subdomain
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mapped_subdomain_partitioner_test.C' object='mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.obj `if test -f 'mesh/mapped_subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/mapped_subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mapped_subdomain_partitioner_test.C'; fi`
+
+mesh/unit_tests_dbg-write_elemset_data.o: mesh/write_elemset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-write_elemset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-write_elemset_data.Tpo -c -o mesh/unit_tests_dbg-write_elemset_data.o `test -f 'mesh/write_elemset_data.C' || echo '$(srcdir)/'`mesh/write_elemset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-write_elemset_data.Tpo mesh/$(DEPDIR)/unit_tests_dbg-write_elemset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_elemset_data.C' object='mesh/unit_tests_dbg-write_elemset_data.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-write_elemset_data.o `test -f 'mesh/write_elemset_data.C' || echo '$(srcdir)/'`mesh/write_elemset_data.C
+
+mesh/unit_tests_dbg-write_elemset_data.obj: mesh/write_elemset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-write_elemset_data.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-write_elemset_data.Tpo -c -o mesh/unit_tests_dbg-write_elemset_data.obj `if test -f 'mesh/write_elemset_data.C'; then $(CYGPATH_W) 'mesh/write_elemset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_elemset_data.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-write_elemset_data.Tpo mesh/$(DEPDIR)/unit_tests_dbg-write_elemset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_elemset_data.C' object='mesh/unit_tests_dbg-write_elemset_data.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-write_elemset_data.obj `if test -f 'mesh/write_elemset_data.C'; then $(CYGPATH_W) 'mesh/write_elemset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_elemset_data.C'; fi`
 
 mesh/unit_tests_dbg-write_sideset_data.o: mesh/write_sideset_data.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-write_sideset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Tpo -c -o mesh/unit_tests_dbg-write_sideset_data.o `test -f 'mesh/write_sideset_data.C' || echo '$(srcdir)/'`mesh/write_sideset_data.C
@@ -5984,6 +6024,20 @@ mesh/unit_tests_devel-mapped_subdomain_partitioner_test.obj: mesh/mapped_subdoma
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mapped_subdomain_partitioner_test.obj `if test -f 'mesh/mapped_subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/mapped_subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mapped_subdomain_partitioner_test.C'; fi`
 
+mesh/unit_tests_devel-write_elemset_data.o: mesh/write_elemset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-write_elemset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-write_elemset_data.Tpo -c -o mesh/unit_tests_devel-write_elemset_data.o `test -f 'mesh/write_elemset_data.C' || echo '$(srcdir)/'`mesh/write_elemset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-write_elemset_data.Tpo mesh/$(DEPDIR)/unit_tests_devel-write_elemset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_elemset_data.C' object='mesh/unit_tests_devel-write_elemset_data.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-write_elemset_data.o `test -f 'mesh/write_elemset_data.C' || echo '$(srcdir)/'`mesh/write_elemset_data.C
+
+mesh/unit_tests_devel-write_elemset_data.obj: mesh/write_elemset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-write_elemset_data.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-write_elemset_data.Tpo -c -o mesh/unit_tests_devel-write_elemset_data.obj `if test -f 'mesh/write_elemset_data.C'; then $(CYGPATH_W) 'mesh/write_elemset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_elemset_data.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-write_elemset_data.Tpo mesh/$(DEPDIR)/unit_tests_devel-write_elemset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_elemset_data.C' object='mesh/unit_tests_devel-write_elemset_data.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-write_elemset_data.obj `if test -f 'mesh/write_elemset_data.C'; then $(CYGPATH_W) 'mesh/write_elemset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_elemset_data.C'; fi`
+
 mesh/unit_tests_devel-write_sideset_data.o: mesh/write_sideset_data.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-write_sideset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Tpo -c -o mesh/unit_tests_devel-write_sideset_data.o `test -f 'mesh/write_sideset_data.C' || echo '$(srcdir)/'`mesh/write_sideset_data.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Tpo mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Po
@@ -7355,6 +7409,20 @@ mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.obj: mesh/mapped_subdoma
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mapped_subdomain_partitioner_test.C' object='mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.obj `if test -f 'mesh/mapped_subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/mapped_subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mapped_subdomain_partitioner_test.C'; fi`
+
+mesh/unit_tests_oprof-write_elemset_data.o: mesh/write_elemset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-write_elemset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-write_elemset_data.Tpo -c -o mesh/unit_tests_oprof-write_elemset_data.o `test -f 'mesh/write_elemset_data.C' || echo '$(srcdir)/'`mesh/write_elemset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-write_elemset_data.Tpo mesh/$(DEPDIR)/unit_tests_oprof-write_elemset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_elemset_data.C' object='mesh/unit_tests_oprof-write_elemset_data.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-write_elemset_data.o `test -f 'mesh/write_elemset_data.C' || echo '$(srcdir)/'`mesh/write_elemset_data.C
+
+mesh/unit_tests_oprof-write_elemset_data.obj: mesh/write_elemset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-write_elemset_data.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-write_elemset_data.Tpo -c -o mesh/unit_tests_oprof-write_elemset_data.obj `if test -f 'mesh/write_elemset_data.C'; then $(CYGPATH_W) 'mesh/write_elemset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_elemset_data.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-write_elemset_data.Tpo mesh/$(DEPDIR)/unit_tests_oprof-write_elemset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_elemset_data.C' object='mesh/unit_tests_oprof-write_elemset_data.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-write_elemset_data.obj `if test -f 'mesh/write_elemset_data.C'; then $(CYGPATH_W) 'mesh/write_elemset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_elemset_data.C'; fi`
 
 mesh/unit_tests_oprof-write_sideset_data.o: mesh/write_sideset_data.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-write_sideset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Tpo -c -o mesh/unit_tests_oprof-write_sideset_data.o `test -f 'mesh/write_sideset_data.C' || echo '$(srcdir)/'`mesh/write_sideset_data.C
@@ -8728,6 +8796,20 @@ mesh/unit_tests_opt-mapped_subdomain_partitioner_test.obj: mesh/mapped_subdomain
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mapped_subdomain_partitioner_test.obj `if test -f 'mesh/mapped_subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/mapped_subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mapped_subdomain_partitioner_test.C'; fi`
 
+mesh/unit_tests_opt-write_elemset_data.o: mesh/write_elemset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-write_elemset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-write_elemset_data.Tpo -c -o mesh/unit_tests_opt-write_elemset_data.o `test -f 'mesh/write_elemset_data.C' || echo '$(srcdir)/'`mesh/write_elemset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-write_elemset_data.Tpo mesh/$(DEPDIR)/unit_tests_opt-write_elemset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_elemset_data.C' object='mesh/unit_tests_opt-write_elemset_data.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-write_elemset_data.o `test -f 'mesh/write_elemset_data.C' || echo '$(srcdir)/'`mesh/write_elemset_data.C
+
+mesh/unit_tests_opt-write_elemset_data.obj: mesh/write_elemset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-write_elemset_data.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-write_elemset_data.Tpo -c -o mesh/unit_tests_opt-write_elemset_data.obj `if test -f 'mesh/write_elemset_data.C'; then $(CYGPATH_W) 'mesh/write_elemset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_elemset_data.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-write_elemset_data.Tpo mesh/$(DEPDIR)/unit_tests_opt-write_elemset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_elemset_data.C' object='mesh/unit_tests_opt-write_elemset_data.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-write_elemset_data.obj `if test -f 'mesh/write_elemset_data.C'; then $(CYGPATH_W) 'mesh/write_elemset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_elemset_data.C'; fi`
+
 mesh/unit_tests_opt-write_sideset_data.o: mesh/write_sideset_data.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-write_sideset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Tpo -c -o mesh/unit_tests_opt-write_sideset_data.o `test -f 'mesh/write_sideset_data.C' || echo '$(srcdir)/'`mesh/write_sideset_data.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Tpo mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Po
@@ -10100,6 +10182,20 @@ mesh/unit_tests_prof-mapped_subdomain_partitioner_test.obj: mesh/mapped_subdomai
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mapped_subdomain_partitioner_test.obj `if test -f 'mesh/mapped_subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/mapped_subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mapped_subdomain_partitioner_test.C'; fi`
 
+mesh/unit_tests_prof-write_elemset_data.o: mesh/write_elemset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-write_elemset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-write_elemset_data.Tpo -c -o mesh/unit_tests_prof-write_elemset_data.o `test -f 'mesh/write_elemset_data.C' || echo '$(srcdir)/'`mesh/write_elemset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-write_elemset_data.Tpo mesh/$(DEPDIR)/unit_tests_prof-write_elemset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_elemset_data.C' object='mesh/unit_tests_prof-write_elemset_data.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-write_elemset_data.o `test -f 'mesh/write_elemset_data.C' || echo '$(srcdir)/'`mesh/write_elemset_data.C
+
+mesh/unit_tests_prof-write_elemset_data.obj: mesh/write_elemset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-write_elemset_data.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-write_elemset_data.Tpo -c -o mesh/unit_tests_prof-write_elemset_data.obj `if test -f 'mesh/write_elemset_data.C'; then $(CYGPATH_W) 'mesh/write_elemset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_elemset_data.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-write_elemset_data.Tpo mesh/$(DEPDIR)/unit_tests_prof-write_elemset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_elemset_data.C' object='mesh/unit_tests_prof-write_elemset_data.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-write_elemset_data.obj `if test -f 'mesh/write_elemset_data.C'; then $(CYGPATH_W) 'mesh/write_elemset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_elemset_data.C'; fi`
+
 mesh/unit_tests_prof-write_sideset_data.o: mesh/write_sideset_data.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-write_sideset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Tpo -c -o mesh/unit_tests_prof-write_sideset_data.o `test -f 'mesh/write_sideset_data.C' || echo '$(srcdir)/'`mesh/write_sideset_data.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Tpo mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Po
@@ -11258,6 +11354,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_elemset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_vec_and_scalar.Po
@@ -11286,6 +11383,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_elemset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_vec_and_scalar.Po
@@ -11314,6 +11412,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_elemset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_vec_and_scalar.Po
@@ -11342,6 +11441,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_elemset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_vec_and_scalar.Po
@@ -11370,6 +11470,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_elemset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_vec_and_scalar.Po
@@ -11795,6 +11896,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_elemset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_vec_and_scalar.Po
@@ -11823,6 +11925,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_elemset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_vec_and_scalar.Po
@@ -11851,6 +11954,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_elemset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_vec_and_scalar.Po
@@ -11879,6 +11983,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_elemset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_vec_and_scalar.Po
@@ -11907,6 +12012,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_edgeset_data.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_elemset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_nodeset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_vec_and_scalar.Po

--- a/tests/mesh/write_elemset_data.C
+++ b/tests/mesh/write_elemset_data.C
@@ -88,14 +88,14 @@ public:
     mesh.add_elemset_code(3, {1,2});
 
     // Debugging: print valid elemset_codes values
-    for (const auto & elem : mesh.element_ptr_range())
-      {
-        dof_id_type elemset_code =
-          elem->get_extra_integer(elemset_index);
-
-        if (elemset_code != DofObject::invalid_id)
-          libMesh::out << "Elem " << elem->id() << ", elemset_code = " << elemset_code << std::endl;
-      }
+    // for (const auto & elem : mesh.element_ptr_range())
+    //   {
+    //     dof_id_type elemset_code =
+    //       elem->get_extra_integer(elemset_index);
+    //
+    //     if (elemset_code != DofObject::invalid_id)
+    //       libMesh::out << "Elem " << elem->id() << ", elemset_code = " << elemset_code << std::endl;
+    //   }
 
     // Write the file in the ExodusII format, including the element set information.
     // Note: elemsets should eventually be written during ExodusII_IO::write(), this
@@ -106,105 +106,50 @@ public:
       writer.write_elemsets();
     }
 
-   // Make sure that the writing is done before the reading starts.
-   TestCommWorld->barrier();
+    // Make sure that the writing is done before the reading starts.
+    TestCommWorld->barrier();
 
-   // Now read it back in
-   Mesh read_mesh(*TestCommWorld);
-   IOClass reader(read_mesh);
-   reader.verbose(true); // additional messages while debugging
-   reader.read(filename);
+    // Now read it back in
+    Mesh read_mesh(*TestCommWorld);
 
-//    if (write_vars)
-//      {
-//        std::vector<std::string> read_in_var_names;
-//        std::vector<std::set<boundary_id_type>> read_in_side_ids;
-//        std::vector<std::map<BoundaryInfo::BCTuple, Real>> read_in_bc_vals;
-//        reader.read_sideset_data
-//          (/*timestep=*/1, read_in_var_names, read_in_side_ids, read_in_bc_vals);
-//
-//        // Assert that we got back out what we put in.
-//        CPPUNIT_ASSERT(read_in_var_names == var_names);
-//        CPPUNIT_ASSERT(read_in_side_ids == side_ids);
-//        CPPUNIT_ASSERT(read_in_bc_vals == bc_vals);
-//      } // if (write_vars)
-//
-//    // Also check that the flat indices match those in the file
-//    std::map<BoundaryInfo::BCTuple, unsigned int> bc_array_indices;
-//    reader.get_sideset_data_indices(bc_array_indices);
-//
-//    // Debugging
-//    // for (const auto & pr : bc_array_indices)
-//    //   {
-//    //     const auto & t = pr.first;
-//    //     const auto & elem_id = std::get<0>(t);
-//    //     const auto & side_id = std::get<1>(t);
-//    //     const auto & boundary_id = std::get<2>(t);
-//    //     libMesh::out << "(elem, side, boundary_id) = "
-//    //                  << "(" << elem_id << ", " << side_id << ", " << boundary_id << ")"
-//    //                  << std::endl;
-//    //   }
-//
-//    // For this test case, the sideset arrays are ordered as follows:
-//    // elem_ss1 = 1, 2, 3, 4, 5 ;
-//    // side_ss1 = 1, 1, 1, 1, 1 ;
-//    // elem_ss2 = 5, 10, 15, 20, 25 ;
-//    // side_ss2 = 2, 2, 2, 2, 2 ;
-//    // elem_ss3 = 21, 22, 23, 24, 25 ;
-//    // side_ss3 = 3, 3, 3, 3, 3 ;
-//    // elem_ss4 = 1, 6, 11, 16, 21 ;
-//    // side_ss4 = 4, 4, 4, 4, 4 ;
-//
-//    // Check that the 0th side of the 0th element on boundary 0
-//    // corresponds to array index 0.
-//    // CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(0),
-//    //                      libmesh_map_find(bc_array_indices,
-//    //                                       std::make_tuple(/*elem id*/static_cast<dof_id_type>(0),
-//    //                                                       /*side id*/static_cast<unsigned short int>(0),
-//    //                                                       /*boundary id*/static_cast<boundary_id_type>(0))));
-//
-//    // CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(0),
-//    //                      libmesh_map_find(bc_array_indices, std::make_tuple(0,0,0)));
-//    //
-//    // CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(1),
-//    //                      libmesh_map_find(bc_array_indices, std::make_tuple(1,0,0)));
-//
-//    // Check the first five elements, which all have side 0 on
-//    // boundary 0, and which happen to be in order in the BC array.
-//    for (unsigned int i=0; i<5; ++i)
-//      CPPUNIT_ASSERT_EQUAL
-//        (static_cast<unsigned int>(i),
-//         libmesh_map_find(bc_array_indices,
-//                          std::make_tuple(/*elem_id=*/cast_int<dof_id_type>(i),
-//                                          /*side_id=*/0,
-//                                          /*b_id=*/0)));
-//
-//    // Check side 1 of every fifth element starting with element 4, they are all in sideset 1.
-//    for (unsigned int i=0; i<5; ++i)
-//      CPPUNIT_ASSERT_EQUAL
-//        (static_cast<unsigned int>(i),
-//         libmesh_map_find(bc_array_indices,
-//                          std::make_tuple(/*elem_id=*/cast_int<dof_id_type>(5*i + 4),
-//                                          /*side_id*/1,
-//                                          /*b_id=*/1)));
-//
-//    // Check side 2 of the 5 consecutive elements starting with Elem 20. They are all in sideset 2.
-//    for (unsigned int i=0; i<5; ++i)
-//      CPPUNIT_ASSERT_EQUAL
-//        (static_cast<unsigned int>(i),
-//         libmesh_map_find(bc_array_indices,
-//                          std::make_tuple(/*elem_id=*/cast_int<dof_id_type>(20+i),
-//                                          /*side_id*/2,
-//                                          /*b_id=*/2)));
-//
-//    // Check side 3 of every fifth element, they are all in sideset 3
-//    for (unsigned int i=0; i<5; ++i)
-//      CPPUNIT_ASSERT_EQUAL
-//        (static_cast<unsigned int>(i),
-//         libmesh_map_find(bc_array_indices,
-//                          std::make_tuple(/*elem_id=*/cast_int<dof_id_type>(5*i),
-//                                          /*side_id*/3,
-//                                          /*b_id=*/3)));
+    // Do not allow renumbering on this mesh either.
+    read_mesh.allow_renumbering(false);
+
+    IOClass reader(read_mesh);
+    // reader.verbose(true); // additional messages while debugging
+    reader.read(filename);
+
+    // Check that the elements in read_mesh are in the correct elemsets.
+    // The elemset_codes will not in general match because they are
+    // created by a generic algorithm in the Exodus reader while above
+    // they were hard-coded.
+
+    // Make sure that the mesh actually has an extra_integer for "elemset_code"
+    CPPUNIT_ASSERT(read_mesh.has_elem_integer("elemset_code"));
+
+    // Make sure the extra integer is in the same index as before
+    CPPUNIT_ASSERT(read_mesh.get_elem_integer_index("elemset_code") == elemset_index);
+
+    // Make sure the elemset_codes match what we are expecting.
+    // The Exodus reader assigns the codes based on operator<
+    // for std::sets, which gives us the ordering {1}, {1,2}, {2}
+    CPPUNIT_ASSERT(read_mesh.get_elemset_code({1}) == 0);
+    CPPUNIT_ASSERT(read_mesh.get_elemset_code({1,2}) == 1);
+    CPPUNIT_ASSERT(read_mesh.get_elemset_code({2}) == 2);
+
+    // Assert that the elemset_codes for particular elements are set as expected
+
+    // Elements 8, 14 are in set1 which has code 0
+    CPPUNIT_ASSERT(read_mesh.elem_ptr(8)->get_extra_integer(elemset_index) == 0);
+    CPPUNIT_ASSERT(read_mesh.elem_ptr(14)->get_extra_integer(elemset_index) == 0);
+
+    // Elements 3, 24 are in both set1 and set2, which has code 1
+    CPPUNIT_ASSERT(read_mesh.elem_ptr(3)->get_extra_integer(elemset_index) == 1);
+    CPPUNIT_ASSERT(read_mesh.elem_ptr(24)->get_extra_integer(elemset_index) == 1);
+
+    // Elements 9, 15 are in set2 which has code 2
+    CPPUNIT_ASSERT(read_mesh.elem_ptr(9)->get_extra_integer(elemset_index) == 2);
+    CPPUNIT_ASSERT(read_mesh.elem_ptr(15)->get_extra_integer(elemset_index) == 2);
   }
 
   void testWriteExodus()

--- a/tests/mesh/write_elemset_data.C
+++ b/tests/mesh/write_elemset_data.C
@@ -110,11 +110,12 @@ public:
    // Make sure that the writing is done before the reading starts.
    TestCommWorld->barrier();
 
-//    // Now read it back in
-//    Mesh read_mesh(*TestCommWorld);
-//    IOClass reader(read_mesh);
-//    reader.read(filename);
-//
+   // Now read it back in
+   Mesh read_mesh(*TestCommWorld);
+   IOClass reader(read_mesh);
+   reader.verbose(true); // additional messages while debugging
+   reader.read(filename);
+
 //    if (write_vars)
 //      {
 //        std::vector<std::string> read_in_var_names;

--- a/tests/mesh/write_elemset_data.C
+++ b/tests/mesh/write_elemset_data.C
@@ -61,27 +61,32 @@ public:
                                         -1., 1.,
                                         QUAD4);
 
-    // Set ids for elements in elemsets A, B
-    std::set<dof_id_type> setA = {3, 8, 14, 24};
-    std::set<dof_id_type> setB = {3, 9, 15, 24};
+    // Set ids for elements in elemsets 1, 2
+    std::set<dof_id_type> set1 = {3, 8, 14, 24};
+    std::set<dof_id_type> set2 = {3, 9, 15, 24};
 
     // Loop over Elems and set "elemset_code" values
     for (const auto & elem : mesh.element_ptr_range())
       {
         bool
-          inA = setA.count(elem->id()),
-          inB = setB.count(elem->id());
+          in1 = set1.count(elem->id()),
+          in2 = set2.count(elem->id());
 
         dof_id_type val = DofObject::invalid_id;
-        if (inA)
+        if (in1)
           val = 1;
-        if (inB)
+        if (in2)
           val = 2;
-        if (inA && inB)
+        if (in1 && in2)
           val = 3;
 
         elem->set_extra_integer(elemset_index, val);
       }
+
+    // Tell the Mesh about these elemsets
+    mesh.add_elemset_code(1, {1});
+    mesh.add_elemset_code(2, {2});
+    mesh.add_elemset_code(3, {1,2});
 
     // Debugging: print valid elemset_codes values
     for (const auto & elem : mesh.element_ptr_range())

--- a/tests/mesh/write_elemset_data.C
+++ b/tests/mesh/write_elemset_data.C
@@ -48,8 +48,7 @@ public:
     // 3                               & elem belongs to sets A and B
     unsigned int elemset_index =
       mesh.add_elem_integer("elemset_code",
-                            /*allocate_data=*/true,
-                            /*default_value=*/0);
+                            /*allocate_data=*/true);
 
     // We are generating this mesh, so it should not be renumbered.
     // No harm in being explicit about it, however.

--- a/tests/mesh/write_elemset_data.C
+++ b/tests/mesh/write_elemset_data.C
@@ -1,0 +1,218 @@
+// Basic include files
+#include "libmesh/equation_systems.h"
+#include "libmesh/exodusII_io.h"
+#include "libmesh/nemesis_io.h"
+#include "libmesh/mesh.h"
+#include "libmesh/mesh_generation.h"
+#include "libmesh/parallel.h" // set_union
+#include "libmesh/string_to_enum.h"
+#include "libmesh/boundary_info.h"
+#include "libmesh/utility.h" // libmesh_map_find
+#include "libmesh/elem.h"
+
+#include "test_comm.h"
+#include "libmesh_cppunit.h"
+
+
+// Bring in everything from the libMesh namespace
+using namespace libMesh;
+
+class WriteElemsetData : public CppUnit::TestCase
+{
+public:
+  LIBMESH_CPPUNIT_TEST_SUITE(WriteElemsetData);
+
+#if LIBMESH_DIM > 1
+#ifdef LIBMESH_HAVE_EXODUS_API
+  CPPUNIT_TEST(testWriteExodus);
+#endif // #ifdef LIBMESH_HAVE_EXODUS_API
+#ifdef LIBMESH_HAVE_NEMESIS_API
+  // CPPUNIT_TEST(testWriteNemesis); // Not yet implemented
+#endif
+#endif
+
+  CPPUNIT_TEST_SUITE_END();
+
+  template <typename IOClass>
+  void testWriteImpl(const std::string & filename)
+  {
+    Mesh mesh(*TestCommWorld);
+
+    // Allocate space for an extra integer on each element to store a "code" which
+    // determines which sets an Elem belongs to. We do this before building the Mesh
+    // extra_integer val & sets elem belongs to
+    // 0                 & elem belongs to no sets
+    // 1                 & elem belongs to set A only
+    // 2                 & elem belongs to set B only
+    // 3                 & elem belongs to sets A and B
+    unsigned int elemset_index =
+      mesh.add_elem_integer("elemset_code",
+                            /*allocate_data=*/true,
+                            /*default_value=*/0);
+
+    // We are generating this mesh, so it should not be renumbered.
+    // No harm in being explicit about it, however.
+    mesh.allow_renumbering(false);
+
+    MeshTools::Generation::build_square(mesh,
+                                        /*nx=*/5, /*ny=*/5,
+                                        -1., 1.,
+                                        -1., 1.,
+                                        QUAD4);
+
+    // Set ids for elements in elemsets A, B
+    std::set<dof_id_type> setA = {3, 8, 14, 24};
+    std::set<dof_id_type> setB = {3, 9, 15, 24};
+
+    // Loop over Elems and set "elemset_code" values
+    for (const auto & elem : mesh.element_ptr_range())
+      {
+        bool
+          inA = setA.count(elem->id()),
+          inB = setB.count(elem->id());
+
+        dof_id_type val = 0;
+        if (inA)
+          val = 1;
+        if (inB)
+          val = 2;
+        if (inA && inB)
+          val = 3;
+
+        elem->set_extra_integer(elemset_index, val);
+      }
+
+    // Debugging: print non-zero elemset_codes values
+    for (const auto & elem : mesh.element_ptr_range())
+      {
+        dof_id_type elemset_code = elem->get_extra_integer(elemset_index);
+
+        if (elemset_code)
+          libMesh::out << "Elem " << elem->id() << ", elemset_code = " << elemset_code << std::endl;
+      }
+
+    // Write the file in the ExodusII format, including the element set information.
+    // Note: elemsets are written during ExodusII_IO::write(), which
+    // matches the behavior of sidesets and nodesets
+    {
+      IOClass writer(mesh);
+      writer.write(filename);
+    }
+
+   // Make sure that the writing is done before the reading starts.
+   TestCommWorld->barrier();
+
+//    // Now read it back in
+//    Mesh read_mesh(*TestCommWorld);
+//    IOClass reader(read_mesh);
+//    reader.read(filename);
+//
+//    if (write_vars)
+//      {
+//        std::vector<std::string> read_in_var_names;
+//        std::vector<std::set<boundary_id_type>> read_in_side_ids;
+//        std::vector<std::map<BoundaryInfo::BCTuple, Real>> read_in_bc_vals;
+//        reader.read_sideset_data
+//          (/*timestep=*/1, read_in_var_names, read_in_side_ids, read_in_bc_vals);
+//
+//        // Assert that we got back out what we put in.
+//        CPPUNIT_ASSERT(read_in_var_names == var_names);
+//        CPPUNIT_ASSERT(read_in_side_ids == side_ids);
+//        CPPUNIT_ASSERT(read_in_bc_vals == bc_vals);
+//      } // if (write_vars)
+//
+//    // Also check that the flat indices match those in the file
+//    std::map<BoundaryInfo::BCTuple, unsigned int> bc_array_indices;
+//    reader.get_sideset_data_indices(bc_array_indices);
+//
+//    // Debugging
+//    // for (const auto & pr : bc_array_indices)
+//    //   {
+//    //     const auto & t = pr.first;
+//    //     const auto & elem_id = std::get<0>(t);
+//    //     const auto & side_id = std::get<1>(t);
+//    //     const auto & boundary_id = std::get<2>(t);
+//    //     libMesh::out << "(elem, side, boundary_id) = "
+//    //                  << "(" << elem_id << ", " << side_id << ", " << boundary_id << ")"
+//    //                  << std::endl;
+//    //   }
+//
+//    // For this test case, the sideset arrays are ordered as follows:
+//    // elem_ss1 = 1, 2, 3, 4, 5 ;
+//    // side_ss1 = 1, 1, 1, 1, 1 ;
+//    // elem_ss2 = 5, 10, 15, 20, 25 ;
+//    // side_ss2 = 2, 2, 2, 2, 2 ;
+//    // elem_ss3 = 21, 22, 23, 24, 25 ;
+//    // side_ss3 = 3, 3, 3, 3, 3 ;
+//    // elem_ss4 = 1, 6, 11, 16, 21 ;
+//    // side_ss4 = 4, 4, 4, 4, 4 ;
+//
+//    // Check that the 0th side of the 0th element on boundary 0
+//    // corresponds to array index 0.
+//    // CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(0),
+//    //                      libmesh_map_find(bc_array_indices,
+//    //                                       std::make_tuple(/*elem id*/static_cast<dof_id_type>(0),
+//    //                                                       /*side id*/static_cast<unsigned short int>(0),
+//    //                                                       /*boundary id*/static_cast<boundary_id_type>(0))));
+//
+//    // CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(0),
+//    //                      libmesh_map_find(bc_array_indices, std::make_tuple(0,0,0)));
+//    //
+//    // CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(1),
+//    //                      libmesh_map_find(bc_array_indices, std::make_tuple(1,0,0)));
+//
+//    // Check the first five elements, which all have side 0 on
+//    // boundary 0, and which happen to be in order in the BC array.
+//    for (unsigned int i=0; i<5; ++i)
+//      CPPUNIT_ASSERT_EQUAL
+//        (static_cast<unsigned int>(i),
+//         libmesh_map_find(bc_array_indices,
+//                          std::make_tuple(/*elem_id=*/cast_int<dof_id_type>(i),
+//                                          /*side_id=*/0,
+//                                          /*b_id=*/0)));
+//
+//    // Check side 1 of every fifth element starting with element 4, they are all in sideset 1.
+//    for (unsigned int i=0; i<5; ++i)
+//      CPPUNIT_ASSERT_EQUAL
+//        (static_cast<unsigned int>(i),
+//         libmesh_map_find(bc_array_indices,
+//                          std::make_tuple(/*elem_id=*/cast_int<dof_id_type>(5*i + 4),
+//                                          /*side_id*/1,
+//                                          /*b_id=*/1)));
+//
+//    // Check side 2 of the 5 consecutive elements starting with Elem 20. They are all in sideset 2.
+//    for (unsigned int i=0; i<5; ++i)
+//      CPPUNIT_ASSERT_EQUAL
+//        (static_cast<unsigned int>(i),
+//         libmesh_map_find(bc_array_indices,
+//                          std::make_tuple(/*elem_id=*/cast_int<dof_id_type>(20+i),
+//                                          /*side_id*/2,
+//                                          /*b_id=*/2)));
+//
+//    // Check side 3 of every fifth element, they are all in sideset 3
+//    for (unsigned int i=0; i<5; ++i)
+//      CPPUNIT_ASSERT_EQUAL
+//        (static_cast<unsigned int>(i),
+//         libmesh_map_find(bc_array_indices,
+//                          std::make_tuple(/*elem_id=*/cast_int<dof_id_type>(5*i),
+//                                          /*side_id*/3,
+//                                          /*b_id=*/3)));
+  }
+
+  void testWriteExodus()
+  {
+    LOG_UNIT_TEST;
+
+    testWriteImpl<ExodusII_IO>("write_elemset_data.e");
+  }
+
+  void testWriteNemesis()
+  {
+    // LOG_UNIT_TEST;
+
+    // FIXME: Not yet implemented
+    // testWriteImpl<Nemesis_IO>("write_elemset_data.n");
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(WriteElemsetData);


### PR DESCRIPTION
This PR adds support for reading and writing elemsets in Exodus files, and the accompanying data structures in MeshBase. Element sets are similar to the existing sidesets and nodesets in the Exodus writer, although they are not quite so specific to boundary conditions as those other two sets are. They also have some characteristics in common with subdomains, but (1) an elem can be in any number of elemsets whereas it can only be in one subdomain and (2) if you are using Exodus files, elemsets are not tied to geometric element type the way that blocks (and unfortunately subdomains) are. Since elemset ids are not exactly boundary ids and not exactly subdomain ids, I introduced a new type, `elemset_id_type`, which is currently `typedef`'d to `subdomain_id_type`. This avoids some confusion and also allows us to change it to something else in the future if desired.

In consultation with @roystgnr, we decided to use the "extra integer" feature of the Elem class in order to implement this. This way there should be less worries about keeping the elemset ids communicated and up-to-date in parallel, though admittedly this first draft of the PR may have some parallel issues... I have only tested in serial up to this point. 

In order to use the extra_integer approach, you must define the *same* number of extra integers per Elem. So, rather than try and define num_elemsets extra_integers on every Elem, we define a *single* extra integer on every Elem and use a table to map from {sets to which an elem belongs} -> extra_integer and back. Currently I've named this extra_integer `"elemset_code"`, but I'm open to discussion on the name. Whatever name we choose would effectively need to be reserved for use by the internals of libMesh in order to avoid strange behavior in e.g. the Exodus writer, which currently checks for the existence of an extra_integer by this name.

