### PR TITLE
Elem::orient(), MeshTools::Modification::orient_elements()

### DIFF
--- a/include/geom/cell_hex.h
+++ b/include/geom/cell_hex.h
@@ -172,6 +172,8 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 24; }
 
+  virtual void orient(BoundaryInfo *) override final;
+
   /**
    * This maps each edge to the sides that contain said edge.
    */

--- a/include/geom/cell_hex20.h
+++ b/include/geom/cell_hex20.h
@@ -236,6 +236,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   ElemType side_type (const unsigned int s) const override final;
 
 protected:

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -252,6 +252,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   unsigned int center_node_on_side(const unsigned short side) const override final;
 
   ElemType side_type (const unsigned int s) const override final;

--- a/include/geom/cell_hex8.h
+++ b/include/geom/cell_hex8.h
@@ -211,6 +211,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   ElemType side_type (const unsigned int s) const override final;
 
 protected:

--- a/include/geom/cell_inf_hex.h
+++ b/include/geom/cell_inf_hex.h
@@ -187,6 +187,8 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 4; }
 
+  virtual void orient(BoundaryInfo *) override final;
+
   /**
    * This maps each edge to the sides that contain said edge.
    */

--- a/include/geom/cell_inf_hex16.h
+++ b/include/geom/cell_inf_hex16.h
@@ -234,6 +234,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   ElemType side_type (const unsigned int s) const override final;
 
 protected:

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -249,6 +249,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   ElemType side_type (const unsigned int s) const override final;
 
 protected:

--- a/include/geom/cell_inf_hex8.h
+++ b/include/geom/cell_inf_hex8.h
@@ -184,6 +184,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   ElemType side_type (const unsigned int s) const override final;
 
 protected:

--- a/include/geom/cell_inf_prism.h
+++ b/include/geom/cell_inf_prism.h
@@ -171,6 +171,8 @@ public:
 
   std::vector<unsigned int> sides_on_edge(const unsigned int e) const override final;
 
+  virtual void orient(BoundaryInfo *) override final;
+
   /**
    * This maps each edge to the sides that contain said edge.
    */

--- a/include/geom/cell_inf_prism12.h
+++ b/include/geom/cell_inf_prism12.h
@@ -222,6 +222,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   ElemType side_type (const unsigned int s) const override final;
 
 protected:

--- a/include/geom/cell_inf_prism6.h
+++ b/include/geom/cell_inf_prism6.h
@@ -183,6 +183,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   ElemType side_type (const unsigned int s) const override final;
 
 protected:

--- a/include/geom/cell_prism.h
+++ b/include/geom/cell_prism.h
@@ -151,6 +151,8 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 6; }
 
+  virtual void orient(BoundaryInfo *) override final;
+
   /**
    * This maps each edge to the sides that contain said edge.
    */

--- a/include/geom/cell_prism15.h
+++ b/include/geom/cell_prism15.h
@@ -241,6 +241,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   ElemType side_type (const unsigned int s) const override final;
 
 protected:

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -257,6 +257,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   unsigned int center_node_on_side(const unsigned short side) const override final;
 
   ElemType side_type (const unsigned int s) const override final;

--- a/include/geom/cell_prism20.h
+++ b/include/geom/cell_prism20.h
@@ -256,6 +256,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   unsigned int center_node_on_side(const unsigned short side) const override final;
 
   ElemType side_type (const unsigned int s) const override final;

--- a/include/geom/cell_prism21.h
+++ b/include/geom/cell_prism21.h
@@ -259,6 +259,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   unsigned int center_node_on_side(const unsigned short side) const override final;
 
   ElemType side_type (const unsigned int s) const override final;

--- a/include/geom/cell_prism6.h
+++ b/include/geom/cell_prism6.h
@@ -201,6 +201,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   ElemType side_type (const unsigned int s) const override final;
 
 protected:

--- a/include/geom/cell_pyramid.h
+++ b/include/geom/cell_pyramid.h
@@ -175,6 +175,8 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 4; }
 
+  virtual void orient(BoundaryInfo *) override final;
+
   /**
    * This maps each edge to the sides that contain said edge.
    */

--- a/include/geom/cell_pyramid13.h
+++ b/include/geom/cell_pyramid13.h
@@ -229,6 +229,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   ElemType side_type (const unsigned int s) const override final;
 
 protected:

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -248,6 +248,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   unsigned int center_node_on_side(const unsigned short side) const override final;
 
   ElemType side_type (const unsigned int s) const override final;

--- a/include/geom/cell_pyramid5.h
+++ b/include/geom/cell_pyramid5.h
@@ -194,6 +194,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   ElemType side_type (const unsigned int s) const override final;
 
 protected:

--- a/include/geom/cell_tet.h
+++ b/include/geom/cell_tet.h
@@ -196,6 +196,8 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 12; }
 
+  virtual void orient(BoundaryInfo *) override final;
+
   /**
    * This maps each edge to the sides that contain said edge.
    */

--- a/include/geom/cell_tet10.h
+++ b/include/geom/cell_tet10.h
@@ -237,6 +237,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   ElemType side_type (const unsigned int s) const override final;
 
 protected:

