### PR TITLE
Allow access to an existing user constrain object.

### DIFF
--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1408,6 +1408,11 @@ public:
   void attach_constraint_object (Constraint & constrain);
 
   /**
+   * Return the user object for imposing constraints.
+   */
+  Constraint& get_constraint_object ();
+
+  /**
    * Register a user function for evaluating the quantities of interest,
    * whose values should be placed in \p System::qoi
    */

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -2010,6 +2010,12 @@ void System::attach_constraint_object (System::Constraint & constrain)
   _constrain_system_object = &constrain;
 }
 
+System::Constraint& System::get_constraint_object ()
+{
+  libmesh_assert_msg(_constrain_system_object,"No constraint object available.");
+  return *_constrain_system_object;
+}
+
 
 
 void System::attach_QOI_function(void fptr(EquationSystems &,


### PR DESCRIPTION
This can be useful, for example, when needing to modify constraints
during the solution stepping.