### PR TITLE
Add TensorTraits

### DIFF
--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -697,6 +697,13 @@ inline Tnew libmesh_cast_int (Told oldvar)
   return cast_int<Tnew>(oldvar);
 }
 
+/**
+ * This is a helper variable template for cases when we want to use a default compile-time
+ * error with constexpr-based if conditions. The templating delays the triggering
+ * of the static assertion until the template is instantiated.
+ */
+template <class T>
+constexpr std::false_type always_false{};
 
 // build a integer representation of version
 #define LIBMESH_VERSION_ID(major,minor,patch) (((major) << 16) | ((minor) << 8) | ((patch) & 0xFF))

--- a/include/numerics/tensor_tools.h
+++ b/include/numerics/tensor_tools.h
@@ -350,6 +350,51 @@ struct MakeBaseNumber<
   typedef typename MakeBaseNumber<T>::type type;
 };
 
+template <typename T, typename Enable = void>
+struct TensorTraits
+{
+  static_assert(always_false<T>,
+                "Instantiating the generic template of TensorTraits. You must specialize "
+                "TensorTraits for your type.");
+  static constexpr unsigned char rank = 0;
+};
+
+template <typename T>
+struct TensorTraits<T, typename std::enable_if<ScalarTraits<T>::value>::type>
+{
+  static constexpr unsigned char rank = 0;
+};
+
+template <typename T>
+struct TensorTraits<TypeVector<T>>
+{
+  static constexpr unsigned char rank = 1;
+};
+
+template <typename T>
+struct TensorTraits<VectorValue<T>>
+{
+  static constexpr unsigned char rank = 1;
+};
+
+template <typename T>
+struct TensorTraits<TypeTensor<T>>
+{
+  static constexpr unsigned char rank = 2;
+};
+
+template <typename T>
+struct TensorTraits<TensorValue<T>>
+{
+  static constexpr unsigned char rank = 2;
+};
+
+template <typename T, unsigned int N>
+struct TensorTraits<TypeNTensor<N, T>>
+{
+  static constexpr unsigned char rank = static_cast<unsigned char>(N);
+};
+
 }//namespace TensorTools
 
 }//namespace libMesh

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -99,6 +99,7 @@ unit_tests_sources = \
   numerics/diagonal_matrix_test.C \
   numerics/lumped_mass_matrix_test.C \
   numerics/eigen_sparse_matrix_test.C \
+  numerics/tensor_traits_test.C \
   parallel/message_tag.C \
   parallel/packed_range_test.C \
   parallel/parallel_sort_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -235,7 +235,8 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
 	numerics/petsc_matrix_test.C numerics/diagonal_matrix_test.C \
 	numerics/lumped_mass_matrix_test.C \
-	numerics/eigen_sparse_matrix_test.C parallel/message_tag.C \
+	numerics/eigen_sparse_matrix_test.C \
+	numerics/tensor_traits_test.C parallel/message_tag.C \
 	parallel/packed_range_test.C parallel/parallel_sort_test.C \
 	parallel/parallel_sync_test.C parallel/parallel_test.C \
 	parallel/parallel_point_test.C partitioning/partitioner_test.h \
@@ -342,6 +343,7 @@ am__objects_3 = unit_tests_dbg-driver.$(OBJEXT) \
 	numerics/unit_tests_dbg-diagonal_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-lumped_mass_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-eigen_sparse_matrix_test.$(OBJEXT) \
+	numerics/unit_tests_dbg-tensor_traits_test.$(OBJEXT) \
 	parallel/unit_tests_dbg-message_tag.$(OBJEXT) \
 	parallel/unit_tests_dbg-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_dbg-parallel_sort_test.$(OBJEXT) \
@@ -420,7 +422,8 @@ am__unit_tests_devel_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
 	numerics/petsc_matrix_test.C numerics/diagonal_matrix_test.C \
 	numerics/lumped_mass_matrix_test.C \
-	numerics/eigen_sparse_matrix_test.C parallel/message_tag.C \
+	numerics/eigen_sparse_matrix_test.C \
+	numerics/tensor_traits_test.C parallel/message_tag.C \
 	parallel/packed_range_test.C parallel/parallel_sort_test.C \
 	parallel/parallel_sync_test.C parallel/parallel_test.C \
 	parallel/parallel_point_test.C partitioning/partitioner_test.h \
