### PR TITLE
EIM on nodesets

### DIFF
--- a/contrib/capnproto/rb_data.capnp
+++ b/contrib/capnproto/rb_data.capnp
@@ -121,6 +121,7 @@ struct RBEIMEvaluationReal @0xf8121d2237427a80 {
   interpolationSideIndex      @14 :List(Integer);
   interpolationBoundaryId     @15 :List(Integer);
   interpolationSpatialIndices @16 :List(List(Integer));
+  interpolationNodeId         @17 :List(Integer);
 }
 struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   nBfs                        @0  :Integer;
@@ -140,4 +141,5 @@ struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   interpolationSideIndex      @14 :List(Integer);
   interpolationBoundaryId     @15 :List(Integer);
   interpolationSpatialIndices @16 :List(List(Integer));
+  interpolationNodeId         @17 :List(Integer);
 }

--- a/include/reduced_basis/rb_eim_assembly.h
+++ b/include/reduced_basis/rb_eim_assembly.h
@@ -84,6 +84,12 @@ public:
                                     std::vector<Number> & values);
 
   /**
+   * Same as evaluate_basis_function() except for side data.
+   */
+  Number evaluate_node_basis_function(dof_id_type node_id,
+                                      unsigned int var);
+
+  /**
    * Get a reference to the RBEIMEvaluation object.
    */
   RBEIMConstruction & get_rb_eim_construction();

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -374,18 +374,15 @@ private:
   }
 
   /**
+   * Get the maximum absolute value from a vector stored in the format that we use
+   * for basis functions. This case handles NodeDataMap.
+   */
+  Real get_node_max_abs_value(const NodeDataMap & v) const;
+
+  /**
    * Add a new basis function to the EIM approximation.
    */
   void enrich_eim_approximation(unsigned int training_index);
-
-  /**
-   * We compute the best fit of parametrized_function
-   * into the EIM space and then evaluate the error
-   * in the norm defined by inner_product_matrix.
-   *
-   * \returns The error in the best fit
-   */
-  Real compute_best_fit_error();
 
   /**
    * Scale all values in \p pf by \p scaling_factor
@@ -409,6 +406,14 @@ private:
           }
       }
   }
+
+  /**
+   * Scale all values in \p pf by \p scaling_factor
+   * The templated function above handles the elem and side cases,
+   * and this separate case handles the node case.
+   */
+  static void scale_node_parametrized_function(NodeDataMap & local_pf,
+                                               Number scaling_factor);
 
   /**
    * Maximum number of EIM basis functions we are willing to use.

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -86,6 +86,11 @@ public:
   typedef RBEIMEvaluation::SideQpDataMap SideQpDataMap;
 
   /**
+   * Type of the data structure used to map from node id -> [n_vars] data.
+   */
+  typedef RBEIMEvaluation::NodeDataMap NodeDataMap;
+
+  /**
    * Clear this object.
    */
   virtual void clear() override;
@@ -234,6 +239,7 @@ public:
    */
   const QpDataMap & get_parametrized_function_from_training_set(unsigned int training_index) const;
   const SideQpDataMap & get_side_parametrized_function_from_training_set(unsigned int training_index) const;
+  const NodeDataMap & get_node_parametrized_function_from_training_set(unsigned int training_index) const;
 
   /**
    * Get the interior and side quadrature weights.
@@ -265,6 +271,11 @@ protected:
    * Implementation of enrich_eim_approximation() for the case of element sides.
    */
   void enrich_eim_approximation_on_sides(const SideQpDataMap & side_pf);
+
+  /**
+   * Implementation of enrich_eim_approximation() for the case of element nodes.
+   */
+  void enrich_eim_approximation_on_nodes(const NodeDataMap & node_pf);
 
   /**
    * Implementation of enrich_eim_approximation() for the case of element interiors.
@@ -321,6 +332,11 @@ private:
   Number side_inner_product(const SideQpDataMap & v, const SideQpDataMap & w);
 
   /**
+   * Same as inner_product() except for node data.
+   */
+  Number node_inner_product(const NodeDataMap & v, const NodeDataMap & w);
+
+  /**
    * Get the maximum absolute value from a vector stored in the format that we use
    * for basis functions.
    */
@@ -356,12 +372,6 @@ private:
     comm().max(max_value);
     return max_value;
   }
-
-
-  /**
-   * Same as get_max_abs_value() except for side data.
-   */
-  Real get_side_max_abs_value(const SideQpDataMap & v) const;
 
   /**
    * Add a new basis function to the EIM approximation.
@@ -399,13 +409,6 @@ private:
           }
       }
   }
-
-  /**
-   * Same as scale_parametrized_function() excecpt for side data.
-   */
-  static void scale_side_parametrized_function(
-    SideQpDataMap & local_pf,
-    Number scaling_factor);
 
   /**
    * Maximum number of EIM basis functions we are willing to use.
@@ -454,6 +457,13 @@ private:
    *   basis function index --> (element ID,side index) --> variable --> quadrature point --> value
    */
   std::vector<SideQpDataMap> _local_side_parametrized_functions_for_training;
+
+  /**
+   * Same as _local_parametrized_functions_for_training except for node data.
+   * The indexing is as follows:
+   *   basis function index --> node ID --> variable --> value
+   */
+  std::vector<NodeDataMap> _local_node_parametrized_functions_for_training;
 
   /**
    * Maximum value in _local_parametrized_functions_for_training across all processors.
@@ -507,6 +517,12 @@ private:
   std::map<std::pair<dof_id_type,unsigned int>, subdomain_id_type > _local_side_quad_point_subdomain_ids;
   std::map<std::pair<dof_id_type,unsigned int>, boundary_id_type > _local_side_quad_point_boundary_ids;
   std::map<std::pair<dof_id_type,unsigned int>, std::vector<std::vector<Point>> > _local_side_quad_point_locations_perturbations;
+
+  /**
+   * Same as above except for node data.
+   */
+  std::unordered_map<dof_id_type, Point > _local_node_locations;
+  std::unordered_map<dof_id_type, boundary_id_type > _local_node_boundary_ids;
 
   /**
    * For side data, we also store "side type" info. This is used to distinguish between

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -240,6 +240,15 @@ public:
     unsigned int qp);
 
   /**
+   * Same as get_parametrized_function_value() except for node data.
+   */
+  static Number get_parametrized_function_node_value(
+    const Parallel::Communicator & comm,
+    const NodeDataMap & pf,
+    dof_id_type node_id,
+    unsigned int comp);
+
+  /**
    * Fill up \p values with the basis function values for basis function
    * \p basis_function_index and variable \p var, at all quadrature points
    * on element \p elem_id. Each processor stores data for only the
@@ -263,9 +272,9 @@ public:
   /**
    * Same as get_eim_basis_function_values_at_qps() except for node data.
    */
-  Number get_eim_basis_function_node_values(unsigned int basis_function_index,
-                                            dof_id_type node_id,
-                                            unsigned int var) const;
+  Number get_eim_basis_function_node_value(unsigned int basis_function_index,
+                                           dof_id_type node_id,
+                                           unsigned int var) const;
 
   /**
    * Same as above, except that we just return the value at the qp^th
@@ -410,9 +419,7 @@ public:
     Point p,
     unsigned int comp,
     dof_id_type node_id,
-    subdomain_id_type subdomain_id,
-    boundary_id_type boundary_id,
-    const std::vector<Point> & perturbs);
+    boundary_id_type boundary_id);
 
   /**
    * Set the observation points and components.

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -81,6 +81,11 @@ public:
   typedef std::map<std::pair<dof_id_type,unsigned int>, std::vector<std::vector<Number>>> SideQpDataMap;
 
   /**
+   * Type of the data structure used to map from (node id) -> [n_vars] data.
+   */
+  typedef std::map<dof_id_type, std::vector<Number>> NodeDataMap;
+
+  /**
    * Clear this object.
    */
   virtual void clear() override;
@@ -160,6 +165,12 @@ public:
                              const DenseVector<Number> & coeffs);
 
   /**
+   * Same as decrement_vector() except for node data.
+   */
+  void node_decrement_vector(NodeDataMap & v,
+                             const DenseVector<Number> & coeffs);
+
+  /**
    * Build a vector of RBTheta objects that accesses the components
    * of the RB_solution member variable of this RBEvaluation.
    * Store these objects in the member vector rb_theta_objects.
@@ -197,6 +208,14 @@ public:
     unsigned int side_index,
     unsigned int comp,
     std::vector<Number> & values);
+
+  /**
+   * Same as get_parametrized_function_values_at_qps() except for node data.
+   */
+  static Number get_parametrized_function_node_value(
+    const NodeDataMap & pf,
+    dof_id_type node_id,
+    unsigned int comp);
 
   /**
    * Same as above, except that we just return the value at the qp^th
@@ -242,6 +261,13 @@ public:
                                                  std::vector<Number> & values) const;
 
   /**
+   * Same as get_eim_basis_function_values_at_qps() except for node data.
+   */
+  Number get_eim_basis_function_node_values(unsigned int basis_function_index,
+                                            dof_id_type node_id,
+                                            unsigned int var) const;
+
+  /**
    * Same as above, except that we just return the value at the qp^th
    * quadrature point.
    */
@@ -268,6 +294,11 @@ public:
    * Get a reference to the i^th side basis function.
    */
   const SideQpDataMap & get_side_basis_function(unsigned int i) const;
