### PR TITLE
DofObject::old_dof_object can be a unique_ptr

### DIFF
--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -32,6 +32,7 @@
 #include <cstddef>
 #include <cstring>
 #include <vector>
+#include <memory>
 
 namespace libMesh
 {
@@ -64,13 +65,12 @@ protected:
    */
   DofObject ();
 
-  /**
-   * Destructor. Protected so that you can't destroy one of these
-   * except as a part of a Node or Elem.
-   */
-  ~DofObject ();
-
 public:
+
+  /**
+   * Destructor.
+   */
+  ~DofObject () = default;
 
 #ifdef LIBMESH_ENABLE_AMR
 
@@ -78,7 +78,7 @@ public:
    * This object on the last mesh.  Useful for projecting
    * solutions from one mesh to another.
    */
-  DofObject * old_dof_object;
+  std::unique_ptr<DofObject> old_dof_object;
 
   /**
    * Sets the \p old_dof_object to nullptr
@@ -676,9 +676,6 @@ public:
 // Inline functions
 inline
 DofObject::DofObject () :
-#ifdef LIBMESH_ENABLE_AMR
-  old_dof_object(nullptr),
-#endif
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
   _unique_id (invalid_unique_id),
 #endif
@@ -689,18 +686,6 @@ DofObject::DofObject () :
 }
 
 
-
-
-
-inline
-DofObject::~DofObject ()
-{
-  // Free all memory.
-#ifdef LIBMESH_ENABLE_AMR
-  this->clear_old_dof_object ();
-#endif
-  this->clear_dofs ();
-}
 
 
 

--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -81,6 +81,31 @@ public:
   std::unique_ptr<DofObject> old_dof_object;
 
   /**
+   * Pointer accessor for previously public old_dof_object. If you
+   * want to assert that the old_dof_object pointer is valid as well,
+   * consider using the get_old_dof_object_ref() accessor instead.
+   */
+  DofObject * get_old_dof_object() { return old_dof_object.get(); }
+  const DofObject * get_old_dof_object() const  { return old_dof_object.get(); }
+
+  /**
+   * As above, but do not use in situations where the old_dof_object
+   * may be nullptr, since this function asserts that the
+   * old_dof_object is valid before returning a reference to it.
+   */
+  DofObject & get_old_dof_object_ref()
+  {
+    libmesh_assert(old_dof_object);
+    return *old_dof_object;
+  }
+
+  const DofObject & get_old_dof_object_ref() const
+  {
+    libmesh_assert(old_dof_object);
+    return *old_dof_object;
+  }
+
+  /**
    * Sets the \p old_dof_object to nullptr
    */
   void clear_old_dof_object ();

--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -78,8 +78,10 @@ public:
    * This object on the last mesh.  Useful for projecting
    * solutions from one mesh to another.
    */
+protected:
   std::unique_ptr<DofObject> old_dof_object;
 
+public:
   /**
    * Pointer accessor for previously public old_dof_object. If you
    * want to assert that the old_dof_object pointer is valid as well,

--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -77,8 +77,14 @@ public:
   /**
    * This object on the last mesh.  Useful for projecting
    * solutions from one mesh to another.
+   *
+   * Public access to old_dof_object is now officially deprecated and will
+   * be removed in future libMesh versions.  Use the \p get_old_dof_object()
+   * accessor instead.
    */
+#ifndef LIBMESH_ENABLE_DEPRECATED
 protected:
+#endif
   std::unique_ptr<DofObject> old_dof_object;
 
 public:

--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -502,6 +502,17 @@ private:
   DofObject (const DofObject &);
 
   /**
+   * Convenient factory function that calls either the (deep) copy
+   * constructor or the default constructor depending on the input
+   * arg. Like the copy constructor, this function is also private. We
+   * can't use std::make_unique to construct a DofObject since the
+   * copy constructor is private, but we can at least encapsulate the
+   * code which calls "new" directly.
+   */
+  std::unique_ptr<DofObject>
+  construct(const DofObject * other = nullptr);
+
+  /**
    * Deep-copying assignment operator
    */
   DofObject & operator= (const DofObject & dof_obj);
@@ -686,6 +697,15 @@ DofObject::DofObject () :
 }
 
 
