### PR TITLE
Minor XdrIO cleanup/refactoring

### DIFF
--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -701,9 +701,6 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id,
 
   std::size_t n_written=0;
 
-  MeshBase::const_node_iterator       node_iter = mesh.local_nodes_begin();
-  const MeshBase::const_node_iterator nodes_end = mesh.local_nodes_end();
-
   for (std::size_t blk=0, last_node=0; last_node<max_node_id; blk++)
     {
       const std::size_t first_node = blk*io_blksize;
@@ -715,20 +712,19 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id,
       xfer_ids.clear();
       xfer_coords.clear();
 
-      for (; node_iter != nodes_end; ++node_iter)
+      for (const auto & node : mesh.local_node_ptr_range())
         {
-          const Node & node = **node_iter;
-          libmesh_assert_greater_equal(node.id(), first_node);
-          if (node.id() >= last_node)
+          libmesh_assert_greater_equal(node->id(), first_node);
+          if (node->id() >= last_node)
             break;
 
-          xfer_ids.push_back(node.id());
-          xfer_coords.push_back(node(0));
+          xfer_ids.push_back(node->id());
+          xfer_coords.push_back((*node)(0));
 #if LIBMESH_DIM > 1
-          xfer_coords.push_back(node(1));
+          xfer_coords.push_back((*node)(1));
 #endif
 #if LIBMESH_DIM > 2
-          xfer_coords.push_back(node(2));
+          xfer_coords.push_back((*node)(2));
 #endif
         }
 
@@ -865,9 +861,6 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id,
   // Reset write counter
   n_written = 0;
 
-  // Return node iterator to the beginning
-  node_iter = mesh.local_nodes_begin();
-
   for (std::size_t blk=0, last_node=0; last_node<max_node_id; blk++)
     {
       const std::size_t first_node = blk*io_blksize;
@@ -881,15 +874,14 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id,
       xfer_unique_ids.clear();
       xfer_unique_ids.reserve(tot_id_size);
 
-      for (; node_iter != nodes_end; ++node_iter)
+      for (const auto & node : mesh.local_node_ptr_range())
         {
-          const Node & node = **node_iter;
-          libmesh_assert_greater_equal(node.id(), first_node);
-          if (node.id() >= last_node)
+          libmesh_assert_greater_equal(node->id(), first_node);
+          if (node->id() >= last_node)
             break;
 
-          xfer_ids.push_back(node.id());
-          xfer_unique_ids.push_back(node.unique_id());
+          xfer_ids.push_back(node->id());
+          xfer_unique_ids.push_back(node->unique_id());
         }
 
       //-------------------------------------
@@ -993,9 +985,6 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id,
       // Reset write counter
       n_written = 0;
 
-      // Return node iterator to the beginning
-      node_iter = mesh.local_nodes_begin();
-
       // Data structures for writing "extra" node integers
       std::vector<dof_id_type> xfer_node_integers;
       std::vector<dof_id_type> & node_integers = xfer_node_integers;
@@ -1014,18 +1003,17 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id,
           xfer_node_integers.clear();
           xfer_node_integers.reserve(tot_id_size * n_node_integers);
 
-          for (; node_iter != nodes_end; ++node_iter)
+          for (const auto & node : mesh.local_node_ptr_range())
             {
-              const Node & node = **node_iter;
-              libmesh_assert_greater_equal(node.id(), first_node);
-              if (node.id() >= last_node)
+              libmesh_assert_greater_equal(node->id(), first_node);
+              if (node->id() >= last_node)
                 break;
 
-              xfer_ids.push_back(node.id());
+              xfer_ids.push_back(node->id());
 
               // Append current node's node integers to xfer buffer
               for (unsigned int i=0; i != n_node_integers; ++i)
-                xfer_node_integers.push_back(node.get_extra_integer(i));
+                xfer_node_integers.push_back(node->get_extra_integer(i));
             }
 
           //-------------------------------------

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -1976,7 +1976,8 @@ XdrIO::read_serialized_nodes (Xdr & io,
   // build up a list of the nodes contained in our local mesh.  These are the nodes
   // stored on the local processor whose (x,y,z) and unique_id values
   // need to be corrected.
-  std::vector<dof_id_type> needed_nodes; needed_nodes.reserve (mesh.n_nodes());
+  std::vector<dof_id_type> needed_nodes;
+  needed_nodes.reserve (mesh.n_nodes());
   {
     for (auto & node : mesh.node_ptr_range())
       needed_nodes.push_back(node->id());

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -40,7 +40,7 @@
 #include <cstdio>
 #include <vector>
 #include <string>
-
+#include <tuple>
 
 namespace libMesh
 {
@@ -436,11 +436,9 @@ XdrIO::write_serialized_connectivity (Xdr & io,
           // which could be 0.
           libmesh_assert (!recv_conn.empty());
 
-          {
-            const xdr_id_type n_elem_received = recv_conn.back();
-            std::vector<xdr_id_type>::const_iterator recv_conn_iter = recv_conn.begin();
-
-            for (xdr_id_type elem=0; elem<n_elem_received; elem++, next_global_elem++)
+            for (auto [elem, recv_conn_iter, n_elem_received] =
+                   std::tuple{xdr_id_type(0), recv_conn.begin(), recv_conn.back()};
+                 elem<n_elem_received; elem++, next_global_elem++)
               {
                 output_buffer.clear();
 
@@ -484,7 +482,6 @@ XdrIO::write_serialized_connectivity (Xdr & io,
                    cast_int<unsigned int>(output_buffer.size()),
                    cast_int<unsigned int>(output_buffer.size()));
               }
-          }
         }
     }
   else
@@ -561,11 +558,10 @@ XdrIO::write_serialized_connectivity (Xdr & io,
               // which could be 0.
               libmesh_assert (!recv_conn.empty());
 
-              {
-                const xdr_id_type n_elem_received = recv_conn.back();
-                std::vector<xdr_id_type>::const_iterator recv_conn_iter = recv_conn.begin();
-
-                for (xdr_id_type elem=0; elem<n_elem_received; elem++, next_global_elem++)
+                for (auto [elem, recv_conn_iter, n_elem_received] =
+                       std::tuple{xdr_id_type(0), recv_conn.begin(), recv_conn.back()};
+                     elem<n_elem_received;
+                     elem++, next_global_elem++)
                   {
                     output_buffer.clear();
 
@@ -611,7 +607,6 @@ XdrIO::write_serialized_connectivity (Xdr & io,
                        cast_int<unsigned int>(output_buffer.size()),
                        cast_int<unsigned int>(output_buffer.size()));
                   }
-              }
             }
         }
       else
@@ -1832,8 +1827,7 @@ XdrIO::read_serialized_connectivity (Xdr & io,
       this->comm().broadcast (conn);
 
       // All processors now have the connectivity for this block.
-      typename std::vector<T>::const_iterator it = conn.begin();
-      for (dof_id_type e=first_elem; e<last_elem; e++)
+      for (auto [e, it] = std::tuple{first_elem, conn.begin()}; e<last_elem; e++)
         {
           // Temporary variable for reading connectivity array
           // entries.

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -528,22 +528,21 @@ XdrIO::write_serialized_connectivity (Xdr & io,
         {
           // Write the number of elements at this level.
           {
-            char buf[80];
-            std::sprintf(buf, "# n_elem at level %u", level);
-            std::string comment(buf), legend  = ", [ type ";
+            std::ostringstream buf;
+            buf << "# n_elem at level " << level << ", [ type ";
 
             if (_write_unique_id)
-              legend += "uid ";
-            legend += "parent ";
+              buf << "uid ";
+            buf << "parent ";
             if (write_partitioning)
-              legend += "pid ";
+              buf << "pid ";
             if (write_subdomain_id)
-              legend += "sid ";
+              buf << "sid ";
             if (write_p_level)
-              legend += "p_level ";
-            legend += "(n0 ... nN-1) ]";
-            comment += legend;
-            io.data (n_global_elem_at_level[level], comment.c_str());
+              buf << "p_level ";
+            buf << "(n0 ... nN-1) ]";
+
+            io.data (n_global_elem_at_level[level], buf.str().c_str());
           }
 
           for (auto pid : make_range(this->n_processors()))


### PR DESCRIPTION
These were some things I came across while working on adding support for elemsets to XDR in #3313. I rather like the approach of using a `std::tuple` to [declare multiple for-loop iteration variables with loop scope](https://stackoverflow.com/questions/2687392/is-it-possible-to-declare-two-variables-of-different-types-in-a-for-loop). It requires C++17, but it works with my old compiler just fine, so hopefully it also works with our other "min" compilers.
