### PR TITLE
Report a failing subexpression when it fails

### DIFF
--- a/include/numerics/parsed_fem_function.h
+++ b/include/numerics/parsed_fem_function.h
@@ -847,9 +847,15 @@ ParsedFEMFunction<Output>::eval (FunctionParserBase<Output> & parser,
     {
       libMesh::err << "ERROR: FunctionParser is unable to evaluate component "
                    << component_idx
-                   << " of expression '"
-                   << function_name
-                   << "' with arguments:\n";
+                   << " for '"
+                   << function_name;
+
+      for (auto i : index_range(parsers))
+        if (parsers[i].get() == &parser)
+          libMesh::err << "' of expression '"
+                       << _subexpressions[i];
+
+      libMesh::err << "' with arguments:\n";
       for (const auto & st : _spacetime)
         libMesh::err << '\t' << st << '\n';
       libMesh::err << '\n';

--- a/include/numerics/parsed_function.h
+++ b/include/numerics/parsed_function.h
@@ -679,9 +679,15 @@ ParsedFunction<Output,OutputGradient>::eval (FunctionParserADBase<Output> & pars
     {
       libMesh::err << "ERROR: FunctionParser is unable to evaluate component "
                    << component_idx
-                   << " of expression '"
-                   << function_name
-                   << "' with arguments:\n";
+                   << " for '"
+                   << function_name;
+
+      for (auto i : index_range(parsers))
+        if (parsers[i].get() == &parser)
+          libMesh::err << "' of expression '"
+                       << _subexpressions[i];
+
+      libMesh::err << "' with arguments:\n";
       for (const auto & item : _spacetime)
         libMesh::err << '\t' << item << '\n';
       libMesh::err << '\n';


### PR DESCRIPTION
It's much more useful to find out that we're getting a Division-by-zero
error from e.g. `'f' of '-x^2/(4*k/(rho*cp)*t)'` rather than just from
`'f'`.