@@ -525,6 +528,7 @@ am__objects_5 = unit_tests_devel-driver.$(OBJEXT) \
 	numerics/unit_tests_devel-diagonal_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_devel-lumped_mass_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_devel-eigen_sparse_matrix_test.$(OBJEXT) \
+	numerics/unit_tests_devel-tensor_traits_test.$(OBJEXT) \
 	parallel/unit_tests_devel-message_tag.$(OBJEXT) \
 	parallel/unit_tests_devel-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_devel-parallel_sort_test.$(OBJEXT) \
@@ -599,7 +603,8 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
 	numerics/petsc_matrix_test.C numerics/diagonal_matrix_test.C \
 	numerics/lumped_mass_matrix_test.C \
-	numerics/eigen_sparse_matrix_test.C parallel/message_tag.C \
+	numerics/eigen_sparse_matrix_test.C \
+	numerics/tensor_traits_test.C parallel/message_tag.C \
 	parallel/packed_range_test.C parallel/parallel_sort_test.C \
 	parallel/parallel_sync_test.C parallel/parallel_test.C \
 	parallel/parallel_point_test.C partitioning/partitioner_test.h \
@@ -704,6 +709,7 @@ am__objects_7 = unit_tests_oprof-driver.$(OBJEXT) \
 	numerics/unit_tests_oprof-diagonal_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-lumped_mass_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-eigen_sparse_matrix_test.$(OBJEXT) \
+	numerics/unit_tests_oprof-tensor_traits_test.$(OBJEXT) \
 	parallel/unit_tests_oprof-message_tag.$(OBJEXT) \
 	parallel/unit_tests_oprof-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_oprof-parallel_sort_test.$(OBJEXT) \
@@ -778,7 +784,8 @@ am__unit_tests_opt_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
 	numerics/petsc_matrix_test.C numerics/diagonal_matrix_test.C \
 	numerics/lumped_mass_matrix_test.C \
-	numerics/eigen_sparse_matrix_test.C parallel/message_tag.C \
+	numerics/eigen_sparse_matrix_test.C \
+	numerics/tensor_traits_test.C parallel/message_tag.C \
 	parallel/packed_range_test.C parallel/parallel_sort_test.C \
 	parallel/parallel_sync_test.C parallel/parallel_test.C \
 	parallel/parallel_point_test.C partitioning/partitioner_test.h \
@@ -883,6 +890,7 @@ am__objects_9 = unit_tests_opt-driver.$(OBJEXT) \
 	numerics/unit_tests_opt-diagonal_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_opt-lumped_mass_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_opt-eigen_sparse_matrix_test.$(OBJEXT) \
+	numerics/unit_tests_opt-tensor_traits_test.$(OBJEXT) \
 	parallel/unit_tests_opt-message_tag.$(OBJEXT) \
 	parallel/unit_tests_opt-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_opt-parallel_sort_test.$(OBJEXT) \
@@ -957,7 +965,8 @@ am__unit_tests_prof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
 	numerics/petsc_matrix_test.C numerics/diagonal_matrix_test.C \
 	numerics/lumped_mass_matrix_test.C \
-	numerics/eigen_sparse_matrix_test.C parallel/message_tag.C \
+	numerics/eigen_sparse_matrix_test.C \
+	numerics/tensor_traits_test.C parallel/message_tag.C \
 	parallel/packed_range_test.C parallel/parallel_sort_test.C \
 	parallel/parallel_sync_test.C parallel/parallel_test.C \
 	parallel/parallel_point_test.C partitioning/partitioner_test.h \
@@ -1062,6 +1071,7 @@ am__objects_11 = unit_tests_prof-driver.$(OBJEXT) \
 	numerics/unit_tests_prof-diagonal_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_prof-lumped_mass_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_prof-eigen_sparse_matrix_test.$(OBJEXT) \
+	numerics/unit_tests_prof-tensor_traits_test.$(OBJEXT) \
 	parallel/unit_tests_prof-message_tag.$(OBJEXT) \
 	parallel/unit_tests_prof-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_prof-parallel_sort_test.$(OBJEXT) \
