### PR TITLE
Use declarations header for declarations

### DIFF
--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -47,18 +47,8 @@
 #include <initializer_list>
 
 #ifdef LIBMESH_HAVE_METAPHYSICL
-#include "metaphysicl/dualnumber_forward.h"
+#include "metaphysicl/dualnumber_decl.h"
 #include "metaphysicl/raw_type.h"
-
-namespace std
-{
-// These declarations must be visible to the DenseMatrix method declarations that use
-// a std::abs trailing return type in order to instantiate a DenseMatrix<DualNumber>
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> abs(const MetaPhysicL::DualNumber<T, D, asd> & in);
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> abs(MetaPhysicL::DualNumber<T, D, asd> && in);
-}
 #endif
 
 namespace libMesh

--- a/include/numerics/dense_matrix_impl.h
+++ b/include/numerics/dense_matrix_impl.h
@@ -30,17 +30,7 @@
 #include "libmesh/libmesh.h"
 
 #ifdef LIBMESH_HAVE_METAPHYSICL
-#include "metaphysicl/dualnumber_forward.h"
-
-namespace std
-{
-// When instantiating a DenseMatrix<DualNumber> we need these declarations visible
-// in order to compile the DenseMatrix<T>::_cholesky_decompose method
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> sqrt(const MetaPhysicL::DualNumber<T, D, asd> & in);
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> sqrt(MetaPhysicL::DualNumber<T, D, asd> && in);
-}
+#include "metaphysicl/dualnumber_decl.h"
 #endif
 
 namespace libMesh

--- a/include/numerics/tensor_tools.h
+++ b/include/numerics/tensor_tools.h
@@ -25,15 +25,7 @@
 #include "libmesh/compare_types.h"
 
 #ifdef LIBMESH_HAVE_METAPHYSICL
-#include "metaphysicl/dualnumber_forward.h"
-
-namespace std
-{
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> norm(const MetaPhysicL::DualNumber<T, D, asd> & in);
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> norm(MetaPhysicL::DualNumber<T, D, asd> && in);
-}
+#include "metaphysicl/dualnumber_decl.h"
 #endif
 
 namespace libMesh

--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -30,23 +30,7 @@
 #include <tuple>
 
 #ifdef LIBMESH_HAVE_METAPHYSICL
-#include "metaphysicl/dualnumber_forward.h"
-
-namespace std
-{
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> norm(const MetaPhysicL::DualNumber<T, D, asd> & in);
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> norm(MetaPhysicL::DualNumber<T, D, asd> && in);
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> sqrt(const MetaPhysicL::DualNumber<T, D, asd> & in);
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> sqrt(MetaPhysicL::DualNumber<T, D, asd> && in);
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> abs(const MetaPhysicL::DualNumber<T, D, asd> & in);
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> abs(MetaPhysicL::DualNumber<T, D, asd> && in);
-}
+#include "metaphysicl/dualnumber_decl.h"
 #endif
 
 namespace libMesh

--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -37,23 +37,10 @@
 #endif
 
 #ifdef LIBMESH_HAVE_METAPHYSICL
-#include "metaphysicl/dualnumber_forward.h"
+#include "metaphysicl/dualnumber_decl.h"
 
 namespace std
 {
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> norm(const MetaPhysicL::DualNumber<T, D, asd> & in);
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> norm(MetaPhysicL::DualNumber<T, D, asd> && in);
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> sqrt(const MetaPhysicL::DualNumber<T, D, asd> & in);
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> sqrt(MetaPhysicL::DualNumber<T, D, asd> && in);
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> abs(const MetaPhysicL::DualNumber<T, D, asd> & in);
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> abs(MetaPhysicL::DualNumber<T, D, asd> && in);
-
 #ifdef LIBMESH_HAVE_EIGEN
 template <typename T, typename D, bool asd>
 using ADRealEigenVector = Eigen::Matrix<MetaPhysicL::DualNumber<T, D, asd>, Eigen::Dynamic, 1>;


### PR DESCRIPTION
Otherwise we can't adjust the declarations in MetaPhysicL (which we've
started doing in complicated ways, to handle bugs with clang-9) unless
we carefully reflect them here.