### PR TITLE
Add support for QUADSHELL4/8 elements in MeshTools::Generation::build_square()

### DIFF
--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -89,6 +89,7 @@ unsigned int idx(const ElemType type,
       }
 
     case QUAD8:
+    case QUADSHELL8:
     case QUAD9:
     case TRI6:
     case TRI7:
@@ -589,6 +590,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
           case QUAD4:
           case QUADSHELL4:
           case QUAD8:
+          case QUADSHELL8:
           case QUAD9:
             {
               mesh.reserve_elem (nx*ny);
@@ -623,6 +625,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
             }
 
           case QUAD8:
+          case QUADSHELL8:
           case QUAD9:
           case TRI6:
             {
@@ -675,6 +678,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
             }
 
           case QUAD8:
+          case QUADSHELL8:
           case QUAD9:
           case TRI6:
           case TRI7:
@@ -797,6 +801,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
 
 
           case QUAD8:
+          case QUADSHELL8:
           case QUAD9:
             {
               for (unsigned int j=0; j<(2*ny); j += 2)

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -82,6 +82,7 @@ unsigned int idx(const ElemType type,
     {
     case INVALID_ELEM:
     case QUAD4:
+    case QUADSHELL4:
     case TRI3:
       {
         return i + j*(nx+1);
@@ -586,6 +587,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
           {
           case INVALID_ELEM:
           case QUAD4:
+          case QUADSHELL4:
           case QUAD8:
           case QUAD9:
             {
@@ -613,6 +615,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
           {
           case INVALID_ELEM:
           case QUAD4:
+          case QUADSHELL4:
           case TRI3:
             {
               mesh.reserve_nodes( (nx+1)*(ny+1) );
@@ -647,6 +650,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
           {
           case INVALID_ELEM:
           case QUAD4:
+          case QUADSHELL4:
           case TRI3:
             {
               for (unsigned int j=0; j<=ny; j++)
@@ -731,11 +735,12 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
 
           case INVALID_ELEM:
           case QUAD4:
+          case QUADSHELL4:
             {
               for (unsigned int j=0; j<ny; j++)
                 for (unsigned int i=0; i<nx; i++)
                   {
-                    Elem * elem = mesh.add_elem(Elem::build_with_id(QUAD4, elem_id++));
+                    Elem * elem = mesh.add_elem(Elem::build_with_id(type == INVALID_ELEM ? QUAD4 : type, elem_id++));
                     elem->set_node(0) = mesh.node_ptr(idx(type,nx,i,j)    );
                     elem->set_node(1) = mesh.node_ptr(idx(type,nx,i+1,j)  );
                     elem->set_node(2) = mesh.node_ptr(idx(type,nx,i+1,j+1));


### PR DESCRIPTION
These elements can be handled almost identically to `QUAD4` and `QUAD8` so there is not really any new implementation in this PR, just new case blocks.