### PR TITLE
More code deduplication

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1585,6 +1585,18 @@ private:
                                          MeshBase & mesh);
 
   /*
+   * Helper method for the above two to count + distriubte SCALAR dofs
+   */
+  void distribute_scalar_dofs (dof_id_type & next_free_dof);
+
+#ifdef DEBUG
+  /*
+   * Internal assertions for distribute_local_dofs_*
+   */
+  void assert_no_nodes_missed(MeshBase & mesh);
+#endif
+
+  /*
    * A utility method for obtaining a set of elements to ghost along
    * with merged coupling matrices.
    */

--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -354,6 +354,14 @@ protected:
                                        const std::set<subdomain_id_type> * subdomain_ids = nullptr) const;
 
   /**
+   * Helper function for finding a gradient as evaluated from a
+   * specific element
+   */
+  void _gradient_on_elem (const Point & p,
+                          const Elem * element,
+                          std::vector<Gradient> & output);
+
+  /**
    * The equation systems handler, from which
    * the data are gathered.
    */

--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -774,6 +774,13 @@ private:
    */
   template <typename T2>
   void _left_multiply_transpose (const DenseMatrix<T2> & A);
+
+  /**
+   * Right multiplies by the transpose of the matrix \p A which
+   * may contain a different numerical type.
+   */
+  template <typename T2>
+  void _right_multiply_transpose (const DenseMatrix<T2> & A);
 };
 
 

--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -767,6 +767,13 @@ private:
                     DenseVector<T> & dest,
                     const DenseVector<T> & arg,
                     bool trans=false) const;
+
+  /**
+   * Left multiplies by the transpose of the matrix \p A which
+   * may contain a different numerical type.
+   */
+  template <typename T2>
+  void _left_multiply_transpose (const DenseMatrix<T2> & A);
 };
 
 

--- a/include/numerics/dense_matrix_impl.h
+++ b/include/numerics/dense_matrix_impl.h
@@ -95,68 +95,21 @@ void DenseMatrix<T>::left_multiply_transpose(const DenseMatrix<T> & A)
   if (this->use_blas_lapack)
     this->_multiply_blas(A, LEFT_MULTIPLY_TRANSPOSE);
   else
-    {
-      //Check to see if we are doing (A^T)*A
-      if (this == &A)
-        {
-          //libmesh_here();
-          DenseMatrix<T> B(*this);
-
-          // Simple but inefficient way
-          // return this->left_multiply_transpose(B);
-
-          // More efficient, but more code way
-          // If A is mxn, the result will be a square matrix of Size n x n.
-          const unsigned int n_rows = A.m();
-          const unsigned int n_cols = A.n();
-
-          // resize() *this and also zero out all entries.
-          this->resize(n_cols,n_cols);
-
-          // Compute the lower-triangular part
-          for (unsigned int i=0; i<n_cols; ++i)
-            for (unsigned int j=0; j<=i; ++j)
-              for (unsigned int k=0; k<n_rows; ++k) // inner products are over n_rows
-                (*this)(i,j) += B(k,i)*B(k,j);
-
-          // Copy lower-triangular part into upper-triangular part
-          for (unsigned int i=0; i<n_cols; ++i)
-            for (unsigned int j=i+1; j<n_cols; ++j)
-              (*this)(i,j) = (*this)(j,i);
-        }
-
-      else
-        {
-          DenseMatrix<T> B(*this);
-
-          this->resize (A.n(), B.n());
-
-          libmesh_assert_equal_to (A.m(), B.m());
-          libmesh_assert_equal_to (this->m(), A.n());
-          libmesh_assert_equal_to (this->n(), B.n());
-
-          const unsigned int m_s = A.n();
-          const unsigned int p_s = A.m();
-          const unsigned int n_s = this->n();
-
-          // Do it this way because there is a
-          // decent chance (at least for constraint matrices)
-          // that A.transpose(i,k) = 0.
-          for (unsigned int i=0; i<m_s; i++)
-            for (unsigned int k=0; k<p_s; k++)
-              if (A.transpose(i,k) != 0.)
-                for (unsigned int j=0; j<n_s; j++)
-                  (*this)(i,j) += A.transpose(i,k)*B(k,j);
-        }
-    }
-
+    this->_left_multiply_transpose(A);
 }
-
 
 
 template<typename T>
 template<typename T2>
 void DenseMatrix<T>::left_multiply_transpose(const DenseMatrix<T2> & A)
+{
+  this->_left_multiply_transpose(A);
+}
+
+
+template<typename T>
+template<typename T2>
+void DenseMatrix<T>::_left_multiply_transpose(const DenseMatrix<T2> & A)
 {
   //Check to see if we are doing (A^T)*A
   if (this == &A)

--- a/include/numerics/dense_matrix_impl.h
+++ b/include/numerics/dense_matrix_impl.h
@@ -220,60 +220,7 @@ void DenseMatrix<T>::right_multiply_transpose (const DenseMatrix<T> & B)
   if (this->use_blas_lapack)
     this->_multiply_blas(B, RIGHT_MULTIPLY_TRANSPOSE);
   else
-    {
-      //Check to see if we are doing B*(B^T)
-      if (this == &B)
-        {
-          //libmesh_here();
-          DenseMatrix<T> A(*this);
-
-          // Simple but inefficient way
-          // return this->right_multiply_transpose(A);
-
-          // More efficient, more code
-          // If B is mxn, the result will be a square matrix of Size m x m.
-          const unsigned int n_rows = B.m();
-          const unsigned int n_cols = B.n();
-
-          // resize() *this and also zero out all entries.
-          this->resize(n_rows,n_rows);
-
-          // Compute the lower-triangular part
-          for (unsigned int i=0; i<n_rows; ++i)
-            for (unsigned int j=0; j<=i; ++j)
-              for (unsigned int k=0; k<n_cols; ++k) // inner products are over n_cols
-                (*this)(i,j) += A(i,k)*A(j,k);
-
-          // Copy lower-triangular part into upper-triangular part
-          for (unsigned int i=0; i<n_rows; ++i)
-            for (unsigned int j=i+1; j<n_rows; ++j)
-              (*this)(i,j) = (*this)(j,i);
-        }
-
-      else
-        {
-          DenseMatrix<T> A(*this);
-
-          this->resize (A.m(), B.m());
-
-          libmesh_assert_equal_to (A.n(), B.n());
-          libmesh_assert_equal_to (this->m(), A.m());
-          libmesh_assert_equal_to (this->n(), B.m());
-
-          const unsigned int m_s = A.m();
-          const unsigned int p_s = A.n();
-          const unsigned int n_s = this->n();
-
-          // Do it this way because there is a
-          // decent chance (at least for constraint matrices)
-          // that B.transpose(k,j) = 0.
-          for (unsigned int j=0; j<n_s; j++)
-            for (unsigned int k=0; k<p_s; k++)
-              if (B.transpose(k,j) != 0.)
-                for (unsigned int i=0; i<m_s; i++)
-                  (*this)(i,j) += A(i,k)*B.transpose(k,j);
-        }
-    }
+    this->_right_multiply_transpose(B);
 }
 
 
@@ -281,6 +228,15 @@ void DenseMatrix<T>::right_multiply_transpose (const DenseMatrix<T> & B)
 template<typename T>
 template<typename T2>
 void DenseMatrix<T>::right_multiply_transpose (const DenseMatrix<T2> & B)
