### PR TITLE
ErrorMap should manage the memory for its ErrorVectors

### DIFF
--- a/include/error_estimation/error_estimator.h
+++ b/include/error_estimation/error_estimator.h
@@ -38,6 +38,7 @@ enum ErrorEstimatorType : int;
 #include <map>
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace libMesh
 {
@@ -124,7 +125,7 @@ public:
    * When calculating many error vectors at once, we need a data structure to
    * hold them all
    */
-  typedef std::map<std::pair<const System *, unsigned int>, ErrorVector *> ErrorMap;
+  typedef std::map<std::pair<const System *, unsigned int>, std::unique_ptr<ErrorVector>> ErrorMap;
 
   /**
    * This virtual function can be redefined

--- a/include/error_estimation/uniform_refinement_estimator.h
+++ b/include/error_estimation/uniform_refinement_estimator.h
@@ -128,7 +128,7 @@ protected:
   virtual void _estimate_error (const EquationSystems * equation_systems,
                                 const System * system,
                                 ErrorVector * error_per_cell,
-                                std::map<std::pair<const System *, unsigned int>, ErrorVector *> * errors_per_cell,
+                                ErrorMap * errors_per_cell,
                                 const std::map<const System *, SystemNorm > * error_norms,
                                 const std::map<const System *, const NumericVector<Number> *> * solution_vectors = nullptr,
                                 bool estimate_parent_error = false);

--- a/src/error_estimation/adjoint_residual_error_estimator.C
+++ b/src/error_estimation/adjoint_residual_error_estimator.C
@@ -100,9 +100,9 @@ void AdjointResidualErrorEstimator::estimate_error (const System & _system,
   if (!error_norm_is_identity)
     for (unsigned int v = 0; v < n_vars; v++)
       {
-        primal_errors_per_cell[std::make_pair(&_system, v)] = new ErrorVector;
-        dual_errors_per_cell[std::make_pair(&_system, v)] = new ErrorVector;
-        total_dual_errors_per_cell[std::make_pair(&_system, v)] = new ErrorVector;
+        primal_errors_per_cell[std::make_pair(&_system, v)] = std::make_unique<ErrorVector>();
+        dual_errors_per_cell[std::make_pair(&_system, v)] = std::make_unique<ErrorVector>();
+        total_dual_errors_per_cell[std::make_pair(&_system, v)] = std::make_unique<ErrorVector>();
       }
   ErrorVector primal_error_per_cell;
   ErrorVector dual_error_per_cell;
@@ -227,8 +227,8 @@ void AdjointResidualErrorEstimator::estimate_error (const System & _system,
                        << std::right
                        << v;
 
-              (*primal_errors_per_cell[std::make_pair(&_system, v)]).plot_error(primal_out.str(), _system.get_mesh());
-              (*total_dual_errors_per_cell[std::make_pair(&_system, v)]).plot_error(dual_out.str(), _system.get_mesh());
+              primal_errors_per_cell[std::make_pair(&_system, v)]->plot_error(primal_out.str(), _system.get_mesh());
+              total_dual_errors_per_cell[std::make_pair(&_system, v)]->plot_error(dual_out.str(), _system.get_mesh());
 
               primal_out.clear();
               dual_out.clear();
@@ -275,15 +275,6 @@ void AdjointResidualErrorEstimator::estimate_error (const System & _system,
           error_per_cell[i] = primal_error_per_cell[i]*total_dual_error_per_cell[i];
         }
     }
-
-  // Deallocate the ErrorMap contents if we allocated them earlier
-  if (!error_norm_is_identity)
-    for (unsigned int v = 0; v < n_vars; v++)
-      {
-        delete primal_errors_per_cell[std::make_pair(&_system, v)];
-        delete dual_errors_per_cell[std::make_pair(&_system, v)];
-        delete total_dual_errors_per_cell[std::make_pair(&_system, v)];
-      }
 }
 
 } // namespace libMesh

--- a/src/error_estimation/error_estimator.C
+++ b/src/error_estimation/error_estimator.C
@@ -107,8 +107,7 @@ void ErrorEstimator::estimate_errors(const EquationSystems & equation_systems,
       for (unsigned int v = 0; v != n_vars; ++v)
         {
           // Only fill in ErrorVectors the user asks for
-          if (errors_per_cell.find(std::make_pair(&sys, v)) ==
-              errors_per_cell.end())
+          if (!errors_per_cell.count(std::make_pair(&sys, v)))
             continue;
 
           // Calculate error in only one variable

--- a/src/error_estimation/uniform_refinement_estimator.C
+++ b/src/error_estimation/uniform_refinement_estimator.C
@@ -162,8 +162,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
               std::vector<Real> weights(n_vars, 0.0);
               for (unsigned int v = 0; v != n_vars; ++v)
                 {
-                  if (errors_per_cell->find(std::make_pair(&sys, v)) ==
-                      errors_per_cell->end())
+                  if (!errors_per_cell->count(std::make_pair(&sys, v)))
                     continue;
 
                   weights[v] = 1.0;
@@ -208,7 +207,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
       libmesh_assert(errors_per_cell);
       for (const auto & pr : *errors_per_cell)
         {
-          ErrorVector * e = pr.second;
+          ErrorVector * e = pr.second.get();
           e->clear();
           e->resize(mesh.max_elem_id(), 0.);
         }
@@ -501,7 +500,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
             {
               libmesh_assert(errors_per_cell);
               err_vec =
-                (*errors_per_cell)[std::make_pair(&system,var)];
+                (*errors_per_cell)[std::make_pair(&system,var)].get();
             }
 
           // The type of finite element to use for this variable


### PR DESCRIPTION
Another cleanup PR that I've had laying around for a while. `ErrorMap` is a public typedef of the `ErrorEstimator` class so technically this is an API change. Practically it was only used internally by a couple of the `ErrorEstimator` classes, so it's possible there's not much code out there (if any) that would be affected by the change.