### PR TITLE
Fix remaining typos

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -640,7 +640,7 @@ public:
    * for a system of PDEs, to construct an efficient multilevel preconditioner, we coarsen
    * the matrix of one single PDE instead of the entire huge matrix. In order to
    * accomplish this, we need to know many PDEs we have. Another use case,
-   * the fieldsplit preconditioner can be constructed in place with this info wihtout
+   * the fieldsplit preconditioner can be constructed in place with this info without
    * involving any user efforts.
    */
   unsigned int block_size() const
@@ -952,7 +952,7 @@ public:
    *
    * \note The original "cyclic constraint" terminology was
    * unfortunate since the word cyclic is used by some software to
-   * indicate an actual type of rotational/angular contraint and not
+   * indicate an actual type of rotational/angular constraint and not
    * (as here) a cyclic graph. The former nomenclature will eventually
    * be deprecated in favor of "constraint loop".
    */
@@ -1677,7 +1677,7 @@ private:
   bool _error_on_constraint_loop;
 
   /**
-   * This flag indicates whether or not we explicity take constraint
+   * This flag indicates whether or not we explicitly take constraint
    * equations into account when computing a sparsity pattern.
    */
   bool _constrained_sparsity_construction;

--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -666,7 +666,7 @@ private:
    *            my-variable   =    '007 J. B.'
    *      into
    *            my-variable='007 J. B.'
-   *    3) interprete sections like '[../my-section]' etc.
+   *    3) interpret sections like '[../my-section]' etc.
    */
   inline void _skip_whitespace(std::istream& istr);
   inline const std::string _get_next_token(std::istream& istr);
@@ -2681,7 +2681,7 @@ GetPot::_request_variable(const char* VarName) const
 
 
 ///////////////////////////////////////////////////////////////////////////////
-// (*) ouput (basically for debugging reasons
+// (*) output (basically for debugging reasons
 //.............................................................................
 //
 inline int

--- a/include/base/periodic_boundary_base.h
+++ b/include/base/periodic_boundary_base.h
@@ -138,7 +138,7 @@ protected:
    * boundary and the counterpart boundary. This is necessary for
    * periodic-boundaries with vector-valued quantities (e.g.
    * velocity or displacement) on a sector of a circular domain,
-   * for exaple, since in that case we must map each variable
+   * for example, since in that case we must map each variable
    * to a corresponding linear combination of all the variables.
    * We store the DenseMatrix via a unique_ptr, and an uninitialized
    * pointer is treated as equivalent to the identity matrix.

--- a/include/base/sparsity_pattern.h
+++ b/include/base/sparsity_pattern.h
@@ -214,7 +214,7 @@ private:
   // element_dofs_j) pairs which have already been handled and not
   // repeat the computation. We use this data structure to keep track
   // of hashes of sets of dofs we have already seen, thus avoiding
