### PR TITLE
Give a warning if an Exodus variable will be truncated.

### DIFF
--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1923,7 +1923,14 @@ ExodusII_IO_Helper::write_var_names_impl(const char * var_type,
 
       // Store the input names in the format required by Exodus.
       for (int i=0; i != count; ++i)
-        names_table.push_back_entry(names[i]);
+        {
+          if(names[i].length() > MAX_STR_LENGTH)
+            libmesh_warning(
+              "*** Warning, Exodus variable name \""
+              << names[i] << "\" too long (max " << MAX_STR_LENGTH
+              << " characters). Name will be truncated. ");
+          names_table.push_back_entry(names[i]);
+        }
 
       if (verbose)
         {


### PR DESCRIPTION
The default limit is defined in MAX_STR_LENGTH as 32 characters.
If you exceed that limit, the Exodus library will truncate your variable, until now without any warning.

In the longer term, libMesh should probably be using MAX_NAME_LENGTH instead of MAX_STR_LENGTH, because it's possible to change MAX_NAME_LENGTH with API calls in order to support arbitrarily long names.