### PR TITLE
Add RawType and ReplaceAlgebraicType to TypeTensor/Vector

### DIFF
--- a/include/numerics/tensor_value.h
+++ b/include/numerics/tensor_value.h
@@ -429,6 +429,12 @@ struct RawType<libMesh::TensorValue<T>>
       return ret;
     }
 };
+
+template <typename T, typename U>
+struct ReplaceAlgebraicType<libMesh::TensorValue<T>, U>
+{
+  typedef U type;
+};
 }
 #endif
 

--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -1383,4 +1383,31 @@ outer_product(const TypeVector<T> & a, const TypeVector<T2> & b)
 
 } // namespace libMesh
 
+#ifdef LIBMESH_HAVE_METAPHYSICL
+namespace MetaPhysicL
+{
+template <typename T>
+struct RawType<libMesh::TypeTensor<T>>
+{
+  typedef libMesh::TypeTensor<typename RawType<T>::value_type> value_type;
+
+  static value_type value (const libMesh::TypeTensor<T> & in)
+  {
+    value_type ret;
+    for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
+      for (unsigned int j = 0; j < LIBMESH_DIM; ++j)
+        ret(i,j) = raw_value(in(i,j));
+
+    return ret;
+  }
+};
+
+template <typename T, typename U>
+struct ReplaceAlgebraicType<libMesh::TypeTensor<T>, U>
+{
+  typedef U type;
+};
+}
+#endif
+
 #endif // LIBMESH_TYPE_TENSOR_H

--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -1186,4 +1186,30 @@ auto norm(const libMesh::TypeVector<T> & vector) -> decltype(std::norm(T()))
 }
 } // namespace std
 
+#ifdef LIBMESH_HAVE_METAPHYSICL
+namespace MetaPhysicL
+{
+template <typename T>
+struct RawType<libMesh::TypeVector<T>>
+{
+  typedef libMesh::TypeVector<typename RawType<T>::value_type> value_type;
+
+  static value_type value (const libMesh::TypeVector<T> & in)
+    {
+      value_type ret;
+      for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
+        ret(i) = raw_value(in(i));
+
+      return ret;
+    }
+};
+
+template <typename T, typename U>
+struct ReplaceAlgebraicType<libMesh::TypeVector<T>, U>
+{
+  typedef U type;
+};
+}
+#endif
+
 #endif // LIBMESH_TYPE_VECTOR_H

--- a/tests/numerics/type_tensor_test.C
+++ b/tests/numerics/type_tensor_test.C
@@ -23,7 +23,9 @@ public:
   CPPUNIT_TEST(testRotation);
 #endif
   CPPUNIT_TEST(testIsZero);
-
+#ifdef LIBMESH_HAVE_METAPHYSICL
+  CPPUNIT_TEST(testReplaceAlgebraicType);
+#endif
   CPPUNIT_TEST_SUITE_END();
 
 
@@ -138,6 +140,19 @@ private:
       LIBMESH_ASSERT_FP_EQUAL(1, rotated(2), tol);
     }
   }
+#ifdef LIBMESH_HAVE_METAPHYSICL
+  void testReplaceAlgebraicType()
+  {
+    typedef typename MetaPhysicL::ReplaceAlgebraicType<
+        std::vector<TypeTensor<double>>,
+        typename TensorTools::IncrementRank<
+            typename MetaPhysicL::ValueType<std::vector<TypeTensor<double>>>::type>::type>::type
+        ReplacedType;
+    constexpr bool assertion =
+        std::is_same<ReplacedType, std::vector<TypeNTensor<3,double>>>::value;
+    CPPUNIT_ASSERT(assertion);
+  }
+#endif
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TypeTensorTest);

--- a/tests/numerics/type_vector_test.h
+++ b/tests/numerics/type_vector_test.h
@@ -49,7 +49,9 @@
   CPPUNIT_TEST( testVectorSubBase );            \
   CPPUNIT_TEST( testVectorMultBase );           \
   CPPUNIT_TEST( testVectorAddAssignBase );      \
-  CPPUNIT_TEST( testVectorSubAssignBase );
+  CPPUNIT_TEST( testVectorSubAssignBase );      \
+  if (LIBMESH_HAVE_METAPHYSICL)                 \
+    CPPUNIT_TEST( testReplaceAlgebraicType );
 
 
 using namespace libMesh;
@@ -491,6 +493,20 @@ public:
     if (LIBMESH_DIM > 2)
       LIBMESH_ASSERT_FP_EQUAL( 2.0 , libmesh_real(avector(2)) , TOLERANCE*TOLERANCE );
   }
+
+#ifdef LIBMESH_HAVE_METAPHYSICL
+  void testReplaceAlgebraicType()
+  {
+    typedef typename MetaPhysicL::ReplaceAlgebraicType<
+        std::vector<TypeVector<double>>,
+        typename TensorTools::IncrementRank<
+            typename MetaPhysicL::ValueType<std::vector<TypeVector<double>>>::type>::type>::type
+        ReplacedType;
+    constexpr bool assertion =
+        std::is_same<ReplacedType, std::vector<TensorValue<double>>>::value;
+    CPPUNIT_ASSERT(assertion);
+  }
+#endif
 };
 
 #endif // #ifdef __type_vector_test_h__

--- a/tests/numerics/vector_value_test.C
+++ b/tests/numerics/vector_value_test.C
@@ -133,6 +133,16 @@ public:
             std::is_same<ReplacedType, std::vector<VectorValue<double>>>::value;
         CPPUNIT_ASSERT(assertion);
       }
+      {
+        typedef typename MetaPhysicL::ReplaceAlgebraicType<
+            std::vector<VectorValue<double>>,
+            typename TensorTools::IncrementRank<
+                typename MetaPhysicL::ValueType<std::vector<VectorValue<double>>>::type>::type>::type
+            ReplacedType;
+        constexpr bool assertion =
+            std::is_same<ReplacedType, std::vector<TensorValue<double>>>::value;
+        CPPUNIT_ASSERT(assertion);
+      }
 #endif
     }
 };


### PR DESCRIPTION
To enable flexible templated harmonic interpolation in MOOSE, we need specializations of MetaphysicL::RawValue for TypeTensor/TypeVector.