+
+  /**
+   * Get a reference to the i^th node basis function.
+   */
+  const NodeDataMap & get_node_basis_function(unsigned int i) const;
 
   /**
    * Set _rb_eim_solutions. Normally we update _rb_eim_solutions by performing
@@ -306,6 +337,7 @@ public:
   void add_interpolation_points_xyz_perturbations(const std::vector<Point> & perturbs);
   void add_interpolation_points_elem_id(dof_id_type elem_id);
   void add_interpolation_points_side_index(unsigned int side_index);
+  void add_interpolation_points_node_id(dof_id_type node_id);
   void add_interpolation_points_qp(unsigned int qp);
   void add_interpolation_points_phi_i_qp(const std::vector<Real> & phi_i_qp);
   void add_interpolation_points_spatial_indices(const std::vector<unsigned int> & spatial_indices);
@@ -320,6 +352,7 @@ public:
   const std::vector<Point> & get_interpolation_points_xyz_perturbations(unsigned int index) const;
   dof_id_type get_interpolation_points_elem_id(unsigned int index) const;
   unsigned int get_interpolation_points_side_index(unsigned int index) const;
+  dof_id_type get_interpolation_points_node_id(unsigned int index) const;
   unsigned int get_interpolation_points_qp(unsigned int index) const;
   const std::vector<Real> & get_interpolation_points_phi_i_qp(unsigned int index) const;
   const std::vector<unsigned int> & get_interpolation_points_spatial_indices(unsigned int index) const;
@@ -368,6 +401,18 @@ public:
     unsigned int qp,
     const std::vector<Point> & perturbs,
     const std::vector<Real> & phi_i_qp);
+
+  /**
+   * Add \p node_bf to our EIM basis.
+   */
+  void add_node_basis_function_and_interpolation_data(
+    const NodeDataMap & node_bf,
+    Point p,
+    unsigned int comp,
+    dof_id_type node_id,
+    subdomain_id_type subdomain_id,
+    boundary_id_type boundary_id,
+    const std::vector<Point> & perturbs);
 
   /**
    * Set the observation points and components.
@@ -567,6 +612,13 @@ private:
   std::vector<boundary_id_type> _interpolation_points_boundary_id;
 
   /**
+   * If the EIM approximation applies to element nodes (e.g. from a nodeset),
+   * then we need to store the ID for each node. We also store the associated
+   * boundary ID in this case, using _interpolation_points_boundary_id.
+   */
+  std::vector<dof_id_type> _interpolation_points_node_id;
+
+  /**
    * We store the shape function values at the qp as well. These values
    * allows us to evaluate parametrized functions that depend on nodal
    * data.
@@ -614,6 +666,16 @@ private:
    * general will not start at zero.
    */
   std::vector<SideQpDataMap> _local_side_eim_basis_functions;
+
+  /**
+   * The EIM basis functions on element nodes (e.g. on a nodeset). We store values at nodes
+   * that are local to this processor. The indexing
+   * is as follows:
+   *   basis function index --> node ID --> variable --> value
+   * We use a map to index the node ID, since the IDs on this processor in
+   * general will not start at zero.
+   */
+  std::vector<NodeDataMap> _local_node_eim_basis_functions;
 
   /**
    * Print the contents of _local_eim_basis_functions to libMesh::out.

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -541,6 +541,13 @@ private:
                                       bool write_binary_basis_functions);
 
   /**
+   * Method that writes out element node EIM basis functions. This may be called by
+   * write_out_basis_functions().
+   */
+  void write_out_node_basis_functions(const std::string & directory_name,
+                                      bool write_binary_basis_functions);
+
+  /**
    * Method that reads in element interior EIM basis functions. This may be called by
    * read_in_basis_functions().
    */
@@ -553,6 +560,14 @@ private:
    * read_in_basis_functions().
    */
   void read_in_side_basis_functions(const System & sys,
+                                    const std::string & directory_name,
+                                    bool read_binary_basis_functions);
+
+  /**
+   * Method that reads in element node EIM basis functions. This may be called by
+   * read_in_basis_functions().
+   */
+  void read_in_node_basis_functions(const System & sys,
                                     const std::string & directory_name,
                                     bool read_binary_basis_functions);
 
@@ -703,6 +718,11 @@ private:
   void side_gather_bfs();
 
   /**
+   * Same as gather_bfs() except for node data.
+   */
+  void node_gather_bfs();
+
+  /**
    * Helper function that distributes the entries of
    * _local_eim_basis_functions to their respective processors after
    * they are read in on processor 0.
@@ -713,6 +733,11 @@ private:
    * Same as distribute_bfs() except for side data.
    */
   void side_distribute_bfs(const System & sys);
+
+  /**
+   * Same as distribute_bfs() except for node data.
+   */
+  void node_distribute_bfs(const System & sys);
 
   /**
    * Let {p_1,...,p_n} be a set of n "observation points", where we can

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -211,8 +211,10 @@ public:
 
   /**
    * Same as get_parametrized_function_values_at_qps() except for node data.
+   * Note that this does not do any parallel communication, so it is only
+   * applicable to looking up local values.
    */
