### PR TITLE
Fix up raw-QoI-access deprecation

### DIFF
--- a/examples/adjoints/adjoints_ex1/L-shaped.h
+++ b/examples/adjoints/adjoints_ex1/L-shaped.h
@@ -19,7 +19,7 @@ public:
     _fe_family("LAGRANGE"),
     _fe_order(1),
     _analytic_jacobians(true)
-  { qoi.resize(2); }
+  { this->init_qois(2); }
 
   std::string & fe_family() { return _fe_family; }
   unsigned int & fe_order() { return _fe_order; }

--- a/examples/adjoints/adjoints_ex2/L-qoi.C
+++ b/examples/adjoints/adjoints_ex2/L-qoi.C
@@ -4,7 +4,7 @@
 
 using namespace libMesh;
 
-void LaplaceQoI::init_qoi(System & sys)
+void LaplaceQoI::init_qoi_count(System & sys)
 {
   // Only 1 qoi to worry about
   sys.init_qois(1);

--- a/examples/adjoints/adjoints_ex2/L-qoi.C
+++ b/examples/adjoints/adjoints_ex2/L-qoi.C
@@ -1,11 +1,13 @@
 #include "L-qoi.h"
 
+#include "libmesh/system.h"
+
 using namespace libMesh;
 
-void LaplaceQoI::init_qoi(std::vector<Number> & sys_qoi)
+void LaplaceQoI::init_qoi(System & sys)
 {
   // Only 1 qoi to worry about
-  sys_qoi.resize(1);
+  sys.init_qois(1);
 }
 
 void LaplaceQoI::init_context(DiffContext & context)

--- a/examples/adjoints/adjoints_ex2/L-qoi.h
+++ b/examples/adjoints/adjoints_ex2/L-qoi.h
@@ -21,7 +21,7 @@ public:
   LaplaceQoI() = default;
   virtual ~LaplaceQoI() = default;
 
-  virtual void init_qoi(std::vector<Number> & sys_qoi);
+  virtual void init_qoi(System & sys);
 
   // Context initialization
   virtual void init_context (DiffContext & context);

--- a/examples/adjoints/adjoints_ex2/L-qoi.h
+++ b/examples/adjoints/adjoints_ex2/L-qoi.h
@@ -21,7 +21,7 @@ public:
   LaplaceQoI() = default;
   virtual ~LaplaceQoI() = default;
 
-  virtual void init_qoi(System & sys);
+  virtual void init_qoi_count(System & sys);
 
   // Context initialization
   virtual void init_context (DiffContext & context);

--- a/examples/adjoints/adjoints_ex3/H-qoi.C
+++ b/examples/adjoints/adjoints_ex3/H-qoi.C
@@ -7,10 +7,10 @@
 
 using namespace libMesh;
 
-void CoupledSystemQoI::init_qoi(std::vector<Number> & sys_qoi)
+void CoupledSystemQoI::init_qoi(System & sys)
 {
   //Only 1 qoi to worry about
-  sys_qoi.resize(1);
+  sys.init_qois(1);
 }
 
 void CoupledSystemQoI::init_context(DiffContext & context)

--- a/examples/adjoints/adjoints_ex3/H-qoi.C
+++ b/examples/adjoints/adjoints_ex3/H-qoi.C
@@ -7,7 +7,7 @@
 
 using namespace libMesh;
 
-void CoupledSystemQoI::init_qoi(System & sys)
+void CoupledSystemQoI::init_qoi_count(System & sys)
 {
   //Only 1 qoi to worry about
   sys.init_qois(1);

--- a/examples/adjoints/adjoints_ex3/H-qoi.h
+++ b/examples/adjoints/adjoints_ex3/H-qoi.h
@@ -18,7 +18,7 @@ public:
   CoupledSystemQoI() = default;
   virtual ~CoupledSystemQoI() = default;
 
-  virtual void init_qoi(System & sys);
+  virtual void init_qoi_count(System & sys);
   virtual void init_context(DiffContext &);
 
   virtual void postprocess(){}

--- a/examples/adjoints/adjoints_ex3/H-qoi.h
+++ b/examples/adjoints/adjoints_ex3/H-qoi.h
@@ -18,7 +18,7 @@ public:
   CoupledSystemQoI() = default;
   virtual ~CoupledSystemQoI() = default;
 
-  virtual void init_qoi(std::vector<Number> & sys_qoi);
+  virtual void init_qoi(System & sys);
   virtual void init_context(DiffContext &);
 
   virtual void postprocess(){}

--- a/examples/adjoints/adjoints_ex3/coupled_system.C
+++ b/examples/adjoints/adjoints_ex3/coupled_system.C
@@ -429,7 +429,7 @@ void CoupledSystem::postprocess()
   // We need to overload the postprocess function to set the
   // computed_QoI variable of the CoupledSystem class to the qoi value
   // stored in System::qoi[0]
-  computed_QoI = System::qoi[0];
+  computed_QoI = this->get_qoi_value(0);
 }
 
 // These functions supply the nonlinear weighting for the adjoint residual error estimate which

--- a/examples/adjoints/adjoints_ex3/coupled_system.h
+++ b/examples/adjoints/adjoints_ex3/coupled_system.h
@@ -39,7 +39,7 @@ public:
   CoupledSystem(EquationSystems & es,
                 const std::string & name_in,
                 const unsigned int number_in)
-    : FEMSystem(es, name_in, number_in), Peclet(1.) {qoi.resize(1);}
+    : FEMSystem(es, name_in, number_in), Peclet(1.) {this->init_qois(1);}
 
   // Function to get computed QoI values
 

--- a/examples/adjoints/adjoints_ex4/L-shaped.h
+++ b/examples/adjoints/adjoints_ex4/L-shaped.h
@@ -19,7 +19,7 @@ public:
     _fe_family("LAGRANGE"),
     _fe_order(1),
     _analytic_jacobians(true)
-  { qoi.resize(2); }
+  { this->init_qois(2); }
 
   std::string & fe_family() { return _fe_family; }
   unsigned int & fe_order() { return _fe_order; }

--- a/examples/adjoints/adjoints_ex5/heatsystem.h
+++ b/examples/adjoints/adjoints_ex5/heatsystem.h
@@ -41,7 +41,7 @@ public:
       _fe_order(1),
       _analytic_jacobians(true),
       dp(1.e-6)
-  { qoi.resize(1); }
+  { this->init_qois(1); }
 
   std::string & fe_family() { return _fe_family; }
   unsigned int & fe_order() { return _fe_order; }

--- a/examples/adjoints/adjoints_ex6/poisson.h
+++ b/examples/adjoints/adjoints_ex6/poisson.h
@@ -16,7 +16,7 @@ public:
                 const unsigned int number_in)
     : FEMSystem(es, name_in, number_in),
       _fe_family("LAGRANGE"), _fe_order(2),
