### PR TITLE
Add support for elemsets when stitching meshes

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -314,8 +314,15 @@ public:
    * Replace elemset code "old_code" with "new_code". This function loops over
    * all elements and changes the extra integer corresponding to the "elemset_code"
    * label, and updates the _elemset_codes and _elemset_codes_inverse_map members.
+   * Does not change the elemset ids of any of the sets.
    */
   void change_elemset_code(dof_id_type old_code, dof_id_type new_code);
+
+  /**
+   * Replace elemset id "old_id" with "new_id". Does not change any of the
+   * elemset codes, so does not need to loop over the elements themselves.
+   */
+  void change_elemset_id(elemset_id_type old_id, elemset_id_type new_id);
 
   /**
    * \returns The "spatial dimension" of the mesh.

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -295,9 +295,9 @@ public:
   void add_elemset_code(dof_id_type code, MeshBase::elemset_type id_set);
 
   /**
-   * Determines the number of unique elemset ids which have been added
-   * via add_elemset_code() calls by looping over the
-   * _elemset_codes_inverse_map and counting them.
+   * Returns the number of unique elemset ids which have been added
+   * via add_elemset_code(), which is the size of the _all_elemset_ids
+   * set.
    */
   unsigned int n_elemsets() const;
 
@@ -309,6 +309,12 @@ public:
    */
   void get_elemsets(dof_id_type elemset_code, MeshBase::elemset_type & id_set_to_fill) const;
   dof_id_type get_elemset_code(const MeshBase::elemset_type & id_set) const;
