### PR TITLE
Stop writing "poly2tri_holes.e" in unit tests

### DIFF
--- a/tests/mesh/mesh_triangulation.C
+++ b/tests/mesh/mesh_triangulation.C
@@ -491,8 +491,6 @@ public:
 
     mesh.comm().sum(area);
 
-    mesh.write("poly2tri_holes.e");
-
     LIBMESH_ASSERT_FP_EQUAL(area, expected_total_area, TOLERANCE*TOLERANCE);
   }
 


### PR DESCRIPTION
I added this when debugging but forgot to take it out afterward, and
it's breaking non-Exodus builds.