### PR TITLE
ExodusII_IO: Allow edges with different orientations to match

### DIFF
--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1576,21 +1576,6 @@ void ExodusII_IO_Helper::read_edge_blocks(MeshBase & mesh)
                       bi.add_edge(elem_edge_pair.first,
                                   elem_edge_pair.second,
                                   edge_block_id);
-
-                      // Debugging
-                      libMesh::out << "Added (Elem=" << elem_edge_pair.first
-                                   << ", Edge=" << elem_edge_pair.second
-                                   << ", Id=" << edge_block_id
-                                   << ") to BoundaryInfo." << std::endl;
-                    }
-                  // Debugging
-                  else
-                    {
-                      // We didn't find a match for some reason
-                      libMesh::out << "Skipped adding (Elem=" << elem_edge_pair.first
-                                   << ", Edge=" << elem_edge_pair.second
-                                   << ", Id=" << edge_block_id
-                                   << ") to BoundaryInfo, orientation check failed." << std::endl;
                     }
                 } // end loop over elem_edge_pairs
             } // end loop over connectivity array

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1575,6 +1575,21 @@ void ExodusII_IO_Helper::read_edge_blocks(MeshBase & mesh)
                       bi.add_edge(elem_edge_pair.first,
                                   elem_edge_pair.second,
                                   edge_block_id);
+
+                      // Debugging
+                      libMesh::out << "Added (Elem=" << elem_edge_pair.first
+                                   << ", Edge=" << elem_edge_pair.second
+                                   << ", Id=" << edge_block_id
+                                   << ") to BoundaryInfo." << std::endl;
+                    }
+                  // Debugging
+                  else
+                    {
+                      // We didn't find a match for some reason
+                      libMesh::out << "Skipped adding (Elem=" << elem_edge_pair.first
+                                   << ", Edge=" << elem_edge_pair.second
+                                   << ", Id=" << edge_block_id
+                                   << ") to BoundaryInfo, orientation check failed." << std::endl;
                     }
                 } // end loop over elem_edge_pairs
             } // end loop over connectivity array

--- a/tests/mesh/boundary_info.C
+++ b/tests/mesh/boundary_info.C
@@ -746,9 +746,9 @@ public:
         std::vector<boundary_id_type> container;
         bi.boundary_ids(elem, 3, container);
 
-        CPPUNIT_ASSERT_EQUAL((unsigned long) 2, container.size());
-        CPPUNIT_ASSERT_EQUAL((short int) 5, container[0]);
-        CPPUNIT_ASSERT_EQUAL((short int) 3, container[1]);
+        CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(2), container.size());
+        CPPUNIT_ASSERT_EQUAL(static_cast<boundary_id_type>(5), container[0]);
+        CPPUNIT_ASSERT_EQUAL(static_cast<boundary_id_type>(3), container[1]);
       }
     }
   }

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -253,8 +253,12 @@ public:
     // reader threw an exception while trying to read this mesh.
     if (mesh.is_serial())
     {
-      // Mesh has 15 boundary ids total (including edge and side ids).
-      CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(15), bi.n_boundary_ids());
+      // Mesh has 26 boundary ids total (including edge and side ids).
+      // ss_prop1 = 200, 201 ;
+      // ed_prop1 = 8000, 8001, 8002, 8003, 8004, 8005, 8006, 8007, 8008, 8009, 8010,
+      //            8011, 9001, 9002, 9003, 9004, 9005, 9006, 9007, 9008, 9009, 9010,
+      //            9011, 9012 ;
+      CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(26), bi.n_boundary_ids());
 
       // We can binary_search() the build_edge_list() which is sorted
       // in lexicographical order before it's returned.


### PR DESCRIPTION
I previously had a check in the Exodus reader to make sure that the orientation of an Edge specified in an edge block matched the orientation of a candidate Elem's edge before adding it to the `BoundaryInfo` object. What I should have realized (since I added a unit test which demonstrated the issue) is that it is possible for two neighboring elements to have the same orientation for a given edge while the edge block specifies the edge in the opposite orientation. In this case, we were (incorrectly) adding no edges to the `BoundaryInfo` object. I have now updated this check so that Edges specified in edge blocks match either possible orientation.

This means that when adding edgesets via Exodus edge blocks, one gets an (Elem, edge, id) tuple in the `BoundaryInfo` object for *each* neighboring Elem that touches it (regardless of orientation). This is a byproduct of the way that we use Exodus edge blocks, since Exodus edge blocks don't specify the Elem which each edge in the block is meant to belong to, but this actually works well for my personal use case since I need to know about all neighboring Elems anyway.
