### PR TITLE
Drop long-commented-out code in Elem::connectivity() functions

### DIFF
--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -416,13 +416,13 @@ void Hex27::connectivity(const unsigned int sc,
         conn[8] = this->node_id(8);
         conn[9] = this->node_id(9);
         conn[10] = this->node_id(10);
-        conn[11] = this->node_id(11); //
+        conn[11] = this->node_id(11);
         conn[12] = this->node_id(16);
         conn[13] = this->node_id(17);
         conn[14] = this->node_id(18);
         conn[15] = this->node_id(19);
         conn[16] = this->node_id(12);
-        conn[17] = this->node_id(13); //
+        conn[17] = this->node_id(13);
         conn[18] = this->node_id(14);
         conn[19] = this->node_id(15);
         conn[20] = this->node_id(24);
@@ -434,118 +434,6 @@ void Hex27::connectivity(const unsigned int sc,
         conn[26] = this->node_id(26);
 
         return;
-
-        /*
-          switch (sc)
-          {
-          case 0:
-
-          conn[0] = this->node_id(0);
-          conn[1] = this->node_id(8);
-          conn[2] = this->node_id(20);
-          conn[3] = this->node_id(11);
-          conn[4] = this->node_id(12);
-          conn[5] = this->node_id(21);
-          conn[6] = this->node_id(26);
-          conn[7] = this->node_id(24);
-
-          return;
-
-          case 1:
-
-          conn[0] = this->node_id(8);
-          conn[1] = this->node_id(1);
-          conn[2] = this->node_id(9);
-          conn[3] = this->node_id(20);
-          conn[4] = this->node_id(21);
-          conn[5] = this->node_id(13);
-          conn[6] = this->node_id(22);
-          conn[7] = this->node_id(26);
-
-          return;
-
-          case 2:
-
-          conn[0] = this->node_id(11);
-          conn[1] = this->node_id(20);
-          conn[2] = this->node_id(10);
-          conn[3] = this->node_id(3);
-          conn[4] = this->node_id(24);
-          conn[5] = this->node_id(26);
-          conn[6] = this->node_id(23);
-          conn[7] = this->node_id(15);
-
-          return;
-
-          case 3:
-
-          conn[0] = this->node_id(20);
-          conn[1] = this->node_id(9);
-          conn[2] = this->node_id(2);
-          conn[3] = this->node_id(10);
-          conn[4] = this->node_id(26);
-          conn[5] = this->node_id(22);
-          conn[6] = this->node_id(14);
-          conn[7] = this->node_id(23);
-
-          return;
-
-          case 4:
-
-          conn[0] = this->node_id(12);
-          conn[1] = this->node_id(21);
-          conn[2] = this->node_id(26);
-          conn[3] = this->node_id(24);
-          conn[4] = this->node_id(4);
-          conn[5] = this->node_id(16);
-          conn[6] = this->node_id(25);
-          conn[7] = this->node_id(19);
-
-          return;
-
-          case 5:
-
-          conn[0] = this->node_id(21);
-          conn[1] = this->node_id(13);
-          conn[2] = this->node_id(22);
-          conn[3] = this->node_id(26);
-          conn[4] = this->node_id(16);
-          conn[5] = this->node_id(5);
-          conn[6] = this->node_id(17);
-          conn[7] = this->node_id(25);
-
-          return;
-
-          case 6:
-
-          conn[0] = this->node_id(24);
-          conn[1] = this->node_id(26);
-          conn[2] = this->node_id(23);
-          conn[3] = this->node_id(15);
-          conn[4] = this->node_id(19);
-          conn[5] = this->node_id(25);
-          conn[6] = this->node_id(18);
-          conn[7] = this->node_id(7);
-
-          return;
-
-          case 7:
-
-          conn[0] = this->node_id(26);
-          conn[1] = this->node_id(22);
-          conn[2] = this->node_id(14);
-          conn[3] = this->node_id(23);
-          conn[4] = this->node_id(25);
-          conn[5] = this->node_id(17);
-          conn[6] = this->node_id(6);
-          conn[7] = this->node_id(18);
-
-          return;
-
-          default:
-          libmesh_error_msg("Invalid sc = " << sc);
-          }
-        */
       }
 
     default:

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -203,14 +203,8 @@ void Hex8::connectivity(const unsigned int libmesh_dbg_var(sc),
 
     case VTK:
       {
-        conn[0] = this->node_id(0);
-        conn[1] = this->node_id(1);
-        conn[2] = this->node_id(2);
-        conn[3] = this->node_id(3);
-        conn[4] = this->node_id(4);
-        conn[5] = this->node_id(5);
-        conn[6] = this->node_id(6);
-        conn[7] = this->node_id(7);
+        for (auto i : index_range(conn))
+          conn[i] = this->node_id(i);
         return;
       }
 

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -342,16 +342,6 @@ void Prism15::connectivity(const unsigned int libmesh_dbg_var(sc),
 
     case VTK:
       {
-        /*
-          conn.resize(6);
-          conn[0] = this->node_id(0);
-          conn[1] = this->node_id(2);
-          conn[2] = this->node_id(1);
-          conn[3] = this->node_id(3);
-          conn[4] = this->node_id(5);
-          conn[5] = this->node_id(4);
-        */
-
         // VTK's VTK_QUADRATIC_WEDGE first 9 nodes match, then their
         // middle and top layers of mid-edge nodes are reversed from
         // LibMesh's.
@@ -368,7 +358,6 @@ void Prism15::connectivity(const unsigned int libmesh_dbg_var(sc),
         conn[12] = this->node_id(9);
         conn[13] = this->node_id(10);
         conn[14] = this->node_id(11);
-
 
         return;
       }

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -372,108 +372,11 @@ void Tet10::connectivity(const unsigned int sc,
 
     case VTK:
       {
-        conn.resize(10);
-        conn[0] = this->node_id(0);
-        conn[1] = this->node_id(1);
-        conn[2] = this->node_id(2);
-        conn[3] = this->node_id(3);
-        conn[4] = this->node_id(4);
-        conn[5] = this->node_id(5);
-        conn[6] = this->node_id(6);
-        conn[7] = this->node_id(7);
-        conn[8] = this->node_id(8);
-        conn[9] = this->node_id(9);
+        // VTK connectivity for VTK_QUADRATIC_TETRA matches libMesh's own.
+        conn.resize(Tet10::num_nodes);
+        for (auto i : index_range(conn))
+          conn[i] = this->node_id(i);
         return;
-        /*
-          conn.resize(4);
-          switch (sc)
-          {
-          // Linear sub-tet 0
-          case 0:
-
-          conn[0] = this->node_id(0);
-          conn[1] = this->node_id(4);
-          conn[2] = this->node_id(6);
-          conn[3] = this->node_id(7);
-
-          return;
-
-          // Linear sub-tet 1
-          case 1:
-
-          conn[0] = this->node_id(4);
-          conn[1] = this->node_id(1);
-          conn[2] = this->node_id(5);
-          conn[3] = this->node_id(8);
-
-          return;
-
-          // Linear sub-tet 2
-          case 2:
-
-          conn[0] = this->node_id(5);
-          conn[1] = this->node_id(2);
-          conn[2] = this->node_id(6);
-          conn[3] = this->node_id(9);
-
-          return;
-
-          // Linear sub-tet 3
-          case 3:
-
-          conn[0] = this->node_id(7);
-          conn[1] = this->node_id(8);
-          conn[2] = this->node_id(9);
-          conn[3] = this->node_id(3);
-
-          return;
-
-          // Linear sub-tet 4
-          case 4:
-
-          conn[0] = this->node_id(4);
-          conn[1] = this->node_id(8);
-          conn[2] = this->node_id(6);
-          conn[3] = this->node_id(7);
-
-          return;
-
-          // Linear sub-tet 5
-          case 5:
-
-          conn[0] = this->node_id(4);
-          conn[1] = this->node_id(5);
-          conn[2] = this->node_id(6);
-          conn[3] = this->node_id(8);
-
-          return;
-
-          // Linear sub-tet 6
-          case 6:
-
-          conn[0] = this->node_id(5);
-          conn[1] = this->node_id(9);
-          conn[2] = this->node_id(6);
-          conn[3] = this->node_id(8);
-
-          return;
-
-          // Linear sub-tet 7
-          case 7:
-
-          conn[0] = this->node_id(7);
-          conn[1] = this->node_id(6);
-          conn[2] = this->node_id(9);
-          conn[3] = this->node_id(8);
-
-          return;
-
-
-          default:
-
-          libmesh_error_msg("Invalid sc = " << sc);
-          }
-        */
       }
 
     default:

--- a/src/geom/cell_tet14.C
+++ b/src/geom/cell_tet14.C
@@ -395,108 +395,14 @@ void Tet14::connectivity(const unsigned int sc,
 
     case VTK:
       {
-        conn.resize(10);
-        conn[0] = this->node_id(0);
-        conn[1] = this->node_id(1);
-        conn[2] = this->node_id(2);
-        conn[3] = this->node_id(3);
-        conn[4] = this->node_id(4);
-        conn[5] = this->node_id(5);
-        conn[6] = this->node_id(6);
-        conn[7] = this->node_id(7);
-        conn[8] = this->node_id(8);
-        conn[9] = this->node_id(9);
+        // VTK has vtkHigherOrderTetra which might have the same
+        // connectivity as our Tet14, but this has not been tested
+        // yet.
+        libmesh_experimental();
+        conn.resize(Tet14::num_nodes);
+        for (auto i : index_range(conn))
+          conn[i] = this->node_id(i);
         return;
-        /*
-          conn.resize(4);
-          switch (sc)
-          {
-          // Linear sub-tet 0
-          case 0:
-
-          conn[0] = this->node_id(0);
-          conn[1] = this->node_id(4);
-          conn[2] = this->node_id(6);
-          conn[3] = this->node_id(7);
-
-          return;
-
-          // Linear sub-tet 1
-          case 1:
-
-          conn[0] = this->node_id(4);
-          conn[1] = this->node_id(1);
-          conn[2] = this->node_id(5);
-          conn[3] = this->node_id(8);
-
-          return;
-
-          // Linear sub-tet 2
-          case 2:
-
-          conn[0] = this->node_id(5);
-          conn[1] = this->node_id(2);
-          conn[2] = this->node_id(6);
-          conn[3] = this->node_id(9);
-
-          return;
-
-          // Linear sub-tet 3
-          case 3:
-
-          conn[0] = this->node_id(7);
-          conn[1] = this->node_id(8);
-          conn[2] = this->node_id(9);
-          conn[3] = this->node_id(3);
-
-          return;
-
-          // Linear sub-tet 4
-          case 4:
-
-          conn[0] = this->node_id(4);
-          conn[1] = this->node_id(8);
-          conn[2] = this->node_id(6);
-          conn[3] = this->node_id(7);
-
-          return;
-
-          // Linear sub-tet 5
-          case 5:
-
-          conn[0] = this->node_id(4);
-          conn[1] = this->node_id(5);
-          conn[2] = this->node_id(6);
-          conn[3] = this->node_id(8);
-
-          return;
-
-          // Linear sub-tet 6
-          case 6:
-
-          conn[0] = this->node_id(5);
-          conn[1] = this->node_id(9);
-          conn[2] = this->node_id(6);
-          conn[3] = this->node_id(8);
-
-          return;
-
-          // Linear sub-tet 7
-          case 7:
-
-          conn[0] = this->node_id(7);
-          conn[1] = this->node_id(6);
-          conn[2] = this->node_id(9);
-          conn[3] = this->node_id(8);
-
-          return;
-
-
-          default:
-
-          libmesh_error_msg("Invalid sc = " << sc);
-          }
-        */
       }
 
     default:

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -309,73 +309,14 @@ void Quad8::connectivity(const unsigned int sf,
       }
 
 
-      // Note: VTK connectivity is output as four triangles with
-      // a central quadrilateral.  Therefore most of the connectivity
-      // arrays have length three.
+      // VTK connectivity for this element matches libmesh's own.
     case VTK:
       {
-        // Create storage
-        conn.resize(8);
-        conn[0] = this->node_id(0);
-        conn[1] = this->node_id(1);
-        conn[2] = this->node_id(2);
-        conn[3] = this->node_id(3);
-        conn[4] = this->node_id(4);
-        conn[5] = this->node_id(5);
-        conn[6] = this->node_id(6);
-        conn[7] = this->node_id(7);
+        conn.resize(Quad8::num_nodes);
+        for (auto i : index_range(conn))
+          conn[i] = this->node_id(i);
+
         return;
-        /*
-          conn.resize(3);
-
-          switch (sf)
-          {
-          case 0:
-          // linear sub-tri 0
-          conn[0] = this->node_id(0);
-          conn[1] = this->node_id(4);
-          conn[2] = this->node_id(7);
-
-          return;
-
-          case 1:
-          // linear sub-tri 1
-          conn[0] = this->node_id(4);
-          conn[1] = this->node_id(1);
-          conn[2] = this->node_id(5);
-
-          return;
-
-          case 2:
-          // linear sub-tri 2
-          conn[0] = this->node_id(5);
-          conn[1] = this->node_id(2);
-          conn[2] = this->node_id(6);
-
-          return;
-
-          case 3:
-          // linear sub-tri 3
-          conn[0] = this->node_id(7);
-          conn[1] = this->node_id(6);
-          conn[2] = this->node_id(3);
-
-          return;
-
-          case 4:
-          conn.resize(4);
-
-          // linear sub-quad
-          conn[0] = this->node_id(4);
-          conn[1] = this->node_id(5);
-          conn[2] = this->node_id(6);
-          conn[3] = this->node_id(7);
-        */
-        //        return;
-
-        //      default:
-        //        libmesh_error_msg("Invalid sf = " << sf);
-        //      }
       }
 
     default:

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -308,60 +308,10 @@ void Quad9::connectivity(const unsigned int sf,
 
     case VTK:
       {
-        conn.resize(9);
-        conn[0] = this->node_id(0);
-        conn[1] = this->node_id(1);
-        conn[2] = this->node_id(2);
-        conn[3] = this->node_id(3);
-        conn[4] = this->node_id(4);
-        conn[5] = this->node_id(5);
-        conn[6] = this->node_id(6);
-        conn[7] = this->node_id(7);
-        conn[8] = this->node_id(8);
+        conn.resize(Quad9::num_nodes);
+        for (auto i : index_range(conn))
+          conn[i] = this->node_id(i);
         return;
-
-        /*
-          switch(sf)
-          {
-          case 0:
-          // linear sub-quad 0
-          conn[0] = this->node_id(0);
-          conn[1] = this->node_id(4);
-          conn[2] = this->node_id(8);
-          conn[3] = this->node_id(7);
-
-          return;
-
-          case 1:
-          // linear sub-quad 1
-          conn[0] = this->node_id(4);
-          conn[1] = this->node_id(1);
-          conn[2] = this->node_id(5);
-          conn[3] = this->node_id(8);
-
-          return;
-
-          case 2:
-          // linear sub-quad 2
-          conn[0] = this->node_id(7);
-          conn[1] = this->node_id(8);
-          conn[2] = this->node_id(6);
-          conn[3] = this->node_id(3);
-
-          return;
-
-          case 3:
-          // linear sub-quad 3
-          conn[0] = this->node_id(8);
-          conn[1] = this->node_id(5);
-          conn[2] = this->node_id(2);
-          conn[3] = this->node_id(6);
-
-          return;
-
-          default:
-          libmesh_error_msg("Invalid sf = " << sf);
-          }*/
       }
 
     default:

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -281,56 +281,10 @@ void Tri6::connectivity(const unsigned int sf,
     case VTK:
       {
         // VTK_QUADRATIC_TRIANGLE has same numbering as libmesh TRI6
-        conn.resize(6);
-        conn[0] = this->node_id(0);
-        conn[1] = this->node_id(1);
-        conn[2] = this->node_id(2);
-        conn[3] = this->node_id(3);
-        conn[4] = this->node_id(4);
-        conn[5] = this->node_id(5);
+        conn.resize(Tri6::num_nodes);
+        for (auto i : index_range(conn))
+          conn[i] = this->node_id(i);
         return;
-
-        // Used to write out linear sub-triangles for VTK...
-        /*
-          conn.resize(3);
-          switch(sf)
-          {
-          case 0:
-          // linear sub-triangle 0
-          conn[0] = this->node_id(0);
-          conn[1] = this->node_id(3);
-          conn[2] = this->node_id(5);
-
-          return;
-
-          case 1:
-          // linear sub-triangle 1
-          conn[0] = this->node_id(3);
-          conn[1] = this->node_id(1);
-          conn[2] = this->node_id(4);
-
-          return;
-
-          case 2:
-          // linear sub-triangle 2
-          conn[0] = this->node_id(5);
-          conn[1] = this->node_id(4);
-          conn[2] = this->node_id(2);
-
-          return;
-
-          case 3:
-          // linear sub-triangle 3
-          conn[0] = this->node_id(3);
-          conn[1] = this->node_id(4);
-          conn[2] = this->node_id(5);
-
-          return;
-
-          default:
-          libmesh_error_msg("Invalid sf = " << sf);
-          }
-        */
       }
 
     default:

--- a/src/geom/face_tri7.C
+++ b/src/geom/face_tri7.C
@@ -313,57 +313,11 @@ void Tri7::connectivity(const unsigned int sf,
 
     case VTK:
       {
-        // VTK_QUADRATIC_TRIANGLE has same numbering as libmesh TRI6
-        conn.resize(6);
-        conn[0] = this->node_id(0);
-        conn[1] = this->node_id(1);
-        conn[2] = this->node_id(2);
-        conn[3] = this->node_id(3);
-        conn[4] = this->node_id(4);
-        conn[5] = this->node_id(5);
+        // VTK has a vtkBiQuadraticTriangle class whose connectivity matches libMesh's
+        conn.resize(Tri7::num_nodes);
+        for (auto i : index_range(conn))
+          conn[i] = this->node_id(i);
         return;
-
-        // Used to write out linear sub-triangles for VTK...
-        /*
-          conn.resize(3);
-          switch(sf)
-          {
-          case 0:
-          // linear sub-triangle 0
-          conn[0] = this->node_id(0);
-          conn[1] = this->node_id(3);
-          conn[2] = this->node_id(5);
-
-          return;
-
-          case 1:
-          // linear sub-triangle 1
-          conn[0] = this->node_id(3);
-          conn[1] = this->node_id(1);
-          conn[2] = this->node_id(4);
-
-          return;
-
-          case 2:
-          // linear sub-triangle 2
-          conn[0] = this->node_id(5);
-          conn[1] = this->node_id(4);
-          conn[2] = this->node_id(2);
-
-          return;
-
-          case 3:
-          // linear sub-triangle 3
-          conn[0] = this->node_id(3);
-          conn[1] = this->node_id(4);
-          conn[2] = this->node_id(5);
-
-          return;
-
-          default:
-          libmesh_error_msg("Invalid sf = " << sf);
-          }
-        */
       }
 
     default:


### PR DESCRIPTION
Most (if not all) of our Elems have had VTK counterparts for some time now, so it is no longer necessary to keep big commented-out blocks of code around for writing out "sub-elements" to VTK files. I'm not even sure it was all that well-tested to begin with...