### PR TITLE
Options for restricting solves to unconstrained DoFs only

### DIFF
--- a/examples/adjoints/adjoints_ex3/adjoints_ex3.C
+++ b/examples/adjoints/adjoints_ex3/adjoints_ex3.C
@@ -790,6 +790,17 @@ int main (int argc, char ** argv)
 
   equation_systems.init ();
 
+  if (infile.search("--restrict_solves_to_unconstrained"))
+    {
+      libMesh::out << "Restricting solves to unconstrained DoFs" << std::endl;
+      system.restrict_solves_to_unconstrained(true);
+      libmesh_assert_equal_to(system.get_linear_solver()->restrictions_to_unconstrained(),
+                              &system.get_dof_map());
+      libmesh_assert(system.get_time_solver().diff_solver()->get_restrict_solves_to_unconstrained());
+    }
+  else
+    libMesh::out << "Not restricting solves to unconstrained DoFs" << std::endl;
+
   // Print information about the mesh and system to the screen.
   mesh.print_info();
   equation_systems.print_info();
@@ -830,8 +841,16 @@ int main (int argc, char ** argv)
                    << std::endl
                    << std::endl;
 
+      libmesh_assert_equal_to(system.get_linear_solver()->restrictions_to_unconstrained(),
+                              &system.get_dof_map());
+      libmesh_assert(system.get_time_solver().diff_solver()->get_restrict_solves_to_unconstrained());
+
       // Solve the forward system
       system.solve();
+
+      libmesh_assert_equal_to(system.get_linear_solver()->restrictions_to_unconstrained(),
+                              &system.get_dof_map());
+      libmesh_assert(system.get_time_solver().diff_solver()->get_restrict_solves_to_unconstrained());
 
       // Write the output
       write_output(equation_systems, 0, a_step, "primal", param);

--- a/examples/adjoints/adjoints_ex3/run.sh
+++ b/examples/adjoints/adjoints_ex3/run.sh
@@ -8,7 +8,7 @@ example_name=adjoints_ex3
 
 example_dir=examples/adjoints/$example_name
 
-run_example "$example_name" $options
+run_example "$example_name" --restrict_solves_to_unconstrained $options
 
 # This example needs better solvers on larger meshes + processor counts
 #benchmark_example 1 "$example_name" "max_adaptivesteps=18 -pc_type bjacobi -sub_pc_factor_levels 4"

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1257,12 +1257,28 @@ public:
    * solver's solutions do not satisfy your DoF constraints to a tight enough
    * tolerance.
    *
