### PR TITLE
ParameterMultiAccessor should store a vector of unique_ptrs

### DIFF
--- a/include/systems/parameter_multiaccessor.h
+++ b/include/systems/parameter_multiaccessor.h
@@ -106,11 +106,11 @@ public:
    */
   virtual std::unique_ptr<ParameterAccessor<T>> clone() const override
   {
-    ParameterMultiAccessor * pmp = new ParameterMultiAccessor<T>();
+    auto pmp = std::make_unique<ParameterMultiAccessor<T>>();
     for (auto & accessor : _accessors)
       pmp->_accessors.push_back(accessor->clone().release());
 
-    return std::unique_ptr<ParameterAccessor<T>>(pmp);
+    return pmp;
   }
 
 

--- a/include/systems/parameter_multiaccessor.h
+++ b/include/systems/parameter_multiaccessor.h
@@ -50,7 +50,7 @@ public:
   /**
    * Constructor: no parameters attached yet
    */
-  ParameterMultiAccessor() {}
+  ParameterMultiAccessor() = default;
 
   /**
    * Constructor: take the first sub-accessor for the parameter
@@ -59,12 +59,9 @@ public:
     _accessors(1, param_accessor.clone()) {}
 
   /*
-   * Destructor: delete our clones of sub-accessors
+   * Destructor
    */
-  ~ParameterMultiAccessor() {
-    for (auto & accessor : _accessors)
-      delete accessor;
-  }
+  ~ParameterMultiAccessor() = default;
 
   /**
    * Setter: change the value of the parameter we access.
@@ -108,7 +105,7 @@ public:
   {
     auto pmp = std::make_unique<ParameterMultiAccessor<T>>();
     for (auto & accessor : _accessors)
-      pmp->_accessors.push_back(accessor->clone().release());
+      pmp->_accessors.push_back(accessor->clone());
 
     return pmp;
   }
@@ -126,7 +123,7 @@ public:
   std::size_t size() const { return _accessors.size(); }
 
 private:
-  std::vector<ParameterAccessor<T> *> _accessors;
+  std::vector<std::unique_ptr<ParameterAccessor<T>>> _accessors;
 };
 
 } // namespace libMesh

--- a/include/systems/parameter_multipointer.h
+++ b/include/systems/parameter_multipointer.h
@@ -97,10 +97,9 @@ public:
    */
   virtual std::unique_ptr<ParameterAccessor<T>> clone() const override
   {
-    ParameterMultiPointer * pmp = new ParameterMultiPointer<T>();
+    auto pmp = std::make_unique<ParameterMultiPointer<T>>();
     pmp->_ptrs = _ptrs;
-
-    return std::unique_ptr<ParameterAccessor<T>>(pmp);
+    return pmp;
   }
 
   void push_back (T * new_ptr) { _ptrs.push_back(new_ptr); }


### PR DESCRIPTION
Another hopefully straightforward update similar to #3274, #3273, #3270. We don't have any tests (or even code that includes the header for) `ParameterMultiAccessor` so strictly speaking this should be run through the GRINS regression testing before being merged, and (even more strictly speaking) we should probably add a unit test for this in libmesh.