+
+  /**
+   * Return a vector of all elemset codes defined on the mesh. We get
+   * this by looping over the _elemset_codes map.
+   */
+  std::vector<dof_id_type> get_elemset_codes() const;
 
   /**
    * Replace elemset code "old_code" with "new_code". This function loops over

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -311,6 +311,13 @@ public:
   dof_id_type get_elemset_code(const MeshBase::elemset_type & id_set) const;
 
   /**
+   * Replace elemset code "old_code" with "new_code". This function loops over
+   * all elements and changes the extra integer corresponding to the "elemset_code"
+   * label, and updates the _elemset_codes and _elemset_codes_inverse_map members.
+   */
+  void change_elemset_code(dof_id_type old_code, dof_id_type new_code);
+
+  /**
    * \returns The "spatial dimension" of the mesh.
    *
    * The spatial dimension is defined as:

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -1167,13 +1167,6 @@ void FEAbstract::compute_periodic_node_constraints (NodeConstraints & constraint
 
                       const Node * my_node = my_nodes[my_side_n];
 
-                      // Figure out where my node lies on their reference element.
-                      const Point neigh_point = periodic->get_corresponding_pos(*my_node);
-
-                      const Point mapped_point =
-                        FEMap::inverse_map(Dim-1, neigh_side.get(),
-                                           neigh_point);
-
                       // If we've already got a constraint on this
                       // node, then the periodic constraint is
                       // redundant

--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -396,7 +396,7 @@ Real Hex::quality (const ElemQuality q) const
         // it's OK because we are only interested in determinants and
         // products which are not affected by taking the transpose.
         std::array<RealTensor, 8> A =
-          {
+          {{
             RealTensor(d1, d2, d3),
             RealTensor(d1, b2 + d2, b3 + d3),
             RealTensor(b1 + d1, b2 + d2, a3 + b3 + c3 + d3),
@@ -405,7 +405,7 @@ Real Hex::quality (const ElemQuality q) const
             RealTensor(c1 + d1, a2 + b2 + c2 + d2, b3 + d3),
             RealTensor(a1 + b1 + c1 + d1, a2 + b2 + c2 + d2, a3 + b3 + c3 + d3),
             RealTensor(a1 + b1 + c1 + d1, c2 + d2, c3 + d3)
-          };
+          }};
 
         // Compute Nodal areas, alpha_k = det(A_k).
         // If any of these are zero or negative, we return zero

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -290,6 +290,15 @@ dof_id_type MeshBase::get_elemset_code(const MeshBase::elemset_type & id_set) co
   return (it == _elemset_codes_inverse_map.end()) ? DofObject::invalid_id : it->second;
 }
 
+std::vector<dof_id_type> MeshBase::get_elemset_codes() const
+{
+  std::vector<dof_id_type> ret;
+  ret.reserve(_elemset_codes.size());
+  for (const auto & pr : _elemset_codes)
+    ret.push_back(pr.first);
+  return ret;
+}
+
 void MeshBase::change_elemset_code(dof_id_type old_code, dof_id_type new_code)
 {
   // Look up elemset ids for old_code

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -311,15 +311,14 @@ void MeshBase::change_elemset_code(dof_id_type old_code, dof_id_type new_code)
   libmesh_error_msg_if(inverse_it == _elemset_codes_inverse_map.end(),
                        "Expected _elemset_codes_inverse_map entry for elemset code " << old_code);
 
-  // Erase entry from inverse map and re-add with new elemset code
+  // Erase entry from inverse map
   _elemset_codes_inverse_map.erase(inverse_it);
-  auto [new_inverse_it, inserted1] = _elemset_codes_inverse_map.emplace(id_set_copy, new_code);
-  libmesh_error_msg_if(!inserted1, "Error inserting new elemset code: " << new_code);
 
-  // Erase entry from forward map and re-add with new pointer
+  // Erase entry from forward map
   _elemset_codes.erase(it);
-  auto [new_it, inserted2] = _elemset_codes.emplace(new_code, &new_inverse_it->first);
-  libmesh_error_msg_if(!inserted2, "Error inserting new elemset code: " << new_code);
+
+  // Add new code with original set of ids.
+  this->add_elemset_code(new_code, id_set_copy);
 
   // We can't update any actual elemset codes if there is no extra integer defined for it.
   if (!this->has_elem_integer("elemset_code"))

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -2159,6 +2159,24 @@ void UnstructuredMesh::stitching_helper (const UnstructuredMesh * other_mesh,
       const auto & other_es_id_to_name = other_boundary.get_edgeset_name_map();
       auto & es_id_to_name = boundary.set_edgeset_name_map();
       es_id_to_name.insert(other_es_id_to_name.begin(), other_es_id_to_name.end());
+
+      // Merge other_mesh's elemset information with ours. Throw an
+      // error if this and other_mesh have overlapping elemset codes
+      // that refer to different elemset ids.
+      // std::vector<dof_id_type> elemset_codes = this->get_elemset_codes();
+      MeshBase::elemset_type id_set_to_fill;
+      for (const auto & elemset_code : other_mesh->get_elemset_codes())
+        {
+          // Get the elemset ids for this elemset_code on other_mesh
+          other_mesh->get_elemsets(elemset_code, id_set_to_fill);
+
+          // TODO: check that this elemset code does not already exist
+          // in this mesh, or if it does, that it has the same elemset
+          // ids associated with it.
+
+          // Add it to this mesh
+          this->add_elemset_code(elemset_code, id_set_to_fill);
+        }
     } // end if (other_mesh)
 
   // Finally, we need to "merge" the overlapping nodes

--- a/tests/mesh/extra_integers.C
+++ b/tests/mesh/extra_integers.C
@@ -68,7 +68,7 @@ protected:
                                        0., ymax,
                                        0., zmax,
                                        elem_type);
-    return {i1, r1, ni1, ni2, nr1, nr2};
+    return {{i1, r1, ni1, ni2, nr1, nr2}};
   }
 
 

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -980,8 +980,8 @@ public:
 
     testDynaFileMappings("meshes/PressurizedCyl_Patch6_256Elem.bxt.gz",
     // Regression values for sin_x_plus_cos_y
-                         {0.9639857809698268, 1.839870171669186,
-                          0.7089812562241862, 1.306121188539059});
+                         {{0.9639857809698268, 1.839870171669186,
+                           0.7089812562241862, 1.306121188539059}});
   }
 
   void testDynaFileMappingsBlockWithHole ()
@@ -990,8 +990,8 @@ public:
 
     testDynaFileMappings("meshes/BlockWithHole_Patch9.bxt.gz",
     // Regression values for sin_x_plus_cos_y
-                         {3.22612556930183, 1.97405365384733,
-                          2.53376235803176, 1.41374070517223});
+                         {{3.22612556930183, 1.97405365384733,
+                           2.53376235803176, 1.41374070517223}});
   }
 
   void testDynaFileMappingsPlateWithHole ()
@@ -1000,8 +1000,8 @@ public:
 
     testDynaFileMappings("meshes/PlateWithHole_Patch8.bxt.gz",
     // Regression values for sin_x_plus_cos_y
-                         {2.2812154374012, 1.974049990211937,
-                          1.791640772215248, 1.413679237529376});
+                         {{2.2812154374012, 1.974049990211937,
+                           1.791640772215248, 1.413679237529376}});
   }
 
   void testDynaFileMappingsCyl3d ()
@@ -1010,8 +1010,8 @@ public:
 
     testDynaFileMappings("meshes/PressurizedCyl3d_Patch1_8Elem.bxt.gz",
     // Regression values for sin_x_plus_cos_y
-                         {0.963612880188165, 1.82329452603503,
-                          0.707998701597943, 1.31399222566683});
+                         {{0.963612880188165, 1.82329452603503,
+                           0.707998701597943, 1.31399222566683}});
   }
 
   void testExodusFileMappings (const std::string & filename, std::array<Real, 4> expected_norms)
@@ -1059,8 +1059,8 @@ public:
 
     testExodusFileMappings("meshes/PlateWithHole_Patch8.e",
     // Regression values for sin_x_plus_cos_y
-                           {2.2812154374012, 1.974049990211937,
-                            1.791640772215248, 1.413679237529376});
+                           {{2.2812154374012, 1.974049990211937,
+                             1.791640772215248, 1.413679237529376}});
   }
 
   void testExodusFileMappingsTwoBlocks ()
@@ -1069,8 +1069,8 @@ public:
 
     testExodusFileMappings("meshes/two_quads_two_blocks.e",
     // Regression values for sin_x_plus_cos_y
-                           {2.03496953073072, 1.97996853164955,
-                            1.18462134113435, 1.03085301158959});
+                           {{2.03496953073072, 1.97996853164955,
+                             1.18462134113435, 1.03085301158959}});
   }
   void testExodusFileMappingsTwoElemIGA()
   {
@@ -1078,8 +1078,8 @@ public:
 
     testExodusFileMappings("meshes/two_element_iga_in.e",
     // Regression values for sin_x_plus_cos_y
-                           {1.26865962862531, 1.42562070158386,
-                            1.54905363492342, 1.29782906548366});
+                           {{1.26865962862531, 1.42562070158386,
+                             1.54905363492342, 1.29782906548366}});
   }
 
   void testExodusFileMappingsCyl3d ()
@@ -1087,8 +1087,8 @@ public:
     LOG_UNIT_TEST;
 
     testExodusFileMappings("meshes/PressurizedCyl3d_Patch1_8Elem.e",
-                           {0.963612880188165, 1.82329452603503,
-                            0.707998701597943, 1.31399222566683});
+                           {{0.963612880188165, 1.82329452603503,
+                             0.707998701597943, 1.31399222566683}});
   }
 };
 

--- a/tests/mesh/mesh_stitch.C
+++ b/tests/mesh/mesh_stitch.C
@@ -308,43 +308,14 @@ public:
 
     // Check that the stitched mesh has merged elemset codes and ids as expected
     MeshBase::elemset_type id_set_to_fill;
-    for (const auto elemset_code : {1, 2, 3, 4})
+    const elemset_id_type code_to_type[] = {0,1,2,100,200};
+    for (dof_id_type elemset_code=1; elemset_code<5; ++elemset_code)
       {
         mesh0->get_elemsets(elemset_code, id_set_to_fill);
 
-        // Should be one elemset id in each set
+        // Assert one elemset id in each set, and that set contains the correct id
         CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(1), id_set_to_fill.size());
-
-        switch (elemset_code)
-          {
-          case 1:
-            {
-              CPPUNIT_ASSERT(id_set_to_fill.count(1));
-              break;
-            }
-
-          case 2:
-            {
-              CPPUNIT_ASSERT(id_set_to_fill.count(2));
-              break;
-            }
-
-          case 3:
-            {
-              CPPUNIT_ASSERT(id_set_to_fill.count(100));
-              break;
-            }
-
-          case 4:
-            {
-              CPPUNIT_ASSERT(id_set_to_fill.count(200));
-              break;
-            }
-
-          default:
-            // Unrecognized elemset_code
-            CPPUNIT_ASSERT(false);
-          }
+        CPPUNIT_ASSERT(id_set_to_fill.count(code_to_type[elemset_code]));
       }
 
     bool ps_odd = ps % 2;

--- a/tests/mesh/mesh_stitch.C
+++ b/tests/mesh/mesh_stitch.C
@@ -280,6 +280,11 @@ public:
     mesh1->change_elemset_code(/*old*/1, /*new*/3); // 1 -> 3
     mesh1->change_elemset_code(/*old*/2, /*new*/4); // 2 -> 4
 
