### PR TITLE
TreeNode should store unique_ptrs to its children

### DIFF
--- a/include/utils/tree.h
+++ b/include/utils/tree.h
@@ -52,9 +52,10 @@ public:
         Trees::BuildType bt = Trees::NODES);
 
   /**
-   * Copy-constructor.  Not currently implemented.
+   * Copy-constructor. Class cannot be default copy constructed
+   * because TreeNode cannot be default copy constructed.
    */
-  Tree (const Tree<N> & other_tree);
+  Tree (const Tree<N> &) = delete;
 
   /**
    * Destructor.

--- a/include/utils/tree_node.h
+++ b/include/utils/tree_node.h
@@ -30,6 +30,7 @@
 #include <set>
 #include <unordered_map>
 #include <vector>
+#include <memory>
 
 namespace libMesh
 {
@@ -63,11 +64,16 @@ public:
             const TreeNode<N> * p = nullptr);
 
   /**
+   * Class contains unique_ptrs and cannot be default copied.
+   */
+  TreeNode (const TreeNode<N> &) = delete;
+
+  /**
    * Destructor.  Deletes all children, if any.  Thus
    * to delete a tree it is sufficient to explicitly
    * delete the root node.
    */
-  ~TreeNode ();
+  ~TreeNode () = default;
 
   /**
    * \returns \p true if this node is the root node, false
@@ -209,7 +215,7 @@ private:
    * Pointers to our children.  This vector
    * is empty if the node is active.
    */
-  std::vector<TreeNode<N> * > children;
+  std::vector<std::unique_ptr<TreeNode<N>>> children;
 
   /**
    * The Cartesian bounding box for the node.
@@ -271,19 +277,6 @@ TreeNode<N>::TreeNode (const MeshBase & m,
   // Reserve space for the nodes & elements
   nodes.reserve    (tgt_bin_size);
   elements.reserve (tgt_bin_size);
-}
-
-
-
-template <unsigned int N>
-inline
-TreeNode<N>::~TreeNode ()
-{
-  // When we are destructed we must delete all of our
-  // children.  They will thus delete their children,
-  // All the way down the line...
-  for (auto c : children)
-    delete c;
 }
 
 

--- a/src/utils/tree.C
+++ b/src/utils/tree.C
@@ -101,21 +101,6 @@ Tree<N>::Tree (const MeshBase & m,
 
 
 
-// copy-constructor is not implemented
-template <unsigned int N>
-Tree<N>::Tree (const Tree<N> & other_tree) :
-  TreeBase   (other_tree),
-  root       (other_tree.root),
-  build_type (other_tree.build_type)
-{
-  libmesh_not_implemented();
-}
-
-
-
-
-
-
 template <unsigned int N>
 void Tree<N>::print_nodes(std::ostream & my_out) const
 {

--- a/src/utils/tree_node.C
+++ b/src/utils/tree_node.C
@@ -219,7 +219,7 @@ void TreeNode<N>::refine ()
   for (unsigned int c=0; c<N; c++)
     {
       // Create the child and set its bounding box.
-      children[c] = new TreeNode<N> (mesh, new_target_bin_size, this);
+      children[c] = std::make_unique<TreeNode<N>>(mesh, new_target_bin_size, this);
       children[c]->set_bounding_box(this->create_bounding_box(c));
 
       // Pass off our nodes to our children
@@ -419,7 +419,7 @@ void TreeNode<N>::print_nodes(std::ostream & out_stream) const
       out_stream << std::endl << std::endl;
     }
   else
-    for (TreeNode<N> * child : children)
+    for (const auto & child : children)
       child->print_nodes();
 }
 
@@ -438,7 +438,7 @@ void TreeNode<N>::print_elements(std::ostream & out_stream) const
       out_stream << std::endl << std::endl;
     }
   else
-    for (TreeNode<N> * child : children)
+    for (const auto & child : children)
       child->print_elements();
 }
 
@@ -493,7 +493,7 @@ void TreeNode<N>::transform_nodes_to_elements (std::vector<std::vector<const Ele
         }
     }
   else
-    for (TreeNode<N> * child : children)
+    for (auto & child : children)
       child->transform_nodes_to_elements (nodes_to_elem);
 }
 
@@ -547,7 +547,7 @@ void TreeNode<N>::transform_nodes_to_elements (std::unordered_map<dof_id_type, s
         }
     }
   else
-    for (TreeNode<N> * child : children)
+    for (auto & child : children)
       child->transform_nodes_to_elements (nodes_to_elem);
 }
 
@@ -563,7 +563,7 @@ unsigned int TreeNode<N>::n_active_bins() const
     {
       unsigned int sum=0;
 
-      for (TreeNode<N> * child : children)
+      for (const auto & child : children)
         sum += child->n_active_bins();
 
       return sum;


### PR DESCRIPTION
Explicitly delete the TreeNode (and Tree) copy constructors since
TreeNode now contains unique_ptrs and the TreeNode copy constructor
was marked libmesh_not_implemented() anyway.