### PR TITLE
Poly2TriTriangulator fixes for DistributedMesh

### DIFF
--- a/examples/subdomains/subdomains_ex3/subdomains_ex3.C
+++ b/examples/subdomains/subdomains_ex3/subdomains_ex3.C
@@ -90,7 +90,7 @@ int main (int argc, char ** argv)
 
     if (argc == 3 && std::atoi(argv[2]) == 3)
       {
-        libmesh_here();
+        std::cout << "Running in 3D" << std::endl;
         dim=3;
       }
 

--- a/include/mesh/poly2tri_triangulator.h
+++ b/include/mesh/poly2tri_triangulator.h
@@ -27,7 +27,6 @@
 
 // Local Includes
 #include "libmesh/dof_object.h"
-#include "libmesh/mesh_serializer.h"
 #include "libmesh/triangulator_interface.h"
 
 namespace libMesh
@@ -138,11 +137,6 @@ private:
    * versions
    */
   std::map<const Hole *, std::unique_ptr<ArbitraryHole>> replaced_holes;
-
-  /**
-   * We only operate on serialized meshes.
-   */
-  MeshSerializer _serializer;
 
   /**
    * Keep track of how many mesh nodes are boundary nodes.

--- a/include/mesh/triangulator_interface.h
+++ b/include/mesh/triangulator_interface.h
@@ -234,10 +234,16 @@ public:
 protected:
   /**
    * Helper function to create PSLG segments from our other
-   * boundary-defining options (nodal ordering, 1D mesh edges, 2D mesh
+   * boundary-defining options (1D mesh edges, 2D mesh
    * boundary sides), if no segments already exist.
    */
   void elems_to_segments();
+
+  /**
+   * Helper function to create PSLG segments from our node ordering,
+   * up to the maximum node id, if no segments already exist.
+   */
+  void nodes_to_segments(dof_id_type max_node_id);
 
   /**
    * Helper function to add extra points (midpoints of initial

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -24,6 +24,7 @@
 #include "libmesh/function_base.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/mesh_function.h"
+#include "libmesh/mesh_serializer.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/parallel.h"
 #include "libmesh/quadrature.h"
@@ -475,9 +476,14 @@ void ExactSolution::_compute_error(std::string_view sys_name,
   const unsigned int var_component =
     computed_system.variable_scalar_number(var, 0);
 
-  // Prepare a global solution and a MeshFunction of the coarse system if we need one
+  // Prepare a global solution, a serialized mesh, and a MeshFunction
+  // of the coarse system, if we need them for fine-system integration
   std::unique_ptr<MeshFunction> coarse_values;
-  std::unique_ptr<NumericVector<Number>> comparison_soln = NumericVector<Number>::build(_equation_systems.comm());
+  std::unique_ptr<NumericVector<Number>> comparison_soln =
+    NumericVector<Number>::build(_equation_systems.comm());
+  MeshSerializer
+    serial(const_cast<MeshBase&>(_equation_systems.get_mesh()),
+           _equation_systems_fine);
   if (_equation_systems_fine)
     {
       const System & comparison_system

--- a/src/mesh/mesh_serializer.C
+++ b/src/mesh/mesh_serializer.C
@@ -26,7 +26,8 @@ namespace libMesh
 
 MeshSerializer::MeshSerializer(MeshBase & mesh, bool need_serial, bool serial_only_needed_on_proc_0) :
   _mesh(mesh),
-  reparallelize(false)
+  reparallelize(false),
+  resume_allow_remote_element_removal(false)
 {
   libmesh_parallel_only(mesh.comm());
   if (need_serial && !_mesh.is_serial() && !serial_only_needed_on_proc_0) {
@@ -38,6 +39,12 @@ MeshSerializer::MeshSerializer(MeshBase & mesh, bool need_serial, bool serial_on
     // Just waste a bit of space on processor 0 to speed things up
     _mesh.gather_to_zero();
   }
+
+  if (_mesh.allow_remote_element_removal())
+    {
+      resume_allow_remote_element_removal = true;
+      _mesh.allow_remote_element_removal(false);
+    }
 }
 
 
@@ -46,6 +53,9 @@ MeshSerializer::~MeshSerializer()
 {
   if (reparallelize)
     _mesh.delete_remote_elements();
+
+  if (resume_allow_remote_element_removal)
+    _mesh.allow_remote_element_removal(true);
 }
 
 } // namespace libMesh

--- a/src/mesh/mesh_triangle_holes.C
+++ b/src/mesh/mesh_triangle_holes.C
@@ -25,6 +25,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/int_range.h"
 #include "libmesh/mesh_base.h"
+#include "libmesh/mesh_serializer.h"
 #include "libmesh/node.h"
 #include "libmesh/parallel_algebra.h" // Packing<Point>
 #include "libmesh/simple_range.h"
@@ -261,6 +262,9 @@ TriangulatorInterface::MeshedHole::MeshedHole(const MeshBase & mesh,
   // otherwise we can get out of sync by doing things like using
   // pointers as keys.
   libmesh_parallel_only(mesh.comm());
+
+  MeshSerializer serial(const_cast<MeshBase &>(mesh),
+                        /* serial */ true, /* only proc 0 */ true);
 
   if (mesh.processor_id() != 0)
     {

--- a/src/mesh/mesh_triangle_interface.C
+++ b/src/mesh/mesh_triangle_interface.C
@@ -60,11 +60,15 @@ void TriangleInterface::triangulate()
   // Will the triangulation have holes?
   const bool have_holes = ((_holes != nullptr) && (!_holes->empty()));
 
+  unsigned int n_hole_points = this->total_hole_points();
+
+  // If we're doing PSLG without segments, construct them from all our
+  // mesh nodes
+  this->nodes_to_segments(_mesh.max_node_id());
+
   // Insert additional new points in between existing boundary points,
   // if that is requested and reasonable
   this->insert_any_extra_boundary_points();
-
-  unsigned int n_hole_points = this->total_hole_points();
 
   // Regardless of whether we added additional points, the set of points to
   // triangulate is now sitting in the mesh.
@@ -338,6 +342,8 @@ void TriangleInterface::triangulate()
                                       _elem_type);
   }
 