+    // Before stitching, change the elemset ids on mesh1 so they
+    // don't overlap with the elemset ids on mesh0.
+    mesh1->change_elemset_id(/*old*/1, /*new*/100);
+    mesh1->change_elemset_id(/*old*/2, /*new*/200);
+
     // Stitch the meshes together at the indicated boundary ids
     mesh0->stitch_meshes(dynamic_cast<UnstructuredMesh &>(*mesh1),
                          /*this boundary=*/2,

--- a/tests/mesh/mesh_stitch.C
+++ b/tests/mesh/mesh_stitch.C
@@ -82,13 +82,6 @@ public:
     const auto & nbi = bi.get_node_boundary_ids();
     CPPUNIT_ASSERT_EQUAL(expected_size, nbi.size());
 
-    const auto & ss_id_to_name = bi.get_sideset_name_map();
-    std::set<std::string> ss_names;
-    std::for_each(ss_id_to_name.begin(),
-                  ss_id_to_name.end(),
-                  [&ss_names](const std::pair<boundary_id_type, std::string> & map_pr) {
-                    ss_names.insert(map_pr.second);
-                  });
     std::set<std::string> expected_names = {{"zero_left",
                                              "zero_top",
                                              "zero_front",
@@ -99,15 +92,14 @@ public:
                                              "one_front",
                                              "one_back",
                                              "one_bottom"}};
+    std::set<std::string> ss_names;
+    for (const auto & pr : bi.get_sideset_name_map())
+      ss_names.insert(pr.second);
     CPPUNIT_ASSERT(ss_names == expected_names);
 
-    const auto & ns_id_to_name = bi.get_nodeset_name_map();
     std::set<std::string> ns_names;
-    std::for_each(ns_id_to_name.begin(),
-                  ns_id_to_name.end(),
-                  [&ns_names](const std::pair<boundary_id_type, std::string> & map_pr) {
-                    ns_names.insert(map_pr.second);
-                  });
+    for (const auto & pr : bi.get_nodeset_name_map())
+      ns_names.insert(pr.second);
     CPPUNIT_ASSERT(ns_names == expected_names);
   }
 

