### PR TITLE
Let Poly2TriTriangulator users disallow boundary refinement

### DIFF
--- a/include/mesh/mesh_triangle_holes.h
+++ b/include/mesh/mesh_triangle_holes.h
@@ -87,6 +87,30 @@ public:
     seg.push_back(n_points());
     return seg;
   }
+
+  /**
+   * Set whether or not a triangulator is allowed to refine the
+   * hole boundary when refining the mesh interior.  This is true by
+   * default, but may be set to false to make the hole boundary more
+   * predictable (and so easier to stitch to other meshes) later.
+   */
+  virtual void set_refine_boundary_allowed (bool refine_bdy_allowed)
+  { _refine_bdy_allowed = refine_bdy_allowed; }
+
+  /**
+   * Get whether or not the triangulation is allowed to refine the
+   * mesh boundary when refining the interior.  True by default.
+   */
+  virtual bool refine_boundary_allowed () const
+  { return _refine_bdy_allowed; }
+
+protected:
+
+  /**
+   * Whether to allow boundary refinement.  True by default; specified
+   * here so we can use the default constructor.
+   */
+  bool _refine_bdy_allowed = true;
 };
 
 

--- a/include/mesh/poly2tri_triangulator.h
+++ b/include/mesh/poly2tri_triangulator.h
@@ -93,8 +93,6 @@ public:
    * mesh boundary when refining the interior.  This is true by
    * default, but may be set to false to make the mesh boundary more
    * predictable (and so easier to stitch to other meshes) later.
-   *
-   * This may not be implemented in all subclasses.
    */
   virtual void set_refine_boundary_allowed (bool refine_bdy_allowed)
   { _refine_bdy_allowed = refine_bdy_allowed; }

--- a/include/mesh/poly2tri_triangulator.h
+++ b/include/mesh/poly2tri_triangulator.h
@@ -87,6 +87,24 @@ public:
    */
   virtual FunctionBase<Real> * get_desired_area_function () override;
 
+  /**
+   * Set whether or not the triangulation is allowed to refine the
+   * mesh boundary when refining the interior.  This is true by
+   * default, but may be set to false to make the mesh boundary more
+   * predictable (and so easier to stitch to other meshes) later.
+   *
+   * This may not be implemented in all subclasses.
+   */
+  virtual void set_refine_boundary_allowed (bool refine_bdy_allowed)
+  { _refine_bdy_allowed = refine_bdy_allowed; }
+
+  /**
+   * Get whether or not the triangulation is allowed to refine the
+   * mesh boundary when refining the interior.  True by default.
+   */
+  virtual bool refine_boundary_allowed ()
+  { return _refine_bdy_allowed; }
+
 
 protected:
   /**
@@ -128,6 +146,11 @@ private:
    * Location-dependent area requirements
    */
   std::unique_ptr<FunctionBase<Real>> _desired_area_func;
+
+  /**
+   * Whether to allow boundary refinement
+   */
+  bool _refine_bdy_allowed;
 };
 
 } // namespace libMesh

--- a/include/mesh/poly2tri_triangulator.h
+++ b/include/mesh/poly2tri_triangulator.h
@@ -109,6 +109,13 @@ public:
 
 protected:
   /**
+   * Is refining this element's boundary side allowed?
+   */
+  bool is_refine_boundary_allowed(const BoundaryInfo & boundary_info,
+                                  const Elem & elem,
+                                  unsigned int side);
+
+  /**
    * Triangulate the current mesh and hole points.
    */
   void triangulate_current_points();

--- a/include/mesh/poly2tri_triangulator.h
+++ b/include/mesh/poly2tri_triangulator.h
@@ -101,7 +101,7 @@ public:
    * Get whether or not the triangulation is allowed to refine the
    * mesh boundary when refining the interior.  True by default.
    */
-  virtual bool refine_boundary_allowed ()
+  virtual bool refine_boundary_allowed () const
   { return _refine_bdy_allowed; }
 
 

