### PR TITLE
Always add elements/nodes to mesh when unpacking

### DIFF
--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -300,11 +300,14 @@ public:
   virtual Node * add_node (Node * n) override final;
   virtual Node * add_node (std::unique_ptr<Node> n) override final;
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
   /**
+   * These methods are deprecated. Please use \p add_node instead
    * Calls add_node().
    */
   virtual Node * insert_node(Node * n) override final;
   virtual Node * insert_node(std::unique_ptr<Node> n) override final;
+#endif
 
   /**
    * Takes ownership of node \p n on this partition of a distributed

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -659,8 +659,7 @@ public:
   /**
    * Insert \p Node \p n into the Mesh at a location consistent with
    * n->id(), allocating extra storage if necessary.  Will error
-   * rather than overwriting an existing Node.  Primarily intended for
-   * use with the mesh_inserter_iterator, only use if you know what
+   * rather than overwriting an existing Node. Only use if you know what
    * you are doing...
    */
   virtual Node * insert_node(Node * n) = 0;

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -656,7 +656,9 @@ public:
    */
   virtual Node * add_node (std::unique_ptr<Node> n) = 0;
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
   /**
+   * This method is deprecated. Please use \p add_node instead
    * Insert \p Node \p n into the Mesh at a location consistent with
    * n->id(), allocating extra storage if necessary.  Will error
    * rather than overwriting an existing Node. Only use if you know what
@@ -665,14 +667,14 @@ public:
   virtual Node * insert_node(Node * n) = 0;
 
   /**
-   * Version of insert_node() taking a std::unique_ptr by value. The version
-   * taking a dumb pointer will eventually be deprecated in favor of this
-   * version. This API is intended to indicate that ownership of the Node
-   * is transferred to the Mesh when this function is called, and it should
-   * play more nicely with the Node::build() API which has always returned
-   * a std::unique_ptr.
+   * This method is deprecated. Please use \p add_node instead
+   * Version of insert_node() taking a std::unique_ptr by value. This API is
+   * intended to indicate that ownership of the Node is transferred to the Mesh
+   * when this function is called, and it should play more nicely with the
+   * Node::build() API which has always returned a std::unique_ptr.
    */
   virtual Node * insert_node(std::unique_ptr<Node> n) = 0;
+#endif
 
   /**
    * Removes the Node n from the mesh.

--- a/include/mesh/mesh_inserter_iterator.h
+++ b/include/mesh/mesh_inserter_iterator.h
@@ -20,6 +20,10 @@
 #ifndef LIBMESH_MESH_INSERTER_ITERATOR_H
 #define LIBMESH_MESH_INSERTER_ITERATOR_H
 
+#include "libmesh/libmesh_config.h"
+
+#ifdef LIBMESH_ENABLE_DEPRECATED
+
 // Local includes
 #include "libmesh/mesh_base.h"
 
@@ -39,11 +43,13 @@ class Point;
  * arguments, which adds objects to the Mesh.
  * Although any mesh_inserter_iterator can add any object, we
  * template it around object type so that type inference and
- * iterator_traits will work.
+ * iterator_traits will work. This class used to be intended
+ * for use with packed range methods in TIMPI. However, our
+ * packing routines now automatically add elements and nodes
+ * to the mesh, so this class is deprecated
  *
  * \author Roy Stogner
  * \date 2012
- * \brief An output iterator for use with packed_range functions.
  */
 template <typename T>
 struct mesh_inserter_iterator
@@ -54,7 +60,7 @@ struct mesh_inserter_iterator
   using pointer = T*;
   using reference = T&;
 
-  mesh_inserter_iterator (MeshBase & m) : mesh(m) {}
+  mesh_inserter_iterator (MeshBase & m) : mesh(m) { libmesh_deprecated(); }
 
   void operator=(Elem * e) { mesh.add_elem(e); }
 
@@ -82,5 +88,5 @@ private:
 
 } // namespace libMesh
 
-
+#endif // LIBMESH_ENABLE_DEPRECATED
 #endif // LIBMESH_MESH_INSERTER_ITERATOR_H

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -175,7 +175,9 @@ public:
   virtual Node * add_node (Node * n) override final;
   virtual Node * add_node (std::unique_ptr<Node> n) override final;
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
   /**
+   * These methods are deprecated. Please use \p add_node instead
    * Insert \p Node \p n into the Mesh at a location consistent with
    * n->id(), allocating extra storage if necessary.  Throws an error if:
    * .) n==nullptr
@@ -188,6 +190,7 @@ public:
    */
   virtual Node * insert_node(Node * n) override final;
   virtual Node * insert_node(std::unique_ptr<Node> n) override final;
