### PR TITLE
Create MeshBase::reinit_ghosting_functors API

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -219,6 +219,11 @@ public:
   virtual void delete_remote_elements () {}
 
   /**
+   * Loops over ghosting functors and calls mesh_reinit()
+   */
+  void reinit_ghosting_functors();
+
+  /**
    * \returns The logical dimension of the mesh; i.e. the manifold
    * dimension of the elements in the mesh.  If we ever support
    * multi-dimensional meshes (e.g. hexes and quads in the same mesh)

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -711,11 +711,7 @@ void MeshBase::prepare_for_use ()
   // Allow our GhostingFunctor objects to reinit if necessary.
   // Do this before partitioning and redistributing, and before
   // deleting remote elements.
-  for (auto & gf : _ghosting_functors)
-    {
-      libmesh_assert(gf);
-      gf->mesh_reinit();
-    }
+  this->reinit_ghosting_functors();
 
   // Partition the mesh unless *all* partitioning is to be skipped.
   // If only noncritical partitioning is to be skipped, the
@@ -747,7 +743,15 @@ void MeshBase::prepare_for_use ()
 #endif
 }
 
-
+void
+MeshBase::reinit_ghosting_functors()
+{
+  for (auto & gf : _ghosting_functors)
+    {
+      libmesh_assert(gf);
+      gf->mesh_reinit();
+    }
+}
 
 void MeshBase::clear ()
 {


### PR DESCRIPTION
This is useful for users who wish to do-fine grained calling
of `partition` or `delete_remote_elements` in which case for
some ghosting functors to work well we must first call `mesh_reinit`
on them. This will be used in idaholab/moose#21699