### PR TITLE
Don't let send_list go unprepared

### DIFF
--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -791,6 +791,15 @@ namespace libMesh
     static_assert(sizeof(PetscInt) == sizeof(dof_id_type),"PetscInt is not a dof_id_type!");
     PetscInt * local_dofs = reinterpret_cast<PetscInt *>(const_cast<dof_id_type *>(send_list.data()));
 
+#ifdef DEBUG
+    // PETSc 3.18 and above don't want duplicate entries here ... and
+    // frankly we shouldn't have duplicates in the first place!
+    {
+      std::set<dof_id_type> send_set(send_list.begin(), send_list.end());
+      libmesh_assert_equal_to(send_list.size(), send_set.size());
+    }
+#endif
+
     // This is the vector of PetscSFNode's for the local_dofs.
     // For each entry in local_dof, we have to supply the rank from which
     // that dof stems and its local index on that rank.

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -574,6 +574,7 @@ namespace libMesh
           {
             LOG_CALL("PDM_coarsen", "PetscDMWrapper", mesh_refinement.uniformly_coarsen(1));
             LOG_CALL("PDM_dist_dof", "PetscDMWrapper", system.get_dof_map().distribute_dofs(mesh));
+            LOG_CALL("PDM_prep_send", "PetscDMWrapper", system.get_dof_map().prepare_send_list());
           }
       } // End PETSc data structure creation
 
@@ -645,6 +646,7 @@ namespace libMesh
         LOG_CALL ("PDM_refine", "PetscDMWrapper", mesh_refinement.uniformly_refine(1));
         LOG_CALL ("PDM_dist_dof", "PetscDMWrapper", system.get_dof_map().distribute_dofs(mesh));
         LOG_CALL ("PDM_cnstrnts", "PetscDMWrapper", system.reinit_constraints());
+        LOG_CALL ("PDM_prep_send", "PetscDMWrapper", system.get_dof_map().prepare_send_list());
       }
 
     // Create the Interpolation Matrices between adjacent mesh levels
@@ -698,6 +700,7 @@ namespace libMesh
             LOG_CALL ("PDM_refine", "PetscDMWrapper", mesh_refinement.uniformly_refine(1));
             LOG_CALL ("PDM_dist_dof", "PetscDMWrapper", system.get_dof_map().distribute_dofs(mesh));
             LOG_CALL ("PDM_cnstrnts", "PetscDMWrapper", system.reinit_constraints());
+            LOG_CALL ("PDM_prep_send", "PetscDMWrapper", system.get_dof_map().prepare_send_list());
           }
       } // End create transfer operators. System back at the finest grid
 

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -200,6 +200,8 @@ bool EquationSystems::reinit_solutions ()
         // Recreate any user or internal constraints
         sys.reinit_constraints();
 
+        sys.get_dof_map().prepare_send_list();
+
         sys.prolong_vectors();
       }
     mesh_changed = true;
@@ -222,6 +224,7 @@ bool EquationSystems::reinit_solutions ()
               System & sys = this->get_system(i);
               sys.get_dof_map().distribute_dofs(_mesh);
               sys.reinit_constraints();
+              sys.get_dof_map().prepare_send_list();
               sys.restrict_vectors();
             }
           mesh_changed = true;
@@ -241,6 +244,7 @@ bool EquationSystems::reinit_solutions ()
               System & sys = this->get_system(i);
               sys.get_dof_map().distribute_dofs(_mesh);
               sys.reinit_constraints();
+              sys.get_dof_map().prepare_send_list();
               sys.prolong_vectors();
             }
           mesh_changed = true;


### PR DESCRIPTION
This was failing when using PETSc DM on newer PETSc, and it was probably a performance penalty regardless.