@@ -1422,6 +1432,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-parsed_function_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-petsc_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-petsc_vector_test.Po \
+	numerics/$(DEPDIR)/unit_tests_dbg-tensor_traits_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-trilinos_epetra_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-type_tensor_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-vector_value_test.Po \
@@ -1438,6 +1449,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-parsed_function_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-petsc_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-petsc_vector_test.Po \
+	numerics/$(DEPDIR)/unit_tests_devel-tensor_traits_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-trilinos_epetra_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-type_tensor_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-vector_value_test.Po \
@@ -1454,6 +1466,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-parsed_function_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-petsc_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-petsc_vector_test.Po \
+	numerics/$(DEPDIR)/unit_tests_oprof-tensor_traits_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-trilinos_epetra_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-type_tensor_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-vector_value_test.Po \
@@ -1470,6 +1483,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-parsed_function_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-petsc_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-petsc_vector_test.Po \
+	numerics/$(DEPDIR)/unit_tests_opt-tensor_traits_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-trilinos_epetra_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-type_tensor_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-vector_value_test.Po \
@@ -1486,6 +1500,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-parsed_function_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-petsc_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-petsc_vector_test.Po \
+	numerics/$(DEPDIR)/unit_tests_prof-tensor_traits_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-trilinos_epetra_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-type_tensor_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-vector_value_test.Po \
@@ -2105,7 +2120,8 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
 	numerics/petsc_matrix_test.C numerics/diagonal_matrix_test.C \
 	numerics/lumped_mass_matrix_test.C \
-	numerics/eigen_sparse_matrix_test.C parallel/message_tag.C \
+	numerics/eigen_sparse_matrix_test.C \
+	numerics/tensor_traits_test.C parallel/message_tag.C \
 	parallel/packed_range_test.C parallel/parallel_sort_test.C \
 	parallel/parallel_sync_test.C parallel/parallel_test.C \
 	parallel/parallel_point_test.C partitioning/partitioner_test.h \
@@ -2421,6 +2437,8 @@ numerics/unit_tests_dbg-lumped_mass_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_dbg-eigen_sparse_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_dbg-tensor_traits_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 parallel/$(am__dirstamp):
 	@$(MKDIR_P) parallel
 	@: > parallel/$(am__dirstamp)
@@ -2673,6 +2691,8 @@ numerics/unit_tests_devel-lumped_mass_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-eigen_sparse_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_devel-tensor_traits_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_devel-message_tag.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_devel-packed_range_test.$(OBJEXT):  \
@@ -2882,6 +2902,8 @@ numerics/unit_tests_oprof-diagonal_matrix_test.$(OBJEXT):  \
 numerics/unit_tests_oprof-lumped_mass_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_oprof-eigen_sparse_matrix_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_oprof-tensor_traits_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_oprof-message_tag.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
@@ -3093,6 +3115,8 @@ numerics/unit_tests_opt-lumped_mass_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-eigen_sparse_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_opt-tensor_traits_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_opt-message_tag.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_opt-packed_range_test.$(OBJEXT):  \
@@ -3302,6 +3326,8 @@ numerics/unit_tests_prof-diagonal_matrix_test.$(OBJEXT):  \
 numerics/unit_tests_prof-lumped_mass_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_prof-eigen_sparse_matrix_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_prof-tensor_traits_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_prof-message_tag.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
