### PR TITLE
Fixes/workarounds for Nvidia HPC compiler warnings

### DIFF
--- a/include/solvers/eigen_sparse_linear_solver.h
+++ b/include/solvers/eigen_sparse_linear_solver.h
@@ -192,8 +192,7 @@ EigenSparseLinearSolver<T>::solve (SparseMatrix<T> &,
 {
   libmesh_error_msg("ERROR: Eigen does not support a user-supplied preconditioner!");
 
-  std::pair<unsigned int, Real> p;
-  return p;
+  return std::pair<unsigned int, Real>();
 }
 
 } // namespace libMesh

--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -104,9 +104,11 @@
 #  pragma nv_diagnostic push
 // Warning numbers are from --display_error_number
 #  ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#    pragma nv_diag_suppress 541 // allowing all exceptions is incompatible with previous function
 #    pragma nv_diag_suppress 1758 // conversion between incompatible vector types
 #    pragma nv_diag_suppress = integer_sign_change
 #  else
+#    pragma diag_suppress 541 // allowing all exceptions is incompatible with previous function
 #    pragma diag_suppress 1758 // conversion between incompatible vector types
 #    pragma diag_suppress = integer_sign_change
 #  endif

--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -104,12 +104,16 @@
 #  pragma nv_diagnostic push
 // Warning numbers are from --display_error_number
 #  ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#    pragma nv_diag_suppress 11 // unrecognized preprocessing directive
+#    pragma nv_diag_suppress 177 // declared but never referenced
 #    pragma nv_diag_suppress 541 // allowing all exceptions is incompatible with previous function
 #    pragma nv_diag_suppress 1758 // conversion between incompatible vector types
 #    pragma nv_diag_suppress = integer_sign_change
 #  else
-#    pragma diag_suppress 541 // allowing all exceptions is incompatible with previous function
-#    pragma diag_suppress 1758 // conversion between incompatible vector types
+#    pragma diag_suppress 11
+#    pragma diag_suppress 177
+#    pragma diag_suppress 541
+#    pragma diag_suppress 1758
 #    pragma diag_suppress = integer_sign_change
 #  endif
 #endif

--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -99,3 +99,15 @@
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
 #endif // __GNUC__ && !__INTEL_COMPILER
+
+#ifdef __NVCOMPILER
+#  pragma nv_diagnostic push
+// Warning numbers are from --display_error_number
+#  ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#    pragma nv_diag_suppress 1758 // conversion between incompatible vector types
+#    pragma nv_diag_suppress = integer_sign_change
+#  else
+#    pragma diag_suppress 1758 // conversion between incompatible vector types
+#    pragma diag_suppress = integer_sign_change
+#  endif
+#endif

--- a/include/utils/restore_warnings.h
+++ b/include/utils/restore_warnings.h
@@ -31,3 +31,7 @@
 #pragma GCC diagnostic pop
 #endif // GCC > 4.5
 #endif // __GNUC__ && !__INTEL_COMPILER
+
+#ifdef __NVCOMPILER
+#  pragma nv_diagnostic pop
+#endif

--- a/src/fe/fe_hierarchic_shape_3D.C
+++ b/src/fe/fe_hierarchic_shape_3D.C
@@ -1997,8 +1997,6 @@ Real fe_hierarchic_3D_shape(const Elem * elem,
             returnval *= zeta[3];
             return returnval;
           }
-
-        libmesh_error();
       }
 
     default:

--- a/src/fe/fe_side_hierarchic.C
+++ b/src/fe/fe_side_hierarchic.C
@@ -150,7 +150,6 @@ unsigned int side_hierarchic_n_dofs(const ElemType t, const Order o)
     case EDGE3:
     case EDGE4:
       return 2; // One per side
-      libmesh_assert_less (o, 2);
       libmesh_fallthrough();
     case QUAD8:
     case QUADSHELL8:

