### PR TITLE
Fix unused variable warning in --disable-exodus case

### DIFF
--- a/examples/adjoints/adjoints_ex6/adjoints_ex6.C
+++ b/examples/adjoints/adjoints_ex6/adjoints_ex6.C
@@ -98,6 +98,9 @@ void write_output(EquationSystems & es,
                   unsigned int a_step,       // The adaptive step count
                   std::string solution_type) // primal or adjoint solve
 {
+  // Avoid unused variable warnings in the --disable-gmv configuration
+  libmesh_ignore(es, a_step, solution_type);
+
 #ifdef LIBMESH_HAVE_GMV
   MeshBase & mesh = es.get_mesh();
 

--- a/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
+++ b/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
@@ -401,6 +401,9 @@ void scale_mesh_and_plot(EquationSystems & es,
 #endif
 #endif
 
+  // Avoid unused variable warnings when Exodus is not enabled
+  libmesh_ignore(file_basename);
+
   // Loop over the mesh nodes and move them!
   for (auto & node : mesh.node_ptr_range())
     (*node)(0) /= mu.get_value("x_scaling");

--- a/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
+++ b/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
@@ -338,6 +338,9 @@ void transform_mesh_and_plot(EquationSystems & es,
 #ifdef LIBMESH_HAVE_EXODUS_API
   ExodusII_IO(mesh).write_equation_systems(filename, es);
 #endif
+
+  // Avoid unused variable warnings in the --disable-exodus case
+  libmesh_ignore(filename, es);
 }
 
 #endif // LIBMESH_ENABLE_DIRICHLET


### PR DESCRIPTION
Noticed this in the devel->master merge, where `-Werror` has recently been added to a few recipes. I will add Test No Exodus and Test No Optional recipes to this PR momentarily.