### PR TITLE
DTKSolutionTransfer should store std::unique_ptrs

### DIFF
--- a/include/solution_transfer/dtk_solution_transfer.h
+++ b/include/solution_transfer/dtk_solution_transfer.h
@@ -24,21 +24,24 @@
 
 #ifdef LIBMESH_TRILINOS_HAVE_DTK
 
+// libMesh includes
 #include "libmesh/solution_transfer.h"
 #include "libmesh/dtk_adapter.h"
 
 #include "libmesh/ignore_warnings.h"
 
-// Trilinos
+// Trilinos includes
 #include <Teuchos_CommHelpers.hpp>
 #include <Teuchos_DefaultComm.hpp>
 
-// DTK
+// DTK includes
 #include <DTK_SharedDomainMap.hpp>
 
 #include "libmesh/restore_warnings.h"
 
+// C++ includes
 #include <string>
+#include <memory>
 
 namespace libMesh
 {
@@ -77,10 +80,10 @@ protected:
   Teuchos::RCP<const Teuchos::Comm<int>> comm_default;
 
   /// The DTKAdapter associated with each EquationSystems
-  std::map<EquationSystems *, DTKAdapter *> adapters;
+  std::map<EquationSystems *, std::unique_ptr<DTKAdapter>> adapters;
 
   /// The dtk shared domain maps for pairs of EquationSystems (from, to)
-  std::map<std::pair<EquationSystems *, EquationSystems *>, shared_domain_map_type * > dtk_maps;
+  std::map<std::pair<EquationSystems *, EquationSystems *>, std::unique_ptr<shared_domain_map_type>> dtk_maps;
 };
 
 } // namespace libMesh

--- a/src/solution_transfer/dtk_solution_transfer.C
+++ b/src/solution_transfer/dtk_solution_transfer.C
@@ -54,14 +54,7 @@ DTKSolutionTransfer::DTKSolutionTransfer(const libMesh::Parallel::Communicator &
   comm_default = Teuchos::rcp(new Teuchos::MpiComm<int>(Teuchos::rcp(new Teuchos::OpaqueWrapper<MPI_Comm>(comm.get()))));
 }
 
-DTKSolutionTransfer::~DTKSolutionTransfer()
-{
-  for (auto & pr : adapters)
-    delete pr.second;
-
-  for (auto & pr : dtk_maps)
-    delete pr.second;
-}
+DTKSolutionTransfer::~DTKSolutionTransfer() = default;
 
 void
 DTKSolutionTransfer::transfer(const Variable & from_var,
@@ -73,15 +66,15 @@ DTKSolutionTransfer::transfer(const Variable & from_var,
   EquationSystems * to_es = &to_var.system()->get_equation_systems();
 
   // Possibly make an Adapter for from_es
-  if (adapters.find(from_es) == adapters.end())
-    adapters[from_es] = new DTKAdapter(comm_default, *from_es);
+  if (!adapters.count(from_es))
+    adapters[from_es] = std::make_unique<DTKAdapter>(comm_default, *from_es);
 
   // Possibly make an Adapter for to_es
-  if (adapters.find(to_es) == adapters.end())
-    adapters[to_es] = new DTKAdapter(comm_default, *to_es);
+  if (!adapters.count(to_es))
+    adapters[to_es] = std::make_unique<DTKAdapter>(comm_default, *to_es);
 
-  DTKAdapter * from_adapter = adapters[from_es];
-  DTKAdapter * to_adapter = adapters[to_es];
+  DTKAdapter * from_adapter = adapters[from_es].get();
+  DTKAdapter * to_adapter = adapters[to_es].get();
 
   std::pair<EquationSystems *, EquationSystems *> from_to(from_es, to_es);
 
@@ -90,11 +83,10 @@ DTKSolutionTransfer::transfer(const Variable & from_var,
     {
       libmesh_assert(from_es->get_mesh().mesh_dimension() == to_es->get_mesh().mesh_dimension());
 
-      shared_domain_map_type * map = new shared_domain_map_type(comm_default, from_es->get_mesh().mesh_dimension(), true);
-      dtk_maps[from_to] = map;
+      dtk_maps[from_to] = std::make_unique<shared_domain_map_type>(comm_default, from_es->get_mesh().mesh_dimension(), true);
 
       // The tolerance here is for the "contains_point()" implementation in DTK.  Set a larger value for a looser tolerance...
-      map->setup(from_adapter->get_mesh_manager(), to_adapter->get_target_coords(), 30*Teuchos::ScalarTraits<double>::eps());
+      dtk_maps[from_to]->setup(from_adapter->get_mesh_manager(), to_adapter->get_target_coords(), 30*Teuchos::ScalarTraits<double>::eps());
     }
 
   DTKAdapter::RCP_Evaluator from_evaluator = from_adapter->get_variable_evaluator(from_var.name());
@@ -103,7 +95,7 @@ DTKSolutionTransfer::transfer(const Variable & from_var,
   dtk_maps[from_to]->apply(from_evaluator, to_values);
 
   if (dtk_maps[from_to]->getMissedTargetPoints().size())
-    libMesh::out<<"Warning: Some points were missed in the transfer of "<<from_var.name()<<" to "<<to_var.name()<<"!"<<std::endl;
+    libMesh::out << "Warning: Some points were missed in the transfer of " << from_var.name() << " to " << to_var.name() << "!" << std::endl;
 
   to_adapter->update_variable_values(to_var.name());
 }


### PR DESCRIPTION
This one is not an API change but it's complicated by the fact that I don't have a Trilinos (let alone DTK) build so while the change should be pretty straightforward I'm not sure it actually compiles. Was hoping maybe there's an attachable CIVET recipe that could test this...