+{
+  this->_right_multiply_transpose(B);
+}
+
+
+
+template<typename T>
+template<typename T2>
+void DenseMatrix<T>::_right_multiply_transpose (const DenseMatrix<T2> & B)
 {
   //Check to see if we are doing B*(B^T)
   if (this == &B)

--- a/include/solvers/petsc_linear_solver.h
+++ b/include/solvers/petsc_linear_solver.h
@@ -279,11 +279,25 @@ private:
    */
   virtual std::pair<unsigned int, Real>
   shell_solve_common (const ShellMatrix<T> & shell_matrix,
-                      const PetscMatrix<T> * precond_matrix,
+                      PetscMatrix<T> * precond_matrix,
                       NumericVector<T> & solution_in,
                       NumericVector<T> & rhs_in,
                       const double tol,
                       const unsigned int m_its);
+
+  /*
+   * Helper function for the helper functions
+   */
+  std::pair<unsigned int, Real>
+  solve_base (SparseMatrix<T> * matrix,
+              PetscMatrix<T> * precond,
+              Mat mat,
+              NumericVector<T> & solution_in,
+              NumericVector<T> & rhs_in,
+              const double tol,
+              const unsigned int m_its,
+              ksp_solve_func_type solve_func);
+
 
   /**
    * Tells PETSC to use the user-specified solver stored in

--- a/include/utils/xdr_cxx.h
+++ b/include/utils/xdr_cxx.h
@@ -36,12 +36,10 @@
 #include "libmesh/restore_warnings.h"
 #endif
 
+#include <complex>
 #include <iosfwd>
 #include <vector>
 #include <string>
-#ifdef LIBMESH_USE_COMPLEX_NUMBERS
-# include <complex>
-#endif
 
 const unsigned int xdr_MAX_STRING_LENGTH=256;
 
@@ -196,6 +194,13 @@ private:
 
   template <typename T>
   void do_write(std::vector<std::complex<T>> & a);
+
+  /**
+   * Helper method for complex types
+   */
+  template <typename T>
+  void _complex_data_stream (std::complex<T> * val, const unsigned int len,
+                             const unsigned int line_break);
 
   /**
    * Helper method for extended FP types

--- a/include/utils/xdr_cxx.h
+++ b/include/utils/xdr_cxx.h
@@ -202,6 +202,12 @@ private:
    */
   template <typename XFP>
   void _xfp_data_stream (XFP * val, const unsigned int len,
+#ifdef LIBMESH_HAVE_XDR
+                         xdrproc_t
+#else
+                         void *
+#endif
+                           xdr_proc,
                          const unsigned int line_break,
                          const int n_digits);
 

--- a/include/utils/xdr_cxx.h
+++ b/include/utils/xdr_cxx.h
@@ -198,6 +198,14 @@ private:
   void do_write(std::vector<std::complex<T>> & a);
 
   /**
+   * Helper method for extended FP types
+   */
+  template <typename XFP>
+  void _xfp_data_stream (XFP * val, const unsigned int len,
+                         const unsigned int line_break,
+                         const int n_digits);
+
+  /**
    * The mode used for accessing the file.
    */
   const XdrMODE mode;

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -322,212 +322,104 @@ std::unique_ptr<FEAbstract> FEAbstract::build(const unsigned int dim,
 
 void FEAbstract::get_refspace_nodes(const ElemType itemType, std::vector<Point> & nodes)
 {
+  nodes.resize(Elem::type_to_n_nodes_map[itemType]);
   switch(itemType)
     {
     case NODEELEM:
       {
-        nodes.resize(1);
         nodes[0] = Point (0.,0.,0.);
-        return;
-      }
-    case EDGE2:
-      {
-        nodes.resize(2);
-        nodes[0] = Point (-1.,0.,0.);
-        nodes[1] = Point (1.,0.,0.);
         return;
       }
     case EDGE3:
       {
-        nodes.resize(3);
+        nodes[2] = Point (0.,0.,0.);
+        libmesh_fallthrough();
+      }
+    case EDGE2:
+      {
         nodes[0] = Point (-1.,0.,0.);
         nodes[1] = Point (1.,0.,0.);
-        nodes[2] = Point (0.,0.,0.);
         return;
       }
-    case EDGE4:
+    case EDGE4: // not nested with EDGE3
       {
-        nodes.resize(4);
         nodes[0] = Point (-1.,0.,0.);
         nodes[1] = Point (1.,0.,0.);
         nodes[2] = Point (-1./3.,0.,0.);
         nodes[3] - Point (1./3.,0.,0.);
         return;
       }
-    case TRI3:
-    case TRISHELL3:
+    case TRI7:
       {
-        nodes.resize(3);
-        nodes[0] = Point (0.,0.,0.);
-        nodes[1] = Point (1.,0.,0.);
-        nodes[2] = Point (0.,1.,0.);
-        return;
+        nodes[6] = Point (1./3.,1./3.,0.);
+        libmesh_fallthrough();
       }
     case TRI6:
       {
-        nodes.resize(6);
-        nodes[0] = Point (0.,0.,0.);
-        nodes[1] = Point (1.,0.,0.);
-        nodes[2] = Point (0.,1.,0.);
         nodes[3] = Point (.5,0.,0.);
         nodes[4] = Point (.5,.5,0.);
         nodes[5] = Point (0.,.5,0.);
-        return;
+        libmesh_fallthrough();
       }
-    case TRI7:
+    case TRI3:
+    case TRISHELL3:
       {
-        nodes.resize(7);
         nodes[0] = Point (0.,0.,0.);
         nodes[1] = Point (1.,0.,0.);
         nodes[2] = Point (0.,1.,0.);
-        nodes[3] = Point (.5,0.,0.);
-        nodes[4] = Point (.5,.5,0.);
-        nodes[5] = Point (0.,.5,0.);
-        nodes[6] = Point (1./3.,1./3.,0.);
-        return;
-      }
-    case QUAD4:
-    case QUADSHELL4:
-      {
-        nodes.resize(4);
-        nodes[0] = Point (-1.,-1.,0.);
-        nodes[1] = Point (1.,-1.,0.);
-        nodes[2] = Point (1.,1.,0.);
-        nodes[3] = Point (-1.,1.,0.);
-        return;
-      }
-    case QUAD8:
-    case QUADSHELL8:
-      {
-        nodes.resize(8);
-        nodes[0] = Point (-1.,-1.,0.);
-        nodes[1] = Point (1.,-1.,0.);
-        nodes[2] = Point (1.,1.,0.);
-        nodes[3] = Point (-1.,1.,0.);
-        nodes[4] = Point (0.,-1.,0.);
-        nodes[5] = Point (1.,0.,0.);
-        nodes[6] = Point (0.,1.,0.);
-        nodes[7] = Point (-1.,0.,0.);
         return;
       }
     case QUAD9:
       {
-        nodes.resize(9);
-        nodes[0] = Point (-1.,-1.,0.);
-        nodes[1] = Point (1.,-1.,0.);
-        nodes[2] = Point (1.,1.,0.);
-        nodes[3] = Point (-1.,1.,0.);
+        nodes[8] = Point (0.,0.,0.);
+        libmesh_fallthrough();
+      }
+    case QUAD8:
+    case QUADSHELL8:
+      {
         nodes[4] = Point (0.,-1.,0.);
         nodes[5] = Point (1.,0.,0.);
         nodes[6] = Point (0.,1.,0.);
         nodes[7] = Point (-1.,0.,0.);
-        nodes[8] = Point (0.,0.,0.);
-        return;
+        libmesh_fallthrough();
       }
-    case TET4:
+    case QUAD4:
+    case QUADSHELL4:
       {
-        nodes.resize(4);
-        nodes[0] = Point (0.,0.,0.);
-        nodes[1] = Point (1.,0.,0.);
-        nodes[2] = Point (0.,1.,0.);
-        nodes[3] = Point (0.,0.,1.);
-        return;
-      }
-    case TET10:
-      {
-        nodes.resize(10);
-        nodes[0] = Point (0.,0.,0.);
-        nodes[1] = Point (1.,0.,0.);
-        nodes[2] = Point (0.,1.,0.);
-        nodes[3] = Point (0.,0.,1.);
-        nodes[4] = Point (.5,0.,0.);
-        nodes[5] = Point (.5,.5,0.);
-        nodes[6] = Point (0.,.5,0.);
-        nodes[7] = Point (0.,0.,.5);
-        nodes[8] = Point (.5,0.,.5);
-        nodes[9] = Point (0.,.5,.5);
+        nodes[0] = Point (-1.,-1.,0.);
+        nodes[1] = Point (1.,-1.,0.);
+        nodes[2] = Point (1.,1.,0.);
+        nodes[3] = Point (-1.,1.,0.);
         return;
       }
     case TET14:
       {
-        nodes.resize(14);
-        nodes[0] = Point (0.,0.,0.);
-        nodes[1] = Point (1.,0.,0.);
-        nodes[2] = Point (0.,1.,0.);
-        nodes[3] = Point (0.,0.,1.);
+        nodes[10] = Point (1/Real(3),1/Real(3),0.);
+        nodes[11] = Point (1/Real(3),0.,1/Real(3));
+        nodes[12] = Point (1/Real(3),1/Real(3),1/Real(3));
+        nodes[13] = Point (0.,1/Real(3),1/Real(3));
+        libmesh_fallthrough();
+      }
+    case TET10:
+      {
         nodes[4] = Point (.5,0.,0.);
         nodes[5] = Point (.5,.5,0.);
         nodes[6] = Point (0.,.5,0.);
         nodes[7] = Point (0.,0.,.5);
         nodes[8] = Point (.5,0.,.5);
         nodes[9] = Point (0.,.5,.5);
-        nodes[10] = Point (1/Real(3),1/Real(3),0.);
-        nodes[11] = Point (1/Real(3),0.,1/Real(3));
-        nodes[12] = Point (1/Real(3),1/Real(3),1/Real(3));
-        nodes[13] = Point (0.,1/Real(3),1/Real(3));
-        return;
+        libmesh_fallthrough();
       }
-    case HEX8:
+    case TET4:
       {
-        nodes.resize(8);
-        nodes[0] = Point (-1.,-1.,-1.);
-        nodes[1] = Point (1.,-1.,-1.);
-        nodes[2] = Point (1.,1.,-1.);
-        nodes[3] = Point (-1.,1.,-1.);
-        nodes[4] = Point (-1.,-1.,1.);
-        nodes[5] = Point (1.,-1.,1.);
-        nodes[6] = Point (1.,1.,1.);
-        nodes[7] = Point (-1.,1.,1.);
-        return;
-      }
-    case HEX20:
-      {
-        nodes.resize(20);
-        nodes[0] = Point (-1.,-1.,-1.);
-        nodes[1] = Point (1.,-1.,-1.);
-        nodes[2] = Point (1.,1.,-1.);
-        nodes[3] = Point (-1.,1.,-1.);
-        nodes[4] = Point (-1.,-1.,1.);
-        nodes[5] = Point (1.,-1.,1.);
-        nodes[6] = Point (1.,1.,1.);
-        nodes[7] = Point (-1.,1.,1.);
-        nodes[8] = Point (0.,-1.,-1.);
-        nodes[9] = Point (1.,0.,-1.);
-        nodes[10] = Point (0.,1.,-1.);
-        nodes[11] = Point (-1.,0.,-1.);
-        nodes[12] = Point (-1.,-1.,0.);
-        nodes[13] = Point (1.,-1.,0.);
-        nodes[14] = Point (1.,1.,0.);
-        nodes[15] = Point (-1.,1.,0.);
-        nodes[16] = Point (0.,-1.,1.);
-        nodes[17] = Point (1.,0.,1.);
-        nodes[18] = Point (0.,1.,1.);
-        nodes[19] = Point (-1.,0.,1.);
+        nodes[0] = Point (0.,0.,0.);
+        nodes[1] = Point (1.,0.,0.);
+        nodes[2] = Point (0.,1.,0.);
+        nodes[3] = Point (0.,0.,1.);
         return;
       }
     case HEX27:
       {
-        nodes.resize(27);
-        nodes[0] = Point (-1.,-1.,-1.);
-        nodes[1] = Point (1.,-1.,-1.);
-        nodes[2] = Point (1.,1.,-1.);
-        nodes[3] = Point (-1.,1.,-1.);
-        nodes[4] = Point (-1.,-1.,1.);
-        nodes[5] = Point (1.,-1.,1.);
-        nodes[6] = Point (1.,1.,1.);
-        nodes[7] = Point (-1.,1.,1.);
-        nodes[8] = Point (0.,-1.,-1.);
-        nodes[9] = Point (1.,0.,-1.);
-        nodes[10] = Point (0.,1.,-1.);
-        nodes[11] = Point (-1.,0.,-1.);
-        nodes[12] = Point (-1.,-1.,0.);
-        nodes[13] = Point (1.,-1.,0.);
-        nodes[14] = Point (1.,1.,0.);
-        nodes[15] = Point (-1.,1.,0.);
-        nodes[16] = Point (0.,-1.,1.);
-        nodes[17] = Point (1.,0.,1.);
-        nodes[18] = Point (0.,1.,1.);
-        nodes[19] = Point (-1.,0.,1.);
         nodes[20] = Point (0.,0.,-1.);
         nodes[21] = Point (0.,-1.,0.);
         nodes[22] = Point (1.,0.,0.);
@@ -535,48 +427,45 @@ void FEAbstract::get_refspace_nodes(const ElemType itemType, std::vector<Point> 
         nodes[24] = Point (-1.,0.,0.);
         nodes[25] = Point (0.,0.,1.);
         nodes[26] = Point (0.,0.,0.);
-        return;
+        libmesh_fallthrough();
       }
-    case PRISM6:
+    case HEX20:
       {
-        nodes.resize(6);
-        nodes[0] = Point (0.,0.,-1.);
-        nodes[1] = Point (1.,0.,-1.);
-        nodes[2] = Point (0.,1.,-1.);
-        nodes[3] = Point (0.,0.,1.);
-        nodes[4] = Point (1.,0.,1.);
-        nodes[5] = Point (0.,1.,1.);
-        return;
+        nodes[8] = Point (0.,-1.,-1.);
+        nodes[9] = Point (1.,0.,-1.);
+        nodes[10] = Point (0.,1.,-1.);
+        nodes[11] = Point (-1.,0.,-1.);
+        nodes[12] = Point (-1.,-1.,0.);
+        nodes[13] = Point (1.,-1.,0.);
+        nodes[14] = Point (1.,1.,0.);
+        nodes[15] = Point (-1.,1.,0.);
+        nodes[16] = Point (0.,-1.,1.);
+        nodes[17] = Point (1.,0.,1.);
+        nodes[18] = Point (0.,1.,1.);
+        nodes[19] = Point (-1.,0.,1.);
+        libmesh_fallthrough();
       }
-    case PRISM15:
+    case HEX8:
       {
-        nodes.resize(15);
-        nodes[0] = Point (0.,0.,-1.);
-        nodes[1] = Point (1.,0.,-1.);
-        nodes[2] = Point (0.,1.,-1.);
-        nodes[3] = Point (0.,0.,1.);
-        nodes[4] = Point (1.,0.,1.);
-        nodes[5] = Point (0.,1.,1.);
-        nodes[6] = Point (.5,0.,-1.);
-        nodes[7] = Point (.5,.5,-1.);
-        nodes[8] = Point (0.,.5,-1.);
-        nodes[9] = Point (0.,0.,0.);
-        nodes[10] = Point (1.,0.,0.);
-        nodes[11] = Point (0.,1.,0.);
-        nodes[12] = Point (.5,0.,1.);
-        nodes[13] = Point (.5,.5,1.);
-        nodes[14] = Point (0.,.5,1.);
+        nodes[0] = Point (-1.,-1.,-1.);
+        nodes[1] = Point (1.,-1.,-1.);
+        nodes[2] = Point (1.,1.,-1.);
+        nodes[3] = Point (-1.,1.,-1.);
+        nodes[4] = Point (-1.,-1.,1.);
+        nodes[5] = Point (1.,-1.,1.);
+        nodes[6] = Point (1.,1.,1.);
+        nodes[7] = Point (-1.,1.,1.);
         return;
       }
     case PRISM18:
       {
-        nodes.resize(18);
-        nodes[0] = Point (0.,0.,-1.);
-        nodes[1] = Point (1.,0.,-1.);
-        nodes[2] = Point (0.,1.,-1.);
-        nodes[3] = Point (0.,0.,1.);
-        nodes[4] = Point (1.,0.,1.);
-        nodes[5] = Point (0.,1.,1.);
+        nodes[15] = Point (.5,0.,0.);
+        nodes[16] = Point (.5,.5,0.);
+        nodes[17] = Point (0.,.5,0.);
+        libmesh_fallthrough();
+      }
+    case PRISM15:
+      {
         nodes[6] = Point (.5,0.,-1.);
         nodes[7] = Point (.5,.5,-1.);
         nodes[8] = Point (0.,.5,-1.);
@@ -586,61 +475,27 @@ void FEAbstract::get_refspace_nodes(const ElemType itemType, std::vector<Point> 
         nodes[12] = Point (.5,0.,1.);
         nodes[13] = Point (.5,.5,1.);
         nodes[14] = Point (0.,.5,1.);
-        nodes[15] = Point (.5,0.,0.);
-        nodes[16] = Point (.5,.5,0.);
-        nodes[17] = Point (0.,.5,0.);
-        return;
+        libmesh_fallthrough();
       }
-    case PYRAMID5:
+    case PRISM6:
       {
-        nodes.resize(5);
-        nodes[0] = Point (-1.,-1.,0.);
-        nodes[1] = Point (1.,-1.,0.);
-        nodes[2] = Point (1.,1.,0.);
-        nodes[3] = Point (-1.,1.,0.);
-        nodes[4] = Point (0.,0.,1.);
-        return;
-      }
-    case PYRAMID13:
-      {
-        nodes.resize(13);
-
-        // base corners
-        nodes[0] = Point (-1.,-1.,0.);
-        nodes[1] = Point (1.,-1.,0.);
-        nodes[2] = Point (1.,1.,0.);
-        nodes[3] = Point (-1.,1.,0.);
-
-        // apex
-        nodes[4] = Point (0.,0.,1.);
-
-        // base midedge
-        nodes[5] = Point (0.,-1.,0.);
-        nodes[6] = Point (1.,0.,0.);
-        nodes[7] = Point (0.,1.,0.);
-        nodes[8] = Point (-1,0.,0.);
-
-        // lateral midedge
-        nodes[9] = Point (-.5,-.5,.5);
-        nodes[10] = Point (.5,-.5,.5);
-        nodes[11] = Point (.5,.5,.5);
-        nodes[12] = Point (-.5,.5,.5);
-
+        nodes[0] = Point (0.,0.,-1.);
+        nodes[1] = Point (1.,0.,-1.);
+        nodes[2] = Point (0.,1.,-1.);
+        nodes[3] = Point (0.,0.,1.);
+        nodes[4] = Point (1.,0.,1.);
+        nodes[5] = Point (0.,1.,1.);
         return;
       }
     case PYRAMID14:
       {
-        nodes.resize(14);
+        // base center
+        nodes[13] = Point (0.,0.,0.);
 
-        // base corners
-        nodes[0] = Point (-1.,-1.,0.);
-        nodes[1] = Point (1.,-1.,0.);
-        nodes[2] = Point (1.,1.,0.);
-        nodes[3] = Point (-1.,1.,0.);
-
-        // apex
-        nodes[4] = Point (0.,0.,1.);
-
+        libmesh_fallthrough();
+      }
+    case PYRAMID13:
+      {
         // base midedge
         nodes[5] = Point (0.,-1.,0.);
         nodes[6] = Point (1.,0.,0.);
@@ -653,9 +508,17 @@ void FEAbstract::get_refspace_nodes(const ElemType itemType, std::vector<Point> 
         nodes[11] = Point (.5,.5,.5);
         nodes[12] = Point (-.5,.5,.5);
 
-        // base center
-        nodes[13] = Point (0.,0.,0.);
-
+        libmesh_fallthrough();
+      }
+    case PYRAMID5:
+      {
+        // base corners
+        nodes[0] = Point (-1.,-1.,0.);
+        nodes[1] = Point (1.,-1.,0.);
+        nodes[2] = Point (1.,1.,0.);
+        nodes[3] = Point (-1.,1.,0.);
+        // apex
+        nodes[4] = Point (0.,0.,1.);
         return;
       }
 

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -420,99 +420,9 @@ void MeshFunction::gradient (const Point & p,
   const Elem * element = this->find_element(p,subdomain_ids);
 
   if (!element)
-    {
-      output.resize(0);
-      return;
-    }
+    output.resize(0);
   else
-    {
-      // resize the output vector to the number of output values
-      // that the user told us
-      output.resize (this->_system_vars.size());
-
-
-      {
-        const unsigned int dim = element->dim();
-
-
-        /*
-         * Get local coordinates to feed these into compute_data().
-         * Note that the fe_type can safely be used from the 0-variable,
-         * since the inverse mapping is the same for all FEFamilies
-         */
-        const Point mapped_point (FEMap::inverse_map (dim, element,
-                                                      p));
-
-        std::vector<Point> point_list (1, mapped_point);
-
-        // loop over all vars
-        for (auto index : index_range(this->_system_vars))
-          {
-            /*
-             * the data for this variable
-             */
-            const unsigned int var = _system_vars[index];
-
-            if (var == libMesh::invalid_uint)
-              {
-                libmesh_assert (_out_of_mesh_mode &&
-                                index < _out_of_mesh_value.size());
-                output[index] = Gradient(_out_of_mesh_value(index));
-                continue;
-              }
-
-            const FEType & fe_type = this->_dof_map.variable_type(var);
-
-            // where the solution values for the var-th variable are stored
-            std::vector<dof_id_type> dof_indices;
-            this->_dof_map.dof_indices (element, dof_indices, var);
-
-            // interpolate the solution
-            Gradient grad(0.);
-#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
-            //The other algorithm works in case of finite elements as well,
-            //but this one is faster.
-            if (!element->infinite())
-              {
-#endif
-                std::unique_ptr<FEBase> point_fe (FEBase::build(dim, fe_type));
-                const std::vector<std::vector<RealGradient>> & dphi = point_fe->get_dphi();
-                point_fe->reinit(element, &point_list);
-
-                for (auto i : index_range(dof_indices))
-                  grad.add_scaled(dphi[i][0], this->_vector(dof_indices[i]));
-
-#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
-              }
-            else
-              {
-                /**
-                 * Build an FEComputeData that contains both input and output data
-                 * for the specific compute_data method.
-                 */
-                FEComputeData data (this->_eqn_systems, mapped_point);
-                data.enable_derivative();
-                FEInterface::compute_data (dim, fe_type, element, data);
-                //grad [x] = data.dshape[i](v) * dv/dx  * dof_index [i]
-                // sum over all indices
-                for (auto i : index_range(dof_indices))
-                  {
-                    // local coordinates
-                    for (std::size_t v=0; v<dim; v++)
-                      for (std::size_t xyz=0; xyz<LIBMESH_DIM; xyz++)
-                        {
-                          // FIXME: this needs better syntax: It is matrix-vector multiplication.
-                          grad(xyz) += data.local_transform[v][xyz]
-                            * data.dshape[i](v)
-                            * this->_vector(dof_indices[i]);
-                        }
-                  }
-              }
-#endif
-            output[index] = grad;
-          }
-      }
-    }
+    this->_gradient_on_elem(p, element, output);
 }
 
 
@@ -542,96 +452,110 @@ void MeshFunction::discontinuous_gradient (const Point & p,
   // empty map
   for (const auto & element : candidate_element)
     {
-      const unsigned int dim = element->dim();
-
       // define a temporary vector to store all values
       std::vector<Gradient> temp_output (cast_int<unsigned int>(this->_system_vars.size()));
 
-      /*
-       * Get local coordinates to feed these into compute_data().
-       * Note that the fe_type can safely be used from the 0-variable,
-       * since the inverse mapping is the same for all FEFamilies
-       */
-      const Point mapped_point (FEMap::inverse_map (dim, element, p));
-
-
-      // loop over all vars
-      std::vector<Point> point_list (1, mapped_point);
-      for (auto index : index_range(this->_system_vars))
-        {
-          /*
-           * the data for this variable
-           */
-          const unsigned int var = _system_vars[index];
-
-          if (var == libMesh::invalid_uint)
-            {
-              libmesh_assert (_out_of_mesh_mode &&
-                              index < _out_of_mesh_value.size());
-              temp_output[index] = Gradient(_out_of_mesh_value(index));
-              continue;
-            }
-
-          const FEType & fe_type = this->_dof_map.variable_type(var);
-
-          // where the solution values for the var-th variable are stored
-          std::vector<dof_id_type> dof_indices;
-          this->_dof_map.dof_indices (element, dof_indices, var);
-
-          Gradient grad(0.);
-
-          // for performance-reasons, we use different algorithms now.
-          // TODO: Check that both give the same result for finite elements.
-          // Otherwive it is wrong...
-#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
-          if (!element->infinite())
-            {
-#endif
-              std::unique_ptr<FEBase> point_fe (FEBase::build(dim, fe_type));
-              const std::vector<std::vector<RealGradient>> & dphi = point_fe->get_dphi();
-              point_fe->reinit(element, & point_list);
-
-              for (auto i : index_range(dof_indices))
-                grad.add_scaled(dphi[i][0], this->_vector(dof_indices[i]));
-#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
-            }
-          else
-            {
-              /**
-               * Build an FEComputeData that contains both input and output data
-               * for the specific compute_data method.
-               */
-              //TODO: enable this for a vector of points as well...
-              FEComputeData data (this->_eqn_systems, mapped_point);
-              data.enable_derivative();
-              FEInterface::compute_data (dim, fe_type, element, data);
-
-              //grad [x] = data.dshape[i](v) * dv/dx  * dof_index [i]
-              // sum over all indices
-              for (auto i : index_range(dof_indices))
-                {
-                  // local coordinates.
-                  for (std::size_t v=0; v<dim; v++)
-                    for (std::size_t xyz=0; xyz<LIBMESH_DIM; xyz++)
-                      {
-                        // FIXME: this needs better syntax: It is matrix-vector multiplication.
-                        grad(xyz) += data.local_transform[v][xyz]
-                          * data.dshape[i](v)
-                          * this->_vector(dof_indices[i]);
-                      }
-                }
-            }
-#endif
-          temp_output[index] = grad;
-
-          // next variable
-        }
+      this->_gradient_on_elem(p, element, temp_output);
 
       // Insert temp_output into output
-      output[element] = temp_output;
+      output.emplace(element, std::move(temp_output));
     }
 }
 
+
+
+void MeshFunction::_gradient_on_elem (const Point & p,
+                                      const Elem * element,
+                                      std::vector<Gradient> & output)
+{
+  libmesh_assert(element);
+
+  // resize the output vector to the number of output values
+  // that the user told us
+  output.resize (this->_system_vars.size());
+
+  const unsigned int dim = element->dim();
+
+  /*
+   * Get local coordinates to feed these into compute_data().
+   * Note that the fe_type can safely be used from the 0-variable,
+   * since the inverse mapping is the same for all FEFamilies
+   */
+  const Point mapped_point (FEMap::inverse_map (dim, element,
+                                                p));
+
+  std::vector<Point> point_list (1, mapped_point);
+
+  // loop over all vars
+  for (auto index : index_range(this->_system_vars))
+    {
+      /*
+       * the data for this variable
+       */
+      const unsigned int var = _system_vars[index];
+
+      if (var == libMesh::invalid_uint)
+        {
+          libmesh_assert (_out_of_mesh_mode &&
+                          index < _out_of_mesh_value.size());
+          output[index] = Gradient(_out_of_mesh_value(index));
+          continue;
+        }
+
+      const FEType & fe_type = this->_dof_map.variable_type(var);
+
+      // where the solution values for the var-th variable are stored
+      std::vector<dof_id_type> dof_indices;
+      this->_dof_map.dof_indices (element, dof_indices, var);
+
+      // interpolate the solution
+      Gradient grad(0.);
+
+      // for performance-reasons, we use different algorithms now.
+      // TODO: Check that both give the same result for finite elements.
+      // Otherwive it is wrong...
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+      if (!element->infinite())
+        {
+#endif
+          std::unique_ptr<FEBase> point_fe (FEBase::build(dim, fe_type));
+          const std::vector<std::vector<RealGradient>> & dphi = point_fe->get_dphi();
+          point_fe->reinit(element, &point_list);
+
+          for (auto i : index_range(dof_indices))
+            grad.add_scaled(dphi[i][0], this->_vector(dof_indices[i]));
+
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+        }
+      else
+        {
+          /**
+           * Build an FEComputeData that contains both input and output data
+           * for the specific compute_data method.
+           */
+          //TODO: enable this for a vector of points as well...
+          FEComputeData data (this->_eqn_systems, mapped_point);
+          data.enable_derivative();
+          FEInterface::compute_data (dim, fe_type, element, data);
+          //grad [x] = data.dshape[i](v) * dv/dx  * dof_index [i]
+          // sum over all indices
+          for (auto i : index_range(dof_indices))
+            {
+              // local coordinates
+              for (std::size_t v=0; v<dim; v++)
+                for (std::size_t xyz=0; xyz<LIBMESH_DIM; xyz++)
+                  {
+                    // FIXME: this needs better syntax: It is matrix-vector multiplication.
+                    grad(xyz) += data.local_transform[v][xyz]
+                      * data.dshape[i](v)
+                      * this->_vector(dof_indices[i]);
+                  }
+            }
+        }
+#endif
+      output[index] = grad;
+    }
+}
 
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -414,7 +414,10 @@ PetscLinearSolver<T>::solve_common (SparseMatrix<T> &  matrix_in,
   WrappedPetsc<Vec> subrhs;
   WrappedPetsc<Vec> subsolution;
   WrappedPetsc<VecScatter> scatter;
+
   std::unique_ptr<PetscMatrix<Number>> subprecond_matrix;
+
+  auto & mat = matrix->mat();
 
   // Set operators.  Also restrict rhs and solution vector to
   // subdomain if necessary.
@@ -442,7 +445,7 @@ PetscLinearSolver<T>::solve_common (SparseMatrix<T> &  matrix_in,
       VecScatterBeginEnd(this->comm(), scatter, rhs->vec(), subrhs, INSERT_VALUES, SCATTER_FORWARD);
       VecScatterBeginEnd(this->comm(), scatter, solution->vec(), subsolution, INSERT_VALUES, SCATTER_FORWARD);
 
-      ierr = LibMeshCreateSubMatrix(matrix->mat(),
+      ierr = LibMeshCreateSubMatrix(mat,
                                     _restrict_solve_to_is,
                                     _restrict_solve_to_is,
                                     MAT_INITIAL_MATRIX,
@@ -484,7 +487,7 @@ PetscLinearSolver<T>::solve_common (SparseMatrix<T> &  matrix_in,
           LIBMESH_CHKERR(ierr);
 
           WrappedPetsc<Mat> submat1;
-          ierr = LibMeshCreateSubMatrix(matrix->mat(),
+          ierr = LibMeshCreateSubMatrix(mat,
                                         _restrict_solve_to_is,
                                         _restrict_solve_to_is_complement,
                                         MAT_INITIAL_MATRIX,

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -532,7 +532,11 @@ PetscLinearSolver<T>::solve_common (SparseMatrix<T> &  matrix_in,
 
       if (this->_preconditioner)
         {
-          this->_preconditioner->set_matrix(matrix_in);
+          if (matrix)
+            this->_preconditioner->set_matrix(*matrix);
+          else if (precond)
+            this->_preconditioner->set_matrix(const_cast<PetscMatrix<Number> &>(*precond));
+
           this->_preconditioner->init();
         }
     }
@@ -598,11 +602,15 @@ PetscLinearSolver<T>::solve_common (SparseMatrix<T> &  matrix_in,
 
       VecScatterBeginEnd(this->comm(), scatter, subsolution, solution->vec(), INSERT_VALUES, SCATTER_REVERSE);
 
-      if (this->_preconditioner)
+      if (precond && this->_preconditioner)
         {
           // Before subprecond_matrix gets cleaned up, we should give
           // the _preconditioner a different matrix.
-          this->_preconditioner->set_matrix(matrix_in);
+          if (matrix)
+            this->_preconditioner->set_matrix(*matrix);
+          else
+            this->_preconditioner->set_matrix(*precond);
+
           this->_preconditioner->init();
         }
     }
@@ -811,12 +819,16 @@ PetscLinearSolver<T>::shell_solve_common (const ShellMatrix<T> & shell_matrix,
         {
           ierr = KSPSetOperators(_ksp, mat, const_cast<PetscMatrix<T> *>(precond)->mat());
           LIBMESH_CHKERR(ierr);
+        }
 
-          if (this->_preconditioner)
-            {
-              this->_preconditioner->set_matrix(const_cast<PetscMatrix<Number> &>(*precond));
-              this->_preconditioner->init();
-            }
+      if (this->_preconditioner)
+        {
+          if (matrix)
+            this->_preconditioner->set_matrix(*matrix);
+          else if (precond)
+            this->_preconditioner->set_matrix(const_cast<PetscMatrix<Number> &>(*precond));
+
+          this->_preconditioner->init();
         }
     }
 
@@ -885,7 +897,11 @@ PetscLinearSolver<T>::shell_solve_common (const ShellMatrix<T> & shell_matrix,
         {
           // Before subprecond_matrix gets cleaned up, we should give
           // the _preconditioner a different matrix.
-          this->_preconditioner->set_matrix(const_cast<PetscMatrix<Number> &>(*precond));
+          if (matrix)
+            this->_preconditioner->set_matrix(*matrix);
+          else
+            this->_preconditioner->set_matrix(*precond);
+
           this->_preconditioner->init();
         }
     }

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -823,6 +823,13 @@ PetscLinearSolver<T>::shell_solve_common (const ShellMatrix<T> & shell_matrix,
   ierr = KSPSetFromOptions(_ksp);
   LIBMESH_CHKERR(ierr);
 
+  // If the SolverConfiguration object is provided, use it to override
+  // solver options.
+  if (this->_solver_configuration)
+    {
+      this->_solver_configuration->configure_solver();
+    }
+
   // Solve the linear system
   if (_restrict_solve_to_is)
     {

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -767,26 +767,7 @@ PetscLinearSolver<T>::shell_solve_common (const ShellMatrix<T> & shell_matrix,
                                         submat1.get());
           LIBMESH_CHKERR(ierr);
 
-          // The following lines would be correct, but don't work
-          // correctly in PETSc up to 3.1.0-p5.  See discussion in
-          // petsc-users of Nov 9, 2010.
-          //
-          // ierr = MatMultAdd(submat1, subvec1, subrhs, subrhs);
-          // LIBMESH_CHKERR(ierr);
-          //
-          // We workaround by using a temporary vector.  Note that the
-          // fix in PETsc 3.1.0-p6 uses a temporary vector internally,
-          // so this is no effective performance loss.
-          WrappedPetsc<Vec> subvec2;
-          ierr = VecCreate(this->comm().get(), subvec2.get());
-          LIBMESH_CHKERR(ierr);
-          ierr = VecSetSizes(subvec2, is_local_size, PETSC_DECIDE);
-          LIBMESH_CHKERR(ierr);
-          ierr = VecSetFromOptions(subvec2);
-          LIBMESH_CHKERR(ierr);
-          ierr = MatMult(submat1, subvec1, subvec2);
-          LIBMESH_CHKERR(ierr);
-          ierr = VecAXPY(subrhs, 1.0, subvec2);
+          ierr = MatMultAdd(submat1, subvec1, subrhs, subrhs);
           LIBMESH_CHKERR(ierr);
         }
 

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -417,7 +417,7 @@ PetscLinearSolver<T>::solve_common (SparseMatrix<T> &  matrix_in,
 
   std::unique_ptr<PetscMatrix<Number>> subprecond_matrix;
 
-  auto & mat = matrix->mat();
+  auto mat = matrix->mat();
 
   // Set operators.  Also restrict rhs and solution vector to
   // subdomain if necessary.

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -1124,6 +1124,27 @@ void Xdr::data_stream (float * val, const unsigned int len, const unsigned int l
 template <>
 void Xdr::data_stream (long double * val, const unsigned int len, const unsigned int line_break)
 {
+  this->_xfp_data_stream
+    (val, len, line_break,
+     std::numeric_limits<long double>::max_digits10);
+}
+
+
+#ifdef LIBMESH_DEFAULT_QUADRUPLE_PRECISION
+template <>
+void Xdr::data_stream (Real * val, const unsigned int len, const unsigned int line_break)
+{
+  this->_xfp_data_stream(val, len, line_break, 36);
+}
+#endif // LIBMESH_DEFAULT_QUADRUPLE_PRECISION
+
+
+
+template <typename XFP>
+void Xdr::_xfp_data_stream (XFP * val, const unsigned int len,
+                            const unsigned int line_break,
+                            const int n_digits)
+{
   switch (mode)
     {
     case ENCODE:
@@ -1145,133 +1166,9 @@ void Xdr::data_stream (long double * val, const unsigned int len, const unsigned
         //      sizeof(double),
         //      (xdrproc_t) xdr_quadruple);
 
-        if (len > 0)
-          {
-            std::vector<double> io_buffer (len);
-
-            // Fill io_buffer if we are writing.
-            if (mode == ENCODE)
-              for (unsigned int i=0, cnt=0; i<len; i++)
-                io_buffer[cnt++] = double(val[i]);
-
-            xdr_vector(xdrs.get(),
-                       reinterpret_cast<char *>(io_buffer.data()),
-                       len,
-                       sizeof(double),
-                       (xdrproc_t) xdr_double);
-
-            // Fill val array if we are reading.
-            if (mode == DECODE)
-              for (unsigned int i=0, cnt=0; i<len; i++)
-                {
-                  val[i] = io_buffer[cnt++];
-                }
-          }
-
-#else
-
-        libmesh_error_msg("ERROR: Functionality is not available.\n"    \
-                          << "Make sure LIBMESH_HAVE_XDR is defined at build time\n" \
-                          << "The XDR interface is not available in this installation");
-
-#endif
-        return;
-      }
-
-    case READ:
-      {
-        libmesh_assert(in.get());
-        libmesh_assert (in->good());
-
-        for (unsigned int i=0; i<len; i++)
-          {
-            libmesh_assert(in.get());
-            libmesh_assert (in->good());
-            *in >> val[i];
-          }
-
-        return;
-      }
-
-    case WRITE:
-      {
-        libmesh_assert(out.get());
-        libmesh_assert (out->good());
-
-        // Save stream flags
-        std::ios_base::fmtflags out_flags = out->flags();
-
-        // We will use scientific notation sufficient to exactly
-        // represent our floating point precision in the following
-        // output.  The desired precision and format will
-        // automatically determine the width.
-        *out << std::scientific
-             << std::setprecision(std::numeric_limits<long double>::max_digits10);
-
-        if (line_break == libMesh::invalid_uint)
-          for (unsigned int i=0; i<len; i++)
-            {
-              libmesh_assert(out.get());
-              libmesh_assert (out->good());
-              *out << val[i] << ' ';
-            }
-        else
-          {
-            const unsigned imax = std::min(line_break, len);
-            unsigned int cnt=0;
-            while (cnt < len)
-              {
-                for (unsigned int i=0; (i<imax && cnt<len); i++)
-                  {
-                    libmesh_assert(out.get());
-                    libmesh_assert (out->good());
-                    *out << val[cnt++];
-
-                    // Write a space unless this is the last character on the current line.
-                    if (i+1 != imax)
-                      *out << " ";
-                  }
-                libmesh_assert(out.get());
-                libmesh_assert (out->good());
-                *out << '\n';
-              }
-          }
-
-        // Restore stream flags
-        out->flags(out_flags);
-
-        return;
-      }
-
-    default:
-      libmesh_error_msg("Invalid mode = " << mode);
-    }
-}
-
-
-#ifdef LIBMESH_DEFAULT_QUADRUPLE_PRECISION
-template <>
-void Xdr::data_stream (Real * val, const unsigned int len, const unsigned int line_break)
-{
-  switch (mode)
-    {
-    case ENCODE:
-    case DECODE:
-      {
-#ifdef LIBMESH_HAVE_XDR
-
-        libmesh_assert (this->is_open());
-
-        // FIXME[RHS]: This has the same "xdr_quadruple may not be
-        // defined" problem as long double, and the problem may be
-        // much worse since even _Quad/__float128 aren't standard
+        // FIXME[RHS]: 128 bit FP has the same problem as long double,
+        // only much worse since even _Quad/__float128 aren't standard
         // either.
-        // if (len > 0)
-        //   xdr_vector(xdrs.get(),
-        //      (char *) val,
-        //      len,
-        //      sizeof(double),
-        //      (xdrproc_t) xdr_quadruple);
 
         if (len > 0)
           {
@@ -1329,11 +1226,11 @@ void Xdr::data_stream (Real * val, const unsigned int len, const unsigned int li
         // Save stream flags
         std::ios_base::fmtflags out_flags = out->flags();
 
-        // We will use scientific notation with a precision of 36
-        // digits in the following output.  The desired precision and
+        // We will use scientific notation with specified digit
+        // count in the following output.  The desired precision and
         // format will automatically determine the width.
         *out << std::scientific
-             << std::setprecision(36);
+             << std::setprecision(n_digits);
 
         if (line_break == libMesh::invalid_uint)
           for (unsigned int i=0; i<len; i++)
@@ -1374,7 +1271,6 @@ void Xdr::data_stream (Real * val, const unsigned int len, const unsigned int li
       libmesh_error_msg("Invalid mode = " << mode);
     }
 }
-#endif // LIBMESH_DEFAULT_QUADRUPLE_PRECISION
 
 
 

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -924,208 +924,28 @@ void Xdr::data_stream (T * val, const unsigned int len, const unsigned int line_
 template <>
 void Xdr::data_stream (double * val, const unsigned int len, const unsigned int line_break)
 {
-  switch (mode)
-    {
-    case ENCODE:
-    case DECODE:
-      {
-#ifdef LIBMESH_HAVE_XDR
-
-        libmesh_assert (this->is_open());
-
-        if (len > 0)
-          xdr_vector(xdrs.get(),
-                     (char *) val,
-                     len,
-                     sizeof(double),
-                     (xdrproc_t) xdr_double);
-
-#else
-
-        libmesh_error_msg("ERROR: Functionality is not available.\n"    \
-                          << "Make sure LIBMESH_HAVE_XDR is defined at build time\n" \
-                          << "The XDR interface is not available in this installation");
-
-#endif
-        return;
-      }
-
-    case READ:
-      {
-        libmesh_assert(in.get());
-        libmesh_assert (in->good());
-
-        for (unsigned int i=0; i<len; i++)
-          {
-            libmesh_assert(in.get());
-            libmesh_assert (in->good());
-            *in >> val[i];
-          }
-
-        return;
-      }
-
-    case WRITE:
-      {
-        libmesh_assert(out.get());
-        libmesh_assert (out->good());
-
-        // Save stream flags
-        std::ios_base::fmtflags out_flags = out->flags();
-
-        // We will use scientific notation sufficient to exactly
-        // represent our floating point precision in the following
-        // output.  The desired precision and format will
-        // automatically determine the width.
-        *out << std::scientific
-             << std::setprecision(std::numeric_limits<double>::max_digits10);
-
-        if (line_break == libMesh::invalid_uint)
-          for (unsigned int i=0; i<len; i++)
-            {
-              libmesh_assert(out.get());
-              libmesh_assert (out->good());
-              *out << val[i] << ' ';
-            }
-        else
-          {
-            const unsigned imax = std::min(line_break, len);
-            unsigned int cnt=0;
-            while (cnt < len)
-              {
-                for (unsigned int i=0; (i<imax && cnt<len); i++)
-                  {
-                    libmesh_assert(out.get());
-                    libmesh_assert (out->good());
-                    *out << val[cnt++];
-
-                    // Write a space unless this is the last character on the current line.
-                    if (i+1 != imax)
-                      *out << " ";
-                  }
-                libmesh_assert(out.get());
-                libmesh_assert (out->good());
-                *out << '\n';
-              }
-          }
-
-        // Restore stream flags
-        out->flags(out_flags);
-
-        return;
-      }
-
-    default:
-      libmesh_error_msg("Invalid mode = " << mode);
-    }
+  this->_xfp_data_stream
+    (val, len, (xdrproc_t)xdr_double, line_break,
+     std::numeric_limits<double>::max_digits10);
 }
+
 
 
 template <>
 void Xdr::data_stream (float * val, const unsigned int len, const unsigned int line_break)
 {
-  switch (mode)
-    {
-    case ENCODE:
-    case DECODE:
-      {
-#ifdef LIBMESH_HAVE_XDR
-
-        libmesh_assert (this->is_open());
-
-        if (len > 0)
-          xdr_vector(xdrs.get(),
-                     (char *) val,
-                     len,
-                     sizeof(float),
-                     (xdrproc_t) xdr_float);
-
-#else
-
-        libmesh_error_msg("ERROR: Functionality is not available.\n"    \
-                          << "Make sure LIBMESH_HAVE_XDR is defined at build time\n" \
-                          << "The XDR interface is not available in this installation");
-
-#endif
-        return;
-      }
-
-    case READ:
-      {
-        libmesh_assert(in.get());
-        libmesh_assert (in->good());
-
-        for (unsigned int i=0; i<len; i++)
-          {
-            libmesh_assert(in.get());
-            libmesh_assert (in->good());
-            *in >> val[i];
-          }
-
-        return;
-      }
-
-    case WRITE:
-      {
-        libmesh_assert(out.get());
-        libmesh_assert (out->good());
-
-        // Save stream flags
-        std::ios_base::fmtflags out_flags = out->flags();
-
-        // We will use scientific notation sufficient to exactly
-        // represent our floating point precision in the following
-        // output.  The desired precision and format will
-        // automatically determine the width.
-        *out << std::scientific
-             << std::setprecision(std::numeric_limits<float>::max_digits10);
-
-        if (line_break == libMesh::invalid_uint)
-          for (unsigned int i=0; i<len; i++)
-            {
-              libmesh_assert(out.get());
-              libmesh_assert (out->good());
-              *out << val[i] << ' ';
-            }
-        else
-          {
-            const unsigned imax = std::min(line_break, len);
-            unsigned int cnt=0;
-            while (cnt < len)
-              {
-                for (unsigned int i=0; (i<imax && cnt<len); i++)
-                  {
-                    libmesh_assert(out.get());
-                    libmesh_assert (out->good());
-                    *out << val[cnt++];
-
-                    // Write a space unless this is the last character on the current line.
-                    if (i+1 != imax)
-                      *out << " ";
-                  }
-                libmesh_assert(out.get());
-                libmesh_assert (out->good());
-                *out << '\n';
-              }
-          }
-
-        // Restore stream flags
-        out->flags(out_flags);
-
-        return;
-      }
-
-    default:
-      libmesh_error_msg("Invalid mode = " << mode);
-    }
+  this->_xfp_data_stream
+    (val, len, (xdrproc_t)xdr_float, line_break,
+     std::numeric_limits<float>::max_digits10);
 }
+
 
 
 template <>
 void Xdr::data_stream (long double * val, const unsigned int len, const unsigned int line_break)
 {
   this->_xfp_data_stream
-    (val, len, line_break,
+    (val, len, nullptr, line_break,
      std::numeric_limits<long double>::max_digits10);
 }
 
@@ -1134,7 +954,7 @@ void Xdr::data_stream (long double * val, const unsigned int len, const unsigned
 template <>
 void Xdr::data_stream (Real * val, const unsigned int len, const unsigned int line_break)
 {
-  this->_xfp_data_stream(val, len, line_break, 36);
+  this->_xfp_data_stream(val, len, nullptr, line_break, 36);
 }
 #endif // LIBMESH_DEFAULT_QUADRUPLE_PRECISION
 
@@ -1142,6 +962,12 @@ void Xdr::data_stream (Real * val, const unsigned int len, const unsigned int li
 
 template <typename XFP>
 void Xdr::_xfp_data_stream (XFP * val, const unsigned int len,
+#ifdef LIBMESH_HAVE_XDR
+                            xdrproc_t
+#else
+                            void *
+#endif
+                              xdr_proc,
                             const unsigned int line_break,
                             const int n_digits)
 {
@@ -1151,27 +977,30 @@ void Xdr::_xfp_data_stream (XFP * val, const unsigned int len,
     case DECODE:
       {
 #ifdef LIBMESH_HAVE_XDR
-
         libmesh_assert (this->is_open());
-
-        // FIXME[JWP]: How to implement this for long double?  Mac OS
-        // X defines 'xdr_quadruple' but AFAICT, it does not exist for
-        // Linux... for now, reading/writing XDR files with long
-        // doubles drops back to double precision, but you can still
-        // write long double ASCII files of course.
-        // if (len > 0)
-        //   xdr_vector(xdrs.get(),
-        //      (char *) val,
-        //      len,
-        //      sizeof(double),
-        //      (xdrproc_t) xdr_quadruple);
-
-        // FIXME[RHS]: 128 bit FP has the same problem as long double,
-        // only much worse since even _Quad/__float128 aren't standard
-        // either.
 
         if (len > 0)
           {
+            if (xdr_proc)
+              {
+                xdr_vector(xdrs.get(),
+                           (char *) val,
+                           len,
+                           sizeof(XFP),
+                           xdr_proc);
+                return;
+              }
+
+            // FIXME[JWP]: How to implement this for long double?  Mac
+            // OS X defines 'xdr_quadruple' but AFAICT, it does not
+            // exist for Linux... for now, reading/writing XDR files
+            // with long doubles drops back to double precision, but
+            // you can still write long double ASCII files of course.
+
+            // FIXME[RHS]: 128 bit FP has the same problem as long
+            // double, only much worse since even _Quad/__float128
+            // aren't standard either.
+
             std::vector<double> io_buffer (len);
 
             // Fill io_buffer if we are writing.


### PR DESCRIPTION
This shaves off another 500-odd more lines, and in theory it adds support for a couple PetscLinearSolver feature combinations that were ignored before.

In practice I hope it doesn't just outright break PETSc solves.  We'll see what CI says.

I think this is the last of the low-hanging fruit.  Much of PatchRecovery/WrappedPatchRecovery ought to be factored out but it'll be tricky to do so without slowing down the non-Wrapped case (but perhaps only trivially?), and there's some bits in fem_system.C that I'd like to consolidate but made a mess of when I tried ... and there's a bunch of projection code bits here and there that ought to be refactored, except that's much less trivial than the rest of this stuff so I'll save it for another time.