### PR TITLE
Get function calls out of for loop tests

### DIFF
--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -1230,9 +1230,10 @@ struct RawType<libMesh::DenseMatrix<T>>
 
   static value_type value (const libMesh::DenseMatrix<T> & in)
     {
-      value_type ret(in.m(), in.n());
-      for (unsigned int i = 0; i < in.m(); ++i)
-        for (unsigned int j = 0; j < in.n(); ++j)
+      const auto m = in.m(), n = in.n();
+      value_type ret(m, n);
+      for (unsigned int i = 0; i < m; ++i)
+        for (unsigned int j = 0; j < n; ++j)
           ret(i,j) = raw_value(in(i,j));
 
       return ret;

--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -22,8 +22,9 @@
 
 // Local Includes
 #include "libmesh/libmesh_common.h"
-#include "libmesh/compare_types.h"
 #include "libmesh/dense_vector_base.h"
+#include "libmesh/compare_types.h"
+#include "libmesh/int_range.h"
 #include "libmesh/tensor_tools.h"
 
 #ifdef LIBMESH_HAVE_EIGEN
@@ -710,8 +711,9 @@ struct RawType<libMesh::DenseVector<T>>
 
   static value_type value (const libMesh::DenseVector<T> & in)
     {
-      value_type ret(in.size());
-      for (unsigned int i = 0; i < in.size(); ++i)
+      const auto s = in.size();
+      value_type ret(s);
+      for (unsigned int i = 0; i < s; ++i)
           ret(i) = raw_value(in(i));
 
       return ret;

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -1093,7 +1093,7 @@ eval_at_node(const FEMContext & c,
     {
       Gradient return_val;
 
-      for (unsigned int dim = 0; dim < elem.dim(); ++dim)
+      for (auto dim : make_range(elem.dim()))
       {
         const dof_id_type old_id =
           old_dof_object->dof_number(sys.number(), var, dim);
@@ -2051,7 +2051,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectVert
                 libmesh_assert_equal_to(vertex.n_comp(sys_num, var), elem.dim());
 
                 // We will have a number of nodal value DoFs equal to the elem dim
-                for (unsigned int i = 0; i < elem.dim(); ++i)
+                for (auto i : make_range(elem.dim()))
                 {
                   const dof_id_type id = vertex.dof_number(sys_num, var, i);
 
@@ -2370,7 +2370,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectEdge
                   if (fe_type.family == LAGRANGE_VEC)
                   {
                     // We will have a number of nodal value DoFs equal to the elem dim
-                    for (unsigned int i = 0; i < elem.dim(); ++i)
+                    for (auto i : make_range(elem.dim()))
                     {
                       const dof_id_type dof_id =
                         edge_node.dof_number(sys_num, var, i);
@@ -2552,7 +2552,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectSide
                   if (fe_type.family == LAGRANGE_VEC)
                   {
                     // We will have a number of nodal value DoFs equal to the elem dim
-                    for (unsigned int i = 0; i < elem.dim(); ++i)
+                    for (auto i : make_range(elem.dim()))
                     {
                       const dof_id_type dof_id = side_node.dof_number(sys_num, var, i);
 

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1826,7 +1826,8 @@ void DofMap::create_dof_constraints(const MeshBase & mesh, Real time)
 
   // Look at all the variables in the system.  Reset the element
   // range at each iteration -- there is no need to reconstruct it.
-  for (unsigned int variable_number=0; variable_number<this->n_variables();
+  const auto n_vars = this->n_variables();
+  for (unsigned int variable_number=0; variable_number<n_vars;
        ++variable_number, range.reset())
     Threads::parallel_for (range,
                            ComputeConstraints (_dof_constraints,

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -30,6 +30,7 @@
 #include "libmesh/dof_map.h"
 #include "libmesh/elem.h"
 #include "libmesh/fe_interface.h"
+#include "libmesh/int_range.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/periodic_boundary_base.h"
 #include "libmesh/periodic_boundaries.h"
@@ -1508,7 +1509,7 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
 {
   Ue.resize(0);
 
-  for (unsigned int v=0; v != dof_map.n_variables(); ++v)
+  for (auto v : make_range(dof_map.n_variables()))
     {
       DenseVector<Number> Usub;
 

--- a/src/fe/fe_xyz_shape_2D.C
+++ b/src/fe/fe_xyz_shape_2D.C
@@ -20,7 +20,9 @@
 
 // Local includes
 #include "libmesh/fe.h"
+
 #include "libmesh/elem.h"
+#include "libmesh/int_range.h"
 
 
 namespace libMesh
@@ -403,7 +405,7 @@ Real FE<2,XYZ>::shape_second_deriv(const Elem * elem,
 
   Point avg = elem->vertex_average();
   Point max_distance = Point(0.,0.,0.);
-  for (unsigned int p = 0; p < elem->n_nodes(); p++)
+  for (auto p : make_range(elem->n_nodes()))
     for (unsigned int d = 0; d < 2; d++)
       {
         const Real distance = std::abs(avg(d) - elem->point(p)(d));

--- a/src/fe/fe_xyz_shape_3D.C
+++ b/src/fe/fe_xyz_shape_3D.C
@@ -20,7 +20,9 @@
 
 // Local includes
 #include "libmesh/fe.h"
+
 #include "libmesh/elem.h"
+#include "libmesh/int_range.h"
 
 
 namespace libMesh
@@ -42,7 +44,7 @@ Real FE<3,XYZ>::shape(const Elem * elem,
 
   Point avg = elem->vertex_average();
   Point max_distance = Point(0.,0.,0.);
-  for (unsigned int p = 0; p < elem->n_nodes(); p++)
+  for (auto p : make_range(elem->n_nodes()))
     for (unsigned int d = 0; d < 3; d++)
       {
         const Real distance = std::abs(avg(d) - elem->point(p)(d));
@@ -251,7 +253,7 @@ Real FE<3,XYZ>::shape_deriv(const Elem * elem,
 
   Point avg = elem->vertex_average();
   Point max_distance = Point(0.,0.,0.);
-  for (unsigned int p = 0; p < elem->n_nodes(); p++)
+  for (auto p : make_range(elem->n_nodes()))
     for (unsigned int d = 0; d < 3; d++)
       {
         const Real distance = std::abs(avg(d) - elem->point(p)(d));

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -18,22 +18,24 @@
 
 // Local includes
 #include "libmesh/exodusII_io.h"
+
 #include "libmesh/boundary_info.h"
-#include "libmesh/mesh_base.h"
+#include "libmesh/dof_map.h"
+#include "libmesh/dyna_io.h"  // ElementDefinition for BEX
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/elem.h"
-#include "libmesh/equation_systems.h"
-#include "libmesh/libmesh_logging.h"
-#include "libmesh/system.h"
-#include "libmesh/numeric_vector.h"
-#include "libmesh/exodusII_io_helper.h"
 #include "libmesh/enum_to_string.h"
+#include "libmesh/equation_systems.h"
+#include "libmesh/exodusII_io_helper.h"
+#include "libmesh/int_range.h"
+#include "libmesh/libmesh_logging.h"
+#include "libmesh/mesh_base.h"
 #include "libmesh/mesh_communication.h"
+#include "libmesh/numeric_vector.h"
 #include "libmesh/parallel_mesh.h"
-#include "libmesh/dof_map.h"
 #include "libmesh/parallel.h"
+#include "libmesh/system.h"
 #include "libmesh/utility.h"
-#include "libmesh/dyna_io.h"  // ElementDefinition for BEX
 
 // TIMPI includes
 #include "timpi/parallel_sync.h"
@@ -361,7 +363,7 @@ void ExodusII_IO::read (const std::string & fname)
   // We use the last time step to load the IDs
   exio_helper->read_num_time_steps();
   unsigned int last_step = exio_helper->num_time_steps;
-  for (unsigned int i = 0; i < extra_ids.size(); i++)
+  for (auto i : index_range(extra_ids))
     exio_helper->read_elemental_var_values(_extra_integer_vars[i], last_step, elem_ids[i]);
 
   // Read in the element connectivity for each block.

--- a/src/mesh/mesh_smoother_laplace.C
+++ b/src/mesh/mesh_smoother_laplace.C
@@ -322,14 +322,16 @@ void LaplaceMeshSmoother::allgather_graph()
 
   // Make sure the old graph is cleared out
   _graph.clear();
-  _graph.resize(_mesh.max_node_id());
+  const auto max_node_id = _mesh.max_node_id();
+  _graph.resize(max_node_id);
 
   // Our current position in the allgather'd flat_graph
   std::size_t cursor=0;
 
   // There are max_node_id * n_processors entries to read in total
-  for (processor_id_type p=0; p<_mesh.n_processors(); ++p)
-    for (dof_id_type node_ctr=0; node_ctr<_mesh.max_node_id(); ++node_ctr)
+  const auto n_procs = _mesh.n_processors();
+  for (processor_id_type p = 0; p != n_procs; ++p)
+    for (dof_id_type node_ctr : make_range(max_node_id))
       {
         // Read the number of entries for this node, move cursor
         std::size_t n_entries = flat_graph[cursor++];

--- a/src/solution_transfer/dtk_adapter.C
+++ b/src/solution_transfer/dtk_adapter.C
@@ -24,6 +24,7 @@
 // libMesh includes
 #include "libmesh/dtk_adapter.h"
 #include "libmesh/dtk_evaluator.h"
+#include "libmesh/int_range.h"
 #include "libmesh/mesh.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/elem.h"
@@ -238,7 +239,7 @@ DTKAdapter::find_sys(std::string var_name)
   System * sys = nullptr;
 
   // Find the system this variable is from
-  for (unsigned int i=0; i<es.n_systems(); i++)
+  for (auto i : make_range(es.n_systems()))
     {
       if (es.get_system(i).has_variable(var_name))
         {

--- a/src/solution_transfer/meshfree_interpolation.C
+++ b/src/solution_transfer/meshfree_interpolation.C
@@ -18,11 +18,13 @@
 
 
 // Local includes
-#include "libmesh/point.h"
 #include "libmesh/meshfree_interpolation.h"
+
+#include "libmesh/int_range.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/parallel.h"
 #include "libmesh/parallel_algebra.h"
+#include "libmesh/point.h"
 
 // C++ includes
 #include <iomanip>
@@ -43,7 +45,7 @@ void MeshfreeInterpolation::print_info (std::ostream & os) const
   if (this->n_field_variables())
     {
       os << "  variables = ";
-      for (unsigned int v=0; v<this->n_field_variables(); v++)
+      for (auto v : make_range(this->n_field_variables()))
         os << _names[v] << " ";
       os << std::endl;
     }
@@ -83,7 +85,7 @@ void MeshfreeInterpolation::add_field_data (const std::vector<std::string> & fie
       libmesh_error_msg_if(_names.size() != field_names.size(),
                            "ERROR:  when adding field data to an existing list the \nvariable list must be the same!");
 
-      for (std::size_t v=0; v<_names.size(); v++)
+      for (auto v : index_range(_names))
         libmesh_error_msg_if(_names[v] != field_names[v],
                              "ERROR:  when adding field data to an existing list the \nvariable list must be the same!");
     }
@@ -209,7 +211,7 @@ void InverseDistanceInterpolation<KDDim>::interpolate_field_data (const std::vec
   libmesh_error_msg_if(_names.size() != field_names.size(),
                        "ERROR:  when adding field data to an existing list the \nvariable list must be the same!");
 
-  for (std::size_t v=0; v<_names.size(); v++)
+  for (auto v : index_range(_names))
     libmesh_error_msg_if(_names[v] != field_names[v],
                          "ERROR:  when adding field data to an existing list the \nvariable list must be the same!");
 

--- a/src/solution_transfer/radial_basis_interpolation.C
+++ b/src/solution_transfer/radial_basis_interpolation.C
@@ -17,21 +17,23 @@
 
 
 
-// C++ includes
-#include <iomanip>
-
 // Local includes
 #include "libmesh/radial_basis_interpolation.h"
-#include "libmesh/radial_basis_functions.h"
-#include "libmesh/mesh_tools.h" // BoundingBox
-#include "libmesh/libmesh_logging.h"
+
 #include "libmesh/eigen_core_support.h"
+#include "libmesh/int_range.h"
+#include "libmesh/libmesh_logging.h"
+#include "libmesh/mesh_tools.h" // BoundingBox
+#include "libmesh/radial_basis_functions.h"
 
 #ifdef LIBMESH_HAVE_EIGEN
 # include "libmesh/ignore_warnings.h"
 # include <Eigen/Dense>
 # include "libmesh/restore_warnings.h"
 #endif
+
+// C++ includes
+#include <iomanip>
 
 
 namespace libMesh
@@ -185,7 +187,7 @@ void RadialBasisInterpolation<KDDim,RBF>::interpolate_field_data (const std::vec
   libmesh_error_msg_if(this->_names.size() != field_names.size(),
                        "ERROR:  when adding field data to an existing list the \nvariable list must be the same!");
 
-  for (std::size_t v=0; v<this->_names.size(); v++)
+  for (auto v : index_range(this->_names))
     libmesh_error_msg_if(_names[v] != field_names[v],
                          "ERROR:  when adding field data to an existing list the \nvariable list must be the same!");
 

--- a/src/solvers/euler2_solver.C
+++ b/src/solvers/euler2_solver.C
@@ -16,12 +16,14 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-#include "libmesh/diff_system.h"
+// Local includes
 #include "libmesh/euler2_solver.h"
 
-#include "libmesh/error_vector.h"
-#include "libmesh/numeric_vector.h"
 #include "libmesh/adjoint_refinement_estimator.h"
+#include "libmesh/diff_system.h"
+#include "libmesh/error_vector.h"
+#include "libmesh/int_range.h"
+#include "libmesh/numeric_vector.h"
 
 namespace libMesh
 {
@@ -377,7 +379,7 @@ void Euler2Solver::integrate_adjoint_refinement_error_estimate(AdjointRefinement
   }
   else
   {
-    for(unsigned int i = 0; i < QoI_elementwise_error.size(); i++)
+    for(auto i : index_range(QoI_elementwise_error))
       QoI_elementwise_error_left[i] = 0.0;
   }
 
@@ -461,7 +463,7 @@ void Euler2Solver::integrate_adjoint_refinement_error_estimate(AdjointRefinement
   }
 
   // Error contribution from this timestep
-  for(unsigned int i = 0; i < QoI_elementwise_error.size(); i++)
+  for (auto i : index_range(QoI_elementwise_error))
     QoI_elementwise_error[i] = float(((QoI_elementwise_error_right[i] + QoI_elementwise_error_left[i])/2)
                                      * (time_right - time_left));
 

--- a/src/solvers/euler_solver.C
+++ b/src/solvers/euler_solver.C
@@ -16,12 +16,13 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-#include "libmesh/diff_system.h"
 #include "libmesh/euler_solver.h"
 
-#include "libmesh/error_vector.h"
-#include "libmesh/numeric_vector.h"
 #include "libmesh/adjoint_refinement_estimator.h"
+#include "libmesh/diff_system.h"
+#include "libmesh/error_vector.h"
+#include "libmesh/int_range.h"
+#include "libmesh/numeric_vector.h"
 
 namespace libMesh
 {
@@ -310,7 +311,7 @@ void EulerSolver::integrate_adjoint_refinement_error_estimate(AdjointRefinementE
   }
   else
   {
-    for(unsigned int i = 0; i < QoI_elementwise_error.size(); i++)
+    for (auto i : index_range(QoI_elementwise_error))
       QoI_elementwise_error_left[i] = 0.0;
   }
 
@@ -394,7 +395,7 @@ void EulerSolver::integrate_adjoint_refinement_error_estimate(AdjointRefinementE
   }
 
   // Error contribution from this timestep
-  for(unsigned int i = 0; i < QoI_elementwise_error.size(); i++)
+  for (auto i : index_range(QoI_elementwise_error))
     QoI_elementwise_error[i] = float(((QoI_elementwise_error_right[i] + QoI_elementwise_error_left[i])/2)
                                      * (time_right - time_left));
 

--- a/src/solvers/twostep_time_solver.C
+++ b/src/solvers/twostep_time_solver.C
@@ -18,16 +18,16 @@
 
 #include "libmesh/twostep_time_solver.h"
 
+#include "libmesh/adjoint_refinement_estimator.h"
 #include "libmesh/diff_system.h"
 #include "libmesh/enum_norm_type.h"
+#include "libmesh/error_vector.h"
 #include "libmesh/euler_solver.h"
+#include "libmesh/int_range.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/parameter_vector.h"
 #include "libmesh/sensitivity_data.h"
 #include "libmesh/solution_history.h"
-
-#include "libmesh/adjoint_refinement_estimator.h"
-#include "libmesh/error_vector.h"
 
 // C++ includes
 #include <memory>
@@ -390,9 +390,10 @@ void TwostepTimeSolver::integrate_adjoint_sensitivity(const QoISet & qois, const
   core_time_solver->integrate_adjoint_sensitivity(qois, parameter_vector, sensitivities_second_half);
 
   // Get the contributions for each sensitivity from this timestep
-  for(unsigned int i = 0; i != qois.size(_system); i++)
-    for(unsigned int j = 0; j != parameter_vector.size(); j++)
-     sensitivities[i][j] = sensitivities_first_half[i][j] + sensitivities_second_half[i][j];
+  const auto pv_size = parameter_vector.size();
+  for (auto i : make_range(qois.size(_system)))
+    for (auto j : make_range(pv_size))
+      sensitivities[i][j] = sensitivities_first_half[i][j] + sensitivities_second_half[i][j];
 }
 
 #ifdef LIBMESH_ENABLE_AMR
@@ -435,7 +436,7 @@ void TwostepTimeSolver::integrate_adjoint_refinement_error_estimate(AdjointRefin
   }
 
   // Error contribution from this timestep
-  for(unsigned int i = 0; i < QoI_elementwise_error.size(); i++)
+  for (auto i : index_range(QoI_elementwise_error))
     QoI_elementwise_error[i] = QoI_elementwise_error_first_half[i] + QoI_elementwise_error_second_half[i];
 
   for (auto j : make_range(_system.n_qois()))

--- a/src/solvers/unsteady_solver.C
+++ b/src/solvers/unsteady_solver.C
@@ -18,15 +18,16 @@
 
 #include "libmesh/unsteady_solver.h"
 
+#include "libmesh/adjoint_refinement_estimator.h"
 #include "libmesh/diff_solver.h"
 #include "libmesh/diff_system.h"
 #include "libmesh/dof_map.h"
+#include "libmesh/error_vector.h"
+#include "libmesh/int_range.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/parameter_vector.h"
 #include "libmesh/sensitivity_data.h"
 #include "libmesh/solution_history.h"
-#include "libmesh/adjoint_refinement_estimator.h"
-#include "libmesh/error_vector.h"
 
 namespace libMesh
 {
@@ -315,10 +316,10 @@ void UnsteadySolver::integrate_adjoint_sensitivity(const QoISet & qois, const Pa
   _system.remove_vector("sensitivity_rhs0");
 
   // Get the contributions for each sensitivity from this timestep
-  for(unsigned int i = 0; i != qois.size(_system); i++)
-    for(unsigned int j = 0; j != parameter_vector.size(); j++)
-     sensitivities[i][j] = ( (sensitivities_left[i][j] + sensitivities_right[i][j])/2. )*(time_right - time_left);
-
+  const auto pv_size = parameter_vector.size();
+  for (auto i : make_range(qois.size(_system)))
+    for (auto j : make_range(pv_size))
+      sensitivities[i][j] = ( (sensitivities_left[i][j] + sensitivities_right[i][j])/2. )*(time_right - time_left);
 }
 
 void UnsteadySolver::integrate_qoi_timestep()

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -18,23 +18,24 @@
 
 // Local Includes
 #include "libmesh/default_coupling.h" // For downconversion
+#include "libmesh/dof_map.h"
+#include "libmesh/eigen_system.h"
+#include "libmesh/elem.h"
 #include "libmesh/explicit_system.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/frequency_system.h"
+#include "libmesh/int_range.h"
+#include "libmesh/libmesh_logging.h"
 #include "libmesh/linear_implicit_system.h"
+#include "libmesh/mesh_base.h"
 #include "libmesh/mesh_refinement.h"
 #include "libmesh/newmark_system.h"
 #include "libmesh/nonlinear_implicit_system.h"
+#include "libmesh/parallel.h"
 #include "libmesh/rb_construction.h"
 #include "libmesh/remote_elem.h"
 #include "libmesh/transient_rb_construction.h"
-#include "libmesh/eigen_system.h"
-#include "libmesh/parallel.h"
 #include "libmesh/transient_system.h"
-#include "libmesh/dof_map.h"
-#include "libmesh/mesh_base.h"
-#include "libmesh/elem.h"
-#include "libmesh/libmesh_logging.h"
 
 // System includes
 #include <functional> // std::plus
@@ -90,7 +91,7 @@ void EquationSystems::init ()
   for (auto & elem : _mesh.element_ptr_range())
     elem->set_n_systems(n_sys);
 
-  for (unsigned int i=0; i != this->n_systems(); ++i)
+  for (auto i : make_range(this->n_systems()))
     this->get_system(i).init();
 
 #ifdef LIBMESH_ENABLE_AMR
@@ -125,7 +126,7 @@ void EquationSystems::reinit_mesh ()
   for (auto & elem : _mesh.element_ptr_range())
     elem->set_n_systems(n_sys);
 
-  //for (unsigned int i=0; i != this->n_systems(); ++i)
+  //for (auto i : make_range(this->n_systems()))
     //this->get_system(i).init();
 
 #ifdef LIBMESH_ENABLE_AMR
@@ -135,7 +136,7 @@ void EquationSystems::reinit_mesh ()
 
  // Now loop over all the systems belonging to this ES
  // and call reinit_mesh for each system
- for (unsigned int i=0; i != this->n_systems(); ++i)
+ for (auto i : make_range(this->n_systems()))
     this->get_system(i).reinit_mesh();
 
 }
@@ -216,7 +217,7 @@ bool EquationSystems::reinit_solutions ()
       // if necessary
       if (mesh_refine.coarsen_elements())
         {
-          for (unsigned int i=0; i != this->n_systems(); ++i)
+          for (auto i : make_range(this->n_systems()))
             {
               System & sys = this->get_system(i);
               sys.get_dof_map().distribute_dofs(_mesh);
@@ -235,7 +236,7 @@ bool EquationSystems::reinit_solutions ()
       // if necessary
       if (mesh_refine.refine_elements())
         {
-          for (unsigned int i=0; i != this->n_systems(); ++i)
+          for (auto i : make_range(this->n_systems()))
             {
               System & sys = this->get_system(i);
               sys.get_dof_map().distribute_dofs(_mesh);
@@ -257,7 +258,7 @@ bool EquationSystems::reinit_solutions ()
 
 void EquationSystems::reinit_systems()
 {
-  for (unsigned int i=0; i != this->n_systems(); ++i)
+  for (auto i : make_range(this->n_systems()))
     this->get_system(i).reinit();
 }
 
@@ -285,7 +286,7 @@ void EquationSystems::allgather ()
     elem->set_n_systems(n_sys);
 
   // And distribute each system's dofs
-  for (unsigned int i=0; i != this->n_systems(); ++i)
+  for (auto i : make_range(this->n_systems()))
     {
       System & sys = this->get_system(i);
       DofMap & dof_map = sys.get_dof_map();
@@ -311,7 +312,7 @@ void EquationSystems::enable_default_ghosting (bool enable)
   else
     mesh.remove_ghosting_functor(mesh.default_ghosting());
 
-  for (unsigned int i=0; i != this->n_systems(); ++i)
+  for (auto i : make_range(this->n_systems()))
     {
       DofMap & dof_map = this->get_system(i).get_dof_map();
       if (enable)
@@ -328,7 +329,7 @@ void EquationSystems::update ()
   LOG_SCOPE("update()", "EquationSystems");
 
   // Localize each system's vectors
-  for (unsigned int i=0; i != this->n_systems(); ++i)
+  for (auto i : make_range(this->n_systems()))
     this->get_system(i).update();
 }
 
@@ -420,7 +421,7 @@ void EquationSystems::solve ()
 {
   libmesh_assert (this->n_systems());
 
-  for (unsigned int i=0; i != this->n_systems(); ++i)
+  for (auto i : make_range(this->n_systems()))
     this->get_system(i).solve();
 }
 
@@ -430,7 +431,7 @@ void EquationSystems::sensitivity_solve (const ParameterVector & parameters_in)
 {
   libmesh_assert (this->n_systems());
 
-  for (unsigned int i=0; i != this->n_systems(); ++i)
+  for (auto i : make_range(this->n_systems()))
     this->get_system(i).sensitivity_solve(parameters_in);
 }
 

--- a/src/systems/frequency_system.C
+++ b/src/systems/frequency_system.C
@@ -25,7 +25,9 @@
 
 // Local includes
 #include "libmesh/frequency_system.h"
+
 #include "libmesh/equation_systems.h"
+#include "libmesh/int_range.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/linear_solver.h"
 #include "libmesh/numeric_vector.h"
@@ -249,7 +251,7 @@ void FrequencySystem::set_frequencies (const std::vector<Real> & frequencies,
   es.parameters.set<unsigned int>("n_frequencies") = frequencies.size();
 
   // set frequencies, build solution storage
-  for (std::size_t n=0; n<frequencies.size(); n++)
+  for (auto n : index_range(frequencies))
     {
       // remember frequencies as parameters
       es.parameters.set<Number>(this->form_freq_param_name(n)) = static_cast<Number>(frequencies[n]);

--- a/src/utils/plt_loader.C
+++ b/src/utils/plt_loader.C
@@ -19,6 +19,8 @@
 
 #include "libmesh/plt_loader.h"
 
+#include "libmesh/int_range.h"
+
 namespace libMesh
 {
 
@@ -73,7 +75,7 @@ void PltLoader::set_n_vars (const unsigned int nv)
     {
       _data.resize  (this->n_zones());
 
-      for (unsigned int z=0; z<this->n_zones(); z++)
+      for (auto z : make_range(this->n_zones()))
         _data[z].resize  (this->n_vars());
     }
 }
@@ -97,7 +99,7 @@ void PltLoader::set_n_zones (const unsigned int nz)
 
   // If the number of variables are set, resize the data.
   if (this->n_vars())
-    for (unsigned int z=0; z<this->n_zones(); z++)
+    for (auto z : make_range(this->n_zones()))
       _data[z].resize (this->n_vars());
 }
 

--- a/src/utils/plt_loader_write.C
+++ b/src/utils/plt_loader_write.C
@@ -17,11 +17,13 @@
 
 
 
-// C++ includes
-#include <fstream>
-
 // Local includes
 #include "libmesh/plt_loader.h"
+
+#include "libmesh/int_range.h"
+
+// C++ includes
+#include <fstream>
 
 namespace libMesh
 {
@@ -460,10 +462,10 @@ void PltLoader::write_dat (const std::string & name,
 
   out_stream << "VARIABLES = ";
 
-  for (unsigned int v=0; v<this->n_vars(); v++)
+  for (auto v : make_range(this->n_vars()))
     out_stream << "\"" << this->var_name(v) << "\"\n";
 
-  for (unsigned int z=0; z<this->n_zones(); z++)
+  for (auto z : make_range(this->n_zones()))
     {
       out_stream << "ZONE T=\"" << this->zone_name(z) << "\"\n";
       out_stream << " I="  << this->imax(z)
@@ -490,7 +492,7 @@ void PltLoader::write_dat (const std::string & name,
 
           out_stream.precision(9);
 
-          for (unsigned int v=0; v<this->n_vars(); v++)
+          for (auto v : make_range(this->n_vars()))
             {
               unsigned int l=0;
 
@@ -539,7 +541,7 @@ void PltLoader::write_dat (const std::string & name,
               for (unsigned int j=0; j<this->jmax(z); j++)
                 for (unsigned int i=0; i<this->imax(z); i++)
                   {
-                    for (unsigned int v=0; v<this->n_vars(); v++)
+                    for (auto v : make_range(this->n_vars()))
                       out_stream << std::scientific
                                  << _data[z][v][l] << " ";
 


### PR DESCRIPTION
Refs #1053

I haven't touched the reduced_basis code here, the ratio of importance to CI coverage there is way too high to futz with for a microoptimization, but this cleans up all the other redundantly-called functions I could find in include/ and src/

None of this (except maybe the new RawType specializations?) is likely to be in an inner kernel, so no rush to merge this, I just noticed a few of these cases while I was looking into vectorization reports.