### PR TITLE
WIP: General unsteady adjoint weighted integration

### DIFF
--- a/include/solvers/adaptive_time_solver.h
+++ b/include/solvers/adaptive_time_solver.h
@@ -88,6 +88,8 @@ public:
   virtual void integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error) override = 0;
 #endif // LIBMESH_ENABLE_AMR
 
+  virtual void advance_postprocessing_timestep(std::vector<std::function<void(Real, System &)>> integration_operations) override = 0;
+
   virtual Real last_completed_timestep_size() override { return completed_timestep_size; };
 
   /**

--- a/include/solvers/euler2_solver.h
+++ b/include/solvers/euler2_solver.h
@@ -87,6 +87,8 @@ public:
   virtual void integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error) override;
 #endif // LIBMESH_ENABLE_AMR
 
+  virtual void advance_postprocessing_timestep(std::vector<std::function<void(Real, System &)>> integration_operations) override;
+
   /**
    * This method uses the DifferentiablePhysics'
    * element_time_derivative() and element_constraint()

--- a/include/solvers/euler_solver.h
+++ b/include/solvers/euler_solver.h
@@ -109,6 +109,8 @@ public:
   virtual void integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error) override;
 #endif // LIBMESH_ENABLE_AMR
 
+  virtual void advance_postprocessing_timestep(std::vector<std::function<void(Real, System &)>> integration_operations) override;
+
   /**
    * The value for the theta method to employ: 1.0 corresponds
    * to backwards Euler, 0.0 corresponds to forwards Euler,

--- a/include/solvers/first_order_unsteady_solver.h
+++ b/include/solvers/first_order_unsteady_solver.h
@@ -96,6 +96,8 @@ public:
   virtual void integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error) override = 0;
 #endif // LIBMESH_ENABLE_AMR
 
+  virtual void advance_postprocessing_timestep(std::vector<std::function<void(Real, System &)>> integration_operations) override = 0;
+
 protected:
 
   /**

--- a/include/solvers/newmark_solver.h
+++ b/include/solvers/newmark_solver.h
@@ -78,6 +78,8 @@ public:
    */
   virtual void adjoint_advance_timestep () override;
 
+  virtual void advance_postprocessing_timestep(std::vector<std::function<void(Real, System &)>> integration_operations) override;
+
   /**
    * This method uses the specified initial displacement and velocity
    * to compute the initial acceleration \f$a_0\f$.

--- a/include/solvers/second_order_unsteady_solver.h
+++ b/include/solvers/second_order_unsteady_solver.h
@@ -85,6 +85,8 @@ public:
    */
   virtual void retrieve_timestep () override;
 
+  virtual void advance_postprocessing_timestep(std::vector<std::function<void(Real, System &)>> integration_operations) override = 0;
+
   /**
    * Specify non-zero initial velocity. Should be called before solve().
    * The function value f and its gradient g are user-provided cloneable functors.

--- a/include/solvers/steady_solver.h
+++ b/include/solvers/steady_solver.h
@@ -133,6 +133,8 @@ public:
   virtual void integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error) override;
 #endif // LIBMESH_ENABLE_AMR
 
+  virtual void advance_postprocessing_timestep(std::vector<std::function<void(Real, System &)>> integration_operations) override;
+
 protected:
 
   /**

--- a/include/solvers/time_solver.h
+++ b/include/solvers/time_solver.h
@@ -34,6 +34,7 @@ namespace libMesh
 class DiffContext;
 class DiffSolver;
 class DifferentiablePhysics;
+class System;
 class DifferentiableSystem;
 class ParameterVector;
 class SensitivityData;
@@ -155,6 +156,16 @@ public:
    */
   virtual void integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error);
 #endif // LIBMESH_ENABLE_AMR
+
+
+  /**
+   * A method to evaluate generic integrals of the form:
+   * int_{0}^{T} f(u,z;p) dt ~ (sum_{i=1}^{N_outer_timesteps} sum_{k=1}^{K} ( sum_{j=1}^{N_inner_steps} w_ij f_k(u^j,z^j; p^j) )
+   * The library will supply the weights w_ij and current time t_ij to the user supplied function integration_operations.
+   * Also provided will be the primal and adjoint solution(s) values, u^j, u^j-1 and z^j, z^j+1
+   * The user defined integration_operations function will evaluate w_ij * f_k(u^j,z^j; p^j).
+   */
+  virtual void advance_postprocessing_timestep(std::vector<std::function<void(Real, System &)>> integration_operations) = 0;
 
   /**
    * This method uses the DifferentiablePhysics

--- a/include/solvers/twostep_time_solver.h
+++ b/include/solvers/twostep_time_solver.h
@@ -94,6 +94,7 @@ public:
   virtual void integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & adjoint_refinement_error_estimator, ErrorVector & QoI_elementwise_error) override;
 #endif // LIBMESH_ENABLE_AMR
 
+  virtual void advance_postprocessing_timestep(std::vector<std::function<void(Real, System &)>> integration_operations) override;
 };
 
 

--- a/include/solvers/unsteady_solver.h
+++ b/include/solvers/unsteady_solver.h
@@ -140,6 +140,8 @@ public:
   virtual void integrate_adjoint_refinement_error_estimate(AdjointRefinementEstimator & /*adjoint_refinement_error_estimator*/, ErrorVector & /*QoI_elementwise_error*/) override;
 #endif // LIBMESH_ENABLE_AMR
 
