### PR TITLE
Call GhostingFunctor::redistribute() even when our mesh is serialized.

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1105,10 +1105,11 @@ public:
 
   /**
    * Redistribute elements between processors.  This gets called
-   * automatically by the Partitioner, and is a no-op in the case of a
+   * automatically by the Partitioner, and merely notifies any
+   * GhostingFunctors of redistribution in the case of a
    * ReplicatedMesh or serialized DistributedMesh
    */
-  virtual void redistribute () {}
+  virtual void redistribute ();
 
   /**
    * Recalculate any cached data after elements and nodes have been

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -1026,6 +1026,10 @@ void DistributedMesh::redistribute ()
       // delete nodes until we do.
       // this->delete_remote_elements();
     }
+  else
+    // The base class can handle non-distributed things, like
+    // notifying any GhostingFunctors of changes
+    MeshBase::redistribute();
 }
 
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -814,6 +814,18 @@ void MeshBase::subdomain_ids (std::set<subdomain_id_type> & ids, const bool glob
 
 
 
+void MeshBase::redistribute()
+{
+  // We now have all elements and nodes redistributed; our ghosting
+  // functors should be ready to redistribute and/or recompute any
+  // cached data they use too.
+  for (auto & gf : as_range(this->ghosting_functors_begin(),
+                            this->ghosting_functors_end()))
+    gf->redistribute();
+}
+
+
+
 subdomain_id_type MeshBase::n_subdomains() const
 {
   // This requires an inspection on every processor

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -596,11 +596,10 @@ void MeshCommunication::redistribute (DistributedMesh & mesh,
   // elements it can't locate.
   mesh.clear_point_locator();
 
-  // We now have all elements and nodes redistributed; our ghosting
-  // functors should be ready to redistribute and/or recompute any
-  // cached data they use too.
-  for (auto & gf : as_range(mesh.ghosting_functors_begin(), mesh.ghosting_functors_end()))
-    gf->redistribute();
+  // Let the mesh handle any other post-redistribute() tasks, like
+  // notifying GhostingFunctors.  Be sure we're just calling the base
+  // class method so we don't recurse back into ourselves here.
+  mesh.MeshBase::redistribute();
 }
 #endif // LIBMESH_HAVE_MPI
 


### PR DESCRIPTION
This is going to be useful for letting higher-level code know when to redistribute its own distributed data.