### PR TITLE
Do Elem/FE order compatibility testing in optimized modes too 

### DIFF
--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -629,25 +629,25 @@ void DofMap::reinit(MeshBase & mesh)
 
           FEType fe_type = base_fe_type;
 
-#ifdef LIBMESH_ENABLE_AMR
           const ElemType type = elem->type();
 
+          libmesh_error_msg_if(base_fe_type.order.get_order() >
+                               int(FEInterface::max_order(base_fe_type,type)),
+                               "ERROR: Finite element "
+                               << Utility::enum_to_string(base_fe_type.family)
+                               << " on geometric element "
+                               << Utility::enum_to_string(type)
+                               << "\nonly supports FEInterface::max_order = "
+                               << FEInterface::max_order(base_fe_type,type)
+                               << ", not fe_type.order = "
+                               << base_fe_type.order);
+
+#ifdef LIBMESH_ENABLE_AMR
           // Make sure we haven't done more p refinement than we can
           // handle
           if (elem->p_level() + base_fe_type.order >
               FEInterface::max_order(base_fe_type, type))
             {
-              libmesh_assert_less_msg(base_fe_type.order.get_order(),
-                                      FEInterface::max_order(base_fe_type,type),
-                                      "ERROR: Finite element "
-                                      << Utility::enum_to_string(base_fe_type.family)
-                                      << " on geometric element "
-                                      << Utility::enum_to_string(type)
-                                      << "\nonly supports FEInterface::max_order = "
-                                      << FEInterface::max_order(base_fe_type,type)
-                                      << ", not fe_type.order = "
-                                      << base_fe_type.order);
-
 #  ifdef DEBUG
               libMesh::err << "WARNING: Finite element "
                            << Utility::enum_to_string(base_fe_type.family)


### PR DESCRIPTION
This shouldn't be too expensive compared to the rest of the reinit(), and getting a baffling low-level error in opt mode instead is a constant source of confusion for users whenever they create an inconsistent combination for the first time.

Pinging @bwspenc, who's patiently + politely "complained about this a million times"; turns out the million-and-first time did the trick.  In hindsight I should have dug into this when he first talked with me about it long ago, not waited for yet-another-victim to pop up on Slack this week.