--- a/src/fe/inf_fe_boundary.C
+++ b/src/fe/inf_fe_boundary.C
@@ -200,31 +200,32 @@ void InfFE<Dim,T_radial,T_base>::init_face_shape_functions(const std::vector<Poi
       // the quadrature points must be assembled differently for lower dims.
       libmesh_not_implemented();
     }
-  {
-    const std::vector<Real> & radial_qw = radial_qrule->get_weights();
-    const std::vector<Real> & base_qw   = base_qrule->get_weights();
-    const std::vector<Point> & radial_qp = radial_qrule->get_points();
-    const std::vector<Point> & base_qp   = base_qrule->get_points();
+  else
+    {
+      const std::vector<Real> & radial_qw = radial_qrule->get_weights();
+      const std::vector<Real> & base_qw   = base_qrule->get_weights();
+      const std::vector<Point> & radial_qp = radial_qrule->get_points();
+      const std::vector<Point> & base_qp   = base_qrule->get_points();
 
-    libmesh_assert_equal_to (radial_qw.size(), n_radial_qp);
-    libmesh_assert_equal_to (base_qw.size(), n_base_qp);
+      libmesh_assert_equal_to (radial_qw.size(), n_radial_qp);
+      libmesh_assert_equal_to (base_qw.size(), n_base_qp);
 
-    for (unsigned int rp=0; rp<n_radial_qp; rp++)
-      for (unsigned int bp=0; bp<n_base_qp; bp++)
-        {
-          _total_qrule_weights[bp + rp*n_base_qp] = radial_qw[rp] * base_qw[bp];
-          // initialize the quadrature-points for the 2D side element
-          // - either the base element or it has a 1D base + radial direction.
-          if (inf_side->infinite())
-            qp[bp + rp*n_base_qp]=Point(base_qp[bp](0),
-                                        0.,
-                                        radial_qp[rp](0));
-          else
-            qp[bp + rp*n_base_qp]=Point(base_qp[bp](0),
-                                        base_qp[bp](1),
-                                        -1.);
-        }
-  }
+      for (unsigned int rp=0; rp<n_radial_qp; rp++)
+        for (unsigned int bp=0; bp<n_base_qp; bp++)
+          {
+            _total_qrule_weights[bp + rp*n_base_qp] = radial_qw[rp] * base_qw[bp];
+            // initialize the quadrature-points for the 2D side element
+            // - either the base element or it has a 1D base + radial direction.
+            if (inf_side->infinite())
+              qp[bp + rp*n_base_qp]=Point(base_qp[bp](0),
+                                          0.,
+                                          radial_qp[rp](0));
+            else
+              qp[bp + rp*n_base_qp]=Point(base_qp[bp](0),
+                                          base_qp[bp](1),
+                                          -1.);
+          }
+    }
 
   this->reinit(inf_side->interior_parent(), &qp);
 

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -370,9 +370,9 @@ std::pair<Real, Real> InfHex::qual_bounds (const ElemQuality) const
 {
   libmesh_not_implemented();
 
+  /*
   std::pair<Real, Real> bounds;
 
-  /*
     switch (q)
     {
 
@@ -432,9 +432,11 @@ std::pair<Real, Real> InfHex::qual_bounds (const ElemQuality) const
     bounds.first  = -1;
     bounds.second = -1;
     }
-  */
 
   return bounds;
+  */
+
+  return std::pair<Real,Real>();
 }
 
 

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -587,7 +587,7 @@ unsigned short int Prism18::second_order_adjacent_vertex (const unsigned int n,
 
     }
 
-  libmesh_error_msg("We'll never ge here!");
+  // libmesh_error_msg("We'll never get here!"); // static checkers agree
   return static_cast<unsigned short int>(-1);
 }
 

--- a/src/geom/cell_prism20.C
+++ b/src/geom/cell_prism20.C
@@ -366,12 +366,13 @@ void Prism20::build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i
 
 
 