-  static Number get_parametrized_function_node_value(
+  static Number get_parametrized_function_node_local_value(
     const NodeDataMap & pf,
     dof_id_type node_id,
     unsigned int comp);
@@ -241,6 +243,9 @@ public:
 
   /**
    * Same as get_parametrized_function_value() except for node data.
+   * Unlike get_parametrized_function_node_local_value(), this does
+   * parallel communication, and therefore if can be used to look up
+   * values regardless of whether or not \p node_id is local.
    */
   static Number get_parametrized_function_node_value(
     const Parallel::Communicator & comm,
@@ -271,10 +276,12 @@ public:
 
   /**
    * Same as get_eim_basis_function_values_at_qps() except for node data.
+   * Note that this does not do any parallel communication, it just looks
+   * up the value from _local_node_eim_basis_functions.
    */
-  Number get_eim_basis_function_node_value(unsigned int basis_function_index,
-                                           dof_id_type node_id,
-                                           unsigned int var) const;
+  Number get_eim_basis_function_node_local_value(unsigned int basis_function_index,
+                                                 dof_id_type node_id,
+                                                 unsigned int var) const;
 
   /**
    * Same as above, except that we just return the value at the qp^th
@@ -293,6 +300,16 @@ public:
                                           unsigned int side_index,
                                           unsigned int comp,
                                           unsigned int qp) const;
+
+  /**
+   * Same as get_eim_basis_function_value() except for node data.
+   * Note that unlike get_eim_basis_function_node_local_value(),
+   * this does do parallel communication so that it can be called
+   * on any processor regardless of whether \p node_id is local or not.
+   */
+  Number get_eim_basis_function_node_value(unsigned int basis_function_index,
+                                           dof_id_type node_id,
+                                           unsigned int var) const;
 
   /**
    * Get a reference to the i^th basis function.

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -111,9 +111,7 @@ public:
                                     unsigned int comp,
                                     const Point & xyz,
                                     dof_id_type node_id,
-                                    subdomain_id_type subdomain_id,
-                                    boundary_id_type boundary_id,
-                                    const std::vector<Point> & xyz_perturb);
+                                    boundary_id_type boundary_id);
 
   /**
    * Evaluate the parametrized function at the specified point for
@@ -149,9 +147,7 @@ public:
   virtual std::vector<Number> node_evaluate(const RBParameters & mu,
                                             const Point & xyz,
                                             dof_id_type node_id,
-                                            subdomain_id_type subdomain_id,
-                                            boundary_id_type boundary_id,
-                                            const std::vector<Point> & xyz_perturb);
+                                            boundary_id_type boundary_id);
 
   /**
    * Vectorized version of evaluate. If requires_xyz_perturbations==false, then all_xyz_perturb will not be used.
@@ -185,9 +181,7 @@ public:
   virtual void node_vectorized_evaluate(const std::vector<RBParameters> & mus,
                                         const std::vector<Point> & all_xyz,
                                         const std::vector<dof_id_type> & node_ids,
-                                        const std::vector<subdomain_id_type> & sbd_ids,
                                         const std::vector<boundary_id_type> & boundary_ids,
-                                        const std::vector<std::vector<Point>> & all_xyz_perturb,
                                         std::vector<std::vector<std::vector<Number>>> & output);
 
   /**
@@ -217,9 +211,7 @@ public:
    */
   virtual void preevaluate_parametrized_function_on_mesh_nodes(const RBParameters & mu,
                                                                const std::unordered_map<dof_id_type, Point> & all_xyz,
-                                                               const std::unordered_map<dof_id_type, subdomain_id_type> & sbd_ids,
                                                                const std::unordered_map<dof_id_type, boundary_id_type> & node_boundary_ids,
-                                                               const std::unordered_map<dof_id_type, std::vector<Point> > & all_xyz_perturb,
                                                                const System & sys);
 
   /**

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -306,6 +306,7 @@ public:
   virtual void get_spatial_indices(std::vector<std::vector<unsigned int>> & spatial_indices,
                                    const std::vector<dof_id_type> & elem_ids,
                                    const std::vector<unsigned int> & side_indices,
+                                   const std::vector<dof_id_type> & node_ids,
                                    const std::vector<unsigned int> & qps,
                                    const std::vector<subdomain_id_type> & sbd_ids,
                                    const std::vector<boundary_id_type> & boundary_ids);
@@ -318,6 +319,7 @@ public:
   virtual void initialize_spatial_indices(const std::vector<std::vector<unsigned int>> & spatial_indices,
                                           const std::vector<dof_id_type> & elem_ids,
                                           const std::vector<unsigned int> & side_indices,
+                                          const std::vector<dof_id_type> & node_ids,
                                           const std::vector<unsigned int> & qps,
                                           const std::vector<subdomain_id_type> & sbd_ids,
                                           const std::vector<boundary_id_type> & boundary_ids);

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -774,6 +774,20 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
       }
   }
 
+  // Interpolation points node IDs
+  {
+    auto interpolation_points_node_id_list =
+      rb_eim_evaluation_reader.getInterpolationNodeId();
+
+    libmesh_error_msg_if(interpolation_points_node_id_list.size() != n_bfs,
+                         "Size error while reading the eim interpolation node IDs.");
+
+    for (unsigned int i=0; i<n_bfs; ++i)
+      {
+        rb_eim_evaluation.add_interpolation_points_node_id(interpolation_points_node_id_list[i]);
+      }
+  }
+
   // Interpolation points side indices, relevant if the parametrized function is defined on mesh sides
   if (rb_eim_evaluation.get_parametrized_function().on_mesh_sides())
   {

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -774,7 +774,8 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
       }
   }
 
-  // Interpolation points node IDs
+  // Interpolation points node IDs, relevant if the parametrized function is defined on mesh sides
+  if (rb_eim_evaluation.get_parametrized_function().on_mesh_nodes())
   {
     auto interpolation_points_node_id_list =
       rb_eim_evaluation_reader.getInterpolationNodeId();

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -655,7 +655,8 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
                                             rb_eim_evaluation.get_interpolation_points_elem_id(i));
   }
 
-  // Interpolation points node IDs
+  // Interpolation points node IDs, relevant if the parametrized function is defined on mesh sides
+  if (rb_eim_evaluation.get_parametrized_function().on_mesh_nodes())
   {
     auto interpolation_points_node_id_list =
       rb_eim_evaluation_builder.initInterpolationNodeId(n_bfs);

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -655,6 +655,15 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
                                             rb_eim_evaluation.get_interpolation_points_elem_id(i));
   }
 
+  // Interpolation points node IDs
+  {
+    auto interpolation_points_node_id_list =
+      rb_eim_evaluation_builder.initInterpolationNodeId(n_bfs);
+    for (unsigned int i=0; i<n_bfs; ++i)
+      interpolation_points_node_id_list.set(i,
+                                            rb_eim_evaluation.get_interpolation_points_node_id(i));
+  }
+
   // Interpolation points side indices, relevant if the parametrized function is defined on mesh sides
   if (rb_eim_evaluation.get_parametrized_function().on_mesh_sides())
   {

--- a/src/reduced_basis/rb_eim_assembly.C
+++ b/src/reduced_basis/rb_eim_assembly.C
@@ -62,6 +62,13 @@ void RBEIMAssembly::evaluate_side_basis_function(dof_id_type elem_id,
   libmesh_error_msg_if(values.empty(), "Error: EIM basis function has no entries on this element for this processor");
 }
 
+Number RBEIMAssembly::evaluate_node_basis_function(dof_id_type node_id,
+                                                   unsigned int comp)
+{
+  return get_rb_eim_construction().get_rb_eim_evaluation().get_eim_basis_function_node_value(
+    _basis_function_index, node_id, comp);
+}
+
 RBEIMConstruction & RBEIMAssembly::get_rb_eim_construction()
 {
   return _rb_eim_con;

--- a/src/reduced_basis/rb_eim_assembly.C
+++ b/src/reduced_basis/rb_eim_assembly.C
@@ -65,7 +65,7 @@ void RBEIMAssembly::evaluate_side_basis_function(dof_id_type elem_id,
 Number RBEIMAssembly::evaluate_node_basis_function(dof_id_type node_id,
                                                    unsigned int comp)
 {
-  return get_rb_eim_construction().get_rb_eim_evaluation().get_eim_basis_function_node_value(
+  return get_rb_eim_construction().get_rb_eim_evaluation().get_eim_basis_function_node_local_value(
     _basis_function_index, node_id, comp);
 }
 

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -137,6 +137,10 @@ void RBEIMConstruction::clear()
   _local_side_quad_point_boundary_ids.clear();
   _local_side_quad_point_side_types.clear();
 
+  _local_node_parametrized_functions_for_training.clear();
+  _local_node_locations.clear();
+  _local_node_boundary_ids.clear();
+
   _eim_projection_matrix.resize(0,0);
 }
 
@@ -526,6 +530,12 @@ Real RBEIMConstruction::train_eim_approximation_with_POD()
                 _local_side_parametrized_functions_for_training[i],
                 _local_side_parametrized_functions_for_training[j]);
             }
+          else if (rbe.get_parametrized_function().on_mesh_nodes())
+            {
+              inner_prod = node_inner_product(
+                _local_node_parametrized_functions_for_training[i],
+                _local_node_parametrized_functions_for_training[j]);
+            }
           else
             {
               inner_prod = inner_product(
@@ -593,6 +603,21 @@ Real RBEIMConstruction::train_eim_approximation_with_POD()
           scale(v, 1./norm_v);
 
           enrich_eim_approximation_on_sides(v);
+          update_eim_matrices();
+        }
+      else if (rbe.get_parametrized_function().on_mesh_nodes())
+        {
+          // Make a "zero clone" by copying to get the same data layout, and then scaling by zero
+          NodeDataMap v = _local_node_parametrized_functions_for_training[j];
+          scale(v, 0.);
+
+          for ( unsigned int i=0; i<n_snapshots; ++i )
+            add(v, U.el(i, j), _local_node_parametrized_functions_for_training[i] );
+
+          Real norm_v = std::sqrt(sigma(j));
+          scale(v, 1./norm_v);
+
+          enrich_eim_approximation_on_nodes(v);
           update_eim_matrices();
         }
       else
@@ -728,6 +753,27 @@ void RBEIMConstruction::store_eim_solutions_for_training_set()
               eim_solutions[i] = eim_eval.rb_eim_solve(EIM_rhs);
             }
         }
+      else if (eim_eval.get_parametrized_function().on_mesh_nodes())
+        {
+          const auto & local_node_pf = _local_node_parametrized_functions_for_training[i];
+
+          if (RB_size > 0)
+            {
+              // Get the right-hand side vector for the EIM approximation
+              // by sampling the parametrized function (stored in solution)
+              // at the interpolation points.
+              DenseVector<Number> EIM_rhs(RB_size);
+              for (unsigned int j=0; j<RB_size; j++)
+                {
+                  EIM_rhs(j) =
+                    RBEIMEvaluation::get_parametrized_function_node_value(comm(),
+                                                                          local_node_pf,
+                                                                          eim_eval.get_interpolation_points_node_id(j),
+                                                                          eim_eval.get_interpolation_points_comp(j));
+                }
+              eim_solutions[i] = eim_eval.rb_eim_solve(EIM_rhs);
+            }
+        }
       else
         {
           const auto & local_pf = _local_parametrized_functions_for_training[i];
@@ -767,6 +813,13 @@ const RBEIMEvaluation::SideQpDataMap & RBEIMConstruction::get_side_parametrized_
   return _local_side_parametrized_functions_for_training[training_index];
 }
 
+const RBEIMEvaluation::NodeDataMap & RBEIMConstruction::get_node_parametrized_function_from_training_set(unsigned int training_index) const
+{
+  libmesh_error_msg_if(training_index >= _local_node_parametrized_functions_for_training.size(),
+                       "Invalid index: " << training_index);
+  return _local_node_parametrized_functions_for_training[training_index];
+}
+
 const std::unordered_map<dof_id_type, std::vector<Real> > & RBEIMConstruction::get_local_quad_point_JxW()
 {
   return _local_quad_point_JxW;
@@ -780,13 +833,11 @@ const std::map<std::pair<dof_id_type,unsigned int>, std::vector<Real> > & RBEIMC
 unsigned int RBEIMConstruction::get_n_parametrized_functions_for_training() const
 {
   if (get_rb_eim_evaluation().get_parametrized_function().on_mesh_sides())
-  {
     return _local_side_parametrized_functions_for_training.size();
-  }
+  else if (get_rb_eim_evaluation().get_parametrized_function().on_mesh_nodes())
+    return _local_node_parametrized_functions_for_training.size();
   else
-  {
     return _local_parametrized_functions_for_training.size();
-  }
 }
 
 void RBEIMConstruction::reinit_eim_projection_matrix()
@@ -839,6 +890,36 @@ std::pair<Real,unsigned int> RBEIMConstruction::compute_max_eim_error()
               RB_inner_product_matrix_N.lu_solve(best_fit_rhs, best_fit_coeffs);
 
               get_rb_eim_evaluation().side_decrement_vector(solution_copy, best_fit_coeffs);
+              Real best_fit_error = get_max_abs_value(solution_copy);
+
+              if (best_fit_error > max_err)
+                {
+                  max_err_index = training_index;
+                  max_err = best_fit_error;
+                }
+            }
+          else if (get_rb_eim_evaluation().get_parametrized_function().on_mesh_nodes())
+            {
+              // Make a copy of the pre-computed solution for the specified training sample
+              // since we will modify it below to compute the best fit error.
+              NodeDataMap solution_copy = _local_node_parametrized_functions_for_training[training_index];
+
+              // Perform an L2 projection in order to find the best approximation to
+              // the parametrized function from the current EIM space.
+              DenseVector<Number> best_fit_rhs(RB_size);
+              for (unsigned int i=0; i<RB_size; i++)
+                {
+                  best_fit_rhs(i) = node_inner_product(solution_copy, get_rb_eim_evaluation().get_node_basis_function(i));
+                }
+
+              // Now compute the best fit by an LU solve
+              DenseMatrix<Number> RB_inner_product_matrix_N(RB_size);
+              _eim_projection_matrix.get_principal_submatrix(RB_size, RB_inner_product_matrix_N);
+
+              DenseVector<Number> best_fit_coeffs;
+              RB_inner_product_matrix_N.lu_solve(best_fit_rhs, best_fit_coeffs);
+
+              get_rb_eim_evaluation().node_decrement_vector(solution_copy, best_fit_coeffs);
               Real best_fit_error = get_max_abs_value(solution_copy);
 
               if (best_fit_error > max_err)
@@ -901,6 +982,18 @@ std::pair<Real,unsigned int> RBEIMConstruction::compute_max_eim_error()
             {
               SideQpDataMap solution_copy = _local_side_parametrized_functions_for_training[training_index];
               get_rb_eim_evaluation().side_decrement_vector(solution_copy, best_fit_coeffs);
+              Real best_fit_error = get_max_abs_value(solution_copy);
+
+              if (best_fit_error > max_err)
+                {
+                  max_err_index = training_index;
+                  max_err = best_fit_error;
+                }
+            }
+          else if (get_rb_eim_evaluation().get_parametrized_function().on_mesh_nodes())
+            {
+              NodeDataMap solution_copy = _local_node_parametrized_functions_for_training[training_index];
+              get_rb_eim_evaluation().node_decrement_vector(solution_copy, best_fit_coeffs);
               Real best_fit_error = get_max_abs_value(solution_copy);
 
               if (best_fit_error > max_err)
@@ -1009,6 +1102,72 @@ void RBEIMConstruction::initialize_parametrized_functions_in_training_set()
               }
 
             _local_side_parametrized_functions_for_training[i][elem_side_pair] = comps_and_qps;
+          }
+        }
+
+      libMesh::out << "Parametrized functions in training set initialized" << std::endl;
+
+      unsigned int max_id = 0;
+      comm().maxloc(_max_abs_value_in_training_set, max_id);
+      comm().broadcast(_max_abs_value_in_training_set_index, max_id);
+      libMesh::out << "Maximum absolute value in the training set: "
+        << _max_abs_value_in_training_set << std::endl << std::endl;
+
+      // Calculate the maximum value for each component in the training set
+      // across all components
+      comm().max(max_abs_value_per_component_in_training_set);
+
+      // We store the maximum value across all components divided by the maximum value for this component
+      // so that when we scale using these factors all components should have a magnitude on the same
+      // order as the maximum component.
+      _component_scaling_in_training_set.resize(n_comps);
+      for(unsigned int i : make_range(n_comps))
+        {
+          if (max_abs_value_per_component_in_training_set[i] == 0.)
+            _component_scaling_in_training_set[i] = 1.;
+          else
+            _component_scaling_in_training_set[i] = _max_abs_value_in_training_set / max_abs_value_per_component_in_training_set[i];
+        }
+    }
+  else if (eim_eval.get_parametrized_function().on_mesh_nodes())
+    {
+      _local_node_parametrized_functions_for_training.resize( get_n_training_samples() );
+      for (auto i : make_range(get_n_training_samples()))
+        {
+          libMesh::out << "Initializing parametrized function for training sample "
+            << (i+1) << " of " << get_n_training_samples() << std::endl;
+
+          set_params_from_training_set(i);
+
+          eim_eval.get_parametrized_function().preevaluate_parametrized_function_on_mesh_nodes(get_parameters(),
+                                                                                               _local_node_locations,
+                                                                                               _local_node_boundary_ids,
+                                                                                               *this);
+
+          for (const auto & pr : _local_node_locations)
+          {
+            const auto & node_id = pr.first;
+
+            std::vector<Number> comps(n_comps);
+            for (unsigned int comp=0; comp<n_comps; comp++)
+              {
+                Number value =
+                  eim_eval.get_parametrized_function().lookup_preevaluated_node_value_on_mesh(comp,
+                                                                                              node_id);
+                comps[comp] = value;
+
+                Real abs_value = std::abs(value);
+                if (abs_value > _max_abs_value_in_training_set)
+                  {
+                    _max_abs_value_in_training_set = abs_value;
+                    _max_abs_value_in_training_set_index = i;
+                  }
+
+                if (abs_value > max_abs_value_per_component_in_training_set[comp])
+                  max_abs_value_per_component_in_training_set[comp] = abs_value;
+              }
+
+            _local_node_parametrized_functions_for_training[i][node_id] = comps;
           }
         }
 
@@ -1384,6 +1543,55 @@ void RBEIMConstruction::initialize_qp_data()
                 }
         }
     }
+  else if (get_rb_eim_evaluation().get_parametrized_function().on_mesh_nodes())
+    {
+      const std::set<boundary_id_type> & parametrized_function_boundary_ids =
+        get_rb_eim_evaluation().get_parametrized_function().get_parametrized_function_boundary_ids();
+      libmesh_error_msg_if (parametrized_function_boundary_ids.empty(),
+                            "Need to have non-empty boundary IDs to initialize node data");
+
+      _local_node_locations.clear();
+      _local_node_boundary_ids.clear();
+
+      const auto & binfo = mesh.get_boundary_info();
+
+      // Make a set with all the nodes that have nodesets. Use
+      // a set so that we don't have any duplicate entries. We
+      // deal with duplicate entries below by getting all boundary
+      // IDs on each node.
+      std::set<dof_id_type> nodes_with_nodesets;
+      for (const auto & t : binfo.build_node_list())
+        nodes_with_nodesets.insert(std::get<0>(t));
+
+      // To be filled in by BoundaryInfo calls in loop below
+      std::vector<boundary_id_type> node_boundary_ids;
+
+      for(dof_id_type node_id : nodes_with_nodesets)
+        {
+          const Node * node = mesh.node_ptr(node_id);
+
+          if (node->processor_id() != mesh.comm().rank())
+            continue;
+
+          binfo.boundary_ids(node, node_boundary_ids);
+
+          bool has_node_boundary_id = false;
+          boundary_id_type matching_boundary_id = BoundaryInfo::invalid_id;
+          for(boundary_id_type node_boundary_id : node_boundary_ids)
+            if(parametrized_function_boundary_ids.count(node_boundary_id))
+              {
+                has_node_boundary_id = true;
+                matching_boundary_id = node_boundary_id;
+                break;
+              }
+
+          if(has_node_boundary_id)
+            {
+              _local_node_locations[node_id] = *node;
+              _local_node_boundary_ids[node_id] = matching_boundary_id;
+            }
+        }
+    }
   else
     {
       _local_quad_point_locations.clear();
@@ -1584,6 +1792,29 @@ RBEIMConstruction::side_inner_product(const SideQpDataMap & v, const SideQpDataM
   return val;
 }
 
+Number
+RBEIMConstruction::node_inner_product(const NodeDataMap & v, const NodeDataMap & w)
+{
+  LOG_SCOPE("node_inner_product()", "RBEIMConstruction");
+
+  Number val = 0.;
+
+  for (const auto & [node_id, v_comps] : v)
+    {
+      const auto & w_comps = libmesh_map_find(w, node_id);
+
+      for (const auto & comp : index_range(v_comps))
+        {
+          // There is no quadrature rule on nodes, so we just multiply the values directly.
+          // Hence we effectively work with the Euclidean inner product in this case.
+          val += v_comps[comp] * libmesh_conj(w_comps[comp]);
+        }
+    }
+
+  comm().sum(val);
+  return val;
+}
+
 void RBEIMConstruction::enrich_eim_approximation(unsigned int training_index)
 {
   LOG_SCOPE("enrich_eim_approximation()", "RBEIMConstruction");
@@ -1594,6 +1825,8 @@ void RBEIMConstruction::enrich_eim_approximation(unsigned int training_index)
 
   if (eim_eval.get_parametrized_function().on_mesh_sides())
     enrich_eim_approximation_on_sides(_local_side_parametrized_functions_for_training[training_index]);
+  else if (eim_eval.get_parametrized_function().on_mesh_nodes())
+    enrich_eim_approximation_on_nodes(_local_node_parametrized_functions_for_training[training_index]);
   else
     {
       bool has_obs_vals = (eim_eval.get_n_observation_points() > 0);
@@ -1777,6 +2010,100 @@ void RBEIMConstruction::enrich_eim_approximation_on_sides(const SideQpDataMap & 
                                                           optimal_qp,
                                                           optimal_point_perturbs,
                                                           optimal_point_phi_i_qp);
+}
+
+void RBEIMConstruction::enrich_eim_approximation_on_nodes(const NodeDataMap & node_pf)
+{
+  // Make a copy of the input parametrized function, since we will modify this below
+  // to give us a new basis function.
+  NodeDataMap local_pf = node_pf;
+
+  RBEIMEvaluation & eim_eval = get_rb_eim_evaluation();
+
+  // If we have at least one basis function, then we need to use
+  // rb_eim_solve() to find the EIM interpolation error. Otherwise,
+  // just use solution as is.
+  if (eim_eval.get_n_basis_functions() > 0)
+    {
+      // Get the right-hand side vector for the EIM approximation
+      // by sampling the parametrized function (stored in solution)
+      // at the interpolation points.
+      unsigned int RB_size = eim_eval.get_n_basis_functions();
+      DenseVector<Number> EIM_rhs(RB_size);
+      for (unsigned int i=0; i<RB_size; i++)
+        {
+          EIM_rhs(i) =
+            RBEIMEvaluation::get_parametrized_function_node_value(comm(),
+                                                                  local_pf,
+                                                                  eim_eval.get_interpolation_points_node_id(i),
+                                                                  eim_eval.get_interpolation_points_comp(i));
+        }
+
+      eim_eval.set_parameters( get_parameters() );
+      DenseVector<Number> rb_eim_solution = eim_eval.rb_eim_solve(EIM_rhs);
+
+      // Load the "EIM residual" into solution by subtracting
+      // the EIM approximation
+      eim_eval.node_decrement_vector(local_pf, rb_eim_solution);
+    }
+
+  // Find the quadrature point at which local_pf (which now stores
+  // the "EIM residual") has maximum absolute value
+  Number optimal_value = 0.;
+  Point optimal_point;
+  unsigned int optimal_comp = 0;
+  dof_id_type optimal_node_id = DofObject::invalid_id;
+  boundary_id_type optimal_boundary_id = 0;
+
+  // Initialize largest_abs_value to be negative so that it definitely gets updated.
+  Real largest_abs_value = -1.;
+
+  for (const auto & [node_id, values] : local_pf)
+    {
+      for (unsigned int comp : index_range(values))
+        {
+          Number value = values[comp];
+          Real abs_value = std::abs(value);
+
+          if (abs_value > largest_abs_value)
+            {
+              largest_abs_value = abs_value;
+              optimal_value = value;
+              optimal_comp = comp;
+              optimal_node_id = node_id;
+
+              optimal_point = libmesh_map_find(_local_node_locations, node_id);
+
+              optimal_boundary_id = libmesh_map_find(_local_node_boundary_ids, node_id);
+            }
+        }
+    }
+
+  // Find out which processor has the largest of the abs values
+  // and broadcast from that processor.
+  unsigned int proc_ID_index;
+  this->comm().maxloc(largest_abs_value, proc_ID_index);
+
+  this->comm().broadcast(optimal_value, proc_ID_index);
+  this->comm().broadcast(optimal_point, proc_ID_index);
+  this->comm().broadcast(optimal_comp, proc_ID_index);
+  this->comm().broadcast(optimal_node_id, proc_ID_index);
+  this->comm().broadcast(optimal_boundary_id, proc_ID_index);
+
+  libmesh_error_msg_if(optimal_node_id == DofObject::invalid_id, "Error: Invalid node ID");
+
+  libmesh_error_msg_if(optimal_value == 0., "New EIM basis function should not be zero");
+
+  // Scale local_pf so that its largest value is 1.0
+  scale_parametrized_function(local_pf, 1./optimal_value);
+
+  // Add local_pf as the new basis function and store data
+  // associated with the interpolation point.
+  eim_eval.add_node_basis_function_and_interpolation_data(local_pf,
+                                                          optimal_point,
+                                                          optimal_comp,
+                                                          optimal_node_id,
+                                                          optimal_boundary_id);
 }
 
 void RBEIMConstruction::enrich_eim_approximation_on_interiors(const QpDataMap & interior_pf,
@@ -1993,6 +2320,38 @@ void RBEIMConstruction::update_eim_matrices()
                                                        eim_eval.get_interpolation_points_side_index(RB_size-1),
                                                        eim_eval.get_interpolation_points_comp(RB_size-1),
                                                        eim_eval.get_interpolation_points_qp(RB_size-1));
+          eim_eval.set_interpolation_matrix_entry(RB_size-1, j, value);
+        }
+    }
+  else if (eim_eval.get_parametrized_function().on_mesh_nodes())
+    {
+      // update the matrix that is used to evaluate L2 projections
+      // into the EIM approximation space
+      for (unsigned int i=(RB_size-1); i<RB_size; i++)
+        {
+          for (unsigned int j=0; j<RB_size; j++)
+            {
+              Number value = node_inner_product(eim_eval.get_node_basis_function(j),
+                                                eim_eval.get_node_basis_function(i));
+
+              _eim_projection_matrix(i,j) = value;
+              if (i!=j)
+                {
+                  // The inner product matrix is assumed to be hermitian
+                  _eim_projection_matrix(j,i) = libmesh_conj(value);
+                }
+            }
+        }
+
+      // update the EIM interpolation matrix
+      for (unsigned int j=0; j<RB_size; j++)
+        {
+          // Evaluate the basis functions at the new interpolation point in order
+          // to update the interpolation matrix
+          Number value =
+            eim_eval.get_eim_basis_function_node_value(j,
+                                                       eim_eval.get_interpolation_points_node_id(RB_size-1),
+                                                       eim_eval.get_interpolation_points_comp(RB_size-1));
           eim_eval.set_interpolation_matrix_entry(RB_size-1, j, value);
         }
     }

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -885,6 +885,17 @@ void RBEIMEvaluation::add_node_basis_function_and_interpolation_data(
   _interpolation_points_comp.emplace_back(comp);
   _interpolation_points_node_id.emplace_back(node_id);
   _interpolation_points_boundary_id.emplace_back(boundary_id);
+
+  // Add dummy values for the other properties, which are unused in the
+  // node case.
+  std::vector<Point> empty_perturbs;
+  std::vector<Real> empty_phi_i_qp;
+  _interpolation_points_elem_id.emplace_back(0);
+  _interpolation_points_side_index.emplace_back(0);
+  _interpolation_points_subdomain_id.emplace_back(0);
+  _interpolation_points_qp.emplace_back(0);
+  _interpolation_points_xyz_perturbations.emplace_back(empty_perturbs);
+  _interpolation_points_phi_i_qp.emplace_back(empty_phi_i_qp);
 }
 
 void RBEIMEvaluation::

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -1215,9 +1215,10 @@ write_out_node_basis_functions(const std::string & directory_name,
       for (auto bf : index_range(_local_node_eim_basis_functions))
         {
           unsigned int node_counter = 0;
-          for (const auto & [node_id, array] : _local_node_eim_basis_functions[bf])
+          for (const auto & pr : _local_node_eim_basis_functions[bf])
             {
               // array[n_vars] per Node
+              const auto & array = pr.second;
               for (auto var : index_range(array))
                 {
                   // Based on the error check above, we know that node_id is numbered
@@ -2623,21 +2624,12 @@ void RBEIMEvaluation::node_distribute_bfs(const System & sys)
     {
       counts.resize(n_procs);
 
-      auto & bf_map = _local_node_eim_basis_functions[0];
-
       for (processor_id_type p=0; p<n_procs; ++p)
         {
-          for (auto n : make_range(start_node_ids_index[p], end_node_ids_index[p]))
-            {
-              auto node_id = gathered_local_node_ids[n];
+          auto node_ids_range = (end_node_ids_index[p] - start_node_ids_index[p]);
 
-              // Get reference to array[n_vars] for current Node.
-              // Throws an error if the required elem_id is not found.
-              const auto & array = libmesh_map_find(bf_map, node_id);
-
-              // Accumulate the count for this proc
-              counts[p] += n_vars;
-            } // end for (e)
+          // Accumulate the count for this proc
+          counts[p] += node_ids_range*n_vars;
         } // end for proc_id
     } // if (rank == 0)
 

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -537,6 +537,7 @@ Number RBEIMEvaluation::get_eim_basis_function_node_value(unsigned int basis_fun
                        "Invalid basis function index: " << basis_function_index);
 
   return get_parametrized_function_node_value(
+    comm(),
     _local_node_eim_basis_functions[basis_function_index],
     node_id,
     comp);

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -1526,10 +1526,10 @@ read_in_node_basis_functions(const System & sys,
               // parameter of data_stream() is ignored while reading.
               xdr.data_stream(node_value.data(), node_value.size());
 
-              for (auto node_id : node_ids)
+              for (unsigned int node_counter=0; node_counter<n_node; node_counter++)
                 {
-                  auto & array = bf_map[node_id];
-                  array[var] = node_value[node_id];
+                  auto & array = bf_map[node_ids[node_counter]];
+                  array[var] = node_value[node_counter];
                 }
             } // end for (var)
         } // end for (i)

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -1177,12 +1177,13 @@ write_out_node_basis_functions(const std::string & directory_name,
       // We assume that the list of nodes for each basis function
       // is the same as basis function 0.
       dof_id_type expected_node_id = 0;
-      for (const auto & [actual_node_id, array] : _local_node_eim_basis_functions[0])
+      for (const auto & pr : _local_node_eim_basis_functions[0])
         {
           // Note: Currently we require that the Nodes are numbered
           // contiguously from [0..n_nodes).  This allows us to avoid
           // writing the Node ids to the Xdr file, but if we need to
           // generalize this assumption later, we can.
+          auto actual_node_id = pr.first;
           libmesh_error_msg_if(actual_node_id != expected_node_id++,
                                "RBEIMEvaluation currently assumes a contiguous Node numbering starting from 0.");
         }
@@ -2545,12 +2546,10 @@ void RBEIMEvaluation::node_distribute_bfs(const System & sys)
         binfo.boundary_ids(node, node_boundary_ids);
 
         bool has_node_boundary_id = false;
-        boundary_id_type matching_boundary_id = BoundaryInfo::invalid_id;
         for(boundary_id_type node_boundary_id : node_boundary_ids)
           if(parametrized_function_boundary_ids.count(node_boundary_id))
             {
               has_node_boundary_id = true;
-              matching_boundary_id = node_boundary_id;
               break;
             }
 

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -2635,8 +2635,6 @@ void RBEIMEvaluation::node_distribute_bfs(const System & sys)
               // Throws an error if the required elem_id is not found.
               const auto & array = libmesh_map_find(bf_map, node_id);
 
-              auto n_vars = array.size();
-
               // Accumulate the count for this proc
               counts[p] += n_vars;
             } // end for (e)

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -418,12 +418,12 @@ void RBEIMEvaluation::get_parametrized_function_side_values_at_qps(
   }
 }
 
-Number RBEIMEvaluation::get_parametrized_function_node_value(
+Number RBEIMEvaluation::get_parametrized_function_node_local_value(
   const NodeDataMap & pf,
   dof_id_type node_id,
   unsigned int comp)
 {
-  LOG_SCOPE("get_parametrized_function_node_value()", "RBEIMConstruction");
+  LOG_SCOPE("get_parametrized_function_node_local_value()", "RBEIMConstruction");
 
   auto it = pf.find(node_id);
   if (it != pf.end())
@@ -491,7 +491,7 @@ Number RBEIMEvaluation::get_parametrized_function_node_value(
 {
   LOG_SCOPE("get_parametrized_function_node_value()", "RBEIMConstruction");
 
-  Number value = get_parametrized_function_node_value(pf, node_id, comp);
+  Number value = get_parametrized_function_node_local_value(pf, node_id, comp);
   comm.sum(value);
 
   return value;
@@ -527,6 +527,19 @@ void RBEIMEvaluation::get_eim_basis_function_side_values_at_qps(unsigned int bas
     side_index,
     comp,
     values);
+}
+
+Number RBEIMEvaluation::get_eim_basis_function_node_local_value(unsigned int basis_function_index,
+                                                                dof_id_type node_id,
+                                                                unsigned int comp) const
+{
+  libmesh_error_msg_if(basis_function_index >= _local_node_eim_basis_functions.size(),
+                       "Invalid basis function index: " << basis_function_index);
+
+  return get_parametrized_function_node_local_value(
+    _local_node_eim_basis_functions[basis_function_index],
+    node_id,
+    comp);
 }
 
 Number RBEIMEvaluation::get_eim_basis_function_node_value(unsigned int basis_function_index,

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -244,6 +244,7 @@ void RBEIMEvaluation::initialize_interpolation_points_spatial_indices()
   get_parametrized_function().get_spatial_indices(_interpolation_points_spatial_indices,
                                                   _interpolation_points_elem_id,
                                                   _interpolation_points_side_index,
+                                                  _interpolation_points_node_id,
                                                   _interpolation_points_qp,
                                                   _interpolation_points_subdomain_id,
                                                   _interpolation_points_boundary_id);
@@ -254,6 +255,7 @@ void RBEIMEvaluation::initialize_param_fn_spatial_indices()
   get_parametrized_function().initialize_spatial_indices(_interpolation_points_spatial_indices,
                                                          _interpolation_points_elem_id,
                                                          _interpolation_points_side_index,
+                                                         _interpolation_points_node_id,
                                                          _interpolation_points_qp,
                                                          _interpolation_points_subdomain_id,
                                                          _interpolation_points_boundary_id);

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -1526,10 +1526,8 @@ read_in_node_basis_functions(const System & sys,
               // parameter of data_stream() is ignored while reading.
               xdr.data_stream(node_value.data(), node_value.size());
 
-              for (std::size_t node_id=0; node_id<n_node; ++node_id)
+              for (auto node_id : node_ids)
                 {
-                  // Get reference to the [n_vars] array for this Node. We assign() into the vector of
-                  // values, which allocates space if it doesn't already exist.
                   auto & array = bf_map[node_id];
                   array[var] = node_value[node_id];
                 }

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -906,6 +906,8 @@ write_out_basis_functions(const std::string & directory_name,
 
   if (get_parametrized_function().on_mesh_sides())
     write_out_side_basis_functions(directory_name, write_binary_basis_functions);
+  else if (get_parametrized_function().on_mesh_nodes())
+    write_out_node_basis_functions(directory_name, write_binary_basis_functions);
   else
     write_out_interior_basis_functions(directory_name, write_binary_basis_functions);
 }

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -265,6 +265,8 @@ unsigned int RBEIMEvaluation::get_n_basis_functions() const
 {
   if (get_parametrized_function().on_mesh_sides())
     return _local_side_eim_basis_functions.size();
+  else if (get_parametrized_function().on_mesh_nodes())
+    return _local_node_eim_basis_functions.size();
   else
     return _local_eim_basis_functions.size();
 }
@@ -273,6 +275,8 @@ void RBEIMEvaluation::set_n_basis_functions(unsigned int n_bfs)
 {
   if (get_parametrized_function().on_mesh_sides())
     _local_side_eim_basis_functions.resize(n_bfs);
+  else if (get_parametrized_function().on_mesh_nodes())
+    _local_node_eim_basis_functions.resize(n_bfs);
   else
     _local_eim_basis_functions.resize(n_bfs);
 }

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -1124,6 +1124,102 @@ write_out_side_basis_functions(const std::string & directory_name,
 }
 
 void RBEIMEvaluation::
+write_out_node_basis_functions(const std::string & directory_name,
+                               bool write_binary_basis_functions)
+{
+  LOG_SCOPE("write_out_node_basis_functions()", "RBEIMEvaluation");
+
+  // Quick return if there is no work to do. Note: make sure all procs
+  // agree there is no work to do.
+  bool is_empty = _local_node_eim_basis_functions.empty();
+  this->comm().verify(is_empty);
+
+  if (is_empty)
+    return;
+
+  // Gather basis function data from other procs, storing it in
+  // _local_eim_basis_functions, so that we can then print everything
+  // from processor 0.
+  this->node_gather_bfs();
+
+  // Write values from processor 0 only.
+  if (this->processor_id() == 0)
+    {
+      // Make a directory to store all the data files
+      Utility::mkdir(directory_name.c_str());
+
+      // Create filename
+      std::ostringstream file_name;
+      const std::string basis_function_suffix = (write_binary_basis_functions ? ".xdr" : ".dat");
+      file_name << directory_name << "/" << "bf_data" << basis_function_suffix;
+
+      // Create XDR writer object
+      Xdr xdr(file_name.str(), write_binary_basis_functions ? ENCODE : WRITE);
+
+      // Write number of basis functions to file. Note: the
+      // Xdr::data() function takes non-const references, so you can't
+      // pass e.g. vec.size() to that interface.
+      auto n_bf = _local_node_eim_basis_functions.size();
+      xdr.data(n_bf, "# Number of basis functions");
+
+      // We assume that each basis function has data for the same
+      // number of elements as basis function 0, which is equal to the
+      // size of the map.
+      auto n_elem = _local_node_eim_basis_functions[0].size();
+      xdr.data(n_elem, "# Number of nodes");
+
+      // We assume that each element has the same number of variables,
+      // and we get the number of vars from the first element of the
+      // first basis function.
+      auto n_vars = _local_eim_basis_functions[0].begin()->second.size();
+      xdr.data(n_vars, "# Number of variables");
+
+      // We assume that the list of nodes for each basis function
+      // is the same as basis function 0.
+      dof_id_type expected_node_id = 0;
+      for (const auto & [actual_node_id, array] : _local_node_eim_basis_functions[0])
+        {
+          // Note: Currently we require that the Nodes are numbered
+          // contiguously from [0..n_nodes).  This allows us to avoid
+          // writing the Node ids to the Xdr file, but if we need to
+          // generalize this assumption later, we can.
+          libmesh_error_msg_if(actual_node_id != expected_node_id++,
+                               "RBEIMEvaluation currently assumes a contiguous Node numbering starting from 0.");
+        }
+
+      // Now we construct a vector for each basis function, for each
+      // variable which is ordered according to:
+      // [ [val for Node 0], [val for Node 1], ... [val for Node N] ]
+      // and write it to file.
+
+      // After the loop above expected_node_id holds the total number of nodes,
+      // so we resize the vectors to this size.
+      std::vector<std::vector<Number>> var_data(n_vars);
+      for (unsigned int var=0; var<n_vars; var++)
+        var_data[var].resize(expected_node_id);
+
+      for (auto bf : index_range(_local_node_eim_basis_functions))
+        {
+          for (const auto & [node_id, array] : _local_node_eim_basis_functions[bf])
+            {
+              // array[n_vars] per Node
+              for (auto var : index_range(array))
+                {
+                  // Based on the error check above, we know that node_id is numbered
+                  // contiguously from [0..nodes], so we can use it as the vector
+                  // index here.
+                  var_data[var][node_id] = array[var];
+                }
+            }
+
+          // Write all the var values for this bf
+          for (auto var : index_range(var_data))
+            xdr.data_stream(var_data[var].data(), var_data[var].size(), /*line_break=*/var_data[var].size());
+        }
+    }
+}
+
+void RBEIMEvaluation::
 read_in_basis_functions(const System & sys,
                         const std::string & directory_name,
                         bool read_binary_basis_functions)
