### PR TITLE
abstract_multi_predicate should store a vector of unique_ptrs

### DIFF
--- a/include/base/multi_predicates.h
+++ b/include/base/multi_predicates.h
@@ -116,7 +116,6 @@ protected:
 template <typename T>
 struct IsNull : abstract_multi_predicate<T>
 {
-  // Constructor, pushes back a single predicate
   IsNull()
   {
     this->_predicates.push_back(std::make_unique<is_null<T>>());
@@ -131,7 +130,6 @@ struct IsNull : abstract_multi_predicate<T>
 template <typename T>
 struct NotNull : abstract_multi_predicate<T>
 {
-  // Constructor, pushes back a single predicate
   NotNull()
   {
     this->_predicates.push_back(std::make_unique<not_null<T>>());
@@ -146,7 +144,6 @@ struct NotNull : abstract_multi_predicate<T>
 template <typename T>
 struct Active : abstract_multi_predicate<T>
 {
-  // Constructor, pushes back two single predicates
   Active()
   {
     this->_predicates.push_back(std::make_unique<not_null<T>>());
@@ -162,7 +159,6 @@ struct Active : abstract_multi_predicate<T>
 template <typename T>
 struct NotActive : abstract_multi_predicate<T>
 {
-  // Constructor, pushes back two single predicates
   NotActive()
   {
     this->_predicates.push_back(std::make_unique<not_null<T>>());
@@ -180,7 +176,6 @@ struct NotActive : abstract_multi_predicate<T>
 template <typename T>
 struct Ancestor : abstract_multi_predicate<T>
 {
-  // Constructor, pushes back two single predicates
   Ancestor()
   {
     this->_predicates.push_back(std::make_unique<not_null<T>>());
@@ -198,7 +193,6 @@ struct Ancestor : abstract_multi_predicate<T>
 template <typename T>
 struct NotAncestor : abstract_multi_predicate<T>
 {
-  // Constructor, pushes back two single predicates
   NotAncestor()
   {
     this->_predicates.push_back(std::make_unique<not_null<T>>());
@@ -216,7 +210,6 @@ struct NotAncestor : abstract_multi_predicate<T>
 template <typename T>
 struct SubActive : abstract_multi_predicate<T>
 {
-  // Constructor, pushes back two single predicates
   SubActive()
   {
     this->_predicates.push_back(std::make_unique<not_null<T>>());
@@ -234,7 +227,6 @@ struct SubActive : abstract_multi_predicate<T>
 template <typename T>
 struct NotSubActive : abstract_multi_predicate<T>
 {
-  // Constructor, pushes back two single predicates
   NotSubActive()
   {
     this->_predicates.push_back(std::make_unique<not_null<T>>());
@@ -251,7 +243,6 @@ struct NotSubActive : abstract_multi_predicate<T>
 template <typename T>
 struct Local : abstract_multi_predicate<T>
 {
-  // Constructor, pushes back two single predicates
   Local(processor_id_type my_pid)
   {
     this->_predicates.push_back(std::make_unique<not_null<T>>());
@@ -272,7 +263,6 @@ struct Local : abstract_multi_predicate<T>
 // template <typename T>
 // struct SemiLocal : abstract_multi_predicate<T>
 // {
-//   // Constructor, pushes back two single predicates
 //   SemiLocal(processor_id_type my_pid)
 //   {
 //     this->_predicates.push_back(std::make_unique<not_null<T>>());
@@ -289,7 +279,6 @@ struct Local : abstract_multi_predicate<T>
 template <typename T>
 struct ActiveSemiLocal : abstract_multi_predicate<T>
 {
-  // Constructor, pushes back two single predicates
   ActiveSemiLocal(processor_id_type my_pid)
   {
     this->_predicates.push_back(std::make_unique<not_null<T>>());
@@ -308,7 +297,6 @@ struct ActiveSemiLocal : abstract_multi_predicate<T>
 template <typename T>
 struct FaceLocal : abstract_multi_predicate<T>
 {
-  // Constructor, pushes back two single predicates
   FaceLocal(processor_id_type my_pid)
   {
     this->_predicates.push_back(std::make_unique<not_null<T>>());
@@ -326,7 +314,6 @@ struct FaceLocal : abstract_multi_predicate<T>
 template <typename T>
 struct NotLocal : abstract_multi_predicate<T>
 {
-  // Constructor, pushes back two single predicates
   NotLocal(processor_id_type my_pid)
   {
     this->_predicates.push_back(std::make_unique<not_null<T>>());
@@ -342,7 +329,6 @@ struct NotLocal : abstract_multi_predicate<T>
 template <typename T>
 struct ActiveNotLocal : abstract_multi_predicate<T>
 {
-  // Constructor, pushes back two single predicates
   ActiveNotLocal(processor_id_type my_pid)
   {
     this->_predicates.push_back(std::make_unique<not_null<T>>());

--- a/include/base/multi_predicates.h
+++ b/include/base/multi_predicates.h
@@ -62,10 +62,7 @@ struct abstract_multi_predicate : multi_predicate
   // operator= (perform deep copy of entries in _predicates vector
   abstract_multi_predicate & operator=(const abstract_multi_predicate & rhs)
   {
-    // First clear out the predicates vector
-    _predicates.clear();
-
-    // Now copy over the information from the rhs.
+    // Copy over the information from the rhs.
     this->deep_copy(rhs);
 
     return *this;
@@ -100,6 +97,9 @@ protected:
   // copy constructor for the predicate class.
   void deep_copy(const abstract_multi_predicate & rhs)
   {
+    // First clear out the predicates vector
+    _predicates.clear();
+
     for (const auto & p : rhs._predicates)
       _predicates.push_back(p->clone());
   }

--- a/include/base/single_predicates.h
+++ b/include/base/single_predicates.h
@@ -37,6 +37,7 @@ enum ElemType : int;
 // C++ includes
 #include <vector>
 #include <set>
+#include <memory>
 
 namespace libMesh
 {
@@ -73,7 +74,7 @@ struct predicate
 
 protected:
   friend struct abstract_multi_predicate<T>;
-  virtual predicate * clone() const = 0;
+  virtual std::unique_ptr<predicate> clone() const = 0;
 };
 
 
@@ -87,7 +88,7 @@ struct is_null : predicate<T>
   virtual bool operator()(const T & it) const override { return *it == nullptr; }
 
 protected:
-  virtual predicate<T> * clone() const override { return new is_null<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<is_null<T>>(*this); }
 };
 
 /**
@@ -99,7 +100,7 @@ struct not_null : is_null<T>
   virtual bool operator()(const T & it) const override { return !is_null<T>::operator()(it); }
 
 protected:
-  virtual predicate<T> * clone() const override { return new not_null<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<not_null<T>>(*this); }
 };
 
 
@@ -113,7 +114,7 @@ struct active : predicate<T>
   virtual bool operator()(const T & it) const override { return (*it)->active(); }
 
 protected:
-  virtual predicate<T> * clone() const override { return new active<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<active<T>>(*this); }
 };
 
 /**
@@ -125,7 +126,7 @@ struct not_active : active<T>
   virtual bool operator()(const T & it) const override { return !active<T>::operator()(it); }
 
 protected:
-  virtual predicate<T> * clone() const override { return new not_active<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<not_active<T>>(*this); }
 };
 
 
@@ -139,7 +140,7 @@ struct ancestor : predicate<T>
   virtual bool operator()(const T & it) const override { return (*it)->ancestor(); }
 
 protected:
-  virtual predicate<T> * clone() const override { return new ancestor<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<ancestor<T>>(*this); }
 };
 
 /**
@@ -151,7 +152,7 @@ struct not_ancestor : ancestor<T>
   virtual bool operator()(const T & it) const override { return !ancestor<T>::operator()(it); }
 
 protected:
-  virtual predicate<T> * clone() const override { return new not_ancestor<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<not_ancestor<T>>(*this); }
 };
 
 
@@ -165,7 +166,7 @@ struct subactive : predicate<T>
   virtual bool operator()(const T & it) const override { return (*it)->subactive(); }
 
 protected:
-  virtual predicate<T> * clone() const override { return new subactive<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<subactive<T>>(*this); }
 };
 
 /**
@@ -177,7 +178,7 @@ struct not_subactive : subactive<T>
   virtual bool operator()(const T & it) const override { return !subactive<T>::operator()(it); }
 
 protected:
-  virtual predicate<T> * clone() const override { return new not_subactive<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<not_subactive<T>>(*this); }
 };
 
 
@@ -195,7 +196,7 @@ struct pid : predicate<T>
   virtual bool operator()(const T & it) const override { return (*it)->processor_id() == _pid; }
 
 protected:
-  virtual predicate<T> * clone() const override { return new pid<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<pid<T>>(*this); }
   const processor_id_type _pid;
 };
 
@@ -218,7 +219,7 @@ struct bid : predicate<T>
   virtual bool operator()(const T & it) const override;
 
 protected:
-  virtual predicate<T> * clone() const override { return new bid<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<bid<T>>(*this); }
   const boundary_id_type _bid;
   const BoundaryInfo & _bndry_info;
 };
@@ -240,7 +241,7 @@ struct bnd : predicate<T>
   virtual bool operator()(const T & it) const override;
 
 protected:
-  virtual predicate<T> * clone() const override { return new bnd<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<bnd<T>>(*this); }
   const BoundaryInfo & _bndry_info;
 };
 
@@ -260,7 +261,7 @@ struct semilocal_pid : predicate<T>
   virtual bool operator()(const T & it) const override { return (*it)->is_semilocal(_pid); }
 
 protected:
-  virtual predicate<T> * clone() const override { return new semilocal_pid<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<semilocal_pid<T>>(*this); }
   const processor_id_type _pid;
 };
 
@@ -288,7 +289,7 @@ struct facelocal_pid : predicate<T>
   }
 
 protected:
-  virtual predicate<T> * clone() const override { return new facelocal_pid<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<facelocal_pid<T>>(*this); }
   const processor_id_type _pid;
 };
 
@@ -305,7 +306,7 @@ struct not_pid : pid<T>
   virtual bool operator()(const T & it) const override { return !pid<T>::operator()(it); }
 
 protected:
-  virtual predicate<T> * clone() const override { return new not_pid<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<not_pid<T>>(*this); }
 };
 
 
@@ -323,7 +324,7 @@ struct elem_type : predicate<T>
   virtual bool operator()(const T & it) const override { return (*it)->type() == _elem_type; }
 
 protected:
-  virtual predicate<T> * clone() const override { return new elem_type<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<elem_type<T>>(*this); }
   const ElemType _elem_type;
 };
 
@@ -344,7 +345,7 @@ struct flagged : predicate<T>
   virtual bool operator()(const T & it) const override { return (*it)->refinement_flag() == _rflag; }
 
 protected:
-  virtual predicate<T> * clone() const override { return new flagged<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<flagged<T>>(*this); }
   const unsigned char _rflag;
 };
 #endif // LIBMESH_ENABLE_AMR
@@ -366,7 +367,7 @@ struct level : predicate<T>
   virtual bool operator()(const T & it) const override { return (*it)->level() == _level; }
 
 protected:
-  virtual predicate<T> * clone() const override { return new level<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<level<T>>(*this); }
   const unsigned int _level;
 };
 
@@ -384,7 +385,7 @@ struct not_level : level<T>
   virtual bool operator()(const T & it) const override { return !level<T>::operator()(it); }
 
 protected:
-  virtual predicate<T> * clone() const override { return new not_level<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<not_level<T>>(*this); }
 };
 
 
@@ -403,7 +404,7 @@ struct null_neighbor : predicate<T>
   }
 
 protected:
-  virtual predicate<T> * clone() const override { return new null_neighbor<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<null_neighbor<T>>(*this); }
 };
 
 
@@ -425,7 +426,7 @@ struct boundary_side : predicate<T>
   }
 
 protected:
-  virtual predicate<T> * clone() const override { return new boundary_side<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<boundary_side<T>>(*this); }
 };
 
 /**
@@ -442,7 +443,7 @@ struct subdomain : predicate<T>
   virtual bool operator()(const T & it) const override { return (*it)->subdomain_id() == _subdomain; }
 
 protected:
-  virtual predicate<T> * clone() const override { return new subdomain<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<subdomain<T>>(*this); }
   const subdomain_id_type _subdomain;
 };
 
@@ -461,7 +462,7 @@ struct subdomain_set : predicate<T>
   virtual bool operator()(const T & it) const override { return _subdomain_set.count((*it)->subdomain_id()); }
 
 protected:
-  virtual predicate<T> * clone() const override { return new subdomain_set<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<subdomain_set<T>>(*this); }
   const std::set<subdomain_id_type> _subdomain_set;
 };
 
@@ -483,7 +484,7 @@ struct evaluable : predicate<T>
   virtual bool operator()(const T & it) const override;
 
 protected:
-  virtual predicate<T> * clone() const override { return new evaluable<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<evaluable<T>>(*this); }
   const DofMap & _dof_map;
   unsigned int _var_num;
 };
@@ -504,7 +505,7 @@ struct multi_evaluable : predicate<T>
   virtual bool operator()(const T & it) const override;
 
 protected:
-  virtual predicate<T> * clone() const override { return new multi_evaluable<T>(*this); }
+  virtual std::unique_ptr<predicate<T>> clone() const override { return std::make_unique<multi_evaluable<T>>(*this); }
   std::vector<const DofMap *> _dof_maps;
 };
 


### PR DESCRIPTION
I tried a number of different ways to change from our existing constructors that `push_back` entries onto the `_predicates` vector:
```
template <typename T>
struct IsNull : abstract_multi_predicate<T>
{
  IsNull()
  {
    this->_predicates.push_back(std::make_unique<is_null<T>>());
  }
};
```
to a constructor that actually uses the initialization list, e.g. 
```
template <typename T>
struct IsNull : abstract_multi_predicate<T>
{
  IsNull() : abstract_multi_predicate<T>(std::make_unique<is_null<T>>()) {}
};
```
but I could not get anything to actually compile... No matter what I tried, I triggered the (deleted) unique_ptr copy constructor for some reason. I think what we have now is certainly fine as-is (it works and is simple to understand) but am a bit annoyed that I could not make it less verbose.