### PR TITLE
allow reading of Abaqus mesh containing TRI6 and QUAD8 elements

### DIFF
--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -136,10 +136,24 @@ void init_eletypes ()
       }
 
       {
+        // TRI6
+        const unsigned int   node_map[] = {0,1,2,3,4,5}; // identity
+        const unsigned short side_map[] = {0,1,2}; // identity
+        add_eletype_entry(TRI6, node_map, 6, side_map, 3);
+      }
+
+      {
         // QUAD4
         const unsigned int   node_map[] = {0,1,2,3}; // identity
         const unsigned short side_map[] = {0,1,2,3}; // identity
         add_eletype_entry(QUAD4, node_map, 4, side_map, 4);
+      }
+
+      {
+        // QUAD8
+        const unsigned int   node_map[] = {0,1,2,3,4,5,6,7}; // identity
+        const unsigned short side_map[] = {0,1,2,3}; // identity
+        add_eletype_entry(QUAD8, node_map, 8, side_map, 4);
       }
 
       {


### PR DESCRIPTION
As discussed [here](https://github.com/libMesh/libmesh/discussions/3259), libmesh is missing support for reading in some higher-order 2D Abaqus elements. The node and side ordering are the same for libmesh and Abaqus for TRI6 and QUAD8: [see bottom of page here](https://abaqus-docs.mit.edu/2017/English/SIMACAEELMRefMap/simaelm-r-2delem.htm), so it is straight-forward to add the element maps.

I don't have a test for this off-hand, but my end use for this is in MOOSE and I could submit something there, or I could learn the libmesh test system (which I've neglected to look into thus far). I'll leave it up to the developers.