### PR TITLE
Pass configure args to netcdf in a less hacked-together way.

### DIFF
--- a/configure
+++ b/configure
@@ -710,7 +710,6 @@ LIBMESH_ENABLE_NETCDF_V4_TRUE
 LIBMESH_ENABLE_NETCDF_FALSE
 LIBMESH_ENABLE_NETCDF_TRUE
 NETCDF_INCLUDE
-subdirs
 LIBMESH_ENABLE_HDF5_FALSE
 LIBMESH_ENABLE_HDF5_TRUE
 HDF5_PREFIX
@@ -1329,7 +1328,7 @@ VTK_DIR
 HDF5_DIR
 YACC
 YFLAGS'
-ac_subdirs_all='contrib/netcdf/v4'
+
 
 # Initialize some variables set by options.
 ac_init_help=
@@ -47714,9 +47713,6 @@ $as_echo "$as_me: WARNING: could not find source tree for $ax_dir" >&2;}
 # source tree for building contributed packages that do not
 # need to be exported as part of the installation environment.
 #
-# libmesh_subpackage_arguments is a list of configure arguments
-# that will be passed down to any subpackages that we are nesting.
-#
 # libmesh_pkgconfig_requires is a list of pkgconfig requirements
 # we will add
 #
@@ -47726,7 +47722,6 @@ $as_echo "$as_me: WARNING: could not find source tree for $ax_dir" >&2;}
 libmesh_optional_INCLUDES=""
 libmesh_optional_LIBS=""
 libmesh_contrib_INCLUDES=""
-libmesh_subpackage_arguments=""
 libmesh_pkgconfig_requires=""
 libmesh_installed_LIBS=""
 
@@ -55340,14 +55335,264 @@ esac
 
     if test "x$enablenested" = "xyes"; then :
 
-                    if test "x$enablecurl" = "xyes"; then :
-  libmesh_subpackage_arguments="$libmesh_subpackage_arguments --enable-dap"
-else
-  libmesh_subpackage_arguments="$libmesh_subpackage_arguments --disable-dap --disable-curl"
-fi
-                    libmesh_subpackage_arguments="$libmesh_subpackage_arguments --disable-testsets"
-          subdirs="$subdirs contrib/netcdf/v4"
+                                                            SUB_CPPFLAGS="$CPPFLAGS"
+          SUB_LIBS="$LIBS"
+          if test $enablehdf5 = yes; then :
 
+                 SUB_CPPFLAGS="$HDF5_CPPFLAGS $SUB_CPPFLAGS"
+                 SUB_LIBS="$HDF5_LIBS $SUB_LIBS"
+                 if test "x$enablepetsc" != "xno"; then :
+
+                        SUB_CPPFLAGS="$PETSCINCLUDEDIRS $SUB_CPPFLAGS"
+                        SUB_LIBS="$PETSCLINKLIBS $SUB_LIBS"
+
+fi
+fi
+
+                              if test "x$enablecurl" = "xyes"; then :
+
+
+  # Various preliminary checks.
+
+
+
+
+
+    ax_dir="contrib/netcdf/v4"
+
+                    # Do not complain, so a configure script can configure whichever parts of a
+    # large source tree are present.
+    if test -d "$srcdir/$ax_dir"; then
+      ac_builddir=.
+
+case "$ax_dir" in
+.) ac_dir_suffix= ac_top_builddir_sub=. ac_top_build_prefix= ;;
+*)
+  ac_dir_suffix=/`$as_echo "$ax_dir" | sed 's|^\.[\\/]||'`
+  # A ".." for each directory in $ac_dir_suffix.
+  ac_top_builddir_sub=`$as_echo "$ac_dir_suffix" | sed 's|/[^\\/]*|/..|g;s|/||'`
+  case $ac_top_builddir_sub in
+  "") ac_top_builddir_sub=. ac_top_build_prefix= ;;
+  *)  ac_top_build_prefix=$ac_top_builddir_sub/ ;;
+  esac ;;
+esac
+ac_abs_top_builddir=$ac_pwd
+ac_abs_builddir=$ac_pwd$ac_dir_suffix
+# for backward compatibility:
+ac_top_builddir=$ac_top_build_prefix
+
+case $srcdir in
+  .)  # We are building in place.
+    ac_srcdir=.
+    ac_top_srcdir=$ac_top_builddir_sub
+    ac_abs_top_srcdir=$ac_pwd ;;
+  [\\/]* | ?:[\\/]* )  # Absolute name.
+    ac_srcdir=$srcdir$ac_dir_suffix;
+    ac_top_srcdir=$srcdir
+    ac_abs_top_srcdir=$srcdir ;;
+  *) # Relative name.
+    ac_srcdir=$ac_top_build_prefix$srcdir$ac_dir_suffix
+    ac_top_srcdir=$ac_top_build_prefix$srcdir
+    ac_abs_top_srcdir=$ac_pwd/$srcdir ;;
+esac
+ac_abs_srcdir=$ac_abs_top_srcdir$ac_dir_suffix
+
+      # Remove --cache-file, --srcdir, and --disable-option-checking arguments
+      # so they do not pile up.
+      ax_args=
+      ax_prev=
+      eval "set x $ac_configure_args"
+      shift
+      for ax_arg; do
+        if test -n "$ax_prev"; then
+          ax_prev=
+          continue
+        fi
+        case $ax_arg in
+          -cache-file | --cache-file | --cache-fil | --cache-fi | --cache-f \
+          | --cache- | --cache | --cach | --cac | --ca | --c)
+            ax_prev=cache_file ;;
+          -cache-file=* | --cache-file=* | --cache-fil=* | --cache-fi=* \
+          | --cache-f=* | --cache-=* | --cache=* | --cach=* | --cac=* | --ca=* \
+          | --c=*)
+            ;;
+          --config-cache | -C)
+            ;;
+          -srcdir | --srcdir | --srcdi | --srcd | --src | --sr)
+            ax_prev=srcdir ;;
+          -srcdir=* | --srcdir=* | --srcdi=* | --srcd=* | --src=* | --sr=*)
+            ;;
+          -prefix | --prefix | --prefi | --pref | --pre | --pr | --p)
+            ax_prev=prefix ;;
+          -prefix=* | --prefix=* | --prefi=* | --pref=* | --pre=* | --pr=* \
+          | --p=*)
+            ;;
+          --disable-option-checking)
+            ;;
+          *) case $ax_arg in
+              *\'*) ax_arg=$($as_echo "$ax_arg" | sed "s/'/'\\\\\\\\''/g");;
+            esac
+            as_fn_append ax_args " '$ax_arg'" ;;
+        esac
+      done
+      # Always prepend --disable-option-checking to silence warnings, since
+      # different subdirs can have different --enable and --with options.
+      ax_args="--disable-option-checking $ax_args"
+      # Options that must be added as they are provided.
+      as_fn_append ax_args " 'CXX=$CXX'"
+      as_fn_append ax_args " 'CC=$CC'"
+      as_fn_append ax_args " 'F77=$F77'"
+      as_fn_append ax_args " 'FC=$FC'"
+      as_fn_append ax_args " 'CPPFLAGS=$SUB_CPPFLAGS'"
+      as_fn_append ax_args " 'LIBS=$SUB_LIBS'"
+      as_fn_append ax_args " '--enable-dap'"
+      as_fn_append ax_args " '--disable-testsets'"
+
+      # New options that may need to be merged with existing options.
+
+      # New options that must replace existing options.
+
+      # Options that must be removed.
+
+      as_fn_append ax_args " '--srcdir=$ac_srcdir'"
+
+      # Add the subdirectory to the list of target subdirectories.
+      ax_subconfigures="$ax_subconfigures $ax_dir"
+      # Save the argument list for this subdirectory.
+                              ax_var=$(printf "$ax_dir" | tr -c "0-9a-zA-Z_" "_")
+      eval "ax_sub_configure_args_$ax_var=\"$ax_args\""
+      eval "ax_sub_configure_$ax_var=\"yes\""
+    else
+      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: could not find source tree for $ax_dir" >&5
+$as_echo "$as_me: WARNING: could not find source tree for $ax_dir" >&2;}
+    fi
+
+
+
+
+else
+
+
+  # Various preliminary checks.
+
+
+
+
+
+    ax_dir="contrib/netcdf/v4"
+
+                    # Do not complain, so a configure script can configure whichever parts of a
+    # large source tree are present.
+    if test -d "$srcdir/$ax_dir"; then
+      ac_builddir=.
+
+case "$ax_dir" in
+.) ac_dir_suffix= ac_top_builddir_sub=. ac_top_build_prefix= ;;
+*)
+  ac_dir_suffix=/`$as_echo "$ax_dir" | sed 's|^\.[\\/]||'`
+  # A ".." for each directory in $ac_dir_suffix.
+  ac_top_builddir_sub=`$as_echo "$ac_dir_suffix" | sed 's|/[^\\/]*|/..|g;s|/||'`
+  case $ac_top_builddir_sub in
+  "") ac_top_builddir_sub=. ac_top_build_prefix= ;;
+  *)  ac_top_build_prefix=$ac_top_builddir_sub/ ;;
+  esac ;;
+esac
+ac_abs_top_builddir=$ac_pwd
+ac_abs_builddir=$ac_pwd$ac_dir_suffix
+# for backward compatibility:
+ac_top_builddir=$ac_top_build_prefix
+
+case $srcdir in
+  .)  # We are building in place.
+    ac_srcdir=.
+    ac_top_srcdir=$ac_top_builddir_sub
+    ac_abs_top_srcdir=$ac_pwd ;;
+  [\\/]* | ?:[\\/]* )  # Absolute name.
+    ac_srcdir=$srcdir$ac_dir_suffix;
+    ac_top_srcdir=$srcdir
+    ac_abs_top_srcdir=$srcdir ;;
+  *) # Relative name.
+    ac_srcdir=$ac_top_build_prefix$srcdir$ac_dir_suffix
+    ac_top_srcdir=$ac_top_build_prefix$srcdir
+    ac_abs_top_srcdir=$ac_pwd/$srcdir ;;
+esac
+ac_abs_srcdir=$ac_abs_top_srcdir$ac_dir_suffix
+
+      # Remove --cache-file, --srcdir, and --disable-option-checking arguments
+      # so they do not pile up.
+      ax_args=
+      ax_prev=
+      eval "set x $ac_configure_args"
+      shift
+      for ax_arg; do
+        if test -n "$ax_prev"; then
+          ax_prev=
+          continue
+        fi
+        case $ax_arg in
+          -cache-file | --cache-file | --cache-fil | --cache-fi | --cache-f \
+          | --cache- | --cache | --cach | --cac | --ca | --c)
+            ax_prev=cache_file ;;
+          -cache-file=* | --cache-file=* | --cache-fil=* | --cache-fi=* \
+          | --cache-f=* | --cache-=* | --cache=* | --cach=* | --cac=* | --ca=* \
+          | --c=*)
+            ;;
+          --config-cache | -C)
+            ;;
+          -srcdir | --srcdir | --srcdi | --srcd | --src | --sr)
+            ax_prev=srcdir ;;
+          -srcdir=* | --srcdir=* | --srcdi=* | --srcd=* | --src=* | --sr=*)
+            ;;
+          -prefix | --prefix | --prefi | --pref | --pre | --pr | --p)
+            ax_prev=prefix ;;
+          -prefix=* | --prefix=* | --prefi=* | --pref=* | --pre=* | --pr=* \
+          | --p=*)
+            ;;
+          --disable-option-checking)
+            ;;
+          *) case $ax_arg in
+              *\'*) ax_arg=$($as_echo "$ax_arg" | sed "s/'/'\\\\\\\\''/g");;
+            esac
+            as_fn_append ax_args " '$ax_arg'" ;;
+        esac
+      done
+      # Always prepend --disable-option-checking to silence warnings, since
+      # different subdirs can have different --enable and --with options.
+      ax_args="--disable-option-checking $ax_args"
+      # Options that must be added as they are provided.
+      as_fn_append ax_args " 'CXX=$CXX'"
+      as_fn_append ax_args " 'CC=$CC'"
+      as_fn_append ax_args " 'F77=$F77'"
+      as_fn_append ax_args " 'FC=$FC'"
+      as_fn_append ax_args " 'CPPFLAGS=$SUB_CPPFLAGS'"
+      as_fn_append ax_args " 'LIBS=$SUB_LIBS'"
+      as_fn_append ax_args " '--disable-dap'"
+      as_fn_append ax_args " '--disable-curl'"
+      as_fn_append ax_args " '--disable-testsets'"
+
+      # New options that may need to be merged with existing options.
+
+      # New options that must replace existing options.
+
+      # Options that must be removed.
+
+      as_fn_append ax_args " '--srcdir=$ac_srcdir'"
+
+      # Add the subdirectory to the list of target subdirectories.
+      ax_subconfigures="$ax_subconfigures $ax_dir"
+      # Save the argument list for this subdirectory.
+                              ax_var=$(printf "$ax_dir" | tr -c "0-9a-zA-Z_" "_")
+      eval "ax_sub_configure_args_$ax_var=\"$ax_args\""
+      eval "ax_sub_configure_$ax_var=\"yes\""
+    else
+      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: could not find source tree for $ax_dir" >&5
+$as_echo "$as_me: WARNING: could not find source tree for $ax_dir" >&2;}
+    fi
+
+
+
+
+fi
 
 fi
 
