### PR TITLE
Mesh equality tests, MeshTools::valid_is_prepared() test

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -1632,7 +1632,7 @@ public:
 
 #endif
 
-#ifdef DEBUG
+#ifndef NDEBUG
   /**
    * Checks for consistent neighbor links on this element.
    */
@@ -1643,7 +1643,7 @@ public:
    * this element.
    */
   void libmesh_assert_valid_node_pointers() const;
-#endif // DEBUG
+#endif // !NDEBUG
 
   /**
    * \returns The local node index of the given point IF said node

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -263,12 +263,21 @@ public:
   virtual dof_id_type key () const;
 
   /**
-   * \returns \p true if two elements are identical, false otherwise.
+   * \returns \p true if two elements are equivalent, false otherwise.
    * This is true if the elements are connected to identical global
    * nodes, regardless of how those nodes might be numbered local
    * to the elements.
    */
   bool operator == (const Elem & rhs) const;
+
+  /**
+   * \returns \p true if two elements have equal topologies, false
+   * otherwise.
+   * This is true if the elements connect to nodes of the same id in
+   * the same order, and neighbors of the same id on each side, the
+   * same id on any parent and/or interior_parent link, etc.
+   */
+  bool topologically_equal (const Elem & rhs) const;
 
   /**
    * \returns A const pointer to the \f$ i^{th} \f$ neighbor of this

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -83,9 +83,9 @@ public:
   /**
    * This tests for data equality via element ids
    */
-  bool operator== (const BoundaryInfo & other_boundary_info);
+  bool operator== (const BoundaryInfo & other_boundary_info) const;
 
