### PR TITLE
Configuring with --enable-hdf5-required now implies --enable-hdf5 

### DIFF
--- a/configure
+++ b/configure
@@ -33822,7 +33822,7 @@ fi
   # before this can be enabled.
   hardcode_into_libs=yes
 
-  # Ideally, we could use ldconfig to report *all* directories which are
+  # Ideally, we could use ldconfig to report *all* directores which are
   # searched for libraries, however this is still not possible.  Aside from not
   # being certain /sbin/ldconfig is available, command
   # 'ldconfig -N -X -v | grep ^/' on 64bit Fedora does not report /usr/lib64,
@@ -37784,7 +37784,7 @@ fi
   # before this can be enabled.
   hardcode_into_libs=yes
 
-  # Ideally, we could use ldconfig to report *all* directories which are
+  # Ideally, we could use ldconfig to report *all* directores which are
   # searched for libraries, however this is still not possible.  Aside from not
   # being certain /sbin/ldconfig is available, command
   # 'ldconfig -N -X -v | grep ^/' on 64bit Fedora does not report /usr/lib64,
@@ -40734,7 +40734,7 @@ fi
   # before this can be enabled.
   hardcode_into_libs=yes
 
-  # Ideally, we could use ldconfig to report *all* directories which are
+  # Ideally, we could use ldconfig to report *all* directores which are
   # searched for libraries, however this is still not possible.  Aside from not
   # being certain /sbin/ldconfig is available, command
   # 'ldconfig -N -X -v | grep ^/' on 64bit Fedora does not report /usr/lib64,
@@ -43825,7 +43825,7 @@ fi
   # before this can be enabled.
   hardcode_into_libs=yes
 
-  # Ideally, we could use ldconfig to report *all* directories which are
+  # Ideally, we could use ldconfig to report *all* directores which are
   # searched for libraries, however this is still not possible.  Aside from not
   # being certain /sbin/ldconfig is available, command
   # 'ldconfig -N -X -v | grep ^/' on 64bit Fedora does not report /usr/lib64,
@@ -54896,11 +54896,12 @@ else
 fi
 
 
-                # Check whether --enable-hdf5-required was given.
+                        # Check whether --enable-hdf5-required was given.
 if test "${enable_hdf5_required+set}" = set; then :
   enableval=$enable_hdf5_required; case "${enableval}" in #(
   yes) :
-    hdf5required=yes ;; #(
+    hdf5required=yes
+                                 enablehdf5=yes ;; #(
   no) :
     hdf5required=no ;; #(
   *) :

--- a/contrib/eigen/gitshim/Makefile.in
+++ b/contrib/eigen/gitshim/Makefile.in
@@ -521,7 +521,6 @@ psdir = @psdir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
-subdirs = @subdirs@
 subdirs_extra = @subdirs_extra@
 sysconfdir = @sysconfdir@
 target = @target@

--- a/m4/hdf5.m4
+++ b/m4/hdf5.m4
@@ -19,11 +19,16 @@ AC_DEFUN([CONFIGURE_HDF5],
   dnl libmesh is accidentally built without HDF5 support (which may
   dnl take a very long time), and then the read fails at runtime,
   dnl requiring you to redo everything.
+  dnl
+  dnl --enable-hdf5-required now implies --enable-hdf5, previously one had to pass both
+  dnl of those flags in order to both enable HDF5 and make it required, now the latter
+  dnl is no longer required if you provide the former.
   AC_ARG_ENABLE(hdf5-required,
                 AS_HELP_STRING([--enable-hdf5-required],
                                [Error if HDF5 is not detected by configure]),
                 [AS_CASE("${enableval}",
-                         [yes], [hdf5required=yes],
+                         [yes], [hdf5required=yes
+                                 enablehdf5=yes],
                          [no],  [hdf5required=no],
                          [AC_MSG_ERROR(bad value ${enableval} for --enable-hdf5-required)])],
                 [hdf5required=no])

--- a/m4/libtool.m4
+++ b/m4/libtool.m4
@@ -2867,7 +2867,7 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
   # before this can be enabled.
   hardcode_into_libs=yes
 
-  # Ideally, we could use ldconfig to report *all* directories which are
+  # Ideally, we could use ldconfig to report *all* directores which are
   # searched for libraries, however this is still not possible.  Aside from not
   # being certain /sbin/ldconfig is available, command
   # 'ldconfig -N -X -v | grep ^/' on 64bit Fedora does not report /usr/lib64,


### PR DESCRIPTION
Previously, the user was required to pass both args:
```
  --enable-hdf5 --enable-hdf5-required
```
to configure in order to achieve this, but now only the latter is necessary.