### PR TITLE
Handle GhostingFunctor subclasses returning ancestor elements

### DIFF
--- a/include/ghosting/ghosting_functor.h
+++ b/include/ghosting/ghosting_functor.h
@@ -71,12 +71,21 @@ class PeriodicBoundaries;
  * The user should omit from their implementations relations which we
  * already have enough information to understand implicitly. For
  * instance, K is obviously in C(K), so a GhostingFunctor should never
- * bother telling us so. We may have a PeriodicBoundary, a hanging
- * node constraint equation, or a user-defined constraint equation
- * which creates a dependency between two elements; if so then we
- * don't need the user to also tell us about that relation.  The
- * DefaultCoupling functor will make both direct and periodic neighbor
- * elements algebraically ghosted by default.
+ * bother telling us so.  We pass a processor_id_type parameter to the
+ * GhostingFunctor::operator(), e.g. when determining what ghosted
+ * elements need to be sent to that processor while redistributing,
+ * and a GhostingFunctor should not return any elements which already
+ * have that processor_id.  We determine what ancestor elements should
+ * be ghosted based on what active elements are being ghosted, and a
+ * GhostingFunctor should not return any elements which are not
+ * active.
+ *
+ * We may have a PeriodicBoundary, a hanging node constraint equation,
+ * or a user-defined constraint equation which creates a dependency
+ * between two elements; if so then we don't need the user to also
+ * tell us about that relation.  The DefaultCoupling functor will make
+ * both direct and periodic neighbor elements algebraically ghosted by
+ * default.
  *
  * However, note that geometric ghosting information needs to all be
  * inferrable (e.g. with PeriodicBoundary objects already all

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1451,6 +1451,7 @@ merge_ghost_functor_outputs(GhostingFunctor::map_type & elements_to_ghost,
           const Elem * elem = it->first;
           if (!elem->active())
             {
+              libmesh_deprecated();
               std::vector<const Elem*> children_to_ghost;
               elem->active_family_tree(children_to_ghost,
                                        /*reset=*/ false);

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1440,8 +1440,39 @@ merge_ghost_functor_outputs(GhostingFunctor::map_type & elements_to_ghost,
       libmesh_assert(gf);
       (*gf)(elems_begin, elems_end, p, more_elements_to_ghost);
 
+      // A GhostingFunctor should only return active elements, but
+      // I forgot to *document* that, so let's go as easy as we
+      // can on functors that return inactive elements.
+#ifdef LIBMESH_ENABLE_DEPRECATED
+      std::vector<std::pair<const Elem*, const CouplingMatrix*>> children_to_couple;
+      for (auto it = more_elements_to_ghost.begin();
+           it != more_elements_to_ghost.end();)
+        {
+          const Elem * elem = it->first;
+          if (!elem->active())
+            {
+              std::vector<const Elem*> children_to_ghost;
+              elem->active_family_tree(children_to_ghost,
+                                       /*reset=*/ false);
+              for (const Elem * child : children_to_ghost)
+                if (child->processor_id() != p)
+                  children_to_couple.emplace_back(child, it->second);
+
+              it = more_elements_to_ghost.erase(it);
+            }
+          else
+            ++it;
+        }
+      more_elements_to_ghost.insert(children_to_couple.begin(),
+                                    children_to_couple.end());
+#endif
+
       for (const auto & [elem, elem_cm] : more_elements_to_ghost)
         {
+          // At this point we should only have active elements, even
+          // if we had to fix up gf output to get here.
+          libmesh_assert(elem->active());
+
           GhostingFunctor::map_type::iterator existing_it =
             elements_to_ghost.find (elem);
 


### PR DESCRIPTION
We've got this happening in MOOSE now, and it's causing failures in e.g. https://github.com/idaholab/moose/issues/23389

We don't want to support this long-term, but I foolishly never documented "the elements you return must be active" as a requirement, so let's:

1. Document that.
2. Handle existing ancestor returns with --enable-deprecated (by default); this isn't as efficient as when we know we only have to deal with active elements, but there's a reasonable natural interpretation of being handed ancestors.
3. Throw up `libmesh_deprecated()` when we see an ancestor return, to make it easier for people (okay, me) to fix those GhostingFunctors downstream.