+
+inline
+std::unique_ptr<DofObject>
+DofObject::construct(const DofObject * other)
+{
+  return other
+    ? std::unique_ptr<DofObject>(new DofObject(*other))
+    : std::unique_ptr<DofObject>(new DofObject());
+}
 
 
 

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -609,7 +609,7 @@ protected:
           }
         else
           {
-            if (!elem.old_dof_object)
+            if (!elem.get_old_dof_object())
               {
                 libmesh_error();
               }
@@ -659,7 +659,7 @@ protected:
           }
         else
           {
-            if (!elem.old_dof_object)
+            if (!elem.get_old_dof_object())
               return false;
 
             old_context.pre_fe_reinit(sys, &elem);
@@ -795,12 +795,13 @@ public:
 
     // Be sure to handle cases where the variable wasn't defined on
     // this node (e.g. due to changing subdomain support)
-    if (n.old_dof_object &&
-        n.old_dof_object->n_vars(this->sys.number()) &&
-        n.old_dof_object->n_comp(this->sys.number(), var))
+    const DofObject * old_dof_object = n.get_old_dof_object();
+    if (old_dof_object &&
+        old_dof_object->n_vars(this->sys.number()) &&
+        old_dof_object->n_comp(this->sys.number(), var))
       {
         const dof_id_type first_old_id =
-          n.old_dof_object->dof_number(this->sys.number(), var, dim);
+          old_dof_object->dof_number(this->sys.number(), var, dim);
         std::vector<dof_id_type> old_ids(n_mixed);
         std::iota(old_ids.begin(), old_ids.end(), first_old_id);
         old_solution.get(old_ids, derivs);
@@ -1031,15 +1032,16 @@ eval_at_node(const FEMContext & c,
 
   const Elem::RefinementState flag = c.get_elem().refinement_flag();
 
-  if (n.old_dof_object &&
+  const DofObject * old_dof_object = n.get_old_dof_object();
+  if (old_dof_object &&
       (!extra_hanging_dofs ||
        flag == Elem::JUST_COARSENED ||
        flag == Elem::DO_NOTHING) &&
-      n.old_dof_object->n_vars(sys.number()) &&
-      n.old_dof_object->n_comp(sys.number(), var))
+      old_dof_object->n_vars(sys.number()) &&
+      old_dof_object->n_comp(sys.number(), var))
     {
       const dof_id_type old_id =
-        n.old_dof_object->dof_number(sys.number(), var, 0);
+        old_dof_object->dof_number(sys.number(), var, 0);
       return old_solution(old_id);
     }
 
@@ -1081,19 +1083,20 @@ eval_at_node(const FEMContext & c,
 
   const Elem::RefinementState flag = elem.refinement_flag();
 
-  if (n.old_dof_object &&
+  const DofObject * old_dof_object = n.get_old_dof_object();
+  if (old_dof_object &&
       (!extra_hanging_dofs ||
        flag == Elem::JUST_COARSENED ||
        flag == Elem::DO_NOTHING) &&
-      n.old_dof_object->n_vars(sys.number()) &&
-      n.old_dof_object->n_comp(sys.number(), var))
+      old_dof_object->n_vars(sys.number()) &&
+      old_dof_object->n_comp(sys.number(), var))
     {
       Gradient return_val;
 
       for (unsigned int dim = 0; dim < elem.dim(); ++dim)
       {
         const dof_id_type old_id =
-          n.old_dof_object->dof_number(sys.number(), var, dim);
+          old_dof_object->dof_number(sys.number(), var, dim);
         return_val(dim) = old_solution(old_id);
       }
 
@@ -1138,18 +1141,19 @@ eval_at_node(const FEMContext & c,
 
   const Elem::RefinementState flag = c.get_elem().refinement_flag();
 
-  if (n.old_dof_object &&
+  const DofObject * old_dof_object = n.get_old_dof_object();
+  if (old_dof_object &&
       (!extra_hanging_dofs ||
        flag == Elem::JUST_COARSENED ||
        flag == Elem::DO_NOTHING) &&
-      n.old_dof_object->n_vars(sys.number()) &&
-      n.old_dof_object->n_comp(sys.number(), var))
+      old_dof_object->n_vars(sys.number()) &&
+      old_dof_object->n_comp(sys.number(), var))
     {
       Gradient g;
       for (unsigned int d = 0; d != elem_dim; ++d)
         {
           const dof_id_type old_id =
-            n.old_dof_object->dof_number(sys.number(), var, d+1);
+            old_dof_object->dof_number(sys.number(), var, d+1);
           g(d) = old_solution(old_id);
         }
       return g;
@@ -1516,7 +1520,8 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::SortAndCopy
           // wasn't just refined or just coarsened into activity, then
           // it must be newly added, so the user is responsible for
           // setting the new dofs on it during a grid projection.
-          if (!elem->old_dof_object &&
+          const DofObject * old_dof_object = elem->get_old_dof_object();
+          if (!old_dof_object &&
               elem->refinement_flag() != Elem::JUST_REFINED &&
               elem->refinement_flag() != Elem::JUST_COARSENED)
             continue;

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -887,8 +887,7 @@ public:
     // zero.
     if (nc != 0)
       {
-        const DofObject *old_dof_object = old_elem.old_dof_object.get();
-        libmesh_assert(old_dof_object);
+        const DofObject & old_dof_object = old_elem.get_old_dof_object_ref();
         libmesh_assert_greater(elem.n_systems(), sys_num);
 
         const std::pair<unsigned int, unsigned int>
@@ -896,7 +895,7 @@ public:
         const unsigned int vg = vg_and_offset.first;
         const unsigned int vig = vg_and_offset.second;
 
-        unsigned int n_comp = old_dof_object->n_comp_group(sys_num,vg);
+        unsigned int n_comp = old_dof_object.n_comp_group(sys_num,vg);
         n_comp = std::min(n_comp, nc);
 
         std::vector<dof_id_type> old_dof_indices(n_comp);
@@ -904,7 +903,7 @@ public:
         for (unsigned int i=0; i != n_comp; ++i)
           {
             const dof_id_type d_old =
-              old_dof_object->dof_number(sys_num, vg, vig, i, n_comp);
+              old_dof_object.dof_number(sys_num, vg, vig, i, n_comp);
             const dof_id_type d_new =
               elem.dof_number(sys_num, vg, vig, i, n_comp);
             libmesh_assert_not_equal_to (d_old, DofObject::invalid_id);

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -887,7 +887,7 @@ public:
     // zero.
     if (nc != 0)
       {
-        const DofObject *old_dof_object = old_elem.old_dof_object;
+        const DofObject *old_dof_object = old_elem.old_dof_object.get();
         libmesh_assert(old_dof_object);
         libmesh_assert_greater(elem.n_systems(), sys_num);
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2260,9 +2260,8 @@ void DofMap::old_dof_indices (const Elem & elem,
                               std::vector<dof_id_type> & di,
                               const unsigned int vn) const
 {
-  const DofObject * old_obj = elem.node_ref(n).old_dof_object.get();
-  libmesh_assert(old_obj);
-  this->_node_dof_indices(elem, n, *old_obj, di, vn);
+  const DofObject & old_obj = elem.node_ref(n).get_old_dof_object_ref();
+  this->_node_dof_indices(elem, n, old_obj, di, vn);
 }
 
 #endif // LIBMESH_ENABLE_AMR
@@ -2687,8 +2686,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
                     for (unsigned int n=0; n<n_nodes; n++)
                       {
                         const Node * node = nodes_ptr[n];
-                        const DofObject * old_dof_obj = node->old_dof_object.get();
-                        libmesh_assert(old_dof_obj);
+                        const DofObject & old_dof_obj = node->get_old_dof_object_ref();
 
                         // There is a potential problem with h refinement.  Imagine a
                         // quad9 that has a linear FE on it.  Then, on the hanging side,
@@ -2701,7 +2699,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
 #endif
                           ndan (type, static_cast<Order>(var.type().order + extra_order), n);
 
-                        const int n_comp = old_dof_obj->n_comp_group(sys_num,vg);
+                        const int n_comp = old_dof_obj.n_comp_group(sys_num,vg);
 
                         // If this is a non-vertex on a hanging node with extra
                         // degrees of freedom, we use the non-vertex dofs (which
@@ -2724,7 +2722,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
                               for (int i=n_comp-1; i>=dof_offset; i--)
                                 {
                                   const dof_id_type d =
-                                    old_dof_obj->dof_number(sys_num, vg, vig, i, n_comp);
+                                    old_dof_obj.dof_number(sys_num, vg, vig, i, n_comp);
 
                                   // On a newly-expanded subdomain, we
                                   // may have some DoFs that didn't
@@ -2748,7 +2746,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
                             for (unsigned int i=0; i != old_nc; ++i)
                               {
                                 const dof_id_type d =
-                                  old_dof_obj->dof_number(sys_num, vg, vig, i, n_comp);
+                                  old_dof_obj.dof_number(sys_num, vg, vig, i, n_comp);
 
                                 libmesh_assert_not_equal_to (d, DofObject::invalid_id);
 
@@ -2765,20 +2763,19 @@ void DofMap::old_dof_indices (const Elem * const elem,
 
                     if (nc != 0)
                       {
-                        const DofObject * old_dof_obj = elem->old_dof_object.get();
-                        libmesh_assert(old_dof_obj);
+                        const DofObject & old_dof_obj = elem->get_old_dof_object_ref();
 
                         const unsigned int n_comp =
-                          old_dof_obj->n_comp_group(sys_num,vg);
+                          old_dof_obj.n_comp_group(sys_num,vg);
 
-                        if (old_dof_obj->n_systems() > sys_num &&
+                        if (old_dof_obj.n_systems() > sys_num &&
                             nc <= n_comp)
                           {
 
                             for (unsigned int i=0; i<nc; i++)
                               {
                                 const dof_id_type d =
-                                  old_dof_obj->dof_number(sys_num, vg, vig, i, n_comp);
+                                  old_dof_obj.dof_number(sys_num, vg, vig, i, n_comp);
 
                                 di.push_back(d);
                               }

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -546,13 +546,13 @@ void DofMap::reinit(MeshBase & mesh)
   for (auto & node : mesh.node_ptr_range())
     {
       node->clear_old_dof_object();
-      libmesh_assert (!node->old_dof_object);
+      libmesh_assert (!node->get_old_dof_object());
     }
 
   for (auto & elem : mesh.element_ptr_range())
     {
       elem->clear_old_dof_object();
-      libmesh_assert (!elem->old_dof_object);
+      libmesh_assert (!elem->get_old_dof_object());
     }
 
 
@@ -567,11 +567,11 @@ void DofMap::reinit(MeshBase & mesh)
         continue;
 
       for (Node & node : elem->node_ref_range())
-        if (node.old_dof_object == nullptr)
+        if (node.get_old_dof_object() == nullptr)
           if (node.has_dofs(sys_num))
             node.set_old_dof_object();
 
-      libmesh_assert (!elem->old_dof_object);
+      libmesh_assert (!elem->get_old_dof_object());
 
       if (elem->has_dofs(sys_num))
         elem->set_old_dof_object();
@@ -2608,7 +2608,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
   // then we should have old dof indices too.
   libmesh_assert(!elem->has_dofs(sys_num) ||
                  elem->p_refinement_flag() == Elem::JUST_REFINED ||
-                 elem->old_dof_object);
+                 elem->get_old_dof_object());
 
   // Clear the DOF indices vector.
   di.clear();

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2260,7 +2260,7 @@ void DofMap::old_dof_indices (const Elem & elem,
                               std::vector<dof_id_type> & di,
                               const unsigned int vn) const
 {
-  const DofObject * old_obj = elem.node_ref(n).old_dof_object;
+  const DofObject * old_obj = elem.node_ref(n).old_dof_object.get();
   libmesh_assert(old_obj);
   this->_node_dof_indices(elem, n, *old_obj, di, vn);
 }
@@ -2687,7 +2687,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
                     for (unsigned int n=0; n<n_nodes; n++)
                       {
                         const Node * node = nodes_ptr[n];
-                        const DofObject * old_dof_obj = node->old_dof_object;
+                        const DofObject * old_dof_obj = node->old_dof_object.get();
                         libmesh_assert(old_dof_obj);
 
                         // There is a potential problem with h refinement.  Imagine a
@@ -2765,7 +2765,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
 
                     if (nc != 0)
                       {
-                        const DofObject * old_dof_obj = elem->old_dof_object;
+                        const DofObject * old_dof_obj = elem->old_dof_object.get();
                         libmesh_assert(old_dof_obj);
 
                         const unsigned int n_comp =

--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -81,11 +81,7 @@ DofObject & DofObject::operator= (const DofObject & dof_obj)
 
 #ifdef LIBMESH_ENABLE_AMR
   this->clear_old_dof_object();
-
-  // Note: we can't use std::make_unique here because the DofObject
-  // copy constructor is private, and std::make_unique effectively
-  // calls "placement new" which requires a public constructor.
-  this->old_dof_object = std::unique_ptr<DofObject>(new DofObject(*dof_obj.old_dof_object));
+  this->old_dof_object = this->construct(dof_obj.old_dof_object.get());
 #endif
 
   _id           = dof_obj._id;
@@ -142,10 +138,9 @@ void DofObject::set_old_dof_object ()
 
   libmesh_assert (!this->old_dof_object);
 
-  // Note: we can't use std::make_unique here because the DofObject
-  // copy constructor is private, and std::make_unique effectively
-  // calls "placement new" which requires a public constructor.
-  this->old_dof_object = std::unique_ptr<DofObject>(new DofObject(*this));
+  // Make a new DofObject, assign a copy of \p this.
+  // Make sure the copy ctor for DofObject works!!
+  this->old_dof_object = this->construct(this);
 }
 
 #endif
@@ -634,7 +629,7 @@ void DofObject::unpack_indexing(std::vector<largest_id_type>::const_iterator beg
 #ifdef LIBMESH_ENABLE_AMR
   if (has_old_dof_object)
     {
-      this->old_dof_object = std::unique_ptr<DofObject>(new DofObject());
+      this->old_dof_object = this->construct();
       this->old_dof_object->unpack_indexing(begin+size);
     }
 #endif

--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -81,7 +81,7 @@ DofObject & DofObject::operator= (const DofObject & dof_obj)
 
 #ifdef LIBMESH_ENABLE_AMR
   this->clear_old_dof_object();
-  this->old_dof_object = this->construct(dof_obj.old_dof_object.get());
+  this->old_dof_object = this->construct(dof_obj.get_old_dof_object());
 #endif
 
   _id           = dof_obj._id;

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1217,11 +1217,11 @@ void MeshTools::libmesh_assert_old_dof_objects (const MeshBase & mesh)
         continue;
 
       if (elem->has_dofs())
-        libmesh_assert(elem->old_dof_object);
+        libmesh_assert(elem->get_old_dof_object());
 
       for (auto & node : elem->node_ref_range())
         if (node.has_dofs())
-          libmesh_assert(node.old_dof_object);
+          libmesh_assert(node.get_old_dof_object());
     }
 }
 #else

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -1379,7 +1379,7 @@ void BuildProjectionList::operator()(const ConstElemRange & range)
 
           for (auto & node : elem->node_ref_range())
             {
-              const DofObject * old_dofs = node.old_dof_object;
+              const DofObject * old_dofs = node.old_dof_object.get();
 
               if (old_dofs)
                 {

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -1379,7 +1379,7 @@ void BuildProjectionList::operator()(const ConstElemRange & range)
 
           for (auto & node : elem->node_ref_range())
             {
-              const DofObject * old_dofs = node.old_dof_object.get();
+              const DofObject * old_dofs = node.get_old_dof_object();
 
               if (old_dofs)
                 {


### PR DESCRIPTION
Technically this is an API change because `DofObject::old_dof_object` was a public member, but (a) it is a dumb-pointer -> smart-pointer change so this does not necessarily break all code that previously used the object and (b) it is mostly internal AMR code (projections, etc.) that uses this member and I have updated all that already in this PR.

Similarly to what was done for `MeshBase::boundary_info()`, I have also deprecated direct public access to the `DofObject::old_dof_object` member so that, at some point in the future, we can switch over to requiring use of the accessors.