-void Prism20::connectivity(const unsigned int sc,
-                           const IOPackage iop,
-                           std::vector<dof_id_type> & conn) const
+void Prism20::connectivity(const unsigned int /*sc*/,
+                           const IOPackage /*iop*/,
+                           std::vector<dof_id_type> & /*conn*/) const
 {
   libmesh_not_implemented(); // FIXME RHS
 
+/*
   libmesh_assert(_nodes);
   libmesh_assert_less (sc, this->n_sub_elem());
   libmesh_assert_not_equal_to (iop, INVALID_IO_PACKAGE);
@@ -530,6 +531,7 @@ void Prism20::connectivity(const unsigned int sc,
     default:
       libmesh_error_msg("Unsupported IO package " << iop);
     }
+*/
 }
 
 

--- a/src/geom/cell_prism21.C
+++ b/src/geom/cell_prism21.C
@@ -384,12 +384,13 @@ void Prism21::build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i
 
 
 
-void Prism21::connectivity(const unsigned int sc,
-                           const IOPackage iop,
-                           std::vector<dof_id_type> & conn) const
+void Prism21::connectivity(const unsigned int /*sc*/,
+                           const IOPackage /*iop*/,
+                           std::vector<dof_id_type> & /*conn*/) const
 {
   libmesh_not_implemented(); // FIXME RHS
 
+/*
   libmesh_assert(_nodes);
   libmesh_assert_less (sc, this->n_sub_elem());
   libmesh_assert_not_equal_to (iop, INVALID_IO_PACKAGE);
@@ -548,6 +549,7 @@ void Prism21::connectivity(const unsigned int sc,
     default:
       libmesh_error_msg("Unsupported IO package " << iop);
     }
+*/
 }
 
 

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -361,15 +361,15 @@ Real Tri6::volume () const
   const unsigned int N = 7;
 
   // Parameters of the quadrature rule
-  const static Real
+  static const Real
     w1 = Real(31)/480 + Real(std::sqrt(15.0L)/2400),
     w2 = Real(31)/480 - Real(std::sqrt(15.0L)/2400),
     q1 = Real(2)/7 + Real(std::sqrt(15.0L)/21),
     q2 = Real(2)/7 - Real(std::sqrt(15.0L)/21);
 
-  const static Real xi[N]  = {Real(1)/3,  q1, q1,     1-2*q1, q2, q2,     1-2*q2};
-  const static Real eta[N] = {Real(1)/3,  q1, 1-2*q1, q1,     q2, 1-2*q2, q2};
-  const static Real wts[N] = {Real(9)/80, w1, w1,     w1,     w2, w2,     w2};
+  static const Real xi[N]  = {Real(1)/3,  q1, q1,     1-2*q1, q2, q2,     1-2*q2};
+  static const Real eta[N] = {Real(1)/3,  q1, 1-2*q1, q1,     q2, 1-2*q2, q2};
+  static const Real wts[N] = {Real(9)/80, w1, w1,     w1,     w2, w2,     w2};
 
   // Approximate the area with quadrature
   for (unsigned int q=0; q<N; ++q)

--- a/src/geom/remote_elem.C
+++ b/src/geom/remote_elem.C
@@ -41,6 +41,7 @@ class RemoteElemSetup : public Singleton::Setup
     RemoteElem::create();
   }
 } remote_elem_setup;
+
 }
 
 
@@ -56,6 +57,11 @@ const RemoteElem * remote_elem;
 RemoteElem::~RemoteElem()
 {
   remote_elem = nullptr;
+
+  // Putting this somewhere to unconfuse Nvidia, which thinks an
+  // object used solely to invoke its constructor is "never
+  // referenced".
+  libmesh_ignore(remote_elem_setup);
 }
 
 

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -145,12 +145,16 @@ const std::vector<int> hex_inverse_face_map = {5, 1, 2, 3, 4, 6};
 const std::vector<int> prism_inverse_face_map = {4, 1, 2, 3, 5};
 
 // 3D element edge maps. Map 0-based Exodus id -> libMesh id.
-const std::vector<int> hex_edge_map =
-  {0,1,2,3,8,9,10,11,4,5,7,6};
+// Commented out until we have code that needs it, to keep compiler
+// warnings happy.
+// const std::vector<int> hex_edge_map =
+  // {0,1,2,3,8,9,10,11,4,5,7,6};
 
 // 3D inverse element edge maps. Map libmesh edge ids to 1-based Exodus edge ids.
