### PR TITLE
Fix NumericVector::compare

### DIFF
--- a/src/numerics/numeric_vector.C
+++ b/src/numerics/numeric_vector.C
@@ -114,15 +114,14 @@ int NumericVector<T>::compare (const NumericVector<T> & other_vector,
   int first_different_i = std::numeric_limits<int>::max();
   numeric_index_type i = first_local_index();
 
-  do
-    {
-      if (std::abs((*this)(i) - other_vector(i)) > threshold)
-        first_different_i = i;
-      else
-        i++;
-    }
   while (first_different_i==std::numeric_limits<int>::max()
-         && i<last_local_index());
+         && i<last_local_index())
+  {
+    if (std::abs((*this)(i) - other_vector(i)) > threshold)
+      first_different_i = i;
+    else
+      i++;
+  }
 
   // Find the correct first differing index in parallel
   this->comm().min(first_different_i);


### PR DESCRIPTION
The parallel failures from idaholab/moose#23788 are:

```
libMesh terminating:
No index 5 in ghosted vector.
Vector contains [5,5)
And ghost array {4,0}
```

because prior to this commit if the first local index was equal to the last local index we would go ahead and attempt to index into the vector with first local index anyway. Now we avoid that scenario