### PR TITLE
Moving _values_manually_retrieved to after _get_array in PetscVector

### DIFF
--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -1110,8 +1110,8 @@ template <typename T>
 inline
 PetscScalar * PetscVector<T>::get_array()
 {
-  _values_manually_retrieved = true;
   _get_array(false);
+  _values_manually_retrieved = true;
 
   return _values;
 }
@@ -1121,8 +1121,8 @@ template <typename T>
 inline
 const PetscScalar * PetscVector<T>::get_array_read() const
 {
-  _values_manually_retrieved = true;
   _get_array(true);
+  _values_manually_retrieved = true;
 
   return _read_only_values;
 }

--- a/tests/numerics/petsc_vector_test.C
+++ b/tests/numerics/petsc_vector_test.C
@@ -77,6 +77,21 @@ public:
     CPPUNIT_ASSERT_EQUAL((intptr_t)read_only_values, (intptr_t)values);
 
     v.restore_array();
+
+    // Test to make sure we can get arrays after other operators
+    for (unsigned int i = 0; i < local_size; i++)
+      v.set(my_offset + i, i * 2.0);
+    v.close();
+    for (unsigned int i = 0; i < local_size; i++)
+      LIBMESH_ASSERT_FP_EQUAL(i * 2.0, std::abs(v(my_offset + i)), TOLERANCE * TOLERANCE);
+    values = v.get_array();
+    read_only_values = v.get_array_read();
+    for (unsigned int i = 0; i < local_size; i++)
+    {
+      LIBMESH_ASSERT_FP_EQUAL(i * 2.0, std::abs(values[i]), TOLERANCE * TOLERANCE);
+      LIBMESH_ASSERT_FP_EQUAL(i * 2.0, std::abs(read_only_values[i]), TOLERANCE * TOLERANCE);
+    }
+    v.restore_array();
   }
 
   void testPetscOperations()


### PR DESCRIPTION
Closes #3493 