### PR TITLE
Configure --enable-xdr-required option

### DIFF
--- a/configure
+++ b/configure
@@ -1219,6 +1219,7 @@ enable_perflog
 enable_examples
 enable_strict_lgpl
 enable_nested
+enable_xdr_required
 enable_xdr
 enable_boost
 with_boost
@@ -2032,6 +2033,7 @@ Optional Features:
   --disable-strict-lgpl   Compile libmesh with even non-LGPL-compatible
                           contrib libraries
   --disable-nested        Do not use nested autoconf subpackages
+  --enable-xdr-required   Error if XDR is not detected by configure
   --disable-xdr           build without XDR platform-independent binary I/O
   --disable-boost         build without either external or built-in BOOST
                           support
@@ -47829,6 +47831,23 @@ fi
 # XDR headers to be in different places, so it's more convenient
 # to test for it here.
 # --------------------------------------------------------------
+
+# Check whether --enable-xdr-required was given.
+if test "${enable_xdr_required+set}" = set; then :
+  enableval=$enable_xdr_required; case "${enableval}" in #(
+  yes) :
+    xdrrequired=yes ;; #(
+  no) :
+    xdrrequired=no ;; #(
+  *) :
+    as_fn_error $? "bad value ${enableval} for --enable-xdr-required" "$LINENO" 5 ;;
+esac
+else
+  xdrrequired=no
+fi
+
+
+
 # Check whether --enable-xdr was given.
 if test "${enable_xdr+set}" = set; then :
   enableval=$enable_xdr; enablexdr=$enableval
@@ -47939,6 +47958,10 @@ fi
 fi
 
 fi
+if test "x$enablexdr" = "xno" && test "x$xdrrequired" = "xyes"; then :
+  as_fn_error 4 "*** XDR was not found, but --enable-xdr-required was specified." "$LINENO" 5
+fi
+
 # -------------------------------------------------------------
 
 

--- a/m4/libmesh_optional_packages.m4
+++ b/m4/libmesh_optional_packages.m4
@@ -105,6 +105,21 @@ AC_ARG_ENABLE(nested,
 # XDR headers to be in different places, so it's more convenient
 # to test for it here.
 # --------------------------------------------------------------
+
+dnl Setting --enable-xdr-required causes an error to be emitted
+dnl during configure if XDR headers are not detected successfully during
+dnl configure.  This is useful for app codes which require XDR (like
+dnl MOOSE-based apps).
+AC_ARG_ENABLE(xdr-required,
+              AC_HELP_STRING([--enable-xdr-required],
+                             [Error if XDR is not detected by configure]),
+              [AS_CASE("${enableval}",
+                       [yes], [xdrrequired=yes],
+                       [no],  [xdrrequired=no],
+                       [AC_MSG_ERROR(bad value ${enableval} for --enable-xdr-required)])],
+                   [xdrrequired=no])
+
+
 AC_ARG_ENABLE(xdr,
               AS_HELP_STRING([--disable-xdr],
                              [build without XDR platform-independent binary I/O]),
@@ -140,6 +155,9 @@ AS_IF([test "$enablexdr" != no],
               LIBS="$old_LIBS"
            ])
       ])
+AS_IF([test "x$enablexdr" = "xno" && test "x$xdrrequired" = "xyes"],
+      [AC_MSG_ERROR([*** XDR was not found, but --enable-xdr-required was specified.], 4)])
+
 # -------------------------------------------------------------
 
 


### PR DESCRIPTION
Pinging @loganharbour to try this out on a system that actually lacks xdr.h; I've only tested it in conjunction with `--disable-xdr`, because Ubuntu 20.10 doesn't want to let me `apt remove libtirpc-dev` unless I'm willing to remove a hundred other -dev packages and all my compilers with it.