--- a/include/geom/cell_tet14.h
+++ b/include/geom/cell_tet14.h
@@ -237,6 +237,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   ElemType side_type (const unsigned int s) const override final;
 
 #ifdef LIBMESH_ENABLE_AMR

--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -244,6 +244,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   ElemType side_type (const unsigned int s) const override final;
 
 protected:

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -202,6 +202,8 @@ public:
 
   virtual void permute(unsigned int) override final { libmesh_error(); }
 
+  virtual void orient(BoundaryInfo *) override final;
+
   unsigned int center_node_on_side(const unsigned short side) const override final;
 
   ElemType side_type (const unsigned int s) const override final;

--- a/include/geom/edge_edge2.h
+++ b/include/geom/edge_edge2.h
@@ -177,6 +177,8 @@ public:
   static const int nodes_per_side = 1;
   static const int nodes_per_edge = invalid_int;
 
+  virtual void flip(BoundaryInfo *) override final;
+
 protected:
 
   /**

--- a/include/geom/edge_edge3.h
+++ b/include/geom/edge_edge3.h
@@ -204,6 +204,8 @@ public:
   static const int nodes_per_side = 1;
   static const int nodes_per_edge = invalid_int;
 
+  virtual void flip(BoundaryInfo *) override final;
+
 protected:
 
   /**

--- a/include/geom/edge_edge4.h
+++ b/include/geom/edge_edge4.h
@@ -198,6 +198,8 @@ public:
   static const int nodes_per_side = 1;
   static const int nodes_per_edge = invalid_int;
 
+  virtual void flip(BoundaryInfo *) override final;
+
 protected:
 
   /**

--- a/include/geom/edge_inf_edge2.h
+++ b/include/geom/edge_inf_edge2.h
@@ -126,6 +126,11 @@ public:
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;
 
+  /**
+   * No such thing as a misoriented InfEdge
+   */
+  virtual void flip(BoundaryInfo *) override final {};
+
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
   /**

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -1762,12 +1762,16 @@ public:
   virtual unsigned int n_permutations() const = 0;
 
   /**
-   * Permutes the element (by swapping node_ptr values) according to
-   * the specified index.
+   * Permutes the element (by swapping node and neighbor pointers)
+   * according to the specified index.
    *
    * This is useful for regression testing, by making it easy to make
    * a structured mesh behave more like an arbitrarily unstructured
    * mesh.
+   *
+   * This is so far *only* used for regression testing, so we do
+   * not currently provide a way to permute any boundary side/edge ids
+   * along with the element permutation.
    */
   virtual void permute(unsigned int perm_num) = 0;
 

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -50,9 +50,9 @@ namespace libMesh
 
 // Forward declarations
 class BoundaryInfo;
+class Elem;
 class MeshBase;
 class MeshRefinement;
-class Elem;
 #ifdef LIBMESH_ENABLE_PERIODIC
 class PeriodicBoundaries;
 class PointLocatorBase;
@@ -1775,6 +1775,19 @@ public:
    * along with the element permutation.
    */
   virtual void permute(unsigned int perm_num) = 0;
+
+  /**
+   * Flips the element (by swapping node and neighbor pointers) to
+   * have a mapping Jacobian of opposite sign.
+   *
+   * This is useful for automatically fixing up elements that have
+   * been newly created (e.g. from extrusions) with a negative
+   * Jacobian.
+   *
+   * If \p boundary_info is not null, swap boundary side/edge ids
+   * consistently.
+   */
+  virtual void flip(BoundaryInfo * boundary_info) = 0;
 
 #ifdef LIBMESH_ENABLE_AMR
 

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -49,6 +49,7 @@ namespace libMesh
 {
 
 // Forward declarations
+class BoundaryInfo;
 class MeshBase;
 class MeshRefinement;
 class Elem;
@@ -1875,6 +1876,18 @@ protected:
     this->set_neighbor(n1, this->neighbor_ptr(n2));
     this->set_neighbor(n2, temp);
   }
+
+  /**
+   * Swaps two sides in \p boundary_info, if it is non-null.
+   */
+  void swap2boundarysides(unsigned short s1, unsigned short s2,
+                          BoundaryInfo * boundary_info) const;
+
+  /**
+   * Swaps two edges in \p boundary_info, if it is non-null.
+   */
+  void swap2boundaryedges(unsigned short e1, unsigned short e2,
+                          BoundaryInfo * boundary_info) const;
 
   /**
    * Swaps three node_ptrs, "rotating" them.

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -1789,6 +1789,14 @@ public:
    */
   virtual void flip(BoundaryInfo * boundary_info) = 0;
 
