### PR TITLE
Option for discontinuous Bezier Extraction meshes

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -569,6 +569,17 @@ public:
   void set_hdf5_writing(bool write_hdf5);
 
   /**
+   * Set to true (false is the default) to generate independent nodes
+   * for every Bezier Extraction element in an input file containing
+   * them, causing those elements to be disconnected from each other.
+   * (Their vertices will be multiple distinct nodes at overlapping
+   * points.)  If this is false, Bezier Extraction elements will be
+   * connected where possible, thereby using fewer redundancies and
+   * less memory, but the input mesh will need to be conforming.
+   */
+  void set_discontinuous_bex(bool disc_bex);
+
+  /**
    * This function factors out a bunch of code which is common to the
    * write_nodal_data() and write_nodal_data_discontinuous() functions
    */
@@ -636,6 +647,12 @@ private:
    * by not writing out.
    */
   bool _write_complex_abs;
+
+  /**
+   * Set to true (false is the default) to generate independent nodes
+   * for every Bezier Extraction element.
+   */
+  bool _disc_bex;
 };
 
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -137,7 +137,8 @@ ExodusII_IO::ExodusII_IO (MeshBase & mesh,
   _append(false),
 #endif
   _allow_empty_variables(false),
-  _write_complex_abs(true)
+  _write_complex_abs(true),
+  _disc_bex(false)
 {
 }
 
@@ -620,7 +621,12 @@ void ExodusII_IO::read (const std::string & fname)
                       Node *n = mesh.add_point(p);
                       if (weights_exist)
                         n->set_extra_datum<Real>(weight_index, w);
-                      local_nodes[key] = n;
+
+                      // If we're building disconnected Bezier
+                      // extraction elements then we don't want to
+                      // find the new nodes to reuse later.
+                      if (!_disc_bex)
+                        local_nodes[key] = n;
                       elem->set_node(dyna_elem_defn.nodes[elem_node_index]) = n;
 
                       constraint_rows[n] = constraint_row;
@@ -2346,6 +2352,12 @@ ExodusII_IO_Helper & ExodusII_IO::get_exio_helper()
 void ExodusII_IO::set_hdf5_writing(bool write_hdf5)
 {
   exio_helper->set_hdf5_writing(write_hdf5);
+}
+
+
+void ExodusII_IO::set_discontinuous_bex(bool disc_bex)
+{
+  _disc_bex = disc_bex;
 }
 
 

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -2070,6 +2070,12 @@ void System::solve_for_unconstrained_dofs(NumericVector<Number> & vec,
   // to get C^T*K*C*x = C^T*f - C^T*K*h
   // - a constrained and no-longer-singular system that finds the
   // closest approximation for the unconstrained degrees of freedom.
+  //
+  // Here, though "closest" is in an algebraic sense; we're
+  // effectively using a pseudoinverse that optimizes in a
+  // discretization-dependent norm.  That only seems to give ~0.1%
+  // excess error even in coarse unit test cases, but at some point it
+  // might be reasonable to weight K and f properly.
 
   for (dof_id_type d : IntRange<dof_id_type>(dof_map.first_dof(),
                                              dof_map.end_dof()))


### PR DESCRIPTION
If we rely entirely on the extraction operators to achieve continuous solution spaces, then we can handle extraction-based meshes which aren't isotropically refined or even conforming.