### PR TITLE
Use unique_ptr in DofMap::merge_ghost_functor_outputs() API

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -32,6 +32,7 @@
 #include "libmesh/sparsity_pattern.h"
 #include "libmesh/parallel_object.h"
 #include "libmesh/point.h"
+#include "libmesh/utility.h"
 
 #ifdef LIBMESH_FORWARD_DECLARE_ENUMS
 namespace libMesh
@@ -1595,9 +1596,10 @@ private:
    * A utility method for obtaining a set of elements to ghost along
    * with merged coupling matrices.
    */
+  typedef std::set<std::unique_ptr<CouplingMatrix>, Utility::CompareUnderlying<CouplingMatrix>> CouplingMatricesSet;
   static void
   merge_ghost_functor_outputs (GhostingFunctor::map_type & elements_to_ghost,
-                               std::set<CouplingMatrix *> & temporary_coupling_matrices,
+                               CouplingMatricesSet & temporary_coupling_matrices,
                                const std::set<GhostingFunctor *>::iterator & gf_begin,
                                const std::set<GhostingFunctor *>::iterator & gf_end,
                                const MeshBase::const_element_iterator & elems_begin,

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1596,7 +1596,7 @@ private:
    * A utility method for obtaining a set of elements to ghost along
    * with merged coupling matrices.
    */
-  typedef std::set<std::unique_ptr<CouplingMatrix>, Utility::CompareUnderlying<CouplingMatrix>> CouplingMatricesSet;
+  typedef std::set<std::unique_ptr<CouplingMatrix>, Utility::CompareUnderlying> CouplingMatricesSet;
   static void
   merge_ghost_functor_outputs (GhostingFunctor::map_type & elements_to_ghost,
                                CouplingMatricesSet & temporary_coupling_matrices,

--- a/include/utils/utility.h
+++ b/include/utils/utility.h
@@ -19,13 +19,14 @@
 #ifndef LIBMESH_UTILITY_H
 #define LIBMESH_UTILITY_H
 
-// Local includes
+// LibMesh includes
 #include "libmesh/libmesh_common.h" // for Real
 
-// System includes
+// C++ includes
 #include <string>
 #include <vector>
 #include <algorithm> // is_sorted, lower_bound
+#include <memory> // unique_ptr
 
 namespace libMesh
 {
@@ -462,6 +463,48 @@ T ReverseBytes::operator() (T & data) const
 
   return data;
 }
+
+
+
+/**
+ * Struct which defines a custom comparison object that
+ * can be used with std::sets of std::unique_ptrs
+ */
+template <class T>
+struct CompareUnderlying
+{
+  /**
+   * As of C++14, std::set::find() can be a templated overload.
+   * https://en.cppreference.com/w/cpp/container/set/find
+   * We enable this by defining is_transparent as a type.
+   */
+  using is_transparent = void;
+
+  /**
+   * This is already what the default operator< comparison for std::unique_ptrs does,
+   * we are not adding anything here.
+   */
+  bool operator()(const std::unique_ptr<T> & a, const std::unique_ptr<T> & b) const
+  {
+    return a.get() < b.get();
+  }
+
+  /**
+   * operator< comparison when rhs is a dumb pointer
+   */
+  bool operator()(const std::unique_ptr<T> & a, const T * const & b) const
+  {
+    return a.get() < b;
+  }
+
+  /**
+   * operator< comparison when lhs is a dumb pointer
+   */
+  bool operator()(const T * const & a, const std::unique_ptr<T> & b) const
+  {
+    return a < b.get();
+  }
+};
 
 
 }

--- a/include/utils/utility.h
+++ b/include/utils/utility.h
@@ -470,7 +470,6 @@ T ReverseBytes::operator() (T & data) const
  * Struct which defines a custom comparison object that
  * can be used with std::sets of std::unique_ptrs
  */
-template <class T>
 struct CompareUnderlying
 {
   /**
@@ -484,6 +483,7 @@ struct CompareUnderlying
    * This is already what the default operator< comparison for std::unique_ptrs does,
    * we are not adding anything here.
    */
+  template <class T>
   bool operator()(const std::unique_ptr<T> & a, const std::unique_ptr<T> & b) const
   {
     return a.get() < b.get();
@@ -492,6 +492,7 @@ struct CompareUnderlying
   /**
    * operator< comparison when rhs is a dumb pointer
    */
+  template <class T>
   bool operator()(const std::unique_ptr<T> & a, const T * const & b) const
   {
     return a.get() < b;
@@ -500,6 +501,7 @@ struct CompareUnderlying
   /**
    * operator< comparison when lhs is a dumb pointer
    */
+  template <class T>
   bool operator()(const T * const & a, const std::unique_ptr<T> & b) const
   {
     return a < b.get();

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -51,6 +51,7 @@
 #include "libmesh/tensor_tools.h"
 #include "libmesh/threads.h"
 #include "libmesh/enum_to_string.h"
+#include "libmesh/coupling_matrix.h"
 
 // TIMPI includes
 #include "timpi/parallel_implementation.h"
@@ -4810,9 +4811,7 @@ void DofMap::scatter_constraints(MeshBase & mesh)
   // element's owner.
 
   GhostingFunctor::map_type elements_to_couple;
-
-  // Man, I wish we had guaranteed unique_ptr availability...
-  std::set<CouplingMatrix*> temporary_coupling_matrices;
+  DofMap::CouplingMatricesSet temporary_coupling_matrices;
 
   this->merge_ghost_functor_outputs
     (elements_to_couple,

--- a/src/base/sparsity_pattern.C
+++ b/src/base/sparsity_pattern.C
@@ -273,9 +273,7 @@ void Build::operator()(const ConstElemRange & range)
                                            Predicates::NotNull<Elem * const *>());
 
         GhostingFunctor::map_type elements_to_couple;
-
-        // Man, I wish we had guaranteed unique_ptr availability...
-        std::set<CouplingMatrix *> temporary_coupling_matrices;
+        DofMap::CouplingMatricesSet temporary_coupling_matrices;
 
         dof_map.merge_ghost_functor_outputs(elements_to_couple,
                                             temporary_coupling_matrices,
@@ -324,10 +322,6 @@ void Build::operator()(const ConstElemRange & range)
                     }
                 }
             } // End ghosted element loop
-
-        for (auto & mat : temporary_coupling_matrices)
-          delete mat;
-
       } // End range element loop
   } // End ghosting functor section
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -122,6 +122,7 @@ unit_tests_sources = \
   systems/systems_test.C \
   utils/parameters_test.C \
   utils/point_locator_test.C \
+  utils/transparent_comparator.C \
   utils/vectormap_test.C \
   utils/xdr_test.C
 

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -251,9 +251,9 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/periodic_bc_test.C \
 	systems/systems_test.C utils/parameters_test.C \
-	utils/point_locator_test.C utils/vectormap_test.C \
-	utils/xdr_test.C meshes/1_quad.bxt.gz meshes/25_quad.bxt.gz \
-	meshes/BlockWithHole_Patch9.bxt.gz \
+	utils/point_locator_test.C utils/transparent_comparator.C \
+	utils/vectormap_test.C utils/xdr_test.C meshes/1_quad.bxt.gz \
+	meshes/25_quad.bxt.gz meshes/BlockWithHole_Patch9.bxt.gz \
 	meshes/PlateWithHole_Patch8.bxt.gz \
 	meshes/PressurizedCyl3d_Patch1_8Elem.bxt.gz \
 	meshes/PressurizedCyl_Patch6_256Elem.bxt.gz \
@@ -362,6 +362,7 @@ am__objects_3 = unit_tests_dbg-driver.$(OBJEXT) \
 	systems/unit_tests_dbg-systems_test.$(OBJEXT) \
 	utils/unit_tests_dbg-parameters_test.$(OBJEXT) \
 	utils/unit_tests_dbg-point_locator_test.$(OBJEXT) \
+	utils/unit_tests_dbg-transparent_comparator.$(OBJEXT) \
 	utils/unit_tests_dbg-vectormap_test.$(OBJEXT) \
 	utils/unit_tests_dbg-xdr_test.$(OBJEXT) $(am__objects_1) \
 	$(am__objects_2)
@@ -434,9 +435,9 @@ am__unit_tests_devel_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/periodic_bc_test.C \
 	systems/systems_test.C utils/parameters_test.C \
-	utils/point_locator_test.C utils/vectormap_test.C \
-	utils/xdr_test.C meshes/1_quad.bxt.gz meshes/25_quad.bxt.gz \
-	meshes/BlockWithHole_Patch9.bxt.gz \
+	utils/point_locator_test.C utils/transparent_comparator.C \
+	utils/vectormap_test.C utils/xdr_test.C meshes/1_quad.bxt.gz \
+	meshes/25_quad.bxt.gz meshes/BlockWithHole_Patch9.bxt.gz \
 	meshes/PlateWithHole_Patch8.bxt.gz \
 	meshes/PressurizedCyl3d_Patch1_8Elem.bxt.gz \
 	meshes/PressurizedCyl_Patch6_256Elem.bxt.gz \
@@ -543,6 +544,7 @@ am__objects_5 = unit_tests_devel-driver.$(OBJEXT) \
 	systems/unit_tests_devel-systems_test.$(OBJEXT) \
 	utils/unit_tests_devel-parameters_test.$(OBJEXT) \
 	utils/unit_tests_devel-point_locator_test.$(OBJEXT) \
+	utils/unit_tests_devel-transparent_comparator.$(OBJEXT) \
 	utils/unit_tests_devel-vectormap_test.$(OBJEXT) \
 	utils/unit_tests_devel-xdr_test.$(OBJEXT) $(am__objects_1) \
 	$(am__objects_4)
@@ -611,9 +613,9 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/periodic_bc_test.C \
 	systems/systems_test.C utils/parameters_test.C \
-	utils/point_locator_test.C utils/vectormap_test.C \
-	utils/xdr_test.C meshes/1_quad.bxt.gz meshes/25_quad.bxt.gz \
-	meshes/BlockWithHole_Patch9.bxt.gz \
+	utils/point_locator_test.C utils/transparent_comparator.C \
+	utils/vectormap_test.C utils/xdr_test.C meshes/1_quad.bxt.gz \
+	meshes/25_quad.bxt.gz meshes/BlockWithHole_Patch9.bxt.gz \
 	meshes/PlateWithHole_Patch8.bxt.gz \
 	meshes/PressurizedCyl3d_Patch1_8Elem.bxt.gz \
 	meshes/PressurizedCyl_Patch6_256Elem.bxt.gz \
@@ -720,6 +722,7 @@ am__objects_7 = unit_tests_oprof-driver.$(OBJEXT) \
 	systems/unit_tests_oprof-systems_test.$(OBJEXT) \
 	utils/unit_tests_oprof-parameters_test.$(OBJEXT) \
 	utils/unit_tests_oprof-point_locator_test.$(OBJEXT) \
+	utils/unit_tests_oprof-transparent_comparator.$(OBJEXT) \
 	utils/unit_tests_oprof-vectormap_test.$(OBJEXT) \
 	utils/unit_tests_oprof-xdr_test.$(OBJEXT) $(am__objects_1) \
 	$(am__objects_6)
@@ -788,9 +791,9 @@ am__unit_tests_opt_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/periodic_bc_test.C \
 	systems/systems_test.C utils/parameters_test.C \
-	utils/point_locator_test.C utils/vectormap_test.C \
-	utils/xdr_test.C meshes/1_quad.bxt.gz meshes/25_quad.bxt.gz \
-	meshes/BlockWithHole_Patch9.bxt.gz \
+	utils/point_locator_test.C utils/transparent_comparator.C \
+	utils/vectormap_test.C utils/xdr_test.C meshes/1_quad.bxt.gz \
+	meshes/25_quad.bxt.gz meshes/BlockWithHole_Patch9.bxt.gz \
 	meshes/PlateWithHole_Patch8.bxt.gz \
 	meshes/PressurizedCyl3d_Patch1_8Elem.bxt.gz \
 	meshes/PressurizedCyl_Patch6_256Elem.bxt.gz \
@@ -897,6 +900,7 @@ am__objects_9 = unit_tests_opt-driver.$(OBJEXT) \
 	systems/unit_tests_opt-systems_test.$(OBJEXT) \
 	utils/unit_tests_opt-parameters_test.$(OBJEXT) \
 	utils/unit_tests_opt-point_locator_test.$(OBJEXT) \
+	utils/unit_tests_opt-transparent_comparator.$(OBJEXT) \
 	utils/unit_tests_opt-vectormap_test.$(OBJEXT) \
 	utils/unit_tests_opt-xdr_test.$(OBJEXT) $(am__objects_1) \
 	$(am__objects_8)
@@ -965,9 +969,9 @@ am__unit_tests_prof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/periodic_bc_test.C \
 	systems/systems_test.C utils/parameters_test.C \
-	utils/point_locator_test.C utils/vectormap_test.C \
-	utils/xdr_test.C meshes/1_quad.bxt.gz meshes/25_quad.bxt.gz \
-	meshes/BlockWithHole_Patch9.bxt.gz \
+	utils/point_locator_test.C utils/transparent_comparator.C \
+	utils/vectormap_test.C utils/xdr_test.C meshes/1_quad.bxt.gz \
+	meshes/25_quad.bxt.gz meshes/BlockWithHole_Patch9.bxt.gz \
 	meshes/PlateWithHole_Patch8.bxt.gz \
 	meshes/PressurizedCyl3d_Patch1_8Elem.bxt.gz \
 	meshes/PressurizedCyl_Patch6_256Elem.bxt.gz \
@@ -1074,6 +1078,7 @@ am__objects_11 = unit_tests_prof-driver.$(OBJEXT) \
 	systems/unit_tests_prof-systems_test.$(OBJEXT) \
 	utils/unit_tests_prof-parameters_test.$(OBJEXT) \
 	utils/unit_tests_prof-point_locator_test.$(OBJEXT) \
+	utils/unit_tests_prof-transparent_comparator.$(OBJEXT) \
 	utils/unit_tests_prof-vectormap_test.$(OBJEXT) \
 	utils/unit_tests_prof-xdr_test.$(OBJEXT) $(am__objects_1) \
 	$(am__objects_10)
@@ -1576,22 +1581,27 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	systems/$(DEPDIR)/unit_tests_prof-systems_test.Po \
 	utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po \
+	utils/$(DEPDIR)/unit_tests_dbg-transparent_comparator.Po \
 	utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Po \
 	utils/$(DEPDIR)/unit_tests_dbg-xdr_test.Po \
 	utils/$(DEPDIR)/unit_tests_devel-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po \
+	utils/$(DEPDIR)/unit_tests_devel-transparent_comparator.Po \
 	utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po \
 	utils/$(DEPDIR)/unit_tests_devel-xdr_test.Po \
 	utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po \
+	utils/$(DEPDIR)/unit_tests_oprof-transparent_comparator.Po \
 	utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Po \
 	utils/$(DEPDIR)/unit_tests_oprof-xdr_test.Po \
 	utils/$(DEPDIR)/unit_tests_opt-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po \
+	utils/$(DEPDIR)/unit_tests_opt-transparent_comparator.Po \
 	utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po \
 	utils/$(DEPDIR)/unit_tests_opt-xdr_test.Po \
 	utils/$(DEPDIR)/unit_tests_prof-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po \
+	utils/$(DEPDIR)/unit_tests_prof-transparent_comparator.Po \
 	utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po \
 	utils/$(DEPDIR)/unit_tests_prof-xdr_test.Po
 am__mv = mv -f
@@ -2107,8 +2117,9 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/periodic_bc_test.C \
 	systems/systems_test.C utils/parameters_test.C \
-	utils/point_locator_test.C utils/vectormap_test.C \
-	utils/xdr_test.C $(data) $(am__append_1)
+	utils/point_locator_test.C utils/transparent_comparator.C \
+	utils/vectormap_test.C utils/xdr_test.C $(data) \
+	$(am__append_1)
 data = meshes/1_quad.bxt.gz \
        meshes/25_quad.bxt.gz \
        meshes/BlockWithHole_Patch9.bxt.gz \
@@ -2489,6 +2500,8 @@ utils/unit_tests_dbg-parameters_test.$(OBJEXT): utils/$(am__dirstamp) \
 	utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_dbg-point_locator_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_dbg-transparent_comparator.$(OBJEXT):  \
+	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_dbg-vectormap_test.$(OBJEXT): utils/$(am__dirstamp) \
 	utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_dbg-xdr_test.$(OBJEXT): utils/$(am__dirstamp) \
@@ -2703,6 +2716,8 @@ utils/unit_tests_devel-parameters_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_devel-point_locator_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_devel-transparent_comparator.$(OBJEXT):  \
+	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_devel-vectormap_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_devel-xdr_test.$(OBJEXT): utils/$(am__dirstamp) \
@@ -2910,6 +2925,8 @@ systems/unit_tests_oprof-systems_test.$(OBJEXT):  \
 utils/unit_tests_oprof-parameters_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_oprof-point_locator_test.$(OBJEXT):  \
+	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_oprof-transparent_comparator.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_oprof-vectormap_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
@@ -3119,6 +3136,8 @@ utils/unit_tests_opt-parameters_test.$(OBJEXT): utils/$(am__dirstamp) \
 	utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_opt-point_locator_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_opt-transparent_comparator.$(OBJEXT):  \
+	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_opt-vectormap_test.$(OBJEXT): utils/$(am__dirstamp) \
 	utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_opt-xdr_test.$(OBJEXT): utils/$(am__dirstamp) \
@@ -3326,6 +3345,8 @@ systems/unit_tests_prof-systems_test.$(OBJEXT):  \
 utils/unit_tests_prof-parameters_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_prof-point_locator_test.$(OBJEXT):  \
+	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_prof-transparent_comparator.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_prof-vectormap_test.$(OBJEXT): utils/$(am__dirstamp) \
 	utils/$(DEPDIR)/$(am__dirstamp)
@@ -3833,22 +3854,27 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@systems/$(DEPDIR)/unit_tests_prof-systems_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-transparent_comparator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-xdr_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-transparent_comparator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-xdr_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-transparent_comparator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-xdr_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-transparent_comparator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-xdr_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-transparent_comparator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-xdr_test.Po@am__quote@ # am--include-marker
 
@@ -5225,6 +5251,20 @@ utils/unit_tests_dbg-point_locator_test.obj: utils/point_locator_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/point_locator_test.C' object='utils/unit_tests_dbg-point_locator_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_dbg-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
+
+utils/unit_tests_dbg-transparent_comparator.o: utils/transparent_comparator.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_dbg-transparent_comparator.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_dbg-transparent_comparator.Tpo -c -o utils/unit_tests_dbg-transparent_comparator.o `test -f 'utils/transparent_comparator.C' || echo '$(srcdir)/'`utils/transparent_comparator.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_dbg-transparent_comparator.Tpo utils/$(DEPDIR)/unit_tests_dbg-transparent_comparator.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/transparent_comparator.C' object='utils/unit_tests_dbg-transparent_comparator.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_dbg-transparent_comparator.o `test -f 'utils/transparent_comparator.C' || echo '$(srcdir)/'`utils/transparent_comparator.C
+
+utils/unit_tests_dbg-transparent_comparator.obj: utils/transparent_comparator.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_dbg-transparent_comparator.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_dbg-transparent_comparator.Tpo -c -o utils/unit_tests_dbg-transparent_comparator.obj `if test -f 'utils/transparent_comparator.C'; then $(CYGPATH_W) 'utils/transparent_comparator.C'; else $(CYGPATH_W) '$(srcdir)/utils/transparent_comparator.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_dbg-transparent_comparator.Tpo utils/$(DEPDIR)/unit_tests_dbg-transparent_comparator.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/transparent_comparator.C' object='utils/unit_tests_dbg-transparent_comparator.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_dbg-transparent_comparator.obj `if test -f 'utils/transparent_comparator.C'; then $(CYGPATH_W) 'utils/transparent_comparator.C'; else $(CYGPATH_W) '$(srcdir)/utils/transparent_comparator.C'; fi`
 
 utils/unit_tests_dbg-vectormap_test.o: utils/vectormap_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_dbg-vectormap_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Tpo -c -o utils/unit_tests_dbg-vectormap_test.o `test -f 'utils/vectormap_test.C' || echo '$(srcdir)/'`utils/vectormap_test.C
@@ -6612,6 +6652,20 @@ utils/unit_tests_devel-point_locator_test.obj: utils/point_locator_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_devel-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
 
+utils/unit_tests_devel-transparent_comparator.o: utils/transparent_comparator.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_devel-transparent_comparator.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_devel-transparent_comparator.Tpo -c -o utils/unit_tests_devel-transparent_comparator.o `test -f 'utils/transparent_comparator.C' || echo '$(srcdir)/'`utils/transparent_comparator.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_devel-transparent_comparator.Tpo utils/$(DEPDIR)/unit_tests_devel-transparent_comparator.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/transparent_comparator.C' object='utils/unit_tests_devel-transparent_comparator.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_devel-transparent_comparator.o `test -f 'utils/transparent_comparator.C' || echo '$(srcdir)/'`utils/transparent_comparator.C
+
+utils/unit_tests_devel-transparent_comparator.obj: utils/transparent_comparator.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_devel-transparent_comparator.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_devel-transparent_comparator.Tpo -c -o utils/unit_tests_devel-transparent_comparator.obj `if test -f 'utils/transparent_comparator.C'; then $(CYGPATH_W) 'utils/transparent_comparator.C'; else $(CYGPATH_W) '$(srcdir)/utils/transparent_comparator.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_devel-transparent_comparator.Tpo utils/$(DEPDIR)/unit_tests_devel-transparent_comparator.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/transparent_comparator.C' object='utils/unit_tests_devel-transparent_comparator.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_devel-transparent_comparator.obj `if test -f 'utils/transparent_comparator.C'; then $(CYGPATH_W) 'utils/transparent_comparator.C'; else $(CYGPATH_W) '$(srcdir)/utils/transparent_comparator.C'; fi`
+
 utils/unit_tests_devel-vectormap_test.o: utils/vectormap_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_devel-vectormap_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Tpo -c -o utils/unit_tests_devel-vectormap_test.o `test -f 'utils/vectormap_test.C' || echo '$(srcdir)/'`utils/vectormap_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Tpo utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po
@@ -7997,6 +8051,20 @@ utils/unit_tests_oprof-point_locator_test.obj: utils/point_locator_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/point_locator_test.C' object='utils/unit_tests_oprof-point_locator_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_oprof-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
+
+utils/unit_tests_oprof-transparent_comparator.o: utils/transparent_comparator.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_oprof-transparent_comparator.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_oprof-transparent_comparator.Tpo -c -o utils/unit_tests_oprof-transparent_comparator.o `test -f 'utils/transparent_comparator.C' || echo '$(srcdir)/'`utils/transparent_comparator.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_oprof-transparent_comparator.Tpo utils/$(DEPDIR)/unit_tests_oprof-transparent_comparator.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/transparent_comparator.C' object='utils/unit_tests_oprof-transparent_comparator.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_oprof-transparent_comparator.o `test -f 'utils/transparent_comparator.C' || echo '$(srcdir)/'`utils/transparent_comparator.C
+
+utils/unit_tests_oprof-transparent_comparator.obj: utils/transparent_comparator.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_oprof-transparent_comparator.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_oprof-transparent_comparator.Tpo -c -o utils/unit_tests_oprof-transparent_comparator.obj `if test -f 'utils/transparent_comparator.C'; then $(CYGPATH_W) 'utils/transparent_comparator.C'; else $(CYGPATH_W) '$(srcdir)/utils/transparent_comparator.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_oprof-transparent_comparator.Tpo utils/$(DEPDIR)/unit_tests_oprof-transparent_comparator.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/transparent_comparator.C' object='utils/unit_tests_oprof-transparent_comparator.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_oprof-transparent_comparator.obj `if test -f 'utils/transparent_comparator.C'; then $(CYGPATH_W) 'utils/transparent_comparator.C'; else $(CYGPATH_W) '$(srcdir)/utils/transparent_comparator.C'; fi`
 
 utils/unit_tests_oprof-vectormap_test.o: utils/vectormap_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_oprof-vectormap_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Tpo -c -o utils/unit_tests_oprof-vectormap_test.o `test -f 'utils/vectormap_test.C' || echo '$(srcdir)/'`utils/vectormap_test.C
@@ -9384,6 +9452,20 @@ utils/unit_tests_opt-point_locator_test.obj: utils/point_locator_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_opt-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
 
+utils/unit_tests_opt-transparent_comparator.o: utils/transparent_comparator.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_opt-transparent_comparator.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_opt-transparent_comparator.Tpo -c -o utils/unit_tests_opt-transparent_comparator.o `test -f 'utils/transparent_comparator.C' || echo '$(srcdir)/'`utils/transparent_comparator.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_opt-transparent_comparator.Tpo utils/$(DEPDIR)/unit_tests_opt-transparent_comparator.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/transparent_comparator.C' object='utils/unit_tests_opt-transparent_comparator.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_opt-transparent_comparator.o `test -f 'utils/transparent_comparator.C' || echo '$(srcdir)/'`utils/transparent_comparator.C
+
+utils/unit_tests_opt-transparent_comparator.obj: utils/transparent_comparator.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_opt-transparent_comparator.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_opt-transparent_comparator.Tpo -c -o utils/unit_tests_opt-transparent_comparator.obj `if test -f 'utils/transparent_comparator.C'; then $(CYGPATH_W) 'utils/transparent_comparator.C'; else $(CYGPATH_W) '$(srcdir)/utils/transparent_comparator.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_opt-transparent_comparator.Tpo utils/$(DEPDIR)/unit_tests_opt-transparent_comparator.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/transparent_comparator.C' object='utils/unit_tests_opt-transparent_comparator.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_opt-transparent_comparator.obj `if test -f 'utils/transparent_comparator.C'; then $(CYGPATH_W) 'utils/transparent_comparator.C'; else $(CYGPATH_W) '$(srcdir)/utils/transparent_comparator.C'; fi`
+
 utils/unit_tests_opt-vectormap_test.o: utils/vectormap_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_opt-vectormap_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Tpo -c -o utils/unit_tests_opt-vectormap_test.o `test -f 'utils/vectormap_test.C' || echo '$(srcdir)/'`utils/vectormap_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Tpo utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po
@@ -10770,6 +10852,20 @@ utils/unit_tests_prof-point_locator_test.obj: utils/point_locator_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_prof-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
 
+utils/unit_tests_prof-transparent_comparator.o: utils/transparent_comparator.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_prof-transparent_comparator.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_prof-transparent_comparator.Tpo -c -o utils/unit_tests_prof-transparent_comparator.o `test -f 'utils/transparent_comparator.C' || echo '$(srcdir)/'`utils/transparent_comparator.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_prof-transparent_comparator.Tpo utils/$(DEPDIR)/unit_tests_prof-transparent_comparator.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/transparent_comparator.C' object='utils/unit_tests_prof-transparent_comparator.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_prof-transparent_comparator.o `test -f 'utils/transparent_comparator.C' || echo '$(srcdir)/'`utils/transparent_comparator.C
+
+utils/unit_tests_prof-transparent_comparator.obj: utils/transparent_comparator.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_prof-transparent_comparator.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_prof-transparent_comparator.Tpo -c -o utils/unit_tests_prof-transparent_comparator.obj `if test -f 'utils/transparent_comparator.C'; then $(CYGPATH_W) 'utils/transparent_comparator.C'; else $(CYGPATH_W) '$(srcdir)/utils/transparent_comparator.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_prof-transparent_comparator.Tpo utils/$(DEPDIR)/unit_tests_prof-transparent_comparator.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/transparent_comparator.C' object='utils/unit_tests_prof-transparent_comparator.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_prof-transparent_comparator.obj `if test -f 'utils/transparent_comparator.C'; then $(CYGPATH_W) 'utils/transparent_comparator.C'; else $(CYGPATH_W) '$(srcdir)/utils/transparent_comparator.C'; fi`
+
 utils/unit_tests_prof-vectormap_test.o: utils/vectormap_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_prof-vectormap_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Tpo -c -o utils/unit_tests_prof-vectormap_test.o `test -f 'utils/vectormap_test.C' || echo '$(srcdir)/'`utils/vectormap_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Tpo utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po
@@ -11651,22 +11747,27 @@ distclean: distclean-am
 	-rm -f systems/$(DEPDIR)/unit_tests_prof-systems_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_dbg-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_devel-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_oprof-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_opt-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_prof-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-xdr_test.Po
 	-rm -f Makefile
@@ -12193,22 +12294,27 @@ maintainer-clean: maintainer-clean-am
 	-rm -f systems/$(DEPDIR)/unit_tests_prof-systems_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_dbg-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_devel-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_oprof-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_opt-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_prof-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-xdr_test.Po
 	-rm -f Makefile

--- a/tests/utils/transparent_comparator.C
+++ b/tests/utils/transparent_comparator.C
@@ -1,0 +1,62 @@
+// libMesh includes
+#include "libmesh/utility.h"
+
+// cppunit includes
+#include "libmesh_cppunit.h"
+
+// C++ includes
+#include <set>
+#include <memory>
+
+using namespace libMesh;
+
+class TransparentComparatorTest : public CppUnit::TestCase
+{
+public:
+  LIBMESH_CPPUNIT_TEST_SUITE ( TransparentComparatorTest );
+  CPPUNIT_TEST( testSet );
+  CPPUNIT_TEST_SUITE_END();
+
+  void testSet()
+  {
+    LOG_UNIT_TEST;
+
+    std::set<std::unique_ptr<int>, Utility::CompareUnderlying> s;
+    s.insert(std::make_unique<int>(1));
+    s.insert(std::make_unique<int>(2));
+    s.insert(std::make_unique<int>(3));
+    s.insert(std::make_unique<int>(3)); // Not a duplicate. This set does pointer comparisons, not value comparisons.
+
+    // Search for entry by pointer-to-int. This tests the desired
+    // behavior of the std::set comparison object.
+    int * first = s.begin()->get();
+    auto result = s.find(first);
+    CPPUNIT_ASSERT(result != s.end());
+    CPPUNIT_ASSERT(result->get() == first);
+
+    // Test set::count(). It should be using the same underlying
+    // machinery as std::set(find) but it's good to verify this.
+    CPPUNIT_ASSERT(s.count(first) == 1);
+
+    // Test that attempting to insert the same underlying pointer again fails. We simulate this by
+    // creating and moving from a standalone object.
+    auto four = std::make_unique<int>(4);
+
+    // The first insert() adds a non-nullptr underlying pointer to the
+    // set and leaves "four" with and underlying nullptr.
+    s.insert(std::move(four));
+    CPPUNIT_ASSERT(s.size() == 5);
+
+    // The second insert() adds a nullptr underlying pointer to the
+    // set and leaves "four" with and underlying nullptr.
+    s.insert(std::move(four));
+    CPPUNIT_ASSERT(s.size() == 6);
+
+    // The third insert() does not change the set because it tries to
+    // add a second nullptr underlying pointer to the set.
+    s.insert(std::move(four));
+    CPPUNIT_ASSERT(s.size() == 6);
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION ( TransparentComparatorTest );


### PR DESCRIPTION
An API change, so if necessary, we could implement a backwards-compatible shim for this. If nothing in MOOSE calls this directly I think we should probably be OK to skip that. Also, this uses a C++14 capability related to the `is_transparent` type, but @roystgnr and I tried it on a bunch of older compilers and it seems to be pretty well-supported.