@@ -56916,39 +57161,6 @@ if test "x$enableexamples" = "xyes"; then :
 
 fi
 
-
-
-# hackery.  If we are supporting nested autoconf packages and we want to specify
-# additional arguments to be passed to those packages, do that here.
-# Specifically, we append libmesh_subpackage_arguments to ac_configure_args
-# before AC_OUTPUT recurses into our subpackages
-
-# We need our netcdf subpackage to be able to use whatever HDF5 we've
-# detected.  That means using whatever $HDF5_CPPFLAGS and $HDF5_LIBS
-# we've determined work - but if we're using PETSc it also means
-# passing along PETSc's directories in case we want to link to a
-# --download-hdf5 build there.
-SUB_CPPFLAGS="$CPPFLAGS"
-SUB_LIBS="$LIBS"
-if test $enablehdf5 = yes; then :
-
-       SUB_CPPFLAGS="$HDF5_CPPFLAGS $SUB_CPPFLAGS"
-       SUB_LIBS="$HDF5_LIBS $SUB_LIBS"
-       if test "x$enablepetsc" != "xno"; then :
-
-              SUB_CPPFLAGS="$PETSCINCLUDEDIRS $SUB_CPPFLAGS"
-              SUB_LIBS="$PETSCLINKLIBS $SUB_LIBS"
-
-fi
-fi
-
-if test "x$enablenested" = "xyes"; then :
-
-        ac_configure_args_SAVE="$ac_configure_args"
-        ac_configure_args="$ac_configure_args $libmesh_subpackage_arguments CXX='$CXX' CC='$CC' F77='$F77' FC='$FC' CPPFLAGS='$SUB_CPPFLAGS' LIBS='$SUB_LIBS'"
-
-fi
-
 # Create output files. Also configures any subpackages
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -57654,6 +57866,196 @@ if test -z "${LIBMESH_ENABLE_HDF5_TRUE}" && test -z "${LIBMESH_ENABLE_HDF5_FALSE
   as_fn_error $? "conditional \"LIBMESH_ENABLE_HDF5\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