--- a/tests/mesh/mesh_stitch.C
+++ b/tests/mesh/mesh_stitch.C
@@ -354,65 +354,6 @@ public:
         // Debugging
         libMesh::out << "Elem " << elem->id() << " in stitched mesh has elemset_code = " << elemset_code << std::endl;
       }
-
-    /**
-     * The following checks only apply if we don't call MeshBase::change_elemset_code()...
-     */
-
-    // // There should still be 2 elemset ids, 1 and 2, on the stitched mesh
-    // CPPUNIT_ASSERT_EQUAL(2u, mesh0->n_elemsets());
-    //
-    // MeshBase::elemset_type id_set_to_fill;
-    //
-    // // Make sure that elemset_code 1 == {1} and 2 == {2} on the new mesh
-    // for (int i=1; i<3; ++i)
-    //   {
-    //     mesh0->get_elemsets(static_cast<dof_id_type>(i), id_set_to_fill);
-    //     CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(1), id_set_to_fill.size());
-    //     CPPUNIT_ASSERT_EQUAL(static_cast<elemset_id_type>(i), *id_set_to_fill.begin());
-    //   }
-    //
-    // // Debugging
-    // // libMesh::out << "In stitched mesh, elemset_index = " << elemset_index << std::endl;
-    //
-    // // The elems from mesh1 will all have n_elem_prestitch added to their ids.
-    // for (const auto & elem : mesh0->element_ptr_range())
-    //   {
-    //     dof_id_type elemset_code = elem->get_extra_integer(elemset_index);
-    //
-    //     // Debugging
-    //     // libMesh::out << "Elem " << elem->id() << " in stitched mesh has elemset_code = " << elemset_code << std::endl;
-    //
-    //     if (ps % 2) // ps == odd
-    //       {
-    //         // i.) If ps == odd, then n_elem_prestitch == odd, and even mesh1
-    //         // elem ids will become odd, and odd mesh1 elem ids will become
-    //         // even..
-    //         if (elem->id() < n_elem_prestitch) // lower half id
-    //           {
-    //             if (elem->id() % 2) // id odd
-    //               CPPUNIT_ASSERT_EQUAL(1u, elemset_code);
-    //             else // id even
-    //               CPPUNIT_ASSERT_EQUAL(2u, elemset_code);
-    //           }
-    //         else // upper half id (sets reversed)
-    //           {
-    //             if (elem->id() % 2) // id odd
-    //               CPPUNIT_ASSERT_EQUAL(2u, elemset_code);
-    //             else // id even
-    //               CPPUNIT_ASSERT_EQUAL(1u, elemset_code);
-    //           }
-    //       }
-    //     else // ps == even
-    //       {
-    //         // ii.) If ps == even, then n_elem_prestitch == even, and even mesh1
-    //         // elem ids will remain even, odd mesh1 elem ids will remain odd.
-    //         if (elem->id() % 2) // id odd
-    //           CPPUNIT_ASSERT_EQUAL(1u, elemset_code);
-    //         else // id even
-    //           CPPUNIT_ASSERT_EQUAL(2u, elemset_code);
-    //       }
-    //   }
   }
 
   void testReplicatedMeshStitchElemsets ()

