### PR TITLE
Fix up subdir build order

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -297,6 +297,8 @@ if LIBMESH_OPROF_MODE
   libmesh_oprof_la_LIBADD   = contrib/libcontrib_oprof.la $(LIBS)
 endif
 
+# Make sure we build the library before we test it
+SUBDIRS += .
 
 if LIBMESH_ENABLE_CPPUNIT
  SUBDIRS += tests

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -240,7 +240,12 @@ endif
 # make already completed", which is an annoying bug; for the dbg
 # noinst case this means "you can't run make unless make already
 # completed", which is a devastating bug.
-
+#
+# Putting . in the top-level SUBDIRS works when make is invoked on the
+# top level, but can leave `make -C tests` runs linked (or failing to
+# link, if there have been ABI changes) against a non-up-to-date
+# library file.
+#
 # As a quick fix we'll ensure library dependencies are built manually:
 # http://lists.gnu.org/archive/html/automake/2009-03/msg00011.html
 

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -12377,7 +12377,12 @@ uninstall-am: uninstall-unit_tests_dbgDATA \
 # make already completed", which is an annoying bug; for the dbg
 # noinst case this means "you can't run make unless make already
 # completed", which is a devastating bug.
-
+#
+# Putting . in the top-level SUBDIRS works when make is invoked on the
+# top level, but can leave `make -C tests` runs linked (or failing to
+# link, if there have been ABI changes) against a non-up-to-date
+# library file.
+#
 # As a quick fix we'll ensure library dependencies are built manually:
 # http://lists.gnu.org/archive/html/automake/2009-03/msg00011.html
 


### PR DESCRIPTION
This doesn't let us get away with removing the hack in
tests/Makefile.am, but it can be a bit more efficient for
highly-parallel builds.