-      _analytic_jacobians(true) { qoi.resize(1); computed_QoI[0] = 0.0; }
+      _analytic_jacobians(true) { this->init_qois(1); computed_QoI[0] = 0.0; }
 
   std::string & fe_family() { return _fe_family;  }
   unsigned int & fe_order() { return _fe_order;  }

--- a/examples/adjoints/adjoints_ex7/heatsystem.h
+++ b/examples/adjoints/adjoints_ex7/heatsystem.h
@@ -38,7 +38,7 @@ public:
       _fe_family("LAGRANGE"),
       _fe_order(1),
       _analytic_jacobians(true)
-  { qoi.resize(2); QoI_time_instant.resize(2);}
+  { this->init_qois(2); QoI_time_instant.resize(2);}
 
   Real & k() { return _k; }
   bool & analytic_jacobians() { return _analytic_jacobians; }

--- a/include/physics/diff_qoi.h
+++ b/include/physics/diff_qoi.h
@@ -82,7 +82,7 @@ public:
    * Initialize system qoi.  Often this will just call
    * sys.init_qois(some_desired_number_of_qois)
    */
-  virtual void init_qoi( System & /*sys*/){}
+  virtual void init_qoi_count( System & /*sys*/){}
 
   /**
    * Clear all the data structures associated with

--- a/include/physics/diff_qoi.h
+++ b/include/physics/diff_qoi.h
@@ -64,11 +64,25 @@ public:
    */
   virtual ~DifferentiableQoI () = default;
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
   /**
-   * Initialize system qoi. By default, does nothing in order to maintain backward
-   * compatibility for FEMSystem applications that control qoi.
+   * Initialize system qoi.  This version of the function required
+   * direct vector access, and is now deprecated.
    */
   virtual void init_qoi( std::vector<Number> & /*sys_qoi*/){}
