### PR TITLE
Save old adjoint vectors

### DIFF
--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -444,23 +444,11 @@ int main (int argc, char ** argv)
                << std::endl
                << std::endl;
 
-  // Add an adjoint vector, this will be computed after the forward
-  // time stepping is complete
-  //
-  // Tell the library not to save adjoint solutions during the forward
-  // solve
-  //
-  // Tell the library not to project this vector, and hence, memory/file
-  // solution history to not save it.
-  //
-  // Make this vector ghosted so we can localize it to each element
-  // later.
-  const std::string & adjoint_solution_name = "adjoint_solution0";
-  system.add_vector("adjoint_solution0", false, GHOSTED);
+  // Tell system that we have two qois
+  system.init_qois(1);
 
-  // To keep the number of vectors consistent between the primal and adjoint
-  // loops, we will also pre-add the adjoint rhs vector
-  system.add_vector("adjoint_rhs0", false, GHOSTED);
+  // Add the adjoint vectors (and the old adjoint vectors) to system
+  system.time_solver->init_adjoints();
 
   // Close up any resources initial.C needed
   finish_initialization();
@@ -519,9 +507,12 @@ int main (int argc, char ** argv)
       // We need to tell the library that it needs to project the adjoint, so
       // MemorySolutionHistory knows it has to save it
 
+      const std::string & adjoint_solution_name0 = "adjoint_solution0";
+      const std::string & old_adjoint_solution_name0 = "old_adjoint_solution0";
       // Tell the library to project the adjoint vector, and hence, memory solution history to
       // save it
-      system.set_vector_preservation(adjoint_solution_name, true);
+      system.set_vector_preservation(adjoint_solution_name0, true);
+      system.set_vector_preservation(old_adjoint_solution_name0, true);
 
       libMesh::out << "Setting adjoint initial conditions Z("
                    << system.time

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -667,6 +667,20 @@ int main (int argc, char ** argv)
       // Retrieve the primal and adjoint solutions at the current timestep
       system.time_solver->retrieve_timestep();
 
+      Z_old_norm = system.calculate_norm(system.get_vector(old_adjoint_solution_name0), 0, H1);
+
+      // Assert that the old adjoint values match hard coded numbers for 1st timestep or 1st half time step from the adjoint solve
+      if(param.timesolver_tolerance)
+      {
+        libmesh_error_msg_if(std::abs(Z_old_norm - (2.23366)) >= 2.e-4,
+                             "Mismatch in expected Z0_old norm for the 1st half timestep!");
+       }
+      else
+      {
+        libmesh_error_msg_if(std::abs(Z_old_norm - (2.23627)) >= 2.e-4,
+                             "Mismatch in expected Z0_old norm for the 1st timestep!");
+      }
+
       // A pretty update message
       libMesh::out << "Retrieved, "
                << "time = "

--- a/examples/adjoints/adjoints_ex7/adjoints_ex7.C
+++ b/examples/adjoints/adjoints_ex7/adjoints_ex7.C
@@ -432,6 +432,9 @@ int main (int argc, char ** argv)
                << std::endl
                << std::endl;
 
+  // Tell system that we have two qois
+  system.init_qois(2);
+
   // Add two adjoint vectors, these will be computed after the forward
   // and QoI calculation time stepping loops are complete
   //
@@ -518,10 +521,10 @@ int main (int argc, char ** argv)
         {
           system.time_solver->integrate_qoi_timestep();
 
-          QoI_1_accumulated += (system.qoi)[1];
+          QoI_1_accumulated += system.get_qoi_value(1);
         }
 
-      std::cout<< "The computed QoI 0 is " << std::setprecision(17) << (system.qoi)[0] << std::endl;
+      std::cout<< "The computed QoI 0 is " << std::setprecision(17) << system.get_qoi_value(0) << std::endl;
       std::cout<< "The computed QoI 1 is " << std::setprecision(17) << QoI_1_accumulated << std::endl;
 
       ///////////////// Now for the Adjoint Solution //////////////////////////////////////
@@ -811,7 +814,7 @@ int main (int argc, char ** argv)
             // Skip this QoI if not in the QoI Set
             if ((adjoint_refinement_error_estimator->qoi_set()).has_index(j))
             {
-              accumulated_QoI_spatially_integrated_error[j] += (system.qoi_error_estimates)[j];
+              accumulated_QoI_spatially_integrated_error[j] += system.get_qoi_error_estimate_value(j);
             }
           }
         }

--- a/examples/adjoints/adjoints_ex7/adjoints_ex7.C
+++ b/examples/adjoints/adjoints_ex7/adjoints_ex7.C
@@ -435,26 +435,8 @@ int main (int argc, char ** argv)
   // Tell system that we have two qois
   system.init_qois(2);
 