@@ -3697,6 +3723,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-parsed_function_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-petsc_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-petsc_vector_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-tensor_traits_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-trilinos_epetra_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-type_tensor_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-vector_value_test.Po@am__quote@ # am--include-marker
@@ -3713,6 +3740,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-parsed_function_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-petsc_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-petsc_vector_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-tensor_traits_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-trilinos_epetra_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-type_tensor_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-vector_value_test.Po@am__quote@ # am--include-marker
@@ -3729,6 +3757,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-parsed_function_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-petsc_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-petsc_vector_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-tensor_traits_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-trilinos_epetra_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-type_tensor_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-vector_value_test.Po@am__quote@ # am--include-marker
@@ -3745,6 +3774,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-parsed_function_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-petsc_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-petsc_vector_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-tensor_traits_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-trilinos_epetra_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-type_tensor_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-vector_value_test.Po@am__quote@ # am--include-marker
@@ -3761,6 +3791,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-parsed_function_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-petsc_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-petsc_vector_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-tensor_traits_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-trilinos_epetra_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-type_tensor_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-vector_value_test.Po@am__quote@ # am--include-marker
@@ -4964,6 +4995,20 @@ numerics/unit_tests_dbg-eigen_sparse_matrix_test.obj: numerics/eigen_sparse_matr
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/eigen_sparse_matrix_test.C' object='numerics/unit_tests_dbg-eigen_sparse_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-eigen_sparse_matrix_test.obj `if test -f 'numerics/eigen_sparse_matrix_test.C'; then $(CYGPATH_W) 'numerics/eigen_sparse_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/eigen_sparse_matrix_test.C'; fi`
+
+numerics/unit_tests_dbg-tensor_traits_test.o: numerics/tensor_traits_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-tensor_traits_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-tensor_traits_test.Tpo -c -o numerics/unit_tests_dbg-tensor_traits_test.o `test -f 'numerics/tensor_traits_test.C' || echo '$(srcdir)/'`numerics/tensor_traits_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_dbg-tensor_traits_test.Tpo numerics/$(DEPDIR)/unit_tests_dbg-tensor_traits_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/tensor_traits_test.C' object='numerics/unit_tests_dbg-tensor_traits_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-tensor_traits_test.o `test -f 'numerics/tensor_traits_test.C' || echo '$(srcdir)/'`numerics/tensor_traits_test.C
+
+numerics/unit_tests_dbg-tensor_traits_test.obj: numerics/tensor_traits_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-tensor_traits_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-tensor_traits_test.Tpo -c -o numerics/unit_tests_dbg-tensor_traits_test.obj `if test -f 'numerics/tensor_traits_test.C'; then $(CYGPATH_W) 'numerics/tensor_traits_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/tensor_traits_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_dbg-tensor_traits_test.Tpo numerics/$(DEPDIR)/unit_tests_dbg-tensor_traits_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/tensor_traits_test.C' object='numerics/unit_tests_dbg-tensor_traits_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-tensor_traits_test.obj `if test -f 'numerics/tensor_traits_test.C'; then $(CYGPATH_W) 'numerics/tensor_traits_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/tensor_traits_test.C'; fi`
 
 parallel/unit_tests_dbg-message_tag.o: parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_dbg-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_dbg-message_tag.Tpo -c -o parallel/unit_tests_dbg-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
@@ -6365,6 +6410,20 @@ numerics/unit_tests_devel-eigen_sparse_matrix_test.obj: numerics/eigen_sparse_ma
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-eigen_sparse_matrix_test.obj `if test -f 'numerics/eigen_sparse_matrix_test.C'; then $(CYGPATH_W) 'numerics/eigen_sparse_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/eigen_sparse_matrix_test.C'; fi`
 
+numerics/unit_tests_devel-tensor_traits_test.o: numerics/tensor_traits_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-tensor_traits_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-tensor_traits_test.Tpo -c -o numerics/unit_tests_devel-tensor_traits_test.o `test -f 'numerics/tensor_traits_test.C' || echo '$(srcdir)/'`numerics/tensor_traits_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-tensor_traits_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-tensor_traits_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/tensor_traits_test.C' object='numerics/unit_tests_devel-tensor_traits_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-tensor_traits_test.o `test -f 'numerics/tensor_traits_test.C' || echo '$(srcdir)/'`numerics/tensor_traits_test.C
+
+numerics/unit_tests_devel-tensor_traits_test.obj: numerics/tensor_traits_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-tensor_traits_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-tensor_traits_test.Tpo -c -o numerics/unit_tests_devel-tensor_traits_test.obj `if test -f 'numerics/tensor_traits_test.C'; then $(CYGPATH_W) 'numerics/tensor_traits_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/tensor_traits_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-tensor_traits_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-tensor_traits_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/tensor_traits_test.C' object='numerics/unit_tests_devel-tensor_traits_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-tensor_traits_test.obj `if test -f 'numerics/tensor_traits_test.C'; then $(CYGPATH_W) 'numerics/tensor_traits_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/tensor_traits_test.C'; fi`
+
 parallel/unit_tests_devel-message_tag.o: parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_devel-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_devel-message_tag.Tpo -c -o parallel/unit_tests_devel-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_devel-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_devel-message_tag.Po