+
+  _mesh.set_mesh_dimension(2);
 
 
   // To the naked eye, a few smoothing iterations usually looks better,

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -28,6 +28,7 @@
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/function_base.h"
 #include "libmesh/hashing.h"
+#include "libmesh/mesh_serializer.h"
 #include "libmesh/mesh_smoother_laplace.h"
 #include "libmesh/mesh_triangle_holes.h"
 #include "libmesh/unstructured_mesh.h"
@@ -151,7 +152,6 @@ namespace libMesh
 Poly2TriTriangulator::Poly2TriTriangulator(UnstructuredMesh & mesh,
                                            dof_id_type n_boundary_nodes)
   : TriangulatorInterface(mesh),
-    _serializer(_mesh),
     _n_boundary_nodes(n_boundary_nodes),
     _refine_bdy_allowed(true)
 {
@@ -164,6 +164,11 @@ Poly2TriTriangulator::~Poly2TriTriangulator() = default;
 // Primary function responsible for performing the triangulation
 void Poly2TriTriangulator::triangulate()
 {
+  // We only operate on serialized meshes.  And it's not safe to
+  // serialize earlier, because it would then be possible for the user
+  // to re-parallelize the mesh in between there and here.
+  MeshSerializer serializer(_mesh);
+
   // We don't yet support every set of Triangulator options in the
   // poly2tri implementation
 

--- a/src/mesh/triangulator_interface.C
+++ b/src/mesh/triangulator_interface.C
@@ -155,7 +155,8 @@ void TriangulatorInterface::insert_any_extra_boundary_points()
 
       // Insert a new point on each PSLG at evenly spaced locations
       // between existing boundary points.
-      // np=index into new points vector
+      // np=index into new points vector, also an explicit node index
+      // (to avoid the stride in automatic DistributedMesh indexing)
       // n =index into original points vector
       for (std::size_t np=0, n=0, tops=n_interpolated*original_points.size(); np<tops; ++np)
         {
@@ -163,7 +164,7 @@ void TriangulatorInterface::insert_any_extra_boundary_points()
 
           // Some entries are the original points
           if (!offset)
-            _mesh.add_point(original_points[n++]);
+            _mesh.add_point(original_points[n++], np);
 
           else // the odd entries are equispaced along the original PSLG segments
             {
@@ -172,7 +173,7 @@ void TriangulatorInterface::insert_any_extra_boundary_points()
               const Point new_point =
                 (offset*original_points[next_n] +
                  (n_interpolated-offset)*original_points[n-1])/n_interpolated;
-              _mesh.add_point(new_point);
+              _mesh.add_point(new_point, np);
             }
         }
     }

--- a/src/mesh/triangulator_interface.C
+++ b/src/mesh/triangulator_interface.C
@@ -170,6 +170,10 @@ void TriangulatorInterface::insert_any_extra_boundary_points()
   const int n_interpolated = this->get_interpolate_boundary_points();
   if ((_triangulation_type==PSLG) && n_interpolated)
     {
+      // If we were lucky enough to start with contiguous node ids,
+      // let's keep them that way.
+      dof_id_type nn = _mesh.max_node_id();
+
       std::vector<std::pair<unsigned int, unsigned int>> old_segments =
         std::move(this->segments);
 
@@ -195,7 +199,7 @@ void TriangulatorInterface::insert_any_extra_boundary_points()
                 ((n_interpolated-i) * *(Point *)(begin_node) +
                  (i+1) * *(Point *)(end_node)) /
                 (n_interpolated + 1);
-              Node * next_node = _mesh.add_point(new_point);
+              Node * next_node = _mesh.add_point(new_point, nn++);
               this->segments.emplace_back(current_id,
                                           next_node->id());
               current_id = next_node->id();

--- a/src/mesh/triangulator_interface.C
+++ b/src/mesh/triangulator_interface.C
@@ -128,6 +128,35 @@ void TriangulatorInterface::elems_to_segments()
 
 
 
+void TriangulatorInterface::nodes_to_segments(dof_id_type max_node_id)
+{
+  // Don't try to override manually specified segments, or try to add
+  // segments if we're doing a convex hull
+  if (!this->segments.empty() || _triangulation_type != PSLG)
+    return;
+
+  for (auto node_it = _mesh.nodes_begin(),
+       node_end = _mesh.nodes_end();
+       node_it != node_end;)
+    {
+      Node * node = *node_it;
+
+      // If we're out of boundary nodes, the rest are going to be
+      // Steiner points or hole points
+      if (node->id() >= max_node_id)
+        break;
+
+      ++node_it;
+
+      Node * next_node = (node_it == node_end) ?
+        *_mesh.nodes_begin() : *node_it;
+
+      this->segments.emplace_back(node->id(), next_node->id());
+    }
+}
+
+
+
 void TriangulatorInterface::insert_any_extra_boundary_points()
 {
   // If the initial PSLG is really simple, e.g. an L-shaped domain or
@@ -141,40 +170,38 @@ void TriangulatorInterface::insert_any_extra_boundary_points()
   const int n_interpolated = this->get_interpolate_boundary_points();
   if ((_triangulation_type==PSLG) && n_interpolated)
     {
-      // Make a copy of the original points from the Mesh
-      std::vector<Point> original_points;
-      original_points.reserve (_mesh.n_nodes());
-      for (auto & node : _mesh.node_ptr_range())
-        original_points.push_back(*node);
+      std::vector<std::pair<unsigned int, unsigned int>> old_segments =
+        std::move(this->segments);
 
-      // Clear out the mesh
-      _mesh.clear();
+      // We expect to have converted any elems and/or nodes into
+      // segments by now.
+      libmesh_assert(!old_segments.empty());
 
-      // Make sure the new Mesh will be 2D
-      _mesh.set_mesh_dimension(2);
+      this->segments.clear();
 
-      // Insert a new point on each PSLG at evenly spaced locations
+      // Insert a new point on each segment at evenly spaced locations
       // between existing boundary points.
-      // np=index into new points vector, also an explicit node index
-      // (to avoid the stride in automatic DistributedMesh indexing)
+      // np=index into new points vector
       // n =index into original points vector
-      for (std::size_t np=0, n=0, tops=n_interpolated*original_points.size(); np<tops; ++np)
+      for (auto old_segment : old_segments)
         {
-          int offset = np % n_interpolated;
-
-          // Some entries are the original points
-          if (!offset)
-            _mesh.add_point(original_points[n++], np);
-
-          else // the odd entries are equispaced along the original PSLG segments
+          Node * begin_node = _mesh.node_ptr(old_segment.first);
+          Node * end_node = _mesh.node_ptr(old_segment.second);
+          dof_id_type current_id = begin_node->id();
+          for (auto i : make_range(n_interpolated))
             {
-              libmesh_assert_less(n-1, original_points.size());
-              const std::size_t next_n = n % original_points.size();
+              // new points are equispaced along the original segments
               const Point new_point =
-                (offset*original_points[next_n] +
-                 (n_interpolated-offset)*original_points[n-1])/n_interpolated;
-              _mesh.add_point(new_point, np);
+                ((n_interpolated-i) * *(Point *)(begin_node) +
+                 (i+1) * *(Point *)(end_node)) /
+                (n_interpolated + 1);
+              Node * next_node = _mesh.add_point(new_point);
+              this->segments.emplace_back(current_id,
+                                          next_node->id());
+              current_id = next_node->id();
             }
+          this->segments.emplace_back(current_id,
+                                      end_node->id());
         }
     }
 }

--- a/tests/mesh/mesh_stitch.C
+++ b/tests/mesh/mesh_stitch.C
@@ -86,6 +86,8 @@ public:
     const auto & nbi = bi.get_node_boundary_ids();
     CPPUNIT_ASSERT_EQUAL(expected_size, nbi.size());
 
+    // We expect that the "zero_right" and "one_left" boundaries have
+    // disappeared after being stitched together.
     std::set<std::string> expected_names = {{"zero_left",
                                              "zero_top",
                                              "zero_front",

--- a/tests/mesh/mesh_stitch.C
+++ b/tests/mesh/mesh_stitch.C
@@ -45,7 +45,7 @@ public:
                       const std::string & boundary_name_prefix)
   {
     BoundaryInfo & boundary_info = mesh.get_boundary_info();
-    const auto & mesh_boundary_ids = boundary_info.get_boundary_ids();
+    const auto & mesh_boundary_ids = boundary_info.get_global_boundary_ids();
     for (auto rit = mesh_boundary_ids.rbegin(); rit != mesh_boundary_ids.rend(); ++rit)
     {
       boundary_info.sideset_name(*rit + boundary_id_offset) =

--- a/tests/mesh/mesh_triangulation.C
+++ b/tests/mesh/mesh_triangulation.C
@@ -32,7 +32,7 @@ public:
 #ifdef LIBMESH_HAVE_POLY2TRI
   CPPUNIT_TEST( testPoly2Tri );
   CPPUNIT_TEST( testPoly2TriInterp );
-  CPPUNIT_TEST( testPoly2TriInterp3 );
+  CPPUNIT_TEST( testPoly2TriInterp2 );
   CPPUNIT_TEST( testPoly2TriHoles );
   CPPUNIT_TEST( testPoly2TriMeshedHoles );
   CPPUNIT_TEST( testPoly2TriEdges );
@@ -54,7 +54,7 @@ public:
 #ifdef LIBMESH_HAVE_TRIANGLE
   CPPUNIT_TEST( testTriangle );
   CPPUNIT_TEST( testTriangleInterp );
-  CPPUNIT_TEST( testTriangleInterp3 );
+  CPPUNIT_TEST( testTriangleInterp2 );
   CPPUNIT_TEST( testTriangleHoles );
   CPPUNIT_TEST( testTriangleMeshedHoles );
   CPPUNIT_TEST( testTriangleSegments );
@@ -397,17 +397,17 @@ public:
 
     Mesh mesh(*TestCommWorld);
     TriangleInterface triangle(mesh);
-    testTriangulatorInterp(mesh, triangle, 2, 6);
+    testTriangulatorInterp(mesh, triangle, 1, 6);
   }
 
 
-  void testTriangleInterp3()
+  void testTriangleInterp2()
   {
     LOG_UNIT_TEST;
 
     Mesh mesh(*TestCommWorld);
     TriangleInterface triangle(mesh);
-    testTriangulatorInterp(mesh, triangle, 3, 10);
+    testTriangulatorInterp(mesh, triangle, 2, 10);
   }
 
 
@@ -459,17 +459,17 @@ public:
 
     Mesh mesh(*TestCommWorld);
     Poly2TriTriangulator p2t_tri(mesh);
-    testTriangulatorInterp(mesh, p2t_tri, 2, 6);
+    testTriangulatorInterp(mesh, p2t_tri, 1, 6);
   }
 
 
-  void testPoly2TriInterp3()
+  void testPoly2TriInterp2()
   {
     LOG_UNIT_TEST;
 
     Mesh mesh(*TestCommWorld);
     Poly2TriTriangulator p2t_tri(mesh);
-    testTriangulatorInterp(mesh, p2t_tri, 3, 10);
+    testTriangulatorInterp(mesh, p2t_tri, 2, 10);
   }
 
 

--- a/tests/mesh/write_elemset_data.C
+++ b/tests/mesh/write_elemset_data.C
@@ -5,6 +5,7 @@
 #include "libmesh/mesh.h"
 #include "libmesh/mesh_generation.h"
 #include "libmesh/parallel.h" // set_union
+#include "libmesh/replicated_mesh.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/boundary_info.h"
 #include "libmesh/utility.h" // libmesh_map_find


### PR DESCRIPTION
This is the set of changes needed to fix our Poly2Tri unit tests (and the tests in https://github.com/idaholab/moose/pull/21303) with `--enable-distmesh`, but that `MeshSerializer` update ought to make the serializer potentially more flexible for other use cases too.