### PR TITLE
Always examine function parser error

### DIFF
--- a/include/numerics/parsed_function.h
+++ b/include/numerics/parsed_function.h
@@ -670,10 +670,9 @@ template <typename Output, typename OutputGradient>
 inline
 Output
 ParsedFunction<Output,OutputGradient>::eval (FunctionParserADBase<Output> & parser,
-                                             std::string_view libmesh_dbg_var(function_name),
-                                             unsigned int libmesh_dbg_var(component_idx)) const
+                                             std::string_view function_name,
+                                             unsigned int component_idx) const
 {
-#ifndef NDEBUG
   Output result = parser.Eval(_spacetime.data());
   int error_code = parser.EvalError();
   if (error_code)
@@ -715,9 +714,6 @@ ParsedFunction<Output,OutputGradient>::eval (FunctionParserADBase<Output> & pars
     }
 
   return result;
-#else
-  return parser.Eval(_spacetime.data());
-#endif
 }
 
 } // namespace libMesh


### PR DESCRIPTION
@bwspenc has pointed out that `EvalError` just returns an
error code that gets set during `Eval`, hence error checking is
really no more expensive than checking an `if` condition. He's
also pointed out that it may be impossible to do an initial setup
check to check all the possible evaluations of the function that
may occur during simulation execution. Given the almost free nature
of the check, I think it makes good sense to always check the error
code and potentially save users compiling in debug mode etc. in order
to figure out the issue in their simulation