### PR TITLE
Fix warning messages about inconsistent flags

### DIFF
--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -644,11 +644,10 @@ bool MeshRefinement::coarsen_elements ()
   // we don't want to abort large parallel runs in opt mode... but we
   // do want to warn that they should be fixed.
   libmesh_assert(flags_were_consistent);
+
   if (!flags_were_consistent)
-    {
-      libMesh::out << "Refinement flags were not consistent between processors!\n"
-                   << "Correcting and continuing.";
-    }
+    libmesh_warning("Warning: Refinement flags were not consistent between processors! "
+                    "Correcting and continuing.\n");
 
   // Smooth coarsening flags
   _smooth_flags(false, true);
@@ -720,11 +719,10 @@ bool MeshRefinement::refine_elements ()
   // we don't want to abort large parallel runs in opt mode... but we
   // do want to warn that they should be fixed.
   libmesh_assert(flags_were_consistent);
+
   if (!flags_were_consistent)
-    {
-      libMesh::out << "Refinement flags were not consistent between processors!\n"
-                   << "Correcting and continuing.";
-    }
+    libmesh_warning("Warning: Refinement flags were not consistent between processors! "
+                    "Correcting and continuing.\n");
 
   // Smooth refinement flags
   _smooth_flags(true, false);


### PR DESCRIPTION
Previously, the terminal ouptut looked like this:
```
Refinement flags were not consistent between processors!
Correcting and continuing.Refinement flags were not consistent between processors!
Correcting and continuing.Refinement flags were not consistent between processors!
Correcting and continuing.Refinement flags were not consistent between processors!
Correcting and continuing.Refinement flags were not consistent between processors!
Correcting and continuing.
```
Now it looks like this (one copy):
```
Warning: Refinement flags were not consistent between processors! Correcting and continuing. 
../../libmesh-src/src/mesh/mesh_refinement.C, line 725, compiled Nov  4 2022 at 09:17:47 ***
```
Note that including a newline in the string passed to libmesh_warning() improves the formatting of the message, since otherwise it appears all on one line with the line number and other information.