+      ax_dir="contrib/netcdf/v4"
+
+      # Convert the path to the subdirectory into a shell variable name.
+      ax_var=$(printf "$ax_dir" | tr -c "0-9a-zA-Z_" "_")
+      ax_configure_ax_var=$(eval "echo \"\$ax_sub_configure_$ax_var\"")
+      if test "$no_recursion" != "yes" -a "x$ax_configure_ax_var" = "xyes"; then
+        subdirs_extra="$subdirs_extra $ax_dir"
+
+        ax_msg="=== configuring in $ax_dir ($(pwd)/$ax_dir)"
+        $as_echo "$as_me:${as_lineno-$LINENO}: $ax_msg" >&5
+        $as_echo "$ax_msg" >&6
+        as_dir="$ax_dir"; as_fn_mkdir_p
+        ac_builddir=.
+
+case "$ax_dir" in
+.) ac_dir_suffix= ac_top_builddir_sub=. ac_top_build_prefix= ;;
+*)
+  ac_dir_suffix=/`$as_echo "$ax_dir" | sed 's|^\.[\\/]||'`
+  # A ".." for each directory in $ac_dir_suffix.
+  ac_top_builddir_sub=`$as_echo "$ac_dir_suffix" | sed 's|/[^\\/]*|/..|g;s|/||'`
+  case $ac_top_builddir_sub in
+  "") ac_top_builddir_sub=. ac_top_build_prefix= ;;
+  *)  ac_top_build_prefix=$ac_top_builddir_sub/ ;;
+  esac ;;
+esac
+ac_abs_top_builddir=$ac_pwd
+ac_abs_builddir=$ac_pwd$ac_dir_suffix
+# for backward compatibility:
+ac_top_builddir=$ac_top_build_prefix
+
+case $srcdir in
+  .)  # We are building in place.
+    ac_srcdir=.
+    ac_top_srcdir=$ac_top_builddir_sub
+    ac_abs_top_srcdir=$ac_pwd ;;
+  [\\/]* | ?:[\\/]* )  # Absolute name.
+    ac_srcdir=$srcdir$ac_dir_suffix;
+    ac_top_srcdir=$srcdir
+    ac_abs_top_srcdir=$srcdir ;;
+  *) # Relative name.
+    ac_srcdir=$ac_top_build_prefix$srcdir$ac_dir_suffix
+    ac_top_srcdir=$ac_top_build_prefix$srcdir
+    ac_abs_top_srcdir=$ac_pwd/$srcdir ;;
+esac
+ac_abs_srcdir=$ac_abs_top_srcdir$ac_dir_suffix
+
+
+        ax_popdir=$(pwd)
+        cd "$ax_dir"
+
+        # Check for guested configure; otherwise get Cygnus style configure.
+        if test -f "$ac_srcdir/configure.gnu"; then
+          ax_sub_configure=$ac_srcdir/configure.gnu
+        elif test -f "$ac_srcdir/configure"; then
+          ax_sub_configure=$ac_srcdir/configure
+        elif test -f "$ac_srcdir/configure.in"; then
+          # This should be Cygnus configure.
+          ax_sub_configure=$ac_aux_dir/configure
+        else
+          { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: no configuration information is in $ax_dir" >&5
+$as_echo "$as_me: WARNING: no configuration information is in $ax_dir" >&2;}
+          ax_sub_configure=
+        fi
+
+        if test -n "$ax_sub_configure"; then
+          # Get the configure arguments for the current configure.
+          eval "ax_sub_configure_args=\"\$ax_sub_configure_args_${ax_var}\""
+
+          # Always prepend --prefix to ensure using the same prefix
+          # in subdir configurations.
+          ax_arg="--prefix=$prefix"
+          case $ax_arg in
+            *\'*) ax_arg=$($as_echo "$ax_arg" | sed "s/'/'\\\\\\\\''/g");;
+          esac
+          ax_sub_configure_args="'$ax_arg' $ax_sub_configure_args"
+          if test "$silent" = yes; then
+            ax_sub_configure_args="--silent $ax_sub_configure_args"
+          fi
+          # Make the cache file name correct relative to the subdirectory.
+          case $cache_file in
+            [\\/]* | ?:[\\/]* )
+              ax_sub_cache_file=$cache_file ;;
+            *) # Relative name.
+              ax_sub_cache_file=$ac_top_build_prefix$cache_file ;;
+          esac
+
+          { $as_echo "$as_me:${as_lineno-$LINENO}: running $SHELL $ax_sub_configure $ax_sub_configure_args --cache-file=$ac_sub_cache_file" >&5
+$as_echo "$as_me: running $SHELL $ax_sub_configure $ax_sub_configure_args --cache-file=$ac_sub_cache_file" >&6;}
+          eval "\$SHELL \"$ax_sub_configure\" $ax_sub_configure_args --cache-file=\"$ax_sub_cache_file\"" \
+              || as_fn_error $? "$ax_sub_configure failed for $ax_dir" "$LINENO" 5
+        fi
+
+        cd "$ax_popdir"
+      fi
+
+      ax_dir="contrib/netcdf/v4"
+
+      # Convert the path to the subdirectory into a shell variable name.
+      ax_var=$(printf "$ax_dir" | tr -c "0-9a-zA-Z_" "_")
+      ax_configure_ax_var=$(eval "echo \"\$ax_sub_configure_$ax_var\"")
+      if test "$no_recursion" != "yes" -a "x$ax_configure_ax_var" = "xyes"; then
+        subdirs_extra="$subdirs_extra $ax_dir"
+
+        ax_msg="=== configuring in $ax_dir ($(pwd)/$ax_dir)"
+        $as_echo "$as_me:${as_lineno-$LINENO}: $ax_msg" >&5
+        $as_echo "$ax_msg" >&6
+        as_dir="$ax_dir"; as_fn_mkdir_p
+        ac_builddir=.
+
+case "$ax_dir" in
+.) ac_dir_suffix= ac_top_builddir_sub=. ac_top_build_prefix= ;;
+*)
+  ac_dir_suffix=/`$as_echo "$ax_dir" | sed 's|^\.[\\/]||'`
+  # A ".." for each directory in $ac_dir_suffix.
+  ac_top_builddir_sub=`$as_echo "$ac_dir_suffix" | sed 's|/[^\\/]*|/..|g;s|/||'`
+  case $ac_top_builddir_sub in
+  "") ac_top_builddir_sub=. ac_top_build_prefix= ;;
+  *)  ac_top_build_prefix=$ac_top_builddir_sub/ ;;
+  esac ;;
+esac
+ac_abs_top_builddir=$ac_pwd
+ac_abs_builddir=$ac_pwd$ac_dir_suffix
+# for backward compatibility:
+ac_top_builddir=$ac_top_build_prefix
+
+case $srcdir in
+  .)  # We are building in place.
+    ac_srcdir=.
+    ac_top_srcdir=$ac_top_builddir_sub
+    ac_abs_top_srcdir=$ac_pwd ;;
+  [\\/]* | ?:[\\/]* )  # Absolute name.
+    ac_srcdir=$srcdir$ac_dir_suffix;
+    ac_top_srcdir=$srcdir
+    ac_abs_top_srcdir=$srcdir ;;
+  *) # Relative name.
+    ac_srcdir=$ac_top_build_prefix$srcdir$ac_dir_suffix
+    ac_top_srcdir=$ac_top_build_prefix$srcdir
+    ac_abs_top_srcdir=$ac_pwd/$srcdir ;;
+esac
+ac_abs_srcdir=$ac_abs_top_srcdir$ac_dir_suffix
+
+
+        ax_popdir=$(pwd)
+        cd "$ax_dir"
+
+        # Check for guested configure; otherwise get Cygnus style configure.
+        if test -f "$ac_srcdir/configure.gnu"; then
+          ax_sub_configure=$ac_srcdir/configure.gnu
+        elif test -f "$ac_srcdir/configure"; then
+          ax_sub_configure=$ac_srcdir/configure
+        elif test -f "$ac_srcdir/configure.in"; then
+          # This should be Cygnus configure.
+          ax_sub_configure=$ac_aux_dir/configure
+        else
+          { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: no configuration information is in $ax_dir" >&5
+$as_echo "$as_me: WARNING: no configuration information is in $ax_dir" >&2;}
+          ax_sub_configure=
+        fi
+
+        if test -n "$ax_sub_configure"; then
+          # Get the configure arguments for the current configure.
+          eval "ax_sub_configure_args=\"\$ax_sub_configure_args_${ax_var}\""
+
+          # Always prepend --prefix to ensure using the same prefix
+          # in subdir configurations.
+          ax_arg="--prefix=$prefix"
+          case $ax_arg in
+            *\'*) ax_arg=$($as_echo "$ax_arg" | sed "s/'/'\\\\\\\\''/g");;
+          esac
+          ax_sub_configure_args="'$ax_arg' $ax_sub_configure_args"
+          if test "$silent" = yes; then
+            ax_sub_configure_args="--silent $ax_sub_configure_args"
+          fi
+          # Make the cache file name correct relative to the subdirectory.
+          case $cache_file in
+            [\\/]* | ?:[\\/]* )
+              ax_sub_cache_file=$cache_file ;;
+            *) # Relative name.
+              ax_sub_cache_file=$ac_top_build_prefix$cache_file ;;
+          esac
+
+          { $as_echo "$as_me:${as_lineno-$LINENO}: running $SHELL $ax_sub_configure $ax_sub_configure_args --cache-file=$ac_sub_cache_file" >&5
+$as_echo "$as_me: running $SHELL $ax_sub_configure $ax_sub_configure_args --cache-file=$ac_sub_cache_file" >&6;}
+          eval "\$SHELL \"$ax_sub_configure\" $ax_sub_configure_args --cache-file=\"$ax_sub_cache_file\"" \
+              || as_fn_error $? "$ax_sub_configure failed for $ax_dir" "$LINENO" 5
+        fi
+
+        cd "$ax_popdir"
+      fi
+
 if test -z "${LIBMESH_ENABLE_NETCDF_TRUE}" && test -z "${LIBMESH_ENABLE_NETCDF_FALSE}"; then
   as_fn_error $? "conditional \"LIBMESH_ENABLE_NETCDF\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
