### PR TITLE
PerfLog: store character strings with unique_ptrs

### DIFF
--- a/include/utils/perf_log.h
+++ b/include/utils/perf_log.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <vector>
 #include <deque>
+#include <memory>
 #ifdef LIBMESH_HAVE_SYS_TIME_H
 #include <sys/time.h> // gettimeofday() on Unix
 #endif
@@ -394,7 +395,7 @@ private:
    * their c_str() pointers... but I can't prove it from the standards
    * doc, so let's be safe.
    */
-  std::map<std::string, const char *> non_temporary_strings;
+  std::map<std::string, std::unique_ptr<const char[]>> non_temporary_strings;
 };
 
 


### PR DESCRIPTION
This removes manual memory management from the PerfLog class and lets us simplify the destructor. As discussed with @roystgnr over IM, I don't believe this will introduce any overhead into the `PerfLog` itself... I haven't confirmed this with any detailed profiling though.