### PR TITLE
Fix edge cases in preconditioner reuse

### DIFF
--- a/include/solvers/nonlinear_solver.h
+++ b/include/solvers/nonlinear_solver.h
@@ -365,14 +365,14 @@ public:
   virtual void set_reuse_preconditioner(bool reuse);
 
   /**
-   *  Get the reuse_preconditioner_max_its parameter
+   *  Get the reuse_preconditioner_max_linear_its parameter
    */
-  virtual unsigned int reuse_preconditioner_max_its() const;
+  virtual unsigned int reuse_preconditioner_max_linear_its() const;
 
   /**
-   *  Set the reuse_preconditioner_max_its parameter
+   *  Set the reuse_preconditioner_max_linear_its parameter
    */
-  virtual void set_reuse_preconditioner_max_its(unsigned int i);
+  virtual void set_reuse_preconditioner_max_linear_its(unsigned int i);
 
   /**
    * Immediately force a new preconditioner
@@ -389,7 +389,7 @@ protected:
   /**
    * Number of linear iterations to retain the preconditioner
    */
-  unsigned int _reuse_preconditioner_max_its;
+  unsigned int _reuse_preconditioner_max_linear_its;
 
   /**
    * A reference to the system we are solving.
@@ -452,7 +452,7 @@ NonlinearSolver<T>::NonlinearSolver (sys_type & s) :
   minimum_linear_tolerance(0),
   converged(false),
   _reuse_preconditioner(false),
-  _reuse_preconditioner_max_its(0),
+  _reuse_preconditioner_max_linear_its(0),
   _system(s),
   _is_initialized (false),
   _preconditioner (nullptr),

--- a/include/solvers/nonlinear_solver.h
+++ b/include/solvers/nonlinear_solver.h
@@ -374,6 +374,11 @@ public:
    */
   virtual void set_reuse_preconditioner_max_its(unsigned int i);
 
+  /**
+   * Immediately force a new preconditioner
+   */
+  virtual void force_new_preconditioner() {};
+
 
 protected:
   /**

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -215,7 +215,7 @@ public:
   /**
    *  Getter for the maximum iterations flag for preconditioner reuse
    */
-  virtual unsigned int reuse_preconditioner_max_its() const override;
+  virtual unsigned int reuse_preconditioner_max_linear_its() const override;
 
   /**
    *  Immediately force a new preconditioner, even if reuse is set

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -287,11 +287,6 @@ protected:
     */
   bool _setup_reuse;
 
-  /**
-   *  Check on operator sizes to see if we need to get a new preconditioner
-   */
-  void check_reuse_operator_sizes(numeric_index_type new_size);
-
 private:
   friend ResidualContext libmesh_petsc_snes_residual_helper (SNES snes, Vec x, void * ctx);
   friend PetscErrorCode libmesh_petsc_snes_residual (SNES snes, Vec x, Vec r, void * ctx);

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -217,6 +217,11 @@ public:
    */
   virtual unsigned int reuse_preconditioner_max_its() const override;
 
+  /**
+   *  Immediately force a new preconditioner, even if reuse is set
+   */
+  virtual void force_new_preconditioner() override;
+
 protected:
 
   /**
@@ -281,6 +286,11 @@ protected:
     * Whether we've triggered the preconditioner reuse
     */
   bool _setup_reuse;
+
+  /**
+   *  Check on operator sizes to see if we need to get a new preconditioner
+   */
+  void check_reuse_operator_sizes(numeric_index_type new_size);
 
 private:
   friend ResidualContext libmesh_petsc_snes_residual_helper (SNES snes, Vec x, void * ctx);

--- a/src/solvers/nonlinear_solver.C
+++ b/src/solvers/nonlinear_solver.C
@@ -97,15 +97,15 @@ void NonlinearSolver<T>::set_reuse_preconditioner(bool reuse)
 }
 
 template <typename T>
-unsigned int NonlinearSolver<T>::reuse_preconditioner_max_its() const
+unsigned int NonlinearSolver<T>::reuse_preconditioner_max_linear_its() const
 {
   libmesh_not_implemented();
 }
 
 template <typename T>