@@ -60938,161 +61340,11 @@ if test "$no_create" != yes; then
   # would make configure fail if this is the last instruction.
   $ac_cs_success || as_fn_exit 1
 fi
-
-#
-# CONFIG_SUBDIRS section.
-#
-if test "$no_recursion" != yes; then
-
-  # Remove --cache-file, --srcdir, and --disable-option-checking arguments
-  # so they do not pile up.
-  ac_sub_configure_args=
-  ac_prev=
-  eval "set x $ac_configure_args"
-  shift
-  for ac_arg
-  do
-    if test -n "$ac_prev"; then
-      ac_prev=
-      continue
-    fi
-    case $ac_arg in
-    -cache-file | --cache-file | --cache-fil | --cache-fi \
-    | --cache-f | --cache- | --cache | --cach | --cac | --ca | --c)
-      ac_prev=cache_file ;;
-    -cache-file=* | --cache-file=* | --cache-fil=* | --cache-fi=* \
-    | --cache-f=* | --cache-=* | --cache=* | --cach=* | --cac=* | --ca=* \
-    | --c=*)
-      ;;
-    --config-cache | -C)
-      ;;
-    -srcdir | --srcdir | --srcdi | --srcd | --src | --sr)
-      ac_prev=srcdir ;;
-    -srcdir=* | --srcdir=* | --srcdi=* | --srcd=* | --src=* | --sr=*)
-      ;;
-    -prefix | --prefix | --prefi | --pref | --pre | --pr | --p)
-      ac_prev=prefix ;;
-    -prefix=* | --prefix=* | --prefi=* | --pref=* | --pre=* | --pr=* | --p=*)
-      ;;
-    --disable-option-checking)
-      ;;
-    *)
-      case $ac_arg in
-      *\'*) ac_arg=`$as_echo "$ac_arg" | sed "s/'/'\\\\\\\\''/g"` ;;
-      esac
-      as_fn_append ac_sub_configure_args " '$ac_arg'" ;;
-    esac
-  done
-
-  # Always prepend --prefix to ensure using the same prefix
-  # in subdir configurations.
-  ac_arg="--prefix=$prefix"
-  case $ac_arg in
-  *\'*) ac_arg=`$as_echo "$ac_arg" | sed "s/'/'\\\\\\\\''/g"` ;;
-  esac
-  ac_sub_configure_args="'$ac_arg' $ac_sub_configure_args"
-
-  # Pass --silent
-  if test "$silent" = yes; then
-    ac_sub_configure_args="--silent $ac_sub_configure_args"
-  fi
-
-  # Always prepend --disable-option-checking to silence warnings, since
-  # different subdirs can have different --enable and --with options.
-  ac_sub_configure_args="--disable-option-checking $ac_sub_configure_args"
-
-  ac_popdir=`pwd`
-  for ac_dir in : $subdirs; do test "x$ac_dir" = x: && continue
-
-    # Do not complain, so a configure script can configure whichever
-    # parts of a large source tree are present.
-    test -d "$srcdir/$ac_dir" || continue
-
-    ac_msg="=== configuring in $ac_dir (`pwd`/$ac_dir)"
-    $as_echo "$as_me:${as_lineno-$LINENO}: $ac_msg" >&5
-    $as_echo "$ac_msg" >&6
-    as_dir="$ac_dir"; as_fn_mkdir_p
-    ac_builddir=.
-
-case "$ac_dir" in
-.) ac_dir_suffix= ac_top_builddir_sub=. ac_top_build_prefix= ;;
-*)
-  ac_dir_suffix=/`$as_echo "$ac_dir" | sed 's|^\.[\\/]||'`
-  # A ".." for each directory in $ac_dir_suffix.
-  ac_top_builddir_sub=`$as_echo "$ac_dir_suffix" | sed 's|/[^\\/]*|/..|g;s|/||'`
-  case $ac_top_builddir_sub in
-  "") ac_top_builddir_sub=. ac_top_build_prefix= ;;
-  *)  ac_top_build_prefix=$ac_top_builddir_sub/ ;;
-  esac ;;
-esac
-ac_abs_top_builddir=$ac_pwd
-ac_abs_builddir=$ac_pwd$ac_dir_suffix
-# for backward compatibility:
-ac_top_builddir=$ac_top_build_prefix
-
-case $srcdir in
-  .)  # We are building in place.
-    ac_srcdir=.
-    ac_top_srcdir=$ac_top_builddir_sub
-    ac_abs_top_srcdir=$ac_pwd ;;
-  [\\/]* | ?:[\\/]* )  # Absolute name.
-    ac_srcdir=$srcdir$ac_dir_suffix;
-    ac_top_srcdir=$srcdir
-    ac_abs_top_srcdir=$srcdir ;;
-  *) # Relative name.
-    ac_srcdir=$ac_top_build_prefix$srcdir$ac_dir_suffix
-    ac_top_srcdir=$ac_top_build_prefix$srcdir
-    ac_abs_top_srcdir=$ac_pwd/$srcdir ;;
-esac
-ac_abs_srcdir=$ac_abs_top_srcdir$ac_dir_suffix
-
-
-    cd "$ac_dir"
-
-    # Check for guested configure; otherwise get Cygnus style configure.
-    if test -f "$ac_srcdir/configure.gnu"; then
-      ac_sub_configure=$ac_srcdir/configure.gnu
-    elif test -f "$ac_srcdir/configure"; then
-      ac_sub_configure=$ac_srcdir/configure
-    elif test -f "$ac_srcdir/configure.in"; then
-      # This should be Cygnus configure.
-      ac_sub_configure=$ac_aux_dir/configure
-    else
-      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: no configuration information is in $ac_dir" >&5
-$as_echo "$as_me: WARNING: no configuration information is in $ac_dir" >&2;}
-      ac_sub_configure=
-    fi
-
-    # The recursion is here.
-    if test -n "$ac_sub_configure"; then
-      # Make the cache file name correct relative to the subdirectory.
-      case $cache_file in
-      [\\/]* | ?:[\\/]* ) ac_sub_cache_file=$cache_file ;;
-      *) # Relative name.
-	ac_sub_cache_file=$ac_top_build_prefix$cache_file ;;
-      esac
-
-      { $as_echo "$as_me:${as_lineno-$LINENO}: running $SHELL $ac_sub_configure $ac_sub_configure_args --cache-file=$ac_sub_cache_file --srcdir=$ac_srcdir" >&5
-$as_echo "$as_me: running $SHELL $ac_sub_configure $ac_sub_configure_args --cache-file=$ac_sub_cache_file --srcdir=$ac_srcdir" >&6;}
-      # The eval makes quoting arguments work.
-      eval "\$SHELL \"\$ac_sub_configure\" $ac_sub_configure_args \
-	   --cache-file=\"\$ac_sub_cache_file\" --srcdir=\"\$ac_srcdir\"" ||
-	as_fn_error $? "$ac_sub_configure failed for $ac_dir" "$LINENO" 5
-    fi
-
-    cd "$ac_popdir"
-  done
-fi
 if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
 
