### PR TITLE
Add support for reading/writing Exodus variables defined on elemsets

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -425,6 +425,20 @@ public:
                      std::vector<std::map<std::pair<dof_id_type, elemset_id_type>, Real>> & elemset_vals);
 
   /**
+   * Similar to read_elemset_data(), but instead of creating one
+   * std::map per nodeset per variable, creates a single map of
+   * (elem_id, elemset_id) pairs -> exo file array indices
+   * for any/all variables on that elemset (they are all the
+   * same). In cases where there are hundreds of elemset variables on
+   * a single elemset, it is more efficient to store the array indices
+   * in a quickly searchable data structure than to repeat the
+   * indexing once per variable as is done in the read_elemset_data()
+   * case.
+   */
+  void
+  get_elemset_data_indices (std::map<std::pair<dof_id_type, elemset_id_type>, unsigned int> & elemset_array_indices);
+
+  /**
    * Set the elemental variables in the Exodus file to be read into extra
    * element integers. The names of these elemental variables will be used to
    * name the extra element integers.

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -398,6 +398,24 @@ public:
   get_nodeset_data_indices (std::map<BoundaryInfo::NodeBCTuple, unsigned int> & bc_array_indices);
 
   /**
+   * The Exodus format can also store values on elemsets. The inputs to the function are:
+   * .) var_names[i] is the name of the ith elemset variable to be written to file.
+   * .) elemset_ids_in[i] is a set of elemset ids where var_names[i] is active.
+   * .) elemset_vals[i] is a map from (elem-id, elemset-id) pairs to the
+   *    corresponding real-valued data.
+   *
+   * \note You must have already written the mesh by calling
+   * e.g. write() (and write_elemsets()) before calling this function,
+   * because it uses the ordering of the elemsets that have already
+   * been written to the Exodus file.
+   */
+  void
+  write_elemset_data (int timestep,
+                      const std::vector<std::string> & var_names,
+                      const std::vector<std::set<elemset_id_type>> & elemset_ids_in,
+                      const std::vector<std::map<std::pair<dof_id_type, elemset_id_type>, Real>> & elemset_vals);
+
+  /**
    * Set the elemental variables in the Exodus file to be read into extra
    * element integers. The names of these elemental variables will be used to
    * name the extra element integers.

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -416,6 +416,15 @@ public:
                       const std::vector<std::map<std::pair<dof_id_type, elemset_id_type>, Real>> & elemset_vals);
 
   /**
+   * Read all the elemset data at a particular timestep.
+   */
+  void
+  read_elemset_data (int timestep,
+                     std::vector<std::string> & var_names,
+                     std::vector<std::set<elemset_id_type>> & elemset_ids_in,
+                     std::vector<std::map<std::pair<dof_id_type, elemset_id_type>, Real>> & elemset_vals);
+
+  /**
    * Set the elemental variables in the Exodus file to be read into extra
    * element integers. The names of these elemental variables will be used to
    * name the extra element integers.

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -423,6 +423,15 @@ public:
                       const std::vector<std::map<std::pair<dof_id_type, elemset_id_type>, Real>> & elemset_vals);
 
   /**
+   * Read elemset variables, if any, into the provided data structures.
+   */
+  void
+  read_elemset_data (int timestep,
+                     std::vector<std::string> & var_names,
+                     std::vector<std::set<elemset_id_type>> & elemset_ids_in,
+                     std::vector<std::map<std::pair<dof_id_type, elemset_id_type>, Real>> & elemset_vals);
+
+  /**
    * Writes the vector of values to the element variables.
    *
    * The 'values' vector is assumed to be in the order:

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -414,6 +414,15 @@ public:
   get_nodeset_data_indices (std::map<BoundaryInfo::NodeBCTuple, unsigned int> & bc_array_indices);
 
   /**
+   * Write elemset data for the requested timestep.
+   */
+  void
+  write_elemset_data (int timestep,
+                      const std::vector<std::string> & var_names,
+                      const std::vector<std::set<elemset_id_type>> & elemset_ids_in,
+                      const std::vector<std::map<std::pair<dof_id_type, elemset_id_type>, Real>> & elemset_vals);
+
+  /**
    * Writes the vector of values to the element variables.
    *
    * The 'values' vector is assumed to be in the order:
@@ -626,6 +635,9 @@ public:
   // Number of nodeset variables
   int num_nodeset_vars;
 
+  // Number of elemset variables
+  int num_elemset_vars;
+
   // Number of elements in this block
   int num_elem_this_blk;
 
@@ -784,11 +796,15 @@ public:
   // The names of the nodeset variables stored in the Exodus file
   std::vector<std::string> nodeset_var_names;
 
+  // The names of the elemset variables stored in the Exodus file
+  std::vector<std::string> elemset_var_names;
+
   // Maps of Ids to named entities
   std::map<int, std::string> id_to_block_names;
   std::map<int, std::string> id_to_edge_block_names;
   std::map<int, std::string> id_to_ss_names;
   std::map<int, std::string> id_to_ns_names;
+  std::map<int, std::string> id_to_elemset_names;
 
   // On/Off message flag
   bool verbose;
@@ -821,7 +837,7 @@ public:
    * SIDESET:   num_sideset_vars sideset_var_names
    * NODESET:   num_nodeset_vars nodeset_var_names
    */
