### PR TITLE
Add System::has_constraint_object()

### DIFF
--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1400,6 +1400,17 @@ public:
   void attach_constraint_object (Constraint & constrain);
 
   /**
+   * \returns true if there is a user-defined constraint object
+   * attached to this object, false otherwise.  Calling System::
+   * get_constraint_object() when there is no user-defined constraint
+   * object attached leads to either undefined behavior (dereferencing
+   * a nullptr) or an assert (in dbg mode) so you should call this
+   * function first unless you are sure there is a user-defined
+   * constraint object attached.
+   */
+  bool has_constraint_object () const;
+
+  /**
    * Return the user object for imposing constraints.
    */
   Constraint& get_constraint_object ();

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -2014,6 +2014,11 @@ void System::attach_constraint_object (System::Constraint & constrain)
   _constrain_system_object = &constrain;
 }
 
+bool System::has_constraint_object () const
+{
+  return _constrain_system_object != nullptr;
+}
+
 System::Constraint& System::get_constraint_object ()
 {
   libmesh_assert_msg(_constrain_system_object,"No constraint object available.");


### PR DESCRIPTION
There was previously no way to safely determine whether a user-defined Constraint object was attached to the System.