### PR TITLE
Switch to unique_ptrs in variant_filter_iterator

### DIFF
--- a/include/base/variant_filter_iterator.h
+++ b/include/base/variant_filter_iterator.h
@@ -22,7 +22,6 @@
 // C++ includes
 #include <algorithm> // for std::swap
 #include <cstddef>
-#include <cstdlib>   // for std::abort()
 #include <iterator>
 #include <memory>
 
@@ -71,7 +70,7 @@ public:
   /**
    * Abstract base class for the iterator type.  Ideally these mixin classes would be protected,
    * but due to the fact that different templated versions of the same class (which are not related
-   * by inheritance) need to be able to see each other's IterBase and PredBase members.  Thus, the
+   * by inheritance) need to be able to see each other's IterBase and PredBase members, the
    * mixin classes are in the public interface.
    */
   struct IterBase
@@ -116,7 +115,6 @@ public:
     virtual std::unique_ptr<PredBase> clone() const = 0;
     virtual bool operator()(const std::unique_ptr<IterBase> & in) const = 0;
 
-    // typedef typename variant_filter_iterator<Predicate, Type, const Type &, const Type *>::PredBase const_PredBase;
     typedef typename variant_filter_iterator<Predicate, ConstType, ConstReferenceType, ConstPointerType>::PredBase const_PredBase;
 
     /**
@@ -139,16 +137,12 @@ public:
   template<typename IterType>
   struct Iter : IterBase
   {
-
     /**
      * Constructor
      */
     Iter (const IterType & v) :
       iter_data (v)
-    {
-      // libMesh::out << "In Iter<IterType>::Iter(const IterType & v)" << std::endl;
-    }
-
+    {}
 
     /**
      * Copy Constructor.
@@ -156,7 +150,6 @@ public:
     Iter (const Iter & other) :
       iter_data(other.iter_data)
     {}
-
 
     /**
      * Destructor
@@ -220,7 +213,9 @@ public:
      * This is the iterator passed by the user.
      */
     IterType iter_data;
+
   private:
+
     /**
      * This seems to work around a bug in g++ prior to version 10 and
      * clang++ prior to version 10
@@ -261,7 +256,6 @@ public:
       return std::make_unique<Pred<IterType,PredType>>(pred_data);
     }
 
-
     /**
      * The redefinition of the const_clone function for the Pred class.
      */
@@ -270,9 +264,6 @@ public:
       typedef typename variant_filter_iterator<Predicate, ConstType, ConstReferenceType, ConstPointerType>::template Pred<IterType, PredType> const_Pred;
       return std::make_unique<const_Pred>(pred_data);
     }
-
-
-
 
     /**
      * Re-implementation of op()
@@ -355,8 +346,6 @@ public:
     end  (rhs.end  ? rhs.end->clone()  : nullptr),
     pred (rhs.pred ? rhs.pred->clone() : nullptr) {}
 
-
-
   /**
    * Copy construct from another (similar) variant_filter_iterator.
    * The Predicate is the same, but the Type, ReferenceType and
@@ -376,13 +365,7 @@ public:
       end  (rhs.end  ? rhs.end->const_clone()  : nullptr),
       pred (rhs.pred ? rhs.pred->const_clone() : nullptr)
   {
-    // libMesh::out << "Called templated copy constructor for variant_filter_iterator" << std::endl;
   }
-
-
-
-
-
 
   /**
    * Destructor
@@ -397,13 +380,12 @@ public:
     return **data;
   }
 
-
   /**
    * op->()
    */
   PointerType operator->() const
   {
-    return (&**this);
+    return &**this;
   }
 
   /**
@@ -413,7 +395,7 @@ public:
   {
     ++*data;
     this->satisfy_predicate();
-    return (*this);
+    return *this;
   }
 
   /**

--- a/include/base/variant_filter_iterator.h
+++ b/include/base/variant_filter_iterator.h
@@ -91,7 +91,6 @@ public:
 
     virtual bool equal(const IterBase * other) const = 0;
 
-    // typedef typename variant_filter_iterator<Predicate, Type, const Type &, const Type *>::IterBase const_IterBase;
     typedef typename variant_filter_iterator<Predicate, ConstType, ConstReferenceType, ConstPointerType>::IterBase const_IterBase;
 
     /**
@@ -99,7 +98,7 @@ public:
      *
      * \returns A pointer to a copy of a different type.
      */
-    virtual const_IterBase * const_clone() const = 0;
+    virtual std::unique_ptr<const_IterBase> const_clone() const = 0;
   };
 
 
@@ -177,18 +176,13 @@ public:
      * \returns A copy of this object as a pointer to a
      * different type of object.
      */
-    virtual typename IterBase::const_IterBase * const_clone() const override
+    virtual std::unique_ptr<typename IterBase::const_IterBase> const_clone() const override
     {
       /**
-       * Important typedef for const_iterators.  Notice the weird syntax!  Does it compile everywhere?
+       * Important typedef for const_iterators.
        */
-      // typedef typename variant_filter_iterator<Predicate, Type, const Type &, const Type *>::template Iter<IterType> const_Iter;
       typedef typename variant_filter_iterator<Predicate, ConstType, ConstReferenceType, ConstPointerType>::template Iter<IterType> const_Iter;
-
-      typename IterBase::const_IterBase * copy =
-        new const_Iter(iter_data);
-
-      return copy;
+      return std::make_unique<const_Iter>(iter_data);
     }
 
     /**

--- a/include/base/variant_filter_iterator.h
+++ b/include/base/variant_filter_iterator.h
@@ -77,7 +77,7 @@ public:
   struct IterBase
   {
     virtual ~IterBase() = default;
-    virtual  IterBase * clone() const = 0;
+    virtual std::unique_ptr<IterBase> clone() const = 0;
 
     /**
      * Dereferences the iterator.
@@ -168,12 +168,9 @@ public:
      * \returns A copy of this object as a pointer to
      * the base (non-templated) class.
      */