--- a/include/mesh/poly2tri_triangulator.h
+++ b/include/mesh/poly2tri_triangulator.h
@@ -33,6 +33,7 @@ namespace libMesh
 {
 
 // Forward Declarations
+class BoundaryInfo;
 class Elem;
 
 /**

--- a/include/mesh/triangulator_interface.h
+++ b/include/mesh/triangulator_interface.h
@@ -190,7 +190,7 @@ public:
    * Get whether or not the triangulation is allowed to refine the
    * mesh boundary when refining the interior.  True by default.
    */
-  virtual bool refine_boundary_allowed ()
+  virtual bool refine_boundary_allowed () const
   { return true; }
 
   /**

--- a/include/mesh/triangulator_interface.h
+++ b/include/mesh/triangulator_interface.h
@@ -176,6 +176,24 @@ public:
   int get_interpolate_boundary_points () const;
 
   /**
+   * Set whether or not the triangulation is allowed to refine the
+   * mesh boundary when refining the interior.  This is true by
+   * default, but may be set to false to make the mesh boundary more
+   * predictable (and so easier to stitch to other meshes) later.
+   *
+   * This may not be implemented in all subclasses.
+   */
+  virtual void set_refine_boundary_allowed (bool)
+  { libmesh_not_implemented(); }
+
+  /**
+   * Get whether or not the triangulation is allowed to refine the
+   * mesh boundary when refining the interior.  True by default.
+   */
+  virtual bool refine_boundary_allowed ()
+  { return true; }
+
+  /**
    * Sets/gets flag which tells whether to do two steps of Laplace
    * mesh smoothing after generating the grid.
    */

--- a/include/utils/hashing.h
+++ b/include/utils/hashing.h
@@ -35,10 +35,30 @@ inline void hash_combine_impl(std::size_t & seed, std::size_t value)
 template <typename T>
 inline void hash_combine(std::size_t & seed, const T & value)
 {
-  hash_combine_impl(seed, std::hash<T>{}(value));
+  using std::hash;
+  hash_combine_impl(seed, hash<T>{}(value));
 }
 
 }
+
+
+// Fix for STL laziness
+struct hash {
+public:
+  template <typename T1, typename T2>
+  std::size_t operator()(const std::pair<T1, T2> & x) const
+  {
+    // Hopefully argument-based lookup lets us recurse with this
+    using std::hash;
+
+    std::size_t returnval = hash<T1>()(x.first);
+    boostcopy::hash_combine(returnval, x.second);
+
+    return returnval;
+  }
+};
+
+
 }
 
 #endif // LIBMESH_HASHING_H

--- a/include/utils/topology_map.h
+++ b/include/utils/topology_map.h
@@ -23,10 +23,10 @@
 // Local Includes
 #include "libmesh/libmesh_config.h"
 #include "libmesh/libmesh_common.h"
+#include "libmesh/hashing.h"
 
 // C++ Includes
 #include <unordered_map>
-#include <functional> // std::hash
 #include <vector>
 
 namespace libMesh
@@ -36,18 +36,6 @@ namespace libMesh
 class Elem;
 class MeshBase;
 class Node;