@@ -1132,6 +1228,8 @@ read_in_basis_functions(const System & sys,
 
   if (get_parametrized_function().on_mesh_sides())
     read_in_side_basis_functions(sys, directory_name, read_binary_basis_functions);
+  else if (get_parametrized_function().on_mesh_nodes())
+    read_in_node_basis_functions(sys, directory_name, read_binary_basis_functions);
   else
     read_in_interior_basis_functions(sys, directory_name, read_binary_basis_functions);
 }
@@ -1341,6 +1439,86 @@ read_in_side_basis_functions(const System & sys,
 
   // Distribute the basis function information to the processors that require it
   this->side_distribute_bfs(sys);
+}
+
+void RBEIMEvaluation::
+read_in_node_basis_functions(const System & sys,
+                             const std::string & directory_name,
+                             bool read_binary_basis_functions)
+{
+  LOG_SCOPE("read_in_node_basis_functions()", "RBEIMEvaluation");
+
+  // Read values on processor 0 only.
+  if (sys.comm().rank() == 0)
+    {
+      // Create filename
+      std::ostringstream file_name;
+      const std::string basis_function_suffix = (read_binary_basis_functions ? ".xdr" : ".dat");
+      file_name << directory_name << "/" << "bf_data" << basis_function_suffix;
+
+      // Create XDR reader object
+      Xdr xdr(file_name.str(), read_binary_basis_functions ? DECODE : READ);
+
+      // Read in the number of basis functions. The comment parameter
+      // is ignored when reading.
+      std::size_t n_bf;
+      xdr.data(n_bf);
+
+      // Read in the number of nodes
+      std::size_t n_node;
+      xdr.data(n_node);
+
+      // Read in the number of variables.
+      std::size_t n_vars;
+      xdr.data(n_vars);
+
+      // Allocate space to store all required basis functions,
+      // clearing any data that may have been there previously.
+      //
+      // TODO: Do we need to also write out/read in Node ids?
+      // Or can we assume they will always be contiguously
+      // numbered (at least on proc 0)?
+      _local_node_eim_basis_functions.clear();
+      _local_node_eim_basis_functions.resize(n_bf);
+      for (auto i : index_range(_local_node_eim_basis_functions))
+        for (std::size_t node_id=0; node_id<n_node; ++node_id)
+          {
+            auto & array = _local_node_eim_basis_functions[i][node_id];
+            array.resize(n_vars);
+          }
+
+      // Read data into node_value from xdr
+      std::vector<Number> node_value;
+
+      // Read in data for each basis function
+      for (auto i : index_range(_local_node_eim_basis_functions))
+        {
+          // Reference to the data map for the current basis function.
+          auto & bf_map = _local_node_eim_basis_functions[i];
+
+          for (std::size_t var=0; var<n_vars; ++var)
+            {
+              node_value.clear();
+              node_value.resize(n_node);
+
+              // Read data using data_stream() since that is
+              // (currently) how we write it out. The "line_break"
+              // parameter of data_stream() is ignored while reading.
+              xdr.data_stream(node_value.data(), node_value.size());
+
+              for (std::size_t node_id=0; node_id<n_node; ++node_id)
+                {
+                  // Get reference to the [n_vars] array for this Node. We assign() into the vector of
+                  // values, which allocates space if it doesn't already exist.
+                  auto & array = bf_map[node_id];
+                  array[var] = node_value[node_id];
+                }
+            } // end for (var)
+        } // end for (i)
+    } // end if processor 0
+
+  // Distribute the basis function information to the processors that require it
+  this->node_distribute_bfs(sys);
 }
 
 void RBEIMEvaluation::print_local_eim_basis_functions() const