+   * If \p homogeneous == true, heterogeneous constraints are enforced
+   * as if they were homogeneous.  This might be appropriate for e.g. a
+   * vector representing a difference between two
+   * heterogeneously-constrained solutions.
+   */
+  void enforce_constraints_exactly (NumericVector<Number> & v,
+                                    bool homogeneous = false) const;
+
+  /**
+   * Constrains the numeric vector \p v, which represents a solution defined on
+   * the mesh.  This may need to be used after a linear solve, if your linear
+   * solver's solutions do not satisfy your DoF constraints to a tight enough
+   * tolerance.
+   *
    * If \p v == nullptr, the system solution vector is constrained
    *
    * If \p homogeneous == true, heterogeneous constraints are enforced
    * as if they were homogeneous.  This might be appropriate for e.g. a
    * vector representing a difference between two
    * heterogeneously-constrained solutions.
+   *
+   * Will be deprecated eventually; use the non-System& overload.
    */
   void enforce_constraints_exactly (const System & system,
                                     NumericVector<Number> * v = nullptr,

--- a/include/solvers/diff_solver.h
+++ b/include/solvers/diff_solver.h
@@ -140,6 +140,15 @@ public:
   sys_type & system () { return _system; }
 
   /**
+   * After calling this method with \p true, all successive solves
+   * will be restricted to unconstrained dofs, with constraints
+   * applied separately as necessary.
+   */
+  virtual void restrict_solves_to_unconstrained(bool restricting) = 0;
+
+  virtual bool get_restrict_solves_to_unconstrained() = 0;
+
+  /**
    * Each linear solver step should exit after \p max_linear_iterations
    * is exceeded.
    */

--- a/include/solvers/linear_solver.h
+++ b/include/solvers/linear_solver.h
@@ -40,6 +40,7 @@ template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 template <typename T> class ShellMatrix;
 template <typename T> class Preconditioner;
+class DofMap;
 class System;
 class SolverConfiguration;
 enum SolverPackage : int;
@@ -151,6 +152,26 @@ public:
    */
   virtual void restrict_solve_to (const std::vector<unsigned int> * const dofs,
                                   const SubsetSolveMode subset_solve_mode=SUBSET_ZERO);
+
+  /**
+   * After calling this method, all successive solves will be
+   * restricted to unconstrained dofs.  This mode can be disabled by
+   * calling this method with \p dof_map being a \p nullptr.
+   *
+   * This does a pure submatrix \ subvector solve, with no correction
+   * of the rhs to account for ignored columns (so the application of
+   * constraints to the matrix should be done symmetrically
+   * beforehand) and no post-solution application of ignored rows (so
+   * homogeneous or heterogeneous primal or heterogeneous adjoint
+   * constraints should be applied manually afterward)
+   */
+  virtual void restrict_solve_to_unconstrained (const DofMap * dof_map);
+
+  /**
+   * Returns the current restriction (or lack thereof) state with
+   * regard to constrained/unconstrained dofs.
+   */
+  virtual const DofMap * restrictions_to_unconstrained();
 
   /**
    * This function calls the solver \p _solver_type preconditioned

--- a/include/solvers/newton_solver.h
+++ b/include/solvers/newton_solver.h
@@ -89,6 +89,15 @@ public:
   }
 
   /**
+   * After calling this method with \p true, all successive solves
+   * will be restricted to unconstrained dofs, with constraints
+   * applied separately as necessary.
+   */
+  virtual void restrict_solves_to_unconstrained(bool restricting) override;
+
+  virtual bool get_restrict_solves_to_unconstrained() override;
+
+  /**
    * If this is set to true, the solver is forced to test the residual
    * after each Newton step, and to reduce the length of its steps
    * whenever necessary to avoid a residual increase.

--- a/include/solvers/petsc_diff_solver.h
+++ b/include/solvers/petsc_diff_solver.h
@@ -87,6 +87,17 @@ public:
   void clear ();
 
   /**
+   * After calling this method with \p true, all successive solves
+   * will be restricted to unconstrained dofs, with constraints
+   * applied separately as necessary.
+   */
+  virtual void restrict_solves_to_unconstrained(bool restricting) override
+  { if (restricting) libmesh_not_implemented(); }
+
+  virtual bool get_restrict_solves_to_unconstrained() override
+  { return false; }
+
+  /**
    * This method performs a solve.  What occurs in
    * this method will depend on the PETSc SNES settings.
    * See the PETSc documentation for more details.

--- a/include/solvers/petsc_diff_solver.h
+++ b/include/solvers/petsc_diff_solver.h
@@ -91,11 +91,9 @@ public:
    * will be restricted to unconstrained dofs, with constraints
    * applied separately as necessary.
    */
-  virtual void restrict_solves_to_unconstrained(bool restricting) override
-  { if (restricting) libmesh_not_implemented(); }
+  virtual void restrict_solves_to_unconstrained(bool restricting) override;
 
-  virtual bool get_restrict_solves_to_unconstrained() override
-  { return false; }
+  virtual bool get_restrict_solves_to_unconstrained() override;
 
   /**
    * This method performs a solve.  What occurs in
@@ -103,6 +101,24 @@ public:
    * See the PETSc documentation for more details.
    */
   virtual unsigned int solve () override;
+
+  /*
+   * Scatter connecting full vectors with unconstrained subvectors
+   */
+  WrappedPetsc<VecScatter> scatter;
+
+  /*
+   * Submatrix of Jacobian with unconstrained-unconstrained coupling
+   */
+  WrappedPetsc<Mat> submat;
+
+  bool submat_created;
+
+  /**
+   * PETSc index set containing unconstrained dofs on which to solve
+   * (\p nullptr means solve on all dofs).
+   */
+  WrappedPetsc<IS> _unconstrained_dofs_is;
 
 protected:
 
@@ -119,6 +135,11 @@ protected:
   PetscDMWrapper _dm_wrapper;
 #endif
 #endif
+
+  /**
+   * Are we restricting solves to unconstrained DoFs?
+   */
+  bool _restrict_to_unconstrained;
 
 private:
 

--- a/include/solvers/petsc_linear_solver.h
+++ b/include/solvers/petsc_linear_solver.h
@@ -148,6 +148,26 @@ public:
                                   const SubsetSolveMode subset_solve_mode=SUBSET_ZERO) override;
 
   /**
+   * After calling this method, all successive solves will be
+   * restricted to unconstrained dofs.  This mode can be disabled by
+   * calling this method with \p dof_map being a \p nullptr.
+   *
+   * This does a pure submatrix \ subvector solve, with no correction
+   * of the rhs to account for ignored columns (so the application of
+   * constraints to the matrix should be done symmetrically
+   * beforehand) and no post-solution application of ignored rows (so
+   * homogeneous or heterogeneous primal or heterogeneous adjoint
+   * constraints should be applied manually afterward)
+   */
+  virtual void restrict_solve_to_unconstrained (const DofMap * dof_map) override;
+
+  /**
+   * Returns the current restriction (or lack thereof) state with
+   * regard to constrained/unconstrained dofs.
+   */
+  virtual const DofMap * restrictions_to_unconstrained() override;
+
+  /**
    * Call the Petsc solver.  It calls the method below, using the
    * same matrix for the system and preconditioner matrices.
    */