-  // Add two adjoint vectors, these will be computed after the forward
-  // and QoI calculation time stepping loops are complete
-  //
-  // Tell the library not to save adjoint solutions during the forward
-  // solve
-  //
-  // Tell the library not to project this vector, and hence, memory/file
-  // solution history to not save it during the forward run.
-  //
-  // Make this vector ghosted so we can localize it to each element
-  // later.
-  const std::string & adjoint_solution_name0 = "adjoint_solution0";
-  const std::string & adjoint_solution_name1 = "adjoint_solution1";
-  system.add_vector("adjoint_solution0", false, GHOSTED);
-  system.add_vector("adjoint_solution1", false, GHOSTED);
-
-  // To keep the number of vectors consistent between the primal and adjoint
-  // loops, we will also pre-add the adjoint rhs vector
-  system.add_vector("adjoint_rhs0", false, GHOSTED);
-  system.add_vector("adjoint_rhs1", false, GHOSTED);
+  // Add the adjoint vectors (and the old adjoint vectors) to system
+  system.time_solver->init_adjoints();
 
   // Plot the initial conditions
   write_output(equation_systems, 0, "primal", param);
@@ -537,8 +519,15 @@ int main (int argc, char ** argv)
 
       // Tell the library to project the adjoint vectors, and hence, solution history to
       // save them.
+      const std::string & adjoint_solution_name0 = "adjoint_solution0";
+      const std::string & adjoint_solution_name1 = "adjoint_solution1";
+      const std::string & old_adjoint_solution_name0 = "old_adjoint_solution0";
+      const std::string & old_adjoint_solution_name1 = "old_adjoint_solution1";
+
       system.set_vector_preservation(adjoint_solution_name0, true);
       system.set_vector_preservation(adjoint_solution_name1, true);
+      system.set_vector_preservation(old_adjoint_solution_name0, true);
+      system.set_vector_preservation(old_adjoint_solution_name1, true);
 
       libMesh::out << "Setting adjoint initial conditions Z("
                    << system.time

--- a/examples/adjoints/adjoints_ex7/adjoints_ex7.C
+++ b/examples/adjoints/adjoints_ex7/adjoints_ex7.C
@@ -802,6 +802,25 @@ int main (int argc, char ** argv)
                    << std::endl
                    << std::endl;
 
+      Z0_old_norm = system.calculate_norm(system.get_vector(old_adjoint_solution_name0), 0, H1);
+      Z1_old_norm = system.calculate_norm(system.get_vector(old_adjoint_solution_name1), 0, H1);
+
+      // Assert that the old adjoint values match hard coded numbers for 1st timestep or 1st half time step from the adjoint solve
+      if(param.timesolver_tolerance)
+      {
+        libmesh_error_msg_if(std::abs(Z0_old_norm - (4.3523242593920151e-06)) >= 2.e-10,
+                             "Mismatch in expected Z0_old norm for the 1st half timestep!");
+        libmesh_error_msg_if(std::abs(Z1_old_norm - (0.3118758855352407)) >= 2.e-5,
+                             "Mismatch in expected Z1_old norm for the 1st half timestep!");
+      }
+      else
+      {
+        libmesh_error_msg_if(std::abs(Z0_old_norm - (0.0030758523361801263)) >= 2.e-7,
+                             "Mismatch in expected Z0_old norm for the 1st timestep!");
+        libmesh_error_msg_if(std::abs(Z1_old_norm - (0.31162043809579365)) >= 2.e-5,
+                             "Mismatch in expected Z1_old norm for the 1st timestep!");
+      }
+
       libMesh::out << "|Z0_old("
                        << system.time + (system.time_solver->last_completed_timestep_size())/((param.timesolver_tolerance) ? 2.0 : 1.0)
                        << ")|= "

--- a/include/solvers/file_solution_history.h
+++ b/include/solvers/file_solution_history.h
@@ -81,9 +81,11 @@ private:
   DifferentiableSystem & _system ;
 
   /**
-   * A vector of pointers to vectors holding the adjoint solution at the last time step
+   * A vector of pointers to adjoint and old adjoint solutions at the last time step.
+   * These are used to prevent the zeroing of the adjoint and old adjoint by es::read.
    */
   std::vector< std::unique_ptr<NumericVector<Number>> > dual_solution_copies;
+  std::vector< std::unique_ptr<NumericVector<Number>> > old_dual_solution_copies;
 };
 
 } // end namespace libMesh

--- a/include/solvers/time_solver.h
+++ b/include/solvers/time_solver.h
@@ -87,6 +87,12 @@ public:
   virtual void init ();
 
   /**
+   * Initialize any adjoint related data structures, based on the number
+   * of qois.
+   */
+  virtual void init_adjoints ();
+
+  /**
    * The data initialization function.  This method is used to
    * initialize internal data structures after the underlying System
    * has been initialized

--- a/include/solvers/unsteady_solver.h
+++ b/include/solvers/unsteady_solver.h
@@ -69,6 +69,12 @@ public:
   virtual void init () override;
 
   /**
+   * @brief Add adjoint vectors and old_adjoint_vectors
+   * as per the indices of QoISet
+   */
+  virtual void init_adjoints () override;
+
+  /**
    * The data initialization function.  This method is used to
    * initialize internal data structures after the underlying System
    * has been initialized

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1603,10 +1603,10 @@ public:
    */
   void init_qois(unsigned int n_qois);
 
