### PR TITLE
Fixes a VTK linking issue I experienced with VTK 9.2

### DIFF
--- a/configure
+++ b/configure
@@ -53513,13 +53513,13 @@ else
                                            -lvtkFiltersCore-$vtkmajorminor -lvtkIOXML-$vtkmajorminor -lvtkImagingCore-$vtkmajorminor \
                                            -lvtkIOImage-$vtkmajorminor -lvtkImagingMath-$vtkmajorminor -lvtkIOParallelXML-$vtkmajorminor \
                                            -lvtkParallelMPI-$vtkmajorminor -lvtkParallelCore-$vtkmajorminor \
-                                           -lvtkCommonExecutionModel-$vtkmajorminor"
+                                           -lvtkCommonExecutionModel-$vtkmajorminor -lvtksys-$vtkmajorminor"
 
                                                                     VTK_LIBRARY_NO_VERSION="-L$VTK_LIB -lvtkIOCore -lvtkCommonCore -lvtkCommonDataModel \
                                          -lvtkFiltersCore -lvtkIOXML -lvtkImagingCore \
                                          -lvtkIOImage -lvtkImagingMath -lvtkIOParallelXML \
                                          -lvtkParallelMPI -lvtkParallelCore \
-                                         -lvtkCommonExecutionModel"
+                                         -lvtkCommonExecutionModel -lvtksys"
 
 fi
 


### PR DESCRIPTION
I recently installed with VTK 9.2 on my system, and configure failed due a missing symbols from an unrequested library. I think probably happens when the VTK library being used is not the system VTK as otherwise it would likely get picked up automatically. This fixes that issue and I makes the link more pedantic. 