### PR TITLE
Drop element orientation check for 1D elements

### DIFF
--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -596,15 +596,13 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
 
                         // If found a match with my side
                         //
-                        // We need special tests here for 1D:
-                        // since parents and children have an equal
-                        // side (i.e. a node), we need to check
-                        // ns != ms, and we also check level() to
-                        // avoid setting our neighbor pointer to
-                        // any of our neighbor's descendants
+                        // In 1D, since parents and children have an
+                        // equal side (i.e. a node) we need to check
+                        // for matching level() to avoid setting our
+                        // neighbor pointer to any of our neighbor's
+                        // descendants.
                         if ((*my_side == *their_side) &&
-                            (element->level() == neighbor->level()) &&
-                            ((element->dim() != 1) || (ns != ms)))
+                            (element->level() == neighbor->level()))
                           {
                             // So share a side.  Is this a mixed pair
                             // of subactive and active/ancestor

--- a/tests/mesh/nodal_neighbors.C
+++ b/tests/mesh/nodal_neighbors.C
@@ -3,6 +3,7 @@
 #include <libmesh/mesh_generation.h>
 #include <libmesh/mesh_tools.h>
 #include <libmesh/replicated_mesh.h>
+#include <libmesh/elem.h>
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"
@@ -19,6 +20,15 @@ class NodalNeighborsTest : public CppUnit::TestCase
    * hard-coded "validation" data with the results of
    * MeshTools::find_nodal_neighbors().  We also use a ReplicatedMesh
    * here to match the hard-coded numbering.
+   *
+   * The testOrientation() test is not specifically related to
+   * find_nodal_neighbors(), instead it is checking that we can still
+   * find_neighbors() correctly in 1D when the mesh is topologically a
+   * straight line, but not all elements have the same "orientation"
+   * (as defined by their local node numbering). As far as I know, we
+   * don't require 2D/3D elements to have the same orientation in
+   * order for them to be considered neighbors, so this test ensures
+   * the same thing works for 1D elements.
    */
 public:
   LIBMESH_CPPUNIT_TEST_SUITE( NodalNeighborsTest );
@@ -26,6 +36,7 @@ public:
   CPPUNIT_TEST( testEdge2 );
   CPPUNIT_TEST( testEdge3 );
   CPPUNIT_TEST( testEdge4 );
+  CPPUNIT_TEST( testOrientation );
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -151,6 +162,86 @@ public:
     do_test(/*n_elem=*/3, EDGE4, validation_data);
   }
 
+  void testOrientation()
+  {
+    LOG_UNIT_TEST;
+
+    ReplicatedMesh mesh(*TestCommWorld);
+
+    // The (1-based) node numbering and element orientation (represented
+    // by arrows) for this mesh:
+    // 1 -> 3 -> 4 -> 7 -> 8 <- 6 <- 5 <- 2
+    // So the two elements that meet at node 8 have opposite orientation
+    // and were not detected as neighbors using the original (before the
+    // addition of this test) find_neighbors() algorithm.
+
+    // These nodes are copied from an exo file where we originally
+    // noticed the problem, but otherwise are not significant to the
+    // test. Note: the actual ids are 0-based but we are using a
+    // 1-based connectivity array below which is copied from the exo
+    // file.
+    mesh.add_point(Point(1.68, -1.695, 8.298), /*id=*/0);
+    mesh.add_point(Point(5.55, -1.695, 8.298), /*id=*/1);
+    mesh.add_point(Point(1.68, -0.175, 8.298), /*id=*/2);
+    mesh.add_point(Point(1.68, -0.175, 9.643), /*id=*/3);
+    mesh.add_point(Point(5.55, -0.175, 8.298), /*id=*/4);
+    mesh.add_point(Point(5.55, -0.175, 9.643), /*id=*/5);
+    mesh.add_point(Point(1.68, -0.075, 9.643), /*id=*/6);
+    mesh.add_point(Point(5.55, -0.075, 9.643), /*id=*/7);
+
+    // 1-based connectivity array (2 nodes per Elem) copied directly
+    // from exo file.  We will convert these to 0-based ids when they
+    // are used.
+    std::vector<unsigned int> conn =
+      {
+        7, 8,
+        1, 3,
+        2, 5,
+        3, 4,
+        5, 6,
+        4, 7,
+        6, 8
+      };
+
+    // Add 7 EDGE2 elements and assign connectivity
+    for (unsigned int e=0; e<7; ++e)
+      {
+        Elem * elem = mesh.add_elem(Elem::build_with_id(EDGE2, e));
+        elem->set_node(0) = mesh.node_ptr(conn[2*e] - 1);     // convert to 0-based index
+        elem->set_node(1) = mesh.node_ptr(conn[2*e + 1] - 1); // convert to 0-based index
+      }
+
+    // Find neighbors, etc.
+    mesh.prepare_for_use();
+
+    for (const auto & elem : mesh.element_ptr_range())
+      {
+        auto elem_id = elem->id();
+
+        // Elems 1, 2 should have no neighbor on side 0
+        if (elem_id == 1 || elem_id == 2)
+          {
+            CPPUNIT_ASSERT(elem->neighbor_ptr(0) == nullptr);
+            CPPUNIT_ASSERT(elem->neighbor_ptr(1) != nullptr);
+          }
+        // Otherwise, elem should have neighbor on both sides
+        else
+          {
+            CPPUNIT_ASSERT(elem->neighbor_ptr(0) != nullptr);
+            CPPUNIT_ASSERT(elem->neighbor_ptr(1) != nullptr);
+          }
+
+        // Debugging
+        // libMesh::out << "elem " << elem_id << std::endl;
+        // for (auto side_idx : make_range(elem->n_sides()))
+        //   {
+        //     if (elem->neighbor_ptr(side_idx))
+        //       libMesh::out << "Neighbor on side " << side_idx << std::endl;
+        //     else
+        //       libMesh::out << "No neighbor on side " << side_idx << std::endl;
+        //   }
+      }
+  }
 };
 
 


### PR DESCRIPTION
According to @roystgnr, this check may simply be unnecessary now:

"I guess we could get rid of it.  We handle flipped 1D and 2D elements these days, as a special case of embedded-in-3D, but that clause might have predated that support."

So let's see if this change passes all the testing. I also added a unit test that would have failed before the update, but passes now.
