### PR TITLE
Remove __SUNPRO_CC specific code

### DIFF
--- a/examples/fem_system/fem_system_ex2/solid_system.C
+++ b/examples/fem_system/fem_system_ex2/solid_system.C
@@ -42,11 +42,6 @@
 
 #include <memory>
 
-// Solaris Studio has no NAN
-#ifdef __SUNPRO_CC
-#define NAN (1.0/0.0)
-#endif
-
 // Bring in everything from the libMesh namespace
 using namespace libMesh;
 

--- a/include/base/libmesh_augment_std_namespace.h
+++ b/include/base/libmesh_augment_std_namespace.h
@@ -47,16 +47,9 @@ LIBMESH_DEFINE_BOTH_MAX_MIN(libMesh::Real, float)
 #endif
 
 // fix for std::abs() overload ambiguity
-#if defined (__SUNPRO_CC) || defined(__PGI)
+#if defined(__PGI)
 inline double abs(double a)
 { return ::fabs(a); }
-
-#endif
-
-// fix for std::pow() overload ambiguity
-#if defined (__SUNPRO_CC)
-inline double pow(double a, int b)
-{ return std::pow(a, static_cast<double>(b)); }
 #endif
 }
 

--- a/include/base/variant_filter_iterator.h
+++ b/include/base/variant_filter_iterator.h
@@ -169,13 +169,8 @@ public:
      */
     virtual IterBase * clone() const override
     {
-#ifdef __SUNPRO_CC
-      variant_filter_iterator::Iter<IterType> * copy =
-        new variant_filter_iterator::Iter<IterType>(iter_data);
-#else
       Iter<IterType> * copy =
         new Iter<IterType>(iter_data);
-#endif
 
       return copy;
     }
@@ -223,13 +218,8 @@ public:
      */
     virtual bool equal(const IterBase * other) const override
     {
-#if defined(__SUNPRO_CC) || (defined(__GNUC__) && (__GNUC__ < 3)  && !defined(__INTEL_COMPILER))
-      const variant_filter_iterator::Iter<IterType> * p =
-        libMesh::cast_ptr<const variant_filter_iterator::Iter<IterType> *>(other);
-#else
       const Iter<IterType> * p =
         libMesh::cast_ptr<const Iter<IterType> *>(other);
-#endif
 
       return (iter_data == p->iter_data);
     }
@@ -276,13 +266,8 @@ public:
      */
     virtual PredBase * clone() const override
     {
-#ifdef __SUNPRO_CC
-      variant_filter_iterator::Pred<IterType,PredType> * copy =
-        new variant_filter_iterator::Pred<IterType,PredType>(pred_data);
-#else
       Pred<IterType,PredType> * copy =
         new Pred<IterType,PredType>(pred_data);
-#endif
 
       return copy;
     }
@@ -317,13 +302,8 @@ public:
       libmesh_assert(in);
 
       // Attempt downcast
-#if defined(__SUNPRO_CC) || (defined(__GNUC__) && (__GNUC__ < 3)  && !defined(__INTEL_COMPILER))
-      const variant_filter_iterator::Iter<IterType> * p =
-        libMesh::cast_ptr<const variant_filter_iterator::Iter<IterType> * >(in);
-#else
       const Iter<IterType> * p =
         libMesh::cast_ptr<const Iter<IterType> *>(in);
-#endif
 
       // Return result of op() for the user's predicate.
       return pred_data(p->iter_data);

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -779,7 +779,7 @@ LibMeshInit::~LibMeshInit()
  */
 void enableFPE(bool on)
 {
-#if !defined(LIBMESH_HAVE_FEENABLEEXCEPT) && defined(LIBMESH_HAVE_XMMINTRIN_H) && !defined(__SUNPRO_CC)
+#if !defined(LIBMESH_HAVE_FEENABLEEXCEPT) && defined(LIBMESH_HAVE_XMMINTRIN_H)
   static int flags = 0;
 #endif
 
@@ -788,10 +788,8 @@ void enableFPE(bool on)
 #ifdef LIBMESH_HAVE_FEENABLEEXCEPT
       feenableexcept(FE_DIVBYZERO | FE_INVALID);
 #elif  LIBMESH_HAVE_XMMINTRIN_H
-#  ifndef __SUNPRO_CC
       flags = _MM_GET_EXCEPTION_MASK();           // store the flags
       _MM_SET_EXCEPTION_MASK(flags & ~_MM_MASK_INVALID);
-#  endif
 #endif
 
 #if LIBMESH_HAVE_DECL_SIGACTION
@@ -812,9 +810,7 @@ void enableFPE(bool on)
 #ifdef LIBMESH_HAVE_FEDISABLEEXCEPT
       fedisableexcept(FE_DIVBYZERO | FE_INVALID);
 #elif  LIBMESH_HAVE_XMMINTRIN_H
-#  ifndef __SUNPRO_CC
       _MM_SET_EXCEPTION_MASK(flags);
-#  endif
 #endif
       signal(SIGFPE, SIG_DFL);
     }


### PR DESCRIPTION
Any compiler old enough to require such guards would likely no longer
be able to compile the library as a whole. In addition, we do not
currently have (and have not had for some time) regular testing of a
compiler which defines __SUNPRO_CC, so it's not even clear whether the
code currently in the guards still compiles.