@@ -7764,6 +7823,20 @@ numerics/unit_tests_oprof-eigen_sparse_matrix_test.obj: numerics/eigen_sparse_ma
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/eigen_sparse_matrix_test.C' object='numerics/unit_tests_oprof-eigen_sparse_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-eigen_sparse_matrix_test.obj `if test -f 'numerics/eigen_sparse_matrix_test.C'; then $(CYGPATH_W) 'numerics/eigen_sparse_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/eigen_sparse_matrix_test.C'; fi`
+
+numerics/unit_tests_oprof-tensor_traits_test.o: numerics/tensor_traits_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-tensor_traits_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-tensor_traits_test.Tpo -c -o numerics/unit_tests_oprof-tensor_traits_test.o `test -f 'numerics/tensor_traits_test.C' || echo '$(srcdir)/'`numerics/tensor_traits_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_oprof-tensor_traits_test.Tpo numerics/$(DEPDIR)/unit_tests_oprof-tensor_traits_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/tensor_traits_test.C' object='numerics/unit_tests_oprof-tensor_traits_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-tensor_traits_test.o `test -f 'numerics/tensor_traits_test.C' || echo '$(srcdir)/'`numerics/tensor_traits_test.C
+
+numerics/unit_tests_oprof-tensor_traits_test.obj: numerics/tensor_traits_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-tensor_traits_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-tensor_traits_test.Tpo -c -o numerics/unit_tests_oprof-tensor_traits_test.obj `if test -f 'numerics/tensor_traits_test.C'; then $(CYGPATH_W) 'numerics/tensor_traits_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/tensor_traits_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_oprof-tensor_traits_test.Tpo numerics/$(DEPDIR)/unit_tests_oprof-tensor_traits_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/tensor_traits_test.C' object='numerics/unit_tests_oprof-tensor_traits_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-tensor_traits_test.obj `if test -f 'numerics/tensor_traits_test.C'; then $(CYGPATH_W) 'numerics/tensor_traits_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/tensor_traits_test.C'; fi`
 
 parallel/unit_tests_oprof-message_tag.o: parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_oprof-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_oprof-message_tag.Tpo -c -o parallel/unit_tests_oprof-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
@@ -9165,6 +9238,20 @@ numerics/unit_tests_opt-eigen_sparse_matrix_test.obj: numerics/eigen_sparse_matr
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-eigen_sparse_matrix_test.obj `if test -f 'numerics/eigen_sparse_matrix_test.C'; then $(CYGPATH_W) 'numerics/eigen_sparse_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/eigen_sparse_matrix_test.C'; fi`
 
+numerics/unit_tests_opt-tensor_traits_test.o: numerics/tensor_traits_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-tensor_traits_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-tensor_traits_test.Tpo -c -o numerics/unit_tests_opt-tensor_traits_test.o `test -f 'numerics/tensor_traits_test.C' || echo '$(srcdir)/'`numerics/tensor_traits_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-tensor_traits_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-tensor_traits_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/tensor_traits_test.C' object='numerics/unit_tests_opt-tensor_traits_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-tensor_traits_test.o `test -f 'numerics/tensor_traits_test.C' || echo '$(srcdir)/'`numerics/tensor_traits_test.C
+
+numerics/unit_tests_opt-tensor_traits_test.obj: numerics/tensor_traits_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-tensor_traits_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-tensor_traits_test.Tpo -c -o numerics/unit_tests_opt-tensor_traits_test.obj `if test -f 'numerics/tensor_traits_test.C'; then $(CYGPATH_W) 'numerics/tensor_traits_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/tensor_traits_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-tensor_traits_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-tensor_traits_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/tensor_traits_test.C' object='numerics/unit_tests_opt-tensor_traits_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-tensor_traits_test.obj `if test -f 'numerics/tensor_traits_test.C'; then $(CYGPATH_W) 'numerics/tensor_traits_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/tensor_traits_test.C'; fi`
+
 parallel/unit_tests_opt-message_tag.o: parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_opt-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_opt-message_tag.Tpo -c -o parallel/unit_tests_opt-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_opt-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_opt-message_tag.Po
@@ -10565,6 +10652,20 @@ numerics/unit_tests_prof-eigen_sparse_matrix_test.obj: numerics/eigen_sparse_mat
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-eigen_sparse_matrix_test.obj `if test -f 'numerics/eigen_sparse_matrix_test.C'; then $(CYGPATH_W) 'numerics/eigen_sparse_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/eigen_sparse_matrix_test.C'; fi`
 