-
-# end hackery
-if test "x$enablenested" = "xyes"; then :
-  ac_configure_args="$ac_configure_args_SAVE"
-fi
 
 # Final summary
 

--- a/configure
+++ b/configure
@@ -55305,6 +55305,7 @@ $as_echo "<<< Using netCDF 3.x is no longer supported, using version 4.x instead
 
 fi
 
+  netcdf_v4_arg=''
   case "${netcdfversion}" in #(
   3) :
 
@@ -55320,7 +55321,7 @@ $as_echo "#define HAVE_NETCDF 1" >>confdefs.h
 fi
 
                                 if test "x$enablehdf5" = "xno"; then :
-  libmesh_subpackage_arguments="$libmesh_subpackage_arguments --disable-netcdf-4"
+  netcdf_v4_arg=--disable-netcdf-4
 fi
 
                                 libmesh_pkgconfig_requires="netcdf >= 4.2 $libmesh_pkgconfig_requires"
@@ -55350,127 +55351,12 @@ fi
 fi
 
                               if test "x$enablecurl" = "xyes"; then :
-
-
-  # Various preliminary checks.
-
-
-
-
-
-    ax_dir="contrib/netcdf/v4"
-
-                    # Do not complain, so a configure script can configure whichever parts of a
-    # large source tree are present.
-    if test -d "$srcdir/$ax_dir"; then
-      ac_builddir=.
-
-case "$ax_dir" in
-.) ac_dir_suffix= ac_top_builddir_sub=. ac_top_build_prefix= ;;
-*)
-  ac_dir_suffix=/`$as_echo "$ax_dir" | sed 's|^\.[\\/]||'`
-  # A ".." for each directory in $ac_dir_suffix.
-  ac_top_builddir_sub=`$as_echo "$ac_dir_suffix" | sed 's|/[^\\/]*|/..|g;s|/||'`
-  case $ac_top_builddir_sub in
-  "") ac_top_builddir_sub=. ac_top_build_prefix= ;;
-  *)  ac_top_build_prefix=$ac_top_builddir_sub/ ;;
-  esac ;;
-esac
-ac_abs_top_builddir=$ac_pwd
-ac_abs_builddir=$ac_pwd$ac_dir_suffix
-# for backward compatibility:
-ac_top_builddir=$ac_top_build_prefix
-
-case $srcdir in
-  .)  # We are building in place.
-    ac_srcdir=.
-    ac_top_srcdir=$ac_top_builddir_sub
-    ac_abs_top_srcdir=$ac_pwd ;;
-  [\\/]* | ?:[\\/]* )  # Absolute name.
-    ac_srcdir=$srcdir$ac_dir_suffix;
-    ac_top_srcdir=$srcdir
-    ac_abs_top_srcdir=$srcdir ;;
-  *) # Relative name.
-    ac_srcdir=$ac_top_build_prefix$srcdir$ac_dir_suffix
-    ac_top_srcdir=$ac_top_build_prefix$srcdir
-    ac_abs_top_srcdir=$ac_pwd/$srcdir ;;
-esac
-ac_abs_srcdir=$ac_abs_top_srcdir$ac_dir_suffix
-
-      # Remove --cache-file, --srcdir, and --disable-option-checking arguments
-      # so they do not pile up.
-      ax_args=
-      ax_prev=
-      eval "set x $ac_configure_args"
-      shift
-      for ax_arg; do
-        if test -n "$ax_prev"; then
-          ax_prev=
-          continue
-        fi
-        case $ax_arg in
-          -cache-file | --cache-file | --cache-fil | --cache-fi | --cache-f \
-          | --cache- | --cache | --cach | --cac | --ca | --c)
-            ax_prev=cache_file ;;
-          -cache-file=* | --cache-file=* | --cache-fil=* | --cache-fi=* \
-          | --cache-f=* | --cache-=* | --cache=* | --cach=* | --cac=* | --ca=* \
-          | --c=*)
-            ;;
-          --config-cache | -C)
-            ;;
-          -srcdir | --srcdir | --srcdi | --srcd | --src | --sr)
-            ax_prev=srcdir ;;
-          -srcdir=* | --srcdir=* | --srcdi=* | --srcd=* | --src=* | --sr=*)
-            ;;
-          -prefix | --prefix | --prefi | --pref | --pre | --pr | --p)
-            ax_prev=prefix ;;
-          -prefix=* | --prefix=* | --prefi=* | --pref=* | --pre=* | --pr=* \
-          | --p=*)
-            ;;
-          --disable-option-checking)
-            ;;
-          *) case $ax_arg in
-              *\'*) ax_arg=$($as_echo "$ax_arg" | sed "s/'/'\\\\\\\\''/g");;
-            esac
-            as_fn_append ax_args " '$ax_arg'" ;;
-        esac
-      done
-      # Always prepend --disable-option-checking to silence warnings, since
-      # different subdirs can have different --enable and --with options.
-      ax_args="--disable-option-checking $ax_args"
-      # Options that must be added as they are provided.
-      as_fn_append ax_args " 'CXX=$CXX'"
-      as_fn_append ax_args " 'CC=$CC'"
-      as_fn_append ax_args " 'F77=$F77'"
-      as_fn_append ax_args " 'FC=$FC'"
-      as_fn_append ax_args " 'CPPFLAGS=$SUB_CPPFLAGS'"
-      as_fn_append ax_args " 'LIBS=$SUB_LIBS'"
-      as_fn_append ax_args " '--enable-dap'"
-      as_fn_append ax_args " '--disable-testsets'"
-
-      # New options that may need to be merged with existing options.
-
-      # New options that must replace existing options.
-
-      # Options that must be removed.
-
-      as_fn_append ax_args " '--srcdir=$ac_srcdir'"
-
-      # Add the subdirectory to the list of target subdirectories.
-      ax_subconfigures="$ax_subconfigures $ax_dir"
-      # Save the argument list for this subdirectory.
-                              ax_var=$(printf "$ax_dir" | tr -c "0-9a-zA-Z_" "_")
-      eval "ax_sub_configure_args_$ax_var=\"$ax_args\""
-      eval "ax_sub_configure_$ax_var=\"yes\""
-    else
-      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: could not find source tree for $ax_dir" >&5
-$as_echo "$as_me: WARNING: could not find source tree for $ax_dir" >&2;}
-    fi
-
-
-
-
+  netcdf_dap_arg=--enable-dap
+                 netcdf_curl_arg=''
 else
+  netcdf_dap_arg=--disable-dap
+                 netcdf_curl_arg=--disable-curl
+fi
 
 
   # Various preliminary checks.
@@ -55566,9 +55452,10 @@ ac_abs_srcdir=$ac_abs_top_srcdir$ac_dir_suffix
       as_fn_append ax_args " 'FC=$FC'"
       as_fn_append ax_args " 'CPPFLAGS=$SUB_CPPFLAGS'"
       as_fn_append ax_args " 'LIBS=$SUB_LIBS'"
-      as_fn_append ax_args " '--disable-dap'"
-      as_fn_append ax_args " '--disable-curl'"
+      as_fn_append ax_args " '$netcdf_dap_arg'"
+      as_fn_append ax_args " '$netcdf_curl_arg'"
       as_fn_append ax_args " '--disable-testsets'"
+      as_fn_append ax_args " '$netcdf_v4_arg'"
 
       # New options that may need to be merged with existing options.
 
@@ -55592,7 +55479,6 @@ $as_echo "$as_me: WARNING: could not find source tree for $ax_dir" >&2;}
 
 
 
-fi
 
 fi
 
