### PR TITLE
Allow Edge/Face elements to define polylines to triangulate

### DIFF
--- a/tests/mesh/mesh_triangulation.C
+++ b/tests/mesh/mesh_triangulation.C
@@ -35,6 +35,7 @@ public:
   CPPUNIT_TEST( testPoly2TriInterp3 );
   CPPUNIT_TEST( testPoly2TriHoles );
   CPPUNIT_TEST( testPoly2TriMeshedHoles );
+  CPPUNIT_TEST( testPoly2TriEdges );
   CPPUNIT_TEST( testPoly2TriSegments );
   CPPUNIT_TEST( testPoly2TriRefined );
   CPPUNIT_TEST( testPoly2TriExtraRefined );
@@ -509,6 +510,40 @@ public:
     Poly2TriTriangulator p2t_tri(mesh);
     testTriangulatorMeshedHoles(mesh, p2t_tri);
   }
+
+
+  void testPoly2TriEdges()
+  {
+    LOG_UNIT_TEST;
+
+    Mesh mesh(*TestCommWorld);
+    Poly2TriTriangulator triangulator(mesh);
+
+    // The same quad as testTriangulator, but out of order
+    auto node0 = mesh.add_point(Point(0,0), 0);
+    auto node1 = mesh.add_point(Point(1,2), 1);
+    auto node2 = mesh.add_point(Point(1,0), 2);
+    auto node3 = mesh.add_point(Point(0,1), 3);
+
+    // Edges, also out of order, but enough to put them in order
+    auto edge13 = mesh.add_elem(Elem::build(EDGE2));
+    edge13->set_node(0) = node1;
+    edge13->set_node(1) = node3;
+    auto edge02 = mesh.add_elem(Elem::build(EDGE2));
+    edge02->set_node(0) = node0;
+    edge02->set_node(1) = node2;
+    auto edge30 = mesh.add_elem(Elem::build(EDGE2));
+    edge30->set_node(0) = node3;
+    edge30->set_node(1) = node0;
+    auto edge21 = mesh.add_elem(Elem::build(EDGE2));
+    edge21->set_node(0) = node2;
+    edge21->set_node(1) = node1;
+
+    mesh.prepare_for_use();
+
+    this->testTriangulatorBase(mesh, triangulator);
+  }
+
 
 
   void testPoly2TriSegments()


### PR DESCRIPTION
This could be useful for doing fully-anisotropic adaptivity (in 2D, anyway...) in the future, but for the present it's just to add a bit of user-friendliness.