@@ -344,9 +364,21 @@ private:
   WrappedPetsc<IS> _restrict_solve_to_is_complement;
 
   /**
-   * \returns The local size of \p _restrict_solve_to_is.
+   * DoFMap to use if we're restricting solves to unconstrained DoFs.
+   * (\p nullptr means solve on constrained DoFs too)
    */
-  PetscInt restrict_solve_to_is_local_size() const;
+  const DofMap * _restrict_to_unconstrained_dofmap;
+
+  /**
+   * PETSc index set containing unconstrained dofs on which to solve
+   * (\p nullptr means solve on all dofs).
+   */
+  WrappedPetsc<IS> _unconstrained_dofs_is;
+
+  /**
+   * \returns The local size of \p is.
+   */
+  PetscInt local_is_size(IS & is) const;
 
   /**
    * Creates \p _restrict_solve_to_is_complement to contain all

--- a/include/systems/diff_system.h
+++ b/include/systems/diff_system.h
@@ -305,6 +305,13 @@ public:
   virtual void side_postprocess (DiffContext &) {}
 
   /**
+   * After calling this method with \p true, all successive solves
+   * will be restricted to unconstrained dofs, with constraints
+   * applied separately as necessary.
+   */
+  virtual void restrict_solves_to_unconstrained(bool restricting) override;
+
+  /**
    * For a given second order (in time) variable var, this method will return
    * the index to the corresponding "dot" variable. For FirstOrderUnsteadySolver
    * classes, the "dot" variable would automatically be added and the returned

--- a/include/systems/implicit_system.h
+++ b/include/systems/implicit_system.h
@@ -309,6 +309,13 @@ public:
   SparseMatrix<Number> & get_system_matrix();
 
   /**
+   * After calling this method with \p true, all successive solves
+   * will be restricted to unconstrained dofs, with constraints
+   * applied separately as necessary.
+   */
+  virtual void restrict_solves_to_unconstrained(bool restricting);
+
+  /**
    * The system matrix.  Implicit systems are characterized by
    * the need to solve the linear system Ax=b.  This is the
    * system matrix A.

--- a/src/solvers/linear_solver.C
+++ b/src/solvers/linear_solver.C
@@ -144,6 +144,22 @@ LinearSolver<T>::restrict_solve_to(const std::vector<unsigned int> * const dofs,
 
 
 template <typename T>
+void
+LinearSolver<T>::restrict_solve_to_unconstrained(const DofMap * dof_map)
+{
+  if (dof_map != nullptr)
+    libmesh_not_implemented();
+}
+
+
+template <typename T>
+const DofMap * LinearSolver<T>::restrictions_to_unconstrained()
+{
+  return nullptr; // No support unless this is overridden
+}
+
+
+template <typename T>
 std::pair<unsigned int, Real> LinearSolver<T>::adjoint_solve (SparseMatrix<T> & mat,
                                                               NumericVector<T> & sol,
                                                               NumericVector<T> & rhs,

--- a/src/solvers/newton_solver.C
+++ b/src/solvers/newton_solver.C
@@ -270,11 +270,33 @@ void NewtonSolver::reinit()
 {
   Parent::reinit();
 
+  const DofMap * d = _linear_solver->restrictions_to_unconstrained();
+
+  // Clear what might be invalidated by system changes
   _linear_solver->clear();
 
+  // Then "un-clear" a few things
+  _linear_solver->restrict_solve_to_unconstrained(d);
   _linear_solver->init_names(_system);
 }
 
+
+void NewtonSolver::restrict_solves_to_unconstrained(bool restricting)
+{
+  if (restricting)
+    {
+      const DofMap * d = &this->system().get_dof_map();
+      this->get_linear_solver().restrict_solve_to_unconstrained(d);
+    }
+  else
+    this->get_linear_solver().restrict_solve_to_unconstrained(nullptr);
+}
+
+
+bool NewtonSolver::get_restrict_solves_to_unconstrained()
+{
+  return this->get_linear_solver().restrictions_to_unconstrained();
+}
 
 
 unsigned int NewtonSolver::solve()

--- a/src/solvers/time_solver.C
+++ b/src/solvers/time_solver.C
@@ -58,7 +58,13 @@ void TimeSolver::reinit ()
   this->diff_solver()->reinit();
 
   libmesh_assert(this->linear_solver().get());
+  const DofMap * d = this->linear_solver()->restrictions_to_unconstrained();
+
+  // Clear what might be invalidated by system changes
   this->linear_solver()->clear();
+
+  // Then "un-clear" a few things
+  this->linear_solver()->restrict_solve_to_unconstrained(d);
   if (libMesh::on_command_line("--solver-system-names"))
     this->linear_solver()->init((_system.name()+"_").c_str());
   else

--- a/src/systems/diff_system.C
+++ b/src/systems/diff_system.C
@@ -176,6 +176,13 @@ std::pair<unsigned int, Real> DifferentiableSystem::get_linear_solve_parameters(
 }
 
 
+void DifferentiableSystem::restrict_solves_to_unconstrained(bool restricting) {
+  // We need to restrict both the linear solver that's used for
+  // adjoint and sensitivity solves *and* the forward solver.
+  ImplicitSystem::restrict_solves_to_unconstrained(restricting);
+  this->time_solver->diff_solver()->restrict_solves_to_unconstrained(restricting);
+}
+
 
 void DifferentiableSystem::add_second_order_dot_vars()
 {

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -108,6 +108,14 @@ void ImplicitSystem::disable_cache () {
 }
 
 
+void ImplicitSystem::restrict_solves_to_unconstrained(bool restricting) {
+  if (restricting)
+    this->get_linear_solver()->restrict_solve_to_unconstrained(&this->get_dof_map());
+  else
+    this->get_linear_solver()->restrict_solve_to_unconstrained(nullptr);
+}
+
+
 
 std::pair<unsigned int, Real>
 ImplicitSystem::sensitivity_solve (const ParameterVector & parameters)
@@ -152,7 +160,8 @@ ImplicitSystem::sensitivity_solve (const ParameterVector & parameters)
       totalrval.second += rval.second;
     }
 
-  // The linear solver may not have fit our constraints exactly
+  // The linear solver may not have fit our constraints exactly, or we
+  // might have disabled solves of constrained dofs
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
   for (auto p : make_range(parameters.size()))
     this->get_dof_map().enforce_constraints_exactly
@@ -203,7 +212,8 @@ ImplicitSystem::adjoint_solve (const QoISet & qoi_indices)
         totalrval.second += rval.second;
       }
 
-  // The linear solver may not have fit our constraints exactly
+  // The linear solver may not have fit our constraints exactly, or we
+  // might have disabled solves of constrained dofs
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
   for (auto i : make_range(this->n_qois()))
     if (qoi_indices.has_index(i))
@@ -348,7 +358,8 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
         totalrval.second += rval.second;
       }
 
-  // The linear solver may not have fit our constraints exactly
+  // The linear solver may not have fit our constraints exactly, or we
+  // might have disabled solves of constrained dofs
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
   for (auto i : make_range(this->n_qois()))
     if (qoi_indices.has_index(i))
@@ -432,7 +443,8 @@ ImplicitSystem::weighted_sensitivity_solve (const ParameterVector & parameters_i
                    double(solver_params.second),
                    solver_params.first);
 
-  // The linear solver may not have fit our constraints exactly
+  // The linear solver may not have fit our constraints exactly, or we
+  // might have disabled solves of constrained dofs
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
   this->get_dof_map().enforce_constraints_exactly
     (*this, &this->get_weighted_sensitivity_solution(),


### PR DESCRIPTION
I'm not sure this is the right interface (there's at least some PetscDiffSolver encapsulation that I've broken with `public:` but should redo properly with `friend`), and I'm not sure this is the right implementation (the related code already in PetscLinearSolver was creating a submatrix, but this is mainly for efficiency so maybe we should be building a composite matrix in the first place?), and it's not complete (PetscLinearSolver and NewtonSolver are working; PetscDiffSolver is giving me a zero pivot on the preconditioner; PetscNonlinearSolver isn't implemented).

But the pre-vacation work year is starting to run low for me, so I'm putting this up to see if CI manages to see even more problems than I do.