+#else
+  /**
+   * Non-virtual, to try to help deprecated user code catch this
+   * change at compile time (if they specified override)
+   */
+  void init_qoi( std::vector<Number> & /*sys_qoi*/){}
+#endif
+
+  /**
+   * Initialize system qoi.  Often this will just call
+   * sys.init_qois(some_desired_number_of_qois)
+   */
+  virtual void init_qoi( System & /*sys*/){}
 
   /**
    * Clear all the data structures associated with

--- a/include/systems/diff_system.h
+++ b/include/systems/diff_system.h
@@ -224,10 +224,7 @@ public:
   /**
    * Attach external QoI object.
    */
-  void attach_qoi( DifferentiableQoI * qoi_in )
-  { this->diff_qoi = (qoi_in->clone()).release();
-    // User needs to resize qoi system qoi accordingly
-    this->diff_qoi->init_qoi( this->qoi );}
+  void attach_qoi( DifferentiableQoI * qoi_in );
 
   /**
    * A pointer to the solver object we're going to use.

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1610,10 +1610,10 @@ public:
   void init_qois(unsigned int n_qois);
 
   void set_qoi(unsigned int qoi_index, Number qoi_value);
-  Number get_qoi_value(unsigned int qoi_index);
+  Number get_qoi_value(unsigned int qoi_index) const;
 
   void set_qoi_error_estimate(unsigned int qoi_index, Number qoi_error_estimate);
-  Number get_qoi_error_estimate_value(unsigned int qoi_index);
+  Number get_qoi_error_estimate_value(unsigned int qoi_index) const;
 
   /**
    * \returns The value of the solution variable \p var at the physical

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -2503,6 +2503,10 @@ void System::disable_cache () { assemble_before_solve = true; }
 inline
 unsigned int System::n_qois() const
 {
+#ifndef LIBMESH_ENABLE_DEPRECATED
+  libmesh_assert_equal_to(this->qoi.size(), this->qoi_error_estimates.size());
+#endif
+
   return cast_int<unsigned int>(this->qoi.size());
 }
 

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1612,6 +1612,13 @@ public:
   void set_qoi(unsigned int qoi_index, Number qoi_value);
   Number get_qoi_value(unsigned int qoi_index) const;
 
+  void set_qoi(std::vector<Number> new_qoi);
+
+  /**
+   * Returns a *copy* of qoi, not a reference
+   */
+  std::vector<Number> get_qoi_values() const;
+
   void set_qoi_error_estimate(unsigned int qoi_index, Number qoi_error_estimate);
   Number get_qoi_error_estimate_value(unsigned int qoi_index) const;
 

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1582,7 +1582,9 @@ public:
    */
   unsigned int n_qois() const;
 
-  #ifdef LIBMESH_ENABLE_DEPRECATED
+#ifndef LIBMESH_ENABLE_DEPRECATED // We use accessors for these now
+private:
+#endif
   /**
    * Values of the quantities of interest.  This vector needs
    * to be both resized and filled by the user before any quantity of
@@ -1598,9 +1600,12 @@ public:
    * User code can use this for accumulating error estimates for example.
    */
   std::vector<Number> qoi_error_estimates;
-  #endif
+#ifndef LIBMESH_ENABLE_DEPRECATED
+public:
+#endif
 
-  /** Accessors for qoi and qoi_error_estimates vectors
+  /**
+   * Accessors for qoi and qoi_error_estimates vectors
    */
   void init_qois(unsigned int n_qois);
 
