### PR TITLE
Allow empty EIM basis

### DIFF
--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -590,7 +590,12 @@ Real RBEIMConstruction::train_eim_approximation_with_POD()
   DenseMatrix<Number> VT( n_snapshots, n_snapshots );
   correlation_matrix.svd(sigma, U, VT );
 
-  libmesh_error_msg_if(sigma(0) == 0., "Zero singular value encountered in POD construction");
+  // If the first singular value is zero then we exit with an empty basis
+  if (sigma(0) == 0.)
+  {
+    libMesh::out << "Terminating EIM POD with empty basis because correlation matrix is zero" << std::endl;
+    return 0.;
+  }
 
   // Add dominant vectors from the POD as basis functions.
   unsigned int j = 0;

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -1258,6 +1258,10 @@ read_in_basis_functions(const System & sys,
 {
   LOG_SCOPE("read_in_basis_functions()", "RBEIMEvaluation");
 
+  // Return early without reading in anything if there are no basis functions
+  if (get_n_basis_functions() == 0)
+    return;
+
   if (get_parametrized_function().on_mesh_sides())
     read_in_side_basis_functions(sys, directory_name, read_binary_basis_functions);
   else if (get_parametrized_function().on_mesh_nodes())


### PR DESCRIPTION
Allow to generate an empty EIM basis in RBEIMConstruction::train_eim_approximation_with_POD().