### PR TITLE
Make linear partitioner idempotent for distributed meshes

### DIFF
--- a/src/partitioning/linear_partitioner.C
+++ b/src/partitioning/linear_partitioner.C
@@ -91,7 +91,7 @@ void LinearPartitioner::partition_range(MeshBase & mesh,
       mesh.comm().set_union(element_ids);
 
       const dof_id_type blksize = cast_int<dof_id_type>
-        (element_ids.size());
+        (element_ids.size() / n);
 
       dof_id_type e = 0;
       for (auto eid : element_ids)


### PR DESCRIPTION
The blksize was wrong if `partition_range` was called (again) after the mesh had been distributed. Now I'm getting the same partitioning even if I call `prepare_for_use` twice

This is relevant to work on idaholab/moose#24018