@@ -2227,24 +2232,6 @@ private:
    * Do we want to apply constraints while projecting vectors ?
    */
   bool project_with_constraints;
-
-  #ifndef LIBMESH_ENABLE_DEPRECATED
-  /**
-   * Values of the quantities of interest.  This vector needs
-   * to be both resized and filled by the user before any quantity of
-   * interest assembly is done and before any sensitivities are
-   * calculated.
-   */
-  std::vector<Number> qoi;
-
-  /**
-   * Vector to hold error estimates for qois, either from a steady
-   * state calculation, or from a single unsteady solver timestep. Used
-   * by the library after resizing to match the size of the qoi vector.
-   * User code can use this for accumulating error estimates for example.
-   */
-  std::vector<Number> qoi_error_estimates;
-  #endif
 };
 
 

--- a/src/systems/diff_context.C
+++ b/src/systems/diff_context.C
@@ -54,7 +54,7 @@ DiffContext::DiffContext (const System & sys) :
 
   // If the user resizes sys.qoi, it will invalidate us
 
-  std::size_t n_qoi = sys.qoi.size();
+  std::size_t n_qoi = sys.n_qois();
   _elem_qoi.resize(n_qoi);
   _elem_qoi_derivative.resize(n_qoi);
   _elem_qoi_subderivatives.resize(n_qoi);

--- a/src/systems/diff_system.C
+++ b/src/systems/diff_system.C
@@ -315,7 +315,7 @@ void DifferentiableSystem::attach_qoi( DifferentiableQoI * qoi_in )
   this->diff_qoi->init_qoi( this->qoi );
 
   // Then the new API for forwards compatibility
-  this->diff_qoi->init_qoi( *this );
+  this->diff_qoi->init_qoi_count( *this );
 #else
 #ifndef NDEBUG
   // Make sure the user has updated their QoI subclass - call the old
@@ -326,7 +326,7 @@ void DifferentiableSystem::attach_qoi( DifferentiableQoI * qoi_in )
 #endif
 
   // Then the new API
-  this->diff_qoi->init_qoi( *this );
+  this->diff_qoi->init_qoi_count( *this );
 #endif
 }
 

--- a/src/systems/diff_system.C
+++ b/src/systems/diff_system.C
@@ -306,6 +306,30 @@ void DifferentiableSystem::add_dot_var_dirichlet_bcs( unsigned int var_idx,
 }
 #endif // LIBMESH_ENABLE_DIRICHLET
 
+void DifferentiableSystem::attach_qoi( DifferentiableQoI * qoi_in )
+{
+  this->diff_qoi = (qoi_in->clone()).release();
+  // User needs to resize qoi system qoi accordingly
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  // Call the old API for backwards compatibility
+  this->diff_qoi->init_qoi( this->qoi );
+
+  // Then the new API for forwards compatibility
+  this->diff_qoi->init_qoi( *this );
+#else
+#ifndef NDEBUG
+  // Make sure the user has updated their QoI subclass - call the old
+  // API and make sure it does nothing
+  std::vector<Number> deprecated_vector;
+  this->diff_qoi->init_qoi( deprecated_vector );
+  libmesh_assert(deprecated_vector.empty());
+#endif
+
+  // Then the new API
+  this->diff_qoi->init_qoi( *this );
+#endif
+}
+
 unsigned int DifferentiableSystem::get_second_order_dot_var( unsigned int var ) const
 {
   // For SteadySolver or SecondOrderUnsteadySolvers, we just give back var

--- a/src/systems/explicit_system.C
+++ b/src/systems/explicit_system.C
@@ -57,7 +57,7 @@ void ExplicitSystem::assemble_qoi (const QoISet & qoi_indices)
   // accumulate on initially zero values
   for (auto i : make_range(this->n_qois()))
     if (qoi_indices.has_index(i))
-      qoi[i] = 0;
+      this->set_qoi(i, 0);
 
   Parent::assemble_qoi (qoi_indices);
 }

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -1126,7 +1126,7 @@ void FEMSystem::assemble_qoi (const QoISet & qoi_indices)
   // side terms
   for (unsigned int i=0; i != Nq; ++i)
     if (qoi_indices.has_index(i))