+  /**
+   * Flips the element (by swapping node and neighbor pointers) to
+   * have a mapping Jacobian of opposite sign, iff we find a negative
+   * orientation.  This only fixes flipped elements; for tangled
+   * elements the only fixes possible are non-local.
+   */
+  virtual void orient(BoundaryInfo * boundary_info) = 0;
+
 #ifdef LIBMESH_ENABLE_AMR
 
   /**

--- a/include/geom/face_inf_quad.h
+++ b/include/geom/face_inf_quad.h
@@ -231,6 +231,8 @@ public:
 
   virtual void permute(unsigned int) override final { libmesh_error(); }
 
+  virtual void orient(BoundaryInfo *) override final;
+
 protected:
 
   /**

--- a/include/geom/face_inf_quad4.h
+++ b/include/geom/face_inf_quad4.h
@@ -162,6 +162,8 @@ public:
 
   ElemType side_type (const unsigned int s) const override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
 protected:
 
   /**

--- a/include/geom/face_inf_quad6.h
+++ b/include/geom/face_inf_quad6.h
@@ -198,6 +198,8 @@ public:
 
   ElemType side_type (const unsigned int s) const override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
 protected:
 
   /**

--- a/include/geom/face_quad.h
+++ b/include/geom/face_quad.h
@@ -188,6 +188,8 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 4; }
 
+  virtual void orient(BoundaryInfo *) override final;
+
 protected:
 
   /**

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -174,6 +174,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   ElemType side_type (const unsigned int s) const override final;
 
 protected:

--- a/include/geom/face_quad8.h
+++ b/include/geom/face_quad8.h
@@ -211,6 +211,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   unsigned int center_node_on_side(const unsigned short side) const override final;
 
   ElemType side_type (const unsigned int s) const override final;

--- a/include/geom/face_quad9.h
+++ b/include/geom/face_quad9.h
@@ -218,6 +218,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   unsigned int center_node_on_side(const unsigned short side) const override final;
 
   ElemType side_type (const unsigned int s) const override final;

--- a/include/geom/face_tri.h
+++ b/include/geom/face_tri.h
@@ -175,6 +175,8 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 3; }
 
+  virtual void orient(BoundaryInfo *) override final;
+
 protected:
 
   /**

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -199,6 +199,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   ElemType side_type (const unsigned int s) const override final;
 
 protected:

--- a/include/geom/face_tri6.h
+++ b/include/geom/face_tri6.h
@@ -221,6 +221,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
   unsigned int center_node_on_side(const unsigned short side) const override final;
 
   ElemType side_type (const unsigned int s) const override final;

--- a/include/geom/face_tri7.h
+++ b/include/geom/face_tri7.h
@@ -219,6 +219,8 @@ public:
 
   virtual void permute(unsigned int perm_num) override final;
 
+  virtual void flip(BoundaryInfo *) override final;
+
 #ifdef LIBMESH_ENABLE_AMR
   virtual
   const std::vector<std::pair<unsigned char, unsigned char>> &

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -266,6 +266,7 @@ public:
   virtual void permute(unsigned int) override final { libmesh_error(); }
 
   virtual void flip(BoundaryInfo *) override final { libmesh_error(); }
+  virtual void orient(BoundaryInfo *) override final {};
 
   virtual ElemType side_type (const unsigned int) const override
   {

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -265,6 +265,8 @@ public:
 
   virtual void permute(unsigned int) override final { libmesh_error(); }
 
+  virtual void flip(BoundaryInfo *) override final { libmesh_error(); }
+
   virtual ElemType side_type (const unsigned int) const override
   {
     libmesh_not_implemented();

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -231,6 +231,7 @@ public:
   virtual void permute(unsigned int) override { libmesh_error(); }
 
   virtual void flip(BoundaryInfo *) override final { libmesh_error(); }
+  virtual void orient(BoundaryInfo *) override final { libmesh_error(); }
 
   virtual unsigned int center_node_on_side(const unsigned short) const override
   { libmesh_error(); return invalid_uint; }

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -230,6 +230,8 @@ public:
 
   virtual void permute(unsigned int) override { libmesh_error(); }
 
+  virtual void flip(BoundaryInfo *) override final { libmesh_error(); }
+
   virtual unsigned int center_node_on_side(const unsigned short) const override
   { libmesh_error(); return invalid_uint; }
 

--- a/include/mesh/mesh_modification.h
+++ b/include/mesh/mesh_modification.h
@@ -57,7 +57,7 @@ void distort (MeshBase & mesh,
 
 /**
  * Randomly permute the nodal ordering of each element (without
- * twisting the element mapping.  This is useful for regression
+ * twisting the element mapping).  This is useful for regression
  * testing with a variety of element orientations.
  *
  * This function does not currently handle meshes with any element
@@ -68,6 +68,15 @@ void distort (MeshBase & mesh,
  * the permutation.
  */
 void permute_elements (MeshBase & mesh);
