### PR TITLE
Fix MultiAccessor push_back()

### DIFF
--- a/include/systems/parameter_multiaccessor.h
+++ b/include/systems/parameter_multiaccessor.h
@@ -112,7 +112,7 @@ public:
 
 
   void push_back (const ParameterAccessor<T> & new_accessor) {
-    _accessors.push_back(new_accessor.clone().release());
+    _accessors.push_back(new_accessor.clone());
   }
 
   /**


### PR DESCRIPTION
This fixes the compilation error in GRINS that #3281 introduced for me.