### PR TITLE
DirichletBoundaries should be a vector of unique_ptrs

### DIFF
--- a/include/base/dirichlet_boundaries.h
+++ b/include/base/dirichlet_boundaries.h
@@ -211,12 +211,11 @@ public:
  * \note \p std::map has no virtual destructor, so downcasting here
  * would be dangerous.
  */
-class DirichletBoundaries : public std::vector<DirichletBoundary *>
+class DirichletBoundaries : public std::vector<std::unique_ptr<DirichletBoundary>>
 {
 public:
-  DirichletBoundaries() {}
-
-  ~DirichletBoundaries();
+  DirichletBoundaries() = default;
+  ~DirichletBoundaries() = default;
 };
 
 } // namespace libMesh


### PR DESCRIPTION
DirichletBoundaries was previously responsible for deleting, but not
allocating, the pointers that it held, which made understanding the
ownership semantics a bit challenging and caused us to have to define
a non-trivial destructor (in dof_map_constraints.C).