### PR TITLE
Fix typos found in docs and examples subdirectories

### DIFF
--- a/configure
+++ b/configure
@@ -2089,7 +2089,7 @@ Optional Features:
   --disable-nanoflann     build without nanoflann KD-tree support
   --enable-nanoflann-pointlocator
                           use Nanoflann-based PointLocator (experimental)
-  --disable-metaphysicl   build without MetaPhysicL suppport
+  --disable-metaphysicl   build without MetaPhysicL support
   --enable-metaphysicl-required
                           Error if MetaPhysicL is not detected by configure
 
@@ -7302,7 +7302,7 @@ fi
 # on the current architecture. For the first argument:
 # [yes] = generate portable code (-mtune)
 # [no]  = generate architecture-specific code (-march)
-# This script is specifc to GCC; the flags it determines might not
+# This script is specific to GCC; the flags it determines might not
 # work for other compilers. There is also an optional third
 # argument which controls what happens when determining an arch flag
 # fails, we don't do anything in that case.
@@ -33823,7 +33823,7 @@ fi
   # before this can be enabled.
   hardcode_into_libs=yes
 
-  # Ideally, we could use ldconfig to report *all* directores which are
+  # Ideally, we could use ldconfig to report *all* directories which are
   # searched for libraries, however this is still not possible.  Aside from not
   # being certain /sbin/ldconfig is available, command
   # 'ldconfig -N -X -v | grep ^/' on 64bit Fedora does not report /usr/lib64,
@@ -37785,7 +37785,7 @@ fi
   # before this can be enabled.
   hardcode_into_libs=yes
 
-  # Ideally, we could use ldconfig to report *all* directores which are
+  # Ideally, we could use ldconfig to report *all* directories which are
   # searched for libraries, however this is still not possible.  Aside from not
   # being certain /sbin/ldconfig is available, command
   # 'ldconfig -N -X -v | grep ^/' on 64bit Fedora does not report /usr/lib64,
@@ -40735,7 +40735,7 @@ fi
   # before this can be enabled.
   hardcode_into_libs=yes
 
-  # Ideally, we could use ldconfig to report *all* directores which are
+  # Ideally, we could use ldconfig to report *all* directories which are
   # searched for libraries, however this is still not possible.  Aside from not
   # being certain /sbin/ldconfig is available, command
   # 'ldconfig -N -X -v | grep ^/' on 64bit Fedora does not report /usr/lib64,
@@ -43826,7 +43826,7 @@ fi
   # before this can be enabled.
   hardcode_into_libs=yes
 
-  # Ideally, we could use ldconfig to report *all* directores which are
+  # Ideally, we could use ldconfig to report *all* directories which are
   # searched for libraries, however this is still not possible.  Aside from not
   # being certain /sbin/ldconfig is available, command
   # 'ldconfig -N -X -v | grep ^/' on 64bit Fedora does not report /usr/lib64,
@@ -56761,7 +56761,7 @@ fi
 # clean up values, if we have perl.  This step is purely cosmetic, but
 # helps create readable (and easier to debug) compile and link lines
 # by stripping out repeated entries.  This can happen for example when
-# several optional packages all want to include and link agains the
+# several optional packages all want to include and link against the
 # same MPI.
 if test -x $PERL; then :
 