+#endif
 
   virtual void delete_node (Node * n) override final;
   virtual void renumber_node (dof_id_type old_id, dof_id_type new_id) override final;

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -33,7 +33,7 @@
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/linear_solver.h" // for spline Dirichlet projection solves
 #include "libmesh/mesh_base.h"
-#include "libmesh/mesh_inserter_iterator.h"
+#include "libmesh/null_output_iterator.h"
 #include "libmesh/mesh_tools.h" // for libmesh_assert_valid_boundary_ids()
 #include "libmesh/nonlinear_implicit_system.h"
 #include "libmesh/numeric_vector.h" // for enforce_constraints_exactly()
@@ -3850,7 +3850,7 @@ void DofMap::allgather_recursive_constraints(MeshBase & mesh)
         // make sure we have all the nodes involved!
         if (dist_mesh)
           this->comm().receive_packed_range
-            (pid, &mesh, mesh_inserter_iterator<Node>(mesh),
+            (pid, &mesh, null_output_iterator<Node>(),
              (Node**)nullptr, range_tag);
 
         libmesh_assert(received_node_keys_vals.count(pid));
@@ -4070,7 +4070,7 @@ void DofMap::allgather_recursive_constraints(MeshBase & mesh)
           // make sure we have all the nodes involved!
           if (dist_mesh)
             this->comm().receive_packed_range
-              (pid, &mesh, mesh_inserter_iterator<Node>(mesh),
+              (pid, &mesh, null_output_iterator<Node>(),
                (Node**)nullptr, range_tag);
 
           // Add any new constraint rows we've found

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -880,18 +880,21 @@ Node * DistributedMesh::add_node (std::unique_ptr<Node> n)
   return add_node(n.release());
 }
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 
 Node * DistributedMesh::insert_node(Node * n)
 {
+  libmesh_deprecated();
   return DistributedMesh::add_node(n);
 }
 
 Node * DistributedMesh::insert_node(std::unique_ptr<Node> n)
 {
+  libmesh_deprecated();
   return insert_node(n.release());
 }
 
-
+#endif
 
 void DistributedMesh::delete_node(Node * n)
 {

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -27,7 +27,7 @@
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/mesh_communication.h"
-#include "libmesh/mesh_inserter_iterator.h"
+#include "libmesh/null_output_iterator.h"
 #include "libmesh/mesh_tools.h"
 #include "libmesh/parallel.h"
 #include "libmesh/parallel_elem.h"
@@ -556,7 +556,7 @@ void MeshCommunication::redistribute (DistributedMesh & mesh,
     // just process whatever message is available next.
     mesh.comm().receive_packed_range (Parallel::any_source,
                                       &mesh,
-                                      mesh_inserter_iterator<Node>(mesh),
+                                      null_output_iterator<Node>(),
                                       (Node**)nullptr,
                                       nodestag);
 
@@ -566,7 +566,7 @@ void MeshCommunication::redistribute (DistributedMesh & mesh,
   for (unsigned int elem_comm_step=0; elem_comm_step<n_recv_elem_pairs; elem_comm_step++)
     mesh.comm().receive_packed_range (Parallel::any_source,
                                       &mesh,
-                                      mesh_inserter_iterator<Elem>(mesh),
+                                      null_output_iterator<Elem>(),
                                       (Elem**)nullptr,
                                       elemstag);
 
@@ -931,7 +931,7 @@ void MeshCommunication::gather_neighboring_elements (DistributedMesh & mesh) con
 
           mesh.comm().receive_packed_range (source_pid_idx,
                                             &mesh,
-                                            mesh_inserter_iterator<Node>(mesh),
+                                            null_output_iterator<Node>(),
                                             (Node**)nullptr,
                                             element_neighbors_tag);
         }
@@ -943,7 +943,7 @@ void MeshCommunication::gather_neighboring_elements (DistributedMesh & mesh) con
 
           mesh.comm().receive_packed_range (source_pid_idx,
                                             &mesh,
-                                            mesh_inserter_iterator<Elem>(mesh),
+                                            null_output_iterator<Elem>(),
                                             (Elem**)nullptr,
                                             element_neighbors_tag);
         }
@@ -1127,7 +1127,7 @@ void MeshCommunication::send_coarse_ghosts(MeshBase & mesh) const
       mesh.comm().receive_packed_range
         (Parallel::any_source,
          &mesh,
-         mesh_inserter_iterator<Node>(mesh),
+         null_output_iterator<Node>(),
          (Node**)nullptr,
          nodestag);
     }
@@ -1137,7 +1137,7 @@ void MeshCommunication::send_coarse_ghosts(MeshBase & mesh) const
       mesh.comm().receive_packed_range
         (Parallel::any_source,
          &mesh,
-         mesh_inserter_iterator<Elem>(mesh),
+         null_output_iterator<Elem>(),
          (Elem**)nullptr,
          elemstag);
     }
