### PR TITLE
Drop support for --disable-forward-declare-enums configure option  

### DIFF
--- a/configure
+++ b/configure
@@ -1999,8 +1999,7 @@ Optional Features:
   --disable-deprecated    Deprecated code use gives errors rather than
                           warnings
   --disable-forward-declare-enums
-                          Directly include enumeration headers rather than
-                          forward declaring them
+                          Avoid forward declaring enums (no longer supported)
   --enable-blocked-storage
                           Support for blocked matrix/vector storage
   --enable-legacy-include-paths
@@ -46663,37 +46662,23 @@ fi
 
 
 # --------------------------------------------------------------
-# forward declared enumerations - enable by default
-# We want to prevent new library code from being added that
-# depends on including enum headers, but still give downstream
-# apps the ability to compile with the old headers for a
-# period of deprecation.
+# forward declared enumerations - this is now required
 # --------------------------------------------------------------
 # Check whether --enable-forward-declare-enums was given.
 if test "${enable_forward_declare_enums+set}" = set; then :
   enableval=$enable_forward_declare_enums; enablefwdenums=$enableval
 else
-  enablefwdenums=yes
+  enablefwdenums=irrelevant
 fi
 
 
-
-if test "$enablefwdenums" != yes; then :
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> INFO: Forward declared enumerations are disabled <<<" >&5
-$as_echo ">>> INFO: Forward declared enumerations are disabled <<<" >&6; }
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> Enumeration headers will be included directly <<<" >&5
-$as_echo ">>> Enumeration headers will be included directly <<<" >&6; }
-
-else
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with forward declared enumerations >>>" >&5
-$as_echo "<<< Configuring library with forward declared enumerations >>>" >&6; }
-
-$as_echo "#define FORWARD_DECLARE_ENUMS 1" >>confdefs.h
-
-
+if test "$enablefwdenums" != irrelevant; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: --enable/disable-forward-declare-enums is now deprecated" >&5
+$as_echo "$as_me: WARNING: --enable/disable-forward-declare-enums is now deprecated" >&2;}
 fi
+
+$enablefwdenums=yes
+
 # --------------------------------------------------------------
 
 

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -34,15 +34,6 @@
 #include "libmesh/point.h"
 #include "libmesh/utility.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum Order : int;
-}
-#else
-#include "libmesh/enum_order.h"
-#endif
-
 // C++ Includes
 #include <algorithm>
 #include <cstddef>
@@ -74,6 +65,7 @@ template <typename T> class DenseVector;
 template <typename T> class DenseMatrix;
 template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
+enum Order : int;
 
 
 

--- a/include/base/libmesh.h
+++ b/include/base/libmesh.h
@@ -25,21 +25,11 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/libmesh_base.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum SolverPackage : int;
-}
-#else
-#include "libmesh/enum_solver_package.h"
-#endif
-
 // C++ includes
 #include <string>
 #include <vector>
 
 // Forward declarations
-
 // For dealing with MPI stuff in VTK.
 #if defined(LIBMESH_HAVE_MPI) && defined(LIBMESH_HAVE_VTK)
 class vtkMPIController;
@@ -65,6 +55,7 @@ namespace libMesh
 namespace Parallel {
   class Communicator;
 }
