### PR TITLE
make clang-tidy

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -679,6 +679,24 @@ test_headers:
 	@$(MAKE) -C $(top_builddir)/include/libmesh
 	@cd $(top_builddir)/include && $(MAKE) test_headers
 
+#
+# run clang-tidy static analysis
+clang-tidy:
+	@echo " "
+	@echo "Checking clang-tidy on sources ..."
+	@echo " "
+	@export MPICH_FLAGS=`$(CXX) -cxx= -compile_info 2>/dev/null`; \
+	export OPENMPI_FLAGS=`$(CXX) -showme:compile 2>/dev/null`; \
+	for word in $(CXX); do \
+	  if printf "%s\n" $$word | grep -- -std=; then \
+	    export STD_FLAG=$$word; \
+	  fi; \
+	done; \
+	for file in $(libmesh_SOURCES); do \
+	  echo "clang-tidy $(top_srcdir)/$$file:"; \
+	  clang-tidy "$(top_srcdir)/$$file" -- $$STD_FLAG $$MPICH_FLAGS $$OPENMPI_FLAGS $(libmesh_contrib_INCLUDES) $(libmesh_optional_INCLUDES) $(CPPFLAGS_DBG) $(CXXFLAGS_DBG) $(CPPFLAGS) -I$(top_builddir)/include -x c++; \
+	done
+
 # -------------------------------------------
 # Optional support for code coverage analysis
 # -------------------------------------------
@@ -709,12 +727,6 @@ coverage: lcov-reset check lcov-report
 	$(MAKE) lcov-reset
 	$(MAKE) check
 	$(MAKE) lcov-report
-
-clang-tidy:
-	@echo " "
-	@echo "Checking clang-tidy on sources ..."
-	@echo " "
-	clang-tidy $(libmesh_SOURCES) -- $(libmesh_contrib_INCLUDES) $(libmesh_optional_INCLUDES) $(CPPFLAGS_DBG) $(CXXFLAGS_DBG) -I$(top_builddir)/include -x c++
 
 CLEANFILES += src/apps/*.gcda src/apps/*.gcno
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -710,6 +710,12 @@ coverage: lcov-reset check lcov-report
 	$(MAKE) check
 	$(MAKE) lcov-report
 
+clang-tidy:
+	@echo " "
+	@echo "Checking clang-tidy on sources ..."
+	@echo " "
+	clang-tidy $(libmesh_SOURCES) -- $(libmesh_contrib_INCLUDES) $(libmesh_optional_INCLUDES) $(CPPFLAGS_DBG) $(CXXFLAGS_DBG) -I$(top_builddir)/include -x c++
+
 CLEANFILES += src/apps/*.gcda src/apps/*.gcno
 
 endif

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -69,3 +69,10 @@ installcheck-local:
 	  PKG_CONFIG_PATH=$(pkgconfigdir) \
 	  LIBMESH_CONFIG_PATH=$(bindir) \
 	  $(top_srcdir)/contrib/bin/test_installed_headers.sh
+
+clang-tidy:
+	@echo " "
+	@echo "Checking clang-tidy on headers ..."
+	@echo " "
+	cd $(top_srcdir) && \
+	clang-tidy $(headers_to_test) -- $(libmesh_contrib_INCLUDES) $(libmesh_optional_INCLUDES) $(CPPFLAGS_DBG) $(CXXFLAGS_DBG) -I$(top_builddir)/include -x c++

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -74,5 +74,14 @@ clang-tidy:
 	@echo " "
 	@echo "Checking clang-tidy on headers ..."
 	@echo " "
-	cd $(top_srcdir) && \
-	clang-tidy $(headers_to_test) -- $(libmesh_contrib_INCLUDES) $(libmesh_optional_INCLUDES) $(CPPFLAGS_DBG) $(CXXFLAGS_DBG) -I$(top_builddir)/include -x c++
+	@export MPICH_FLAGS=`$(CXX) -cxx= -compile_info 2>/dev/null`; \
+	export OPENMPI_FLAGS=`$(CXX) -showme:compile 2>/dev/null`; \
+	for word in $(CXX); do \
+	  if printf "%s\n" $$word | grep -- -std=; then \
+	    export STD_FLAG=$$word; \
+	  fi; \
+	done; \
+	for file in $(headers_to_test); do \
+	  echo "clang-tidy $(top_srcdir)/$(file):"; \
+	  echo clang-tidy $(top_srcdir)/$(file) -- $$STD_FLAG $$MPICH_FLAGS $$OPENMPI_FLAGS $(libmesh_contrib_INCLUDES) $(libmesh_optional_INCLUDES) $(CPPFLAGS_DBG) $(CXXFLAGS_DBG) $(CPPFLAGS) -I$(top_builddir)/include -x c++; \
+	done

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -1491,6 +1491,17 @@ installcheck-local:
 	  LIBMESH_CONFIG_PATH=$(bindir) \
 	  $(top_srcdir)/contrib/bin/test_installed_headers.sh
 
+clang-tidy:
+	@echo " "
+	@echo "Checking clang-tidy on headers ..."
+	@echo " "
+	@export MPICH_FLAGS=`$(CXX) -cxx= -compile_info 2>/dev/null`; \
+	export OPENMPI_FLAGS=`$(CXX) -showme:compile 2>/dev/null`; \
+	for file in $(headers_to_test); do \
+	  echo "clang-tidy $(top_srcdir)/$(file):"; \
+	  echo clang-tidy $(top_srcdir)/$(file) -- $$MPICH_FLAGS $$OPENMPI_FLAGS $(libmesh_contrib_INCLUDES) $(libmesh_optional_INCLUDES) $(CPPFLAGS_DBG) $(CXXFLAGS_DBG) -I$(top_builddir)/include -x c++; \
+	done
+
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.
 .NOEXPORT:


### PR DESCRIPTION
This deserves a ton of improvement (separate targets for each file/`$METHOD` combination, clang-tidy config file to add and remove tests from, CI recipes to keep track of the results) whenever I have time, but for now I just want to get the basic tricks here (querying MPI include paths and `-std=` arguments from `$(CXX)`, getting the right libMesh flags in place) into git before I forget them. 