### PR TITLE
Fix --disable-exceptions builds

### DIFF
--- a/examples/adjoints/adjoints_ex1/adjoints_ex1.C
+++ b/examples/adjoints/adjoints_ex1/adjoints_ex1.C
@@ -321,8 +321,8 @@ int main (int argc, char ** argv)
   // safely
   if (param.mesh_partitioner_type != "Default")
     {
-#ifndef LIBMESH_HAVE_RTTI
-      libmesh_example_requires(false, "RTTI support");
+#if !defined(LIBMESH_HAVE_RTTI) || !defined(LIBMESH_ENABLE_EXCEPTIONS)
+      libmesh_example_requires(false, "RTTI + exceptions support");
 #else
       // Factory failures are *verbose* in parallel; let's silence
       // cerr temporarily.
@@ -349,7 +349,7 @@ int main (int argc, char ** argv)
           libmesh_example_requires(false, param.mesh_partitioner_type + " partitioner support");
         }
       libMesh::err.rdbuf(oldbuf);
-#endif // LIBMESH_HAVE_RTI
+#endif // LIBMESH_HAVE_RTTI, LIBMESH_ENABLE_EXCEPTIONS
     }
 
   // And an object to refine it

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -462,10 +462,10 @@ int main (int argc, char ** argv)
   // In optimized mode we catch any solver errors, so that we can
   // write the proper footers before closing.  In debug mode we just
   // let the exception throw so that gdb can grab it.
-#ifdef NDEBUG
+#if defined(NDEBUG) && defined(LIBMESH_ENABLE_EXCEPTIONS)
   try
-    {
 #endif
+    {
       // Now we begin the timestep loop to compute the time-accurate
       // solution of the equations.
       for (unsigned int t_step=param.initial_timestep;
@@ -777,8 +777,8 @@ int main (int argc, char ** argv)
         libmesh_error_msg_if(std::abs(total_sensitivity - 4.83551) >= 2.e-4,
                              "Mismatch in sensitivity gold value!");
       }
-#ifdef NDEBUG
     }
+#if defined(NDEBUG) && defined(LIBMESH_ENABLE_EXCEPTIONS)
   catch (...)
     {
       libMesh::err << '[' << mesh.processor_id()

--- a/examples/adjoints/adjoints_ex7/adjoints_ex7.C
+++ b/examples/adjoints/adjoints_ex7/adjoints_ex7.C
@@ -450,10 +450,10 @@ int main (int argc, char ** argv)
   // In optimized mode we catch any solver errors, so that we can
   // write the proper footers before closing.  In debug mode we just
   // let the exception throw so that gdb can grab it.
-#ifdef NDEBUG
+#if defined(NDEBUG) && defined(LIBMESH_ENABLE_EXCEPTIONS)
   try
-    {
 #endif
+    {
       // Now we begin the timestep loop to compute the time-accurate
       // solution of the equations.
       for (unsigned int t_step=param.initial_timestep;
@@ -924,8 +924,8 @@ int main (int argc, char ** argv)
         libmesh_error_msg_if(std::abs(accumulated_QoI_spatially_integrated_error[1] - (-0.23895256319278346)) >= 2.e-4,
                              "Error Estimator identity not satisfied!");
       }
-#ifdef NDEBUG
     }
+#if defined(NDEBUG) && defined(LIBMESH_ENABLE_EXCEPTIONS)
   catch (...)
     {
       libMesh::err << '[' << mesh.processor_id()

--- a/include/base/libmesh_exceptions.h
+++ b/include/base/libmesh_exceptions.h
@@ -22,12 +22,9 @@
 
 #include "libmesh/libmesh_config.h"
 
-#ifdef LIBMESH_ENABLE_EXCEPTIONS
 #include <stdexcept>
 #include <string>
 #include <sstream>
-
-#define libmesh_noexcept noexcept
 
 namespace libMesh {
 
@@ -144,6 +141,9 @@ public:
 };
 
 }
+
+#ifdef LIBMESH_ENABLE_EXCEPTIONS
+#define libmesh_noexcept noexcept
 
 #define LIBMESH_THROW(e) do { throw e; } while (0)
 #define libmesh_try try

--- a/src/systems/equation_systems_io.C
+++ b/src/systems/equation_systems_io.C
@@ -131,7 +131,7 @@ void EquationSystems::read (std::string_view name,
                        << "Good Luck!!\n"
                        << "*********************************************************************\n"
                        << std::endl;
-          LIBMESH_THROW();
+          libmesh_error();
         }
     }
 

--- a/tests/geom/which_node_am_i_test.C
+++ b/tests/geom/which_node_am_i_test.C
@@ -114,10 +114,10 @@ public:
     // Test the libmesh_asserts when they are enabled and exceptions
     // are available. If exceptions aren't available, libmesh_assert
     // simply aborts, so we can't unit test in that case.
-    const Elem & prism6 = ReferenceElem::get(PRISM6);
 #if !defined(NDEBUG) && defined(LIBMESH_ENABLE_EXCEPTIONS)
     try
       {
+        const Elem & prism6 = ReferenceElem::get(PRISM6);
         // Avoid sending confusing error messages to the console.
         StreamRedirector stream_redirector;
 
@@ -136,8 +136,11 @@ public:
 
 #ifdef NDEBUG
     // In optimized mode, we expect to get the "dummy" value 99.
-    unsigned int n = prism6.local_side_node(0, 3);
-    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(99), n);
+    {
+      const Elem & prism6 = ReferenceElem::get(PRISM6);
+      unsigned int n = prism6.local_side_node(0, 3);
+      CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(99), n);
+    }
 #endif
 
     // Test the Prism15 midedge nodes.

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -919,8 +919,10 @@ public:
       // Debugging this in parallel is tricky.  Let's make sure that
       // if we have a failure on one rank we see it on all the others
       // and we can go on to other tests.
+#ifdef LIBMESH_ENABLE_EXCEPTIONS
       bool threw_exception = false;
       try
+#endif // LIBMESH_ENABLE_EXCEPTIONS
       {
       for (const auto & elem : mesh.active_local_element_ptr_range())
         {
@@ -987,6 +989,7 @@ public:
             }
         }
       }
+#ifdef LIBMESH_ENABLE_EXCEPTIONS
       catch (...)
       {
         threw_exception = true;
@@ -996,6 +999,7 @@ public:
       if (!threw_exception)
         TestCommWorld->max(threw_exception);
       CPPUNIT_ASSERT(!threw_exception);
+#endif // LIBMESH_ENABLE_EXCEPTIONS
 
       TestCommWorld->sum(n_side_nodes);
       CPPUNIT_ASSERT_EQUAL(n_side_nodes, n_fake_nodes);


### PR DESCRIPTION
Thanks to @jwpeterson for noticing the failure in our devel->master CI.  This goes a bit farther than the fixes for that; I did a gcc build with `libmesh_CXXFLAGS='-fno-exceptions'` as well and fixed the (non-third-party) errors which cropped up from that too.