-      qoi[i] = 0;
+      this->set_qoi(i, 0);
 
   // Create a non-temporary qoi_contributions object, so we can query
   // its results after the reduction
@@ -1137,7 +1137,9 @@ void FEMSystem::assemble_qoi (const QoISet & qoi_indices)
                                             mesh.active_local_elements_end()),
                            qoi_contributions);
 
-  this->diff_qoi->parallel_op( this->comm(), this->qoi, qoi_contributions.qoi, qoi_indices );
+  std::vector<Number> global_qoi = this->get_qoi_values();
+  this->diff_qoi->parallel_op( this->comm(), global_qoi, qoi_contributions.qoi, qoi_indices );
+  this->set_qoi(std::move(global_qoi));
 }
 
 

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -567,13 +567,13 @@ void ImplicitSystem::adjoint_qoi_parameter_sensitivity (const QoISet & qoi_indic
 
       *parameters[j] = old_parameter - delta_p;
       this->assemble_qoi(qoi_indices);
-      std::vector<Number> qoi_minus = this->qoi;
+      const std::vector<Number> qoi_minus = this->get_qoi_values();
 
       NumericVector<Number> & neg_partialR_partialp = this->get_sensitivity_rhs(j);
 
       *parameters[j] = old_parameter + delta_p;
       this->assemble_qoi(qoi_indices);
-      std::vector<Number> & qoi_plus = this->qoi;
+      const std::vector<Number> qoi_plus = this->get_qoi_values();
 
       std::vector<Number> partialq_partialp(Nq, 0);
       for (unsigned int i=0; i != Nq; ++i)
@@ -655,11 +655,11 @@ void ImplicitSystem::forward_qoi_parameter_sensitivity (const QoISet & qoi_indic
 
       *parameters[j] = old_parameter - delta_p;
       this->assemble_qoi(qoi_indices);
-      std::vector<Number> qoi_minus = this->qoi;
+      const std::vector<Number> qoi_minus = this->get_qoi_values();
 
       *parameters[j] = old_parameter + delta_p;
       this->assemble_qoi(qoi_indices);
-      std::vector<Number> & qoi_plus = this->qoi;
+      const std::vector<Number> qoi_plus = this->get_qoi_values();
 
       std::vector<Number> partialq_partialp(Nq, 0);
       for (unsigned int i=0; i != Nq; ++i)
@@ -769,7 +769,7 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product (const QoISet & qoi_in
       this->assemble_qoi(qoi_indices);
       this->assembly(true, false, true);
       this->rhs->close();
-      std::vector<Number> partial2q_term = this->qoi;
+      std::vector<Number> partial2q_term = this->get_qoi_values();
       std::vector<Number> partial2R_term(this->n_qois());
       for (unsigned int i=0; i != Nq; ++i)
         if (qoi_indices.has_index(i))
@@ -782,7 +782,7 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product (const QoISet & qoi_in
       for (unsigned int i=0; i != Nq; ++i)
         if (qoi_indices.has_index(i))
           {
-            partial2q_term[i] -= this->qoi[i];
+            partial2q_term[i] -= this->get_qoi_value(i);
             partial2R_term[i] -= this->rhs->dot(this->get_adjoint_solution(i));
           }
 
@@ -800,7 +800,7 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product (const QoISet & qoi_in
       for (unsigned int i=0; i != Nq; ++i)
         if (qoi_indices.has_index(i))
           {
-            partial2q_term[i] -= this->qoi[i];
+            partial2q_term[i] -= this->get_qoi_value(i);
             partial2R_term[i] -= this->rhs->dot(this->get_adjoint_solution(i));
           }
 
@@ -811,7 +811,7 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product (const QoISet & qoi_in
       for (unsigned int i=0; i != Nq; ++i)
         if (qoi_indices.has_index(i))
           {
-            partial2q_term[i] += this->qoi[i];
+            partial2q_term[i] += this->get_qoi_value(i);
             partial2R_term[i] += this->rhs->dot(this->get_adjoint_solution(i));
           }
 
@@ -971,7 +971,7 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
           this->assemble_qoi(qoi_indices);
           this->assembly(true, false, true);
           this->rhs->close();
-          std::vector<Number> partial2q_term = this->qoi;
+          std::vector<Number> partial2q_term = this->get_qoi_values();
           std::vector<Number> partial2R_term(this->n_qois());
           for (unsigned int i=0; i != Nq; ++i)
             if (qoi_indices.has_index(i))
@@ -984,7 +984,7 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
           for (unsigned int i=0; i != Nq; ++i)
             if (qoi_indices.has_index(i))
               {
-                partial2q_term[i] -= this->qoi[i];
+                partial2q_term[i] -= this->get_qoi_value(i);
                 partial2R_term[i] -= this->rhs->dot(this->get_adjoint_solution(i));
               }
 
@@ -995,7 +995,7 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
           for (unsigned int i=0; i != Nq; ++i)
             if (qoi_indices.has_index(i))
               {
-                partial2q_term[i] += this->qoi[i];
+                partial2q_term[i] += this->get_qoi_value(i);
                 partial2R_term[i] += this->rhs->dot(this->get_adjoint_solution(i));
               }
 
@@ -1006,7 +1006,7 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
           for (unsigned int i=0; i != Nq; ++i)
             if (qoi_indices.has_index(i))
               {
-                partial2q_term[i] -= this->qoi[i];
+                partial2q_term[i] -= this->get_qoi_value(i);
                 partial2R_term[i] -= this->rhs->dot(this->get_adjoint_solution(i));
                 partial2q_term[i] /= (4. * delta_p * delta_p);
                 partial2R_term[i] /= (4. * delta_p * delta_p);

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -2161,7 +2161,8 @@ void System::set_qoi(unsigned int qoi_index, Number qoi_value)
   qoi[qoi_index] = qoi_value;
 }
 
-Number System::get_qoi_value(unsigned int qoi_index)
+
+Number System::get_qoi_value(unsigned int qoi_index) const
 {
   libmesh_assert(qoi_index < qoi.size());
   return qoi[qoi_index];
@@ -2174,7 +2175,7 @@ void System::set_qoi_error_estimate(unsigned int qoi_index, Number qoi_error_est
   qoi_error_estimates[qoi_index] = qoi_error_estimate;
 }
 
-Number System::get_qoi_error_estimate_value(unsigned int qoi_index)
+Number System::get_qoi_error_estimate_value(unsigned int qoi_index) const
 {
   libmesh_assert(qoi_index < qoi_error_estimates.size());
   return qoi_error_estimates[qoi_index];

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -2148,11 +2148,13 @@ void System::user_QOI_derivative(const QoISet & qoi_indices,
       (qoi_indices, include_liftfunc, apply_constraints);
 }
 
+
 void System::init_qois(unsigned int n_qois)
 {
   qoi.resize(n_qois);
   qoi_error_estimates.resize(n_qois);
 }
+
 
 void System::set_qoi(unsigned int qoi_index, Number qoi_value)
 {

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -2168,6 +2168,20 @@ Number System::get_qoi_value(unsigned int qoi_index) const
   return qoi[qoi_index];
 }
 
+
+std::vector<Number> System::get_qoi_values() const
+{
+  return this->qoi;
+}
+
+
+void System::set_qoi(std::vector<Number> new_qoi)
+{
+  libmesh_assert_equal_to(this->qoi.size(), new_qoi.size());
+  this->qoi = std::move(new_qoi);
+}
+
+
 void System::set_qoi_error_estimate(unsigned int qoi_index, Number qoi_error_estimate)
 {
   libmesh_assert(qoi_index < qoi_error_estimates.size());


### PR DESCRIPTION
The hard part of this is the need to change the DifferentiableQoI::init_qoi interface, but I don't see any other forwards-compatible way to avoid that.