+enum SolverPackage : int;
 
 /**
  * The \p LibMeshInit class, when constructed, initializes

--- a/include/base/single_predicates.h
+++ b/include/base/single_predicates.h
@@ -24,17 +24,6 @@
 
 // C++ includes
 #include <cstddef>
-
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum ElemType : int;
-}
-#else
-#include "libmesh/enum_elem_type.h"
-#endif
-
-// C++ includes
 #include <vector>
 #include <set>
 #include <memory>
@@ -45,6 +34,7 @@ namespace libMesh
 // Forward declarations
 class BoundaryInfo;
 class DofMap;
+enum ElemType : int;
 
 /**
  * This file declares several predicates in the Predicates namespace.  They

--- a/include/error_estimation/error_estimator.h
+++ b/include/error_estimation/error_estimator.h
@@ -24,15 +24,6 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/system_norm.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum ErrorEstimatorType : int;
-}
-#else
-#include "libmesh/enum_error_estimator_type.h"
-#endif
-
 // C++ includes
 #include <cstddef>
 #include <map>
@@ -52,6 +43,8 @@ template <typename T> class NumericVector;
 namespace Parallel {
   class Communicator;
 }
+
+enum ErrorEstimatorType : int;
 
 /**
  * This class holds functions that will estimate the error

--- a/include/error_estimation/exact_solution.h
+++ b/include/error_estimation/exact_solution.h
@@ -22,15 +22,6 @@
 // Local Includes
 #include "libmesh/libmesh_common.h" // for Number
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum FEMNormType : int;
-}
-#else
-#include "libmesh/enum_norm_type.h"
-#endif
-
 // C++ includes
 #include <map>
 #include <vector>
@@ -47,6 +38,7 @@ class EquationSystems;
 class Parameters;
 class Mesh;
 template <typename Output> class FunctionBase;
+enum FEMNormType : int;
 
 // Is there any way to simplify this?
 // All we need are Tensor and Gradient. - RHS

--- a/include/error_estimation/patch_recovery_error_estimator.h
+++ b/include/error_estimation/patch_recovery_error_estimator.h
@@ -26,15 +26,6 @@
 #include "libmesh/point.h"
 #include "libmesh/elem_range.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum Order : int;
-}
-#else
-#include "libmesh/enum_order.h"
-#endif
-
 // C++ includes
 #include <cstddef>
 #include <vector>
@@ -44,6 +35,7 @@ namespace libMesh
 
 // Forward Declarations
 class Elem;
+enum Order : int;
 
 /**
  * This class implements the Patch Recovery error indicator.

--- a/include/fe/fe_abstract.h
+++ b/include/fe/fe_abstract.h
@@ -30,15 +30,6 @@
 #include "libmesh/tensor_value.h"
 #endif
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum ElemType : int;
-}
-#else
-#include "libmesh/enum_elem_type.h"
-#endif
-
 // C++ includes
 #include <cstddef>
 #include <vector>
@@ -65,6 +56,7 @@ class Elem;
 class MeshBase;
 template <typename T> class NumericVector;
 class QBase;
+enum ElemType : int;
 
 #ifdef LIBMESH_ENABLE_NODE_CONSTRAINTS
 class NodeConstraints;

--- a/include/fe/fe_lagrange_shape_1D.h
+++ b/include/fe/fe_lagrange_shape_1D.h
@@ -20,8 +20,7 @@
 #define LIBMESH_FE_LAGRANGE_SHAPE_1D_H
 
 // Local includes
-#include "libmesh/enum_elem_type.h"
-#include "libmesh/enum_order.h"
+#include "libmesh/enum_order.h" // FIRST, SECOND, etc.
 #include "libmesh/point.h"
 
 // Inline functions useful to inline on tensor elements.

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -23,7 +23,7 @@
 // Local includes
 #include "libmesh/compare_types.h"
 #include "libmesh/libmesh_config.h"
-#include "libmesh/enum_order.h"
+#include "libmesh/enum_order.h" // return Order objects
 #include "libmesh/enum_fe_family.h" // LAGRANGE
 #include "libmesh/enum_inf_map_type.h" // CARTESIAN
 #include "libmesh/hashing.h"

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -35,19 +35,6 @@
 #include "libmesh/variant_filter_iterator.h"
 #include "libmesh/hashword.h" // Used in compute_key() functions
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum ElemQuality : int;
-enum IOPackage : int;
-enum Order : int;
-}
-#else
-#include "libmesh/enum_elem_quality.h"
-#include "libmesh/enum_io_package.h"
-#include "libmesh/enum_order.h"
-#endif
-
 // C++ includes
 #include <algorithm>
 #include <cstddef>
@@ -71,6 +58,9 @@ class PointLocatorBase;
 #endif
 template <class SideType, class ParentType>
 class Side;
+enum ElemQuality : int;
+enum IOPackage : int;
+enum Order : int;
 
 
 /**

--- a/include/geom/elem_quality.h
+++ b/include/geom/elem_quality.h
@@ -20,23 +20,16 @@
 #ifndef LIBMESH_ELEM_QUALITY_H
 #define LIBMESH_ELEM_QUALITY_H
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum ElemType : int;
-enum ElemQuality : int;
-}
-#else
-#include "libmesh/enum_elem_type.h"
-#include "libmesh/enum_elem_quality.h"
-#endif
-
 // C++ includes
 #include <vector>
 #include <string>
 
 namespace libMesh
 {
+
+// Forward declarations
+enum ElemType : int;
+enum ElemQuality : int;
 
 /**
  * A namespace for quality utility functions.

--- a/include/geom/reference_elem.h
+++ b/include/geom/reference_elem.h
@@ -23,20 +23,12 @@
 // Local includes
 #include "libmesh/libmesh_common.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum ElemType : int;
-}
-#else
-#include "libmesh/enum_elem_type.h"
-#endif
-
 namespace libMesh
 {
 
 // forward declarations
 class Elem;
+enum ElemType : int;
 
 /**
  * This namespace implements singleton reference elements for each

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -196,9 +196,6 @@
 /* Flag indicating if the library should have warnings enabled */
 #undef ENABLE_WARNINGS
 
