### PR TITLE
Make our use of isspace more robust

### DIFF
--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -46,6 +46,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <ctime>
+#include <cctype>
 
 extern "C" {
 #include <stdarg.h> // --> va_list and friends
@@ -1308,7 +1309,7 @@ GetPot::_skip_whitespace(std::istream& istr)
   int tmp = istr.get();
   do {
     // -- search a non whitespace
-    while (isspace(tmp))
+    while (std::isspace(tmp))
       {
         tmp = istr.get();
         if (!istr)
@@ -2811,7 +2812,7 @@ GetPot::_DBE_get_expr_list(const std::string& str_, const unsigned ExpectedNumbe
   unsigned i=0;
   // (1) eat initial whitespaces
   for (; i < str.size(); i++)
-    if (!isspace(str[i]))
+    if (!std::isspace(str[i]))
       break;
 
   STRING_VECTOR   expr_list;
@@ -2825,13 +2826,13 @@ GetPot::_DBE_get_expr_list(const std::string& str_, const unsigned ExpectedNumbe
     {
       const char letter = str[i];
       // whitespace -> end of expression
-      if (isspace(letter) && open_brackets == 0)
+      if (std::isspace(letter) && open_brackets == 0)
         {
           expr_list.push_back(str.substr(start_new_string, i - start_new_string));
           bool no_breakout_f = true;
           for (i++; i < l ; i++)
             {
-              if (!isspace(str[i]))
+              if (!std::isspace(str[i]))
                 {
                   no_breakout_f = false;
                   start_new_string = i;

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -28,7 +28,7 @@
 #include <string>
 #include <cstdlib> // std::strtol
 #include <sstream>
-#include <ctype.h> // isspace
+#include <cctype> // isspace
 
 // Anonymous namespace to hold mapping Data for Abaqus/libMesh element types
 namespace
@@ -56,7 +56,9 @@ bool string_to_num(const std::string & input, dof_id_type & output)
  */
 void strip_ws(std::string & line)
 {
-  line.erase(std::remove_if(line.begin(), line.end(), isspace), line.end());
+  line.erase(std::remove_if(line.begin(), line.end(),
+                            [](unsigned char const c){return std::isspace(c);}),
+             line.end());
 }
 
 /**

--- a/src/mesh/gmv_io.C
+++ b/src/mesh/gmv_io.C
@@ -19,7 +19,7 @@
 #include <iomanip>
 #include <fstream>
 #include <vector>
-#include <ctype.h> // isspace
+#include <cctype> // isspace
 
 // Local includes
 #include "libmesh/libmesh_config.h"
@@ -2135,7 +2135,9 @@ void GMVIO::_read_one_cell()
 ElemType GMVIO::gmv_elem_to_libmesh_elem(std::string elemname)
 {
   // Erase any whitespace padding in name coming from gmv before performing comparison.
-  elemname.erase(std::remove_if(elemname.begin(), elemname.end(), isspace), elemname.end());
+  elemname.erase(std::remove_if(elemname.begin(), elemname.end(),
+                                [](unsigned char const c){return std::isspace(c);}),
+                 elemname.end());
   return libmesh_map_find(_reading_element_map, elemname);
 }
 

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -41,7 +41,7 @@
 #include <iomanip>
 #include <algorithm> // for std::sort
 #include <fstream>
-#include <ctype.h> // isspace
+#include <cctype>  // isspace
 #include <sstream> // std::istringstream
 #include <unordered_map>
 
@@ -156,7 +156,8 @@ void UNVIO::read_implementation (std::istream & in_stream)
             // UNV files always have some amount of leading
             // whitespace, let's not rely on exactly how much...  This
             // command deletes it.
-            current_line.erase(std::remove_if(current_line.begin(), current_line.end(), isspace),
+            current_line.erase(std::remove_if(current_line.begin(), current_line.end(),
+                                              [](unsigned char const c){return std::isspace(c);}),
                                current_line.end());
 
             // Parse the nodes section


### PR DESCRIPTION
We had some users of a modified libMesh who saw the existing code break here - their fault for bringing in a 3rd party header with `using namespace std` (thereby making `isspace` ambiguous), but the workaround is easy enough, and I'm not a big fan of us including C headers when there's a C++ version around anyway.

Pinging @rainiscold and @LabrosV ; hopefully I haven't typo'd either.