### PR TITLE
Add pointwise_divide to PetscVector

### DIFF
--- a/include/numerics/distributed_vector.h
+++ b/include/numerics/distributed_vector.h
@@ -226,6 +226,9 @@ public:
   virtual void pointwise_mult (const NumericVector<T> & vec1,
                                const NumericVector<T> & vec2) override;
 
+  virtual void pointwise_divide (const NumericVector<T> & vec1,
+                                 const NumericVector<T> & vec2) override;
+
   virtual void swap (NumericVector<T> & v) override;
 
   virtual std::size_t max_allowed_id() const override;

--- a/include/numerics/eigen_sparse_vector.h
+++ b/include/numerics/eigen_sparse_vector.h
@@ -228,6 +228,9 @@ public:
   virtual void pointwise_mult (const NumericVector<T> & vec1,
                                const NumericVector<T> & vec2) override;
 
+  virtual void pointwise_divide (const NumericVector<T> & vec1,
+                                 const NumericVector<T> & vec2) override;
+
   virtual void swap (NumericVector<T> & v) override;
 
   virtual std::size_t max_allowed_id() const override;

--- a/include/numerics/laspack_vector.h
+++ b/include/numerics/laspack_vector.h
@@ -226,6 +226,9 @@ public:
   virtual void pointwise_mult (const NumericVector<T> & vec1,
                                const NumericVector<T> & vec2) override;
 
+  virtual void pointwise_divide (const NumericVector<T> & vec1,
+                                 const NumericVector<T> & vec2) override;
+
   virtual void swap (NumericVector<T> & v) override;
 
   virtual std::size_t max_allowed_id() const override;

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -672,6 +672,14 @@ public:
                                const NumericVector<T> & vec2) = 0;
 
   /**
+   * Computes \f$ u_i \leftarrow \frac{v_{1,i}}{v_{2,i}} \f$ (summation not implied)
+   * i.e. the pointwise (component-wise) division of \p vec1 and
+   * \p vec2, and stores the result in \p *this.
+   */
+  virtual void pointwise_divide (const NumericVector<T> & vec1,
+                                 const NumericVector<T> & vec2) = 0;
+
+  /**
    * Prints the local contents of the vector, by default to
    * libMesh::out
    */

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -321,6 +321,9 @@ public:
   virtual void pointwise_mult (const NumericVector<T> & vec1,
                                const NumericVector<T> & vec2) override;
 
+  virtual void pointwise_divide (const NumericVector<T> & vec1,
+                                 const NumericVector<T> & vec2) override;
+
   virtual void print_matlab(const std::string & name = "") const override;
 
   virtual void create_subvector(NumericVector<T> & subvector,

--- a/src/numerics/distributed_vector.C
+++ b/src/numerics/distributed_vector.C
@@ -619,7 +619,12 @@ void DistributedVector<T>::pointwise_mult (const NumericVector<T> &,
   libmesh_not_implemented();
 }
 
-
+template <typename T>
+void DistributedVector<T>::pointwise_divide (const NumericVector<T> &,
+                                             const NumericVector<T> &)
+{
+  libmesh_not_implemented();
+}
 
 //--------------------------------------------------------------
 // Explicit instantiations

--- a/src/numerics/eigen_sparse_vector.C
+++ b/src/numerics/eigen_sparse_vector.C
@@ -418,6 +418,12 @@ void EigenSparseVector<T>::pointwise_mult (const NumericVector<T> & /*vec1*/,
   libmesh_not_implemented();
 }
 
+template <typename T>
+void EigenSparseVector<T>::pointwise_divide (const NumericVector<T> & /*vec1*/,
+                                             const NumericVector<T> & /*vec2*/)
+{
+  libmesh_not_implemented();
+}
 
 
 template <typename T>

--- a/src/numerics/laspack_vector.C
+++ b/src/numerics/laspack_vector.C
@@ -482,7 +482,12 @@ void LaspackVector<T>::pointwise_mult (const NumericVector<T> & /*vec1*/,
   libmesh_not_implemented();
 }
 
-
+template <typename T>
+void LaspackVector<T>::pointwise_divide (const NumericVector<T> & /*vec1*/,
+                                         const NumericVector<T> & /*vec2*/)
+{
+  libmesh_not_implemented();
+}
 
 template <typename T>
 Real LaspackVector<T>::max() const

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -1022,7 +1022,24 @@ void PetscVector<T>::pointwise_mult (const NumericVector<T> & vec1,
   this->_is_closed = true;
 }
 
+template <typename T>
+void PetscVector<T>::pointwise_divide (const NumericVector<T> & vec1,
+                                       const NumericVector<T> & vec2)
+{
+  this->_restore_array();
 
+  // Convert arguments to PetscVector*.
+  const PetscVector<T> * const vec1_petsc = cast_ptr<const PetscVector<T> *>(&vec1);
+  const PetscVector<T> * const vec2_petsc = cast_ptr<const PetscVector<T> *>(&vec2);
+
+  // Call PETSc function.
+  PetscErrorCode ierr = VecPointwiseDivide(_vec, vec1_petsc->vec(), vec2_petsc->vec());
+  LIBMESH_CHKERR(ierr);
+  if (this->type() == GHOSTED)
+    VecGhostUpdateBeginEnd(this->comm(), _vec, INSERT_VALUES, SCATTER_FORWARD);
+
+  this->_is_closed = true;
+}
 
 template <typename T>
 void PetscVector<T>::print_matlab (const std::string & name) const


### PR DESCRIPTION
I would be nice to use the wrapped version of PETSc's `VecPointwiseDivide` here:
https://github.com/idaholab/moose/pull/22699

