### PR TITLE
Explicitly use ReplicatedMesh in test of writing elemset data

### DIFF
--- a/tests/mesh/write_elemset_data.C
+++ b/tests/mesh/write_elemset_data.C
@@ -36,7 +36,13 @@ public:
   template <typename IOClass>
   void testWriteImpl(const std::string & filename)
   {
-    Mesh mesh(*TestCommWorld);
+    // TODO: Currently this test only works for ReplicatedMesh. It
+    // should be updated so that it works for DistributedMesh as well,
+    // and then we can just set MeshType == Mesh.
+    typedef ReplicatedMesh MeshType;
+
+    // Construct mesh for writing
+    MeshType mesh(*TestCommWorld);
 
     // Allocate space for an extra integer on each element to store a "code" which
     // determines which sets an Elem belongs to. We do this before building the Mesh.
@@ -167,7 +173,7 @@ public:
     TestCommWorld->barrier();
 
     // Now read it back in
-    Mesh read_mesh(*TestCommWorld);
+    MeshType read_mesh(*TestCommWorld);
 
     // Do not allow renumbering on this mesh either.
     read_mesh.allow_renumbering(false);


### PR DESCRIPTION
Getting this test working with `DistributedMesh` would probably take more time than I have at the moment, and I don't think there's any pressing desire to use this capability for `DistributedMesh` (certainly not from my end) so for now I'm restricting the test to run with `ReplicatedMesh`. 