### PR TITLE
Directly include <stack>

### DIFF
--- a/include/systems/diff_system.h
+++ b/include/systems/diff_system.h
@@ -29,6 +29,7 @@
 
 // C++ includes
 #include <memory>
+#include <stack>
 
 namespace libMesh
 {


### PR DESCRIPTION
We must have been getting this indirectly in default builds, but we were
failing to compile when turning off all our options.