+  virtual void advance_postprocessing_timestep(std::vector<std::function<void(Real, System &)>> integration_operations) override = 0;
+
   /**
    * This method should return the expected convergence order of the
    * (non-local) error of the time discretization scheme - e.g. 2 for the

--- a/src/solvers/euler2_solver.C
+++ b/src/solvers/euler2_solver.C
@@ -482,4 +482,31 @@ void Euler2Solver::integrate_adjoint_refinement_error_estimate(AdjointRefinement
 }
 #endif // LIBMESH_ENABLE_AMR
 
+void Euler2Solver::advance_postprocessing_timestep(std::vector<std::function<void(Real, System &)>> integration_operations)
+{
+  // Enables the user to evaluate (1 - theta)*f(u_i-1) + theta*f(u_i)
+
+  // For correctness and adjoint consistency reasons we currently only support Backward Euler
+  if(theta != 0)
+   libmesh_not_implemented();
+
+  // The mesh and solutions (primal, adjoint) are already read in.
+  // So we are ready to call the user's integration operations.
+  for (auto integration_operations_iterator:integration_operations)
+    integration_operations_iterator(1.0 - theta, dynamic_cast<System&>(_system));
+
+  // Advance to t_j+1
+  _system.time = _system.time + _system.deltat;
+
+  // Retrieve the state and adjoint vectors for the next time instant
+  retrieve_timestep();
+
+  // Mesh and solution read in. Ready to call the user's integration operations.
+  for (auto integration_operations_iterator:integration_operations)
+   integration_operations_iterator(theta, dynamic_cast<System&>(_system));
+
+  return;
+
+}
+
 } // namespace libMesh

--- a/src/solvers/newmark_solver.C
+++ b/src/solvers/newmark_solver.C
@@ -104,6 +104,11 @@ void NewmarkSolver::adjoint_advance_timestep ()
   libmesh_not_implemented();
 }
 
+void NewmarkSolver::advance_postprocessing_timestep(std::vector<std::function<void(Real, System &)>> /* integration_operations */)
+{
+  libmesh_not_implemented();
+}
+
 void NewmarkSolver::compute_initial_accel()
 {
   // We need to compute the initial acceleration based off of

--- a/src/solvers/steady_solver.C
+++ b/src/solvers/steady_solver.C
@@ -133,4 +133,17 @@ void SteadySolver::integrate_adjoint_refinement_error_estimate
 }
 #endif // LIBMESH_ENABLE_AMR
 
+void SteadySolver::advance_postprocessing_timestep(std::vector<std::function<void(Real, System &)>> integration_operations)
+{
+  // For a steady state solve, time quadrature weight is simply 1.0
+  Real time_quadrature_weight = 1.0;
+  for(auto integration_operations_iterator:integration_operations)
+  {
+    auto f = integration_operations_iterator;
+    f(time_quadrature_weight, dynamic_cast<System&>(_system));
+  }
+
+return;
+}
+
 } // namespace libMesh

--- a/src/solvers/twostep_time_solver.C
+++ b/src/solvers/twostep_time_solver.C
@@ -438,4 +438,14 @@ void TwostepTimeSolver::integrate_adjoint_refinement_error_estimate(AdjointRefin
 }
 #endif // LIBMESH_ENABLE_AMR
 
+void TwostepTimeSolver::advance_postprocessing_timestep(std::vector<std::function<void(Real, System &)>> integration_operations)
+{
+  // First half timestep
+  core_time_solver->advance_postprocessing_timestep(integration_operations);
+
+  // Second half timestep
+  core_time_solver->advance_postprocessing_timestep(integration_operations);
+}
+
+
 } // namespace libMesh


### PR DESCRIPTION
This PR aims to condense and organize the different integrate_xyz_timestep methods currently present in TimeSolver. The currently scattered integrate_xyz_timestep implementations will be consolidated into a single advance_postprocessing_timestep method.
 
TS::integrate_qoi_timestep, integrate_adjoint_sensitivity and integrate_adjoint_refinement_error_estimate will be removed from the library and moved to user/example code. The lambda's to achieve their functionality will be added to relevant adjoint examples.

More details:

In general, to integrate a function f across a time interval [0, T], we have the quadrature:
int_{0}^{T} f(u,z) dt ~ (sum_{i=1}^{N_outer_timesteps} ( sum_{j=1}^{N_inner_steps} **w_ij f(u^j,z^j) )**

1) advance_posprocessing_timestep will take a vector of std::functions as the argument, which specify f(u^j,z^j).
2) advance_posprocessing_timestep will manage the time incrementation, solution and mesh retrieval from history and provide quadrature weights w_ij as per the particular time stepping scheme.
3) The std::functions will also receive a system reference which they can use for any system level operations, for example calling system.qoi().