+numerics/unit_tests_prof-tensor_traits_test.o: numerics/tensor_traits_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-tensor_traits_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-tensor_traits_test.Tpo -c -o numerics/unit_tests_prof-tensor_traits_test.o `test -f 'numerics/tensor_traits_test.C' || echo '$(srcdir)/'`numerics/tensor_traits_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_prof-tensor_traits_test.Tpo numerics/$(DEPDIR)/unit_tests_prof-tensor_traits_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/tensor_traits_test.C' object='numerics/unit_tests_prof-tensor_traits_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-tensor_traits_test.o `test -f 'numerics/tensor_traits_test.C' || echo '$(srcdir)/'`numerics/tensor_traits_test.C
+
+numerics/unit_tests_prof-tensor_traits_test.obj: numerics/tensor_traits_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-tensor_traits_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-tensor_traits_test.Tpo -c -o numerics/unit_tests_prof-tensor_traits_test.obj `if test -f 'numerics/tensor_traits_test.C'; then $(CYGPATH_W) 'numerics/tensor_traits_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/tensor_traits_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_prof-tensor_traits_test.Tpo numerics/$(DEPDIR)/unit_tests_prof-tensor_traits_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/tensor_traits_test.C' object='numerics/unit_tests_prof-tensor_traits_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-tensor_traits_test.obj `if test -f 'numerics/tensor_traits_test.C'; then $(CYGPATH_W) 'numerics/tensor_traits_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/tensor_traits_test.C'; fi`
+
 parallel/unit_tests_prof-message_tag.o: parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_prof-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_prof-message_tag.Tpo -c -o parallel/unit_tests_prof-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_prof-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_prof-message_tag.Po
@@ -11590,6 +11691,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-parsed_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-petsc_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-petsc_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-tensor_traits_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-trilinos_epetra_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-type_tensor_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-vector_value_test.Po
@@ -11606,6 +11708,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-parsed_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-petsc_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-petsc_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_devel-tensor_traits_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-trilinos_epetra_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-type_tensor_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-vector_value_test.Po
@@ -11622,6 +11725,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-parsed_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-petsc_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-petsc_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-tensor_traits_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-trilinos_epetra_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-type_tensor_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-vector_value_test.Po
@@ -11638,6 +11742,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-parsed_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-petsc_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-petsc_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_opt-tensor_traits_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-trilinos_epetra_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-type_tensor_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-vector_value_test.Po
@@ -11654,6 +11759,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-parsed_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-petsc_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-petsc_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_prof-tensor_traits_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-trilinos_epetra_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-type_tensor_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-vector_value_test.Po
@@ -12137,6 +12243,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-parsed_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-petsc_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-petsc_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-tensor_traits_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-trilinos_epetra_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-type_tensor_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-vector_value_test.Po
@@ -12153,6 +12260,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-parsed_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-petsc_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-petsc_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_devel-tensor_traits_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-trilinos_epetra_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-type_tensor_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-vector_value_test.Po
@@ -12169,6 +12277,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-parsed_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-petsc_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-petsc_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-tensor_traits_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-trilinos_epetra_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-type_tensor_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-vector_value_test.Po
@@ -12185,6 +12294,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-parsed_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-petsc_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-petsc_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_opt-tensor_traits_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-trilinos_epetra_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-type_tensor_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-vector_value_test.Po
@@ -12201,6 +12311,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-parsed_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-petsc_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-petsc_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_prof-tensor_traits_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-trilinos_epetra_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-type_tensor_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-vector_value_test.Po

--- a/tests/numerics/tensor_traits_test.C
+++ b/tests/numerics/tensor_traits_test.C
@@ -1,0 +1,31 @@
+#include "libmesh_cppunit.h"
+#include <libmesh/tensor_tools.h>
+
+using namespace libMesh;
+using namespace TensorTools;
+
+class TensorTraitsTest : public CppUnit::TestCase {
+public:
+  LIBMESH_CPPUNIT_TEST_SUITE( TensorTraitsTest );
+
+  CPPUNIT_TEST( test );
+
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void
+  test()
+    {
+      LOG_UNIT_TEST;
+
+      CPPUNIT_ASSERT_EQUAL((unsigned char)0, TensorTraits<Real>::rank);
+      CPPUNIT_ASSERT_EQUAL((unsigned char)1, TensorTraits<VectorValue<Real>>::rank);
+      CPPUNIT_ASSERT_EQUAL((unsigned char)1, TensorTraits<TypeVector<Real>>::rank);
+      CPPUNIT_ASSERT_EQUAL((unsigned char)2, TensorTraits<TensorValue<Real>>::rank);
+      CPPUNIT_ASSERT_EQUAL((unsigned char)2, TensorTraits<TypeTensor<Real>>::rank);
+      typedef TypeNTensor<3, Real> TypeNTensorTestType;
+      CPPUNIT_ASSERT_EQUAL((unsigned char)3, TensorTraits<TypeNTensorTestType>::rank);
+    }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( TensorTraitsTest );


### PR DESCRIPTION
Currently only holds a `rank` attribute, but there could be room for other things in the future perhaps. This would be useful for user code that wants to switch what it's doing for different types of mathematical structures, e.g. in @grmnptr's harmonic interpolation in idaholab/moose#21928