--- a/configure.ac
+++ b/configure.ac
@@ -152,7 +152,7 @@ AC_ARG_ENABLE(march,
 # on the current architecture. For the first argument:
 # [yes] = generate portable code (-mtune)
 # [no]  = generate architecture-specific code (-march)
-# This script is specifc to GCC; the flags it determines might not
+# This script is specific to GCC; the flags it determines might not
 # work for other compilers. There is also an optional third
 # argument which controls what happens when determining an arch flag
 # fails, we don't do anything in that case.

--- a/doc/citations/nineteen.bib
+++ b/doc/citations/nineteen.bib
@@ -90,7 +90,7 @@
 % https://repository.lib.ncsu.edu/bitstream/handle/1840.20/37683/SMiRT_25_special_session_spra.pdf?sequence=1
 @InProceedings{Bolisetti_2019,
   author    = {Chandrakanth Bolisetti and Saran Bodda and Andrew Slaughter and Justin Coleman},
-  title     = {{Seismic probabalistic risk assessment using MASTODON}},
+  title     = {{Seismic probabilistic risk assessment using MASTODON}},
   booktitle = {{Proceedings of the 25th Conference on Structural Mechanics in Reactor Technology (SMiRT-25)}},
   address   = {Charlotte, North Carolina},
   month     = aug # {~4--9,},
@@ -966,7 +966,7 @@
 }
 
 % MOOSE/Rattlesnake
-% "The discretization of the multigroup neutron transport equations is implmented using RattleSnake"
+% "The discretization of the multigroup neutron transport equations is implemented using RattleSnake"
 % Submitted to Numerical Linear Algebra with Applications (Copper Mountain Conference special issue).
 % author:Kong scalable multilevel domain decomposition preconditioner with a subspace-based coarsening algorithm
 @Misc{Kong_2019c,

--- a/doc/html/src/installation.html
+++ b/doc/html/src/installation.html
@@ -87,7 +87,7 @@ specifics that need to be taken into account.
 
 <p>
 After installing msys2 you need to install the mingw-w64 C++ compiler. To check that
-the installation was successfull, you can run
+the installation was successful, you can run
 </p>
 <div class="fragment">
 <pre>g++ --version</pre>

--- a/doc/html/src/publications.html
+++ b/doc/html/src/publications.html
@@ -16607,7 +16607,7 @@ Lane Carasik, Vishal Patel, Samuel Judd, and Paolo Venneri.
 </td>
 <td class="bibtexitem">
 Chandrakanth Bolisetti, Saran Bodda, Andrew Slaughter, and Justin Coleman.
- Seismic probabalistic risk assessment using MASTODON.
+ Seismic probabilistic risk assessment using MASTODON.
  In <em>Proceedings of the 25th Conference on Structural Mechanics
   in Reactor Technology (SMiRT-25)</em>, Charlotte, North Carolina, August&nbsp;4--9,
   2019.
@@ -16615,7 +16615,7 @@ Chandrakanth Bolisetti, Saran Bodda, Andrew Slaughter, and Justin Coleman.
 <a name="Bolisetti_2019"></a><pre>
 @inproceedings{Bolisetti_2019,
   author = {Chandrakanth Bolisetti and Saran Bodda and Andrew Slaughter and Justin Coleman},
-  title = {{Seismic probabalistic risk assessment using MASTODON}},
+  title = {{Seismic probabilistic risk assessment using MASTODON}},
   booktitle = {{Proceedings of the 25th Conference on Structural Mechanics in Reactor Technology (SMiRT-25)}},
   address = {Charlotte, North Carolina},
   month = aug # {~4--9,},

--- a/doc/latex/xda_format/xda_format.tex
+++ b/doc/latex/xda_format/xda_format.tex
@@ -66,7 +66,7 @@ The header of an XDR/XDA file looks something like this:
 \normalsize
 The header defines several important sizes that are used to enable efficient, block-reading of the data section. A line-by-line description of the header follows:
 
-The first line of the file is a string that defines what code wrote the file. There are three possibilies: MGF, DEAL and LIBM. The reason for this first line is backwards-compatibility. In this document we will mostly discuss the ``LIBM'' format. This is the newest and most flexible of the three formats; it allows hybrid meshes and adaptive mesh refinement information to be written out. The number following the string "LIBM" on the first line indicates the number of levels of refinement in the mesh. The mesh in the above example has no refinement structure, so this number is zero.
+The first line of the file is a string that defines what code wrote the file. There are three possibilities: MGF, DEAL and LIBM. The reason for this first line is backwards-compatibility. In this document we will mostly discuss the ``LIBM'' format. This is the newest and most flexible of the three formats; it allows hybrid meshes and adaptive mesh refinement information to be written out. The number following the string "LIBM" on the first line indicates the number of levels of refinement in the mesh. The mesh in the above example has no refinement structure, so this number is zero.
 
 The next line contains a single integer that defines the number of elements in the mesh.  Anything after the \# is ignored and may be used as a comment.
 
@@ -135,7 +135,7 @@ This is an example XDA hybrid-element mesh.
   LIBM 0
   10     # Num. Elements
   11     # Num. Nodes
-  52     # Length of conectivity array
+  52     # Length of connectivity array
   0      # Num. Boundary Conds.
   65536  # String Size (ignore)
   2      # Num. Element Blocks.

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -21,7 +21,7 @@
 // \author Vikram Garg
 // \date 2020
 //
-// This example showcases the solution storage and retrival capabilities of libMesh, in the context of
+// This example showcases the solution storage and retrieval capabilities of libMesh, in the context of
 // unsteady adjoints. The primary motivation is adjoint sensitivity analysis for unsteady
 // problems. The PDE we are interested in is the simple 2-d heat
 // equation:

--- a/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
+++ b/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
@@ -384,7 +384,7 @@ void assemble_wave(EquationSystems & es,
       //const std::vector<std::vector<Real>> & phi = cfe->get_phi();
 
       // The element shape function gradients evaluated at the quadrature
-      // points, devided by weight x rad
+      // points, divided by weight x rad
       const std::vector<std::vector<RealGradient>> & dphi = cfe->get_dphi_over_decayxR();
       //const std::vector<std::vector<RealGradient>> & dphi = cfe->get_dphi();
 

--- a/examples/miscellaneous/miscellaneous_ex14/miscellaneous_ex14.C
+++ b/examples/miscellaneous/miscellaneous_ex14/miscellaneous_ex14.C
@@ -84,7 +84,7 @@ enum SpectralTransform {SHIFT=0,
 
 /**
  * A class that interfaces the \p SolverConfiguration to add the SLEPC option SetST.
- * In case of dense eigenvalues, the application of SINVERT or CAYLEY is highly benefitial
+ * In case of dense eigenvalues, the application of SINVERT or CAYLEY is highly beneficial
  * see <a href='http://slepc.upv.es/documentation/'>the SLEPC-manual</a> for details.
  */
 class SlepcSolverConfiguration : public libMesh::SolverConfiguration
@@ -92,7 +92,7 @@ class SlepcSolverConfiguration : public libMesh::SolverConfiguration
 public:
 
   /**
-   * Constructur: get a reference to the \p SlepcEigenSolver variable to be able to manipulate it
+   * Constructor: get a reference to the \p SlepcEigenSolver variable to be able to manipulate it
    */
   SlepcSolverConfiguration( libMesh::SlepcEigenSolver<libMesh::Number> &slepc_eigen_solver):
     _slepc_solver(slepc_eigen_solver),
@@ -195,7 +195,7 @@ int main (int argc, char** argv)
     if (elem->infinite())
       {
         elem->subdomain_id() = 1;
-        // the base elements are always the 0-th neighor.
+        // the base elements are always the 0-th neighbor.
         elem->neighbor_ptr(0)->subdomain_id()=2;
       }
 
@@ -324,7 +324,7 @@ int main (int argc, char** argv)
 }
 
 /**
- * In this function, we assemble the actual system matrices. The inital equation is the eigen system \f$ H \Psi = \epsilon
+ * In this function, we assemble the actual system matrices. The initial equation is the eigen system \f$ H \Psi = \epsilon
  * \Psi \f$
  * where H is the Hamilton operator and Psi the eigen vector with corresponding eigen value \f$\epsilon\f$.
  * In the FEM-scheme, this becomes the generalised eigen problem  \f$ H \Psi = \epsilon M \Psi \f$ where M is the element mass matrix.
@@ -591,7 +591,7 @@ void assemble_SchroedingerEquation(EquationSystems &es, const std::string &syste
 
             const Elem* relevant_neighbor=elem->neighbor_ptr(prev_neighbor);
 
-            // Get the correct face to the finite element; for thise, continue looping
+            // Get the correct face to the finite element; for this, continue looping
             // until a neighbor is an infinite element.
             // If none is found, we leave this loop
             for (; prev_neighbor<elem->n_neighbors(); prev_neighbor++){

--- a/examples/miscellaneous/miscellaneous_ex15/miscellaneous_ex15.C
+++ b/examples/miscellaneous/miscellaneous_ex15/miscellaneous_ex15.C
@@ -211,7 +211,7 @@ int main (int argc, char** argv)
     if (elem->infinite())
       {
         elem->subdomain_id() = 1;
-        // the base elements are always the 0-th neighor.
+        // the base elements are always the 0-th neighbor.
         elem->neighbor_ptr(0)->subdomain_id()=2;
       }
 

--- a/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
+++ b/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
@@ -560,7 +560,7 @@ int main (int argc, char** argv)
   for (unsigned int rstep=0; rstep<uniform_refinement_steps; rstep++)
     mesh_refinement.uniformly_refine(1);
 
-  // Crate an equation system object
+  // Create an equation system object
   EquationSystems equation_system (mesh);
 
   // Set parameters for the equation system and the solver

--- a/examples/run_common.sh
+++ b/examples/run_common.sh
@@ -41,7 +41,7 @@ run_example() {
     shift
     options=$@
 
-    # when run outside of the automake envionment make sure we get METHODS set
+    # when run outside of the automake environment make sure we get METHODS set
     # to something useful
     if (test "x${METHODS}" = "x"); then
 	if (test "x${METHOD}" = "x"); then

--- a/examples/vector_fe/vector_fe_ex5/vector_fe_ex5.C
+++ b/examples/vector_fe/vector_fe_ex5/vector_fe_ex5.C
@@ -105,7 +105,7 @@ main(int argc, char ** argv)
   // Use the MeshTools::Generation mesh generator to create a uniform
   // 2D grid on the square [-1,1]^2.  We instruct the mesh generator
   // to build a mesh of 15x15 QUAD4 elements. Note that at the end of this
-  // fuction call, the mesh will be prepared and remote elements will be deleted
+  // function call, the mesh will be prepared and remote elements will be deleted
   MeshTools::Generation::build_square(mesh, nx, ny, -1., 1., -1., 1., QUAD4);
 
   // Print information about the mesh to the screen.
@@ -149,7 +149,7 @@ main(int argc, char ** argv)
       std::vector<std::string> varnames;
       equation_systems.build_variable_names(varnames);
 
-      // Create ExodusII object with an unambigous filename (indicating this solution is special)
+      // Create ExodusII object with an unambiguous filename (indicating this solution is special)
       ExodusII_IO exo_ptr(mesh);
       exo_ptr.write("out_constant.e");
       exo_ptr.set_output_variables(varnames);


### PR DESCRIPTION
Found via `codespell -q 3 -S ./contrib,./m4,./NEWS -L ans,inout,nd,parm,som,theses,ue,wirth`