### PR TITLE
Make Hole::contains() FP-robust, and use it in more verification

### DIFF
--- a/include/mesh/mesh_triangle_holes.h
+++ b/include/mesh/mesh_triangle_holes.h
@@ -243,8 +243,9 @@ class TriangulatorInterface::ArbitraryHole : public TriangulatorInterface::Hole
 {
 public:
   /**
-   * The constructor requires a point which lies in the interior of the hole
-   * and a reference to a vector of Points defining the hole.
+   * The fastest constructor requires a point which lies in the
+   * interior of the hole and a reference to a vector of Points
+   * defining the hole.
    */
   ArbitraryHole(const Point & center,
                 std::vector<Point> points);
@@ -252,6 +253,11 @@ public:
   ArbitraryHole(const Point & center,
                 std::vector<Point> points,
                 std::vector<unsigned int> segment_indices);
+
+  /**
+   * If we don't know a center a priori then we can calculate one
+   */
+  ArbitraryHole(std::vector<Point> points);
 
   /**
    * We can also construct an ArbitraryHole which just copies
@@ -277,13 +283,14 @@ public:
   void set_points(std::vector<Point> points)
   {
     _points = std::move(points);
+    _center = this->calculate_inside_point();
   }
 
 private:
   /**
    * arbitrary (x,y) location inside the hole
    */
-  const Point _center;
+  Point _center;
 
   /**
    * Reference to the vector of points which makes up

--- a/include/mesh/mesh_triangle_holes.h
+++ b/include/mesh/mesh_triangle_holes.h
@@ -127,6 +127,11 @@ protected:
                                            Point ray_target) const;
 
   /**
+   * Calculate an inside point based on our boundary
+   */
+  Point calculate_inside_point() const;
+
+  /**
    * Whether to allow boundary refinement.  True by default; specified
    * here so we can use the default constructor.
    */

--- a/include/mesh/triangulator_interface.h
+++ b/include/mesh/triangulator_interface.h
@@ -205,6 +205,15 @@ public:
   void attach_hole_list(const std::vector<Hole*> * holes) {_holes = holes;}
 
   /**
+   * Verifying that hole boundaries don't cross the outer boundary or
+   * each other is something like O(N_bdys^2*N_points_per_bdy^2), so
+   * we only do it if requested
+   */
+  void set_verify_hole_boundaries(bool v) {_verify_hole_boundaries = v;}
+
+  bool get_verify_hole_boundaries() const {return _verify_hole_boundaries;}
+
+  /**
    * When constructing a PSLG, if the node numbers do not define the
    * desired boundary segments implicitly through the ordering of the
    * points, you can use the segments vector to specify the segments
@@ -260,6 +269,11 @@ protected:
    * segments) to a PSLG triangulation
    */
   void insert_any_extra_boundary_points();
+
+  /**
+   * Helper function to check holes for intersections if requested.
+   */
+  void verify_holes(const Hole & outer_bdy);
 
   /**
    * Helper function to count points in and verify holes
@@ -342,6 +356,11 @@ protected:
    * Flag which tells if we want to suppress stdout outputs
    */
   bool _quiet;
+
+  /**
+   * Flag which tells if we want to check hole geometry
+   */
+  bool _verify_hole_boundaries;
 };
 
 } // namespace libMesh

--- a/src/mesh/mesh_triangle_holes.C
+++ b/src/mesh/mesh_triangle_holes.C
@@ -153,7 +153,7 @@ namespace
             const Real n_num = nextdx * raydy -
                                nextdy * raydx;
 
-            if (signof(p_num) == signof(n_num))
+            if (signof(p_num) != -signof(n_num))
               return -1;
           }
 

