### PR TITLE
Convert _diff_physics to vector<unique_ptr>

### DIFF
--- a/examples/adjoints/adjoints_ex7/adjoints_ex7.C
+++ b/examples/adjoints/adjoints_ex7/adjoints_ex7.C
@@ -647,9 +647,8 @@ int main (int argc, char ** argv)
 
           system.set_adjoint_already_solved(false);
 
-          // Swap in the physics we want to be used for the adjoint evaluation
-          DifferentiablePhysics * adjoint_evaluation_physics = dynamic_cast<DifferentiablePhysics *>(sigma_physics);
-          dynamic_cast<DifferentiableSystem &>(system).swap_physics(adjoint_evaluation_physics);
+          // Temporarily enable the physics we want to be used for the adjoint evaluation
+          system.push_physics(*sigma_physics);
 
           system.adjoint_solve();
 
@@ -670,8 +669,8 @@ int main (int argc, char ** argv)
                        << std::endl
                        << std::endl;
 
-          // Swap back the physics
-          dynamic_cast<DifferentiableSystem &>(system).swap_physics(adjoint_evaluation_physics);
+          // Return to the original physics
+          system.pop_physics();
 
           // Now that we have solved the adjoint, set the
           // adjoint_already_solved boolean to true, so we dont solve

--- a/include/systems/diff_system.h
+++ b/include/systems/diff_system.h
@@ -180,7 +180,7 @@ public:
   const DifferentiablePhysics * get_physics() const
   { if (this->_diff_physics.empty())
       return this;
-    return this->_diff_physics.back().get(); }
+    return this->_diff_physics.top().get(); }
 
   /**
    * \returns A reference to a DifferentiablePhysics object.
@@ -191,14 +191,14 @@ public:
   DifferentiablePhysics * get_physics()
   { if (this->_diff_physics.empty())
       return this;
-    return this->_diff_physics.back().get(); }
+    return this->_diff_physics.top().get(); }
 
   /**
    * Attach external Physics object.
    */
   void attach_physics( DifferentiablePhysics * physics_in )
-  { this->_diff_physics.push_back(physics_in->clone_physics());
-    this->_diff_physics.back()->init_physics(*this);}
+  { this->_diff_physics.push(physics_in->clone_physics());
+    this->_diff_physics.top()->init_physics(*this);}
 
   /**
    * Swap current physics object with external object.  This is
@@ -226,7 +226,7 @@ public:
   const DifferentiableQoI * get_qoi() const
   { if (this->_diff_qoi.empty())
       return this;
-    return this->_diff_qoi.back().get(); }
+    return this->_diff_qoi.top().get(); }
 
   /**
    * \returns A reference to a DifferentiableQoI object.
@@ -236,7 +236,7 @@ public:
   DifferentiableQoI * get_qoi()
   { if (this->_diff_qoi.empty())
       return this;
-    return this->_diff_qoi.back().get(); }
+    return this->_diff_qoi.top().get(); }
 
   /**
    * Attach external QoI object.
@@ -418,14 +418,16 @@ private:
    * compatibility if the stack is empty; for the most flexibility
    * users should create separate physics objects.
    */
-  std::vector<std::unique_ptr<DifferentiablePhysics>> _diff_physics;
+  std::stack<std::unique_ptr<DifferentiablePhysics>,
+    std::vector<std::unique_ptr<DifferentiablePhysics>>> _diff_physics;
 
   /**
    * Pointer to object to use for quantity of interest assembly
    * evaluations.  Defaults to \p this for backwards compatibility; in
    * the future users should create separate physics objects.
    */
-  std::vector<std::unique_ptr<DifferentiableQoI>> _diff_qoi;
+  std::stack<std::unique_ptr<DifferentiableQoI>,
+    std::vector<std::unique_ptr<DifferentiableQoI>>> _diff_qoi;
 };
 
 // --------------------------------------------------------------

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -1130,7 +1130,7 @@ void FEMSystem::assemble_qoi (const QoISet & qoi_indices)
 
   // Create a non-temporary qoi_contributions object, so we can query
   // its results after the reduction
-  QoIContributions qoi_contributions(*this, *(this->diff_qoi), qoi_indices);
+  QoIContributions qoi_contributions(*this, *(this->get_qoi()), qoi_indices);
 
   // Loop over every active mesh element on this processor
   Threads::parallel_reduce(elem_range.reset(mesh.active_local_elements_begin(),
@@ -1138,7 +1138,7 @@ void FEMSystem::assemble_qoi (const QoISet & qoi_indices)
                            qoi_contributions);
 
   std::vector<Number> global_qoi = this->get_qoi_values();
-  this->diff_qoi->parallel_op( this->comm(), global_qoi, qoi_contributions.qoi, qoi_indices );
+  this->get_qoi()->parallel_op( this->comm(), global_qoi, qoi_contributions.qoi, qoi_indices );
   this->set_qoi(std::move(global_qoi));
 }
 
@@ -1164,13 +1164,13 @@ void FEMSystem::assemble_qoi_derivative (const QoISet & qoi_indices,
   Threads::parallel_for (elem_range.reset(mesh.active_local_elements_begin(),
                                           mesh.active_local_elements_end()),
                          QoIDerivativeContributions(*this, qoi_indices,
-                                                    *(this->diff_qoi),
+                                                    *(this->get_qoi()),
                                                     include_liftfunc,
                                                     apply_constraints));
 
   for (auto i : make_range(this->n_qois()))
     if (qoi_indices.has_index(i))
-      this->diff_qoi->finalize_derivative(this->get_adjoint_rhs(i),i);
+      this->get_qoi()->finalize_derivative(this->get_adjoint_rhs(i),i);
 }
 
 


### PR DESCRIPTION
This seems cleaner than #3300 to me, though that's certainly debatable.

I tested the new `swap_physics` (and caught bugs in my first cracks at it) against adjoints_ex7 before I upgraded it to push/pop.

I've also put the `_diff_qoi` on a stack rather than just turning it into a single `unique_ptr`, though in that case we don't yet need the full flexibility a stack allows.