### PR TITLE
Fix "Unused variable" warning in opt with gcc 7.5

### DIFF
--- a/src/mesh/mesh_triangle_holes.C
+++ b/src/mesh/mesh_triangle_holes.C
@@ -331,6 +331,7 @@ TriangulatorInterface::MeshedHole::MeshedHole(const MeshBase & mesh,
       for (auto [key, val] : as_range(next_it_begin, next_it_end))
         {
           libmesh_assert_equal_to(key, n);
+          libmesh_ignore(key);
           libmesh_assert_not_equal_to(val, n);
           if (val == last)
             continue;


### PR DESCRIPTION
Thanks to @vikramvgarg for catching this.  It was a bit tricky for me to
find the compiler to replicate it and ensure there weren't more warnings
too.