-
-// Fix for STL laziness
-struct myhash {
-public:
-  template <typename T1, typename T2>
-  std::size_t operator()(const std::pair<T1, T2> & x) const
-  {
-    // recommendation from
-    // http://stackoverflow.com/questions/5889238/why-is-xor-the-default-way-to-combine-hashes
-    return 3 * std::hash<T1>()(x.first) + std::hash<T2>()(x.second);
-  }
-};
 
 /**
  * Data structures that enable topology-based lookups of nodes created
@@ -69,7 +57,7 @@ public:
 class TopologyMap
 {
   // We need to supply our own hash function.
-  typedef std::unordered_map<std::pair<dof_id_type, dof_id_type>, dof_id_type, myhash> map_type;
+  typedef std::unordered_map<std::pair<dof_id_type, dof_id_type>, dof_id_type, libMesh::hash> map_type;
 public:
   void init(MeshBase &);
 

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -236,9 +236,15 @@ bool Poly2TriTriangulator::is_refine_boundary_allowed
 
   if (bcids[0] == 0)
     return this->refine_boundary_allowed();
-  else
-    // We'll query holes in a future upgrade
-    return true;
+
+  // If we're not on an outer boundary side we'd better be on a hole
+  // side
+  libmesh_assert(this->_holes);
+
+  const boundary_id_type hole_num = bcids[0]-1;
+  libmesh_assert_less(hole_num, this->_holes->size());
+  const Hole * hole = (*this->_holes)[hole_num];
+  return hole->refine_boundary_allowed();
 }
 
 

--- a/tests/mesh/libmesh_poly2tri.C
+++ b/tests/mesh/libmesh_poly2tri.C
@@ -87,7 +87,7 @@ public:
     // We mostly wanted to make sure this compiled, but might as well
     // make sure it gave us the expected triangle count while we're at
     // it.
-    CPPUNIT_ASSERT_EQUAL(tris.size(), std::size_t(3));
+    CPPUNIT_ASSERT_EQUAL(tris.size(), std::size_t(18));
   }
 
   void testLibMeshPoly2TriSlivers()

--- a/tests/mesh/libmesh_poly2tri.C
+++ b/tests/mesh/libmesh_poly2tri.C
@@ -14,6 +14,7 @@ public:
 #ifdef LIBMESH_HAVE_POLY2TRI
   CPPUNIT_TEST( testLibMeshPoly2Tri );
   CPPUNIT_TEST( testLibMeshPoly2TriHole );
+  CPPUNIT_TEST( testLibMeshPoly2TriSlivers );
 #endif
 
   CPPUNIT_TEST_SUITE_END();
@@ -86,7 +87,38 @@ public:
     // We mostly wanted to make sure this compiled, but might as well
     // make sure it gave us the expected triangle count while we're at
     // it.
-//    CPPUNIT_ASSERT_EQUAL(tris.size(), std::size_t(3));
+    CPPUNIT_ASSERT_EQUAL(tris.size(), std::size_t(3));
+  }
+
+  void testLibMeshPoly2TriSlivers()
+  {
+    // Points from a libMesh Poly2TriTriangulator failure case
+    std::vector<p2t::Point> outer_boundary
+    {{0, 0}, {1, 0}, {1, 2}, {0, 1}};
+
+    std::vector<p2t::Point *> api_shim(outer_boundary.size());
+    std::iota(api_shim.begin(), api_shim.end(), outer_boundary.data());
+
+    const double r2o4 = std::sqrt(2.)/4;
+    std::vector<p2t::Point> hole_boundary
+      {{0.5,0.5+r2o4},{0.5-r2o4,0.5},{0.5,0.5}};
+
+    std::vector<p2t::Point *> hole_shim(hole_boundary.size());
+    std::iota(hole_shim.begin(), hole_shim.end(), hole_boundary.data());
+
+    p2t::CDT cdt(api_shim);
+    cdt.AddHole(hole_shim);
+
+    // const double eps = 1e-12; // fails
+    const double eps = 1e-11; // succeeds
+
+    std::vector<p2t::Point> interior_points
+    {{0.5-(r2o4/2)-eps, 0.5+(r2o4/2)+eps}};
+
+    for (auto & p : interior_points)
+      cdt.AddPoint(&p);
+
+    cdt.Triangulate();
   }
 
 #endif

--- a/tests/mesh/mesh_triangulation.C
+++ b/tests/mesh/mesh_triangulation.C
@@ -433,14 +433,14 @@ public:
   }
 
 
-  Mesh testPoly2TriRefinementBase
-    (const std::vector<TriangulatorInterface::Hole*> * holes,
+  void testPoly2TriRefinementBase
+    (UnstructuredMesh & mesh,
+     const std::vector<TriangulatorInterface::Hole*> * holes,
      Real expected_total_area,
      dof_id_type n_original_elem,
      Real desired_area = 0.1,
      FunctionBase<Real> * area_func = nullptr)
   {
-    Mesh mesh(*TestCommWorld);
     mesh.add_point(Point(0,0), 0);
     mesh.add_point(Point(1,0), 1);
     mesh.add_point(Point(1,2), 2);
@@ -494,28 +494,29 @@ public:
     mesh.write("poly2tri_holes.e");
 
     LIBMESH_ASSERT_FP_EQUAL(area, expected_total_area, TOLERANCE*TOLERANCE);
-
-    return mesh; // Copy elision, yay C++17
   }
 
   void testPoly2TriRefined()
   {
     LOG_UNIT_TEST;
 
-    testPoly2TriRefinementBase(nullptr, 1.5, 15);
+    Mesh mesh(*TestCommWorld);
+    testPoly2TriRefinementBase(mesh, nullptr, 1.5, 15);
   }
 
   void testPoly2TriExtraRefined()
   {
     LOG_UNIT_TEST;
 
-    testPoly2TriRefinementBase(nullptr, 1.5, 150, 0.01);
+    Mesh mesh(*TestCommWorld);
+    testPoly2TriRefinementBase(mesh, nullptr, 1.5, 150, 0.01);
   }
 
   void testPoly2TriNonUniformRefined()
   {
     ParsedFunction<Real> var_area {"0.002*(1+2*x)*(1+2*y)"};
-    testPoly2TriRefinementBase(nullptr, 1.5, 150, 0, &var_area);
+    Mesh mesh(*TestCommWorld);
+    testPoly2TriRefinementBase(mesh, nullptr, 1.5, 150, 0, &var_area);
   }
 
   void testPoly2TriHolesRefined()
@@ -526,7 +527,8 @@ public:
     TriangulatorInterface::PolygonHole diamond(Point(0.5,0.5), std::sqrt(2)/4, 4);
     const std::vector<TriangulatorInterface::Hole*> holes { &diamond };
 
-    testPoly2TriRefinementBase(&holes, 1.25, 13);
+    Mesh mesh(*TestCommWorld);
+    testPoly2TriRefinementBase(mesh, &holes, 1.25, 13);
   }
 
   void testPoly2TriHolesInteriorRefinedBase
@@ -544,7 +546,8 @@ public:
 
     // Doing extra refinement here to ensure that we had the
     // *opportunity* to refine the hole boundaries.
-    Mesh mesh = testPoly2TriRefinementBase(&holes, 1.25, n_original_elem, desired_area);
+    Mesh mesh(*TestCommWorld);
+    testPoly2TriRefinementBase(mesh, &holes, 1.25, n_original_elem, desired_area);
 
     // Checking that we have more outer boundary sides than we started
     // with, and exactly the 4 hole boundary sides we started with.
@@ -580,7 +583,8 @@ public:
     TriangulatorInterface::PolygonHole diamond(Point(0.5,0.5), std::sqrt(2)/4, 4);
     const std::vector<TriangulatorInterface::Hole*> holes { &diamond };
 
-    testPoly2TriRefinementBase(&holes, 1.25, 125, 0.01);
+    Mesh mesh(*TestCommWorld);
+    testPoly2TriRefinementBase(mesh, &holes, 1.25, 125, 0.01);
   }
 
   void testPoly2TriHolesNonUniformRefined()
@@ -590,7 +594,8 @@ public:
     const std::vector<TriangulatorInterface::Hole*> holes { &diamond };
 
     ParsedFunction<Real> var_area {"0.002*(0.25+2*x)*(0.25+2*y)"};
-    testPoly2TriRefinementBase(&holes, 1.25, 150, 0, &var_area);
+    Mesh mesh(*TestCommWorld);
+    testPoly2TriRefinementBase(mesh, &holes, 1.25, 150, 0, &var_area);
   }
 
 


### PR DESCRIPTION
We can't stitch meshes unless boundary sides line up, and we might want to stitch triangulator output to other meshes, so we should give triangulator users finer control over how to refine boundary sides.