### PR TITLE
More general Triangulator insert_extra_points alternative

### DIFF
--- a/include/mesh/triangulator_interface.h
+++ b/include/mesh/triangulator_interface.h
@@ -166,6 +166,16 @@ public:
   bool & insert_extra_points() {return _insert_extra_points;}
 
   /**
+   * Complicated setter, for compatibility with insert_extra_points()
+   */
+  void set_interpolate_boundary_points (int n_points);
+
+  /**
+   * Complicated getter, for compatibility with insert_extra_points()
+   */
+  int get_interpolate_boundary_points () const;
+
+  /**
    * Sets/gets flag which tells whether to do two steps of Laplace
    * mesh smoothing after generating the grid.
    */
@@ -271,8 +281,17 @@ protected:
    * Flag which tells whether or not to insert additional nodes
    * before triangulation.  This can sometimes be used to "de-regularize"
    * the resulting triangulation.
+   *
+   * This flag is supported for backwards compatibility; setting
+   * _interpolate_boundary_points = 1 is equivalent.
    */
   bool _insert_extra_points;
+
+  /**
+   * Flag which tells how many additional nodes should be inserted
+   * between each pair of original mesh points.
+   */
+  int _interpolate_boundary_points;
 
   /**
    * Flag which tells whether we should smooth the mesh after


### PR DESCRIPTION
We're going to want to be able to disable the insertion of boundary points via triangulator mesh refinement, to make stitching the resulting meshes more robust, but if we do that then we need some other way to request significant boundary refinement, and here it is.