### PR TITLE
Potentially prepare meshes for use when stitching

### DIFF
--- a/include/mesh/unstructured_mesh.h
+++ b/include/mesh/unstructured_mesh.h
@@ -168,6 +168,7 @@ public:
                        const const_element_iterator & it_end) const;
 
   /**
+   * @name Stitching
    * Stitch \p other_mesh to this mesh so that this mesh is the union of the two meshes.
    * \p this_mesh_boundary and \p other_mesh_boundary are used to specify a dim-1 dimensional
    * surface on which we seek to merge any "overlapping" nodes, where we use the parameter
@@ -193,6 +194,11 @@ public:
    * and other_mesh and node IDs in the stitched mesh because the number of nodes (and hence
    * the node IDs) in the stitched mesh depend on how many nodes are stitched.
    */
+  ///@{
+  /**
+   * This mesh stitching overload will call \p prepare_for_use on this mesh if it is not prepared
+   * and \p other_mesh is prepared. \p other_mesh will not be modified
+   */
   void stitch_meshes (const MeshBase & other_mesh,
                       boundary_id_type this_mesh_boundary,
                       boundary_id_type other_mesh_boundary,
@@ -201,6 +207,19 @@ public:
                       bool verbose=true,
                       bool use_binary_search=true,
                       bool enforce_all_nodes_match_on_boundaries=false);
+  /**
+   * This mesh stitching overload will call \p prepare_for_use on this mesh if it is not prepared
+   * and \p other_mesh is prepared, and visa versa
+   */
+  void stitch_meshes (MeshBase & other_mesh,
+                      boundary_id_type this_mesh_boundary,
+                      boundary_id_type other_mesh_boundary,
+                      Real tol=TOLERANCE,
+                      bool clear_stitched_boundary_ids=false,
+                      bool verbose=true,
+                      bool use_binary_search=true,
+                      bool enforce_all_nodes_match_on_boundaries=false);
+  ///@}
 
   /**
    * Similar to stitch_meshes, except that we stitch two adjacent surfaces within this mesh.

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -1727,6 +1727,8 @@ void UnstructuredMesh::stitch_meshes (const MeshBase & other_mesh,
                                       bool enforce_all_nodes_match_on_boundaries)
 {
   LOG_SCOPE("stitch_meshes()", "UnstructuredMesh");
+  if (!this->is_prepared() && other_mesh.is_prepared())
+    this->prepare_for_use();
   stitching_helper(&other_mesh,
                    this_mesh_boundary_id,
                    other_mesh_boundary_id,
@@ -1738,6 +1740,26 @@ void UnstructuredMesh::stitch_meshes (const MeshBase & other_mesh,
                    true);
 }
 
+void UnstructuredMesh::stitch_meshes (MeshBase & other_mesh,
+                                      boundary_id_type this_mesh_boundary_id,
+                                      boundary_id_type other_mesh_boundary_id,
+                                      Real tol,
+                                      bool clear_stitched_boundary_ids,
+                                      bool verbose,
+                                      bool use_binary_search,
+                                      bool enforce_all_nodes_match_on_boundaries)
+{
+  if (this->is_prepared() && !other_mesh.is_prepared())
+    other_mesh.prepare_for_use();
+  stitch_meshes(const_cast<const MeshBase &>(other_mesh),
+                this_mesh_boundary_id,
+                other_mesh_boundary_id,
+                tol,
+                clear_stitched_boundary_ids,
+                verbose,
+                use_binary_search,
+                enforce_all_nodes_match_on_boundaries);
+}
 
 void UnstructuredMesh::stitch_surfaces (boundary_id_type boundary_id_1,
                                         boundary_id_type boundary_id_2,


### PR DESCRIPTION
This is to pass an assertion in `copy_nodes_and_elements` that the meshes have matching states of preparedness. I think these changes are fine from a user perspective. `this` mesh is obviously going to be modified during stitching, and I would wager that the majority of the time a user is going to discard the `other_mesh` anyway since they're merging it into `this`. And if they're not, they can still pass to the `const` overload if they want to ensure it's not modified