### PR TITLE
ExodusII_IO: write elemsets when calling write()

### DIFF
--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -2192,6 +2192,7 @@ void ExodusII_IO::write_nodal_data_common(std::string fname,
 
           exio_helper->write_sidesets(mesh);
           exio_helper->write_nodesets(mesh);
+          exio_helper->write_elemsets(mesh);
 
           exio_helper->initialize_nodal_variables(names);
         }

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -2066,6 +2066,7 @@ void ExodusII_IO::write (const std::string & fname)
   exio_helper->write_elements(mesh);
   exio_helper->write_sidesets(mesh);
   exio_helper->write_nodesets(mesh);
+  exio_helper->write_elemsets(mesh);
 
   if ((mesh.get_boundary_info().n_edge_conds() > 0) && _verbose)
     libmesh_warning("Warning: Mesh contains edge boundary IDs, but these "

--- a/tests/mesh/write_elemset_data.C
+++ b/tests/mesh/write_elemset_data.C
@@ -160,7 +160,6 @@ public:
     {
       IOClass writer(mesh);
       writer.write(filename);
-      writer.write_elemsets();
       writer.write_elemset_data(/*timestep=*/1, var_names, elemset_ids, elemset_vals);
     }
 


### PR DESCRIPTION
This matches the behavior of nodesets and sidesets. Because we now
write the elemset information to the Exodus file header, the file will
not be consistent if the user forgets to call write_elemsets().