### PR TITLE
Turn on fetchRecurseSubmodules by default

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "contrib/metaphysicl"]
 	path = contrib/metaphysicl
 	url = ../../libMesh/MetaPhysicL
+        fetchRecurseSubmodules = true
 [submodule "contrib/timpi"]
 	path = contrib/timpi
 	url = ../../libMesh/TIMPI
+        fetchRecurseSubmodules = true
 [submodule "m4/autoconf-submodule"]
 	path = m4/autoconf-submodule
 	url = ../../libMesh/autoconf-submodule


### PR DESCRIPTION
Going through some old branches of mine (in the dentist's waiting room, too low on laptop battery to do heavy builds/checks...) I ran across one with this little ease-of-use option.  It can still be overridden by --no-recurse-submodules if users ever really want that.