### PR TITLE
Better checking in System::add_variable()

### DIFF
--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1217,16 +1217,6 @@ unsigned int System::add_variable (std::string_view var,
                                    const FEType & type,
                                    const std::set<subdomain_id_type> * const active_subdomains)
 {
-  // Debugging
-  libMesh::out << "Called System::add_variable(), with var = " << var << std::endl;
-  if (active_subdomains)
-  {
-    libMesh::out << "active_subdomains = ";
-    for (const auto & id : *active_subdomains)
-      libMesh::out << id << " ";
-    libMesh::out << std::endl;
-  }
-
   // Make sure the variable isn't there already
   // or if it is, that it's the type we want
   for (auto v : make_range(this->n_vars()))
@@ -1234,11 +1224,6 @@ unsigned int System::add_variable (std::string_view var,
       {
         if (this->variable_type(v) == type)
           {
-            // Debugging
-            libMesh::out << "In System::add_variable(), found existing variable " << var
-                         << " with number " << _variables[v].number()
-                         << std::endl;
-
             // Check whether the existing variable's active subdomains also matches
             // the incoming variable's active subdomains. If they don't match, then
             // either it is an error by the user or the user is trying to change the

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1217,13 +1217,30 @@ unsigned int System::add_variable (std::string_view var,
                                    const FEType & type,
                                    const std::set<subdomain_id_type> * const active_subdomains)
 {
+  // Debugging
+  libMesh::out << "Called System::add_variable(), with var = " << var << std::endl;
+  if (active_subdomains)
+  {
+    libMesh::out << "active_subdomains = ";
+    for (const auto & id : *active_subdomains)
+      libMesh::out << id << " ";
+    libMesh::out << std::endl;
+  }
+
   // Make sure the variable isn't there already
   // or if it is, that it's the type we want
   for (auto v : make_range(this->n_vars()))
     if (this->variable_name(v) == var)
       {
         if (this->variable_type(v) == type)
+        {
+          // Debugging
+          libMesh::out << "In System::add_variable(), found existing variable " << var
+                       << " with number " << _variables[v].number()
+                       << std::endl;
+
           return _variables[v].number();
+        }
 
         libmesh_error_msg("ERROR: incompatible variable " << var << " has already been added for this system!");
       }


### PR DESCRIPTION
This fixes an issue we ran into where a variable with the same name and `FEType` was added to a `System` twice, but with different subdomain restrictions each time. Previously, the code would simply return the number of the existing variable, regardless of whether it had the same subdomain restriction as the variable just added. The previous code therefore effectively ignored attempts by the user to change the subdomain restriction of existing variables, but this new patch makes it an error to add the same variable twice with different subdomain restriction, since IMO this is less confusing than trying to debug why a variable has no DOFs on a subdomain where you expected it to have some. 

It's possible this will cause some tests to fail... but if so I would argue that those tests were only working by accident/not fully understood in the first place.