@@ -1684,6 +1862,127 @@ void RBEIMEvaluation::side_gather_bfs()
 
                   array[var].assign(cursor, cursor + n_qp_this_elem_side);
                   std::advance(cursor, n_qp_this_elem_side);
+                }
+            }
+        }
+    } // end loop over basis functions
+}
+
+void RBEIMEvaluation::node_gather_bfs()
+{
+  // We need to gather _local_node_eim_basis_functions data from other
+  // procs for printing.
+  //
+  // Ideally, this could be accomplished by simply calling:
+  // this->comm().gather(/*root_id=*/0, _local_node_eim_basis_functions);
+  //
+  // but the data structure seems to be too complicated for this to
+  // work automatically. (I get some error about the function called
+  // being "private within this context".) Therefore, we have to
+  // gather the information manually.
+
+  // So we can avoid calling this many times below
+  auto n_procs = this->n_processors();
+
+  // In serial there's nothing to gather
+  if (n_procs == 1)
+    return;
+
+  // Current assumption is that the number of basis functions stored on
+  // each processor is the same, the only thing that differs is the number
+  // of elements, so make sure that is the case now.
+  auto n_bf = _local_node_eim_basis_functions.size();
+  this->comm().verify(n_bf);
+
+  // This function should never be called if there are no basis
+  // functions, so if it was, something went wrong.
+  libmesh_error_msg_if(!n_bf, "RBEIMEvaluation::gather_bfs() should not be called with 0 basis functions.");
+
+  // The number of variables should be the same on all processors
+  // and we can get this from _local_eim_basis_functions. However,
+  // it may be that some processors have no local elements, so on
+  // those processors we cannot look up the size from
+  // _local_eim_basis_functions. As a result we use comm().max(n_vars)
+  // to make sure all processors agree on the final value.
+  std::size_t n_vars =
+    _local_node_eim_basis_functions[0].empty() ? 0 : _local_node_eim_basis_functions[0].begin()->second.size();
+  this->comm().max(n_vars);
+
+  // Gather list of Node ids stored on each processor to proc 0.  We
+  // use basis function 0 as an example and assume all the basis
+  // functions are distributed similarly.
+  unsigned int n_local_nodes = _local_node_eim_basis_functions[0].size();
+  std::vector<dof_id_type> node_ids;
+  node_ids.reserve(n_local_nodes);
+  for (const auto & pr : _local_node_eim_basis_functions[0])
+    node_ids.push_back(pr.first);
+  this->comm().gather(/*root_id=*/0, node_ids);
+
+  // Now we construct a vector for each basis function, for each
+  // variable, which is ordered according to:
+  // [ [val for Node 0], [val for Node 1], ... [val for Node N] ]
+  // and gather it to processor 0.
+  std::vector<std::vector<Number>> gathered_node_data(n_vars);
+  for (auto bf : index_range(_local_node_eim_basis_functions))
+    {
+      // Clear any data from previous bf
+      for (auto var : index_range(gathered_node_data))
+        {
+          gathered_node_data[var].clear();
+          gathered_node_data[var].resize(n_local_nodes);
+        }
+
+      unsigned int local_node_idx = 0;
+      for (const auto & pr : _local_node_eim_basis_functions[bf])
+        {
+          // array[n_vars] per Node
+          const auto & array = pr.second;
+          for (auto var : index_range(array))
+            {
+              gathered_node_data[var][local_node_idx] = array[var];
+            }
+
+          local_node_idx++;
+        }
+
+      // Reference to the data map for the current basis function.
+      auto & bf_map = _local_node_eim_basis_functions[bf];
+
+      for (auto var : index_range(gathered_node_data))
+        {
+          // For each var, gather gathered_qp_data[var] onto processor
+          // 0. There apparently is not a gather overload for
+          // vector-of-vectors...
+          this->comm().gather(/*root_id=*/0, gathered_node_data[var]);
+
+          // On processor 0, iterate over the gathered_qp_data[var]
+          // vector we just gathered, filling in the "small" vectors
+          // for each Elem. Note: here we ignore the fact that we
+          // already have the data on processor 0 and just overwrite
+          // it, this makes the indexing logic a bit simpler.
+          if (this->processor_id() == 0)
+            {
+              auto cursor = gathered_node_data[var].begin();
+              for (auto i : index_range(node_ids))
+                {
+                  auto node_id = node_ids[i];
+
+                  // Get reference to the [n_vars] array for
+                  // this Node. We assign() into the vector of
+                  // node values, which allocates space if
+                  // it doesn't already exist.
+                  auto & array = bf_map[node_id];
+
+                  // Possibly allocate space if this is data for a new
+                  // node we haven't seen before.
+                  if (array.empty())
+                    array.resize(n_vars);
+
+                  // There is only one value per variable per node, so
+                  // we set the value by de-referencing cursor, and
+                  // then advance the cursor by 1.
+                  array[var] = *cursor;
+                  std::advance(cursor, 1);
                 }
             }
         }
@@ -2186,6 +2485,249 @@ void RBEIMEvaluation::side_distribute_bfs(const System & sys)
               for (auto & bf_map : _local_side_eim_basis_functions)
                 bf_map.erase(std::make_pair(elem_id, side_index));
             } // end for (e)
+        } // end for proc_id
+    } // if (rank == 0)
+}
+
+void RBEIMEvaluation::node_distribute_bfs(const System & sys)
+{
+  // So we can avoid calling these many times below
+  auto n_procs = sys.comm().size();
+  auto rank = sys.comm().rank();
+
+  // In serial there's nothing to distribute
+  if (n_procs == 1)
+    return;
+
+  // Broadcast the number of basis functions from proc 0. After
+  // distributing, all procs should have the same number of basis
+  // functions.
+  auto n_bf = _local_node_eim_basis_functions.size();
+  sys.comm().broadcast(n_bf);
+
+  // Allocate enough space to store n_bf basis functions on non-zero ranks
+  if (rank != 0)
+    _local_node_eim_basis_functions.resize(n_bf);
+
+  // Broadcast the number of variables from proc 0. After
+  // distributing, all procs should have the same number of variables.
+  auto n_vars = _local_node_eim_basis_functions[0].begin()->second.size();
+  sys.comm().broadcast(n_vars);
+
+  // Construct lists of elem ids owned by different processors
+  const MeshBase & mesh = sys.get_mesh();
+
+  std::vector<dof_id_type> gathered_local_node_ids;
+  {
+    const std::set<boundary_id_type> & parametrized_function_boundary_ids =
+      get_parametrized_function().get_parametrized_function_boundary_ids();
+
+    const auto & binfo = mesh.get_boundary_info();
+
+    // Make a set with all the nodes that have nodesets. Use
+    // a set so that we don't have any duplicate entries. We
+    // deal with duplicate entries below by getting all boundary
+    // IDs on each node.
+    std::set<dof_id_type> nodes_with_nodesets;
+    for (const auto & t : binfo.build_node_list())
+      nodes_with_nodesets.insert(std::get<0>(t));
+
+    // To be filled in by BoundaryInfo calls in loop below
+    std::vector<boundary_id_type> node_boundary_ids;
+
+    for(dof_id_type node_id : nodes_with_nodesets)
+      {
+        const Node * node = mesh.node_ptr(node_id);
+
+        if (node->processor_id() != mesh.comm().rank())
+          continue;
+
+        binfo.boundary_ids(node, node_boundary_ids);
+
+        bool has_node_boundary_id = false;
+        boundary_id_type matching_boundary_id = BoundaryInfo::invalid_id;
+        for(boundary_id_type node_boundary_id : node_boundary_ids)
+          if(parametrized_function_boundary_ids.count(node_boundary_id))
+            {
+              has_node_boundary_id = true;
+              matching_boundary_id = node_boundary_id;
+              break;
+            }
+
+        if(has_node_boundary_id)
+          {
+            gathered_local_node_ids.push_back(node_id);
+          }
+      }
+  }
+
+  // I _think_ the local node ids are likely to already be sorted in
+  // ascending order, since that is how they are stored on the Mesh,
+  // but we can always just guarantee this to be on the safe side as
+  // well.
+  std::sort(gathered_local_node_ids.begin(), gathered_local_node_ids.end());
+
+  // Gather the number of local nodes from all procs to proc 0
+  auto n_local_nodes = gathered_local_node_ids.size();
+  std::vector<std::size_t> gathered_n_local_nodes = {n_local_nodes};
+  sys.comm().gather(/*root_id=*/0, gathered_n_local_nodes);
+
+  // Gather the node ids owned by each processor onto processor 0.
+  sys.comm().gather(/*root_id=*/0, gathered_local_node_ids);
+
+  // Construct vectors of "start" and "one-past-the-end" indices into
+  // the gathered_local_node_ids vector for each proc. Only valid on
+  // processor 0.
+  std::vector<std::size_t> start_node_ids_index, end_node_ids_index;
+
+  if (rank == 0)
+    {
+      start_node_ids_index.resize(n_procs);
+      start_node_ids_index[0] = 0;
+      for (processor_id_type p=1; p<n_procs; ++p)
+        start_node_ids_index[p] = start_node_ids_index[p-1] + gathered_n_local_nodes[p-1];
+
+      end_node_ids_index.resize(n_procs);
+      end_node_ids_index[n_procs - 1] = gathered_local_node_ids.size();
+      for (processor_id_type p=0; p<n_procs - 1; ++p)
+        end_node_ids_index[p] = start_node_ids_index[p+1];
+    }
+
+  // On processor 0, using basis function 0 and variable 0, prepare a
+  // vector with the nodes.  Then scatter this vector
+  // out to the processors that require it. The order of this vector
+  // matches the gathered_local_node_ids ordering. The counts will be
+  // gathered_n_local_nodes.
+
+  // On rank 0, the "counts" vector holds the number of floating point values that
+  // are to be scattered to each proc. It is only required on proc 0.
+  std::vector<int> counts;
+
+  if (rank == 0)
+    {
+      counts.resize(n_procs);
+
+      auto & bf_map = _local_node_eim_basis_functions[0];
+
+      for (processor_id_type p=0; p<n_procs; ++p)
+        {
+          for (auto n : make_range(start_node_ids_index[p], end_node_ids_index[p]))
+            {
+              auto node_id = gathered_local_node_ids[n];
+
+              // Get reference to array[n_vars] for current Node.
+              // Throws an error if the required elem_id is not found.
+              const auto & array = libmesh_map_find(bf_map, node_id);
+
+              auto n_vars = array.size();
+
+              // Accumulate the count for this proc
+              counts[p] += n_vars;
+            } // end for (e)
+        } // end for proc_id
+    } // if (rank == 0)
+
+  // For each basis function and each variable, build a vector
+  // data in the Node ordering given by the
+  // gathered_local_node_ids, then call
+  //
+  // sys.comm().scatter(data, counts, recv, /*root_id=*/0);
+  std::vector<std::vector<Number>> node_data(n_vars);
+  if (rank == 0)
+    {
+      // The total amount of node data is given by summing the entries
+      // of the "counts" vector.
+      auto n_node_data =
+        std::accumulate(counts.begin(), counts.end(), 0u);
+
+      // On processor 0, reserve enough space to hold all the qp
+      // data for a single basis function for each var.
+      for (auto var : index_range(node_data))
+        node_data[var].reserve(n_node_data);
+    }
+
+  // The recv_node_data vector will be used on the receiving end of all
+  // the scatters below.
+  std::vector<Number> recv_node_data;
+
+  // Loop from 0..n_bf on _all_ procs, since the scatters inside this
+  // loop are collective.
+  for (auto bf : make_range(n_bf))
+    {
+      // Prepare data for scattering (only on proc 0)
+      if (rank == 0)
+        {
+          // Reference to the data map for the current basis function.
+          auto & bf_map = _local_node_eim_basis_functions[bf];
+
+          // Clear any data from previous bf
+          for (auto var : index_range(node_data))
+            node_data[var].clear();
+
+          for (processor_id_type p=0; p<n_procs; ++p)
+            {
+              for (auto n : make_range(start_node_ids_index[p], end_node_ids_index[p]))
+                {
+                  auto node_id = gathered_local_node_ids[n];
+
+                  // Get reference to array[n_vars] for current Node.
+                  // Throws an error if the required node_id is not found.
+                  const auto & array = libmesh_map_find(bf_map, node_id);
+
+                  for (auto var : index_range(array))
+                    {
+                      node_data[var][node_id] = array[var];
+                    } // end for (var)
+                } // end for (n)
+            } // end for proc_id
+        } // end if rank==0
+
+      // Perform the scatters (all procs)
+      for (auto var : make_range(n_vars))
+        {
+          // Do the scatter for the current var
+          sys.comm().scatter(node_data[var], counts, recv_node_data, /*root_id=*/0);
+
+          if (rank != 0)
+            {
+              // Store the scattered data we received in _local_eim_basis_functions[bf]
+              auto & bf_map = _local_node_eim_basis_functions[bf];
+              auto cursor = recv_node_data.begin();
+
+              for (auto i : index_range(gathered_local_node_ids))
+                {
+                  auto node_id = gathered_local_node_ids[i];
+                  auto & array = bf_map[node_id];
+
+                  // Create space to store the data if it doesn't already exist.
+                  if (array.empty())
+                    array.resize(n_vars);
+
+                  // There is only one value per variable per node, so
+                  // we set the value by de-referencing cursor, and
+                  // then advance the cursor by 1.
+                  array[var] = *cursor;
+                  std::advance(cursor, 1);
+                }
+            } // if (rank != 0)
+        } // end for (var)
+    } // end for (bf)
+
+  // Now that the scattering is done, delete non-local Elem
+  // information from processor 0's _local_eim_basis_functions data
+  // structure.
+  if (rank == 0)
+    {
+      for (processor_id_type p=1; p<n_procs; ++p)
+        {
+          for (auto n : make_range(start_node_ids_index[p], end_node_ids_index[p]))
+            {
+              auto node_id = gathered_local_node_ids[n];
+
+              // Delete this Node's information from every basis function.
+              for (auto & bf_map : _local_node_eim_basis_functions)
+                bf_map.erase(node_id);
+            } // end for (n)
         } // end for proc_id
     } // if (rank == 0)
 }

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -516,7 +516,7 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh_sides(con
 void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh_nodes(const RBParameters & mu,
                                                                              const std::unordered_map<dof_id_type, Point> & all_xyz,
                                                                              const std::unordered_map<dof_id_type, boundary_id_type> & node_boundary_ids,
-                                                                             const System & sys)
+                                                                             const System & /*sys*/)
 {
   mesh_to_preevaluated_node_values_map.clear();
 

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -676,6 +676,7 @@ std::vector<std::vector<Number>> RBParametrizedFunction::evaluate_at_observation
 void RBParametrizedFunction::get_spatial_indices(std::vector<std::vector<unsigned int>> & /*spatial_indices*/,
                                                  const std::vector<dof_id_type> & /*elem_ids*/,
                                                  const std::vector<unsigned int> & /*side_indices*/,
+                                                 const std::vector<dof_id_type> & /*node_ids*/,
                                                  const std::vector<unsigned int> & /*qps*/,
                                                  const std::vector<subdomain_id_type> & /*sbd_ids*/,
                                                  const std::vector<boundary_id_type> & /*boundary_ids*/)
@@ -686,6 +687,7 @@ void RBParametrizedFunction::get_spatial_indices(std::vector<std::vector<unsigne
 void RBParametrizedFunction::initialize_spatial_indices(const std::vector<std::vector<unsigned int>> & /*spatial_indices*/,
                                                         const std::vector<dof_id_type> & /*elem_ids*/,
                                                         const std::vector<unsigned int> & /*side_indices*/,
+                                                        const std::vector<dof_id_type> & /*node_ids*/,
                                                         const std::vector<unsigned int> & /*qps*/,
                                                         const std::vector<subdomain_id_type> & /*sbd_ids*/,
                                                         const std::vector<boundary_id_type> & /*boundary_ids*/)


### PR DESCRIPTION
We previously implemented EIM on element interiors and sidesets. This PR adds EIM on nodesets. This is useful for things like point loads.