-/* Flag indicating if the library uses forward declared enumerations */
-#undef FORWARD_DECLARE_ENUMS
-
 /* Enable fparser debugging functions */
 #undef FPARSER_SUPPORT_DEBUGGING
 

--- a/include/mesh/ensight_io.h
+++ b/include/mesh/ensight_io.h
@@ -24,15 +24,6 @@
 #include "libmesh/mesh_base.h"
 #include "libmesh/mesh_output.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum ElemType : int;
-}
-#else
-#include "libmesh/enum_elem_type.h"
-#endif
-
 // C++ includes
 #include <map>
 #include <string>
@@ -43,6 +34,7 @@ namespace libMesh
 
 // Forward declarations
 class EquationSystems;
+enum ElemType : int;
 
 /**
  * This class implements writing meshes and solutions in Ensight's Gold format.

--- a/include/mesh/gmv_io.h
+++ b/include/mesh/gmv_io.h
@@ -25,15 +25,6 @@
 #include "libmesh/mesh_output.h"
 #include "libmesh/mesh_input.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum ElemType : int;
-}
-#else
-#include "libmesh/enum_elem_type.h"
-#endif
-
 // C++ includes
 #include <map>
 
@@ -42,6 +33,7 @@ namespace libMesh
 
 // Forward declarations
 class MeshBase;
+enum ElemType : int;
 
 /**
  * This class implements writing meshes in the GMV format.

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -30,16 +30,6 @@
 #include "libmesh/parallel_object.h"
 #include "libmesh/simple_range.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum ElemType : int;
-enum ElemMappingType : unsigned char;
-}
-#else
-#include "libmesh/enum_elem_type.h"
-#endif
-
 // C++ Includes
 #include <cstddef>
 #include <string>
@@ -55,6 +45,8 @@ class Node;
 class Point;
 class Partitioner;
 class BoundaryInfo;
+enum ElemType : int;
+enum ElemMappingType : unsigned char;
 
 template <class MT>
 class MeshInput;

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -26,15 +26,6 @@
 #include "libmesh/id_types.h"
 #include "libmesh/mesh_base.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum ElemType : int;
-}
-#else
-#include "libmesh/enum_elem_type.h"
-#endif
-
 // C++ Includes
 #include <limits>
 #include <set>
@@ -48,6 +39,7 @@ namespace libMesh
 // forward declarations
 class Sphere;
 class Elem;
+enum ElemType : int;
 
 /**
  * Utility functions for operations on a \p Mesh object.  Here is where

--- a/include/mesh/mesh_triangle_wrapper.h
+++ b/include/mesh/mesh_triangle_wrapper.h
@@ -26,15 +26,6 @@
 // Local Includes
 #include "libmesh/libmesh_common.h" // Real
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum ElemType : int;
-}
-#else
-#include "libmesh/enum_elem_type.h"
-#endif
-
 // C++ includes
 #include <cstddef>
 
@@ -42,6 +33,7 @@ namespace libMesh
 {
 // Forward declarations
 class UnstructuredMesh;
+enum ElemType : int;
 
 // Make sure Triangle uses our "Real" as its "REAL"
 typedef Real REAL;

--- a/include/mesh/triangulator_interface.h
+++ b/include/mesh/triangulator_interface.h
@@ -25,15 +25,6 @@
 // Local Includes
 #include "libmesh/libmesh.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum ElemType : int;
-}
-#else
-#include "libmesh/enum_elem_type.h"
-#endif
-
 // C++ includes
 #include <vector>
 
@@ -43,6 +34,7 @@ namespace libMesh
 // Forward Declarations
 class UnstructuredMesh;
 template <typename Output> class FunctionBase;
+enum ElemType : int;
 
 class TriangulatorInterface
 {

--- a/include/mesh/ucd_io.h
+++ b/include/mesh/ucd_io.h
@@ -20,28 +20,20 @@
 #ifndef LIBMESH_UCD_IO_H
 #define LIBMESH_UCD_IO_H
 
-// C++ includes
-#include <map>
-
 // Local includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/mesh_input.h"
 #include "libmesh/mesh_output.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum ElemType : int;
-}
-#else
-#include "libmesh/enum_elem_type.h"
-#endif
+// C++ includes
+#include <map>
 
 namespace libMesh
 {
 
 // Forward declarations
 class MeshBase;
+enum ElemType : int;
 
 /**
  * This class implements reading & writing meshes in the AVS's UCD format.

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -31,15 +31,6 @@
 #include "libmesh/dense_subvector.h"
 #include "libmesh/dense_vector.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum SolverPackage : int;
-}
-#else
-#include "libmesh/enum_solver_package.h"
-#endif
-
 // C++ includes
 #include <cstddef>
 #include <set>
@@ -57,6 +48,7 @@ template <typename T> class DenseVector;
 template <typename T> class DenseSubVector;
 template <typename T> class SparseMatrix;
 template <typename T> class ShellMatrix;
+enum SolverPackage : int;
 
 /**
  * \brief Provides a uniform interface to vector storage schemes for different

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -22,7 +22,7 @@
 
 // Local includes
 #include "libmesh/libmesh_common.h"
-#include "libmesh/enum_parallel_type.h"
+#include "libmesh/enum_parallel_type.h" // AUTOMATIC
 #include "libmesh/id_types.h"
 #include "libmesh/int_range.h"
 #include "libmesh/reference_counted_object.h"

--- a/include/numerics/petsc_preconditioner.h
+++ b/include/numerics/petsc_preconditioner.h
@@ -32,15 +32,6 @@
 #include "libmesh/petsc_macro.h"
 #include "libmesh/wrapped_petsc.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum PreconditionerType : int;
-}
-#else
-#include "libmesh/enum_preconditioner_type.h"
-#endif
-
 // Petsc includes
 #include "petscpc.h"
 
@@ -51,6 +42,7 @@ namespace libMesh
 template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 template <typename T> class ShellMatrix;
+enum PreconditionerType : int;
 
 /**
  * This class provides an interface to the suite of preconditioners

--- a/include/numerics/preconditioner.h
+++ b/include/numerics/preconditioner.h
@@ -27,18 +27,6 @@
 #include "libmesh/libmesh.h"
 #include "libmesh/parallel_object.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum SolverPackage : int;
-enum PreconditionerType : int;
-}
-#else
-#include "libmesh/enum_solver_package.h"
-#include "libmesh/enum_preconditioner_type.h"
-#endif
-
-
 // C++ includes
 #include <cstddef>
 
@@ -49,6 +37,8 @@ namespace libMesh
 template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 template <typename T> class ShellMatrix;
+enum SolverPackage : int;
+enum PreconditionerType : int;
 
 /**
  * This class provides a uniform interface for preconditioners.  This base

--- a/include/numerics/shell_matrix.h
+++ b/include/numerics/shell_matrix.h
@@ -28,7 +28,6 @@
 #include "libmesh/id_types.h"
 #include "libmesh/parallel_object.h"
 #include "libmesh/dof_map.h"
-#include "libmesh/enum_solver_package.h"
 #include "libmesh/parallel.h"
 
 namespace libMesh
@@ -36,7 +35,7 @@ namespace libMesh
 
 // forward declarations
 template <typename T> class NumericVector;
-
+enum SolverPackage : int;
 
 /**
  * Generic shell matrix, i.e. a matrix that does not define anything

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -27,8 +27,8 @@
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/id_types.h"
 #include "libmesh/parallel_object.h"
-#include "libmesh/enum_parallel_type.h"
-#include "libmesh/enum_matrix_build_type.h"
+#include "libmesh/enum_parallel_type.h" // PARALLEL
+#include "libmesh/enum_matrix_build_type.h" // AUTOMATIC
 
 // C++ includes
 #include <cstddef>

--- a/include/numerics/trilinos_preconditioner.h
+++ b/include/numerics/trilinos_preconditioner.h
@@ -38,15 +38,6 @@
 #include "Teuchos_ParameterList.hpp"
 #include "libmesh/restore_warnings.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum PreconditionerType : int;
-}
-#else
-#include "libmesh/enum_preconditioner_type.h"
-#endif
-
 // C++ includes
 #include <cstddef>
 
@@ -57,6 +48,7 @@ namespace libMesh
 template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 template <typename T> class ShellMatrix;
+enum PreconditionerType : int;
 
 /**
  * This class provides an interface to the suite of preconditioners

--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -27,15 +27,6 @@
 #include "libmesh/enum_elem_type.h" // INVALID_ELEM
 #include "libmesh/enum_order.h" // INVALID_ORDER
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum QuadratureType : int;
-}
-#else
-#include "libmesh/enum_quadrature_type.h"
-#endif
-
 // C++ includes
 #include <vector>
 #include <string>
@@ -47,6 +38,7 @@ namespace libMesh
 
 // forward declarations
 class Elem;
+enum QuadratureType : int;
 
 /**
  * The \p QBase class provides the basic functionality from which

--- a/include/solvers/eigen_solver.h
+++ b/include/solvers/eigen_solver.h
@@ -31,18 +31,6 @@
 #include "libmesh/parallel_object.h"
 #include "libmesh/enum_solver_package.h" // SLEPC_SOLVERS
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum EigenSolverType : int;
-enum EigenProblemType : int;
-enum PositionOfSpectrum : int;
-}
-#else
-#include "libmesh/enum_solver_package.h"
-#include "libmesh/enum_eigen_solver_type.h"
-#endif
-
 // C++ includes
 #include <memory>
 
@@ -54,6 +42,9 @@ template <typename T> class SparseMatrix;
 template <typename T> class ShellMatrix;
 template <typename T> class NumericVector;
 class SolverConfiguration;
+enum EigenSolverType : int;
+enum EigenProblemType : int;
+enum PositionOfSpectrum : int;
 
 /**
  * This class provides an interface to solvers for eigenvalue

--- a/include/solvers/file_solution_history.h
+++ b/include/solvers/file_solution_history.h
@@ -21,19 +21,19 @@
 #define LIBMESH_FILE_SOLUTION_HISTORY_H
 
 // Local includes
-#include "libmesh/numeric_vector.h"
 #include "libmesh/solution_history.h"
-#include "libmesh/enum_xdr_mode.h"
-#include "libmesh/equation_systems.h"
 #include "libmesh/libmesh.h"
-#include "libmesh/diff_system.h"
 
 // C++ includes
-#include <list>
+#include <vector>
 #include <memory>
 
 namespace libMesh
 {
+
+// Forward declarations
+template <typename T> class NumericVector;
+class DifferentiableSystem;
 
 /**
  * Subclass of Solution History that stores the solutions
@@ -51,9 +51,10 @@ public:
    * Constructor, reference to system to be passed by user, set the
    * stored_sols iterator to some initial value
    */