-  void fill_qoi(unsigned int qoi_index, Real qoi_value);
+  void fill_qoi(unsigned int qoi_index, Number qoi_value);
   Real get_qoi_value(unsigned int qoi_index);
 
-  void fill_qoi_error_estimate(unsigned int qoi_index, Real qoi_error_estimate);
+  void fill_qoi_error_estimate(unsigned int qoi_index, Number qoi_error_estimate);
   Real get_qoi_error_estimate_value(unsigned int qoi_index);
 
   /**

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1581,6 +1581,7 @@ public:
    */
   unsigned int n_qois() const;
 
+  #ifdef LIBMESH_ENABLE_DEPRECATED
   /**
    * Values of the quantities of interest.  This vector needs
    * to be both resized and filled by the user before any quantity of
@@ -1596,6 +1597,17 @@ public:
    * User code can use this for accumulating error estimates for example.
    */
   std::vector<Number> qoi_error_estimates;
+  #endif
+
+  /** Accessors for qoi and qoi_error_estimates vectors
+   */
+  void init_qois(unsigned int n_qois);
+
+  void fill_qoi(unsigned int qoi_index, Real qoi_value);
+  Real get_qoi_value(unsigned int qoi_index);
+
+  void fill_qoi_error_estimate(unsigned int qoi_index, Real qoi_error_estimate);
+  Real get_qoi_error_estimate_value(unsigned int qoi_index);
 
   /**
    * \returns The value of the solution variable \p var at the physical
@@ -2214,6 +2226,24 @@ private:
    * Do we want to apply constraints while projecting vectors ?
    */
   bool project_with_constraints;
+
+  #ifndef LIBMESH_ENABLE_DEPRECATED
+  /**
+   * Values of the quantities of interest.  This vector needs
+   * to be both resized and filled by the user before any quantity of
+   * interest assembly is done and before any sensitivities are
+   * calculated.
+   */
+  std::vector<Number> qoi;
+
+  /**
+   * Vector to hold error estimates for qois, either from a steady
+   * state calculation, or from a single unsteady solver timestep. Used
+   * by the library after resizing to match the size of the qoi vector.
+   * User code can use this for accumulating error estimates for example.
+   */
+  std::vector<Number> qoi_error_estimates;
+  #endif
 };
 
 

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1603,10 +1603,10 @@ public:
    */
   void init_qois(unsigned int n_qois);
 
-  void fill_qoi(unsigned int qoi_index, Number qoi_value);
+  void set_qoi(unsigned int qoi_index, Number qoi_value);
   Number get_qoi_value(unsigned int qoi_index);
 