@@ -57866,101 +57752,6 @@ if test -z "${LIBMESH_ENABLE_HDF5_TRUE}" && test -z "${LIBMESH_ENABLE_HDF5_FALSE
   as_fn_error $? "conditional \"LIBMESH_ENABLE_HDF5\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
-      ax_dir="contrib/netcdf/v4"
-
-      # Convert the path to the subdirectory into a shell variable name.
-      ax_var=$(printf "$ax_dir" | tr -c "0-9a-zA-Z_" "_")
-      ax_configure_ax_var=$(eval "echo \"\$ax_sub_configure_$ax_var\"")
-      if test "$no_recursion" != "yes" -a "x$ax_configure_ax_var" = "xyes"; then
-        subdirs_extra="$subdirs_extra $ax_dir"
-
-        ax_msg="=== configuring in $ax_dir ($(pwd)/$ax_dir)"
-        $as_echo "$as_me:${as_lineno-$LINENO}: $ax_msg" >&5
-        $as_echo "$ax_msg" >&6
-        as_dir="$ax_dir"; as_fn_mkdir_p
-        ac_builddir=.
-
-case "$ax_dir" in
-.) ac_dir_suffix= ac_top_builddir_sub=. ac_top_build_prefix= ;;
-*)
-  ac_dir_suffix=/`$as_echo "$ax_dir" | sed 's|^\.[\\/]||'`
-  # A ".." for each directory in $ac_dir_suffix.
-  ac_top_builddir_sub=`$as_echo "$ac_dir_suffix" | sed 's|/[^\\/]*|/..|g;s|/||'`
-  case $ac_top_builddir_sub in
-  "") ac_top_builddir_sub=. ac_top_build_prefix= ;;
-  *)  ac_top_build_prefix=$ac_top_builddir_sub/ ;;
-  esac ;;
-esac
-ac_abs_top_builddir=$ac_pwd
-ac_abs_builddir=$ac_pwd$ac_dir_suffix
-# for backward compatibility:
-ac_top_builddir=$ac_top_build_prefix
-
-case $srcdir in
-  .)  # We are building in place.
-    ac_srcdir=.
-    ac_top_srcdir=$ac_top_builddir_sub
-    ac_abs_top_srcdir=$ac_pwd ;;
-  [\\/]* | ?:[\\/]* )  # Absolute name.
-    ac_srcdir=$srcdir$ac_dir_suffix;
-    ac_top_srcdir=$srcdir
-    ac_abs_top_srcdir=$srcdir ;;
-  *) # Relative name.
-    ac_srcdir=$ac_top_build_prefix$srcdir$ac_dir_suffix
-    ac_top_srcdir=$ac_top_build_prefix$srcdir
-    ac_abs_top_srcdir=$ac_pwd/$srcdir ;;
-esac
-ac_abs_srcdir=$ac_abs_top_srcdir$ac_dir_suffix
-
-
-        ax_popdir=$(pwd)
-        cd "$ax_dir"
-
-        # Check for guested configure; otherwise get Cygnus style configure.
-        if test -f "$ac_srcdir/configure.gnu"; then
-          ax_sub_configure=$ac_srcdir/configure.gnu
-        elif test -f "$ac_srcdir/configure"; then
-          ax_sub_configure=$ac_srcdir/configure
-        elif test -f "$ac_srcdir/configure.in"; then
-          # This should be Cygnus configure.
-          ax_sub_configure=$ac_aux_dir/configure
-        else
-          { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: no configuration information is in $ax_dir" >&5
-$as_echo "$as_me: WARNING: no configuration information is in $ax_dir" >&2;}
-          ax_sub_configure=
-        fi
-
-        if test -n "$ax_sub_configure"; then
-          # Get the configure arguments for the current configure.
-          eval "ax_sub_configure_args=\"\$ax_sub_configure_args_${ax_var}\""
-
-          # Always prepend --prefix to ensure using the same prefix
-          # in subdir configurations.
-          ax_arg="--prefix=$prefix"
-          case $ax_arg in
-            *\'*) ax_arg=$($as_echo "$ax_arg" | sed "s/'/'\\\\\\\\''/g");;
-          esac
-          ax_sub_configure_args="'$ax_arg' $ax_sub_configure_args"
-          if test "$silent" = yes; then
-            ax_sub_configure_args="--silent $ax_sub_configure_args"
-          fi
-          # Make the cache file name correct relative to the subdirectory.
-          case $cache_file in
-            [\\/]* | ?:[\\/]* )
-              ax_sub_cache_file=$cache_file ;;
-            *) # Relative name.
-              ax_sub_cache_file=$ac_top_build_prefix$cache_file ;;
-          esac
-
-          { $as_echo "$as_me:${as_lineno-$LINENO}: running $SHELL $ax_sub_configure $ax_sub_configure_args --cache-file=$ac_sub_cache_file" >&5
-$as_echo "$as_me: running $SHELL $ax_sub_configure $ax_sub_configure_args --cache-file=$ac_sub_cache_file" >&6;}
-          eval "\$SHELL \"$ax_sub_configure\" $ax_sub_configure_args --cache-file=\"$ax_sub_cache_file\"" \
-              || as_fn_error $? "$ax_sub_configure failed for $ax_dir" "$LINENO" 5
-        fi
-
-        cd "$ax_popdir"
-      fi
-
       ax_dir="contrib/netcdf/v4"
 
       # Convert the path to the subdirectory into a shell variable name.

--- a/configure.ac
+++ b/configure.ac
@@ -447,42 +447,8 @@ AS_IF([test "x$enableexamples" = "xyes"],
                          examples/Makefile])
      ])
 
-
-
-# hackery.  If we are supporting nested autoconf packages and we want to specify
-# additional arguments to be passed to those packages, do that here.
-# Specifically, we append libmesh_subpackage_arguments to ac_configure_args
-# before AC_OUTPUT recurses into our subpackages
-
-# We need our netcdf subpackage to be able to use whatever HDF5 we've
-# detected.  That means using whatever $HDF5_CPPFLAGS and $HDF5_LIBS
-# we've determined work - but if we're using PETSc it also means
-# passing along PETSc's directories in case we want to link to a
-# --download-hdf5 build there.
-SUB_CPPFLAGS="$CPPFLAGS"
-SUB_LIBS="$LIBS"
-AS_IF([test $enablehdf5 = yes],
-      [
-       SUB_CPPFLAGS="$HDF5_CPPFLAGS $SUB_CPPFLAGS"
-       SUB_LIBS="$HDF5_LIBS $SUB_LIBS"
-       AS_IF([test "x$enablepetsc" != "xno"],
-             [
-              SUB_CPPFLAGS="$PETSCINCLUDEDIRS $SUB_CPPFLAGS"
-              SUB_LIBS="$PETSCLINKLIBS $SUB_LIBS"
-             ])])
-
-AS_IF([test "x$enablenested" = "xyes"],
-      [
-        ac_configure_args_SAVE="$ac_configure_args"
-        ac_configure_args="$ac_configure_args $libmesh_subpackage_arguments CXX='$CXX' CC='$CC' F77='$F77' FC='$FC' CPPFLAGS='$SUB_CPPFLAGS' LIBS='$SUB_LIBS'"
-      ])
-
 # Create output files. Also configures any subpackages
 AC_OUTPUT
-
-# end hackery
-AS_IF([test "x$enablenested" = "xyes"],
-      [ac_configure_args="$ac_configure_args_SAVE"])
 
 # Final summary
 AX_SUMMARIZE_CONFIG

