### PR TITLE
Only print *uncaught* errors automatically 

### DIFF
--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -80,6 +80,16 @@ void lock_singleton_spin_mutex();
 void unlock_singleton_spin_mutex();
 }
 
+// Let's define a couple output streams - these will default
+// to cout/cerr, but LibMeshInit (or the user) can also set them to
+// something more sophisticated.
+//
+// We use a proxy class rather than references so they can be
+// reseated at runtime.
+
+extern OStreamProxy out;
+extern OStreamProxy err;
+
 // A namespace for functions used in the bodies of the macros below.
 // The macros generally call these functions with __FILE__, __LINE__,
 // __DATE__, and __TIME__ in the appropriate order.  These should not
@@ -87,9 +97,9 @@ void unlock_singleton_spin_mutex();
 // libmesh_common.C.
 namespace MacroFunctions
 {
-void here(const char * file, int line, const char * date, const char * time);
+void here(const char * file, int line, const char * date, const char * time, std::ostream & os = libMesh::err);
 void stop(const char * file, int line, const char * date, const char * time);
-void report_error(const char * file, int line, const char * date, const char * time);
+void report_error(const char * file, int line, const char * date, const char * time, std::ostream & os = libMesh::err);
 }
 
 // Undefine any existing macros
@@ -220,16 +230,6 @@ extern MPI_Comm GLOBAL_COMM_WORLD;
  */
 extern int GLOBAL_COMM_WORLD;
 #endif
-
-// Let's define a couple output streams - these will default
-// to cout/cerr, but LibMeshInit (or the user) can also set them to
-// something more sophisticated.
-//
-// We use a proxy class rather than references so they can be
-// reseated at runtime.
-
-extern OStreamProxy out;
-extern OStreamProxy err;
 
 // This global variable is to help us deprecate AutoPtr.  We can't
 // just use libmesh_deprecated() because then you get one print out

--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -390,7 +390,9 @@ struct casting_compare {
   do {                                                                  \
     std::stringstream message_stream;                                   \
     message_stream << msg << '\n';                                      \
+    libMesh::Threads::lock_singleton_spin_mutex();                      \
     libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME, message_stream); \
+    libMesh::Threads::unlock_singleton_spin_mutex();                    \
     LIBMESH_THROW(libMesh::LogicError(message_stream.str()));           \
   } while (0)
 
@@ -418,7 +420,9 @@ struct casting_compare {
   do {                                                                  \
     std::stringstream message_stream;                                   \
     message_stream << msg << '\n';                                      \
+    libMesh::Threads::lock_singleton_spin_mutex();                      \
     libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME, message_stream); \
+    libMesh::Threads::unlock_singleton_spin_mutex();                    \
     LIBMESH_THROW(libMesh::NotImplemented(message_stream.str()));       \
   } while (0)
 
@@ -428,7 +432,9 @@ struct casting_compare {
   do {                                                                  \
     std::stringstream message_stream;                                   \
     message_stream << msg << '\n';                                      \
+    libMesh::Threads::lock_singleton_spin_mutex();                      \
     libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME, message_stream); \
+    libMesh::Threads::unlock_singleton_spin_mutex();                    \
     LIBMESH_THROW(libMesh::FileError(filename, message_stream.str()));  \
   } while (0)
 

--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -71,6 +71,9 @@
 // compatibility, although we no longer use it in the library.
 #include "libmesh/libmesh_nullptr.h"
 