-  // unnecessary caluclations.
+  // unnecessary calculations.
   std::unordered_set<dof_id_type> hashed_dof_sets;
 
   void handle_vi_vj(const std::vector<dof_id_type> & element_dofs_i,

--- a/include/fe/fe_base.h
+++ b/include/fe/fe_base.h
@@ -597,7 +597,7 @@ protected:
 
   /**
    * Compute \p dual_phi, \p dual_dphi, \p dual_d2phi
-   * It is only valid for this to be called after reinit has occured with a
+   * It is only valid for this to be called after reinit has occurred with a
    * quadrature rule
    */
   void compute_dual_shape_functions();

--- a/include/geom/edge_edge3.h
+++ b/include/geom/edge_edge3.h
@@ -32,7 +32,7 @@ namespace libMesh
  * like this:
  *
  * \verbatim
- *   EGDE3: o----o----o        o---> xi
+ *   EDGE3: o----o----o        o---> xi
  *          0    2    1
  * \endverbatim
  *

--- a/include/geom/edge_edge4.h
+++ b/include/geom/edge_edge4.h
@@ -33,7 +33,7 @@ namespace libMesh
  * It is numbered like this:
  *
  * \verbatim
- *   EGDE4: o----o----o----o        o---> xi
+ *   EDGE4: o----o----o----o        o---> xi
  *          0    2    3    1
  * \endverbatim
  *

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -1636,7 +1636,7 @@ public:
    * is not a node or is a node and does not have a singular Jacobian,
    * this will return invalid_uint.
    *
-   * The intention is for this to be overriden in derived element
+   * The intention is for this to be overridden in derived element
    * classes that do have nodes that have singular Jacobians. When
    * mapping failures are caught, we can check this to see if the
    * failed physical point is actually a singular point and

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -534,7 +534,7 @@ public:
   const std::vector<int> & get_elem_num_map() const;
 
   /**
-   * Idential to the behavior of get_elem_num_map(), but for the
+   * Identical to the behavior of get_elem_num_map(), but for the
    * node_num_map instead.
    */
   const std::vector<int> & get_node_num_map() const;

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -948,7 +948,7 @@ protected:
   /**
    * This class facilitates reading in vectors from Exodus file that
    * may be of a different floating point type than Real. It employs
-   * basically the same approach as the MappedOuputVector, just going
+   * basically the same approach as the MappedOutputVector, just going
    * in the opposite direction. For more information, see the
    * MappedOutputVector class docs.
    */

--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -91,7 +91,7 @@ public:
 
   /**
    * Special functions.
-   * - This class conains a unique_ptr so it can't be default copy constructed.
+   * - This class contains a unique_ptr so it can't be default copy constructed.
    * - This class contains const references so it can't be default copy/move assigned.
    * - The destructor is defaulted out-of-line.
    */

--- a/include/mesh/mesh_serializer.h
+++ b/include/mesh/mesh_serializer.h
@@ -40,7 +40,7 @@ class MeshBase;
  *
  * If allow_remote_element_removal() is set to true, that will also be
  * temporarily disabled by the serializer, to be reenabled after
- * serializer distruction if so; this allows prepare_for_use() to be
+ * serializer destruction if so; this allows prepare_for_use() to be
  * called safely from within serialized code.
  *
  * If a mesh is explicitly distributed by a `delete_remote_elements()`

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -124,8 +124,8 @@ std::unordered_set<dof_id_type> find_boundary_nodes(const MeshBase & mesh);
 /**
  * Returns a std::set containing Node IDs for all of the block boundary nodes
  *
- * A "block boundary node" is a node that is connected to elemenents from 2
- * or more blockse
+ * A "block boundary node" is a node that is connected to elements from 2
+ * or more blocks
  */
 std::unordered_set<dof_id_type> find_block_boundary_nodes(const MeshBase & mesh);
 
@@ -483,7 +483,7 @@ void libmesh_assert_consistent_distributed_nodes(const MeshBase & mesh);
 /**
  * A function for verifying that processor assignment is parallel
  * consistent (every processor agrees on the processor id of each node
- * it can see) even on nodes which have not yet recieved consistent
+ * it can see) even on nodes which have not yet received consistent
  * DofObject::id(), using element topology to identify matching nodes.
  */
 void libmesh_assert_parallel_consistent_new_node_procids (const MeshBase & mesh);

--- a/include/mesh/xdr_io.h
+++ b/include/mesh/xdr_io.h
@@ -271,7 +271,7 @@ private:
   //
   // In the function templates below, the "T type_size" argument is only
   // used for template argument deduction purposes. The value of this
-  // parameter can be arbitary because it will not be used within the
+  // parameter can be arbitrary because it will not be used within the
   // function.
 
   /**

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -218,7 +218,7 @@ public:
                      const ParallelType ptype = AUTOMATIC) = 0;
 
   /**
-   * Create a vector that holds tha local indices plus those specified
+   * Create a vector that holds the local indices plus those specified
    * in the \p ghost argument.
    */
   virtual void init (const numeric_index_type n,

--- a/include/numerics/tensor_value.h
+++ b/include/numerics/tensor_value.h
@@ -146,7 +146,7 @@ public:
   { libmesh_assert_equal_to (p, Scalar(0)); this->zero(); return *this; }
 
   /**
-   * Generate the intrinsic rotation matrix associated with the provided Euler angles. An instrinsic
+   * Generate the intrinsic rotation matrix associated with the provided Euler angles. An intrinsic
    * rotation leaves bodies in the domain fixed while rotating the coordinate axes. We follow the
    * convention described at http://mathworld.wolfram.com/EulerAngles.html (equations 6-14 give the
    * entries of the composite transformation matrix). The rotations are performed sequentially about

--- a/include/parallel/parallel_ghost_sync.h
+++ b/include/parallel/parallel_ghost_sync.h
@@ -173,7 +173,7 @@ bool sync_node_data_by_element_id_once(MeshBase & mesh,
 /**
  * Synchronize data about a range of ghost nodes uniquely identified
  * by an element id and local node id, iterating until data is
- * completely in sync and futher synchronization passes cause no
+ * completely in sync and further synchronization passes cause no
  * changes.
  *
  * Imagine a vertex surrounded by triangles, each on a different

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -293,7 +293,7 @@ private:
   /**
    * Find the training sample that has the largest EIM approximation error
    * based on the current EIM approximation. Return the maximum error, and
-   * the training sample index at which it occured.
+   * the training sample index at which it occurred.
    */
   std::pair<Real, unsigned int> compute_max_eim_error();
 

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -135,7 +135,7 @@ public:
 
   /**
    * The Online counterpart of initialize_interpolation_points_spatial_indices().
-   * This is used to initalize the spatial indices data in _parametrized_function
+   * This is used to initialize the spatial indices data in _parametrized_function
    * so that the _parametrized_function can be used in the Online stage without
    * reconstructing the spatial indices on every element or node in the mesh.
    */

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -401,7 +401,7 @@ protected:
 
   /**
    * In the case that _parametrized_function_boundary_ids is not empty, then this
-   * parametrized function is defined on a mesh boundary. This boolean inidicates
+   * parametrized function is defined on a mesh boundary. This boolean indicates
    * if the mesh boundary under consideration is a set of sides, or a set of nodes.
    */
   bool _is_nodal_boundary;

--- a/include/systems/eigen_system.h
+++ b/include/systems/eigen_system.h
@@ -356,7 +356,7 @@ public:
    * The EigenSolver, defining which interface, i.e solver
    * package to use.
    *
-   * Public access to this member variable will be depreacted in
+   * Public access to this member variable will be deprecated in
    * the future! Use get_eigen_solver instead.
    */
   std::unique_ptr<EigenSolver<Number>> eigen_solver;

--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -400,7 +400,7 @@ public:
    * specified systems.
    * If vertices_only == true, then for higher-order elements only
    * the solution at the vertices is computed. This can be useful
-   * when plotting discontinous solutions on higher-order elements
+   * when plotting discontinuous solutions on higher-order elements
    * and only a lower-order representation is required.
    */
   void build_discontinuous_solution_vector

--- a/include/systems/implicit_system.h
+++ b/include/systems/implicit_system.h
@@ -177,7 +177,7 @@ public:
 
   /**
    * For explicit systems, just assemble and solve the system A*x=b.
-   * Should be overridden in derrived systems to provide a solver for the
+   * Should be overridden in derived systems to provide a solver for the
    * system.
    */
   virtual void solve () override

--- a/include/utils/parameters.h
+++ b/include/utils/parameters.h
@@ -469,7 +469,7 @@ T & Parameters::set (const std::string & name)
 
   set_attributes(name, false);
 
-  // Get pointer to exsiting or just-added entry
+  // Get pointer to existing or just-added entry
   auto ptr = cast_ptr<Parameter<T> *>(_values[name].get());
 
   // Return writeable reference

--- a/include/utils/perf_log.h
+++ b/include/utils/perf_log.h
@@ -525,7 +525,7 @@ void PerfLog::fast_pop(const char * libmesh_dbg_var(label),
       // In debug mode, we carefully check that before popping the stack,
       // we have the correct event.
 
-      // Get pointer to corresonding PerfData, or nullptr if it does not exist.
+      // Get pointer to corresponding PerfData, or nullptr if it does not exist.
       auto it = log.find(std::make_pair(header, label));
       PerfData * perf_data = (it == log.end()) ? nullptr : &(it->second);
 

--- a/src/apps/meshtool.C
+++ b/src/apps/meshtool.C
@@ -168,7 +168,7 @@ int main (int argc, char ** argv)
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
-  // Add infinte elements
+  // Add infinite elements
   if (command_line.search(1, "-a"))
     addinfelems = true;
 

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -479,7 +479,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
         // Get the id of this node
         dof_id_type node_id = node.id();
 
-        // If we havent already processed this node, do so now
+        // If we haven't already processed this node, do so now
         if (processed_node_ids.find(node_id) == processed_node_ids.end())
           {
             // Declare a neighbor_set to be filled by the find_point_neighbors

--- a/src/error_estimation/patch_recovery_error_estimator.C
+++ b/src/error_estimation/patch_recovery_error_estimator.C
@@ -238,7 +238,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
       if (this->error_estimator.patch_reuse && error_per_cell[e_id] != 0)
         continue;
 
-      // If we are not reusing patches or havent built one containing this element, we build one
+      // If we are not reusing patches or haven't built one containing this element, we build one
 
       // Use user specified patch size and growth strategy
       patch.build_around_element (elem, error_estimator.target_patch_size,

--- a/src/error_estimation/weighted_patch_recovery_error_estimator.C
+++ b/src/error_estimation/weighted_patch_recovery_error_estimator.C
@@ -140,7 +140,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
       if (this->error_estimator.patch_reuse && error_per_cell[e_id] != 0)
         continue;
 
-      // If we are not reusing patches or havent built one containing this element, we build one
+      // If we are not reusing patches or haven't built one containing this element, we build one
 
       // Use user specified patch size and growth strategy
       patch.build_around_element (elem, error_estimator.target_patch_size,

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -208,7 +208,7 @@ void InfFE<Dim,T_radial,T_map>::reinit(const Elem * inf_elem,
       this->compute_shape_functions (inf_elem,
                                      base_fe->qrule->get_points(),
                                      radial_qrule->get_points()
-                                     /* weights are computed insid the function*/
+                                     /* weights are computed inside the function*/
                                      );
     }
 
@@ -809,7 +809,7 @@ void InfFE<Dim,T_radial,T_map>::compute_shape_functions(const Elem * inf_elem,
     libmesh_assert_equal_to(n_radial_qp, radial_qrule->n_points());
   if (base_qrule)
     libmesh_assert_equal_to(n_base_qp, base_qrule->n_points());
-  libmesh_assert_equal_to(_n_total_qp % n_radial_qp, 0); // "Error in the structure of quadrature pointes!");
+  libmesh_assert_equal_to(_n_total_qp % n_radial_qp, 0); // "Error in the structure of quadrature points!");
 #endif
 
 

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -1292,7 +1292,7 @@ void InfFE<Dim, T_radial, T_map>::inf_compute_constraints (DofConstraints & cons
   //   the radial polynomials coincide on neighboring elements.
   //   Thus, if one constraines these DOFs at one (arbitrary) point correctly, they match for each point along the radial direction.
   //   Hence, we constrain them with the same values as those DOFs belonging to the first order polynomial, obtaining consistent
-  //   constraints that mimick constraints that are computed at the support points for each radial polynomial contribution.
+  //   constraints that mimic constraints that are computed at the support points for each radial polynomial contribution.
 
   FEType fe_type = dof_map.variable_type(variable_number);
 

--- a/src/geom/elem_cutter.C
+++ b/src/geom/elem_cutter.C
@@ -175,7 +175,7 @@ void ElemCutter::find_intersection_points(const Elem & elem,
         d0 = vertex_distance_func[el0],
         d1 = vertex_distance_func[el1];
 
-      // if this egde has a 0 crossing
+      // if this edge has a 0 crossing
       if (d0*d1 < 0.)
         {
           libmesh_assert_not_equal_to (d0, d1);

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1501,7 +1501,7 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
     derived_vars_active_subdomains(derived_var_names.size());
 
   // A new data structure for keeping track of a list of variable names
-  // that are in the discontinous solution vector on each subdomain. Used
+  // that are in the discontinuous solution vector on each subdomain. Used
   // for indexing. Note: if a variable was inactive at the System level,
   // an entry for it will still be in the discontinuous solution vector,
   // but it will just have a value of zero. On the other hand, when we

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -695,7 +695,7 @@ void ExodusII_IO_Helper::read_and_store_header_info()
 {
   // Read header params from file, storing them in this class's
   // ExodusHeaderInfo struct.  This automatically updates the local
-  // num_dim, num_elem, etc. referenes.
+  // num_dim, num_elem, etc. references.
   this->header_info = this->read_header();
 
   // Read the number of timesteps which are present in the file

--- a/src/mesh/gmsh_io.C
+++ b/src/mesh/gmsh_io.C
@@ -625,7 +625,7 @@ void GmshIO::read_mesh(std::istream & in)
                     std::size_t gmsh_element_id;
                     in >> gmsh_element_id;
 
-                    // Get the remainer of the line that includes the nodes ids
+                    // Get the remainder of the line that includes the nodes ids
                     std::getline(in, s);
                     std::istringstream is(s);
                     std::size_t local_node_counter = 0, gmsh_node_id;

--- a/src/mesh/mesh_smoother_laplace.C
+++ b/src/mesh/mesh_smoother_laplace.C
@@ -53,7 +53,7 @@ void LaplaceMeshSmoother::smooth(unsigned int n_iterations)
   // is probably not something we want!
   auto on_boundary = MeshTools::find_boundary_nodes(_mesh);
 
-  // Also: don't smooth block bondary nodes
+  // Also: don't smooth block boundary nodes
   auto on_block_boundary = MeshTools::find_block_boundary_nodes(_mesh);
 
   // Merge them

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -339,7 +339,7 @@ int VariationalMeshSmoother::readgr(Array2D<Real> & R,
                     // Only try each pairing once
                     for (auto b : IntRange<std::size_t>(a+1, thetas.size()))
                       {
-                        // Find if the two neighbor nodes angles are 180 degrees (pi) off of each other (withing a tolerance)
+                        // Find if the two neighbor nodes angles are 180 degrees (pi) off of each other (within a tolerance)
                         // In order to make this a true movable boundary node... the two that forma  straight line with
                         // it must also be on the boundary
                         if (boundary_node_ids.count(neighbors[a]->id()) &&

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -511,7 +511,7 @@ XdrIO::write_serialized_connectivity (Xdr & io,
               {
                 pack_element (xfer_conn, &child, parent_id, parent_pid, n_elem_integers);
 
-                // this aproach introduces the possibility that we write
+                // this approach introduces the possibility that we write
                 // non-local elements.  These elements may well be parents
                 // at the next step
                 child_id_map[child.id()] = std::make_pair (child.processor_id(),

--- a/src/parallel/parallel_elem.C
+++ b/src/parallel/parallel_elem.C
@@ -624,7 +624,7 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
       if (elem->processor_id() != mesh->processor_id())
         {
           // Do this simultaneously; otherwise we can get a false
-          // positve when a hack_p_level or set_p_refineemnt_flag
+          // positive when a hack_p_level or set_p_refineemnt_flag
           // assertion sees inconsistency between an old flag and new
           // value or vice-versa
           elem->hack_p_level_and_refinement_flag(p_level, p_refinement_flag);

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -2168,7 +2168,7 @@ void RBConstruction::load_rb_solution()
 
   libmesh_error_msg_if(get_rb_evaluation().RB_solution.size() > get_rb_evaluation().get_n_basis_functions(),
                        "ERROR: System contains " << get_rb_evaluation().get_n_basis_functions() << " basis functions."
-                       << " RB_solution vector constains " << get_rb_evaluation().RB_solution.size() << " entries."
+                       << " RB_solution vector contains " << get_rb_evaluation().RB_solution.size() << " entries."
                        << " RB_solution in RBConstruction::load_rb_solution is too long!");
 
   for (auto i : make_range(get_rb_evaluation().RB_solution.size()))

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -1005,7 +1005,7 @@ write_out_interior_basis_functions(const std::string & directory_name,
                         n_qp_per_elem.end(),
                         0u);
 
-      // Reserve space to store continguous vectors of qp data for each var
+      // Reserve space to store contiguous vectors of qp data for each var
       std::vector<std::vector<Number>> qp_data(n_vars);
       for (auto var : index_range(qp_data))
         qp_data[var].reserve(n_qp_data);
@@ -1121,7 +1121,7 @@ write_out_side_basis_functions(const std::string & directory_name,
                         n_qp_per_elem_side.end(),
                         0u);
 
-      // Reserve space to store continguous vectors of qp data for each var
+      // Reserve space to store contiguous vectors of qp data for each var
       std::vector<std::vector<Number>> qp_data(n_vars);
       for (auto var : index_range(qp_data))
         qp_data[var].reserve(n_qp_data);

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -1114,7 +1114,7 @@ void RBEvaluation::read_in_vectors_from_multiple_files(System & sys,
         vector_data.set_version(LIBMESH_VERSION_ID(ver_major, ver_minor, ver_patch));
 
         // Actually read the header data. When we do this, set read_header=false
-        // so taht we do not reinit sys, since we assume that it has already been
+        // so that we do not reinit sys, since we assume that it has already been
         // set up properly (e.g. the appropriate variables have already been added).
         sys.read_header(vector_data, version, /*read_header=*/false, /*read_additional_data=*/false);
       }

--- a/src/reduced_basis/transient_rb_construction.C
+++ b/src/reduced_basis/transient_rb_construction.C
@@ -895,7 +895,7 @@ void TransientRBConstruction::load_rb_solution()
   libmesh_error_msg_if(RB_solution_vector_k.size() > get_rb_evaluation().get_n_basis_functions(),
                        "ERROR: rb_eval object contains "
                        << get_rb_evaluation().get_n_basis_functions()
-                       << " basis functions. RB_solution vector constains "
+                       << " basis functions. RB_solution vector contains "
                        << RB_solution_vector_k.size()
                        << " entries. RB_solution in TransientRBConstruction::load_rb_solution is too long!");
 

--- a/src/reduced_basis/transient_rb_evaluation.C
+++ b/src/reduced_basis/transient_rb_evaluation.C
@@ -92,7 +92,7 @@ void TransientRBEvaluation::resize_data_structures(const unsigned int Nmax,
   RB_initial_condition_all_N.resize(Nmax);
   for (auto i : make_range(RB_initial_condition_all_N.size()))
     {
-      // The i^th row holds a vector of lenght i+1
+      // The i^th row holds a vector of length i+1
       RB_initial_condition_all_N[i].resize(i+1);
     }
 

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -290,7 +290,7 @@ namespace libMesh
           libmesh_assert(ctx_c);
           PetscDMContext * p_ctx_c = static_cast<PetscDMContext*>(ctx_c);
 
-          // propogate subfield info to subDM
+          // propagate subfield info to subDM
           p_ctx_c->subfields = p_ctx_f->subfields;
 
           // return created subDM to PETSc
@@ -457,7 +457,7 @@ namespace libMesh
     MeshBase & mesh = system.get_mesh();   // Convenience
     MeshRefinement mesh_refinement(mesh); // Used for swapping between grids
 
-    // Theres no need for these code paths while traversing the hierarchy
+    // There's no need for these code paths while traversing the hierarchy
     mesh.allow_renumbering(false);
     mesh.allow_remote_element_removal(false);
     mesh.partitioner() = nullptr;
@@ -471,7 +471,7 @@ namespace libMesh
           n_levels = elem->level();
       }
     // On coarse grids some processors may have no active local elements,
-    // these processors shouldnt make projections
+    // these processors shouldn't make projections
     if (n_levels >= 1)
       n_levels += 1;
 */

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -669,7 +669,7 @@ void PetscNonlinearSolver<T>::clear ()
       // between solves.
       if (!(reuse_preconditioner()))
         {
-        // SNESReset really ought to work but replacing destory() with
+        // SNESReset really ought to work but replacing destroy() with
         // SNESReset causes a very slight change in behavior that
         // manifests as two failed MOOSE tests...
         _snes.destroy();

--- a/src/solvers/solution_history.C
+++ b/src/solvers/solution_history.C
@@ -85,7 +85,7 @@ namespace libMesh
     {
       return;
     }
-    else // If we are not storing, then we expected to find something but didnt, so we have a problem
+    else // If we are not storing, then we expected to find something but didn't, so we have a problem
     {
       libmesh_error_msg("Failed to set stored solutions iterator to a valid value.");
     }

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -510,7 +510,7 @@ void ImplicitSystem::adjoint_qoi_parameter_sensitivity (const QoISet & qoi_indic
 
   // We first do an adjoint solve:
   // J^T * z = (partial q / partial u)
-  // if we havent already or dont have an initial condition for the adjoint
+  // if we haven't already or dont have an initial condition for the adjoint
   if (!this->is_adjoint_already_solved())
     {
       this->adjoint_solve(qoi_indices);
@@ -723,7 +723,7 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product (const QoISet & qoi_in
 
   // We first do an adjoint solve to get z for each quantity of
   // interest
-  // if we havent already or dont have an initial condition for the adjoint
+  // if we haven't already or dont have an initial condition for the adjoint
   if (!this->is_adjoint_already_solved())
     {
       this->adjoint_solve(qoi_indices);
@@ -931,7 +931,7 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
 
   // We first do an adjoint solve to get z for each quantity of
   // interest
-  // if we havent already or dont have an initial condition for the adjoint
+  // if we haven't already or dont have an initial condition for the adjoint
   if (!this->is_adjoint_already_solved())
     {
       this->adjoint_solve(qoi_indices);

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -896,7 +896,7 @@ const std::string & System::vector_name (const NumericVector<Number> & vec_refer
                          [&vec_reference](const decltype(_vectors)::value_type & pr)
                          { return &vec_reference == pr.second.get(); });
 
-  // Before returning, make sure we didnt loop till the end and not find any match
+  // Before returning, make sure we didn't loop till the end and not find any match
   libmesh_assert (it != vectors_end());
 
   // Return the string associated with the current vector
@@ -2288,7 +2288,7 @@ Number System::point_value(unsigned int var,
   Point coor = FEMap::inverse_map(e.dim(), &e, p);
 
   // get the shape function value via the FEInterface to also handle the case
-  // of infinite elements correcly, the shape function is not fe->phi().
+  // of infinite elements correctly, the shape function is not fe->phi().
   FEComputeData fe_data(this->get_equation_systems(), coor);
   FEInterface::compute_data(e.dim(), fe_type, &e, fe_data);
 
@@ -2421,7 +2421,7 @@ Gradient System::point_gradient(unsigned int var,
   Point coor = FEMap::inverse_map(dim, &e, p);
 
   // get the shape function value via the FEInterface to also handle the case
-  // of infinite elements correcly, the shape function is not fe->phi().
+  // of infinite elements correctly, the shape function is not fe->phi().
   FEComputeData fe_data(this->get_equation_systems(), coor);
   fe_data.enable_derivative();
   FEInterface::compute_data(dim, fe_type, &e, fe_data);
@@ -2431,7 +2431,7 @@ Gradient System::point_gradient(unsigned int var,
 
   for (unsigned int l=0; l<num_dofs; l++)
     {
-      // Chartesian coordinates have allways LIBMESH_DIM entries,
+      // Chartesian coordinates have always LIBMESH_DIM entries,
       // local coordinates have as many coordinates as the element has.
       for (std::size_t v=0; v<dim; v++)
         for (std::size_t xyz=0; xyz<LIBMESH_DIM; xyz++)

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -207,7 +207,7 @@ void System::read_header (Xdr & io,
         // changed for the monomial and xyz finite element families to
         // simplify extension to arbitrary p.  The consequence is that
         // old restart files will not be read correctly.  This is expected
-        // to be an unlikely occurence, but catch it anyway.
+        // to be an unlikely occurrence, but catch it anyway.
         if (read_legacy_format)
           if ((type.family == MONOMIAL || type.family == XYZ) &&
               ((type.order.get_order() > 2 && this->get_mesh().mesh_dimension() == 2) ||

--- a/src/utils/plt_loader_write.C
+++ b/src/utils/plt_loader_write.C
@@ -48,7 +48,7 @@ namespace libMesh
 //   const std::string gname = basename + ".g";
 //   const std::string qname = basename + ".q";
 
-//   // FORTAN file unit numbers
+//   // FORTRAN file unit numbers
 //   const int gunit = 25;
 //   const int qunit = 26;
 
@@ -266,7 +266,7 @@ namespace libMesh
 // }
 //     }
 
-//   // Close the FORTAN files
+//   // Close the FORTRAN files
 //   close_ (&gunit);
 
 //   if (!gridonly)

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -585,7 +585,7 @@ xdrproc_t xdr_translator<unsigned long int>()
 // for anything larger.
 // 2. You're on a system with sizeof(long long) > 8, and you want to
 // store n>2^64 in one.  Welcome, 22nd century programmers; sorry we
-// couldn't accomodate you.
+// couldn't accommodate you.
 template <>
 xdrproc_t xdr_translator<long long>() { return (xdrproc_t)(xdr_longlong_t); }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -160,7 +160,7 @@ noinst_PROGRAMS = # empty, append below
 # our GLIBC debugging preprocessor flags seem to potentially conflict
 # with libcppunit binaries.  Some cppunit versions work fine for us,
 # others segfault and/or hang.  By default we will not run
-# GLIBCXX-debugging builds with cppunit unless specificallly
+# GLIBCXX-debugging builds with cppunit unless specifically
 # configured to.
 if LIBMESH_ENABLE_CPPUNIT
 if LIBMESH_DBG_MODE

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -101,7 +101,7 @@ noinst_PROGRAMS = $(am__EXEEXT_7) $(am__EXEEXT_3) $(am__EXEEXT_4) \
 # our GLIBC debugging preprocessor flags seem to potentially conflict
 # with libcppunit binaries.  Some cppunit versions work fine for us,
 # others segfault and/or hang.  By default we will not run
-# GLIBCXX-debugging builds with cppunit unless specificallly
+# GLIBCXX-debugging builds with cppunit unless specifically
 # configured to.
 @ACSM_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_TRUE@@ACSM_ENABLE_GLIBCXX_DEBUGGING_TRUE@@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@am__append_2 = unit_tests-dbg
 @ACSM_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_FALSE@@ACSM_ENABLE_GLIBCXX_DEBUGGING_TRUE@@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@am__append_3 = unit_tests-dbg

--- a/tests/driver.C
+++ b/tests/driver.C
@@ -114,7 +114,7 @@ int main(int argc, char ** argv)
   std::string deny_regex_string = "^$";
   deny_regex_string = libMesh::command_line_next("--deny_re", deny_regex_string);
 
-  // Recursively add tests matching the regex tothe runner object.
+  // Recursively add tests matching the regex to the runner object.
   CppUnit::TextUi::TestRunner runner;
 
   // The Cppunit registry object that knows about all the tests.

--- a/tests/geom/edge_test.C
+++ b/tests/geom/edge_test.C
@@ -59,7 +59,7 @@ public:
 #ifdef LIBMESH_ENABLE_AMR
     // Do tests with an Elem having a non-default p_level to ensure
     // that edges which are built have a matching p_level. p-refinement
-    // is only avaiable if LIBMESH_ENABLE_AMR is defined.
+    // is only available if LIBMESH_ENABLE_AMR is defined.
     elem.set_p_level(1);
 #endif
     Point dummy;
@@ -140,7 +140,7 @@ public:
         CPPUNIT_ASSERT(edge->subdomain_id() == elem.subdomain_id());
 
 #ifdef LIBMESH_ENABLE_AMR
-        // p-refinement is only avaiable if LIBMESH_ENABLE_AMR is defined.
+        // p-refinement is only available if LIBMESH_ENABLE_AMR is defined.
         CPPUNIT_ASSERT(edge->p_level() == elem.p_level());
 #endif
       }

--- a/tests/geom/side_test.C
+++ b/tests/geom/side_test.C
@@ -62,7 +62,7 @@ public:
 #ifdef LIBMESH_ENABLE_AMR
     // Do tests with an Elem having a non-default p_level to ensure
     // that sides which are built have a matching p_level. p-refinement
-    // is only avaiable if LIBMESH_ENABLE_AMR is defined.
+    // is only available if LIBMESH_ENABLE_AMR is defined.
     elem.set_p_level(1);
 #endif
     Point dummy;
@@ -171,7 +171,7 @@ public:
         CPPUNIT_ASSERT(side->subdomain_id() == elem.subdomain_id());
 
 #ifdef LIBMESH_ENABLE_AMR
-        // p-refinement is only avaiable if LIBMESH_ENABLE_AMR is defined.
+        // p-refinement is only available if LIBMESH_ENABLE_AMR is defined.
         CPPUNIT_ASSERT(side->p_level() == elem.p_level());
 #endif
       }

--- a/tests/mesh/mesh_collection.C
+++ b/tests/mesh/mesh_collection.C
@@ -26,7 +26,7 @@ private:
     // to trigger duplicate unique ids in the old code, you needed the following circumstances:
     // The single mesh generation routine (e.g. build_cube) *must* add a node after all the elements
     // such that it is not an element that has the largest unique id in the single mesh. (build_cube
-    // with TET10 adds a node after all the elements are added becuase it calls all_second_order
+    // with TET10 adds a node after all the elements are added because it calls all_second_order
     // after all the elements are created.) If an element has the highest unique id, then the final
     // value for _next_unique_id was (and still is) correct at the end of copy_nodes_and_elements
     // because we set the element unique ids before adding the elements into the original mesh, such

--- a/tests/numerics/eigen_sparse_matrix_test.C
+++ b/tests/numerics/eigen_sparse_matrix_test.C
@@ -34,7 +34,7 @@ public:
     _comm = TestCommWorld;
     _matrix = std::make_unique<EigenSparseMatrix<Number>>(*_comm);
 
-    // All parameters are ignored except the number of global rows and colums and nnz.
+    // All parameters are ignored except the number of global rows and columns and nnz.
     _matrix->init(/*m*/10,
                   /*n*/10,
                   /*m_l==m*/10,

--- a/tests/parallel/parallel_sync_test.C
+++ b/tests/parallel/parallel_sync_test.C
@@ -48,7 +48,7 @@ public:
   {}
 
 
-  // Data to send/recieve with each processor rank.  For this test,
+  // Data to send/receive with each processor rank.  For this test,
   // processor p will send to destination d the integer d, in a vector
   // with sqrt(c)+1 copies, iff c := |p-d| is a square number.
   void fill_scalar_data
@@ -67,7 +67,7 @@ public:
   }
 
 
-  // Multimap data to send/recieve with each processor rank.  For this
+  // Multimap data to send/receive with each processor rank.  For this
   // test, processor p will send to destination d the integer d, in a
   // vector with sqrt(c)+1 copies followed by a vector with 1 copy,
   // iff c := |p-d| is a square number.
@@ -93,7 +93,7 @@ public:
   }
 
 
-  // Data to send/recieve with each processor rank.  For this test,
+  // Data to send/receive with each processor rank.  For this test,
   // processor p will send to destination d the integer d, in two
   // subvectors with sqrt(c) and 1 copies, iff c := |p-d| is a square
   // number.
@@ -118,7 +118,7 @@ public:
 
 
 
-  // Multimap data to send/recieve with each processor rank.  For this
+  // Multimap data to send/receive with each processor rank.  For this
   // test, processor p will send to destination d the integer d, in
   // two subvectors with sqrt(c) and 1 copies, followed by a vector
   // with 1 copy, iff c := |p-d| is a square number.

--- a/tests/partitioning/partitioner_test.h
+++ b/tests/partitioning/partitioner_test.h
@@ -80,7 +80,7 @@ public:
 
     // Unfortunately, it turns out that our partitioners *do* suck:
     //
-    // * Metis and ParMetis can't reliabily give us more than
+    // * Metis and ParMetis can't reliably give us more than
     // 13 non-empty ranks on the above 27 element mesh.
     //
     // * Our SFC partitioners are suboptimal with 8 or more ranks for

--- a/tests/run_unit_tests.sh.in
+++ b/tests/run_unit_tests.sh.in
@@ -6,7 +6,7 @@ set -e
 # there's a failure we get the most informative death possible
 ORDERED_METHODS="dbg debug devel profiling pro prof oprofile oprof optimized opt"
 
-# when run outside of the automake envionment make sure we get METHODS set
+# when run outside of the automake environment make sure we get METHODS set
 # to something useful
 if (test "x${METHODS}" = "x"); then
     if (test "x${METHOD}" = "x"); then


### PR DESCRIPTION
Found via `codespell -q 3 -S ./contrib,./m4,./NEWS -L ans,inout,nd,parm,som,theses,ue,wirth`