--- a/src/mesh/mesh_triangle_holes.C
+++ b/src/mesh/mesh_triangle_holes.C
@@ -336,6 +336,15 @@ TriangulatorInterface::ArbitraryHole::ArbitraryHole(const Point & center,
 {}
 
 
+TriangulatorInterface::ArbitraryHole::ArbitraryHole(std::vector<Point> points)
+  : _points(std::move(points))
+{
+  _segment_indices.push_back(0);
+  _segment_indices.push_back(_points.size());
+  _center = this->calculate_inside_point();
+}
+
+
 TriangulatorInterface::ArbitraryHole::ArbitraryHole(const Hole & orig)
   : _center(orig.inside())
 {

--- a/tests/mesh/mesh_triangulation.C
+++ b/tests/mesh/mesh_triangulation.C
@@ -86,6 +86,7 @@ public:
     triangulator.desired_area() = 1000;
     triangulator.minimum_angle() = 0;
     triangulator.smooth_after_generating() = false;
+    triangulator.set_verify_hole_boundaries(true);
   }
 
   void testExceptionBase(MeshBase & mesh,

--- a/tests/mesh/mesh_triangulation.C
+++ b/tests/mesh/mesh_triangulation.C
@@ -200,7 +200,8 @@ public:
     check_corners(hexagon, 6);
 
     TriangulatorInterface::ArbitraryHole jaggy
-    {{1,0}, {{0,-1},{2,-1},{2,1},{1.75,-.5},{1.5,1},{1.25,-.5},{1,1},{.75,-.5},{.5,1},{.25,-.5},{0,1}}};
+    {{1,0}, {{0,-1},{2,-1},{2,1},{1.75,-.5},{1.5,1},{1.25,-.5},
+             {1,1},{.75,-.5},{.5,1},{.25,-.5},{0,1}}};
 
     CPPUNIT_ASSERT(jaggy.contains({.1,-.3}));
     CPPUNIT_ASSERT(jaggy.contains({.5,.9}));
@@ -210,8 +211,62 @@ public:
     CPPUNIT_ASSERT(jaggy.contains({1.5,.9}));
     CPPUNIT_ASSERT(jaggy.contains({1.9,-.3}));
 
-    // Extra corner case
+    CPPUNIT_ASSERT(jaggy.contains({1.9,-.5}));
+    CPPUNIT_ASSERT(jaggy.contains({1.6,-.5}));
+    CPPUNIT_ASSERT(jaggy.contains({1.1,-.5}));
     CPPUNIT_ASSERT(jaggy.contains({.5,-.5}));
+    CPPUNIT_ASSERT(jaggy.contains({.2,-.5}));
+
+    CPPUNIT_ASSERT(!jaggy.contains({.1,.7}));
+    CPPUNIT_ASSERT(!jaggy.contains({.5,1.1}));
+    CPPUNIT_ASSERT(!jaggy.contains({.9,.7}));
+    CPPUNIT_ASSERT(!jaggy.contains({1,-1.1}));
+    CPPUNIT_ASSERT(!jaggy.contains({1.1,.8}));
+    CPPUNIT_ASSERT(!jaggy.contains({1.5,1.1}));
+    CPPUNIT_ASSERT(!jaggy.contains({1.9,.9}));
+
+    CPPUNIT_ASSERT(!jaggy.contains({1.9,1}));
+    CPPUNIT_ASSERT(!jaggy.contains({1.4,1}));
+    CPPUNIT_ASSERT(!jaggy.contains({.9,1}));
+    CPPUNIT_ASSERT(!jaggy.contains({.4,1}));
+    CPPUNIT_ASSERT(!jaggy.contains({-.2,1}));
+    CPPUNIT_ASSERT(!jaggy.contains({-.2,0}));
+    CPPUNIT_ASSERT(!jaggy.contains({1.2,0}));
+
+    TriangulatorInterface::ArbitraryHole square_jaggy
+    {{1,0}, {{-.25,-1},{2,-1},{2,1},{1.75,1},{1.75,-.5},{1.5,-.5},
+             {1.5,1},{1.25,1},{1.25,-.5},{1,-.5},{1,1},{.75,1},
+             {.75,-.5},{.5,-.5},{.5,1},{.25,1},{.25,-.5},{0,-.5},
+             {0,1},{-.25,1}}};
+
+    CPPUNIT_ASSERT(square_jaggy.contains({-.1,-.3}));
+    CPPUNIT_ASSERT(square_jaggy.contains({.4,.9}));
+    CPPUNIT_ASSERT(square_jaggy.contains({.9,-.3}));
+    CPPUNIT_ASSERT(square_jaggy.contains({.9,0}));
+    CPPUNIT_ASSERT(square_jaggy.contains({1.1,-.6}));
+    CPPUNIT_ASSERT(square_jaggy.contains({1.4,.9}));
+    CPPUNIT_ASSERT(square_jaggy.contains({1.9,-.3}));
+
+    CPPUNIT_ASSERT(!square_jaggy.contains({.1,-.3}));
+    CPPUNIT_ASSERT(!square_jaggy.contains({.6,.9}));
+    CPPUNIT_ASSERT(!square_jaggy.contains({1.1,-.3}));
+    CPPUNIT_ASSERT(!square_jaggy.contains({1.1,0}));
+    CPPUNIT_ASSERT(!square_jaggy.contains({1.1,-1.6}));
+    CPPUNIT_ASSERT(!square_jaggy.contains({1.6,.9}));
+    CPPUNIT_ASSERT(!square_jaggy.contains({2.1,-.3}));
+
+    CPPUNIT_ASSERT(square_jaggy.contains({-.1,-.5}));
+    CPPUNIT_ASSERT(square_jaggy.contains({.3,-.5}));
+    CPPUNIT_ASSERT(square_jaggy.contains({.9,-.5}));
+    CPPUNIT_ASSERT(square_jaggy.contains({1.3,-.5}));
+    CPPUNIT_ASSERT(square_jaggy.contains({1.9,-.5}));
+
+    CPPUNIT_ASSERT(!square_jaggy.contains({-.3,1}));
+    CPPUNIT_ASSERT(!square_jaggy.contains({.2,1}));
+    CPPUNIT_ASSERT(!square_jaggy.contains({.6,1}));
+    CPPUNIT_ASSERT(!square_jaggy.contains({1.1,1}));
+    CPPUNIT_ASSERT(!square_jaggy.contains({1.6,1}));
+    CPPUNIT_ASSERT(!square_jaggy.contains({2.1,1}));
   }
 
 


### PR DESCRIPTION
I still need to throw more tests at this, but at the least this version fixes cases that the last version got tricked by, and adds test coverage hitting them.