### PR TITLE
Drop libmesh_experimental() tag from MeshBase::add_elemset_code()

### DIFF
--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -243,8 +243,6 @@ void MeshBase::set_elem_dimensions(std::set<unsigned char> elem_dims)
 
 void MeshBase::add_elemset_code(dof_id_type code, MeshBase::elemset_type id_set)
 {
-  libmesh_experimental();
-
   // Populate inverse map, stealing id_set's resources
   auto [it1, inserted1] = _elemset_codes_inverse_map.emplace(std::move(id_set), code);
 


### PR DESCRIPTION
We use elemsets a lot now, and I don't really consider them to be experimental any more.