-const std::vector<int> hex_inverse_edge_map =
-  {1,2,3,4,9,10,12,11,5,6,7,8};
+// Commented out until we have code that needs it, to keep compiler
+// warnings happy.
+// const std::vector<int> hex_inverse_edge_map =
+  // {1,2,3,4,9,10,12,11,5,6,7,8};
 
   /**
    * \returns The value obtained from a generic exII::ex_inquire() call.

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -48,6 +48,7 @@
 
 //-----------------------------------------------
 // anonymous namespace for implementation details
+#ifdef LIBMESH_HAVE_MPI
 namespace {
 
 using namespace libMesh;
@@ -127,8 +128,8 @@ struct SyncNeighbors
   }
 };
 
-
-}
+} // anonymous namespace
+#endif // LIBMESH_HAVE_MPI
 
 
 

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -42,7 +42,8 @@
 #endif
 
 
-#ifdef LIBMESH_HAVE_LIBHILBERT
+#if defined(LIBMESH_HAVE_LIBHILBERT) && defined(LIBMESH_HAVE_MPI)
+
 namespace { // anonymous namespace for helper functions
 
 using namespace libMesh;
@@ -165,8 +166,9 @@ private:
   const libMesh::BoundingBox & _bbox;
   std::vector<Parallel::DofObjectKey> & _keys;
 };
+
 }
-#endif
+#endif // defined(LIBMESH_HAVE_LIBHILBERT) && defined(LIBMESH_HAVE_MPI)
 
 
 namespace libMesh

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -45,6 +45,8 @@ namespace libMesh
 //-----------------------------------------------
 // anonymous namespace for implementation details
 namespace {
+
+#if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
 struct CompareGlobalIdxMappings
 {
   // strict weak ordering for a.first -> a.second mapping.  since we can only map to one
@@ -59,6 +61,7 @@ struct CompareGlobalIdxMappings
                   const unsigned int b) const
   { return a.first < b; }
 };
+#endif // defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
 
 // Nemesis & ExodusII use int for all integer values, even the ones which
 // should never be negative.  we like to use unsigned as a force of habit,

--- a/src/solvers/petscdmlibmeshimpl.C
+++ b/src/solvers/petscdmlibmeshimpl.C
@@ -878,7 +878,7 @@ static PetscErrorCode  DMView_libMesh(DM dm, PetscViewer viewer)
           if (dit != dbegin) {
             ierr = PetscViewerASCIIPrintf(viewer, ","); CHKERRQ(ierr);
           }
-          ierr = PetscViewerASCIIPrintf(viewer, LIBMESH_PETSCINT_FMT, *dit); CHKERRQ(ierr);
+          ierr = PetscViewerASCIIPrintf(viewer, "%u", *dit); CHKERRQ(ierr);
         }
         ierr = PetscViewerASCIIPrintf(viewer, ";"); CHKERRQ(ierr);
       }

--- a/tests/base/overlapping_coupling_test.C
+++ b/tests/base/overlapping_coupling_test.C
@@ -298,7 +298,7 @@ protected:
 #endif // LIBMESH_ENABLE_AMR
   }
 
-  void init(MeshBase & mesh)
+  void init()
   {
     _es = std::make_unique<EquationSystems>(*_mesh);
     LinearImplicitSystem & sys = _es->add_system<LinearImplicitSystem> ("SimpleSystem");
@@ -373,7 +373,7 @@ public:
   void setUp()
   {
     this->build_quad_mesh();
-    this->init(*_mesh);
+    this->init();
   }
 
   void tearDown()
@@ -544,7 +544,7 @@ private:
   void run_ghosting_test(const unsigned int n_refinements, bool build_coupling_matrix)
   {
     this->build_quad_mesh(n_refinements);
-    this->init(*_mesh);
+    this->init();
 
     std::unique_ptr<CouplingMatrix> coupling_matrix;
     if (build_coupling_matrix)
@@ -662,7 +662,7 @@ private:
   void run_sparsity_pattern_test(const unsigned int n_refinements, bool build_coupling_matrix)
   {
     this->build_quad_mesh(n_refinements);
-    this->init(*_mesh);
+    this->init();
 
     std::unique_ptr<CouplingMatrix> coupling_matrix;
     if (build_coupling_matrix)

--- a/tests/fe/fe_test.h
+++ b/tests/fe/fe_test.h
@@ -38,13 +38,13 @@ class SkewFunc : public FunctionBase<Real>
   std::unique_ptr<FunctionBase<Real>> clone () const override
   { return std::make_unique<SkewFunc>(); }
 
-  Real operator() (const Point & p,
-                     const Real time = 0.) override
+  Real operator() (const Point &,
+                   const Real = 0.) override
   { libmesh_not_implemented(); } // scalar-only API
 
   // Skew in x based on y, y based on z
   void operator() (const Point & p,
-                   const Real time,
+                   const Real,
                    DenseVector<Real> & output)
   {
     output.resize(3);

--- a/tests/fe/inf_fe_radial_test.C
+++ b/tests/fe/inf_fe_radial_test.C
@@ -206,6 +206,7 @@ public:
 
     return intersection;
 #else
+    libmesh_ignore(physical_point, inf_elem);
     // lets make the compilers happy:
     return Point(0.,0.,-2.);
 #endif // LIBMESH_ENABLE_INFINITE_ELEMENTS

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -1219,11 +1219,9 @@ public:
         if (elem->dim() > 2)
           master_pt(2) = 0.75;
 
-        FEMap fe_map;
+        Point physical_pt = FEMap::map(elem->dim(), elem, master_pt);
 
-        Point physical_pt = fe_map.map(elem->dim(), elem, master_pt);
-
-        Point inverse_pt = fe_map.inverse_map(elem->dim(), elem,
+        Point inverse_pt = FEMap::inverse_map(elem->dim(), elem,
                                               physical_pt);
 
         CPPUNIT_ASSERT((inverse_pt-master_pt).norm() < TOLERANCE);

--- a/tests/mesh/write_vec_and_scalar.C
+++ b/tests/mesh/write_vec_and_scalar.C
@@ -235,6 +235,8 @@ public:
 
     // FIXME - Nemesis still needs work for vector-valued variables
     // testSolution(read_mesh, sys2);
+#else
+    libmesh_ignore(filename);
 #endif // #ifdef LIBMESH_HAVE_NEMESIS_API
   }
 

--- a/tests/numerics/vector_value_test.C
+++ b/tests/numerics/vector_value_test.C
@@ -81,8 +81,8 @@ public:
       VectorValue<float> fvec;
       VectorValue<double> dvec;
 
-      auto ftype = fvec * 1;
-      auto dtype = dvec * 1;
+      [[maybe_unused]] auto ftype = fvec * 1;
+      [[maybe_unused]] auto dtype = dvec * 1;
 
       {
         bool assertion = std::is_same<decltype(ftype), TypeVector<float>>::value;
@@ -93,33 +93,27 @@ public:
         CPPUNIT_ASSERT(assertion);
       }
       {
-        auto temp = average(ftype, ftype);
-        bool assertion = std::is_same<decltype(temp), TypeVector<float>>::value;
+        bool assertion = std::is_same<decltype(average(ftype, ftype)), TypeVector<float>>::value;
         CPPUNIT_ASSERT(assertion);
       }
       {
-        auto temp = average(ftype, dtype);
-        bool assertion = std::is_same<decltype(temp), TypeVector<double>>::value;
+        bool assertion = std::is_same<decltype(average(ftype, dtype)), TypeVector<double>>::value;
         CPPUNIT_ASSERT(assertion);
       }
       {
-        auto temp = average(fvec, fvec);
-        bool assertion = std::is_same<decltype(temp), VectorValue<float>>::value;
+        bool assertion = std::is_same<decltype(average(fvec, fvec)), VectorValue<float>>::value;
         CPPUNIT_ASSERT(assertion);
       }
       {
-        auto temp = average(fvec, dvec);
-        bool assertion = std::is_same<decltype(temp), VectorValue<double>>::value;
+        bool assertion = std::is_same<decltype(average(fvec, dvec)), VectorValue<double>>::value;
         CPPUNIT_ASSERT(assertion);
       }
       {
-        auto temp = average(fvec, dtype);
-        bool assertion = std::is_same<decltype(temp), VectorValue<double>>::value;
+        bool assertion = std::is_same<decltype(average(fvec, dtype)), VectorValue<double>>::value;
         CPPUNIT_ASSERT(assertion);
       }
       {
-        auto temp = average(ftype, dvec);
-        bool assertion = std::is_same<decltype(temp), VectorValue<double>>::value;
+        bool assertion = std::is_same<decltype(average(ftype, dvec)), VectorValue<double>>::value;
         CPPUNIT_ASSERT(assertion);
       }
 #ifdef LIBMESH_HAVE_METAPHYSICL

--- a/tests/parallel/parallel_sync_test.C
+++ b/tests/parallel/parallel_sync_test.C
@@ -219,7 +219,7 @@ public:
 
     auto compose_replies =
       []
-      (processor_id_type pid,
+      (processor_id_type,
        const std::vector<unsigned int> & query,
        std::vector<unsigned int> & response)
       {
@@ -354,7 +354,7 @@ public:
 
     auto compose_replies =
       []
-      (processor_id_type pid,
+      (processor_id_type,
        const std::vector<std::vector<unsigned int>> & query,
        std::vector<std::vector<unsigned int>> & response)
       {

--- a/tests/systems/periodic_bc_test.C
+++ b/tests/systems/periodic_bc_test.C
@@ -47,7 +47,7 @@ struct PeriodicQuadFunction : public FunctionBase<Number>
   { libmesh_error(); }
 
   virtual void operator() (const Point & p,
-                           const Real time,
+                           const Real,
                            DenseVector<Number> & output) override
   {
     libmesh_assert_equal_to(output.size(), 1);
@@ -72,7 +72,7 @@ struct PeriodicQuadFunction : public FunctionBase<Number>
 
 
 void periodic_bc_test_poisson(EquationSystems& es,
-                              const std::string& system_name)
+                              const std::string&)
 {
   const MeshBase& mesh = es.get_mesh();
   LinearImplicitSystem& system = es.get_system<LinearImplicitSystem>("PBCSys");

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -121,7 +121,7 @@ public:
 
 // Assembly function used in testDofCouplingWithVarGroups
 void assemble_matrix_and_rhs(EquationSystems& es,
-                             const std::string& system_name)
+                             const std::string&)
 {
   const MeshBase& mesh = es.get_mesh();
   LinearImplicitSystem& system = es.get_system<LinearImplicitSystem>("test");
@@ -400,7 +400,7 @@ struct TripleFunction : public FunctionBase<Number>
   { libmesh_error(); }
 
   virtual void operator() (const Point & p,
-                           const Real time,
+                           const Real,
                            DenseVector<Number> & output) override
   {
     libmesh_assert_greater(output.size(), 0);

--- a/tests/utils/parameters_test.C
+++ b/tests/utils/parameters_test.C
@@ -31,6 +31,7 @@ public:
   template <typename T>
   void testScalar ()
   {
+    [[maybe_unused]] // nvc++ has some issues...
     Parameters param;
 
     T t = 10, t_orig = 10;


### PR DESCRIPTION
A few of these were overzealous, a few warning classes were overzealous enough that I disabled them completely, but a few of these are actual bugs.

There's still a bug in nvc++ itself that's got one of our unit tests failing, and in a way which makes me think "let's not encourage nvc++ use until that's fixed" rather than "let's just put in a workaround", but once they've got that fixed we ought to get at least a serial configuration nvc++ build going in CI.