-  FileSolutionHistory(DifferentiableSystem & system_);
+  FileSolutionHistory(DifferentiableSystem & system);
+
   /**
-   * Destructor
+   * Destructor, defaulted out-of-line.
    */
   ~FileSolutionHistory();
 
@@ -70,15 +71,12 @@ public:
   /**
    * Definition of the clone function needed for the setter function
    */
-  virtual std::unique_ptr<SolutionHistory > clone() const override
-  {
-    return std::make_unique<FileSolutionHistory>(_system);
-  }
+  virtual std::unique_ptr<SolutionHistory> clone() const override;
 
 private:
 
   // A system reference
-  DifferentiableSystem & _system ;
+  DifferentiableSystem & _system;
 
   /**
    * A vector of pointers to adjoint and old adjoint solutions at the last time step.

--- a/include/solvers/linear_solver.h
+++ b/include/solvers/linear_solver.h
@@ -27,21 +27,6 @@
 #include "libmesh/libmesh.h"
 #include "libmesh/parallel_object.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum SolverPackage : int;
-enum PreconditionerType : int;
-enum SolverType : int;
-enum LinearConvergenceReason : int;
-}
-#else
-#include "libmesh/enum_solver_package.h"
-#include "libmesh/enum_preconditioner_type.h"
-#include "libmesh/enum_solver_type.h"
-#include "libmesh/enum_convergence_flags.h"
-#endif
-
 // C++ includes
 #include <cstddef>
 #include <vector>
@@ -57,6 +42,10 @@ template <typename T> class ShellMatrix;
 template <typename T> class Preconditioner;
 class System;
 class SolverConfiguration;
+enum SolverPackage : int;
+enum PreconditionerType : int;
+enum SolverType : int;
+enum LinearConvergenceReason : int;
 
 /**
  * This base class can be inherited from to provide interfaces to

--- a/include/solvers/nonlinear_solver.h
+++ b/include/solvers/nonlinear_solver.h
@@ -27,15 +27,6 @@
 #include "libmesh/libmesh.h"
 #include "libmesh/parallel_object.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum SolverPackage : int;
-}
-#else
-#include "libmesh/enum_solver_package.h"
-#endif
-
 // C++ includes
 #include <cstddef>
 #include <memory>
@@ -48,6 +39,7 @@ template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 template <typename T> class Preconditioner;
 class SolverConfiguration;
+enum SolverPackage : int;
 
 /**
  * This base class can be inherited from to provide interfaces to

--- a/include/solvers/optimization_solver.h
+++ b/include/solvers/optimization_solver.h
@@ -27,15 +27,6 @@
 #include "libmesh/parallel_object.h"
 #include "libmesh/optimization_system.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum SolverPackage : int;
-}
-#else
-#include "libmesh/enum_solver_package.h"
-#endif
-
 // C++ includes
 #include <cstddef>
 #include <memory>
@@ -47,6 +38,7 @@ namespace libMesh
 template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 template <typename T> class Preconditioner;
+enum SolverPackage : int;
 
 /**
  * This base class can be inherited from to provide interfaces to

--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -26,15 +26,6 @@
 #include "libmesh/system.h"
 #include "libmesh/parallel_object.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum XdrMODE : int;
-}
-#else
-#include "libmesh/enum_xdr_mode.h"
-#endif
-
 // HP aCC needs these for some reason
 #ifdef __HP_aCC
 # include "libmesh/frequency_system.h"
@@ -58,6 +49,7 @@ namespace libMesh
 // Forward Declarations
 class Elem;
 class MeshBase;
+enum XdrMODE : int;
 
 /**
  * This is the \p EquationSystems class.  It is in charge

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -33,15 +33,6 @@
 #include "libmesh/variable.h"
 #include "libmesh/enum_matrix_build_type.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum FEMNormType : int;
-}
-#else
-#include "libmesh/enum_norm_type.h"
-#endif
-
 // C++ includes
 #include <cstddef>
 #include <set>
@@ -82,6 +73,7 @@ typedef NumberVectorValue Gradient;
 class SystemSubset;
 class FEType;
 class SystemNorm;
+enum FEMNormType : int;
 
 /**
  * \brief Manages consistently variables, degrees of freedom, and coefficient

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -31,7 +31,7 @@
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/tensor_value.h" // For point_hessian
 #include "libmesh/variable.h"
-#include "libmesh/enum_matrix_build_type.h"
+#include "libmesh/enum_matrix_build_type.h" // AUTOMATIC
 
 // C++ includes
 #include <cstddef>

--- a/include/systems/system_norm.h
+++ b/include/systems/system_norm.h
@@ -23,20 +23,14 @@
 // Local includes
 #include "libmesh/libmesh_common.h" // for Real
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum FEMNormType : int;
-}
-#else
-#include "libmesh/enum_norm_type.h"
-#endif
-
 // C++ includes
 #include <vector>
 
 namespace libMesh
 {
+
+// Forward declarations
+enum FEMNormType : int;
 
 /**
  * This class defines a norm/seminorm to be applied to a NumericVector which

--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -24,15 +24,6 @@
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/libmesh_common.h"
 
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum PointLocatorType : int;
-}
-#else
-#include "libmesh/enum_point_locator_type.h"
-#endif
-
 // C++ includes
 #include <cstddef>
 #include <memory>
@@ -49,6 +40,7 @@ class Point;
 class TreeBase;
 class Elem;
 class Node;
+enum PointLocatorType : int;
 
 
 /**

--- a/m4/libmesh_core_features.m4
+++ b/m4/libmesh_core_features.m4
@@ -89,27 +89,18 @@ AS_IF([test "$enabledeprecated" != yes],
 
 
 # --------------------------------------------------------------
-# forward declared enumerations - enable by default
-# We want to prevent new library code from being added that
-# depends on including enum headers, but still give downstream
-# apps the ability to compile with the old headers for a
-# period of deprecation.
+# forward declared enumerations - this is now required
 # --------------------------------------------------------------
 AC_ARG_ENABLE(forward-declare-enums,
-              [AS_HELP_STRING([--disable-forward-declare-enums],[Directly include enumeration headers rather than forward declaring them])],
+              [AS_HELP_STRING([--disable-forward-declare-enums],[Avoid forward declaring enums (no longer supported)])],
               enablefwdenums=$enableval,
-              enablefwdenums=yes)
+              enablefwdenums=irrelevant)
 
+AS_IF([test "$enablefwdenums" != irrelevant],
+      [AC_MSG_WARN([--enable/disable-forward-declare-enums is now deprecated])])
+
+$enablefwdenums=yes
 AC_SUBST(enablefwdenums)
-AS_IF([test "$enablefwdenums" != yes],
-      [
-        AC_MSG_RESULT([>>> INFO: Forward declared enumerations are disabled <<<])
-        AC_MSG_RESULT([>>> Enumeration headers will be included directly <<<])
-      ],
-      [
-        AC_MSG_RESULT([<<< Configuring library with forward declared enumerations >>>])
-        AC_DEFINE(FORWARD_DECLARE_ENUMS, 1, [Flag indicating if the library uses forward declared enumerations])
-      ])
 # --------------------------------------------------------------
 
 

--- a/src/numerics/shell_matrix.C
+++ b/src/numerics/shell_matrix.C
@@ -17,12 +17,11 @@
 
 
 
-// C++ includes
-
 // Local Includes
 #include "libmesh/petsc_matrix.h"
 #include "libmesh/shell_matrix.h"
 #include "libmesh/petsc_shell_matrix.h"
+#include "libmesh/enum_solver_package.h"
 
 namespace libMesh
 {

--- a/src/solvers/file_solution_history.C
+++ b/src/solvers/file_solution_history.C
@@ -15,14 +15,14 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-// C++ include files that we need
-#include <iostream>
-// Local includes
+// libMesh includes
 #include "libmesh/file_solution_history.h"
 #include "libmesh/file_history_data.h"
-
 #include "libmesh/diff_system.h"
+#include "libmesh/numeric_vector.h"
 
+// C++ includes
+#include <iostream>
 #include <cmath>
 #include <iterator>
 
@@ -30,22 +30,25 @@ namespace libMesh
 {
 
 /**
-   * Constructor, reference to system to be passed by user, set the
-   * stored_datum iterator to some initial value
-   */
-  FileSolutionHistory::FileSolutionHistory(DifferentiableSystem & system_)
-  : SolutionHistory(), _system(system_)
-  {
-    dual_solution_copies.resize(system_.n_qois());
-    old_dual_solution_copies.resize(system_.n_qois());
-
-    libmesh_experimental();
-
-  }
-
-
-FileSolutionHistory::~FileSolutionHistory ()
+ * Constructor, reference to system to be passed by user, set the
+ * stored_datum iterator to some initial value
+ */
+FileSolutionHistory::FileSolutionHistory(DifferentiableSystem & system)
+  : SolutionHistory(), _system(system)
 {
+  dual_solution_copies.resize(_system.n_qois());
+  old_dual_solution_copies.resize(_system.n_qois());
+
+  libmesh_experimental();
+}
+
+
+FileSolutionHistory::~FileSolutionHistory () = default;
+
+std::unique_ptr<SolutionHistory>
+FileSolutionHistory::clone() const
+{
+  return std::make_unique<FileSolutionHistory>(_system);
 }
 
 // This functions writes the solution at the current system time to disk


### PR DESCRIPTION
This was something I added temporarily before we were sure that all relevant compilers supported fixed-type enumerations and enum forward declarations. It's well past time to get rid of it.