-  enum ExodusVarType {NODAL=0, ELEMENTAL=1, GLOBAL=2, SIDESET=3, NODESET=4};
+  enum ExodusVarType {NODAL=0, ELEMENTAL=1, GLOBAL=2, SIDESET=3, NODESET=4, ELEMSET=5};
   void read_var_names(ExodusVarType type);
 
   const ExodusII_IO_Helper::Conversion &

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -432,6 +432,16 @@ public:
                      std::vector<std::map<std::pair<dof_id_type, elemset_id_type>, Real>> & elemset_vals);
 
   /**
+   * Similar to read_elemset_data(), but instead of creating one
+   * std::map per elemset per variable, creates a single map of
+   * (elem_id, elemset_id) tuples, and stores the exo file array
+   * indexing for any/all elemset variables on that elemset (they are
+   * all the same).
+   */
+  void
+  get_elemset_data_indices (std::map<std::pair<dof_id_type, elemset_id_type>, unsigned int> & elemset_array_indices);
+
+  /**
    * Writes the vector of values to the element variables.
    *
    * The 'values' vector is assumed to be in the order:

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1989,6 +1989,18 @@ read_nodeset_data (int timestep,
   exio_helper->read_nodeset_data(timestep, var_names, node_boundary_ids, bc_vals);
 }
 
+void
+ExodusII_IO::
+write_elemset_data (int timestep,
+                    const std::vector<std::string> & var_names,
+                    const std::vector<std::set<elemset_id_type>> & elemset_ids_in,
+                    const std::vector<std::map<std::pair<dof_id_type, elemset_id_type>, Real>> & elemset_vals)
+{
+  libmesh_error_msg_if(!exio_helper->opened_for_writing,
+                       "ERROR, ExodusII file must be opened for writing "
+                       "before calling ExodusII_IO::write_elemset_data()!");
+  exio_helper->write_elemset_data(timestep, var_names, elemset_ids_in, elemset_vals);
+}
 
 
 
@@ -2391,6 +2403,50 @@ read_sideset_data (int,
   libmesh_error_msg("ERROR, ExodusII API is not defined.");
 }
 
+void
+ExodusII_IO::
+get_sideset_data_indices (std::map<BoundaryInfo::BCTuple, unsigned int> &)
+
+{
+  libmesh_error_msg("ERROR, ExodusII API is not defined.");
+}
+
+void
+ExodusII_IO::
+write_nodeset_data (int,
+                    const std::vector<std::string> &,
+                    const std::vector<std::set<boundary_id_type>> &,
+                    const std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> &)
+{
+  libmesh_error_msg("ERROR, ExodusII API is not defined.");
+}
+
+void
+ExodusII_IO::
+read_nodeset_data (int,
+                   std::vector<std::string> &,
+                   std::vector<std::set<boundary_id_type>> &,
+                   std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> &)
+{
+  libmesh_error_msg("ERROR, ExodusII API is not defined.");
+}
+
+void
+ExodusII_IO::
+get_nodeset_data_indices (std::map<BoundaryInfo::NodeBCTuple, unsigned int> &)
+{
+  libmesh_error_msg("ERROR, ExodusII API is not defined.");
+}
+
+void
+ExodusII_IO::
+write_elemset_data (int timestep,
+                    const std::vector<std::string> &,
+                    const std::vector<std::set<elemset_id_type>> &,
+                    const std::vector<std::map<std::pair<dof_id_type, elemset_id_type>, Real>> &)
+{
+  libmesh_error_msg("ERROR, ExodusII API is not defined.");
+}
 
 
 void ExodusII_IO::write (const std::string &)

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1986,6 +1986,10 @@ read_nodeset_data (int timestep,
                    std::vector<std::set<boundary_id_type>> & node_boundary_ids,
                    std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> & bc_vals)
 {
+  libmesh_error_msg_if(!exio_helper->opened_for_reading,
+                       "ERROR, ExodusII file must be opened for reading "
+                       "before calling ExodusII_IO::read_nodeset_data()!");
+
   exio_helper->read_nodeset_data(timestep, var_names, node_boundary_ids, bc_vals);
 }
 
@@ -1999,6 +2003,7 @@ write_elemset_data (int timestep,
   libmesh_error_msg_if(!exio_helper->opened_for_writing,
                        "ERROR, ExodusII file must be opened for writing "
                        "before calling ExodusII_IO::write_elemset_data()!");
+
   exio_helper->write_elemset_data(timestep, var_names, elemset_ids_in, elemset_vals);
 }
 
@@ -2011,8 +2016,23 @@ read_elemset_data (int timestep,
                    std::vector<std::set<elemset_id_type>> & elemset_ids_in,
                    std::vector<std::map<std::pair<dof_id_type, elemset_id_type>, Real>> & elemset_vals)
 {
+  libmesh_error_msg_if(!exio_helper->opened_for_reading,
+                       "ERROR, ExodusII file must be opened for reading "
+                       "before calling ExodusII_IO::read_elemset_data()!");
+
   exio_helper->read_elemset_data(timestep, var_names, elemset_ids_in, elemset_vals);
 }
+
+void
+ExodusII_IO::get_elemset_data_indices (std::map<std::pair<dof_id_type, elemset_id_type>, unsigned int> & elemset_array_indices)
+{
+  libmesh_error_msg_if(!exio_helper->opened_for_reading,
+                       "ERROR, ExodusII file must be opened for reading "
+                       "before calling ExodusII_IO::get_elemset_data_indices()!");
+
+  exio_helper->get_elemset_data_indices(elemset_array_indices);
+}
+
 
 void ExodusII_IO::write (const std::string & fname)
 {
@@ -2464,6 +2484,13 @@ read_elemset_data (int,
                    std::vector<std::string> &,
                    std::vector<std::set<elemset_id_type>> &,
                    std::vector<std::map<std::pair<dof_id_type, elemset_id_type>, Real>> &)
+{
+  libmesh_error_msg("ERROR, ExodusII API is not defined.");
+}
+
+void
+ExodusII_IO::
+get_elemset_data_indices (std::map<std::pair<dof_id_type, elemset_id_type>, unsigned int> &)
 {
   libmesh_error_msg("ERROR, ExodusII API is not defined.");
 }

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -2004,6 +2004,16 @@ write_elemset_data (int timestep,
 
 
 
+void
+ExodusII_IO::
+read_elemset_data (int timestep,
+                   std::vector<std::string> & var_names,
+                   std::vector<std::set<elemset_id_type>> & elemset_ids_in,
+                   std::vector<std::map<std::pair<dof_id_type, elemset_id_type>, Real>> & elemset_vals)
+{
+  exio_helper->read_elemset_data(timestep, var_names, elemset_ids_in, elemset_vals);
+}
+
 void ExodusII_IO::write (const std::string & fname)
 {
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
@@ -2440,7 +2450,7 @@ get_nodeset_data_indices (std::map<BoundaryInfo::NodeBCTuple, unsigned int> &)
 
 void
 ExodusII_IO::
-write_elemset_data (int timestep,
+write_elemset_data (int,
                     const std::vector<std::string> &,
                     const std::vector<std::set<elemset_id_type>> &,
                     const std::vector<std::map<std::pair<dof_id_type, elemset_id_type>, Real>> &)
@@ -2448,6 +2458,15 @@ write_elemset_data (int timestep,
   libmesh_error_msg("ERROR, ExodusII API is not defined.");
 }
 
+void
+ExodusII_IO::
+read_elemset_data (int,
+                   std::vector<std::string> &,
+                   std::vector<std::set<elemset_id_type>> &,
+                   std::vector<std::map<std::pair<dof_id_type, elemset_id_type>, Real>> &)
+{
+  libmesh_error_msg("ERROR, ExodusII API is not defined.");
+}
 
 void ExodusII_IO::write (const std::string &)
 {

--- a/tests/mesh/write_elemset_data.C
+++ b/tests/mesh/write_elemset_data.C
@@ -223,6 +223,24 @@ public:
     CPPUNIT_ASSERT(read_in_elemset_ids == elemset_ids);
     CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(8), read_in_elemset_vals[/*var3 index=*/2].size());
     CPPUNIT_ASSERT(read_in_elemset_vals == elemset_vals);
+
+    // Also check that the flat indices match those in the file
+    std::map<std::pair<dof_id_type, elemset_id_type>, unsigned int> elemset_array_indices;
+    reader.get_elemset_data_indices(elemset_array_indices);
+
+    // Verify that we have the following (Exodus-based) elem ids in the following indices.
+    // These indices were copied from an ncdump of the exo file.
+    std::vector<dof_id_type> elem_els1 = {4, 9, 15, 25};
+    std::vector<dof_id_type> elem_els2 = {4, 10, 16, 25};
+
+    for (auto i : index_range(elem_els1))
+      CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(i),
+                           elemset_array_indices[std::make_pair(/*elem id=*/elem_els1[i] - 1, // convert to libmesh id
+                                                                /*set id*/1)]);
+    for (auto i : index_range(elem_els2))
+      CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(i),
+                           elemset_array_indices[std::make_pair(/*elem id=*/elem_els2[i] - 1, // convert to libmesh id
+                                                                /*set id*/2)]);
   }
 
   void testWriteExodus()


### PR DESCRIPTION
This is related to the work in #3225, and is analogous to the support we currently have for writing sideset and nodeset data to Exodus files.