### PR TITLE
Fix missing _all_elemset_ids lines in MeshBase copy ctor, move-assignment operator

### DIFF
--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -745,6 +745,13 @@ void ExodusII_IO::read (const std::string & fname)
         for (const auto & s : unique_elemsets)
           mesh.add_elemset_code(code++, s);
 
+        // Sanity check: make sure that MeshBase::n_elemsets() reports
+        // the expected value after calling MeshBase::add_elemset_code()
+        // one or more times.
+        libmesh_assert_msg(exio_helper->num_elem_sets == cast_int<int>(mesh.n_elemsets()),
+                           "Error: mesh.n_elemsets() is " << mesh.n_elemsets()
+                           << ", but mesh should have " << exio_helper->num_elem_sets << " elemsets.");
+
         // Create storage for the extra integer on all Elems. Elems which
         // are not in any set will use the default value of DofObject::invalid_id
         unsigned int elemset_index =

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -3193,6 +3193,15 @@ ExodusII_IO_Helper::write_elemsets(const MeshBase & mesh)
               current_set.distribution_factor_list = nullptr; // not used for elemsets
             }
 
+          // Sanity check: make sure the number of elemsets we already wrote to the header
+          // matches the number of elemsets we just constructed by looping over the Mesh.
+          libmesh_assert_msg(num_elem_sets == cast_int<int>(exodus_elemsets.size()),
+                             "Mesh has " << exodus_elemsets.size()
+                             << " elemsets, but header was written with num_elem_sets == " << num_elem_sets);
+          libmesh_assert_msg(num_elem_sets == cast_int<int>(mesh.n_elemsets()),
+                             "mesh.n_elemsets() == " << mesh.n_elemsets()
+                             << ", but header was written with num_elem_sets == " << num_elem_sets);
+
           ex_err = exII::ex_put_sets(ex_id, exodus_elemsets.size(), sets.data());
           EX_CHECK_ERR(ex_err, "Error writing elemsets");
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -105,6 +105,7 @@ MeshBase::MeshBase (const MeshBase & other_mesh) :
   _allow_remote_element_removal(other_mesh._allow_remote_element_removal),
   _elem_dims(other_mesh._elem_dims),
   _elemset_codes_inverse_map(other_mesh._elemset_codes_inverse_map),
+  _all_elemset_ids(other_mesh._all_elemset_ids),
   _spatial_dimension(other_mesh._spatial_dimension),
   _default_ghosting(std::make_unique<GhostPointNeighbors>(*this)),
   _point_locator_close_to_point_tol(other_mesh._point_locator_close_to_point_tol)
@@ -172,6 +173,7 @@ MeshBase& MeshBase::operator= (MeshBase && other_mesh)
   _elem_dims = std::move(other_mesh.elem_dimensions());
   _elemset_codes = std::move(other_mesh._elemset_codes);
   _elemset_codes_inverse_map = std::move(other_mesh._elemset_codes_inverse_map);
+  _all_elemset_ids = std::move(other_mesh._all_elemset_ids),
   _spatial_dimension = other_mesh.spatial_dimension();
   _elem_integer_names = std::move(other_mesh._elem_integer_names);
   _elem_integer_default_values = std::move(other_mesh._elem_integer_default_values);

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -56,7 +56,7 @@ namespace libMesh
 MeshBase::MeshBase (const Parallel::Communicator & comm_in,
                     unsigned char d) :
   ParallelObject (comm_in),
-  boundary_info  (new BoundaryInfo(*this)),
+  boundary_info  (new BoundaryInfo(*this)), // BoundaryInfo has protected ctor, can't use std::make_unique
   _n_parts       (1),
   _default_mapping_type(LAGRANGE_MAP),
   _default_mapping_data(0),
@@ -87,7 +87,7 @@ MeshBase::MeshBase (const Parallel::Communicator & comm_in,
 
 MeshBase::MeshBase (const MeshBase & other_mesh) :
   ParallelObject (other_mesh),
-  boundary_info  (new BoundaryInfo(*this)),
+  boundary_info  (new BoundaryInfo(*this)), // BoundaryInfo has protected ctor, can't use std::make_unique
   _n_parts       (other_mesh._n_parts),
   _default_mapping_type(other_mesh._default_mapping_type),
   _default_mapping_data(other_mesh._default_mapping_data),


### PR DESCRIPTION
This issue didn't initially show up in our elemset unit tests because we don't `clone()` the `Mesh` there.