+
+/**
+ * Redo the nodal ordering of each element as necessary to give the
+ * element Jacobian a positive orientation.
+ *
+ * This function does not currently handle meshes with any element
+ * refinement.
+ */
+void orient_elements (MeshBase & mesh);
 
 /**
  * Deterministically perturb the nodal locations.  This function will

--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -226,6 +226,17 @@ unsigned int Hex::opposite_node(const unsigned int node_in,
 
 
 
+void
+Hex::orient(BoundaryInfo * boundary_info)
+{
+  if (triple_product(this->point(1)-this->point(0),
+                     this->point(3)-this->point(0),
+                     this->point(4)-this->point(0)) < 0)
+    this->flip(boundary_info);
+}
+
+
+
 Real Hex::quality (const ElemQuality q) const
 {
   switch (q)

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -761,6 +761,26 @@ Hex20::permute(unsigned int perm_num)
 }
 
 
+void
+Hex20::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(2,3);
+  swap2nodes(4,5);
+  swap2nodes(6,7);
+  swap2nodes(9,11);
+  swap2nodes(12,13);
+  swap2nodes(14,15);
+  swap2nodes(17,19);
+  swap2neighbors(2,4);
+  swap2boundarysides(2,4,boundary_info);
+  swap2boundaryedges(1,3,boundary_info);
+  swap2boundaryedges(4,5,boundary_info);
+  swap2boundaryedges(6,7,boundary_info);
+  swap2boundaryedges(9,11,boundary_info);
+}
+
+
 ElemType
 Hex20::side_type (const unsigned int libmesh_dbg_var(s)) const
 {

--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -1138,6 +1138,27 @@ Hex27::permute(unsigned int perm_num)
 }
 
 
+void
+Hex27::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(2,3);
+  swap2nodes(4,5);
+  swap2nodes(6,7);
+  swap2nodes(9,11);
+  swap2nodes(12,13);
+  swap2nodes(14,15);
+  swap2nodes(17,19);
+  swap2nodes(22,24);
+  swap2neighbors(2,4);
+  swap2boundarysides(2,4,boundary_info);
+  swap2boundaryedges(1,3,boundary_info);
+  swap2boundaryedges(4,5,boundary_info);
+  swap2boundaryedges(6,7,boundary_info);
+  swap2boundaryedges(9,11,boundary_info);
+}
+
+
 unsigned int Hex27::center_node_on_side(const unsigned short side) const
 {
   libmesh_assert_less (side, Hex27::num_sides);

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -508,6 +508,22 @@ Hex8::permute(unsigned int perm_num)
 }
 
 
+void
+Hex8::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(2,3);
+  swap2nodes(4,5);
+  swap2nodes(6,7);
+  swap2neighbors(2,4);
+  swap2boundarysides(2,4,boundary_info);
+  swap2boundaryedges(1,3,boundary_info);
+  swap2boundaryedges(4,5,boundary_info);
+  swap2boundaryedges(6,7,boundary_info);
+  swap2boundaryedges(9,11,boundary_info);
+}
+
+
 ElemType
 Hex8::side_type (const unsigned int libmesh_dbg_var(s)) const
 {

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -245,6 +245,16 @@ std::vector<unsigned int> InfHex::sides_on_edge(const unsigned int e) const
 }
 
 
+void
+InfHex::orient(BoundaryInfo * boundary_info)
+{
+  if (triple_product(this->point(1)-this->point(0),
+                     this->point(3)-this->point(0),
+                     this->point(4)-this->point(0)) < 0)
+    this->flip(boundary_info);
+}
+
+
 Real InfHex::quality (const ElemQuality q) const
 {
   switch (q)

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -539,6 +539,23 @@ InfHex16::permute(unsigned int perm_num)
 }
 
 
+void
+InfHex16::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(2,3);
+  swap2nodes(4,5);
+  swap2nodes(6,7);
+  swap2nodes(9,11);
+  swap2nodes(13,15);
+  swap2neighbors(2,4);
+  swap2boundarysides(2,4,boundary_info);
+  swap2boundaryedges(1,3,boundary_info);
+  swap2boundaryedges(4,5,boundary_info);
+  swap2boundaryedges(6,7,boundary_info);
+}
+
+
 ElemType
 InfHex16::side_type (const unsigned int s) const
 {

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -656,6 +656,23 @@ InfHex18::permute(unsigned int perm_num)
 }
 
 
+void
+InfHex18::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(2,3);
+  swap2nodes(4,5);
+  swap2nodes(6,7);
+  swap2nodes(9,11);
+  swap2nodes(13,15);
+  swap2neighbors(0,4);
+  swap2boundarysides(0,4,boundary_info);
+  swap2boundaryedges(1,3,boundary_info);
+  swap2boundaryedges(4,5,boundary_info);
+  swap2boundaryedges(6,7,boundary_info);
+}
+
+
 ElemType
 InfHex18::side_type (const unsigned int s) const
 {

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -386,6 +386,21 @@ InfHex8::permute(unsigned int perm_num)
 }
 
 
+void
+InfHex8::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(2,3);
+  swap2nodes(4,5);
+  swap2nodes(6,7);
+  swap2neighbors(0,4);
+  swap2boundarysides(0,4,boundary_info);
+  swap2boundaryedges(1,3,boundary_info);
+  swap2boundaryedges(4,5,boundary_info);
+  swap2boundaryedges(6,7,boundary_info);
+}
+
+
 ElemType
 InfHex8::side_type (const unsigned int s) const
 {

--- a/src/geom/cell_inf_prism.C
+++ b/src/geom/cell_inf_prism.C
@@ -302,6 +302,17 @@ InfPrism::sides_on_edge(const unsigned int e) const
   return {std::begin(edge_sides_map[e]), std::end(edge_sides_map[e])};
 }
 
+
+void
+InfPrism::orient(BoundaryInfo * boundary_info)
+{
+  if (triple_product(this->point(1)-this->point(0),
+                     this->point(2)-this->point(0),
+                     this->point(3)-this->point(0)) < 0)
+    this->flip(boundary_info);
+}
+
+
 } // namespace libMesh
 
 

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -567,6 +567,19 @@ InfPrism12::permute(unsigned int perm_num)
 }
 
 
+void
+InfPrism12::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(3,4);
+  swap2nodes(7,8);
+  swap2nodes(10,11);
+  swap2neighbors(2,3);
+  swap2boundarysides(2,3,boundary_info);
+  swap2boundaryedges(3,4,boundary_info);
+}
+
+
 ElemType
 InfPrism12::side_type (const unsigned int s) const
 {

--- a/src/geom/cell_inf_prism6.C
+++ b/src/geom/cell_inf_prism6.C
@@ -372,6 +372,18 @@ InfPrism6::permute(unsigned int perm_num)
 }
 
 
+void
+InfPrism6::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(3,4);
+  swap2nodes(7,8);
+  swap2neighbors(2,3);
+  swap2boundarysides(2,3,boundary_info);
+  swap2boundaryedges(3,4,boundary_info);
+}
+
+
 ElemType
 InfPrism6::side_type (const unsigned int s) const
 {

--- a/src/geom/cell_prism.C
+++ b/src/geom/cell_prism.C
@@ -236,6 +236,16 @@ std::vector<unsigned int> Prism::sides_on_edge(const unsigned int e) const
 }
 
 
+void
+Prism::orient(BoundaryInfo * boundary_info)
+{
+  if (triple_product(this->point(1)-this->point(0),
+                     this->point(2)-this->point(0),
+                     this->point(3)-this->point(0)) < 0)
+    this->flip(boundary_info);
+}
+
+
 
 const unsigned short int Prism::_second_order_vertex_child_number[18] =
   {

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -755,6 +755,22 @@ Prism15::permute(unsigned int perm_num)
 }
 
 
+void
+Prism15::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(3,4);
+  swap2nodes(7,8);
+  swap2nodes(9,10);
+  swap2nodes(13,14);
+  swap2neighbors(2,3);
+  swap2boundarysides(2,3,boundary_info);
+  swap2boundaryedges(0,1,boundary_info);
+  swap2boundaryedges(3,4,boundary_info);
+  swap2boundaryedges(7,8,boundary_info);
+}
+
+
 ElemType
 Prism15::side_type (const unsigned int s) const
 {

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -1029,6 +1029,23 @@ Prism18::permute(unsigned int perm_num)
 }
 
 
+void
+Prism18::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(3,4);
+  swap2nodes(7,8);
+  swap2nodes(9,10);
+  swap2nodes(13,14);
+  swap2nodes(16,17);
+  swap2neighbors(2,3);
+  swap2boundarysides(2,3,boundary_info);
+  swap2boundaryedges(0,1,boundary_info);
+  swap2boundaryedges(3,4,boundary_info);
+  swap2boundaryedges(7,8,boundary_info);
+}
+
+
 unsigned int Prism18::center_node_on_side(const unsigned short side) const
 {
   libmesh_assert_less (side, Prism18::num_sides);

--- a/src/geom/cell_prism20.C
+++ b/src/geom/cell_prism20.C
@@ -868,6 +868,23 @@ Prism20::permute(unsigned int perm_num)
 }
 
 
+void
+Prism20::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(3,4);
+  swap2nodes(7,8);
+  swap2nodes(9,10);
+  swap2nodes(13,14);
+  swap2nodes(16,17);
+  swap2neighbors(2,3);
+  swap2boundarysides(2,3,boundary_info);
+  swap2boundaryedges(0,1,boundary_info);
+  swap2boundaryedges(3,4,boundary_info);
+  swap2boundaryedges(7,8,boundary_info);
+}
+
+
 unsigned int Prism20::center_node_on_side(const unsigned short side) const
 {
   libmesh_assert_less (side, Prism20::num_sides);

--- a/src/geom/cell_prism21.C
+++ b/src/geom/cell_prism21.C
@@ -889,6 +889,23 @@ Prism21::permute(unsigned int perm_num)
 }
 
 
+void
+Prism21::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(3,4);
+  swap2nodes(7,8);
+  swap2nodes(9,10);
+  swap2nodes(13,14);
+  swap2nodes(16,17);
+  swap2neighbors(2,3);
+  swap2boundarysides(2,3,boundary_info);
+  swap2boundaryedges(0,1,boundary_info);
+  swap2boundaryedges(3,4,boundary_info);
+  swap2boundaryedges(7,8,boundary_info);
+}
+
+
 unsigned int Prism21::center_node_on_side(const unsigned short side) const
 {
   libmesh_assert_less (side, Prism21::num_sides);

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -519,6 +519,19 @@ Prism6::permute(unsigned int perm_num)
 }
 
 
+void
+Prism6::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(3,4);
+  swap2neighbors(2,3);
+  swap2boundarysides(2,3,boundary_info);
+  swap2boundaryedges(0,1,boundary_info);
+  swap2boundaryedges(3,4,boundary_info);
+  swap2boundaryedges(7,8,boundary_info);
+}
+
+
 ElemType
 Prism6::side_type (const unsigned int s) const
 {

--- a/src/geom/cell_pyramid.C
+++ b/src/geom/cell_pyramid.C
@@ -229,6 +229,16 @@ std::vector<unsigned int> Pyramid::sides_on_edge(const unsigned int e) const
 }
 
 
+void
+Pyramid::orient(BoundaryInfo * boundary_info)
+{
+  if (triple_product(this->point(1)-this->point(0),
+                     this->point(3)-this->point(0),
+                     this->point(4)-this->point(0)) < 0)
+    this->flip(boundary_info);
+}
+
+
 
 unsigned int Pyramid::local_singular_node(const Point & p, const Real tol) const
 {

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -717,6 +717,21 @@ void Pyramid13::permute(unsigned int perm_num)
 }
 
 
+void Pyramid13::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(2,3);
+  swap2nodes(6,8);
+  swap2nodes(9,10);
+  swap2nodes(11,12);
+  swap2neighbors(1,3);
+  swap2boundarysides(1,3,boundary_info);
+  swap2boundaryedges(1,3,boundary_info);
+  swap2boundaryedges(4,5,boundary_info);
+  swap2boundaryedges(6,7,boundary_info);
+}
+
+
 ElemType Pyramid13::side_type (const unsigned int s) const
 {
   libmesh_assert_less (s, 5);

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -764,6 +764,21 @@ void Pyramid14::permute(unsigned int perm_num)
 }
 
 
+void Pyramid14::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(2,3);
+  swap2nodes(6,8);
+  swap2nodes(9,10);
+  swap2nodes(11,12);
+  swap2neighbors(1,3);
+  swap2boundarysides(1,3,boundary_info);
+  swap2boundaryedges(1,3,boundary_info);
+  swap2boundaryedges(4,5,boundary_info);
+  swap2boundaryedges(6,7,boundary_info);
+}
+
+
 unsigned int Pyramid14::center_node_on_side(const unsigned short side) const
 {
   libmesh_assert_less (side, Pyramid14::num_sides);

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -323,6 +323,19 @@ void Pyramid5::permute(unsigned int perm_num)
     }
 }
 
+
+void Pyramid5::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(2,3);
+  swap2neighbors(1,3);
+  swap2boundarysides(1,3,boundary_info);
+  swap2boundaryedges(1,3,boundary_info);
+  swap2boundaryedges(4,5,boundary_info);
+  swap2boundaryedges(6,7,boundary_info);
+}
+
+
 ElemType Pyramid5::side_type (const unsigned int s) const
 {
   libmesh_assert_less (s, 5);

--- a/src/geom/cell_tet.C
+++ b/src/geom/cell_tet.C
@@ -220,6 +220,17 @@ std::vector<unsigned int> Tet::sides_on_edge(const unsigned int e) const
 
 
 
+void
+Tet::orient(BoundaryInfo * boundary_info)
+{
+  if (triple_product(this->point(1)-this->point(0),
+                     this->point(2)-this->point(0),
+                     this->point(3)-this->point(0)) < 0)
+    this->flip(boundary_info);
+}
+
+
+
 Real Tet::quality(const ElemQuality q) const
 {
   return Elem::quality(q); // Not implemented

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -778,6 +778,18 @@ void Tet10::permute(unsigned int perm_num)
 }
 
 
+void Tet10::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,2);
+  swap2nodes(4,5);
+  swap2nodes(7,9);
+  swap2neighbors(1,2);
+  swap2boundarysides(1,2,boundary_info);
+  swap2boundaryedges(0,1,boundary_info);
+  swap2boundaryedges(3,5,boundary_info);
+}
+
+
 ElemType Tet10::side_type (const unsigned int libmesh_dbg_var(s)) const
 {
   libmesh_assert_less (s, 4);

--- a/src/geom/cell_tet14.C
+++ b/src/geom/cell_tet14.C
@@ -790,6 +790,19 @@ void Tet14::permute(unsigned int perm_num)
 }
 
 
+void Tet14::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,2);
+  swap2nodes(4,5);
+  swap2nodes(7,9);
+  swap2nodes(11,12);
+  swap2neighbors(1,2);
+  swap2boundarysides(1,2,boundary_info);
+  swap2boundaryedges(0,1,boundary_info);
+  swap2boundaryedges(3,5,boundary_info);
+}
+
+
 ElemType Tet14::side_type (const unsigned int libmesh_dbg_var(s)) const
 {
   libmesh_assert_less (s, 4);

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -611,6 +611,16 @@ void Tet4::permute(unsigned int perm_num)
 }
 
 
+void Tet4::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,2);
+  swap2neighbors(1,2);
+  swap2boundarysides(1,2,boundary_info);
+  swap2boundaryedges(0,1,boundary_info);
+  swap2boundaryedges(3,5,boundary_info);
+}
+
+
 ElemType Tet4::side_type (const unsigned int libmesh_dbg_var(s)) const
 {
   libmesh_assert_less (s, 4);

--- a/src/geom/edge.C
+++ b/src/geom/edge.C
@@ -148,4 +148,21 @@ ElemType Edge::side_type (const unsigned int libmesh_dbg_var(s)) const
   return NODEELEM;
 }
 
+
+void
+Edge::orient(BoundaryInfo * boundary_info)
+{
+  // Don't bother on 1D elements embedded in 2D/3D
+  if (
+#if LIBMESH_DIM > 2
+      !this->point(0)(2) && !this->point(1)(2) &&
+#endif
+#if LIBMESH_DIM > 1
+      !this->point(0)(1) && !this->point(1)(1) &&
+#endif
+      this->point(0)(0) > this->point(1)(0))
+    this->flip(boundary_info);
+}
+
+
 } // namespace libMesh

--- a/src/geom/edge_edge2.C
+++ b/src/geom/edge_edge2.C
@@ -153,4 +153,13 @@ dof_id_type Edge2::key () const
                            this->node_id(1));
 }
 
+
+void Edge2::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2neighbors(0,1);
+  swap2boundarysides(0,1,boundary_info);
+}
+
+
 } // namespace libMesh

--- a/src/geom/edge_edge3.C
+++ b/src/geom/edge_edge3.C
@@ -298,4 +298,12 @@ dof_id_type Edge3::key () const
 }
 
 
+void Edge3::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2neighbors(0,1);
+  swap2boundarysides(0,1,boundary_info);
+}
+
+
 } // namespace libMesh

--- a/src/geom/edge_edge4.C
+++ b/src/geom/edge_edge4.C
@@ -336,4 +336,14 @@ Real Edge4::volume () const
   return vol;
 }
 
+
+void Edge4::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(2,3);
+  swap2neighbors(0,1);
+  swap2boundarysides(0,1,boundary_info);
+}
+
+
 } // namespace libMesh

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -18,6 +18,8 @@
 
 // Local includes
 #include "libmesh/elem.h"
+
+#include "libmesh/boundary_info.h"
 #include "libmesh/fe_type.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/node_elem.h"
@@ -72,7 +74,6 @@
 #ifdef LIBMESH_ENABLE_PERIODIC
 #include "libmesh/mesh.h"
 #include "libmesh/periodic_boundaries.h"
-#include "libmesh/boundary_info.h"
 #endif
 
 
@@ -2966,5 +2967,36 @@ unsigned int Elem::center_node_on_side(const unsigned short libmesh_dbg_var(side
   return invalid_uint;
 }
 
+
+void Elem::swap2boundarysides(unsigned short s1,
+                              unsigned short s2,
+                              BoundaryInfo * boundary_info) const
+{
+  std::vector<boundary_id_type> ids1, ids2;
+  boundary_info->boundary_ids(this, s1, ids1);
+  boundary_info->boundary_ids(this, s2, ids2);
+  boundary_info->remove_side(this, s1);
+  boundary_info->remove_side(this, s2);
+  if (!ids1.empty())
+    boundary_info->add_side(this, s2, ids1);
+  if (!ids2.empty())
+    boundary_info->add_side(this, s1, ids2);
+}
+
+
+void Elem::swap2boundaryedges(unsigned short e1,
+                              unsigned short e2,
+                              BoundaryInfo * boundary_info) const
+{
+  std::vector<boundary_id_type> ids1, ids2;
+  boundary_info->edge_boundary_ids(this, e1, ids1);
+  boundary_info->edge_boundary_ids(this, e2, ids2);
+  boundary_info->remove_edge(this, e1);
+  boundary_info->remove_edge(this, e2);
+  if (!ids1.empty())
+    boundary_info->add_edge(this, e2, ids1);
+  if (!ids2.empty())
+    boundary_info->add_edge(this, e1, ids2);
+}
 
 } // namespace libMesh

--- a/src/geom/face_inf_quad.C
+++ b/src/geom/face_inf_quad.C
@@ -167,6 +167,22 @@ bool InfQuad::is_child_on_side(const unsigned int c,
 }
 
 
+void
+InfQuad::orient(BoundaryInfo * boundary_info)
+{
+  if (
+#if LIBMESH_DIM > 2
+      // Don't bother outside the XY plane
+      this->point(0)(2) && this->point(1)(2) &&
+      this->point(2)(2) && this->point(3)(2) &&
+#endif
+      ((this->point(1)(0)-this->point(0)(0))*
+       (this->point(2)(1)-this->point(0)(1)) >
+       (this->point(2)(0)-this->point(0)(0))*
+       (this->point(1)(1)-this->point(0)(1))))
+    this->flip(boundary_info);
+}
+
 
 Real InfQuad::quality (const ElemQuality) const
 {

--- a/src/geom/face_inf_quad4.C
+++ b/src/geom/face_inf_quad4.C
@@ -314,6 +314,15 @@ InfQuad4::side_type (const unsigned int s) const
 }
 
 
+void InfQuad4::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(2,3);
+  swap2neighbors(1,2);
+  swap2boundarysides(1,2,boundary_info);
+  swap2boundaryedges(1,2,boundary_info);
+}
+
 } // namespace libMesh
 
 

--- a/src/geom/face_inf_quad6.C
+++ b/src/geom/face_inf_quad6.C
@@ -376,6 +376,16 @@ InfQuad6::side_type (const unsigned int s) const
 }
 
 
+void InfQuad6::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(2,3);
+  swap2neighbors(1,2);
+  swap2boundarysides(1,2,boundary_info);
+  swap2boundaryedges(1,2,boundary_info);
+}
+
+
 } // namespace libMesh
 
 

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -163,6 +163,22 @@ unsigned int Quad::opposite_node(const unsigned int node_in,
 }
 
 
+void Quad::orient(BoundaryInfo * boundary_info)
+{
+  if (
+#if LIBMESH_DIM > 2
+      // Don't bother outside the XY plane
+      !this->point(0)(2) && !this->point(1)(2) &&
+      !this->point(2)(2) && !this->point(3)(2) &&
+#endif
+      ((this->point(1)(0)-this->point(0)(0))*
+       (this->point(3)(1)-this->point(0)(1)) <
+       (this->point(3)(0)-this->point(0)(0))*
+       (this->point(1)(1)-this->point(0)(1))))
+    this->flip(boundary_info);
+}
+
+
 Real Quad::quality (const ElemQuality q) const
 {
   switch (q)

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -369,6 +369,16 @@ void Quad4::permute(unsigned int perm_num)
 }
 
 
+void Quad4::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(2,3);
+  swap2neighbors(1,3);
+  swap2boundarysides(1,3,boundary_info);
+  swap2boundaryedges(1,3,boundary_info);
+}
+
+
 ElemType Quad4::side_type (const unsigned int libmesh_dbg_var(s)) const
 {
   libmesh_assert_less (s, 4);

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -447,6 +447,17 @@ void Quad8::permute(unsigned int perm_num)
 }
 
 
+void Quad8::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(2,3);
+  swap2nodes(5,7);
+  swap2neighbors(1,3);
+  swap2boundarysides(1,3,boundary_info);
+  swap2boundaryedges(1,3,boundary_info);
+}
+
+
 unsigned int Quad8::center_node_on_side(const unsigned short side) const
 {
   libmesh_assert_less (side, Quad8::num_sides);

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -471,6 +471,17 @@ void Quad9::permute(unsigned int perm_num)
 }
 
 
+void Quad9::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(2,3);
+  swap2nodes(5,7);
+  swap2neighbors(1,3);
+  swap2boundarysides(1,3,boundary_info);
+  swap2boundaryedges(1,3,boundary_info);
+}
+
+
 unsigned int Quad9::center_node_on_side(const unsigned short side) const
 {
   libmesh_assert_less (side, Quad9::num_sides);

--- a/src/geom/face_tri.C
+++ b/src/geom/face_tri.C
@@ -121,6 +121,22 @@ bool Tri::is_child_on_side(const unsigned int c,
 }
 
 
+void Tri::orient(BoundaryInfo * boundary_info)
+{
+  if (
+#if LIBMESH_DIM > 2
+      // Don't bother outside the XY plane
+      !this->point(0)(2) && !this->point(1)(2) &&
+      !this->point(2)(2) &&
+#endif
+      ((this->point(1)(0)-this->point(0)(0))*
+       (this->point(2)(1)-this->point(0)(1)) <
+       (this->point(2)(0)-this->point(0)(0))*
+       (this->point(1)(1)-this->point(0)(1))))
+    this->flip(boundary_info);
+}
+
+
 
 Real Tri::quality (const ElemQuality q) const
 {

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -274,6 +274,16 @@ void Tri3::permute(unsigned int perm_num)
     }
 }
 
+
+void Tri3::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2neighbors(1,2);
+  swap2boundarysides(1,2,boundary_info);
+  swap2boundaryedges(1,2,boundary_info);
+}
+
+
 ElemType
 Tri3::side_type (const unsigned int libmesh_dbg_var(s)) const
 {

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -442,6 +442,16 @@ void Tri6::permute(unsigned int perm_num)
 }
 
 
+void Tri6::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(4,5);
+  swap2neighbors(1,2);
+  swap2boundarysides(1,2,boundary_info);
+  swap2boundaryedges(1,2,boundary_info);
+}
+
+
 unsigned int Tri6::center_node_on_side(const unsigned short side) const
 {
   libmesh_assert_less (side, Tri6::num_sides);

--- a/src/geom/face_tri7.C
+++ b/src/geom/face_tri7.C
@@ -455,6 +455,16 @@ void Tri7::permute(unsigned int perm_num)
 }
 
 
+void Tri7::flip(BoundaryInfo * boundary_info)
+{
+  swap2nodes(0,1);
+  swap2nodes(4,5);
+  swap2neighbors(1,2);
+  swap2boundarysides(1,2,boundary_info);
+  swap2boundaryedges(1,2,boundary_info);
+}
+
+
 unsigned int Tri7::center_node_on_side(const unsigned short side) const
 {
   libmesh_assert_less (side, Tri7::num_sides);

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -186,6 +186,23 @@ void MeshTools::Modification::permute_elements(MeshBase & mesh)
 }
 
 
+void MeshTools::Modification::orient_elements(MeshBase & mesh)
+{
+  LOG_SCOPE("orient_elements()", "MeshTools::Modification");
+
+  // We don't yet support doing orient() on a parent element, which
+  // would require us to consistently orient all its children and
+  // give them different local child numbers.
+  unsigned int n_levels = MeshTools::n_levels(mesh);
+  if (n_levels > 1)
+    libmesh_error();
+
+  BoundaryInfo & boundary_info = mesh.get_boundary_info();
+  for (auto elem : mesh.element_ptr_range())
+    elem->orient(&boundary_info);
+}
+
+
 
 void MeshTools::Modification::redistribute (MeshBase & mesh,
                                             const FunctionBase<Real> & mapfunc)


### PR DESCRIPTION
This ought to close #3424

@GiudGiud - you've got a MOOSE MeshGenerator test case you can try this out on, make sure it handles bad extrusion vectors properly, before we merge here?