### PR TITLE
Fix duplicate pid_t typedefs

### DIFF
--- a/src/base/print_trace.C
+++ b/src/base/print_trace.C
@@ -47,19 +47,19 @@
 #include "libmesh/libmesh.h"
 
 #ifdef LIBMESH_HAVE_UNISTD_H
+#include <sys/types.h>
 #include <unistd.h>  // needed for getpid() on Unix
 #endif
+
 #ifdef LIBMESH_HAVE_PROCESS_H
 #include <process.h> // for getpid() on Windows
-
-typedef int pid_t;
 #endif
+
 #include <fstream>
 #include <sstream>
 #include <string>
 #include <cstdio> // std::remove
 #include <cstdlib> // std::system
-#include <sys/types.h> // pid_t
 #ifndef LIBMESH_HAVE_MKSTEMP
 #include "win_mkstemp.h"
 #endif
@@ -154,7 +154,7 @@ bool gdb_backtrace(std::ostream & out_stream)
     {
       // Run gdb using a system() call, redirecting the output to our
       // temporary file.
-      pid_t this_pid = getpid();
+      auto this_pid = getpid();
 
       int exit_status = 1;
 

--- a/src/mesh/namebased_io.C
+++ b/src/mesh/namebased_io.C
@@ -46,14 +46,14 @@
 #include <iomanip>
 #include <fstream>
 #include <vector>
+
 #ifdef LIBMESH_HAVE_UNISTD_H
-#include <sys/types.h> // pid_t
+#include <sys/types.h>
 #include <unistd.h>  // for getpid() on Unix
 #endif
+
 #ifdef LIBMESH_HAVE_PROCESS_H
 #include <process.h> // for getpid() on Windows
-
-typedef int pid_t;
 #endif
 
 
@@ -341,7 +341,7 @@ void NameBasedIO::write (const std::string & name)
     {
       // Nasty hack for reading/writing zipped files
       std::string new_name = name;
-      pid_t pid_0 = 0;
+      int pid_0 = 0;
       if (mymesh.processor_id() == 0)
         pid_0 = getpid();
       mymesh.comm().broadcast(pid_0);


### PR DESCRIPTION
The manual pid_t typedef was added for compatibility with Visual Studio, but it apparently breaks msys2 builds. Luckily we didn't really need it as far as I can tell, so we can just drop it.

Refs #3471