--- a/contrib/Makefile.in
+++ b/contrib/Makefile.in
@@ -778,7 +778,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/boost/include/Makefile.in
+++ b/contrib/boost/include/Makefile.in
@@ -2170,7 +2170,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/capnproto/Makefile.in
+++ b/contrib/capnproto/Makefile.in
@@ -637,7 +637,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/eigen/3.3.9/Makefile.in
+++ b/contrib/eigen/3.3.9/Makefile.in
@@ -521,7 +521,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/exodusii/5.22b/exodus/Makefile.in
+++ b/contrib/exodusii/5.22b/exodus/Makefile.in
@@ -3509,7 +3509,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/exodusii/5.22b/nemesis/Makefile.in
+++ b/contrib/exodusii/5.22b/nemesis/Makefile.in
@@ -582,7 +582,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/exodusii/Lib/Makefile.in
+++ b/contrib/exodusii/Lib/Makefile.in
@@ -2144,7 +2144,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/exodusii/v8.11/exodus/Makefile.in
+++ b/contrib/exodusii/v8.11/exodus/Makefile.in
@@ -4437,7 +4437,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/exodusii/v8.11/nemesis/Makefile.in
+++ b/contrib/exodusii/v8.11/nemesis/Makefile.in
@@ -592,7 +592,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/fparser/Makefile.in
+++ b/contrib/fparser/Makefile.in
@@ -1055,7 +1055,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/fparser/extrasrc/Makefile.in
+++ b/contrib/fparser/extrasrc/Makefile.in
@@ -474,7 +474,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/gmv/Makefile.in
+++ b/contrib/gmv/Makefile.in
@@ -577,7 +577,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/gzstream/Makefile.in
+++ b/contrib/gzstream/Makefile.in
@@ -630,7 +630,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/laspack/Makefile.in
+++ b/contrib/laspack/Makefile.in
@@ -687,7 +687,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/libHilbert/Makefile.in
+++ b/contrib/libHilbert/Makefile.in
@@ -660,7 +660,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/metis/Makefile.in
+++ b/contrib/metis/Makefile.in
@@ -1205,7 +1205,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/nanoflann/Makefile.in
+++ b/contrib/nanoflann/Makefile.in
@@ -630,7 +630,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/nemesis/Lib/Makefile.in
+++ b/contrib/nemesis/Lib/Makefile.in
@@ -972,7 +972,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/parmetis/Makefile.in
+++ b/contrib/parmetis/Makefile.in
@@ -1038,7 +1038,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/poly2tri/modified/Makefile.in
+++ b/contrib/poly2tri/modified/Makefile.in
@@ -673,7 +673,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/qhull/2012.1/Makefile.in
+++ b/contrib/qhull/2012.1/Makefile.in
@@ -1344,7 +1344,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/sfcurves/Makefile.in
+++ b/contrib/sfcurves/Makefile.in
@@ -597,7 +597,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/tecplot/binary/Makefile.in
+++ b/contrib/tecplot/binary/Makefile.in
@@ -568,7 +568,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/tecplot/tecio/Makefile.in
+++ b/contrib/tecplot/tecio/Makefile.in
@@ -806,7 +806,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/tetgen/Makefile.in
+++ b/contrib/tetgen/Makefile.in
@@ -617,7 +617,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/contrib/triangle/Makefile.in
+++ b/contrib/triangle/Makefile.in
@@ -612,7 +612,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -530,7 +530,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/doc/html/Makefile.in
+++ b/doc/html/Makefile.in
@@ -490,7 +490,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/Makefile.in
+++ b/examples/Makefile.in
@@ -562,7 +562,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/adaptivity/adaptivity_ex1/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex1/Makefile.in
@@ -649,7 +649,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/adaptivity/adaptivity_ex2/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex2/Makefile.in
@@ -668,7 +668,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/adaptivity/adaptivity_ex3/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex3/Makefile.in
@@ -655,7 +655,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/adaptivity/adaptivity_ex4/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex4/Makefile.in
@@ -655,7 +655,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/adaptivity/adaptivity_ex5/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex5/Makefile.in
@@ -664,7 +664,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/adjoints/adjoints_ex1/Makefile.in
+++ b/examples/adjoints/adjoints_ex1/Makefile.in
@@ -743,7 +743,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/adjoints/adjoints_ex2/Makefile.in
+++ b/examples/adjoints/adjoints_ex2/Makefile.in
@@ -711,7 +711,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/adjoints/adjoints_ex3/Makefile.in
+++ b/examples/adjoints/adjoints_ex3/Makefile.in
@@ -746,7 +746,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/adjoints/adjoints_ex4/Makefile.in
+++ b/examples/adjoints/adjoints_ex4/Makefile.in
@@ -746,7 +746,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/adjoints/adjoints_ex5/Makefile.in
+++ b/examples/adjoints/adjoints_ex5/Makefile.in
@@ -746,7 +746,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/adjoints/adjoints_ex6/Makefile.in
+++ b/examples/adjoints/adjoints_ex6/Makefile.in
@@ -711,7 +711,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/adjoints/adjoints_ex7/Makefile.in
+++ b/examples/adjoints/adjoints_ex7/Makefile.in
@@ -761,7 +761,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/eigenproblems/eigenproblems_ex1/Makefile.in
+++ b/examples/eigenproblems/eigenproblems_ex1/Makefile.in
@@ -649,7 +649,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/eigenproblems/eigenproblems_ex2/Makefile.in
+++ b/examples/eigenproblems/eigenproblems_ex2/Makefile.in
@@ -649,7 +649,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/eigenproblems/eigenproblems_ex3/Makefile.in
+++ b/examples/eigenproblems/eigenproblems_ex3/Makefile.in
@@ -655,7 +655,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/fem_system/fem_system_ex1/Makefile.in
+++ b/examples/fem_system/fem_system_ex1/Makefile.in
@@ -683,7 +683,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/fem_system/fem_system_ex2/Makefile.in
+++ b/examples/fem_system/fem_system_ex2/Makefile.in
@@ -698,7 +698,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/fem_system/fem_system_ex3/Makefile.in
+++ b/examples/fem_system/fem_system_ex3/Makefile.in
@@ -683,7 +683,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/fem_system/fem_system_ex4/Makefile.in
+++ b/examples/fem_system/fem_system_ex4/Makefile.in
@@ -683,7 +683,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/fem_system/fem_system_ex5/Makefile.in
+++ b/examples/fem_system/fem_system_ex5/Makefile.in
@@ -698,7 +698,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/introduction/introduction_ex1/Makefile.in
+++ b/examples/introduction/introduction_ex1/Makefile.in
@@ -649,7 +649,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/introduction/introduction_ex2/Makefile.in
+++ b/examples/introduction/introduction_ex2/Makefile.in
@@ -649,7 +649,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/introduction/introduction_ex3/Makefile.in
+++ b/examples/introduction/introduction_ex3/Makefile.in
@@ -664,7 +664,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/introduction/introduction_ex4/Makefile.in
+++ b/examples/introduction/introduction_ex4/Makefile.in
@@ -664,7 +664,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/introduction/introduction_ex5/Makefile.in
+++ b/examples/introduction/introduction_ex5/Makefile.in
@@ -664,7 +664,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/miscellaneous/miscellaneous_ex1/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex1/Makefile.in
@@ -649,7 +649,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/miscellaneous/miscellaneous_ex10/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex10/Makefile.in
@@ -649,7 +649,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/miscellaneous/miscellaneous_ex11/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex11/Makefile.in
@@ -655,7 +655,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/miscellaneous/miscellaneous_ex12/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex12/Makefile.in
@@ -655,7 +655,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/miscellaneous/miscellaneous_ex13/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex13/Makefile.in
@@ -655,7 +655,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/miscellaneous/miscellaneous_ex14/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex14/Makefile.in
@@ -649,7 +649,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/miscellaneous/miscellaneous_ex15/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex15/Makefile.in
@@ -649,7 +649,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/miscellaneous/miscellaneous_ex2/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex2/Makefile.in
@@ -655,7 +655,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/miscellaneous/miscellaneous_ex3/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex3/Makefile.in
@@ -654,7 +654,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/miscellaneous/miscellaneous_ex4/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex4/Makefile.in
@@ -649,7 +649,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/miscellaneous/miscellaneous_ex5/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex5/Makefile.in
@@ -663,7 +663,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/miscellaneous/miscellaneous_ex6/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex6/Makefile.in
@@ -649,7 +649,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/miscellaneous/miscellaneous_ex7/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex7/Makefile.in
@@ -692,7 +692,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/miscellaneous/miscellaneous_ex8/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex8/Makefile.in
@@ -678,7 +678,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/miscellaneous/miscellaneous_ex9/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex9/Makefile.in
@@ -689,7 +689,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/optimization/optimization_ex1/Makefile.in
+++ b/examples/optimization/optimization_ex1/Makefile.in
@@ -655,7 +655,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/optimization/optimization_ex2/Makefile.in
+++ b/examples/optimization/optimization_ex2/Makefile.in
@@ -655,7 +655,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/reduced_basis/reduced_basis_ex1/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex1/Makefile.in
@@ -673,7 +673,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/reduced_basis/reduced_basis_ex2/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex2/Makefile.in
@@ -673,7 +673,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/reduced_basis/reduced_basis_ex3/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex3/Makefile.in
@@ -673,7 +673,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/reduced_basis/reduced_basis_ex4/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex4/Makefile.in
@@ -678,7 +678,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/reduced_basis/reduced_basis_ex5/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex5/Makefile.in
@@ -688,7 +688,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/reduced_basis/reduced_basis_ex6/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex6/Makefile.in
@@ -678,7 +678,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/reduced_basis/reduced_basis_ex7/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex7/Makefile.in
@@ -673,7 +673,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/solution_transfer/solution_transfer_ex1/Makefile.in
+++ b/examples/solution_transfer/solution_transfer_ex1/Makefile.in
@@ -649,7 +649,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/subdomains/subdomains_ex1/Makefile.in
+++ b/examples/subdomains/subdomains_ex1/Makefile.in
@@ -664,7 +664,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/subdomains/subdomains_ex2/Makefile.in
+++ b/examples/subdomains/subdomains_ex2/Makefile.in
@@ -664,7 +664,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/subdomains/subdomains_ex3/Makefile.in
+++ b/examples/subdomains/subdomains_ex3/Makefile.in
@@ -658,7 +658,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/systems_of_equations/systems_of_equations_ex1/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex1/Makefile.in
@@ -650,7 +650,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/systems_of_equations/systems_of_equations_ex2/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex2/Makefile.in
@@ -655,7 +655,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/systems_of_equations/systems_of_equations_ex3/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex3/Makefile.in
@@ -650,7 +650,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/systems_of_equations/systems_of_equations_ex4/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex4/Makefile.in
@@ -650,7 +650,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/systems_of_equations/systems_of_equations_ex5/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex5/Makefile.in
@@ -650,7 +650,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/systems_of_equations/systems_of_equations_ex6/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex6/Makefile.in
@@ -650,7 +650,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/systems_of_equations/systems_of_equations_ex7/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex7/Makefile.in
@@ -656,7 +656,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/systems_of_equations/systems_of_equations_ex8/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex8/Makefile.in
@@ -694,7 +694,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/systems_of_equations/systems_of_equations_ex9/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex9/Makefile.in
@@ -656,7 +656,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/transient/transient_ex1/Makefile.in
+++ b/examples/transient/transient_ex1/Makefile.in
@@ -664,7 +664,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/transient/transient_ex2/Makefile.in
+++ b/examples/transient/transient_ex2/Makefile.in
@@ -650,7 +650,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/vector_fe/vector_fe_ex1/Makefile.in
+++ b/examples/vector_fe/vector_fe_ex1/Makefile.in
@@ -662,7 +662,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/vector_fe/vector_fe_ex2/Makefile.in
+++ b/examples/vector_fe/vector_fe_ex2/Makefile.in
@@ -688,7 +688,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/vector_fe/vector_fe_ex3/Makefile.in
+++ b/examples/vector_fe/vector_fe_ex3/Makefile.in
@@ -688,7 +688,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/vector_fe/vector_fe_ex4/Makefile.in
+++ b/examples/vector_fe/vector_fe_ex4/Makefile.in
@@ -688,7 +688,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/examples/vector_fe/vector_fe_ex5/Makefile.in
+++ b/examples/vector_fe/vector_fe_ex5/Makefile.in
@@ -675,7 +675,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -566,7 +566,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -488,7 +488,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/m4/libmesh_optional_packages.m4
+++ b/m4/libmesh_optional_packages.m4
@@ -21,9 +21,6 @@ AC_REQUIRE([LIBMESH_SET_COMPILERS])
 # source tree for building contributed packages that do not
 # need to be exported as part of the installation environment.
 #
