### PR TITLE
Make petsc function begin and return (push and pop) match

### DIFF
--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -335,6 +335,8 @@ extern "C"
   PetscErrorCode
   libmesh_petsc_snes_mffd_interface (void * ctx, Vec x, Vec r)
   {
+    PetscFunctionBegin;
+
     // No way to safety-check this cast, since we got a void *...
     PetscNonlinearSolver<Number> * solver =
       static_cast<PetscNonlinearSolver<Number> *> (ctx);


### PR DESCRIPTION
Else we get errors out of new versions of PETSc.

Refs https://github.com/idaholab/moose/issues/22359#issuecomment-1309211454