### PR TITLE
std::result of is deprecated in C++17 

### DIFF
--- a/contrib/eigen/3.3.9/Eigen/src/Core/util/Macros.h
+++ b/contrib/eigen/3.3.9/Eigen/src/Core/util/Macros.h
@@ -388,9 +388,9 @@
 #endif
 #endif
 
-// Does the compiler support result_of?
+// Does the compiler support result_of? (patched for libmesh as std::result gets deprecated in C++17)
 #ifndef EIGEN_HAS_STD_RESULT_OF
-#if EIGEN_MAX_CPP_VER>=11 && ((__has_feature(cxx_lambdas) || (defined(__cplusplus) && __cplusplus >= 201103L)))
+#if EIGEN_MAX_CPP_VER>=11 && ((__has_feature(cxx_lambdas) || (defined(__cplusplus) && __cplusplus >= 201103L && __cplusplus < 201703L)))
 #define EIGEN_HAS_STD_RESULT_OF 1
 #else
 #define EIGEN_HAS_STD_RESULT_OF 0


### PR DESCRIPTION
Refs #3244