-# libmesh_subpackage_arguments is a list of configure arguments
-# that will be passed down to any subpackages that we are nesting.
-#
 # libmesh_pkgconfig_requires is a list of pkgconfig requirements
 # we will add
 #
@@ -33,7 +30,6 @@ AC_REQUIRE([LIBMESH_SET_COMPILERS])
 libmesh_optional_INCLUDES=""
 libmesh_optional_LIBS=""
 libmesh_contrib_INCLUDES=""
-libmesh_subpackage_arguments=""
 libmesh_pkgconfig_requires=""
 libmesh_installed_LIBS=""
 

--- a/m4/netcdf.m4
+++ b/m4/netcdf.m4
@@ -26,6 +26,7 @@ AC_DEFUN([CONFIGURE_NETCDF],
           netcdfversion=4
         ])
 
+  netcdf_v4_arg=''
   AS_CASE("${netcdfversion}",
           [3], [
                  dnl We shouldn't get here, see if test above.
@@ -37,7 +38,7 @@ AC_DEFUN([CONFIGURE_NETCDF],
                 AS_IF([test "x$enablenested" = "xno"], [AC_MSG_ERROR([NetCDF v4 requires nested subpackages, try --enable-nested])])
 
                 dnl pass --disable-netcdf-4 to the subpackage so that we do not require HDF-5
-                AS_IF([test "x$enablehdf5" = "xno"], [libmesh_subpackage_arguments="$libmesh_subpackage_arguments --disable-netcdf-4"])
+                AS_IF([test "x$enablehdf5" = "xno"], [netcdf_v4_arg=--disable-netcdf-4])
 
                 dnl netcdf will install its own pkgconfig script, use this to get proper static linking
                 libmesh_pkgconfig_requires="netcdf >= 4.2 $libmesh_pkgconfig_requires"
@@ -70,8 +71,11 @@ AC_DEFUN([CONFIGURE_NETCDF],
           dnl ensure that the configuration is consistent
           dnl pass --disable-testsets to the netcdf subpackage to disable the most rigorous tests
           AS_IF([test "x$enablecurl" = "xyes"],
-                [AX_SUBDIRS_CONFIGURE([contrib/netcdf/v4],[[CXX=$CXX],[CC=$CC],[F77=$F77],[FC=$FC],[CPPFLAGS=$SUB_CPPFLAGS],[LIBS=$SUB_LIBS],[--enable-dap],[--disable-testsets]])],
-                [AX_SUBDIRS_CONFIGURE([contrib/netcdf/v4],[[CXX=$CXX],[CC=$CC],[F77=$F77],[FC=$FC],[CPPFLAGS=$SUB_CPPFLAGS],[LIBS=$SUB_LIBS],[--disable-dap],[--disable-curl],[--disable-testsets]])])
+                [netcdf_dap_arg=--enable-dap
+                 netcdf_curl_arg=''],
+                [netcdf_dap_arg=--disable-dap
+                 netcdf_curl_arg=--disable-curl])
+          AX_SUBDIRS_CONFIGURE([contrib/netcdf/v4],[[CXX=$CXX],[CC=$CC],[F77=$F77],[FC=$FC],[CPPFLAGS=$SUB_CPPFLAGS],[LIBS=$SUB_LIBS],[$netcdf_dap_arg],[$netcdf_curl_arg],[--disable-testsets],[$netcdf_v4_arg]])
         ])
 
   AC_SUBST(NETCDF_INCLUDE)

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -2042,7 +2042,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@


### PR DESCRIPTION
Our ac_configure_args hackery was causing those subdir arguments to end
up in our own configure lines as well (and redundantly, too, becoming
longer and longer each time make decided that `config.status --recheck`
was necessary!).  Using the macro here (as we already do with
MetaPhysicL) should be better supported, and it fixes those side effects
for me.

I've tested this with a third-party HDF5, and my initial now-deleted
attempts to fix the problem by making the hackery even more hacked up
have me convinced that my test coverage was solid there.