### PR TITLE
Add NodeElem contains_point() and close_to_point() implementations

### DIFF
--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -274,6 +274,24 @@ public:
     return INVALID_ELEM;
   }
 
+  /**
+   * \returns \p true if the point p is within a distance of "tol" from
+   * the point representing this element, false otherwise.
+   *
+   * The tolerance "tol" is normally treated as a relative tolerance in
+   * contains_point() checks, but in this case there is no relevant length
+   * to use in determing a relative tolerance, so "tol" is treated as an
+   * absolute tolerance. The NodeElem contains_point() and close_to_point()
+   * implementations are identical, whereas they differ for other element
+   * types.
+   */
+  virtual bool contains_point(const Point & p, Real tol) const override;
+
+  /**
+   * \returns this->contains_point(p, tol)
+   */
+  virtual bool close_to_point(const Point & p, Real tol) const override;
+
 protected:
 
   /**

--- a/src/geom/node_elem.C
+++ b/src/geom/node_elem.C
@@ -39,6 +39,16 @@ void NodeElem::connectivity(const unsigned int,
   libmesh_not_implemented();
 }
 
+bool NodeElem::contains_point(const Point & p, Real tol) const
+{
+  return (this->point(0) - p).norm() < tol;
+}
+
+bool NodeElem::close_to_point(const Point & p, Real tol) const
+{
+  return this->contains_point(p, tol);
+}
+
 #ifdef LIBMESH_ENABLE_AMR
 
 const Real NodeElem::_embedding_matrix[1][1][1] =

--- a/tests/mesh/contains_point.C
+++ b/tests/mesh/contains_point.C
@@ -18,6 +18,7 @@ public:
   LIBMESH_CPPUNIT_TEST_SUITE( ContainsPointTest );
 
 #if LIBMESH_DIM > 2
+  CPPUNIT_TEST( testContainsPointNodeElem );
   CPPUNIT_TEST( testContainsPointTri3 );
   CPPUNIT_TEST( testContainsPointTet4 );
 #endif
@@ -28,6 +29,18 @@ public:
   void setUp() {}
 
   void tearDown() {}
+
+  // NodeElem test
+  void testContainsPointNodeElem()
+  {
+    Node node  (1., 1., 1., /*id=*/0);
+    std::unique_ptr<Elem> elem = Elem::build(NODEELEM);
+    elem->set_node(0) = &node;
+
+    Real epsilon = 1.e-4;
+    CPPUNIT_ASSERT(elem->contains_point(Point(1.+epsilon/2, 1.-epsilon/2, 1+epsilon/2), /*tol=*/epsilon));
+    CPPUNIT_ASSERT(!elem->contains_point(Point(1.+epsilon/2, 1.-epsilon/2, 1+epsilon/2), /*tol=*/epsilon/2));
+  }
 
   // TRI3 test
   void testContainsPointTri3()

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -1226,11 +1226,15 @@ public:
 
         CPPUNIT_ASSERT(elem->contains_point(physical_pt));
 
+        // We only want to find elements in the same block
         std::set<subdomain_id_type> my_subdomain { elem->subdomain_id() };
 
-        const Elem * located_elem = (*locator)(physical_pt, &my_subdomain);
+        // We can *still* have overlapping NodeElem from a slit mesh
+        // input file; better check them all
+        std::set<const Elem * > located_elems;
+        (*locator)(physical_pt, located_elems, &my_subdomain);
 
-        CPPUNIT_ASSERT(located_elem == elem);
+        CPPUNIT_ASSERT(located_elems.count(elem));
       }
   }
 


### PR DESCRIPTION
The base class versions of these functions return false for `NodeElem`, even when the `Point` passed in only differs from the `NodeElem`'s position by floating point noise. The main difference is that the tolerance passed to `NodeElem::contains_point()` is used as an absolute tolerance rather than a relative tolerance, since, when you only have a single point, there's no obvious scale (like `hmax()` for an `Elem`) to use.
