### PR TITLE
Update to check_dirichlet_bcid_consistency()

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -845,6 +845,11 @@ public:
   void set_implicit_neighbor_dofs(bool implicit_neighbor_dofs);
 
   /**
+   * Set the _verify_dirichlet_bc_consistency flag.
+   */
+  void set_verify_dirichlet_bc_consistency(bool val);
+
+  /**
    * Tells other library functions whether or not this problem
    * includes coupling between dofs in neighboring cells, as can
    * currently be specified on the command line or inferred from
@@ -1924,6 +1929,18 @@ private:
    */
   bool _implicit_neighbor_dofs_initialized;
   bool _implicit_neighbor_dofs;
+
+  /**
+   * Flag which determines whether we should do some additional
+   * checking of the consistency of the DirichletBoundary objects
+   * added by the user. Defaults to true, but can be disabled in cases
+   * where you only want to add DirichletBoundary objects "locally"
+   * and can guarantee that no repartitioning will be done, since
+   * repartitioning could cause processors to own new boundary sides
+   * for which they no longer have the proper DirichletBoundary
+   * objects stored.
+   */
+  bool _verify_dirichlet_bc_consistency;
 };
 
 

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1381,14 +1381,11 @@ public:
   get_adjoint_dirichlet_boundaries(unsigned int q);
 
   /**
-   * Check that all the \p dbc_bcids (which typically come from DirichetBoundary objects)
-   * are actually present in the mesh. If not, this will throw an error.
-   * This method is useful for detecting the case where DirichletBoundary objects have
-   * been defined using IDs that are not present in the mesh, since this usually indicates
-   * that there is some error in the model setup.
+   * Check that all the ids in dirichlet_bcids are actually present in the mesh.
+   * If not, this will throw an error.
    */
   void check_dirichlet_bcid_consistency (const MeshBase & mesh,
-                                         const std::set<boundary_id_type>& dbc_bcids) const;
+                                         const DirichletBoundary & boundary) const;
 #endif // LIBMESH_ENABLE_DIRICHLET
 
 

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1381,11 +1381,14 @@ public:
   get_adjoint_dirichlet_boundaries(unsigned int q);
 
   /**
-   * Check that all the ids in dirichlet_bcids are actually present in the mesh.
-   * If not, this will throw an error.
+   * Check that all the \p dbc_bcids (which typically come from DirichetBoundary objects)
+   * are actually present in the mesh. If not, this will throw an error.
+   * This method is useful for detecting the case where DirichletBoundary objects have
+   * been defined using IDs that are not present in the mesh, since this usually indicates
+   * that there is some error in the model setup.
    */
   void check_dirichlet_bcid_consistency (const MeshBase & mesh,
-                                         const DirichletBoundary & boundary) const;
+                                         const std::set<boundary_id_type>& dbc_bcids) const;
 #endif // LIBMESH_ENABLE_DIRICHLET
 
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -181,7 +181,8 @@ DofMap::DofMap(const unsigned int number,
   , _adjoint_dirichlet_boundaries()
 #endif
   , _implicit_neighbor_dofs_initialized(false),
-  _implicit_neighbor_dofs(false)
+  _implicit_neighbor_dofs(false),
+  _verify_dirichlet_bc_consistency(true)
 {
   _matrices.clear();
 
@@ -1704,6 +1705,11 @@ void DofMap::set_implicit_neighbor_dofs(bool implicit_neighbor_dofs)
 {
   _implicit_neighbor_dofs_initialized = true;
   _implicit_neighbor_dofs = implicit_neighbor_dofs;
+}
+
+void DofMap::set_verify_dirichlet_bc_consistency(bool val)
+{
+  _verify_dirichlet_bc_consistency = val;
 }
 
 

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1844,9 +1844,14 @@ void DofMap::create_dof_constraints(const MeshBase & mesh, Real time)
     {
       // Sanity check that the boundary ids associated with the
       // DirichletBoundary objects are actually present in the
-      // mesh.
-      for (const auto & dirichlet : *_dirichlet_boundaries)
-        this->check_dirichlet_bcid_consistency(mesh, *dirichlet);
+      // mesh. We do this check by default, but in cases where you
+      // intentionally add "inconsistent but valid" DirichletBoundary
+      // objects in parallel, this check can deadlock since it does a
+      // collective communication internally. In that case it is
+      // possible to disable this check by setting the flag to false.
+      if (_verify_dirichlet_bc_consistency)
+        for (const auto & dirichlet : *_dirichlet_boundaries)
+          this->check_dirichlet_bcid_consistency(mesh, *dirichlet);
 
       // Threaded loop over local over elems applying all Dirichlet BCs
       Threads::parallel_for

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1840,23 +1840,14 @@ void DofMap::create_dof_constraints(const MeshBase & mesh, Real time)
 
 #ifdef LIBMESH_ENABLE_DIRICHLET
 
-  // Call check_dirichlet_bcid_consistency() to check if the boundaries on
-  // which we have defined DirichletBoundary objects are actually defined in
-  // the mesh. Note that we may have set up _dirichlet_boundaries differently
-  // on different processors, and mesh boundary IDs may also be different on
-  // different processors, so we do some parallel communication in order to
-  // set up all_dirichlet_bcids, as well as to check if the IDs are found
-  // inside check_dirichlet_bcid_consistency().
-  std::set<boundary_id_type> all_dirichlet_bcids;
-  for (const auto & dirichlet : *_dirichlet_boundaries)
-  {
-    all_dirichlet_bcids.insert(dirichlet->b.begin(), dirichlet->b.end());
-  }
-  this->comm().set_union(all_dirichlet_bcids);
-  this->check_dirichlet_bcid_consistency(mesh, all_dirichlet_bcids);
-
   if (!_dirichlet_boundaries->empty())
     {
+      // Sanity check that the boundary ids associated with the
+      // DirichletBoundary objects are actually present in the
+      // mesh.
+      for (const auto & dirichlet : *_dirichlet_boundaries)
+        this->check_dirichlet_bcid_consistency(mesh, *dirichlet);
+
       // Threaded loop over local over elems applying all Dirichlet BCs
       Threads::parallel_for
         (range,
@@ -5329,7 +5320,7 @@ void DofMap::remove_adjoint_dirichlet_boundary (const DirichletBoundary & bounda
 
 
 void DofMap::check_dirichlet_bcid_consistency (const MeshBase & mesh,
-                                               const std::set<boundary_id_type>& dbc_bcids) const
+                                               const DirichletBoundary & boundary) const
 {
   const std::set<boundary_id_type>& mesh_side_bcids =
     mesh.get_boundary_info().get_boundary_ids();
@@ -5337,9 +5328,16 @@ void DofMap::check_dirichlet_bcid_consistency (const MeshBase & mesh,
     mesh.get_boundary_info().get_edge_boundary_ids();
   const std::set<boundary_id_type>& mesh_node_bcids =
     mesh.get_boundary_info().get_node_boundary_ids();
+  const std::set<boundary_id_type>& dbc_bcids = boundary.b;
+
+  // DirichletBoundary id sets should be consistent across all ranks
+  libmesh_assert(mesh.comm().verify(dbc_bcids.size()));
 
   for (const auto & bc_id : dbc_bcids)
     {
+      // DirichletBoundary id sets should be consistent across all ranks
+      libmesh_assert(mesh.comm().verify(bc_id));
+
       bool found_bcid = (mesh_side_bcids.find(bc_id) != mesh_side_bcids.end() ||
                          mesh_edge_bcids.find(bc_id) != mesh_edge_bcids.end() ||
                          mesh_node_bcids.find(bc_id) != mesh_node_bcids.end());


### PR DESCRIPTION
Previously check_dirichlet_bcid_consistency() required that all processors had DirichletBoundary objects defined identically, otherwise one could get a parallel deadlock due to calling comm.max() on a subset of processors. In this update we do a comm.set_union() of boundary IDs with DirichetBoundary defined on them so that we can define DirichletBoundary objects differently on different processors. This is desirable since in general other libMesh mesh data is not required to be identical on different processors, and this update to check_dirichlet_bcid_consistency() means that DirichletBoundary also no longer needs to be identical on different processors.