@@ -1193,7 +1193,7 @@ void MeshCommunication::broadcast (MeshBase & mesh) const
                                      mesh.nodes_begin(),
                                      mesh.nodes_end(),
                                      &mesh,
-                                     mesh_inserter_iterator<Node>(mesh));
+                                     null_output_iterator<Node>());
 
   // Broadcast elements from coarsest to finest, so that child
   // elements will see their parents already in place.
@@ -1209,7 +1209,7 @@ void MeshCommunication::broadcast (MeshBase & mesh) const
                                        mesh.level_elements_begin(l),
                                        mesh.level_elements_end(l),
                                        &mesh,
-                                       mesh_inserter_iterator<Elem>(mesh));
+                                       null_output_iterator<Elem>());
 
   // Make sure mesh_dimension and elem_dimensions are consistent.
   mesh.cache_elem_data();
@@ -1317,14 +1317,14 @@ void MeshCommunication::gather (const processor_id_type root_id, MeshBase & mesh
     mesh.comm().allgather_packed_range (&mesh,
                                         mesh.nodes_begin(),
                                         mesh.nodes_end(),
-                                        mesh_inserter_iterator<Node>(mesh),
+                                        null_output_iterator<Node>(),
                                         approx_each_buffer_size) :
 
     mesh.comm().gather_packed_range (root_id,
                                      &mesh,
                                      mesh.nodes_begin(),
                                      mesh.nodes_end(),
-                                     mesh_inserter_iterator<Node>(mesh),
+                                     null_output_iterator<Node>(),
                                      approx_each_buffer_size);
 
   // Gather elements from coarsest to finest, so that child
@@ -1337,14 +1337,14 @@ void MeshCommunication::gather (const processor_id_type root_id, MeshBase & mesh
       mesh.comm().allgather_packed_range (&mesh,
                                           mesh.level_elements_begin(l),
                                           mesh.level_elements_end(l),
-                                          mesh_inserter_iterator<Elem>(mesh),
+                                          null_output_iterator<Elem>(),
                                           approx_each_buffer_size) :
 
       mesh.comm().gather_packed_range (root_id,
                                        &mesh,
                                        mesh.level_elements_begin(l),
                                        mesh.level_elements_end(l),
-                                       mesh_inserter_iterator<Elem>(mesh),
+                                       null_output_iterator<Elem>(),
                                        approx_each_buffer_size);
 
   // If we had a point locator, it's invalid now that there are new

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -539,10 +539,11 @@ Node * ReplicatedMesh::add_node (std::unique_ptr<Node> n)
   return add_node(n.release());
 }
 
-
+#ifdef LIBMESH_ENABLE_DEPRECATED
 
 Node * ReplicatedMesh::insert_node(Node * n)
 {
+  libmesh_deprecated();
   libmesh_error_msg_if(!n, "Error, attempting to insert nullptr node.");
   libmesh_error_msg_if(n->id() == DofObject::invalid_id, "Error, cannot insert node with invalid id.");
 
@@ -589,12 +590,14 @@ Node * ReplicatedMesh::insert_node(Node * n)
 
 Node * ReplicatedMesh::insert_node(std::unique_ptr<Node> n)
 {
+  libmesh_deprecated();
   // The mesh now takes ownership of the Node. Eventually the guts of
   // insert_node(Node*) will get moved to a private helper function, and
   // calling insert_node(Node*) directly will be deprecated.
   return insert_node(n.release());
 }
 
+#endif
 
 void ReplicatedMesh::delete_node(Node * n)
 {

--- a/src/parallel/parallel_elem.C
+++ b/src/parallel/parallel_elem.C
@@ -770,6 +770,8 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
         }
 
       elem->unpack_indexing(in);
+
+      mesh->add_elem(elem);
     }
 
   in += elem->packed_indexing_size();

--- a/src/parallel/parallel_node.C
+++ b/src/parallel/parallel_node.C
@@ -261,6 +261,8 @@ Packing<Node *>::unpack (std::vector<largest_id_type>::const_iterator in,
       libmesh_assert_equal_to (DofObject::unpackable_indexing_size(in),
                                node->packed_indexing_size());
       in += node->packed_indexing_size();
+
+      mesh->add_node(node);
     }
 
   // FIXME: We should add some debug mode tests to ensure that the


### PR DESCRIPTION
The packed range algorithms only work if the object is added as
soon as it is unpacked. But `push_parallel_packed_range` does all
of its unpacking before the user gets a chance to add objects to
the mesh manually. So we need to make sure we do it automatically
in the unpack routines