+// C++ headers
+#include <iomanip> // setprecision, in assertion macros
+
 namespace libMesh
 {
 namespace Threads
@@ -308,75 +311,14 @@ extern bool warned_about_auto_ptr;
 #define libmesh_assert_equal_to_msg(expr1,expr2, msg)                   \
   do {                                                                  \
     if (!((expr1) == (expr2))) {                                        \
-      libMesh::Threads::lock_singleton_spin_mutex();                    \
-      std::streamsize oldp = libMesh::err.precision(17);                \
-      libMesh::err << "Assertion `" #expr1 " == " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
-      libMesh::err.precision(oldp);                                     \
-      libMesh::Threads::unlock_singleton_spin_mutex();                  \
-      libmesh_error();                                                  \
+      libmesh_error_msg(std::setprecision(17) << "Assertion `" #expr1 " == " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl); \
     } } while (0)
 
 #define libmesh_assert_not_equal_to_msg(expr1,expr2, msg)               \
   do {                                                                  \
     if (!((expr1) != (expr2))) {                                        \
-      libMesh::Threads::lock_singleton_spin_mutex();                    \
-      std::streamsize oldp = libMesh::err.precision(17);                \
-      libMesh::err << "Assertion `" #expr1 " != " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
-      libMesh::err.precision(oldp);                                     \
-      libMesh::Threads::unlock_singleton_spin_mutex();                  \
-      libmesh_error();                                                  \
+      libmesh_error_msg(std::setprecision(17) << "Assertion `" #expr1 " != " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl); \
     } } while (0)
-
-// Older Clang has a parsing bug that can't seem to handle the handle the decay statement when
-// expanding these macros. We'll just fall back to the previous behavior with those older compilers
-#if defined(__clang__) && (__clang_major__ <= 3)
-
-#define libmesh_assert_less_msg(expr1,expr2, msg)                       \
-  do {                                                                  \
-    if (!((expr1) < (expr2))) {                                         \
-      libMesh::Threads::lock_singleton_spin_mutex();                    \
-      std::streamsize oldp = libMesh::err.precision(17);                \
-      libMesh::err << "Assertion `" #expr1 " < " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
-      libMesh::err.precision(oldp);                                     \
-      libMesh::Threads::unlock_singleton_spin_mutex();                  \
-      libmesh_error();                                                  \
-    } } while (0)
-
-#define libmesh_assert_greater_msg(expr1,expr2, msg)                    \
-  do {                                                                  \
-    if (!((expr1) > (expr2))) {                                         \
-      libMesh::Threads::lock_singleton_spin_mutex();                    \
-      std::streamsize oldp = libMesh::err.precision(17);                \
-      libMesh::err << "Assertion `" #expr1 " > " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
-      libMesh::err.precision(oldp);                                     \
-      libMesh::Threads::unlock_singleton_spin_mutex();                  \
-      libmesh_error();                                                  \
-    } } while (0)
-
-#define libmesh_assert_less_equal_msg(expr1,expr2, msg)                 \
-  do {                                                                  \
-    if (!((expr1) <= (expr2))) {                                        \
-      libMesh::Threads::lock_singleton_spin_mutex();                    \
-      std::streamsize oldp = libMesh::err.precision(17);                \
-      libMesh::err << "Assertion `" #expr1 " <= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
-      libMesh::err.precision(oldp);                                     \
-      libMesh::Threads::unlock_singleton_spin_mutex();                  \
-      libmesh_error();                                                  \
-    } } while (0)
-
-#define libmesh_assert_greater_equal_msg(expr1,expr2, msg)              \
-  do {                                                                  \
-    if (!((expr1) >= (expr2))) {                                        \
-      libMesh::Threads::lock_singleton_spin_mutex();                    \
-      std::streamsize oldp = libMesh::err.precision(17);                \
-      libMesh::err << "Assertion `" #expr1 " >= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
-      libMesh::err.precision(oldp);                                     \
-      libMesh::Threads::unlock_singleton_spin_mutex();                  \
-      libmesh_error();                                                  \
-    } } while (0)
-
-// Newer clangs and all other supported compilers
-#else
 
 template <template <class> class Comp>
 struct casting_compare {
@@ -400,48 +342,26 @@ struct casting_compare {
 #define libmesh_assert_less_msg(expr1,expr2, msg)                       \
   do {                                                                  \
     if (!libMesh::casting_compare<std::less>()(expr1, expr2)) {         \
-      libMesh::Threads::lock_singleton_spin_mutex();                    \
-      std::streamsize oldp = libMesh::err.precision(17);                \
-      libMesh::err << "Assertion `" #expr1 " < " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
-      libMesh::err.precision(oldp);                                     \
-      libMesh::Threads::unlock_singleton_spin_mutex();                  \
-      libmesh_error();                                                  \
+      libmesh_error_msg(std::setprecision(17) << "Assertion `" #expr1 " < " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl); \
     } } while (0)
 
 #define libmesh_assert_greater_msg(expr1,expr2, msg)                    \
   do {                                                                  \
     if (!libMesh::casting_compare<std::greater>()(expr1, expr2)) {      \
-      libMesh::Threads::lock_singleton_spin_mutex();                    \
-      std::streamsize oldp = libMesh::err.precision(17);                \
-      libMesh::err << "Assertion `" #expr1 " > " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
-      libMesh::err.precision(oldp);                                     \
-      libMesh::Threads::unlock_singleton_spin_mutex();                  \
-      libmesh_error();                                                  \
+      libmesh_error_msg(std::setprecision(17) << "Assertion `" #expr1 " > " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl); \
     } } while (0)
 
 #define libmesh_assert_less_equal_msg(expr1,expr2, msg)                 \
   do {                                                                  \
     if (!libMesh::casting_compare<std::less_equal>()(expr1, expr2)) {   \
-      libMesh::Threads::lock_singleton_spin_mutex();                    \
-      std::streamsize oldp = libMesh::err.precision(17);                \
-      libMesh::err << "Assertion `" #expr1 " <= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
-      libMesh::err.precision(oldp);                                     \
-      libMesh::Threads::unlock_singleton_spin_mutex();                  \
-      libmesh_error();                                                  \
+      libmesh_error_msg(std::setprecision(17) << "Assertion `" #expr1 " <= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl); \
     } } while (0)
 
 #define libmesh_assert_greater_equal_msg(expr1,expr2, msg)              \
   do {                                                                  \
     if (!libMesh::casting_compare<std::greater_equal>()(expr1, expr2)) { \
-      libMesh::Threads::lock_singleton_spin_mutex();                    \
-      std::streamsize oldp = libMesh::err.precision(17);                \
-      libMesh::err << "Assertion `" #expr1 " >= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
-      libMesh::err.precision(oldp);                                     \
-      libMesh::Threads::unlock_singleton_spin_mutex();                  \
-      libmesh_error();                                                  \
+      libmesh_error_msg(std::setprecision(17) << "Assertion `" #expr1 " >= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl); \
     } } while (0)
-
-#endif // clang <4.0
 
 #endif
 
@@ -468,13 +388,10 @@ struct casting_compare {
 // throws a ConvergenceFailure exception
 #define libmesh_error_msg(msg)                                          \
   do {                                                                  \
-    libMesh::Threads::lock_singleton_spin_mutex();                      \
-    libMesh::err << msg << std::endl;                                   \
-    std::stringstream msg_stream;                                       \
-    msg_stream << msg;                                                  \
-    libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME); \
-    libMesh::Threads::unlock_singleton_spin_mutex();                    \
-    LIBMESH_THROW(libMesh::LogicError(msg_stream.str()));               \
+    std::stringstream message_stream;                                   \
+    message_stream << msg << '\n';                                      \
+    libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME, message_stream); \
+    LIBMESH_THROW(libMesh::LogicError(message_stream.str()));           \
   } while (0)
 
 #define libmesh_error() libmesh_error_msg("")
@@ -488,7 +405,7 @@ struct casting_compare {
 #define libmesh_exceptionless_error_msg(msg)                            \
   do {                                                                  \
     libMesh::Threads::lock_singleton_spin_mutex();                      \
-    libMesh::err << msg << std::endl;                                   \
+    libMesh::err << msg << '\n';                                        \
     libmesh_try { libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME); } \
     libmesh_catch (...) {}                                              \
     libMesh::Threads::unlock_singleton_spin_mutex();                    \
@@ -499,23 +416,20 @@ struct casting_compare {
 
 #define libmesh_not_implemented_msg(msg)                                \
   do {                                                                  \
-    libMesh::Threads::lock_singleton_spin_mutex();                      \
-    libMesh::err << msg << std::endl;                                   \
-    libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME); \
-    libMesh::Threads::unlock_singleton_spin_mutex();                    \
-    LIBMESH_THROW(libMesh::NotImplemented());                           \
+    std::stringstream message_stream;                                   \
+    message_stream << msg << '\n';                                      \
+    libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME, message_stream); \
+    LIBMESH_THROW(libMesh::NotImplemented(message_stream.str()));       \
   } while (0)
 
 #define libmesh_not_implemented() libmesh_not_implemented_msg("")
 
 #define libmesh_file_error_msg(filename, msg)                           \
   do {                                                                  \
-    libMesh::Threads::lock_singleton_spin_mutex();                      \
-    libMesh::err << "Error with file `" << filename << "'" << std::endl; \
-    libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME); \
-    libMesh::err << msg << std::endl;                                   \
-    libMesh::Threads::unlock_singleton_spin_mutex();                    \
-    LIBMESH_THROW(libMesh::FileError(filename));                        \
+    std::stringstream message_stream;                                   \
+    message_stream << msg << '\n';                                      \
+    libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME, message_stream); \
+    LIBMESH_THROW(libMesh::FileError(filename, message_stream.str()));  \
   } while (0)
 
 #define libmesh_file_error(filename) libmesh_file_error_msg(filename,"")

--- a/include/base/libmesh_exceptions.h
+++ b/include/base/libmesh_exceptions.h
@@ -51,7 +51,7 @@ public:
 class NotImplemented : public std::logic_error
 {
 public:
-  NotImplemented() : std::logic_error( "Error: not implemented!" ) {}
+  NotImplemented(std::string msg="") : std::logic_error( "Error: feature not implemented!\n" + msg ) {}
 };
 
 
@@ -65,7 +65,8 @@ public:
 class FileError : public std::runtime_error
 {
 public:
-  FileError(const std::string & filename) : std::runtime_error( "Error accessing file: " + filename ) {}
+  FileError(const std::string & filename, const std::string msg="") :
+    std::runtime_error("Error with file `" + filename + "'\n" + std::move(msg)) {}
 };
 
 

--- a/include/base/libmesh_exceptions.h
+++ b/include/base/libmesh_exceptions.h
@@ -151,7 +151,7 @@ public:
 
 #else
 
-#define LIBMESH_THROW(e) do { std::abort(); } while (0)
+#define LIBMESH_THROW(e) do { libMesh::err << e.what(); std::abort(); } while (0)
 #define libmesh_try
 #define libmesh_catch(e) if (0)
 

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -276,6 +276,23 @@ std::terminate_handler old_terminate_handler;
 
 void libmesh_terminate_handler()
 {
+  // If we have an active exception, it may have an error message that
+  // we should print.
+  std::cout << "libMesh terminating";
+  std::exception_ptr ex = std::current_exception();
+  if (ex)
+    {
+      try
+        {
+          std::rethrow_exception(ex);
+        }
+      catch (const std::exception & std_ex)
+        {
+          libMesh::err << ":\n" << std_ex.what();
+        }
+    }
+  libMesh::err << std::endl;
+
   // If this got called then we're probably crashing; let's print a
   // stack trace.  The trace files that are ultimately written depend on:
   // 1.) Who throws the exception.
@@ -319,9 +336,8 @@ void libmesh_terminate_handler()
     MPI_Abort(libMesh::GLOBAL_COMM_WORLD, 1);
   else
 #endif
-    // The system terminate_handler may do useful things like printing
-    // uncaught exception information, or the user may have created
-    // their own terminate handler that we want to call.
+    // The system terminate_handler may do useful things, or the user
+    // may have set their own terminate handler that we want to call.
     old_terminate_handler();
 }
 #endif

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -278,7 +278,7 @@ void libmesh_terminate_handler()
 {
   // If we have an active exception, it may have an error message that
   // we should print.
-  std::cout << "libMesh terminating";
+  libMesh::err << "libMesh terminating";
   std::exception_ptr ex = std::current_exception();
   if (ex)
     {

--- a/src/base/libmesh_common.C
+++ b/src/base/libmesh_common.C
@@ -38,14 +38,14 @@ namespace libMesh
 
 namespace MacroFunctions
 {
-void here(const char * file, int line, const char * date, const char * time)
+void here(const char * file, int line, const char * date, const char * time, std::ostream & os)
 {
-  libMesh::err << "[" << static_cast<std::size_t>(libMesh::global_processor_id()) << "] "
-               << file
-               << ", line " << line
-               << ", compiled " << date
-               << " at " << time
-               << std::endl;
+  os << "[" << static_cast<std::size_t>(libMesh::global_processor_id()) << "] "
+     << file
+     << ", line " << line
+     << ", compiled " << date
+     << " at " << time
+     << std::endl;
 }
 
 
@@ -66,7 +66,7 @@ void stop(const char * file, int line, const char * date, const char * time)
 }
 
 
-void report_error(const char * file, int line, const char * date, const char * time)
+void report_error(const char * file, int line, const char * date, const char * time, std::ostream & os)
 {
   // It is possible to have an error *inside* report_error; e.g. from
   // print_trace.  We don't want to infinitely recurse.
@@ -75,17 +75,17 @@ void report_error(const char * file, int line, const char * date, const char * t
     {
       // I heard you like error reporting, so we put an error report
       // in report_error() so you can report errors from the report.
-      libMesh::err << "libMesh encountered an error while attempting to report_error." << std::endl;
+      os << "libMesh encountered an error while attempting to report_error." << std::endl;
       return;
     }
   reporting_error = true;
 
   if (libMesh::global_n_processors() == 1 ||
       libMesh::on_command_line("--print-trace"))
-    libMesh::print_trace();
+    libMesh::print_trace(os);
   else
     libMesh::write_traceout();
-  libMesh::MacroFunctions::here(file, line, date, time);
+  libMesh::MacroFunctions::here(file, line, date, time, os);
 
   reporting_error = false;
 }


### PR DESCRIPTION
We're increasingly using the ability to catch and recover from some errors, and in cases where we do that it's probably better to let the catch block decide what (if anything) to print about the caught error.  By ensuring `exception::what()` is a valid description of the error, we can wait until an error actually forces us to terminate before we print that description.

Pinging @lindsayad, because although I *think* this design also obviates most of the `lock_singleton_spin_mutex()` use cases (output from `std::terminate()` should only happen after all other threads have been killed) but I'm not certain.