-  bool operator!= (const BoundaryInfo & other_boundary_info) {
+  bool operator!= (const BoundaryInfo & other_boundary_info) const {
     return !(*this == other_boundary_info);
   }
 

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -80,6 +80,14 @@ public:
    */
   BoundaryInfo & operator=(const BoundaryInfo & other_boundary_info);
 
+  /**
+   * This tests for data equality via element ids
+   */
+  bool operator== (const BoundaryInfo & other_boundary_info);
+
+  bool operator!= (const BoundaryInfo & other_boundary_info) {
+    return !(*this == other_boundary_info);
+  }
 
   /**
    * Destructor.  Not much to do.

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -111,7 +111,7 @@ public:
    * Shim to allow operator == (&) to behave like a virtual function
    * without having to be one.
    */
-  virtual bool subclass_locally_equals (const MeshBase & other_mesh) const;
+  virtual bool subclass_locally_equals (const MeshBase & other_mesh) const override;
 
   /**
    * Virtual copy-constructor, creates a copy of this mesh

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -108,6 +108,12 @@ public:
   virtual MeshBase & assign(MeshBase && other_mesh) override;
 
   /**
+   * Shim to allow operator == (&) to behave like a virtual function
+   * without having to be one.
+   */
+  virtual bool subclass_locally_equals (const MeshBase & other_mesh);
+
+  /**
    * Virtual copy-constructor, creates a copy of this mesh
    */
   virtual std::unique_ptr<MeshBase> clone () const override

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -111,7 +111,7 @@ public:
    * Shim to allow operator == (&) to behave like a virtual function
    * without having to be one.
    */
-  virtual bool subclass_locally_equals (const MeshBase & other_mesh);
+  virtual bool subclass_locally_equals (const MeshBase & other_mesh) const;
 
   /**
    * Virtual copy-constructor, creates a copy of this mesh

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -111,6 +111,29 @@ public:
   virtual MeshBase & assign(MeshBase && other_mesh) = 0;
 
   /**
+   * This tests for exactly-equal data in all the senses that a
+   * mathematician would care about (element connectivity, nodal
+   * coordinates), but in the senses a programmer would care about it
+   * allows for non-equal equivalence in some ways (we accept
+   * different Elem/Node addresses in memory) but not others (we do
+   * not accept different subclass types, nor even different Elem/Node
+   * ids).
+   */
+  bool operator== (const MeshBase & other_mesh);
+
+  bool operator!= (const MeshBase & other_mesh) {
+    return !(*this == other_mesh);
+  }
+
+  /**
+   * This behaves the same as operator==, but only for the local and
+   * ghosted aspects of the mesh; i.e. operator== is true iff local
+   * equality is true on every rank.
+   */
+  bool locally_equals (const MeshBase & other_mesh);
+
+
+  /**
    * Virtual "copy constructor"
    */
   virtual std::unique_ptr<MeshBase> clone() const = 0;
@@ -1899,6 +1922,18 @@ protected:
    * operators.
    */
   void post_dofobject_moves(MeshBase && other_mesh);
+
+  /**
+   * Shim to allow operator == (&) to behave like a virtual function
+   * without having to be one.
+   */
+  virtual bool subclass_locally_equals (const MeshBase & other_mesh) = 0;
+
+  /**
+   * Tests for equality of all elements and nodes in the mesh.  Helper
+   * function for subclass_equals() in unstructured mesh subclasses.
+   */
+  bool nodes_and_elements_equal(const MeshBase & other_mesh);
 
   /**
    * \returns A writable reference to the number of partitions.

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -119,9 +119,9 @@ public:
    * not accept different subclass types, nor even different Elem/Node
    * ids).
    */
-  bool operator== (const MeshBase & other_mesh);
+  bool operator== (const MeshBase & other_mesh) const;
 
-  bool operator!= (const MeshBase & other_mesh) {
+  bool operator!= (const MeshBase & other_mesh) const {
     return !(*this == other_mesh);
   }
 
@@ -130,7 +130,7 @@ public:
    * ghosted aspects of the mesh; i.e. operator== is true iff local
    * equality is true on every rank.
    */
-  bool locally_equals (const MeshBase & other_mesh);
+  bool locally_equals (const MeshBase & other_mesh) const;
 
 
   /**
@@ -1927,13 +1927,13 @@ protected:
    * Shim to allow operator == (&) to behave like a virtual function
    * without having to be one.
    */
-  virtual bool subclass_locally_equals (const MeshBase & other_mesh) = 0;
+  virtual bool subclass_locally_equals (const MeshBase & other_mesh) const = 0;
 
   /**
    * Tests for equality of all elements and nodes in the mesh.  Helper
    * function for subclass_equals() in unstructured mesh subclasses.
    */
-  bool nodes_and_elements_equal(const MeshBase & other_mesh);
+  bool nodes_and_elements_equal(const MeshBase & other_mesh) const;
 
   /**
    * \returns A writable reference to the number of partitions.

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -360,13 +360,7 @@ void correct_node_proc_ids(MeshBase &);
  */
 void clear_spline_nodes(MeshBase &);
 
-#ifdef DEBUG
-/**
- * A function for verifying that an element has been cut off
- * from the rest of the mesh
- */
-void libmesh_assert_no_links_to_elem(const MeshBase & mesh,
-                                     const Elem * bad_elem);
+#ifndef NDEBUG
 
 /**
  * A function for testing that all DofObjects within a mesh
@@ -413,6 +407,61 @@ void libmesh_assert_valid_amr_elem_ids (const MeshBase & mesh);
 void libmesh_assert_valid_amr_interior_parents (const MeshBase & mesh);
 
 /**
+ * A function for verifying that all mesh constraint rows express
+ * relations between nodes and elements that are semilocal (local or
+ * ghosted) to the current processor's portion of the mesh.
+ */
+void libmesh_assert_valid_constraint_rows (const MeshBase & mesh);
+
+/**
+ * A function for verifying that degree of freedom indexes are
+ * contiguous on each processors, as is required by libMesh numeric
+ * classes.
+ *
+ * Verify a particular system by specifying that system's number.
+ */
+void libmesh_assert_contiguous_dof_ids (const MeshBase & mesh,
+                                        unsigned int sysnum);
+
+/**
+ * A function for verifying that processor assignment is
+ * topologically consistent on nodes (each node part of an active
+ * element on its processor) or elements (each parent has the
+ * processor id of one of its children).
+ */
+template <typename DofObjectSubclass>
+void libmesh_assert_topology_consistent_procids (const MeshBase & mesh);
+
+/**
+ * A function for verifying that processor assignment of nodes matches
+ * the heuristic specified in Node::choose_processor_id()
+ */
+void libmesh_assert_canonical_node_procids (const MeshBase & mesh);
+
+/**
+ * A function for verifying that elements on this processor have
+ * valid descendants and consistent active flags.
+ */
+void libmesh_assert_valid_refinement_tree (const MeshBase & mesh);
+
+#endif // !NDEBUG
+
+/**
+ * The following functions, only available in builds with DEBUG
+ * defined, typically have surprisingly slow asymptotic behavior, and
+ * so are unsuitable for use even with METHOD=devel
+ */
+
+#ifdef DEBUG
+
+/**
+ * A function for verifying that an element has been cut off
+ * from the rest of the mesh
+ */
+void libmesh_assert_no_links_to_elem(const MeshBase & mesh,
+                                     const Elem * bad_elem);
+
+/**
  * A function for verifying that all nodes are connected to at least
  * one element.
  *
@@ -423,13 +472,6 @@ void libmesh_assert_valid_amr_interior_parents (const MeshBase & mesh);
  * nodes.
  */
 void libmesh_assert_connected_nodes (const MeshBase & mesh);
-
-/**
- * A function for verifying that all mesh constraint rows express
- * relations between nodes and elements that are semilocal (local or
- * ghosted) to the current processor's portion of the mesh.
- */
-void libmesh_assert_valid_constraint_rows (const MeshBase & mesh);
 
 /**
  * A function for verifying that boundary condition ids match
@@ -446,16 +488,6 @@ void libmesh_assert_valid_boundary_ids (const MeshBase & mesh);
  */
 void libmesh_assert_valid_dof_ids (const MeshBase & mesh,
                                    unsigned int sysnum = libMesh::invalid_uint);
-
-/**
- * A function for verifying that degree of freedom indexes are
- * contiguous on each processors, as is required by libMesh numeric
- * classes.
- *
- * Verify a particular system by specifying that system's number.
- */
-void libmesh_assert_contiguous_dof_ids (const MeshBase & mesh,
-                                        unsigned int sysnum);
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
 /**
@@ -498,15 +530,6 @@ void libmesh_assert_parallel_consistent_procids (const MeshBase & mesh);
 
 /**
  * A function for verifying that processor assignment is
- * topologically consistent on nodes (each node part of an active
- * element on its processor) or elements (each parent has the
- * processor id of one of its children).
- */
-template <typename DofObjectSubclass>
-void libmesh_assert_topology_consistent_procids (const MeshBase & mesh);
-
-/**
- * A function for verifying that processor assignment is
  * both parallel and topologically consistent.
  */
 template <typename DofObjectSubclass>
@@ -516,22 +539,10 @@ void libmesh_assert_valid_procids (const MeshBase & mesh) {
 }
 
 /**
- * A function for verifying that processor assignment of nodes matches
- * the heuristic specified in Node::choose_processor_id()
- */
-void libmesh_assert_canonical_node_procids (const MeshBase & mesh);
-
-/**
  * A function for verifying that refinement flags on elements
  * are consistent between processors
  */
 void libmesh_assert_valid_refinement_flags (const MeshBase & mesh);
-
-/**
- * A function for verifying that elements on this processor have
- * valid descendants and consistent active flags.
- */
-void libmesh_assert_valid_refinement_tree (const MeshBase & mesh);
 
 /**
  * A function for verifying that neighbor connectivity is correct (each
@@ -545,7 +556,8 @@ void libmesh_assert_valid_refinement_tree (const MeshBase & mesh);
  */
 void libmesh_assert_valid_neighbors (const MeshBase & mesh,
                                      bool assert_valid_remote_elems=true);
-#endif
+
+#endif // DEBUG
 
 // There is no reason for users to call functions in the MeshTools::Private namespace.
 namespace Private {

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -431,7 +431,7 @@ void libmesh_assert_valid_constraint_rows (const MeshBase & mesh);
 
 /**
  * A function for verifying that degree of freedom indexes are
- * contiguous on each processors, as is required by libMesh numeric
+ * contiguous on each processor, as is required by libMesh numeric
  * classes.
  *
  * Verify a particular system by specifying that system's number.

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -360,13 +360,23 @@ void correct_node_proc_ids(MeshBase &);
  */
 void clear_spline_nodes(MeshBase &);
 
-#ifndef NDEBUG
+/**
+ * A function for testing whether a mesh's cached is_prepared() setting
+ * is not a false positive.  If the mesh is marked as not prepared, or
+ * if preparing the already-partitioned mesh (without any
+ * repartitioning or renumbering) does not change it, then we return
+ * true.  If the mesh believes it is prepared but prepare_for_use()
+ * would change it, we return false.
+ */
+bool valid_is_prepared (const MeshBase & mesh);
 
 /**
- * A function for testing that a mesh's cached is_prepared() setting
- * is not a false positive.
+ * The following functions, only available in builds with NDEBUG
+ * undefined, are for asserting internal consistency that we hope
+ * should never be broken in opt
  */
-void libmesh_assert_valid_is_prepared (const MeshBase & mesh);
+
+#ifndef NDEBUG
 
 /**
  * A function for testing that all DofObjects within a mesh

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -370,6 +370,8 @@ void clear_spline_nodes(MeshBase &);
  */
 bool valid_is_prepared (const MeshBase & mesh);
 
+///@{
+
 /**
  * The following functions, only available in builds with NDEBUG
  * undefined, are for asserting internal consistency that we hope
@@ -461,6 +463,10 @@ void libmesh_assert_canonical_node_procids (const MeshBase & mesh);
 void libmesh_assert_valid_refinement_tree (const MeshBase & mesh);
 
 #endif // !NDEBUG
+
+///@}
+
+///@{
 
 /**
  * The following functions, only available in builds with DEBUG
@@ -574,6 +580,8 @@ void libmesh_assert_valid_neighbors (const MeshBase & mesh,
                                      bool assert_valid_remote_elems=true);
 
 #endif // DEBUG
+
+///@}
 
 // There is no reason for users to call functions in the MeshTools::Private namespace.
 namespace Private {

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -363,6 +363,12 @@ void clear_spline_nodes(MeshBase &);
 #ifndef NDEBUG
 
 /**
+ * A function for testing that a mesh's cached is_prepared() setting
+ * is not a false positive.
+ */
+void libmesh_assert_valid_is_prepared (const MeshBase & mesh);
+
+/**
  * A function for testing that all DofObjects within a mesh
  * have the same n_systems count
  */

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -97,7 +97,7 @@ public:
    * Shim to allow operator == (&) to behave like a virtual function
    * without having to be one.
    */
-  virtual bool subclass_locally_equals (const MeshBase & other_mesh);
+  virtual bool subclass_locally_equals (const MeshBase & other_mesh) const;
 
   /**
    * Virtual copy-constructor, creates a copy of this mesh

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -97,7 +97,7 @@ public:
    * Shim to allow operator == (&) to behave like a virtual function
    * without having to be one.
    */
-  virtual bool subclass_locally_equals (const MeshBase & other_mesh) const;
+  virtual bool subclass_locally_equals (const MeshBase & other_mesh) const override;
 
   /**
    * Virtual copy-constructor, creates a copy of this mesh

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -94,6 +94,12 @@ public:
   virtual void move_nodes_and_elements(MeshBase && other_mesh) override;
 
   /**
+   * Shim to allow operator == (&) to behave like a virtual function
+   * without having to be one.
+   */
+  virtual bool subclass_locally_equals (const MeshBase & other_mesh);
+
+  /**
    * Virtual copy-constructor, creates a copy of this mesh
    */
   virtual std::unique_ptr<MeshBase> clone () const override

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -609,6 +609,58 @@ bool Elem::operator == (const Elem & rhs) const
 
 
 
+bool Elem::topologically_equal (const Elem & rhs) const
+{
+  // If the elements aren't the same type, they aren't equal
+  if (this->type() != rhs.type())
+    return false;
+
+  libmesh_assert_equal_to(this->n_nodes(), rhs.n_nodes());
+
+  for (auto n : make_range(this->n_nodes()))
+    if (this->node_id(n) != rhs.node_id(n))
+      return false;
+
+  for (auto neigh : make_range(this->n_neighbors()))
+    {
+      if (!this->neighbor_ptr(neigh))
+        {
+          if (rhs.neighbor_ptr(neigh))
+            return false;
+          continue;
+        }
+      if (!rhs.neighbor_ptr(neigh) ||
+          this->neighbor_ptr(neigh)->id() !=
+          rhs.neighbor_ptr(neigh)->id())
+        return false;
+    }
+
+  if (this->parent())
+    {
+      if (!rhs.parent())
+        return false;
+      if (this->parent()->id() != rhs.parent()->id())
+        return false;
+    }
+  else if (rhs.parent())
+    return false;
+
+  if (this->interior_parent())
+    {
+      if (!rhs.interior_parent())
+        return false;
+      if (this->interior_parent()->id() !=
+          rhs.interior_parent()->id())
+        return false;
+    }
+  else if (rhs.interior_parent())
+    return false;
+
+  return true;
+}
+
+
+
 bool Elem::is_semilocal(const processor_id_type my_pid) const
 {
   std::set<const Elem *> point_neighbors;

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1172,7 +1172,7 @@ bool Elem::has_topological_neighbor (const Elem * elem,
 
 #endif
 
-#ifdef DEBUG
+#ifndef NDEBUG
 
 void Elem::libmesh_assert_valid_node_pointers() const
 {
@@ -1254,7 +1254,7 @@ void Elem::libmesh_assert_valid_neighbors() const
     }
 }
 
-#endif // DEBUG
+#endif // !NDEBUG
 
 
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -286,7 +286,7 @@ bool BoundaryInfo::operator==(const BoundaryInfo & other_boundary_info) const
   if (_children_on_boundary != other_boundary_info._children_on_boundary)
     return false;
 
-  auto compare_sets = [](auto set1, auto set2)
+  auto compare_sets = [](const auto & set1, const auto & set2)
   {
     if (set1.size() != set2.size())
       return false;
@@ -311,13 +311,13 @@ bool BoundaryInfo::operator==(const BoundaryInfo & other_boundary_info) const
                     other_boundary_info._side_boundary_ids))
     return false;
 
-  auto compare_maps = [](auto map1, auto map2)
+  auto compare_maps = [](const auto & map1, const auto & map2)
   {
     if (map1.size() != map2.size())
       return false;
-    for (auto & pair : map1)
+    for (const auto & pair : map1)
       if (!map2.count(pair.first) ||
-          map2[pair.first] != pair.second)
+          map2.at(pair.first) != pair.second)
         return false;
 
     return true;

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -152,11 +152,11 @@ BoundaryInfo & BoundaryInfo::operator=(const BoundaryInfo & other_boundary_info)
 }
 
 
-bool BoundaryInfo::operator==(const BoundaryInfo & other_boundary_info)
+bool BoundaryInfo::operator==(const BoundaryInfo & other_boundary_info) const
 {
   for (const auto & [other_node, bid] : other_boundary_info._boundary_node_id)
     {
-      Node * node = this->_mesh->query_node_ptr(other_node->id());
+      const Node * node = this->_mesh->query_node_ptr(other_node->id());
       if (!node)
         return false;
       if (!this->has_boundary_id(node, bid))
@@ -164,7 +164,7 @@ bool BoundaryInfo::operator==(const BoundaryInfo & other_boundary_info)
     }
   for (const auto & [node, bid] : this->_boundary_node_id)
     {
-      Node * other_node =
+      const Node * other_node =
         other_boundary_info._mesh->query_node_ptr(node->id());
       if (!other_node)
         return false;
@@ -197,14 +197,14 @@ bool BoundaryInfo::operator==(const BoundaryInfo & other_boundary_info)
 
   for (const auto & [other_elem, edge_id_pair] : other_boundary_info._boundary_edge_id)
     {
-      Elem * elem = this->_mesh->query_elem_ptr(other_elem->id());
+      const Elem * elem = this->_mesh->query_elem_ptr(other_elem->id());
       if (!compare_edges(elem, other_elem, edge_id_pair.first))
         return false;
     }
 
   for (const auto & [elem, edge_id_pair] : this->_boundary_edge_id)
     {
-      Elem * other_elem = other_boundary_info._mesh->query_elem_ptr(elem->id());
+      const Elem * other_elem = other_boundary_info._mesh->query_elem_ptr(elem->id());
       if (!compare_edges(elem, other_elem, edge_id_pair.first))
         return false;
     }
@@ -234,14 +234,14 @@ bool BoundaryInfo::operator==(const BoundaryInfo & other_boundary_info)
 
   for (const auto & [other_elem, side_id_pair] : other_boundary_info._boundary_side_id)
     {
-      Elem * elem = this->_mesh->query_elem_ptr(other_elem->id());
+      const Elem * elem = this->_mesh->query_elem_ptr(other_elem->id());
       if (!compare_sides(elem, other_elem, side_id_pair.first))
         return false;
     }
 
   for (const auto & [elem, side_id_pair] : this->_boundary_side_id)
     {
-      Elem * other_elem = other_boundary_info._mesh->query_elem_ptr(elem->id());
+      const Elem * other_elem = other_boundary_info._mesh->query_elem_ptr(elem->id());
       if (!compare_sides(elem, other_elem, side_id_pair.first))
         return false;
     }
@@ -271,14 +271,14 @@ bool BoundaryInfo::operator==(const BoundaryInfo & other_boundary_info)
 
   for (const auto & [other_elem, shellface_id_pair] : other_boundary_info._boundary_shellface_id)
     {
-      Elem * elem = this->_mesh->query_elem_ptr(other_elem->id());
+      const Elem * elem = this->_mesh->query_elem_ptr(other_elem->id());
       if (!compare_shellfaces(elem, other_elem, shellface_id_pair.first))
         return false;
     }
 
   for (const auto & [elem, shellface_id_pair] : this->_boundary_shellface_id)
     {
-      Elem * other_elem = other_boundary_info._mesh->query_elem_ptr(elem->id());
+      const Elem * other_elem = other_boundary_info._mesh->query_elem_ptr(elem->id());
       if (!compare_shellfaces(elem, other_elem, shellface_id_pair.first))
         return false;
     }

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -88,7 +88,7 @@ MeshBase & DistributedMesh::assign(MeshBase && other_mesh)
   return *this;
 }
 
-bool DistributedMesh::subclass_locally_equals(const MeshBase & other_mesh_base)
+bool DistributedMesh::subclass_locally_equals(const MeshBase & other_mesh_base) const
 {
   const DistributedMesh * dist_mesh_ptr =
     dynamic_cast<const DistributedMesh *>(&other_mesh_base);

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -65,6 +65,8 @@ DistributedMesh::DistributedMesh (const Parallel::Communicator & comm_in,
 
 DistributedMesh & DistributedMesh::operator= (DistributedMesh && other_mesh)
 {
+  LOG_SCOPE("operator=()", "DistributedMesh");
+
   // Move assign as an UnstructuredMesh.
   this->UnstructuredMesh::operator=(std::move(other_mesh));
 

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -88,6 +88,49 @@ MeshBase & DistributedMesh::assign(MeshBase && other_mesh)
   return *this;
 }
 
+bool DistributedMesh::subclass_locally_equals(const MeshBase & other_mesh_base)
+{
+  const DistributedMesh * dist_mesh_ptr =
+    dynamic_cast<const DistributedMesh *>(&other_mesh_base);
+  if (!dist_mesh_ptr)
+    return false;
+  const DistributedMesh & other_mesh = *dist_mesh_ptr;
+
+  if (_is_serial != other_mesh._is_serial ||
+      _is_serial_on_proc_0 != other_mesh._is_serial_on_proc_0 ||
+      _n_nodes != other_mesh._n_nodes ||
+      _n_elem != other_mesh._n_elem ||
+      _max_node_id != other_mesh._max_node_id ||
+      _max_elem_id != other_mesh._max_elem_id ||
+      // We expect these things to change in a prepare_for_use();
+      // they're conceptually "mutable"...
+/*
+      _next_free_local_node_id != other_mesh._next_free_local_node_id ||
+      _next_free_local_elem_id != other_mesh._next_free_local_elem_id ||
+      _next_free_unpartitioned_node_id != other_mesh._next_free_unpartitioned_node_id ||
+      _next_free_unpartitioned_elem_id != other_mesh._next_free_unpartitioned_elem_id ||
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+      _next_unpartitioned_unique_id != other_mesh._next_unpartitioned_unique_id ||
+#endif
+*/
+      !this->nodes_and_elements_equal(other_mesh))
+    return false;
+
+  if (_extra_ghost_elems.size() !=
+      other_mesh._extra_ghost_elems.size())
+    return false;
+  for (auto & elem : _extra_ghost_elems)
+    {
+      libmesh_assert(this->query_elem_ptr(elem->id()) == elem);
+      const Elem * other_elem = other_mesh.query_elem_ptr(elem->id());
+      if (!other_elem ||
+          !other_mesh._extra_ghost_elems.count(const_cast<Elem *>(other_elem)))
+        return false;
+    }
+
+  return true;
+}
+
 DistributedMesh::~DistributedMesh ()
 {
   this->DistributedMesh::clear();  // Free nodes and elements

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -65,7 +65,7 @@ DistributedMesh::DistributedMesh (const Parallel::Communicator & comm_in,
 
 DistributedMesh & DistributedMesh::operator= (DistributedMesh && other_mesh)
 {
-  LOG_SCOPE("operator=()", "DistributedMesh");
+  LOG_SCOPE("operator=(&&)", "DistributedMesh");
 
   // Move assign as an UnstructuredMesh.
   this->UnstructuredMesh::operator=(std::move(other_mesh));

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -841,9 +841,11 @@ void MeshBase::prepare_for_use ()
   // The mesh is now prepared for use.
   _is_prepared = true;
 
-#if defined(DEBUG) && defined(LIBMESH_ENABLE_UNIQUE_ID)
+#ifdef DEBUG
   MeshTools::libmesh_assert_valid_boundary_ids(*this);
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
   MeshTools::libmesh_assert_valid_unique_ids(*this);
+#endif
 #endif
 }
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -152,6 +152,8 @@ MeshBase::MeshBase (const MeshBase & other_mesh) :
 
 MeshBase& MeshBase::operator= (MeshBase && other_mesh)
 {
+  LOG_SCOPE("operator=()", "MeshBase");
+
   // Move assign as a ParallelObject.
   this->ParallelObject::operator=(other_mesh);
 
@@ -207,6 +209,8 @@ MeshBase& MeshBase::operator= (MeshBase && other_mesh)
 
 bool MeshBase::operator== (const MeshBase & other_mesh) const
 {
+  LOG_SCOPE("operator==()", "MeshBase");
+
   bool is_equal = this->locally_equals(other_mesh);
   this->comm().min(is_equal);
   return is_equal;

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -255,9 +255,9 @@ bool MeshBase::locally_equals (const MeshBase & other_mesh) const
 
   const constraint_rows_type & other_rows =
     other_mesh.get_constraint_rows();
-  for (auto constraint_row_pair : this->_constraint_rows)
+  for (const auto & [node, row] : this->_constraint_rows)
     {
-      const dof_id_type node_id = constraint_row_pair.first->id();
+      const dof_id_type node_id = node->id();
       const Node * other_node = other_mesh.query_node_ptr(node_id);
       if (!other_node)
         return false;
@@ -266,32 +266,30 @@ bool MeshBase::locally_equals (const MeshBase & other_mesh) const
       if (it == other_rows.end())
         return false;
 
-      auto & row = constraint_row_pair.second;
-      auto & other_row = it->second;
+      const auto & other_row = it->second;
       if (row.size() != other_row.size())
         return false;
 
       for (auto i : index_range(row))
         {
-          const auto & row_i = row[i];
-          const auto & other_row_i = other_row[i];
-          libmesh_assert(row_i.first.first);
-          libmesh_assert(other_row_i.first.first);
-          if (row_i.first.first->id() !=
-              other_row_i.first.first->id() ||
-              row_i.first.second !=
-              other_row_i.first.second ||
-              row_i.second !=
-              other_row_i.second)
+          const auto & [elem_pair, coef] = row[i];
+          const auto & [other_elem_pair, other_coef] = other_row[i];
+          libmesh_assert(elem_pair.first);
+          libmesh_assert(other_elem_pair.first);
+          if (elem_pair.first->id() !=
+              other_elem_pair.first->id() ||
+              elem_pair.second !=
+              other_elem_pair.second ||
+              coef != other_coef)
             return false;
         }
     }
 
-  for (auto elemset_codes_pair : this->_elemset_codes)
+  for (const auto & [elemset_code, elemset_ptr] : this->_elemset_codes)
     {
-      auto it = other_mesh._elemset_codes.find(elemset_codes_pair.first);
+      auto it = other_mesh._elemset_codes.find(elemset_code);
       if (it == other_mesh._elemset_codes.end() ||
-          elemset_codes_pair.second != it->second)
+          *elemset_ptr != *it->second)
         return false;
     }
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -152,7 +152,7 @@ MeshBase::MeshBase (const MeshBase & other_mesh) :
 
 MeshBase& MeshBase::operator= (MeshBase && other_mesh)
 {
-  LOG_SCOPE("operator=()", "MeshBase");
+  LOG_SCOPE("operator=(&&)", "MeshBase");
 
   // Move assign as a ParallelObject.
   this->ParallelObject::operator=(other_mesh);

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -205,7 +205,7 @@ MeshBase& MeshBase::operator= (MeshBase && other_mesh)
 }
 
 
-bool MeshBase::operator== (const MeshBase & other_mesh)
+bool MeshBase::operator== (const MeshBase & other_mesh) const
 {
   bool is_equal = this->locally_equals(other_mesh);
   this->comm().min(is_equal);
@@ -213,7 +213,7 @@ bool MeshBase::operator== (const MeshBase & other_mesh)
 }
 
 
-bool MeshBase::locally_equals (const MeshBase & other_mesh)
+bool MeshBase::locally_equals (const MeshBase & other_mesh) const
 {
   // Check whether everything in the base is equal
   if (_n_parts != other_mesh._n_parts ||
@@ -1892,7 +1892,7 @@ MeshBase::post_dofobject_moves(MeshBase && other_mesh)
 }
 
 
-bool MeshBase::nodes_and_elements_equal(const MeshBase & other_mesh)
+bool MeshBase::nodes_and_elements_equal(const MeshBase & other_mesh) const
 {
   for (const auto & other_node : other_mesh.node_ptr_range())
     {

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1030,14 +1030,13 @@ void clear_spline_nodes(MeshBase & mesh)
 }
 
 
-#ifndef NDEBUG
 
-void libmesh_assert_valid_is_prepared (const MeshBase & mesh)
+bool valid_is_prepared (const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_valid_is_prepared()", "MeshTools");
 
   if (!mesh.is_prepared())
-    return;
+    return true;
 
   std::unique_ptr<MeshBase> mesh_clone = mesh.clone();
 
@@ -1055,10 +1054,12 @@ void libmesh_assert_valid_is_prepared (const MeshBase & mesh)
   mesh_clone->allow_remote_element_removal(old_allow_remote_element_removal);
   mesh_clone->skip_partitioning(old_skip_partitioning);
 
-  libmesh_assert(mesh == *mesh_clone);
+  return (mesh == *mesh_clone);
 }
 
 
+
+#ifndef NDEBUG
 
 void libmesh_assert_equal_n_systems (const MeshBase & mesh)
 {

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1358,8 +1358,8 @@ void libmesh_assert_topology_consistent_procids<Node>(const MeshBase & mesh)
 
   libmesh_parallel_only(mesh.comm());
 
-  // We want this test to be valid even when called even after nodes
-  // have been added asynchronously but before they're renumbered.
+  // We want this test to be valid even when called after nodes have
+  // been added asynchronously but before they're renumbered.
   //
   // Plus, some code (looking at you, stitch_meshes) modifies
   // DofObject ids without keeping max_elem_id()/max_node_id()

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1031,6 +1031,35 @@ void clear_spline_nodes(MeshBase & mesh)
 
 
 #ifndef NDEBUG
+
+void libmesh_assert_valid_is_prepared (const MeshBase & mesh)
+{
+  LOG_SCOPE("libmesh_assert_valid_is_prepared()", "MeshTools");
+
+  if (!mesh.is_prepared())
+    return;
+
+  std::unique_ptr<MeshBase> mesh_clone = mesh.clone();
+
+  // Try preparing (without allowing repartitioning or renumbering, to
+  // avoid false assertion failures)
+  bool old_allow_renumbering = mesh_clone->allow_renumbering();
+  mesh_clone->allow_renumbering(false);
+  bool old_allow_remote_element_removal =
+    mesh_clone->allow_remote_element_removal();
+  bool old_skip_partitioning = mesh_clone->skip_partitioning();
+  mesh_clone->skip_partitioning(true);
+  mesh_clone->allow_remote_element_removal(false);
+  mesh_clone->prepare_for_use();
+  mesh_clone->allow_renumbering(old_allow_renumbering);
+  mesh_clone->allow_remote_element_removal(old_allow_remote_element_removal);
+  mesh_clone->skip_partitioning(old_skip_partitioning);
+
+  libmesh_assert(mesh == *mesh_clone);
+}
+
+
+
 void libmesh_assert_equal_n_systems (const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_equal_n_systems()", "MeshTools");

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -406,7 +406,11 @@ namespace libMesh
 
 // ------------------------------------------------------------
 // MeshTools functions
-dof_id_type MeshTools::total_weight(const MeshBase & mesh)
+
+namespace MeshTools
+{
+
+dof_id_type total_weight(const MeshBase & mesh)
 {
   if (!mesh.is_serial())
     {
@@ -429,7 +433,7 @@ dof_id_type MeshTools::total_weight(const MeshBase & mesh)
 
 
 
-dof_id_type MeshTools::weight(const MeshBase & mesh, const processor_id_type pid)
+dof_id_type weight(const MeshBase & mesh, const processor_id_type pid)
 {
   SumElemWeight sew;
 
@@ -441,8 +445,8 @@ dof_id_type MeshTools::weight(const MeshBase & mesh, const processor_id_type pid
 
 
 
-void MeshTools::build_nodes_to_elem_map (const MeshBase & mesh,
-                                         std::vector<std::vector<dof_id_type>> & nodes_to_elem_map)
+void build_nodes_to_elem_map (const MeshBase & mesh,
+                              std::vector<std::vector<dof_id_type>> & nodes_to_elem_map)
 {
   // A vector indexed over all nodes is too inefficient to use for a
   // distributed mesh.  Use the unordered_map API instead.
@@ -463,8 +467,8 @@ void MeshTools::build_nodes_to_elem_map (const MeshBase & mesh,
 
 
 
-void MeshTools::build_nodes_to_elem_map (const MeshBase & mesh,
-                                         std::vector<std::vector<const Elem *>> & nodes_to_elem_map)
+void build_nodes_to_elem_map (const MeshBase & mesh,
+                              std::vector<std::vector<const Elem *>> & nodes_to_elem_map)
 {
   // A vector indexed over all nodes is too inefficient to use for a
   // distributed mesh.  Use the unordered_map API instead.
@@ -484,8 +488,8 @@ void MeshTools::build_nodes_to_elem_map (const MeshBase & mesh,
 
 
 
-void MeshTools::build_nodes_to_elem_map (const MeshBase & mesh,
-                                         std::unordered_map<dof_id_type, std::vector<dof_id_type>> & nodes_to_elem_map)
+void build_nodes_to_elem_map (const MeshBase & mesh,
+                              std::unordered_map<dof_id_type, std::vector<dof_id_type>> & nodes_to_elem_map)
 {
   nodes_to_elem_map.clear();
 
@@ -496,8 +500,8 @@ void MeshTools::build_nodes_to_elem_map (const MeshBase & mesh,
 
 
 
-void MeshTools::build_nodes_to_elem_map (const MeshBase & mesh,
-                                         std::unordered_map<dof_id_type, std::vector<const Elem *>> & nodes_to_elem_map)
+void build_nodes_to_elem_map (const MeshBase & mesh,
+                              std::unordered_map<dof_id_type, std::vector<const Elem *>> & nodes_to_elem_map)
 {
   nodes_to_elem_map.clear();
 
@@ -509,7 +513,7 @@ void MeshTools::build_nodes_to_elem_map (const MeshBase & mesh,
 
 
 std::unordered_set<dof_id_type>
-MeshTools::find_boundary_nodes(const MeshBase & mesh)
+find_boundary_nodes(const MeshBase & mesh)
 {
   std::unordered_set<dof_id_type> boundary_nodes;
 
@@ -529,7 +533,7 @@ MeshTools::find_boundary_nodes(const MeshBase & mesh)
 }
 
 std::unordered_set<dof_id_type>
-MeshTools::find_block_boundary_nodes(const MeshBase & mesh)
+find_block_boundary_nodes(const MeshBase & mesh)
 {
   std::unordered_set<dof_id_type> block_boundary_nodes;
 
@@ -551,7 +555,7 @@ MeshTools::find_block_boundary_nodes(const MeshBase & mesh)
 
 
 libMesh::BoundingBox
-MeshTools::create_bounding_box (const MeshBase & mesh)
+create_bounding_box (const MeshBase & mesh)
 {
   // This function must be run on all processors at once
   libmesh_parallel_only(mesh.comm());
@@ -564,7 +568,7 @@ MeshTools::create_bounding_box (const MeshBase & mesh)
                             find_bbox);
 
   // And combine with our local elements
-  find_bbox.bbox().union_with(MeshTools::create_local_bounding_box(mesh));
+  find_bbox.bbox().union_with(create_local_bounding_box(mesh));
 
   // Compare the bounding boxes across processors
   mesh.comm().min(find_bbox.min());
@@ -576,7 +580,7 @@ MeshTools::create_bounding_box (const MeshBase & mesh)
 
 
 libMesh::BoundingBox
-MeshTools::create_nodal_bounding_box (const MeshBase & mesh)
+create_nodal_bounding_box (const MeshBase & mesh)
 {
   // This function must be run on all processors at once
   libmesh_parallel_only(mesh.comm());
@@ -603,9 +607,9 @@ MeshTools::create_nodal_bounding_box (const MeshBase & mesh)
 
 
 Sphere
-MeshTools::bounding_sphere(const MeshBase & mesh)
+bounding_sphere(const MeshBase & mesh)
 {
-  libMesh::BoundingBox bbox = MeshTools::create_bounding_box(mesh);
+  libMesh::BoundingBox bbox = create_bounding_box(mesh);
 
   const Real  diag = (bbox.second - bbox.first).norm();
   const Point cent = (bbox.second + bbox.first)/2;
@@ -616,7 +620,7 @@ MeshTools::bounding_sphere(const MeshBase & mesh)
 
 
 libMesh::BoundingBox
-MeshTools::create_local_bounding_box (const MeshBase & mesh)
+create_local_bounding_box (const MeshBase & mesh)
 {
   FindBBox find_bbox;
 
@@ -630,7 +634,7 @@ MeshTools::create_local_bounding_box (const MeshBase & mesh)
 
 
 libMesh::BoundingBox
-MeshTools::create_processor_bounding_box (const MeshBase & mesh,
+create_processor_bounding_box (const MeshBase & mesh,
                                           const processor_id_type pid)
 {
   // This can only be run in parallel, with consistent arguments.
@@ -655,11 +659,11 @@ MeshTools::create_processor_bounding_box (const MeshBase & mesh,
 
 
 Sphere
-MeshTools::processor_bounding_sphere (const MeshBase & mesh,
+processor_bounding_sphere (const MeshBase & mesh,
                                       const processor_id_type pid)
 {
   libMesh::BoundingBox bbox =
-    MeshTools::create_processor_bounding_box(mesh, pid);
+    create_processor_bounding_box(mesh, pid);
 
   const Real  diag = (bbox.second - bbox.first).norm();
   const Point cent = (bbox.second + bbox.first)/2;
@@ -670,8 +674,8 @@ MeshTools::processor_bounding_sphere (const MeshBase & mesh,
 
 
 libMesh::BoundingBox
-MeshTools::create_subdomain_bounding_box (const MeshBase & mesh,
-                                          const subdomain_id_type sid)
+create_subdomain_bounding_box (const MeshBase & mesh,
+                               const subdomain_id_type sid)
 {
   // This can only be run in parallel, with consistent arguments.
   libmesh_parallel_only(mesh.comm());
@@ -694,11 +698,11 @@ MeshTools::create_subdomain_bounding_box (const MeshBase & mesh,
 
 
 Sphere
-MeshTools::subdomain_bounding_sphere (const MeshBase & mesh,
-                                      const subdomain_id_type sid)
+subdomain_bounding_sphere (const MeshBase & mesh,
+                           const subdomain_id_type sid)
 {
   libMesh::BoundingBox bbox =
-    MeshTools::create_subdomain_bounding_box(mesh, sid);
+    create_subdomain_bounding_box(mesh, sid);
 
   const Real  diag = (bbox.second - bbox.first).norm();
   const Point cent = (bbox.second + bbox.first)/2;
@@ -708,8 +712,8 @@ MeshTools::subdomain_bounding_sphere (const MeshBase & mesh,
 
 
 
-void MeshTools::elem_types (const MeshBase & mesh,
-                            std::vector<ElemType> & et)
+void elem_types (const MeshBase & mesh,
+                 std::vector<ElemType> & et)
 {
   // Loop over the the elements.  If the current element type isn't in
   // the vector, insert it.
@@ -720,8 +724,8 @@ void MeshTools::elem_types (const MeshBase & mesh,
 
 
 
-dof_id_type MeshTools::n_elem_of_type (const MeshBase & mesh,
-                                       const ElemType type)
+dof_id_type n_elem_of_type (const MeshBase & mesh,
+                            const ElemType type)
 {
   return static_cast<dof_id_type>(std::distance(mesh.type_elements_begin(type),
                                                 mesh.type_elements_end  (type)));
@@ -729,16 +733,16 @@ dof_id_type MeshTools::n_elem_of_type (const MeshBase & mesh,
 
 
 
-dof_id_type MeshTools::n_active_elem_of_type (const MeshBase & mesh,
-                                              const ElemType type)
+dof_id_type n_active_elem_of_type (const MeshBase & mesh,
+                                   const ElemType type)
 {
   return static_cast<dof_id_type>(std::distance(mesh.active_type_elements_begin(type),
                                                 mesh.active_type_elements_end  (type)));
 }
 
-dof_id_type MeshTools::n_non_subactive_elem_of_type_at_level(const MeshBase & mesh,
-                                                             const ElemType type,
-                                                             const unsigned int level)
+dof_id_type n_non_subactive_elem_of_type_at_level(const MeshBase & mesh,
+                                                  const ElemType type,
+                                                  const unsigned int level)
 {
   dof_id_type cnt = 0;
 
@@ -752,7 +756,7 @@ dof_id_type MeshTools::n_non_subactive_elem_of_type_at_level(const MeshBase & me
 }
 
 
-unsigned int MeshTools::n_active_local_levels(const MeshBase & mesh)
+unsigned int n_active_local_levels(const MeshBase & mesh)
 {
   unsigned int nl = 0;
 
@@ -764,11 +768,11 @@ unsigned int MeshTools::n_active_local_levels(const MeshBase & mesh)
 
 
 
-unsigned int MeshTools::n_active_levels(const MeshBase & mesh)
+unsigned int n_active_levels(const MeshBase & mesh)
 {
   libmesh_parallel_only(mesh.comm());
 
-  unsigned int nl = MeshTools::n_active_local_levels(mesh);
+  unsigned int nl = n_active_local_levels(mesh);
 
   for (const auto & elem : as_range(mesh.unpartitioned_elements_begin(),
                                     mesh.unpartitioned_elements_end()))
@@ -781,7 +785,7 @@ unsigned int MeshTools::n_active_levels(const MeshBase & mesh)
 
 
 
-unsigned int MeshTools::n_local_levels(const MeshBase & mesh)
+unsigned int n_local_levels(const MeshBase & mesh)
 {
   unsigned int nl = 0;
 
@@ -794,11 +798,11 @@ unsigned int MeshTools::n_local_levels(const MeshBase & mesh)
 
 
 
-unsigned int MeshTools::n_levels(const MeshBase & mesh)
+unsigned int n_levels(const MeshBase & mesh)
 {
   libmesh_parallel_only(mesh.comm());
 
-  unsigned int nl = MeshTools::n_local_levels(mesh);
+  unsigned int nl = n_local_levels(mesh);
 
   for (const auto & elem : as_range(mesh.unpartitioned_elements_begin(),
                                     mesh.unpartitioned_elements_end()))
@@ -810,7 +814,7 @@ unsigned int MeshTools::n_levels(const MeshBase & mesh)
   // the mesh is validly distributed (or serialized).  Let's run an
   // expensive test in debug mode to make sure this is such a case.
 #ifdef DEBUG
-  const unsigned int paranoid_nl = MeshTools::paranoid_n_levels(mesh);
+  const unsigned int paranoid_nl = paranoid_n_levels(mesh);
   libmesh_assert_equal_to(nl, paranoid_nl);
 #endif
   return nl;
@@ -818,7 +822,7 @@ unsigned int MeshTools::n_levels(const MeshBase & mesh)
 
 
 
-unsigned int MeshTools::paranoid_n_levels(const MeshBase & mesh)
+unsigned int paranoid_n_levels(const MeshBase & mesh)
 {
   libmesh_parallel_only(mesh.comm());
 
@@ -832,8 +836,8 @@ unsigned int MeshTools::paranoid_n_levels(const MeshBase & mesh)
 
 
 
-void MeshTools::get_not_subactive_node_ids(const MeshBase & mesh,
-                                           std::set<dof_id_type> & not_subactive_node_ids)
+void get_not_subactive_node_ids(const MeshBase & mesh,
+                                std::set<dof_id_type> & not_subactive_node_ids)
 {
   for (const auto & elem : mesh.element_ptr_range())
     if (!elem->subactive())
@@ -843,23 +847,23 @@ void MeshTools::get_not_subactive_node_ids(const MeshBase & mesh,
 
 
 
-dof_id_type MeshTools::n_elem (const MeshBase::const_element_iterator & begin,
-                               const MeshBase::const_element_iterator & end)
+dof_id_type n_elem (const MeshBase::const_element_iterator & begin,
+                    const MeshBase::const_element_iterator & end)
 {
   return cast_int<dof_id_type>(std::distance(begin, end));
 }
 
 
 
-dof_id_type MeshTools::n_nodes (const MeshBase::const_node_iterator & begin,
-                                const MeshBase::const_node_iterator & end)
+dof_id_type n_nodes (const MeshBase::const_node_iterator & begin,
+                     const MeshBase::const_node_iterator & end)
 {
   return cast_int<dof_id_type>(std::distance(begin, end));
 }
 
 
 
-unsigned int MeshTools::n_p_levels (const MeshBase & mesh)
+unsigned int n_p_levels (const MeshBase & mesh)
 {
   libmesh_parallel_only(mesh.comm());
 
@@ -881,10 +885,10 @@ unsigned int MeshTools::n_p_levels (const MeshBase & mesh)
 
 
 
-void MeshTools::find_nodal_neighbors(const MeshBase &,
-                                     const Node & node,
-                                     const std::vector<std::vector<const Elem *>> & nodes_to_elem_map,
-                                     std::vector<const Node *> & neighbors)
+void find_nodal_neighbors(const MeshBase &,
+                          const Node & node,
+                          const std::vector<std::vector<const Elem *>> & nodes_to_elem_map,
+                          std::vector<const Node *> & neighbors)
 {
   find_nodal_neighbors_helper(node.id(), nodes_to_elem_map[node.id()],
                               neighbors);
@@ -892,10 +896,10 @@ void MeshTools::find_nodal_neighbors(const MeshBase &,
 
 
 
-void MeshTools::find_nodal_neighbors(const MeshBase &,
-                                     const Node & node,
-                                     const std::unordered_map<dof_id_type, std::vector<const Elem *>> & nodes_to_elem_map,
-                                     std::vector<const Node *> & neighbors)
+void find_nodal_neighbors(const MeshBase &,
+                          const Node & node,
+                          const std::unordered_map<dof_id_type, std::vector<const Elem *>> & nodes_to_elem_map,
+                          std::vector<const Node *> & neighbors)
 {
   const std::vector<const Elem *> node_to_elem_vec =
     libmesh_map_find(nodes_to_elem_map, node.id());
@@ -904,8 +908,8 @@ void MeshTools::find_nodal_neighbors(const MeshBase &,
 
 
 
-void MeshTools::find_hanging_nodes_and_parents(const MeshBase & mesh,
-                                               std::map<dof_id_type, std::vector<dof_id_type>> & hanging_nodes)
+void find_hanging_nodes_and_parents(const MeshBase & mesh,
+                                    std::map<dof_id_type, std::vector<dof_id_type>> & hanging_nodes)
 {
   // Loop through all the elements
   for (auto & elem : mesh.active_local_element_ptr_range())
@@ -992,7 +996,7 @@ void MeshTools::find_hanging_nodes_and_parents(const MeshBase & mesh,
 
 
 
-void MeshTools::clear_spline_nodes(MeshBase & mesh)
+void clear_spline_nodes(MeshBase & mesh)
 {
   std::vector<Elem *> nodeelem_to_delete;
 
@@ -1027,7 +1031,7 @@ void MeshTools::clear_spline_nodes(MeshBase & mesh)
 
 
 #ifndef NDEBUG
-void MeshTools::libmesh_assert_equal_n_systems (const MeshBase & mesh)
+void libmesh_assert_equal_n_systems (const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_equal_n_systems()", "MeshTools");
 
@@ -1053,7 +1057,7 @@ void MeshTools::libmesh_assert_equal_n_systems (const MeshBase & mesh)
 
 
 #ifdef LIBMESH_ENABLE_AMR
-void MeshTools::libmesh_assert_old_dof_objects (const MeshBase & mesh)
+void libmesh_assert_old_dof_objects (const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_old_dof_objects()", "MeshTools");
 
@@ -1072,12 +1076,12 @@ void MeshTools::libmesh_assert_old_dof_objects (const MeshBase & mesh)
     }
 }
 #else
-void MeshTools::libmesh_assert_old_dof_objects (const MeshBase &) {}
+void libmesh_assert_old_dof_objects (const MeshBase &) {}
 #endif // LIBMESH_ENABLE_AMR
 
 
 
-void MeshTools::libmesh_assert_valid_node_pointers(const MeshBase & mesh)
+void libmesh_assert_valid_node_pointers(const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_valid_node_pointers()", "MeshTools");
 
@@ -1102,7 +1106,7 @@ void MeshTools::libmesh_assert_valid_node_pointers(const MeshBase & mesh)
 
 
 
-void MeshTools::libmesh_assert_valid_remote_elems(const MeshBase & mesh)
+void libmesh_assert_valid_remote_elems(const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_valid_remote_elems()", "MeshTools");
 
@@ -1133,7 +1137,7 @@ void MeshTools::libmesh_assert_valid_remote_elems(const MeshBase & mesh)
 
 
 
-void MeshTools::libmesh_assert_valid_elem_ids(const MeshBase & mesh)
+void libmesh_assert_valid_elem_ids(const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_valid_elem_ids()", "MeshTools");
 
@@ -1156,7 +1160,7 @@ void MeshTools::libmesh_assert_valid_elem_ids(const MeshBase & mesh)
 
 
 
-void MeshTools::libmesh_assert_valid_amr_elem_ids(const MeshBase & mesh)
+void libmesh_assert_valid_amr_elem_ids(const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_valid_amr_elem_ids()", "MeshTools");
 
@@ -1176,7 +1180,7 @@ void MeshTools::libmesh_assert_valid_amr_elem_ids(const MeshBase & mesh)
 
 
 
-void MeshTools::libmesh_assert_valid_amr_interior_parents(const MeshBase & mesh)
+void libmesh_assert_valid_amr_interior_parents(const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_valid_amr_interior_parents()", "MeshTools");
 
@@ -1212,7 +1216,7 @@ void MeshTools::libmesh_assert_valid_amr_interior_parents(const MeshBase & mesh)
 
 
 
-void MeshTools::libmesh_assert_valid_constraint_rows (const MeshBase & mesh)
+void libmesh_assert_valid_constraint_rows (const MeshBase & mesh)
 {
   for (auto & row : mesh.get_constraint_rows())
     {
@@ -1229,7 +1233,7 @@ void MeshTools::libmesh_assert_valid_constraint_rows (const MeshBase & mesh)
 
 
 
-void MeshTools::libmesh_assert_contiguous_dof_ids(const MeshBase & mesh, unsigned int sysnum)
+void libmesh_assert_contiguous_dof_ids(const MeshBase & mesh, unsigned int sysnum)
 {
   LOG_SCOPE("libmesh_assert_contiguous_dof_ids()", "MeshTools");
 
@@ -1271,7 +1275,7 @@ void MeshTools::libmesh_assert_contiguous_dof_ids(const MeshBase & mesh, unsigne
 
 
 template <>
-void MeshTools::libmesh_assert_topology_consistent_procids<Elem>(const MeshBase & mesh)
+void libmesh_assert_topology_consistent_procids<Elem>(const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_topology_consistent_procids()", "MeshTools");
 
@@ -1315,7 +1319,7 @@ void MeshTools::libmesh_assert_topology_consistent_procids<Elem>(const MeshBase 
 
 
 template <>
-void MeshTools::libmesh_assert_topology_consistent_procids<Node>(const MeshBase & mesh)
+void libmesh_assert_topology_consistent_procids<Node>(const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_topology_consistent_procids()", "MeshTools");
 
@@ -1366,7 +1370,7 @@ void MeshTools::libmesh_assert_topology_consistent_procids<Node>(const MeshBase 
 
 
 
-void MeshTools::libmesh_assert_canonical_node_procids (const MeshBase & mesh)
+void libmesh_assert_canonical_node_procids (const MeshBase & mesh)
 {
   for (const auto & elem : mesh.active_element_ptr_range())
     for (auto & node : elem->node_ref_range())
@@ -1379,7 +1383,7 @@ void MeshTools::libmesh_assert_canonical_node_procids (const MeshBase & mesh)
 
 
 #ifdef LIBMESH_ENABLE_AMR
-void MeshTools::libmesh_assert_valid_refinement_tree(const MeshBase & mesh)
+void libmesh_assert_valid_refinement_tree(const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_valid_refinement_tree()", "MeshTools");
 
@@ -1407,7 +1411,7 @@ void MeshTools::libmesh_assert_valid_refinement_tree(const MeshBase & mesh)
     }
 }
 #else
-void MeshTools::libmesh_assert_valid_refinement_tree(const MeshBase &)
+void libmesh_assert_valid_refinement_tree(const MeshBase &)
 {
 }
 #endif // LIBMESH_ENABLE_AMR
@@ -1417,8 +1421,8 @@ void MeshTools::libmesh_assert_valid_refinement_tree(const MeshBase &)
 
 
 #ifdef DEBUG
-void MeshTools::libmesh_assert_no_links_to_elem(const MeshBase & mesh,
-                                                const Elem * bad_elem)
+void libmesh_assert_no_links_to_elem(const MeshBase & mesh,
+                                     const Elem * bad_elem)
 {
   for (const auto & elem : mesh.element_ptr_range())
     {
@@ -1437,7 +1441,7 @@ void MeshTools::libmesh_assert_no_links_to_elem(const MeshBase & mesh,
 
 
 
-void MeshTools::libmesh_assert_connected_nodes (const MeshBase & mesh)
+void libmesh_assert_connected_nodes (const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_connected_nodes()", "MeshTools");
 
@@ -1459,8 +1463,6 @@ void MeshTools::libmesh_assert_connected_nodes (const MeshBase & mesh)
 }
 
 
-
-namespace MeshTools {
 
 void libmesh_assert_valid_boundary_ids(const MeshBase & mesh)
 {
@@ -1914,12 +1916,8 @@ void libmesh_assert_parallel_consistent_procids<Node>(const MeshBase & mesh)
 
 
 
-} // namespace MeshTools
-
-
-
 #ifdef LIBMESH_ENABLE_AMR
-void MeshTools::libmesh_assert_valid_refinement_flags(const MeshBase & mesh)
+void libmesh_assert_valid_refinement_flags(const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_valid_refinement_flags()", "MeshTools");
 
@@ -1959,15 +1957,15 @@ void MeshTools::libmesh_assert_valid_refinement_flags(const MeshBase & mesh)
     }
 }
 #else
-void MeshTools::libmesh_assert_valid_refinement_flags(const MeshBase &)
+void libmesh_assert_valid_refinement_flags(const MeshBase &)
 {
 }
 #endif // LIBMESH_ENABLE_AMR
 
 
 
-void MeshTools::libmesh_assert_valid_neighbors(const MeshBase & mesh,
-                                               bool assert_valid_remote_elems)
+void libmesh_assert_valid_neighbors(const MeshBase & mesh,
+                                    bool assert_valid_remote_elems)
 {
   LOG_SCOPE("libmesh_assert_valid_neighbors()", "MeshTools");
 
@@ -2154,7 +2152,7 @@ struct SyncProcIdsFromMap
 
 
 
-void MeshTools::correct_node_proc_ids (MeshBase & mesh)
+void correct_node_proc_ids (MeshBase & mesh)
 {
   LOG_SCOPE("correct_node_proc_ids()","MeshTools");
 
@@ -2164,13 +2162,13 @@ void MeshTools::correct_node_proc_ids (MeshBase & mesh)
   // We require all processors to agree on nodal processor ids before
   // going into this algorithm.
 #ifdef DEBUG
-  MeshTools::libmesh_assert_parallel_consistent_procids<Node>(mesh);
+  libmesh_assert_parallel_consistent_procids<Node>(mesh);
 #endif
 
   // If we have any unpartitioned elements at this
   // stage there is a problem
-  libmesh_assert (MeshTools::n_elem(mesh.unpartitioned_elements_begin(),
-                                    mesh.unpartitioned_elements_end()) == 0);
+  libmesh_assert (n_elem(mesh.unpartitioned_elements_begin(),
+                         mesh.unpartitioned_elements_end()) == 0);
 
   // Fix nodes' processor ids.  Coarsening may have left us with nodes
   // which are no longer touched by any elements of the same processor
@@ -2303,17 +2301,19 @@ void MeshTools::correct_node_proc_ids (MeshBase & mesh)
   // this algorithm, but if we're allowed to repartition the mesh then
   // they should be canonically correct too.
 #ifdef DEBUG
-  MeshTools::libmesh_assert_valid_procids<Node>(mesh);
+  libmesh_assert_valid_procids<Node>(mesh);
   //if (repartition_all_nodes)
-  //  MeshTools::libmesh_assert_canonical_node_procids(mesh);
+  //  libmesh_assert_canonical_node_procids(mesh);
 #endif
 }
 
 
 
-void MeshTools::Private::globally_renumber_nodes_and_elements (MeshBase & mesh)
+void Private::globally_renumber_nodes_and_elements (MeshBase & mesh)
 {
   MeshCommunication().assign_global_indices(mesh);
 }
+
+} // namespace MeshTools
 
 } // namespace libMesh

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -155,6 +155,8 @@ ReplicatedMesh::ReplicatedMesh (const UnstructuredMesh & other_mesh) :
 
 ReplicatedMesh & ReplicatedMesh::operator= (ReplicatedMesh && other_mesh)
 {
+  LOG_SCOPE("operator=()", "ReplicatedMesh");
+
   // Move assign as an UnstructuredMesh
   this->UnstructuredMesh::operator=(std::move(other_mesh));
 

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -155,7 +155,7 @@ ReplicatedMesh::ReplicatedMesh (const UnstructuredMesh & other_mesh) :
 
 ReplicatedMesh & ReplicatedMesh::operator= (ReplicatedMesh && other_mesh)
 {
-  LOG_SCOPE("operator=()", "ReplicatedMesh");
+  LOG_SCOPE("operator=(&&)", "ReplicatedMesh");
 
   // Move assign as an UnstructuredMesh
   this->UnstructuredMesh::operator=(std::move(other_mesh));

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -57,6 +57,25 @@ ReplicatedMesh::ReplicatedMesh (const Parallel::Communicator & comm_in,
 }
 
 
+bool ReplicatedMesh::subclass_locally_equals(const MeshBase & other_mesh_base)
+{
+  const ReplicatedMesh * rep_mesh_ptr =
+    dynamic_cast<const ReplicatedMesh *>(&other_mesh_base);
+  if (!rep_mesh_ptr)
+    return false;
+  const ReplicatedMesh & other_mesh = *rep_mesh_ptr;
+
+  if (_n_nodes != other_mesh._n_nodes ||
+      _n_elem != other_mesh._n_elem ||
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+      _next_unique_id != other_mesh._next_unique_id ||
+#endif
+      !this->nodes_and_elements_equal(other_mesh))
+    return false;
+
+  return true;
+}
+
 
 ReplicatedMesh::~ReplicatedMesh ()
 {

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -57,7 +57,7 @@ ReplicatedMesh::ReplicatedMesh (const Parallel::Communicator & comm_in,
 }
 
 
-bool ReplicatedMesh::subclass_locally_equals(const MeshBase & other_mesh_base)
+bool ReplicatedMesh::subclass_locally_equals(const MeshBase & other_mesh_base) const
 {
   const ReplicatedMesh * rep_mesh_ptr =
     dynamic_cast<const ReplicatedMesh *>(&other_mesh_base);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -62,6 +62,7 @@ unit_tests_sources = \
   mesh/contains_point.C \
   mesh/extra_integers.C \
   mesh/mesh_assign.C \
+  mesh/mesh_base_test.C \
   mesh/mesh_collection.C \
   mesh/mesh_extruder.C \
   mesh/mesh_function.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -212,7 +212,7 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/all_second_order.C mesh/all_tri.C mesh/distort.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/boundary_points.C mesh/checkpoint.C mesh/contains_point.C \
-	mesh/extra_integers.C mesh/mesh_assign.C \
+	mesh/extra_integers.C mesh/mesh_assign.C mesh/mesh_base_test.C \
 	mesh/mesh_collection.C mesh/mesh_extruder.C \
 	mesh/mesh_function.C mesh/mesh_function_dfem.C \
 	mesh/mesh_generation_test.C mesh/mesh_input.C \
@@ -310,6 +310,7 @@ am__objects_3 = unit_tests_dbg-driver.$(OBJEXT) \
 	mesh/unit_tests_dbg-contains_point.$(OBJEXT) \
 	mesh/unit_tests_dbg-extra_integers.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_assign.$(OBJEXT) \
+	mesh/unit_tests_dbg-mesh_base_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_collection.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_function.$(OBJEXT) \
@@ -402,7 +403,7 @@ am__unit_tests_devel_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/all_second_order.C mesh/all_tri.C mesh/distort.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/boundary_points.C mesh/checkpoint.C mesh/contains_point.C \
-	mesh/extra_integers.C mesh/mesh_assign.C \
+	mesh/extra_integers.C mesh/mesh_assign.C mesh/mesh_base_test.C \
 	mesh/mesh_collection.C mesh/mesh_extruder.C \
 	mesh/mesh_function.C mesh/mesh_function_dfem.C \
 	mesh/mesh_generation_test.C mesh/mesh_input.C \
@@ -498,6 +499,7 @@ am__objects_5 = unit_tests_devel-driver.$(OBJEXT) \
 	mesh/unit_tests_devel-contains_point.$(OBJEXT) \
 	mesh/unit_tests_devel-extra_integers.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_assign.$(OBJEXT) \
+	mesh/unit_tests_devel-mesh_base_test.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_collection.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_function.$(OBJEXT) \
@@ -586,7 +588,7 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/all_second_order.C mesh/all_tri.C mesh/distort.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/boundary_points.C mesh/checkpoint.C mesh/contains_point.C \
-	mesh/extra_integers.C mesh/mesh_assign.C \
+	mesh/extra_integers.C mesh/mesh_assign.C mesh/mesh_base_test.C \
 	mesh/mesh_collection.C mesh/mesh_extruder.C \
 	mesh/mesh_function.C mesh/mesh_function_dfem.C \
 	mesh/mesh_generation_test.C mesh/mesh_input.C \
@@ -682,6 +684,7 @@ am__objects_7 = unit_tests_oprof-driver.$(OBJEXT) \
 	mesh/unit_tests_oprof-contains_point.$(OBJEXT) \
 	mesh/unit_tests_oprof-extra_integers.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_assign.$(OBJEXT) \
+	mesh/unit_tests_oprof-mesh_base_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_collection.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_function.$(OBJEXT) \
@@ -770,7 +773,7 @@ am__unit_tests_opt_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/all_second_order.C mesh/all_tri.C mesh/distort.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/boundary_points.C mesh/checkpoint.C mesh/contains_point.C \
-	mesh/extra_integers.C mesh/mesh_assign.C \
+	mesh/extra_integers.C mesh/mesh_assign.C mesh/mesh_base_test.C \
 	mesh/mesh_collection.C mesh/mesh_extruder.C \
 	mesh/mesh_function.C mesh/mesh_function_dfem.C \
 	mesh/mesh_generation_test.C mesh/mesh_input.C \
@@ -866,6 +869,7 @@ am__objects_9 = unit_tests_opt-driver.$(OBJEXT) \
 	mesh/unit_tests_opt-contains_point.$(OBJEXT) \
 	mesh/unit_tests_opt-extra_integers.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_assign.$(OBJEXT) \
+	mesh/unit_tests_opt-mesh_base_test.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_collection.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_function.$(OBJEXT) \
@@ -954,7 +958,7 @@ am__unit_tests_prof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/all_second_order.C mesh/all_tri.C mesh/distort.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/boundary_points.C mesh/checkpoint.C mesh/contains_point.C \
-	mesh/extra_integers.C mesh/mesh_assign.C \
+	mesh/extra_integers.C mesh/mesh_assign.C mesh/mesh_base_test.C \
 	mesh/mesh_collection.C mesh/mesh_extruder.C \
 	mesh/mesh_function.C mesh/mesh_function_dfem.C \
 	mesh/mesh_generation_test.C mesh/mesh_input.C \
@@ -1050,6 +1054,7 @@ am__objects_11 = unit_tests_prof-driver.$(OBJEXT) \
 	mesh/unit_tests_prof-contains_point.$(OBJEXT) \
 	mesh/unit_tests_prof-extra_integers.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_assign.$(OBJEXT) \
+	mesh/unit_tests_prof-mesh_base_test.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_collection.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_function.$(OBJEXT) \
@@ -1301,6 +1306,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-libmesh_poly2tri.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mapped_subdomain_partitioner_test.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_assign.Po \
+	mesh/$(DEPDIR)/unit_tests_dbg-mesh_base_test.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_collection.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po \
@@ -1330,6 +1336,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-libmesh_poly2tri.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mapped_subdomain_partitioner_test.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_assign.Po \
+	mesh/$(DEPDIR)/unit_tests_devel-mesh_base_test.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_collection.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po \
@@ -1359,6 +1366,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-libmesh_poly2tri.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mapped_subdomain_partitioner_test.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_assign.Po \
+	mesh/$(DEPDIR)/unit_tests_oprof-mesh_base_test.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_collection.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po \
@@ -1388,6 +1396,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-libmesh_poly2tri.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mapped_subdomain_partitioner_test.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_assign.Po \
+	mesh/$(DEPDIR)/unit_tests_opt-mesh_base_test.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_collection.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po \
@@ -1417,6 +1426,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-libmesh_poly2tri.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mapped_subdomain_partitioner_test.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_assign.Po \
+	mesh/$(DEPDIR)/unit_tests_prof-mesh_base_test.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_collection.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po \
@@ -2117,7 +2127,7 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 	mesh/all_second_order.C mesh/all_tri.C mesh/distort.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/boundary_points.C mesh/checkpoint.C mesh/contains_point.C \
-	mesh/extra_integers.C mesh/mesh_assign.C \
+	mesh/extra_integers.C mesh/mesh_assign.C mesh/mesh_base_test.C \
 	mesh/mesh_collection.C mesh/mesh_extruder.C \
 	mesh/mesh_function.C mesh/mesh_function_dfem.C \
 	mesh/mesh_generation_test.C mesh/mesh_input.C \
@@ -2383,6 +2393,8 @@ mesh/unit_tests_dbg-extra_integers.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-mesh_assign.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_dbg-mesh_base_test.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-mesh_collection.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-mesh_extruder.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -2645,6 +2657,8 @@ mesh/unit_tests_devel-extra_integers.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-mesh_assign.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_devel-mesh_base_test.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-mesh_collection.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-mesh_extruder.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -2858,6 +2872,8 @@ mesh/unit_tests_oprof-contains_point.$(OBJEXT): mesh/$(am__dirstamp) \
 mesh/unit_tests_oprof-extra_integers.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-mesh_assign.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_oprof-mesh_base_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-mesh_collection.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
@@ -3073,6 +3089,8 @@ mesh/unit_tests_opt-extra_integers.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-mesh_assign.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_opt-mesh_base_test.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-mesh_collection.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-mesh_extruder.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -3286,6 +3304,8 @@ mesh/unit_tests_prof-contains_point.$(OBJEXT): mesh/$(am__dirstamp) \
 mesh/unit_tests_prof-extra_integers.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-mesh_assign.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_prof-mesh_base_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-mesh_collection.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
@@ -3609,6 +3629,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-libmesh_poly2tri.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mapped_subdomain_partitioner_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_assign.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_base_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_collection.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po@am__quote@ # am--include-marker
@@ -3638,6 +3659,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-libmesh_poly2tri.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mapped_subdomain_partitioner_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_assign.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_base_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_collection.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po@am__quote@ # am--include-marker
@@ -3667,6 +3689,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-libmesh_poly2tri.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mapped_subdomain_partitioner_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_assign.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_base_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_collection.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po@am__quote@ # am--include-marker
@@ -3696,6 +3719,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-libmesh_poly2tri.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mapped_subdomain_partitioner_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_assign.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_base_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_collection.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po@am__quote@ # am--include-marker
@@ -3725,6 +3749,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-libmesh_poly2tri.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mapped_subdomain_partitioner_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_assign.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_base_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_collection.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po@am__quote@ # am--include-marker
@@ -4542,6 +4567,20 @@ mesh/unit_tests_dbg-mesh_assign.obj: mesh/mesh_assign.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_assign.C' object='mesh/unit_tests_dbg-mesh_assign.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mesh_assign.obj `if test -f 'mesh/mesh_assign.C'; then $(CYGPATH_W) 'mesh/mesh_assign.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_assign.C'; fi`
+
+mesh/unit_tests_dbg-mesh_base_test.o: mesh/mesh_base_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mesh_base_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mesh_base_test.Tpo -c -o mesh/unit_tests_dbg-mesh_base_test.o `test -f 'mesh/mesh_base_test.C' || echo '$(srcdir)/'`mesh/mesh_base_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-mesh_base_test.Tpo mesh/$(DEPDIR)/unit_tests_dbg-mesh_base_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_base_test.C' object='mesh/unit_tests_dbg-mesh_base_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mesh_base_test.o `test -f 'mesh/mesh_base_test.C' || echo '$(srcdir)/'`mesh/mesh_base_test.C
+
+mesh/unit_tests_dbg-mesh_base_test.obj: mesh/mesh_base_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mesh_base_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mesh_base_test.Tpo -c -o mesh/unit_tests_dbg-mesh_base_test.obj `if test -f 'mesh/mesh_base_test.C'; then $(CYGPATH_W) 'mesh/mesh_base_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_base_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-mesh_base_test.Tpo mesh/$(DEPDIR)/unit_tests_dbg-mesh_base_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_base_test.C' object='mesh/unit_tests_dbg-mesh_base_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mesh_base_test.obj `if test -f 'mesh/mesh_base_test.C'; then $(CYGPATH_W) 'mesh/mesh_base_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_base_test.C'; fi`
 
 mesh/unit_tests_dbg-mesh_collection.o: mesh/mesh_collection.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mesh_collection.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mesh_collection.Tpo -c -o mesh/unit_tests_dbg-mesh_collection.o `test -f 'mesh/mesh_collection.C' || echo '$(srcdir)/'`mesh/mesh_collection.C
@@ -5971,6 +6010,20 @@ mesh/unit_tests_devel-mesh_assign.obj: mesh/mesh_assign.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mesh_assign.obj `if test -f 'mesh/mesh_assign.C'; then $(CYGPATH_W) 'mesh/mesh_assign.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_assign.C'; fi`
 
+mesh/unit_tests_devel-mesh_base_test.o: mesh/mesh_base_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mesh_base_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mesh_base_test.Tpo -c -o mesh/unit_tests_devel-mesh_base_test.o `test -f 'mesh/mesh_base_test.C' || echo '$(srcdir)/'`mesh/mesh_base_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mesh_base_test.Tpo mesh/$(DEPDIR)/unit_tests_devel-mesh_base_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_base_test.C' object='mesh/unit_tests_devel-mesh_base_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mesh_base_test.o `test -f 'mesh/mesh_base_test.C' || echo '$(srcdir)/'`mesh/mesh_base_test.C
+
+mesh/unit_tests_devel-mesh_base_test.obj: mesh/mesh_base_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mesh_base_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mesh_base_test.Tpo -c -o mesh/unit_tests_devel-mesh_base_test.obj `if test -f 'mesh/mesh_base_test.C'; then $(CYGPATH_W) 'mesh/mesh_base_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_base_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mesh_base_test.Tpo mesh/$(DEPDIR)/unit_tests_devel-mesh_base_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_base_test.C' object='mesh/unit_tests_devel-mesh_base_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mesh_base_test.obj `if test -f 'mesh/mesh_base_test.C'; then $(CYGPATH_W) 'mesh/mesh_base_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_base_test.C'; fi`
+
 mesh/unit_tests_devel-mesh_collection.o: mesh/mesh_collection.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mesh_collection.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mesh_collection.Tpo -c -o mesh/unit_tests_devel-mesh_collection.o `test -f 'mesh/mesh_collection.C' || echo '$(srcdir)/'`mesh/mesh_collection.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mesh_collection.Tpo mesh/$(DEPDIR)/unit_tests_devel-mesh_collection.Po
@@ -7398,6 +7451,20 @@ mesh/unit_tests_oprof-mesh_assign.obj: mesh/mesh_assign.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_assign.C' object='mesh/unit_tests_oprof-mesh_assign.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mesh_assign.obj `if test -f 'mesh/mesh_assign.C'; then $(CYGPATH_W) 'mesh/mesh_assign.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_assign.C'; fi`
+
+mesh/unit_tests_oprof-mesh_base_test.o: mesh/mesh_base_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mesh_base_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mesh_base_test.Tpo -c -o mesh/unit_tests_oprof-mesh_base_test.o `test -f 'mesh/mesh_base_test.C' || echo '$(srcdir)/'`mesh/mesh_base_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-mesh_base_test.Tpo mesh/$(DEPDIR)/unit_tests_oprof-mesh_base_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_base_test.C' object='mesh/unit_tests_oprof-mesh_base_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mesh_base_test.o `test -f 'mesh/mesh_base_test.C' || echo '$(srcdir)/'`mesh/mesh_base_test.C
+
+mesh/unit_tests_oprof-mesh_base_test.obj: mesh/mesh_base_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mesh_base_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mesh_base_test.Tpo -c -o mesh/unit_tests_oprof-mesh_base_test.obj `if test -f 'mesh/mesh_base_test.C'; then $(CYGPATH_W) 'mesh/mesh_base_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_base_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-mesh_base_test.Tpo mesh/$(DEPDIR)/unit_tests_oprof-mesh_base_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_base_test.C' object='mesh/unit_tests_oprof-mesh_base_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mesh_base_test.obj `if test -f 'mesh/mesh_base_test.C'; then $(CYGPATH_W) 'mesh/mesh_base_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_base_test.C'; fi`
 
 mesh/unit_tests_oprof-mesh_collection.o: mesh/mesh_collection.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mesh_collection.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mesh_collection.Tpo -c -o mesh/unit_tests_oprof-mesh_collection.o `test -f 'mesh/mesh_collection.C' || echo '$(srcdir)/'`mesh/mesh_collection.C
@@ -8827,6 +8894,20 @@ mesh/unit_tests_opt-mesh_assign.obj: mesh/mesh_assign.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mesh_assign.obj `if test -f 'mesh/mesh_assign.C'; then $(CYGPATH_W) 'mesh/mesh_assign.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_assign.C'; fi`
 
+mesh/unit_tests_opt-mesh_base_test.o: mesh/mesh_base_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mesh_base_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mesh_base_test.Tpo -c -o mesh/unit_tests_opt-mesh_base_test.o `test -f 'mesh/mesh_base_test.C' || echo '$(srcdir)/'`mesh/mesh_base_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mesh_base_test.Tpo mesh/$(DEPDIR)/unit_tests_opt-mesh_base_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_base_test.C' object='mesh/unit_tests_opt-mesh_base_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mesh_base_test.o `test -f 'mesh/mesh_base_test.C' || echo '$(srcdir)/'`mesh/mesh_base_test.C
+
+mesh/unit_tests_opt-mesh_base_test.obj: mesh/mesh_base_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mesh_base_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mesh_base_test.Tpo -c -o mesh/unit_tests_opt-mesh_base_test.obj `if test -f 'mesh/mesh_base_test.C'; then $(CYGPATH_W) 'mesh/mesh_base_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_base_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mesh_base_test.Tpo mesh/$(DEPDIR)/unit_tests_opt-mesh_base_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_base_test.C' object='mesh/unit_tests_opt-mesh_base_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mesh_base_test.obj `if test -f 'mesh/mesh_base_test.C'; then $(CYGPATH_W) 'mesh/mesh_base_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_base_test.C'; fi`
+
 mesh/unit_tests_opt-mesh_collection.o: mesh/mesh_collection.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mesh_collection.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mesh_collection.Tpo -c -o mesh/unit_tests_opt-mesh_collection.o `test -f 'mesh/mesh_collection.C' || echo '$(srcdir)/'`mesh/mesh_collection.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mesh_collection.Tpo mesh/$(DEPDIR)/unit_tests_opt-mesh_collection.Po
@@ -10255,6 +10336,20 @@ mesh/unit_tests_prof-mesh_assign.obj: mesh/mesh_assign.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mesh_assign.obj `if test -f 'mesh/mesh_assign.C'; then $(CYGPATH_W) 'mesh/mesh_assign.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_assign.C'; fi`
 
+mesh/unit_tests_prof-mesh_base_test.o: mesh/mesh_base_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mesh_base_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mesh_base_test.Tpo -c -o mesh/unit_tests_prof-mesh_base_test.o `test -f 'mesh/mesh_base_test.C' || echo '$(srcdir)/'`mesh/mesh_base_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mesh_base_test.Tpo mesh/$(DEPDIR)/unit_tests_prof-mesh_base_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_base_test.C' object='mesh/unit_tests_prof-mesh_base_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mesh_base_test.o `test -f 'mesh/mesh_base_test.C' || echo '$(srcdir)/'`mesh/mesh_base_test.C
+
+mesh/unit_tests_prof-mesh_base_test.obj: mesh/mesh_base_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mesh_base_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mesh_base_test.Tpo -c -o mesh/unit_tests_prof-mesh_base_test.obj `if test -f 'mesh/mesh_base_test.C'; then $(CYGPATH_W) 'mesh/mesh_base_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_base_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mesh_base_test.Tpo mesh/$(DEPDIR)/unit_tests_prof-mesh_base_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_base_test.C' object='mesh/unit_tests_prof-mesh_base_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mesh_base_test.obj `if test -f 'mesh/mesh_base_test.C'; then $(CYGPATH_W) 'mesh/mesh_base_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_base_test.C'; fi`
+
 mesh/unit_tests_prof-mesh_collection.o: mesh/mesh_collection.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mesh_collection.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mesh_collection.Tpo -c -o mesh/unit_tests_prof-mesh_collection.o `test -f 'mesh/mesh_collection.C' || echo '$(srcdir)/'`mesh/mesh_collection.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mesh_collection.Tpo mesh/$(DEPDIR)/unit_tests_prof-mesh_collection.Po
@@ -11652,6 +11747,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-libmesh_poly2tri.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_assign.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_collection.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po
@@ -11681,6 +11777,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-libmesh_poly2tri.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_assign.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_collection.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po
@@ -11710,6 +11807,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-libmesh_poly2tri.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_assign.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_collection.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po
@@ -11739,6 +11837,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-libmesh_poly2tri.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_assign.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_collection.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po
@@ -11768,6 +11867,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-libmesh_poly2tri.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_assign.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_collection.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po
@@ -12209,6 +12309,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-libmesh_poly2tri.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_assign.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_collection.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po
@@ -12238,6 +12339,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-libmesh_poly2tri.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_assign.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_collection.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po
@@ -12267,6 +12369,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-libmesh_poly2tri.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_assign.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_collection.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po
@@ -12296,6 +12399,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-libmesh_poly2tri.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_assign.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_collection.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po
@@ -12325,6 +12429,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-libmesh_poly2tri.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_assign.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_collection.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po

--- a/tests/mesh/boundary_info.C
+++ b/tests/mesh/boundary_info.C
@@ -115,8 +115,17 @@ public:
         CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(8), bc_triples.size());
       }
 
+    // Let's test that they are preserved (in a relative sense) when
+    // we clone a mesh.
+    std::unique_ptr<MeshBase> mesh_clone = mesh.clone();
+    CPPUNIT_ASSERT(mesh_clone->get_boundary_info() ==
+                   mesh.get_boundary_info());
+
     // Let's test that we can remove them successfully.
     bi.remove_id(0);
+
+    CPPUNIT_ASSERT(mesh_clone->get_boundary_info() !=
+                   mesh.get_boundary_info());
 
     // Check that there are now only 3 boundary ids total on the Mesh.
     if (mesh.is_serial())

--- a/tests/mesh/boundary_info.C
+++ b/tests/mesh/boundary_info.C
@@ -339,6 +339,12 @@ public:
       // updating bi
       CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(n_elem), bi.n_edge_conds());
 
+      // Let's test that edge BCIDs are preserved (in a relative
+      // sense) when we clone a mesh.
+      std::unique_ptr<MeshBase> mesh_clone = mesh.clone();
+      CPPUNIT_ASSERT(mesh_clone->get_boundary_info() ==
+                     mesh.get_boundary_info());
+
       mesh.write(mesh_filename);
     }
 

--- a/tests/mesh/boundary_info.C
+++ b/tests/mesh/boundary_info.C
@@ -442,6 +442,12 @@ public:
     mesh.allow_renumbering(true);
     mesh.prepare_for_use();
 
+    // Let's test that shellface BCIDs are preserved (in a relative
+    // sense) when we clone a mesh.
+    std::unique_ptr<MeshBase> mesh_clone = mesh.clone();
+    CPPUNIT_ASSERT(mesh_clone->get_boundary_info() ==
+                   mesh.get_boundary_info());
+
     CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(2), bi.n_shellface_conds());
 
     EquationSystems es(mesh);

--- a/tests/mesh/mesh_assign.C
+++ b/tests/mesh/mesh_assign.C
@@ -153,6 +153,9 @@ public:
 
           mesh_refinement->uniformly_refine(1);
 
+          std::unique_ptr<MeshBase> mesh_two_clone =
+            mesh_two->clone();
+
           // Move mesh_two into mesh_one
           system.get_mesh().clear();
           system.get_mesh().assign(std::move(*mesh_two));
@@ -160,6 +163,8 @@ public:
 
           // Assert that the moved into mesh has the right number of elements.
           CPPUNIT_ASSERT_EQUAL(system.get_mesh().n_elem(), dof_id_type(20));
+
+          CPPUNIT_ASSERT(system.get_mesh() == *mesh_two_clone);
 
           // Reinit the dofs and other system related data structures
           // based on its mesh
@@ -179,7 +184,9 @@ public:
         {
           mesh_two->read("meshes/mesh_assign_test_mesh.xda");
 
-          // Read in the mesh at this time instant and reinit to project solutions on to the new mesh
+          std::unique_ptr<MeshBase> mesh_two_clone =
+            mesh_two->clone();
+
           system.get_mesh().clear();
           system.get_mesh().assign(std::move(*mesh_two));
 
@@ -187,6 +194,8 @@ public:
 
           // Assert that the moved into mesh has the right number of elements.
           CPPUNIT_ASSERT_EQUAL(system.get_mesh().n_elem(), dof_id_type(42));
+
+          CPPUNIT_ASSERT(system.get_mesh() == *mesh_two_clone);
 
           system.get_equation_systems().reinit_mesh();
           system.get_equation_systems().reinit();

--- a/tests/mesh/mesh_base_test.C
+++ b/tests/mesh/mesh_base_test.C
@@ -1,0 +1,95 @@
+
+#include <libmesh/distributed_mesh.h>
+#include <libmesh/elem.h>
+#include <libmesh/mesh.h>
+#include <libmesh/mesh_generation.h>
+#include <libmesh/mesh_refinement.h>
+#include <libmesh/mesh_tools.h>
+#include <libmesh/replicated_mesh.h>
+
+#include "test_comm.h"
+#include "libmesh_cppunit.h"
+
+using namespace libMesh;
+
+class MeshBaseTest : public CppUnit::TestCase {
+  /**
+   * This test verifies various operations on the MeshBase and derived
+   * classes.
+   */
+public:
+  LIBMESH_CPPUNIT_TEST_SUITE( MeshBaseTest );
+
+/* Tests need a 2d mesh */
+#if LIBMESH_DIM > 1
+  CPPUNIT_TEST( testDistributedMeshVerifyIsPrepared );
+  CPPUNIT_TEST( testMeshVerifyIsPrepared );
+  CPPUNIT_TEST( testReplicatedMeshVerifyIsPrepared );
+#endif
+
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  void setUp() {}
+
+  void tearDown() {}
+
+  void testMeshBaseVerifyIsPrepared(UnstructuredMesh & mesh)
+  {
+    /**
+     * Build a 2d 2x2 square mesh (mesh_one) covering [0.0, 1.0] x [0.0, 1.0]
+     * with linear Quad elements.
+     */
+
+    MeshTools::Generation::build_square(mesh,
+                                        2, 2,
+                                        0., 1.,
+                                        0., 1.,
+                                        QUAD9);
+
+    // build_square does its own prepare_for_use(), so we should be
+    // prepared.
+    CPPUNIT_ASSERT(MeshTools::valid_is_prepared(mesh));
+
+    // Break some neighbor links.  Of course nobody would do this in
+    // real life, right?
+    Elem * elem0 = mesh.query_elem_ptr(0);
+    if (elem0)
+      for (auto n : elem0->side_index_range())
+        {
+          Elem * neigh = elem0->neighbor_ptr(n);
+          if (!neigh)
+            continue;
+          auto n_neigh = neigh->which_neighbor_am_i(elem0);
+          CPPUNIT_ASSERT(n_neigh != libMesh::invalid_uint);
+
+          elem0->set_neighbor(n, nullptr);
+          neigh->set_neighbor(n_neigh, nullptr);
+        }
+
+    // We're unprepared (prepare_for_use() will restitch those
+    // neighbor pointers) but we're not marked that way.
+    CPPUNIT_ASSERT(!MeshTools::valid_is_prepared(mesh));
+  }
+
+  void testDistributedMeshVerifyIsPrepared ()
+  {
+    DistributedMesh mesh(*TestCommWorld);
+    testMeshBaseVerifyIsPrepared(mesh);
+  }
+
+  void testMeshVerifyIsPrepared ()
+  {
+    Mesh mesh(*TestCommWorld);
+    testMeshBaseVerifyIsPrepared(mesh);
+  }
+
+  void testReplicatedMeshVerifyIsPrepared ()
+  {
+    ReplicatedMesh mesh(*TestCommWorld);
+    testMeshBaseVerifyIsPrepared(mesh);
+  }
+}; // End definition of class MeshBaseTest
+
+CPPUNIT_TEST_SUITE_REGISTRATION( MeshBaseTest );

--- a/tests/mesh/mesh_base_test.C
+++ b/tests/mesh/mesh_base_test.C
@@ -41,7 +41,6 @@ public:
      * Build a 2d 2x2 square mesh (mesh_one) covering [0.0, 1.0] x [0.0, 1.0]
      * with linear Quad elements.
      */
-
     MeshTools::Generation::build_square(mesh,
                                         2, 2,
                                         0., 1.,

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -1490,6 +1490,11 @@ public:
     TestCommWorld->max(order);
     CPPUNIT_ASSERT (order > 0);
 
+    // Let's test that IGA constraints are preserved (in a relative
+    // sense) when we clone a mesh.
+    std::unique_ptr<MeshBase> mesh_clone = mesh.clone();
+    CPPUNIT_ASSERT(*mesh_clone == mesh);
+
     EquationSystems es(mesh);
     System &sys = es.add_system<System> ("SimpleSystem");
     sys.add_variable("n", Order(order), RATIONAL_BERNSTEIN);


### PR DESCRIPTION
The valid_is_prepared() semantics don't quite cover *everything* yet (we still need to verify point_locator validity), but this is a solid start to debugging the sort of MeshGenerator mistakes we've been getting bitten by in MOOSE.

Pinging @lindsayad, but really I'm hoping @jwpeterson has time to review before we merge.  These are all new APIs so shouldn't break anything existing, but some of the code here gets into the weeds.