### PR TITLE
DofMap::_adjoint_dirichlet_boundaries should contain unique_ptrs

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1909,7 +1909,7 @@ private:
    * Data structure containing Dirichlet functions.  The ith
    * entry is the constraint matrix row for boundaryid i.
    */
-  std::vector<DirichletBoundaries *> _adjoint_dirichlet_boundaries;
+  std::vector<std::unique_ptr<DirichletBoundaries>> _adjoint_dirichlet_boundaries;
 #endif
 
   friend class SparsityPattern::Build;

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -209,11 +209,6 @@ DofMap::~DofMap()
   // need to remove those from the mesh too before we die.
   _mesh.remove_ghosting_functor(*_default_coupling);
   _mesh.remove_ghosting_functor(*_default_evaluating);
-
-#ifdef LIBMESH_ENABLE_DIRICHLET
-  for (auto & bnd : _adjoint_dirichlet_boundaries)
-    delete bnd;
-#endif
 }
 
 

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -5248,7 +5248,7 @@ void DofMap::add_adjoint_dirichlet_boundary (const DirichletBoundary & dirichlet
   unsigned int old_size = cast_int<unsigned int>
     (_adjoint_dirichlet_boundaries.size());
   for (unsigned int i = old_size; i <= qoi_index; ++i)
-    _adjoint_dirichlet_boundaries.push_back(new DirichletBoundaries());
+    _adjoint_dirichlet_boundaries.push_back(std::make_unique<DirichletBoundaries>());
 
   // Make copy of DirichletBoundary, owned by _adjoint_dirichlet_boundaries
   _adjoint_dirichlet_boundaries[qoi_index]->push_back
@@ -5269,7 +5269,7 @@ const DirichletBoundaries *
 DofMap::get_adjoint_dirichlet_boundaries(unsigned int q) const
 {
   libmesh_assert_greater(_adjoint_dirichlet_boundaries.size(),q);
-  return _adjoint_dirichlet_boundaries[q];
+  return _adjoint_dirichlet_boundaries[q].get();
 }
 
 
@@ -5279,9 +5279,9 @@ DofMap::get_adjoint_dirichlet_boundaries(unsigned int q)
   unsigned int old_size = cast_int<unsigned int>
     (_adjoint_dirichlet_boundaries.size());
   for (unsigned int i = old_size; i <= q; ++i)
-    _adjoint_dirichlet_boundaries.push_back(new DirichletBoundaries());
+    _adjoint_dirichlet_boundaries.push_back(std::make_unique<DirichletBoundaries>());
 
-  return _adjoint_dirichlet_boundaries[q];
+  return _adjoint_dirichlet_boundaries[q].get();
 }
 
 


### PR DESCRIPTION
This could probably have gone in with #3270, at the time I did not realize it was just a few more lines to get rid of the last manual memory management in DofMap.