### PR TITLE
Add performance logging to some Exodus APIs

### DIFF
--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -176,6 +176,8 @@ ExodusII_IO::~ExodusII_IO ()
 
 void ExodusII_IO::read (const std::string & fname)
 {
+  LOG_SCOPE("read()", "ExodusII_IO");
+
   // Get a reference to the mesh we are reading
   MeshBase & mesh = MeshInput<MeshBase>::mesh();
 
@@ -933,6 +935,8 @@ void ExodusII_IO::copy_nodal_solution(System & system,
                                       std::string exodus_var_name,
                                       unsigned int timestep)
 {
+  LOG_SCOPE("copy_nodal_solution()", "ExodusII_IO");
+
   const unsigned int var_num = system.variable_number(system_var_name);
 
   const MeshBase & mesh = MeshInput<MeshBase>::mesh();
@@ -1033,6 +1037,8 @@ void ExodusII_IO::copy_elemental_solution(System & system,
                                           std::string exodus_var_name,
                                           unsigned int timestep)
 {
+  LOG_SCOPE("copy_elemental_solution()", "ExodusII_IO");
+
   const unsigned int var_num = system.variable_number(system_var_name);
   // Assert that variable is an elemental one.
   //
@@ -1144,6 +1150,8 @@ void ExodusII_IO::copy_scalar_solution(System & system,
                                        std::vector<std::string> exodus_var_names,
                                        unsigned int timestep)
 {
+  LOG_SCOPE("copy_scalar_solution()", "ExodusII_IO");
+
   libmesh_error_msg_if(!exio_helper->opened_for_reading,
                        "ERROR, ExodusII file must be opened for reading before copying a scalar solution!");
 
@@ -1187,6 +1195,8 @@ void ExodusII_IO::read_elemental_variable(std::string elemental_var_name,
                                           unsigned int timestep,
                                           std::map<unsigned int, Real> & unique_id_to_value_map)
 {
+  LOG_SCOPE("read_elemental_variable()", "ExodusII_IO");
+
   // Note that this function MUST be called before renumbering
   std::map<dof_id_type, Real> elem_var_value_map;
 
@@ -1202,6 +1212,8 @@ void ExodusII_IO::read_global_variable(std::vector<std::string> global_var_names
                                        unsigned int timestep,
                                        std::vector<Real> & global_values)
 {
+  LOG_SCOPE("read_global_variable()", "ExodusII_IO");
+
   std::size_t size = global_var_names.size();
   libmesh_error_msg_if(size == 0, "ERROR, empty list of global variables to read from the Exodus file.");
 
@@ -1231,6 +1243,8 @@ void ExodusII_IO::read_global_variable(std::vector<std::string> global_var_names
 
 void ExodusII_IO::write_element_data (const EquationSystems & es)
 {
+  LOG_SCOPE("write_element_data()", "ExodusII_IO");
+
   // Be sure the file has been opened for writing!
   libmesh_error_msg_if(MeshOutput<MeshBase>::mesh().processor_id() == 0 && !exio_helper->opened_for_writing,
                        "ERROR, ExodusII file must be initialized before outputting element variables.");
@@ -1346,6 +1360,8 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
  const std::set<std::string> * system_names,
  const std::string & var_suffix)
 {
+  LOG_SCOPE("write_element_data_from_discontinuous_nodal_data()", "ExodusII_IO");
+
   // Be sure that some other function has already opened the file and prepared it
   // for writing. This is the same behavior as the write_element_data() function
   // which we are trying to mimic.
@@ -1830,6 +1846,8 @@ void ExodusII_IO::write_information_records (const std::vector<std::string> & re
 void ExodusII_IO::write_global_data (const std::vector<Number> & soln,
                                      const std::vector<std::string> & names)
 {
+  LOG_SCOPE("write_global_data()", "ExodusII_IO");
+
   if (MeshOutput<MeshBase>::mesh().processor_id())
     return;
 
@@ -2043,6 +2061,8 @@ ExodusII_IO::get_elemset_data_indices (std::map<std::pair<dof_id_type, elemset_i
 
 void ExodusII_IO::write (const std::string & fname)
 {
+  LOG_SCOPE("write()", "ExodusII_IO");
+
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
 
   // We may need to gather a DistributedMesh to output it, making that

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -31,6 +31,7 @@
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/int_range.h"
 #include "libmesh/utility.h"
+#include "libmesh/libmesh_logging.h"
 
 #ifdef DEBUG
 #include "libmesh/mesh_tools.h"  // for elem_types warning
@@ -792,6 +793,8 @@ void ExodusII_IO_Helper::print_header()
 
 void ExodusII_IO_Helper::read_nodes()
 {
+  LOG_SCOPE("read_nodes()", "ExodusII_IO_Helper");
+
   x.resize(num_nodes);
   y.resize(num_nodes);
   z.resize(num_nodes);
@@ -1089,6 +1092,8 @@ std::string ExodusII_IO_Helper::get_node_set_name(int index)
 
 void ExodusII_IO_Helper::read_elem_in_block(int block)
 {
+  LOG_SCOPE("read_elem_in_block()", "ExodusII_IO_Helper");
+
   libmesh_assert_less (block, block_ids.size());
 
   // Unlike the other "extended" APIs, this one does not use a parameter struct.
@@ -1245,6 +1250,8 @@ void ExodusII_IO_Helper::read_elem_in_block(int block)
 
 void ExodusII_IO_Helper::read_edge_blocks(MeshBase & mesh)
 {
+  LOG_SCOPE("read_edge_blocks()", "ExodusII_IO_Helper");
+
   // Check for quick return if there are no edge blocks.
   if (num_edge_blk == 0)
     return;
@@ -1522,6 +1529,8 @@ void ExodusII_IO_Helper::read_elemset_info()
 
 void ExodusII_IO_Helper::read_sideset(int id, int offset)
 {
+  LOG_SCOPE("read_sideset()", "ExodusII_IO_Helper");
+
   libmesh_assert_less (id, ss_ids.size());
   libmesh_assert_less (id, num_sides_per_set.size());
   libmesh_assert_less (id, num_df_per_set.size());
@@ -1567,6 +1576,8 @@ void ExodusII_IO_Helper::read_sideset(int id, int offset)
 
 void ExodusII_IO_Helper::read_elemset(int id, int offset)
 {
+  LOG_SCOPE("read_elemset()", "ExodusII_IO_Helper");
+
   libmesh_assert_less (id, elemset_ids.size());
   libmesh_assert_less (id, num_elems_per_set.size());
   libmesh_assert_less (id, num_elem_df_per_set.size());
@@ -1610,6 +1621,8 @@ void ExodusII_IO_Helper::read_elemset(int id, int offset)
 
 void ExodusII_IO_Helper::read_all_nodesets()
 {
+  LOG_SCOPE("read_all_nodesets()", "ExodusII_IO_Helper");
+
   // Figure out how many nodesets there are in the file so we can
   // properly resize storage as necessary.
   num_node_sets =
@@ -1734,6 +1747,8 @@ void ExodusII_IO_Helper::read_num_time_steps()
 
 void ExodusII_IO_Helper::read_nodal_var_values(std::string nodal_var_name, int time_step)
 {
+  LOG_SCOPE("read_nodal_var_values()", "ExodusII_IO_Helper");
+
   // Read the nodal variable names from file, so we can see if we have the one we're looking for
   this->read_var_names(NODAL);
 
@@ -1955,6 +1970,8 @@ void ExodusII_IO_Helper::read_elemental_var_values(std::string elemental_var_nam
                                                    int time_step,
                                                    std::map<dof_id_type, Real> & elem_var_value_map)
 {
+  LOG_SCOPE("read_elemental_var_values()", "ExodusII_IO_Helper");
+
   this->read_var_names(ELEMENTAL);
 
   // See if we can find the variable we are looking for
@@ -2345,6 +2362,8 @@ void ExodusII_IO_Helper::write_nodal_coordinates(const MeshBase & mesh, bool use
 
 void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_discontinuous)
 {
+  LOG_SCOPE("write_elements()", "ExodusII_IO_Helper");
+
   // n_active_elem() is a parallel_only function
   libmesh_parallel_only(mesh.comm());
   unsigned int n_active_elem = mesh.n_active_elem();
@@ -2717,6 +2736,8 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
 
 void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
 {
+  LOG_SCOPE("write_sidesets()", "ExodusII_IO_Helper");
+
   if ((_run_only_on_proc0) && (this->processor_id() != 0))
     return;
 
@@ -2844,6 +2865,8 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
 
 void ExodusII_IO_Helper::write_nodesets(const MeshBase & mesh)
 {
+  LOG_SCOPE("write_nodesets()", "ExodusII_IO_Helper");
+
   if ((_run_only_on_proc0) && (this->processor_id() != 0))
     return;
 
@@ -3130,6 +3153,8 @@ void ExodusII_IO_Helper::write_timestep(int timestep, Real time)
 void
 ExodusII_IO_Helper::write_elemsets(const MeshBase & mesh)
 {
+  LOG_SCOPE("write_elemsets()", "ExodusII_IO_Helper");
+
   if ((_run_only_on_proc0) && (this->processor_id() != 0))
     return;
 
@@ -3229,6 +3254,8 @@ write_sideset_data(const MeshBase & mesh,
                    const std::vector<std::set<boundary_id_type>> & side_ids,
                    const std::vector<std::map<BoundaryInfo::BCTuple, Real>> & bc_vals)
 {
+  LOG_SCOPE("write_sideset_data()", "ExodusII_IO_Helper");
+
   if ((_run_only_on_proc0) && (this->processor_id() != 0))
     return;
 
@@ -3367,6 +3394,8 @@ read_sideset_data(const MeshBase & mesh,
                   std::vector<std::set<boundary_id_type>> & side_ids,
                   std::vector<std::map<BoundaryInfo::BCTuple, Real>> & bc_vals)
 {
+  LOG_SCOPE("read_sideset_data()", "ExodusII_IO_Helper");
+
   // This reads the sideset variable names into the local
   // sideset_var_names data structure.
   this->read_var_names(SIDESET);
@@ -3516,6 +3545,8 @@ write_nodeset_data (int timestep,
                     const std::vector<std::set<boundary_id_type>> & node_boundary_ids,
                     const std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> & bc_vals)
 {
+  LOG_SCOPE("write_nodeset_data()", "ExodusII_IO_Helper");
+
   if ((_run_only_on_proc0) && (this->processor_id() != 0))
     return;
 
@@ -3619,6 +3650,8 @@ write_elemset_data (int timestep,
                     const std::vector<std::set<elemset_id_type>> & elemset_ids_in,
                     const std::vector<std::map<std::pair<dof_id_type, elemset_id_type>, Real>> & elemset_vals)
 {
+  LOG_SCOPE("write_elemset_data()", "ExodusII_IO_Helper");
+
   if ((_run_only_on_proc0) && (this->processor_id() != 0))
     return;
 
@@ -3740,6 +3773,8 @@ read_elemset_data (int timestep,
                    std::vector<std::set<elemset_id_type>> & elemset_ids_in,
                    std::vector<std::map<std::pair<dof_id_type, elemset_id_type>, Real>> & elemset_vals)
 {
+  LOG_SCOPE("read_elemset_data()", "ExodusII_IO_Helper");
+
   // This reads the elemset variable names into the local
   // elemset_var_names data structure.
   this->read_var_names(ELEMSET);
@@ -3890,6 +3925,8 @@ read_nodeset_data (int timestep,
                    std::vector<std::set<boundary_id_type>> & node_boundary_ids,
                    std::vector<std::map<BoundaryInfo::NodeBCTuple, Real>> & bc_vals)
 {
+  LOG_SCOPE("read_nodeset_data()", "ExodusII_IO_Helper");
+
   // This reads the sideset variable names into the local
   // sideset_var_names data structure.
   this->read_var_names(NODESET);
@@ -4032,6 +4069,8 @@ void ExodusII_IO_Helper::write_element_values
  int timestep,
  const std::vector<std::set<subdomain_id_type>> & vars_active_subdomains)
 {
+  LOG_SCOPE("write_element_values()", "ExodusII_IO_Helper");
+
   if ((_run_only_on_proc0) && (this->processor_id() != 0))
     return;
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -917,22 +917,6 @@ std::string MeshBase::get_info(const unsigned int verbosity /* = 0 */, const boo
       oss << "}\n";
     }
 
-  if (!_elemset_codes.empty())
-    {
-      // We don't print the inverse map since that is maintained as an
-      // internal implementation detail for fast lookups and is not
-      // really user-facing information.
-      oss << "  elemset_codes()={";
-      for (const auto & [set_code, id_set] : _elemset_codes)
-        {
-          oss << set_code << ": ";
-          for (const auto & id : *id_set)
-            oss << id << " ";
-          oss << "\n";
-        }
-      oss << "}\n";
-    }
-
   oss << "  spatial_dimension()="     << this->spatial_dimension()                            << '\n'
       << "  n_nodes()="               << this->n_nodes()                                      << '\n'
       << "    n_local_nodes()="       << this->n_local_nodes()                                << '\n'
@@ -945,6 +929,9 @@ std::string MeshBase::get_info(const unsigned int verbosity /* = 0 */, const boo
     oss << "  n_subdomains()="        << static_cast<std::size_t>(this->n_subdomains())       << '\n';
   else
     oss << "  n_local_subdomains()= " << static_cast<std::size_t>(this->n_local_subdomains()) << '\n';
+  oss << "  n_elemsets()="            << static_cast<std::size_t>(this->n_elemsets())         << '\n';
+  if (!_elemset_codes.empty())
+    oss << "    n_elemset_codes="     << _elemset_codes.size()                                << '\n';
   oss << "  n_partitions()="          << static_cast<std::size_t>(this->n_partitions())       << '\n'
       << "  n_processors()="          << static_cast<std::size_t>(this->n_processors())       << '\n'
       << "  n_threads()="             << static_cast<std::size_t>(libMesh::n_threads())       << '\n'


### PR DESCRIPTION
We previously had almost no logging of the various Exodus APIs, so this PR adds some coarse-grained logging. This PR originally started out as an investigation into whether our current approach of calling `read_elemset()` once per elemset in cases with many elemsets was a performance bottleneck, but that seems to not be the case:
```
| ExodusII_IO_Helper                                                                                                                     |
|   read_all_nodesets()                                     4          2.1745      0.543623    2.1745      0.543623    0.52     0.52     |
|   read_edge_blocks()                                      4          0.0000      0.000000    0.0000      0.000000    0.00     0.00     |
|   read_elem_in_block()                                    8          0.0009      0.000112    0.0009      0.000112    0.00     0.00     |
|   read_elemset()                                          7128       0.1349      0.000019    0.1349      0.000019    0.03     0.03     |
|   read_nodes()                                            4          0.0012      0.000295    0.0012      0.000295    0.00     0.00     |
|   write_elements()                                        2          1.9762      0.988082    1.9762      0.988082    0.47     0.47     |
|   write_elemsets()                                        2          0.5212      0.260593    0.5212      0.260593    0.13     0.13     |
|   write_nodesets()                                        2          3.3294      1.664696    3.3294      1.664696    0.80     0.80     |
|   write_sidesets()                                        2          0.0000      0.000002    0.0000      0.000002    0.00     0.00     |
|                                                                                                                                        |
```

We also realized that the elemset output in `MeshBase::get_info()` was way too cluttered in the many-elemset case, so I've pared it back to just printing out the number of elemsets and (if applicable) the number of unique elemset codes in the info string.