--- a/tests/mesh/mesh_stitch.C
+++ b/tests/mesh/mesh_stitch.C
@@ -347,12 +347,36 @@ public:
           }
       }
 
+    bool ps_odd = ps % 2;
+
     for (const auto & elem : mesh0->element_ptr_range())
       {
         dof_id_type elemset_code = elem->get_extra_integer(elemset_index);
+        bool elem_id_odd = elem->id() % 2;
 
         // Debugging
-        libMesh::out << "Elem " << elem->id() << " in stitched mesh has elemset_code = " << elemset_code << std::endl;
+        // libMesh::out << "Elem " << elem->id() << " in stitched mesh has elemset_code = " << elemset_code << std::endl;
+
+        // Verify that the stitched mesh elemset codes match their pre-stitched values
+        if (elem->id() < n_elem_prestitch) // lower half id
+          {
+            if (elem_id_odd)
+              CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(1), elemset_code);
+            else
+              CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(2), elemset_code);
+          }
+        else // upper half id
+          {
+            // i.) If ps == odd, then n_elem_prestitch == odd, and even mesh1
+            // elem ids will become odd, and odd mesh1 elem ids will become
+            // even..
+            // ii.) If ps == even, then n_elem_prestitch == even, and even mesh1
+            // elem ids will remain even, odd mesh1 elem ids will remain odd.
+            if (elem_id_odd)
+              CPPUNIT_ASSERT_EQUAL(ps_odd ? static_cast<dof_id_type>(4) : static_cast<dof_id_type>(3), elemset_code);
+            else
+              CPPUNIT_ASSERT_EQUAL(ps_odd ? static_cast<dof_id_type>(3) : static_cast<dof_id_type>(4), elemset_code);
+          }
       }
   }
 

--- a/tests/mesh/mesh_stitch.C
+++ b/tests/mesh/mesh_stitch.C
@@ -282,8 +282,8 @@ public:
 
     // Before stitching, change the elemset ids on mesh1 so they
     // don't overlap with the elemset ids on mesh0.
-    mesh1->change_elemset_id(/*old*/1, /*new*/100);
-    mesh1->change_elemset_id(/*old*/2, /*new*/200);
+    mesh1->change_elemset_id(/*old*/1, /*new*/100); // 1 -> 100
+    mesh1->change_elemset_id(/*old*/2, /*new*/200); // 2 -> 200
 
     // Stitch the meshes together at the indicated boundary ids
     mesh0->stitch_meshes(dynamic_cast<UnstructuredMesh &>(*mesh1),
@@ -305,6 +305,47 @@ public:
     // same index (0) as it was before the meshes were stitched.
     unsigned int elemset_index = mesh0->get_elem_integer_index("elemset_code");
     CPPUNIT_ASSERT_EQUAL(0u, elemset_index);
+
+    // Check that the stitched mesh has merged elemset codes and ids as expected
+    MeshBase::elemset_type id_set_to_fill;
+    for (const auto elemset_code : {1, 2, 3, 4})
+      {
+        mesh0->get_elemsets(elemset_code, id_set_to_fill);
+
+        // Should be one elemset id in each set
+        CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(1), id_set_to_fill.size());
+
+        switch (elemset_code)
+          {
+          case 1:
+            {
+              CPPUNIT_ASSERT(id_set_to_fill.count(1));
+              break;
+            }
+
+          case 2:
+            {
+              CPPUNIT_ASSERT(id_set_to_fill.count(2));
+              break;
+            }
+
+          case 3:
+            {
+              CPPUNIT_ASSERT(id_set_to_fill.count(100));
+              break;
+            }
+
+          case 4:
+            {
+              CPPUNIT_ASSERT(id_set_to_fill.count(200));
+              break;
+            }
+
+          default:
+            // Unrecognized elemset_code
+            CPPUNIT_ASSERT(false);
+          }
+      }
 
     for (const auto & elem : mesh0->element_ptr_range())
       {


### PR DESCRIPTION
This does not yet handle the case of merging different elemset codes that refer to the same elemset ids, e.g.

1. mesh A has elemset_code 0 referring to elemset ids {a, b}
1. mesh B has elemset_code 1 referring to elemset ids {a, b}
1. mesh B is stitched onto mesh A

It should be easy to handle this simply by retaining mesh A's elemset code and updating the Elems which came from Mesh B accordingly, however this is not a case which I need to handle currently (elemset ids of stitched meshes will always be distinct), so it can be left as future work for now.