-void NonlinearSolver<T>::set_reuse_preconditioner_max_its(unsigned int i)
+void NonlinearSolver<T>::set_reuse_preconditioner_max_linear_its(unsigned int i)
 {
-  _reuse_preconditioner_max_its = i;
+  _reuse_preconditioner_max_linear_its = i;
 }
 
 //------------------------------------------------------------------

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -682,8 +682,6 @@ void PetscNonlinearSolver<T>::clear ()
     }
 }
 
-
-
 template <typename T>
 void PetscNonlinearSolver<T>::init (const char * name)
 {
@@ -855,6 +853,9 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  pre_in,  // System Preconditi
   LOG_SCOPE("solve()", "PetscNonlinearSolver");
   this->init ();
 
+  // Backup check on the size of the stored preconditioner to see if the
+  // problem size has changed.  If so do not use the stored preconditioner.
+  check_reuse_operator_sizes(x_in.size());
 
   // Make sure the data passed in are really of Petsc types
   PetscMatrix<T> * pre = cast_ptr<PetscMatrix<T> *>(&pre_in);
@@ -1134,6 +1135,48 @@ unsigned int PetscNonlinearSolver<T>::reuse_preconditioner_max_its() const
   return this->_reuse_preconditioner_max_its;
 }
 
+template <typename T>
+void PetscNonlinearSolver<T>::force_new_preconditioner()
+{
+  // Easiest way is just to clear everything out
+  this->_is_initialized = false;
+  _snes.destroy();
+  _setup_reuse = false;
+}
+
+template <typename T>
+void PetscNonlinearSolver<T>::check_reuse_operator_sizes(numeric_index_type new_size)
+{
+  // There are some special cases where libmesh won't know the
+  // operator size has changed (for example, problems involving
+  // variational inequalities).  This check will force a new
+  // preconditioner if the operator sizes has changed, regardless
+  // of what libmesh itself knows about the problem
+  //
+  if (!(this->_reuse_preconditioner) || !(this->_is_initialized))
+    return;
+
+  if (!_setup_reuse)
+    return;
+
+  KSP ksp;
+  PetscErrorCode ierr = SNESGetKSP(_snes, &ksp);
+  LIBMESH_CHKERR(ierr);
+  Mat A;
+  Mat P;
+  ierr = KSPGetOperators(ksp, &A, &P);
+  LIBMESH_CHKERR(ierr);
+
+  PetscInt Pm, Pn;
+  ierr = MatGetSize(A, &Pm, &Pn);
+  LIBMESH_CHKERR(ierr);
+
+  if ((unsigned) Pn != new_size)
+    {
+      this->force_new_preconditioner();
+      this->init();
+    }
+}
 
 //------------------------------------------------------------------
 // Explicit instantiations

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -1153,15 +1153,22 @@ void PetscNonlinearSolver<T>::check_reuse_operator_sizes(numeric_index_type new_
   // preconditioner if the operator sizes has changed, regardless
   // of what libmesh itself knows about the problem
   //
-  if (!(this->_reuse_preconditioner) || !(this->_is_initialized))
+  if (!(this->_reuse_preconditioner) ||
+      !(this->_is_initialized) ||
+      !(_setup_reuse))
     return;
 
-  if (!_setup_reuse)
-    return;
 
   KSP ksp;
   PetscErrorCode ierr = SNESGetKSP(_snes, &ksp);
   LIBMESH_CHKERR(ierr);
+
+  PetscBool setup_A, setup_P;
+  ierr = KSPGetOperatorsSet(ksp, &setup_A, &setup_P);
+  LIBMESH_CHKERR(ierr);
+  if (!(setup_A && setup_P))
+    return;
+
   Mat A;
   Mat P;
   ierr = KSPGetOperators(ksp, &A, &P);

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -126,7 +126,7 @@ extern "C"
     ierr = KSPGetIterationNumber(ksp, &niter);
     LIBMESH_CHKERR2(solver->comm(),ierr);
 
-    if (niter > cast_int<PetscInt>(solver->reuse_preconditioner_max_its()))
+    if (niter > cast_int<PetscInt>(solver->reuse_preconditioner_max_linear_its()))
     {
       // -2 is a magic number for "recalculate next time you need it
       // and then not again"
@@ -875,7 +875,7 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  pre_in,  // System Preconditi
       ierr = SNESSetLagPreconditioner(_snes, -2);
       LIBMESH_CHKERR(ierr);
       // Add in our callback which will trigger recalculating
-      // the preconditioner when we hit reuse_preconditioner_max_its
+      // the preconditioner when we hit reuse_preconditioner_max_linear_its
       ierr = SNESMonitorSet(_snes, &libmesh_petsc_recalculate_monitor,
                             this,
                             NULL);
@@ -1126,9 +1126,9 @@ bool PetscNonlinearSolver<T>::reuse_preconditioner() const
 }
 
 template <typename T>
-unsigned int PetscNonlinearSolver<T>::reuse_preconditioner_max_its() const
+unsigned int PetscNonlinearSolver<T>::reuse_preconditioner_max_linear_its() const
 {
-  return this->_reuse_preconditioner_max_its;
+  return this->_reuse_preconditioner_max_linear_its;
 }
 
 template <typename T>

--- a/src/systems/nonlinear_implicit_system.C
+++ b/src/systems/nonlinear_implicit_system.C
@@ -82,6 +82,10 @@ void NonlinearImplicitSystem::reinit ()
   // re-initialize the nonlinear solver interface
   nonlinear_solver->clear();
 
+  // force the solver to get a new preconditioner, in
+  // case reuse was set
+  nonlinear_solver->force_new_preconditioner();
+
   // FIXME - this is necessary for petsc_auto_fieldsplit
   // nonlinear_solver->init_names(*this);
 

--- a/src/systems/nonlinear_implicit_system.C
+++ b/src/systems/nonlinear_implicit_system.C
@@ -54,7 +54,7 @@ NonlinearImplicitSystem::NonlinearImplicitSystem (EquationSystems & es,
   es.parameters.set<Real>("nonlinear solver relative step tolerance") = 1e-8;
 
   es.parameters.set<bool>("reuse preconditioner") = false;
-  es.parameters.set<unsigned int>("reuse preconditioner maximum iterations") = 1;
+  es.parameters.set<unsigned int>("reuse preconditioner maximum linear iterations") = 1;
 }
 
 
@@ -138,8 +138,8 @@ void NonlinearImplicitSystem::set_solver_parameters ()
 
   const bool reuse_preconditioner =
       es.parameters.get<bool>("reuse preconditioner");
-  const unsigned int reuse_preconditioner_max_its =
-      es.parameters.get<unsigned int>("reuse preconditioner maximum iterations");
+  const unsigned int reuse_preconditioner_max_linear_its =
+      es.parameters.get<unsigned int>("reuse preconditioner maximum linear iterations");
 
   // Set all the parameters on the NonlinearSolver
   nonlinear_solver->max_nonlinear_iterations = maxits;
@@ -153,7 +153,7 @@ void NonlinearImplicitSystem::set_solver_parameters ()
   nonlinear_solver->initial_linear_tolerance = linear_tol;
   nonlinear_solver->minimum_linear_tolerance = linear_min_tol;
   nonlinear_solver->set_reuse_preconditioner(reuse_preconditioner);
-  nonlinear_solver->set_reuse_preconditioner_max_its(reuse_preconditioner_max_its);
+  nonlinear_solver->set_reuse_preconditioner_max_linear_its(reuse_preconditioner_max_linear_its);
 
   if (diff_solver.get())
     {


### PR DESCRIPTION
There are a few edge cases in the new preconditioner_reuse feature:

1. libmesh doesn't make a new preconditioner when the size of the system changes because of mesh refinement.  This is easy to trigger by forcing a new preconditioner in `NonlinearImplicitSystem::reinit ()`
2. petsc doesn't make a new preconditioner when the size of the system changes in the course of solving a variational inequality problem.  This kind of feels like a petsc issue, but it's possible to address in libmesh by checking the size of the system of equations and making a new preconditioner if it differences from the last time through.