-    virtual IterBase * clone() const override
+    virtual std::unique_ptr<IterBase> clone() const override
     {
-      Iter<IterType> * copy =
-        new Iter<IterType>(iter_data);
-
-      return copy;
+      return std::make_unique<Iter<IterType>>(iter_data);
     }
 
     /**

--- a/include/base/variant_filter_iterator.h
+++ b/include/base/variant_filter_iterator.h
@@ -89,7 +89,7 @@ public:
      */
     virtual IterBase & operator++() = 0;
 
-    virtual bool equal(const IterBase * other) const = 0;
+    virtual bool equal(const std::unique_ptr<IterBase> & other) const = 0;
 
     typedef typename variant_filter_iterator<Predicate, ConstType, ConstReferenceType, ConstPointerType>::IterBase const_IterBase;
 
@@ -208,10 +208,10 @@ public:
      * fails it means you compared two different derived
      * classes.
      */
-    virtual bool equal(const IterBase * other) const override
+    virtual bool equal(const std::unique_ptr<IterBase> & other) const override
     {
       const Iter<IterType> * p =
-        libMesh::cast_ptr<const Iter<IterType> *>(other);
+        libMesh::cast_ptr<const Iter<IterType> *>(other.get());
 
       return (iter_data == p->iter_data);
     }
@@ -433,7 +433,7 @@ public:
    */
   bool equal(const variant_filter_iterator & other) const
   {
-    return data->equal(other.data.get());
+    return data->equal(other.data);
   }
 
   /**
@@ -471,7 +471,7 @@ private:
    */
   void satisfy_predicate()
   {
-    while ( !data->equal(end.get()) && !(*pred)(data.get()) )
+    while ( !data->equal(end) && !(*pred)(data.get()) )
       ++(*data);
   }
 };

--- a/include/base/variant_filter_iterator.h
+++ b/include/base/variant_filter_iterator.h
@@ -114,7 +114,7 @@ public:
   {
     virtual ~PredBase() = default;
     virtual std::unique_ptr<PredBase> clone() const = 0;
-    virtual bool operator()(const IterBase * in) const = 0;
+    virtual bool operator()(const std::unique_ptr<IterBase> & in) const = 0;
 
     // typedef typename variant_filter_iterator<Predicate, Type, const Type &, const Type *>::PredBase const_PredBase;
     typedef typename variant_filter_iterator<Predicate, ConstType, ConstReferenceType, ConstPointerType>::PredBase const_PredBase;
@@ -277,13 +277,13 @@ public:
     /**
      * Re-implementation of op()
      */
-    virtual bool operator() (const IterBase * in) const override
+    virtual bool operator() (const std::unique_ptr<IterBase> & in) const override
     {
       libmesh_assert(in);
 
       // Attempt downcast
       const Iter<IterType> * p =
-        libMesh::cast_ptr<const Iter<IterType> *>(in);
+        libMesh::cast_ptr<const Iter<IterType> *>(in.get());
 
       // Return result of op() for the user's predicate.
       return pred_data(p->iter_data);
@@ -471,7 +471,7 @@ private:
    */
   void satisfy_predicate()
   {
-    while ( !data->equal(end) && !(*pred)(data.get()) )
+    while ( !data->equal(end) && !(*pred)(data) )
       ++(*data);
   }
 };

--- a/include/base/variant_filter_iterator.h
+++ b/include/base/variant_filter_iterator.h
@@ -124,7 +124,7 @@ public:
      *
      * \returns A pointer to a copy of a different type.
      */
-    virtual const_PredBase * const_clone() const = 0;
+    virtual std::unique_ptr<const_PredBase> const_clone() const = 0;
   };
 
 
@@ -265,19 +265,10 @@ public:
     /**
      * The redefinition of the const_clone function for the Pred class.
      */
-    virtual typename PredBase::const_PredBase * const_clone() const override
+    virtual std::unique_ptr<typename PredBase::const_PredBase> const_clone() const override
     {
-      /**
-       * Important typedef for const_iterators.
-       */
-      //      typedef typename variant_filter_iterator<Predicate, Type, const Type &, const Type *>::template Pred<IterType, PredType> const_Pred;
       typedef typename variant_filter_iterator<Predicate, ConstType, ConstReferenceType, ConstPointerType>::template Pred<IterType, PredType> const_Pred;
-
-
-      typename PredBase::const_PredBase * copy =
-        new const_Pred(pred_data);
-
-      return copy;
+      return std::make_unique<const_Pred>(pred_data);
     }
 
 

--- a/include/base/variant_filter_iterator.h
+++ b/include/base/variant_filter_iterator.h
@@ -114,7 +114,7 @@ public:
   struct PredBase
   {
     virtual ~PredBase() = default;
-    virtual PredBase * clone() const = 0;
+    virtual std::unique_ptr<PredBase> clone() const = 0;
     virtual bool operator()(const IterBase * in) const = 0;
 
     // typedef typename variant_filter_iterator<Predicate, Type, const Type &, const Type *>::PredBase const_PredBase;
@@ -262,12 +262,9 @@ public:
     /**
      * \returns A copy of this object as a pointer to the base class.
      */
-    virtual PredBase * clone() const override
+    virtual std::unique_ptr<PredBase> clone() const override
     {
-      Pred<IterType,PredType> * copy =
-        new Pred<IterType,PredType>(pred_data);
-
-      return copy;
+      return std::make_unique<Pred<IterType,PredType>>(pred_data);
     }
 
 


### PR DESCRIPTION
Another fairly straightforward smart pointer update that allows us to get rid of some manual new/delete code.