-  void fill_qoi_error_estimate(unsigned int qoi_index, Number qoi_error_estimate);
+  void set_qoi_error_estimate(unsigned int qoi_index, Number qoi_error_estimate);
   Number get_qoi_error_estimate_value(unsigned int qoi_index);
 
   /**

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1604,10 +1604,10 @@ public:
   void init_qois(unsigned int n_qois);
 
   void fill_qoi(unsigned int qoi_index, Number qoi_value);
-  Real get_qoi_value(unsigned int qoi_index);
+  Number get_qoi_value(unsigned int qoi_index);
 
   void fill_qoi_error_estimate(unsigned int qoi_index, Number qoi_error_estimate);
-  Real get_qoi_error_estimate_value(unsigned int qoi_index);
+  Number get_qoi_error_estimate_value(unsigned int qoi_index);
 
   /**
    * \returns The value of the solution variable \p var at the physical

--- a/src/solvers/adaptive_time_solver.C
+++ b/src/solvers/adaptive_time_solver.C
@@ -21,6 +21,10 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/no_solution_history.h"
 
+// Debug
+#include "libmesh/system_norm.h"
+#include "libmesh/enum_norm_type.h"
+
 namespace libMesh
 {
 
@@ -129,6 +133,16 @@ void AdaptiveTimeSolver::adjoint_advance_timestep ()
   {
     _system.deltat = dynamic_cast<DifferentiableSystem &>(_system).time_solver->TimeSolver::last_completed_timestep_size();
     first_adjoint_step = false;
+  }
+
+  // Before moving to the next time instant, copy over the current adjoint solutions into _old_adjoint_solutions
+  for(auto i : make_range(_system.n_qois()))
+  {
+   std::string old_adjoint_solution_name = "_old_adjoint_solution";
+   old_adjoint_solution_name+= std::to_string(i);
+   NumericVector<Number> & old_adjoint_solution_i = _system.get_vector(old_adjoint_solution_name);
+   NumericVector<Number> & adjoint_solution_i = _system.get_adjoint_solution(i);
+   old_adjoint_solution_i = adjoint_solution_i;
   }
 
   _system.time -= _system.deltat;

--- a/src/solvers/euler2_solver.C
+++ b/src/solvers/euler2_solver.C
@@ -266,13 +266,13 @@ void Euler2Solver::integrate_qoi_timestep()
   // Zero out the system.qoi vector
   for (auto j : make_range(_system.n_qois()))
   {
-    (_system.qoi)[j] = 0.0;
+    _system.fill_qoi(j, 0.0);
   }
 
   // Left and right side contributions
-  std::vector<Number> left_contribution(_system.qoi.size(), 0.0);
+  std::vector<Number> left_contribution(_system.n_qois(), 0.0);
   Number time_left = 0.0;
-  std::vector<Number> right_contribution(_system.qoi.size(), 0.0);
+  std::vector<Number> right_contribution(_system.n_qois(), 0.0);
   Number time_right = 0.0;
 
   time_left = _system.time;
@@ -283,7 +283,7 @@ void Euler2Solver::integrate_qoi_timestep()
   // Also get the spatially integrated errors for all the QoIs in the QoI set
   for (auto j : make_range(_system.n_qois()))
   {
-    left_contribution[j] = (_system.qoi)[j];
+    left_contribution[j] = _system.get_qoi_value(j);
   }
 
   // Advance to t_j+1
@@ -297,7 +297,7 @@ void Euler2Solver::integrate_qoi_timestep()
   // Zero out the system.qoi vector
   for (auto j : make_range(_system.n_qois()))
   {
-    (_system.qoi)[j] = 0.0;
+    _system.fill_qoi(j, 0.0);
   }
 
   // Base class assumes a direct steady evaluation
@@ -305,14 +305,14 @@ void Euler2Solver::integrate_qoi_timestep()
 
   for(auto j : make_range(_system.n_qois()))
   {
-    right_contribution[j] = (_system.qoi)[j];
+    right_contribution[j] = _system.get_qoi_value(j);
   }
 
   // Combine the left and right side contributions as per the specified theta
   // theta = 0.5 (Crank-Nicholson) gives the trapezoidal rule.
   for (auto j : make_range(_system.n_qois()))
   {
-    (_system.qoi)[j] = ( ( ((1.0 - theta)*left_contribution[j]) + (theta*right_contribution[j]) )/2.0 )*(time_right - time_left);
+    _system.fill_qoi(j, ( ( ((1.0 - theta)*left_contribution[j]) + (theta*right_contribution[j]) )/2.0 )*(time_right - time_left));
   }
 }
 
@@ -323,16 +323,12 @@ void Euler2Solver::integrate_adjoint_refinement_error_estimate(AdjointRefinement
   if (theta != 1.0)
   libmesh_not_implemented();
 
-  // Make sure the system::qoi_error_estimates vector is of the same size as system::qoi
-  if(_system.qoi_error_estimates.size() != _system.qoi.size())
-    _system.qoi_error_estimates.resize(_system.qoi.size());
-
   // There are two possibilities regarding the integration rule we need to use for time integration.
   // If we have a instantaneous QoI, then we need to use a left sided Riemann sum, otherwise the trapezoidal rule for temporally smooth QoIs.
 
   // Create left and right error estimate vectors of the right size
-  std::vector<Number> qoi_error_estimates_left(_system.qoi.size());
-  std::vector<Number> qoi_error_estimates_right(_system.qoi.size());
+  std::vector<Number> qoi_error_estimates_left(_system.n_qois());
+  std::vector<Number> qoi_error_estimates_right(_system.n_qois());
 
   // Get t_j
   Real time_left = _system.time;
@@ -475,7 +471,7 @@ void Euler2Solver::integrate_adjoint_refinement_error_estimate(AdjointRefinement
     // Skip this QoI if not in the QoI Set
     if (adjoint_refinement_error_estimator.qoi_set().has_index(j))
     {
-      (_system.qoi_error_estimates)[j] = ( (1.0 - theta)*qoi_error_estimates_left[j] + theta*qoi_error_estimates_right[j] )*last_step_deltat;
+      _system.fill_qoi_error_estimate(j, ( (1.0 - theta)*qoi_error_estimates_left[j] + theta*qoi_error_estimates_right[j] )*last_step_deltat);
     }
   }
 

--- a/src/solvers/euler2_solver.C
+++ b/src/solvers/euler2_solver.C
@@ -266,7 +266,7 @@ void Euler2Solver::integrate_qoi_timestep()
   // Zero out the system.qoi vector
   for (auto j : make_range(_system.n_qois()))
   {
-    _system.fill_qoi(j, 0.0);
+    _system.set_qoi(j, 0.0);
   }
 
   // Left and right side contributions
@@ -297,7 +297,7 @@ void Euler2Solver::integrate_qoi_timestep()
   // Zero out the system.qoi vector
   for (auto j : make_range(_system.n_qois()))
   {
-    _system.fill_qoi(j, 0.0);
+    _system.set_qoi(j, 0.0);
   }
 
   // Base class assumes a direct steady evaluation
@@ -312,7 +312,7 @@ void Euler2Solver::integrate_qoi_timestep()
   // theta = 0.5 (Crank-Nicholson) gives the trapezoidal rule.
   for (auto j : make_range(_system.n_qois()))
   {
-    _system.fill_qoi(j, ( ( ((1.0 - theta)*left_contribution[j]) + (theta*right_contribution[j]) )/2.0 )*(time_right - time_left));
+    _system.set_qoi(j, ( ( ((1.0 - theta)*left_contribution[j]) + (theta*right_contribution[j]) )/2.0 )*(time_right - time_left));
   }
 }
 
@@ -471,7 +471,7 @@ void Euler2Solver::integrate_adjoint_refinement_error_estimate(AdjointRefinement
     // Skip this QoI if not in the QoI Set
     if (adjoint_refinement_error_estimator.qoi_set().has_index(j))
     {
-      _system.fill_qoi_error_estimate(j, ( (1.0 - theta)*qoi_error_estimates_left[j] + theta*qoi_error_estimates_right[j] )*last_step_deltat);
+      _system.set_qoi_error_estimate(j, ( (1.0 - theta)*qoi_error_estimates_left[j] + theta*qoi_error_estimates_right[j] )*last_step_deltat);
     }
   }
 

--- a/src/solvers/euler_solver.C
+++ b/src/solvers/euler_solver.C
@@ -199,7 +199,7 @@ void EulerSolver::integrate_qoi_timestep()
   // Zero out the system.qoi vector
   for (auto j : make_range(_system.n_qois()))
   {
-    _system.fill_qoi(j, 0.0);
+    _system.set_qoi(j, 0.0);
   }
 
   // Left and right side contributions
@@ -230,7 +230,7 @@ void EulerSolver::integrate_qoi_timestep()
   // Zero out the system.qoi vector
   for (auto j : make_range(_system.n_qois()))
   {
-    _system.fill_qoi(j, 0.0);
+    _system.set_qoi(j, 0.0);
   }
 
   // Base class assumes a direct steady evaluation
@@ -245,7 +245,7 @@ void EulerSolver::integrate_qoi_timestep()
   // theta = 0.5 (Crank-Nicholson) gives the trapezoidal rule.
   for (auto j : make_range(_system.n_qois()))
   {
-    _system.fill_qoi(j, ( ((1.0 - theta)*left_contribution[j]) + (theta*right_contribution[j]) )*(time_right - time_left));
+    _system.set_qoi(j, ( ((1.0 - theta)*left_contribution[j]) + (theta*right_contribution[j]) )*(time_right - time_left));
   }
 }
 
@@ -404,7 +404,7 @@ void EulerSolver::integrate_adjoint_refinement_error_estimate(AdjointRefinementE
     // Skip this QoI if not in the QoI Set
     if (adjoint_refinement_error_estimator.qoi_set().has_index(j))
     {
-      _system.fill_qoi_error_estimate(j, ( (1.0 - theta)*qoi_error_estimates_left[j] + theta*qoi_error_estimates_right[j] )*last_step_deltat);
+      _system.set_qoi_error_estimate(j, ( (1.0 - theta)*qoi_error_estimates_left[j] + theta*qoi_error_estimates_right[j] )*last_step_deltat);
     }
   }
 

--- a/src/solvers/file_solution_history.C
+++ b/src/solvers/file_solution_history.C
@@ -37,6 +37,7 @@ namespace libMesh
   : SolutionHistory(), _system(system_)
   {
     dual_solution_copies.resize(system_.n_qois());
+    old_dual_solution_copies.resize(system_.n_qois());
 
     libmesh_experimental();
 
@@ -164,19 +165,27 @@ void FileSolutionHistory::retrieve(bool is_adjoint_solve, Real time)
   if(is_adjoint_solve)
   {
     // Reading in the primal xdas overwrites the adjoint solution with zero
-    // So swap to retain the old adjoint solution
+    // So swap to retain the adjoint and old adjoint vectors
     for (auto j : make_range(_system.n_qois()))
     {
       dual_solution_copies[j] = _system.get_adjoint_solution(j).clone();
+
+      std::string old_adjoint_solution_name = "_old_adjoint_solution";
+      old_adjoint_solution_name+= std::to_string(j);
+      old_dual_solution_copies[j] = _system.get_vector(old_adjoint_solution_name).clone();
     }
 
     // Read in the primal solution stored at the current recovery time from the disk
     (stored_datum->second)->retrieve_primal_solution();
 
-    // Swap back the copy of the last adjoint solution back in place
+    // Swap back the copy of adjoint and old adjoint vectors back in place
     for (auto j : make_range(_system.n_qois()))
     {
       (_system.get_adjoint_solution(j)).swap(*dual_solution_copies[j]);
+
+      std::string old_adjoint_solution_name = "_old_adjoint_solution";
+      old_adjoint_solution_name+= std::to_string(j);
+      (_system.get_vector(old_adjoint_solution_name)).swap(*old_dual_solution_copies[j]);
     }
   }
   else

--- a/src/solvers/steady_solver.C
+++ b/src/solvers/steady_solver.C
@@ -121,7 +121,7 @@ void SteadySolver::integrate_adjoint_refinement_error_estimate
     // Skip this QoI if not in the QoI Set
     if (adjoint_refinement_error_estimator.qoi_set().has_index(j))
     {
-      _system.fill_qoi_error_estimate(j, adjoint_refinement_error_estimator.get_global_QoI_error_estimate(j));
+      _system.set_qoi_error_estimate(j, adjoint_refinement_error_estimator.get_global_QoI_error_estimate(j));
     }
   }
 

--- a/src/solvers/steady_solver.C
+++ b/src/solvers/steady_solver.C
@@ -112,10 +112,6 @@ void SteadySolver::integrate_adjoint_refinement_error_estimate
   (AdjointRefinementEstimator & adjoint_refinement_error_estimator,
    ErrorVector & QoI_elementwise_error)
 {
-  // Make sure the system::qoi_error_estimates vector is of the same size as system::qoi
-  if(_system.qoi_error_estimates.size() != _system.qoi.size())
-      _system.qoi_error_estimates.resize(_system.qoi.size());
-
   // Base class assumes a direct steady state error estimate
   adjoint_refinement_error_estimator.estimate_error(_system, QoI_elementwise_error);
 
@@ -125,7 +121,7 @@ void SteadySolver::integrate_adjoint_refinement_error_estimate
     // Skip this QoI if not in the QoI Set
     if (adjoint_refinement_error_estimator.qoi_set().has_index(j))
     {
-      (_system.qoi_error_estimates)[j] = adjoint_refinement_error_estimator.get_global_QoI_error_estimate(j);
+      _system.fill_qoi_error_estimate(j, adjoint_refinement_error_estimator.get_global_QoI_error_estimate(j));
     }
   }
 

--- a/src/solvers/time_solver.C
+++ b/src/solvers/time_solver.C
@@ -76,7 +76,19 @@ void TimeSolver::init ()
     this->linear_solver() = LinearSolver<Number>::build(_system.comm());
 }
 
+void TimeSolver::init_adjoints ()
+{
+  libmesh_assert_msg(_system.n_qois() != 0, "System qois have to be initialized before initializing adjoints.");
 
+  // Add adjoint vectors
+  for(auto i : make_range(_system.n_qois()))
+  {
+    std::string adjoint_solution_name = "adjoint_solution";
+    adjoint_solution_name+= std::to_string(i);
+    _system.add_vector(adjoint_solution_name, false, GHOSTED);
+  }
+
+}
 
 void TimeSolver::init_data ()
 {

--- a/src/solvers/twostep_time_solver.C
+++ b/src/solvers/twostep_time_solver.C
@@ -361,14 +361,14 @@ void TwostepTimeSolver::integrate_qoi_timestep()
   // Zero out the system.qoi vector
   for (auto j : make_range(_system.n_qois()))
   {
-    _system.fill_qoi(j, 0.0);
+    _system.set_qoi(j, 0.0);
   }
 
   // Add the contributions from the two halftimesteps to get the full QoI
   // contribution from this timestep
   for (auto j : make_range(_system.n_qois()))
   {
-    _system.fill_qoi(j, qois_first_half[j] + qois_second_half[j]);
+    _system.set_qoi(j, qois_first_half[j] + qois_second_half[j]);
   }
 }
 
@@ -441,7 +441,7 @@ void TwostepTimeSolver::integrate_adjoint_refinement_error_estimate(AdjointRefin
     // Skip this QoI if not in the QoI Set
     if (adjoint_refinement_error_estimator.qoi_set().has_index(j))
     {
-      _system.fill_qoi_error_estimate(j, qoi_error_estimates_first_half[j] + qoi_error_estimates_second_half[j]);
+      _system.set_qoi_error_estimate(j, qoi_error_estimates_first_half[j] + qoi_error_estimates_second_half[j]);
     }
   }
 }

--- a/src/solvers/twostep_time_solver.C
+++ b/src/solvers/twostep_time_solver.C
@@ -330,15 +330,15 @@ std::pair<unsigned int, Real> TwostepTimeSolver::adjoint_solve (const QoISet & q
 void TwostepTimeSolver::integrate_qoi_timestep()
 {
   // Vectors to hold qoi contributions from the first and second half timesteps
-  std::vector<Number> qois_first_half(_system.qoi.size(), 0.0);
-  std::vector<Number> qois_second_half(_system.qoi.size(), 0.0);
+  std::vector<Number> qois_first_half(_system.n_qois(), 0.0);
+  std::vector<Number> qois_second_half(_system.n_qois(), 0.0);
 
   // First half contribution
   core_time_solver->integrate_qoi_timestep();
 
   for (auto j : make_range(_system.n_qois()))
   {
-    qois_first_half[j] = (_system.qoi)[j];
+    qois_first_half[j] = _system.get_qoi_value(j);
   }
 
   // Second half contribution
@@ -346,20 +346,20 @@ void TwostepTimeSolver::integrate_qoi_timestep()
 
   for (auto j : make_range(_system.n_qois()))
   {
-    qois_second_half[j] = (_system.qoi)[j];
+    qois_second_half[j] = _system.get_qoi_value(j);
   }
 
   // Zero out the system.qoi vector
   for (auto j : make_range(_system.n_qois()))
   {
-    (_system.qoi)[j] = 0.0;
+    _system.fill_qoi(j, 0.0);
   }
 
   // Add the contributions from the two halftimesteps to get the full QoI
   // contribution from this timestep
   for (auto j : make_range(_system.n_qois()))
   {
-    (_system.qoi)[j] = qois_first_half[j] + qois_second_half[j];
+    _system.fill_qoi(j, qois_first_half[j] + qois_second_half[j]);
   }
 }
 
@@ -390,8 +390,8 @@ void TwostepTimeSolver::integrate_adjoint_refinement_error_estimate(AdjointRefin
   // We use a numerical integration scheme consistent with the theta used for the timesolver.
 
   // Create first and second half error estimate vectors of the right size
-  std::vector<Number> qoi_error_estimates_first_half(_system.qoi.size());
-  std::vector<Number> qoi_error_estimates_second_half(_system.qoi.size());
+  std::vector<Number> qoi_error_estimates_first_half(_system.n_qois());
+  std::vector<Number> qoi_error_estimates_second_half(_system.n_qois());
 
   // First half timestep
   ErrorVector QoI_elementwise_error_first_half;
@@ -404,7 +404,7 @@ void TwostepTimeSolver::integrate_adjoint_refinement_error_estimate(AdjointRefin
     // Skip this QoI if not in the QoI Set
     if (adjoint_refinement_error_estimator.qoi_set().has_index(j))
     {
-      qoi_error_estimates_first_half[j] = (_system.qoi_error_estimates)[j];
+      qoi_error_estimates_first_half[j] = _system.get_qoi_error_estimate_value(j);
     }
   }
 
@@ -419,7 +419,7 @@ void TwostepTimeSolver::integrate_adjoint_refinement_error_estimate(AdjointRefin
     // Skip this QoI if not in the QoI Set
     if (adjoint_refinement_error_estimator.qoi_set().has_index(j))
     {
-      qoi_error_estimates_second_half[j] = (_system.qoi_error_estimates)[j];
+      qoi_error_estimates_second_half[j] = _system.get_qoi_error_estimate_value(j);
     }
   }
 
@@ -432,7 +432,7 @@ void TwostepTimeSolver::integrate_adjoint_refinement_error_estimate(AdjointRefin
     // Skip this QoI if not in the QoI Set
     if (adjoint_refinement_error_estimator.qoi_set().has_index(j))
     {
-      (_system.qoi_error_estimates)[j] = qoi_error_estimates_first_half[j] + qoi_error_estimates_second_half[j];
+      _system.fill_qoi_error_estimate(j, qoi_error_estimates_first_half[j] + qoi_error_estimates_second_half[j]);
     }
   }
 }

--- a/src/solvers/twostep_time_solver.C
+++ b/src/solvers/twostep_time_solver.C
@@ -298,6 +298,15 @@ std::pair<unsigned int, Real> TwostepTimeSolver::adjoint_solve (const QoISet & q
   // Take the first adjoint 'half timestep'
   core_time_solver->adjoint_solve(qoi_indices);
 
+  // We print the forward 'half solution' norms and we will do so for the adjoints if running in dbg.
+  #ifdef DEBUG
+    for(auto i : make_range(_system.n_qois()))
+    {
+      for(auto j : make_range(_system.n_vars()))
+        libMesh::out<<"||Z_"<<"("<<_system.time<<";"<<i<<","<<j<<")||_H1: "<<_system.calculate_norm(_system.get_adjoint_solution(i), j,H1)<<std::endl;
+    }
+  #endif
+
   // Record the sub step deltat we used for the last adjoint solve.
   last_deltat = _system.deltat;
 

--- a/src/solvers/unsteady_solver.C
+++ b/src/solvers/unsteady_solver.C
@@ -75,7 +75,7 @@ void UnsteadySolver::init_adjoints ()
   {
     std::string old_adjoint_solution_name = "_old_adjoint_solution";
     old_adjoint_solution_name+= std::to_string(i);
-    _system.add_vector(old_adjoint_solution_name);
+    _system.add_vector(old_adjoint_solution_name, false, GHOSTED);
 
     std::string adjoint_rhs_name = "adjoint_rhs";
     adjoint_rhs_name+= std::to_string(i);

--- a/src/solvers/unsteady_solver.C
+++ b/src/solvers/unsteady_solver.C
@@ -242,6 +242,16 @@ void UnsteadySolver::adjoint_advance_timestep ()
   // time step for the time instance.
   solution_history->store(true, _system.time);
 
+  // Before moving to the next time instant, copy over the current adjoint solutions into _old_adjoint_solutions
+  for(auto i : make_range(_system.n_qois()))
+  {
+   std::string old_adjoint_solution_name = "_old_adjoint_solution";
+   old_adjoint_solution_name+= std::to_string(i);
+   NumericVector<Number> & old_adjoint_solution_i = _system.get_vector(old_adjoint_solution_name);
+   NumericVector<Number> & adjoint_solution_i = _system.get_adjoint_solution(i);
+   old_adjoint_solution_i = adjoint_solution_i;
+  }
+
   _system.time -= _system.deltat;
 
   // Retrieve the primal solution vectors at this new (or for

--- a/src/solvers/unsteady_solver.C
+++ b/src/solvers/unsteady_solver.C
@@ -64,6 +64,26 @@ void UnsteadySolver::init ()
 }
 
 
+void UnsteadySolver::init_adjoints ()
+{
+  TimeSolver::init_adjoints();
+
+  // Add old adjoint solutions
+  // To keep the number of vectors consistent between the primal and adjoint
+  // time loops, we will also add the adjoint rhs vector during initialization
+  for(auto i : make_range(_system.n_qois()))
+  {
+    std::string old_adjoint_solution_name = "_old_adjoint_solution";
+    old_adjoint_solution_name+= std::to_string(i);
+    _system.add_vector(old_adjoint_solution_name);
+
+    std::string adjoint_rhs_name = "adjoint_rhs";
+    adjoint_rhs_name+= std::to_string(i);
+    _system.add_vector(adjoint_rhs_name, false, GHOSTED);
+  }
+
+}
+
 
 void UnsteadySolver::init_data()
 {

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -2150,7 +2150,7 @@ void System::init_qois(unsigned int n_qois)
   qoi_error_estimates.resize(n_qois);
 }
 
-void System::fill_qoi(unsigned int qoi_index, Number qoi_value)
+void System::set_qoi(unsigned int qoi_index, Number qoi_value)
 {
   libmesh_assert(qoi_index < qoi.size());
 
@@ -2163,7 +2163,7 @@ Number System::get_qoi_value(unsigned int qoi_index)
   return qoi[qoi_index];
 }
 
-void System::fill_qoi_error_estimate(unsigned int qoi_index, Number qoi_error_estimate)
+void System::set_qoi_error_estimate(unsigned int qoi_index, Number qoi_error_estimate)
 {
   libmesh_assert(qoi_index < qoi_error_estimates.size());
 

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -2150,7 +2150,7 @@ void System::init_qois(unsigned int n_qois)
   qoi_error_estimates.resize(n_qois);
 }
 
-void System::fill_qoi(unsigned int qoi_index, Real qoi_value)
+void System::fill_qoi(unsigned int qoi_index, Number qoi_value)
 {
   libmesh_assert(qoi_index < qoi.size());
 
@@ -2163,7 +2163,7 @@ Number System::get_qoi_value(unsigned int qoi_index)
   return qoi[qoi_index];
 }
 
-void System::fill_qoi_error_estimate(unsigned int qoi_index, Real qoi_error_estimate)
+void System::fill_qoi_error_estimate(unsigned int qoi_index, Number qoi_error_estimate)
 {
   libmesh_assert(qoi_index < qoi_error_estimates.size());
 

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -2144,6 +2144,38 @@ void System::user_QOI_derivative(const QoISet & qoi_indices,
       (qoi_indices, include_liftfunc, apply_constraints);
 }
 
+void System::init_qois(unsigned int n_qois)
+{
+  qoi.resize(n_qois);
+  qoi_error_estimates.resize(n_qois);
+}
+
+void System::fill_qoi(unsigned int qoi_index, Real qoi_value)
+{
+  libmesh_assert(qoi_index < qoi.size());
+
+  qoi[qoi_index] = qoi_value;
+}
+
+Number System::get_qoi_value(unsigned int qoi_index)
+{
+  libmesh_assert(qoi_index < qoi.size());
+  return qoi[qoi_index];
+}
+
+void System::fill_qoi_error_estimate(unsigned int qoi_index, Real qoi_error_estimate)
+{
+  libmesh_assert(qoi_index < qoi_error_estimates.size());
+
+  qoi_error_estimates[qoi_index] = qoi_error_estimate;
+}
+
+Number System::get_qoi_error_estimate_value(unsigned int qoi_index)
+{
+  libmesh_assert(qoi_index < qoi_error_estimates.size());
+  return qoi_error_estimates[qoi_index];
+}
+
 
 
 Number System::point_value(unsigned int var,


### PR DESCRIPTION
This branch gives TimeSolver the capability to save old adjoint solutions during the adjoint time march, like old_nonlinear_solution saves the primal solutions during the primal time march.

Detailed steps:
1) There are multiple adjoint solutions, hence the interface between user code and System was extended to allow the user to set the number of qois (System::init_qois) and hence the number of adjoint related vectors via System::init_adjoints.
2) System members qoi and qoi_error_estimates which were public earlier have now been made private, and accessors added.
3) UnsteadySolver and AdaptiveTimeSolver implementations of adjoint_advance_timestep save all old_adjoint_vectors.