### PR TITLE
connected_node_set_type refactoring

### DIFF
--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -25,6 +25,7 @@
 #include "libmesh/compare_elems_by_level.h"
 #include "libmesh/mesh_input.h"
 #include "libmesh/mesh_output.h"
+#include "libmesh/mesh_communication.h"
 #include "libmesh/parallel_object.h"
 
 // C++ includes
@@ -217,7 +218,7 @@ private:
    * Write the nodal locations for part of a mesh
    */
   void write_nodes (Xdr & io,
-                    const std::set<const Node *> & nodeset) const;
+                    const connected_node_set_type & nodeset) const;
 
   /**
    * Write the side boundary conditions for part of a mesh
@@ -230,7 +231,7 @@ private:
    * Write the nodal boundary conditions for part of a mesh
    */
   void write_nodesets (Xdr & io,
-                       const std::set<const Node *> & nodeset,
+                       const connected_node_set_type & nodeset,
                        const std::vector<std::tuple<dof_id_type, boundary_id_type>> & bc_tuples) const;
 
   /**

--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -271,9 +271,12 @@ void connect_children(const MeshBase & mesh,
 void connect_families(std::set<const Elem *, CompareElemIdsByLevel> & connected_elements,
                       const MeshBase * mesh = nullptr);
 
+// What to use to fill sets of connected nodes
+typedef std::set<const Node *> connected_node_set_type;
+
 // Take a set of elements and create a set of connected nodes.
 void reconnect_nodes (const std::set<const Elem *, CompareElemIdsByLevel> & connected_elements,
-                      std::set<const Node *> & connected_nodes);
+                      connected_node_set_type & connected_nodes);
 
 
 

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -478,7 +478,7 @@ void CheckpointIO::write (const std::string & name)
             }
         }
 
-      std::set<const Node *> connected_nodes;
+      connected_node_set_type connected_nodes;
       reconnect_nodes(elements, connected_nodes);
 
       // write the nodal locations
@@ -538,7 +538,7 @@ void CheckpointIO::write_subdomain_names(Xdr & io) const
 
 
 void CheckpointIO::write_nodes (Xdr & io,
-                                const std::set<const Node *> & nodeset) const
+                                const connected_node_set_type & nodeset) const
 {
   largest_id_type n_nodes_here = nodeset.size();
 
@@ -749,7 +749,7 @@ void CheckpointIO::write_bcs (Xdr & io,
 
 
 void CheckpointIO::write_nodesets (Xdr & io,
-                                   const std::set<const Node *> & nodeset,
+                                   const connected_node_set_type & nodeset,
                                    const std::vector<std::tuple<dof_id_type, boundary_id_type>> & bc_tuples) const
 {
   libmesh_assert (io.writing());

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -310,7 +310,7 @@ void connect_families(std::set<const Elem *, CompareElemIdsByLevel> & connected_
 
 
 void reconnect_nodes (const std::set<const Elem *, CompareElemIdsByLevel> & connected_elements,
-                      std::set<const Node *> & connected_nodes)
+                      connected_node_set_type & connected_nodes)
 {
   // We're done using the nodes list for element decisions; now
   // let's reuse it for nodes of the elements we've decided on.
@@ -473,7 +473,7 @@ void MeshCommunication::redistribute (DistributedMesh & mesh,
       // elements with constraining nodes to remain present.
       connect_families(elements_to_send, &mesh);
 
-      std::set<const Node *> connected_nodes;
+      connected_node_set_type connected_nodes;
       reconnect_nodes(elements_to_send, connected_nodes);
 
       // the number of nodes we will ship to pid
@@ -823,7 +823,11 @@ void MeshCommunication::gather_neighboring_elements (DistributedMesh & mesh) con
           // some of these nodes and elements may be replicated from
           // other processors, but that is OK.
           std::set<const Elem *, CompareElemIdsByLevel> elements_to_send;
-          std::set<const Node *> connected_nodes;
+
+          // Technically we're not doing reconnect_nodes on this, but
+          // we might as well use the same data structure since the
+          // performance questions ought to be similar
+          connected_node_set_type connected_nodes;
 
           // Check for quick return?
           if (common_interface_node_list.empty())
@@ -2113,7 +2117,7 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
   connect_families(elements_to_keep, &mesh);
 
   // Don't delete nodes that our semilocal elements need
-  std::set<const Node *> connected_nodes;
+  connected_node_set_type connected_nodes;
   reconnect_nodes(elements_to_keep, connected_nodes);
 
   // Delete all the elements we have no reason to save,


### PR DESCRIPTION
I'd intended to revisit the idea of turning this into an unordered_set,
now that I've got better options for benchmarking that, but we've
already got user code relying on the API here and we'll need to create a
migration path for that.