### PR TITLE
Apply constraints via element nonlinear residuals

### DIFF
--- a/examples/adjoints/adjoints_ex1/femparameters.C
+++ b/examples/adjoints/adjoints_ex1/femparameters.C
@@ -81,6 +81,7 @@ FEMParameters::FEMParameters(const Parallel::Communicator & comm_in) :
   print_element_residuals(false),
   print_element_jacobians(false),
 
+  constrain_in_solver(true),
   use_petsc_snes(false),
   time_solver_quiet(true), solver_quiet(true), solver_verbose(false),
   reuse_preconditioner(true),
@@ -686,6 +687,7 @@ void FEMParameters::read(GetPot & input,
   GETPOT_INPUT(print_element_jacobians);
 
 
+  GETPOT_INPUT(constrain_in_solver);
   GETPOT_INPUT(use_petsc_snes);
   GETPOT_INPUT(time_solver_quiet);
   GETPOT_INPUT(solver_quiet);

--- a/examples/adjoints/adjoints_ex1/femparameters.h
+++ b/examples/adjoints/adjoints_ex1/femparameters.h
@@ -125,6 +125,7 @@ public:
 
   //   Solver options
 
+  bool constrain_in_solver;
   bool use_petsc_snes;
   bool time_solver_quiet, solver_quiet, solver_verbose,
     reuse_preconditioner, require_residual_reduction;

--- a/examples/adjoints/adjoints_ex2/adjoints_ex2.C
+++ b/examples/adjoints/adjoints_ex2/adjoints_ex2.C
@@ -69,6 +69,7 @@
 #include "libmesh/mesh_refinement.h"
 #include "libmesh/newton_solver.h"
 #include "libmesh/numeric_vector.h"
+#include "libmesh/petsc_diff_solver.h"
 #include "libmesh/steady_solver.h"
 #include "libmesh/system_norm.h"
 #include "libmesh/enum_solver_package.h"
@@ -187,6 +188,16 @@ void set_system_parameters(LaplaceSystem & system, FEMParameters & param)
   system.time_solver = std::make_unique<SteadySolver>(system);
 
   // Nonlinear solver options
+  if (param.use_petsc_snes)
+  {
+#ifdef LIBMESH_HAVE_PETSC
+    PetscDiffSolver *solver = new PetscDiffSolver(system);
+    system.time_solver->diff_solver().reset(solver);
+#else
+    libmesh_error_msg("This example requires libMesh to be compiled with PETSc support.");
+#endif
+  }
+  else
   {
     NewtonSolver * solver = new NewtonSolver(system);
     system.time_solver->diff_solver() = std::unique_ptr<DiffSolver>(solver);
@@ -203,6 +214,7 @@ void set_system_parameters(LaplaceSystem & system, FEMParameters & param)
         solver->continue_after_max_iterations = true;
         solver->continue_after_backtrack_failure = true;
       }
+    system.set_constrain_in_solver(param.constrain_in_solver);
 
     // And the linear solver options
     solver->max_linear_iterations    = param.max_linear_iterations;

--- a/examples/adjoints/adjoints_ex2/femparameters.h
+++ b/examples/adjoints/adjoints_ex2/femparameters.h
@@ -125,6 +125,7 @@ public:
 
   //   Solver options
 
+  bool constrain_in_solver;
   bool use_petsc_snes;
   bool time_solver_quiet, solver_quiet, solver_verbose,
     reuse_preconditioner, require_residual_reduction;

--- a/examples/adjoints/adjoints_ex3/adjoints_ex3.C
+++ b/examples/adjoints/adjoints_ex3/adjoints_ex3.C
@@ -579,6 +579,7 @@ void set_system_parameters(FEMSystem & system,
           solver->continue_after_max_iterations = true;
           solver->continue_after_backtrack_failure = true;
         }
+      system.set_constrain_in_solver(param.constrain_in_solver);
 
       // And the linear solver options
       solver->max_linear_iterations       = param.max_linear_iterations;

--- a/examples/adjoints/adjoints_ex3/femparameters.h
+++ b/examples/adjoints/adjoints_ex3/femparameters.h
@@ -125,6 +125,7 @@ public:
 
   //   Solver options
 
+  bool constrain_in_solver;
   bool use_petsc_snes;
   bool time_solver_quiet, solver_quiet, solver_verbose,
     reuse_preconditioner, require_residual_reduction;

--- a/examples/adjoints/adjoints_ex4/adjoints_ex4.C
+++ b/examples/adjoints/adjoints_ex4/adjoints_ex4.C
@@ -65,6 +65,7 @@
 #include "libmesh/mesh_refinement.h"
 #include "libmesh/newton_solver.h"
 #include "libmesh/numeric_vector.h"
+#include "libmesh/petsc_diff_solver.h"
 #include "libmesh/steady_solver.h"
 #include "libmesh/system_norm.h"
 #include "libmesh/enum_solver_package.h"
@@ -177,6 +178,16 @@ void set_system_parameters(LaplaceSystem & system,
   system.time_solver = std::make_unique<SteadySolver>(system);
 
   // Nonlinear solver options
+  if (param.use_petsc_snes)
+  {
+#ifdef LIBMESH_HAVE_PETSC
+    PetscDiffSolver *solver = new PetscDiffSolver(system);
+    system.time_solver->diff_solver().reset(solver);
+#else
+    libmesh_error_msg("This example requires libMesh to be compiled with PETSc support.");
+#endif
+  }
+  else
   {
     NewtonSolver * solver = new NewtonSolver(system);
     system.time_solver->diff_solver() = std::unique_ptr<DiffSolver>(solver);
@@ -193,6 +204,7 @@ void set_system_parameters(LaplaceSystem & system,
         solver->continue_after_max_iterations = true;
         solver->continue_after_backtrack_failure = true;
       }
+    system.set_constrain_in_solver(param.constrain_in_solver);
 
     // And the linear solver options
     solver->max_linear_iterations       = param.max_linear_iterations;

--- a/examples/adjoints/adjoints_ex4/femparameters.h
+++ b/examples/adjoints/adjoints_ex4/femparameters.h
@@ -125,6 +125,7 @@ public:
 
   //   Solver options
 
+  bool constrain_in_solver;
   bool use_petsc_snes;
   bool time_solver_quiet, solver_quiet, solver_verbose,
     reuse_preconditioner, require_residual_reduction;

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -98,6 +98,7 @@
 #include "libmesh/euler_solver.h"
 #include "libmesh/euler2_solver.h"
 #include "libmesh/newton_solver.h"
+#include "libmesh/petsc_diff_solver.h"
 #include "libmesh/twostep_time_solver.h"
 
 #include "libmesh/getpot.h"
@@ -338,6 +339,7 @@ void set_system_parameters(HeatSystem &system, FEMParameters &param)
           solver->continue_after_max_iterations = true;
           solver->continue_after_backtrack_failure = true;
         }
+      system.set_constrain_in_solver(param.constrain_in_solver);
 
       // And the linear solver options
       solver->max_linear_iterations       = param.max_linear_iterations;

--- a/examples/adjoints/adjoints_ex5/femparameters.h
+++ b/examples/adjoints/adjoints_ex5/femparameters.h
@@ -125,6 +125,7 @@ public:
 
   //   Solver options
 
+  bool constrain_in_solver;
   bool use_petsc_snes;
   bool time_solver_quiet, solver_quiet, solver_verbose,
     reuse_preconditioner, require_residual_reduction;

--- a/examples/adjoints/adjoints_ex6/adjoints_ex6.C
+++ b/examples/adjoints/adjoints_ex6/adjoints_ex6.C
@@ -68,6 +68,7 @@
 #include "libmesh/mesh_refinement.h"
 #include "libmesh/newton_solver.h"
 #include "libmesh/numeric_vector.h"
+#include "libmesh/petsc_diff_solver.h"
 #include "libmesh/steady_solver.h"
 #include "libmesh/system_norm.h"
 #include "libmesh/petsc_vector.h"
@@ -142,6 +143,16 @@ void set_system_parameters(PoissonSystem & system, FEMParameters & param)
   system.time_solver = std::make_unique<SteadySolver>(system);
 
   // Nonlinear solver options
+  if (param.use_petsc_snes)
+  {
+#ifdef LIBMESH_HAVE_PETSC
+    PetscDiffSolver *solver = new PetscDiffSolver(system);
+    system.time_solver->diff_solver().reset(solver);
+#else
+    libmesh_error_msg("This example requires libMesh to be compiled with PETSc support.");
+#endif
+  }
+  else
   {
     NewtonSolver * solver = new NewtonSolver(system);
     system.time_solver->diff_solver() = std::unique_ptr<DiffSolver>(solver);
@@ -158,6 +169,7 @@ void set_system_parameters(PoissonSystem & system, FEMParameters & param)
         solver->continue_after_max_iterations = true;
         solver->continue_after_backtrack_failure = true;
       }
+    system.set_constrain_in_solver(param.constrain_in_solver);
 
     // And the linear solver options
     solver->max_linear_iterations       = param.max_linear_iterations;

--- a/examples/adjoints/adjoints_ex6/femparameters.h
+++ b/examples/adjoints/adjoints_ex6/femparameters.h
@@ -125,6 +125,7 @@ public:
 
   //   Solver options
 
+  bool constrain_in_solver;
   bool use_petsc_snes;
   bool time_solver_quiet, solver_quiet, solver_verbose,
     reuse_preconditioner, require_residual_reduction;

--- a/examples/adjoints/adjoints_ex7/adjoints_ex7.C
+++ b/examples/adjoints/adjoints_ex7/adjoints_ex7.C
@@ -62,6 +62,7 @@
 #include "libmesh/euler_solver.h"
 #include "libmesh/euler2_solver.h"
 #include "libmesh/newton_solver.h"
+#include "libmesh/petsc_diff_solver.h"
 #include "libmesh/twostep_time_solver.h"
 
 #include "libmesh/getpot.h"
@@ -299,6 +300,7 @@ void set_system_parameters(HeatSystem &system, FEMParameters &param)
           solver->continue_after_max_iterations = true;
           solver->continue_after_backtrack_failure = true;
         }
+      system.set_constrain_in_solver(param.constrain_in_solver);
 
       // And the linear solver options
       solver->max_linear_iterations       = param.max_linear_iterations;

--- a/examples/adjoints/adjoints_ex7/femparameters.h
+++ b/examples/adjoints/adjoints_ex7/femparameters.h
@@ -125,6 +125,7 @@ public:
 
   //   Solver options
 
+  bool constrain_in_solver;
   bool use_petsc_snes;
   bool time_solver_quiet, solver_quiet, solver_verbose,
     reuse_preconditioner, require_residual_reduction;

--- a/examples/adjoints/adjoints_ex7/run.sh
+++ b/examples/adjoints/adjoints_ex7/run.sh
@@ -13,9 +13,17 @@ example_dir=examples/adjoints/$example_name
 run_example "$example_name" n_timesteps=10 timesolver_tolerance=0.0 timesolver_upper_tolerance=0.0 solution_history_type=memory
 # Save previous timestep solution on disk
 run_example "$example_name" n_timesteps=10 timesolver_tolerance=0.0 timesolver_upper_tolerance=0.0 solution_history_type=file
+# Try using the residual and Jacobian alone to enforce NewtonSolver constraints
+run_example "$example_name" n_timesteps=10 timesolver_tolerance=0.0 timesolver_upper_tolerance=0.0 solution_history_type=memory constrain_in_solver=false
+# Try using the residual and Jacobian alone to enforce PetscDiffSolver constraints
+run_example "$example_name" n_timesteps=10 timesolver_tolerance=0.0 timesolver_upper_tolerance=0.0 solution_history_type=memory constrain_in_solver=false use_petsc_snes=true
 
 # Adaptive time stepping
 # Save previous timestep solution in memory
 run_example "$example_name" n_timesteps=10 timesolver_tolerance=1.0 timesolver_upper_tolerance=1.2 solution_history_type=memory
 # Save previous timestep solution on disk
 run_example "$example_name" n_timesteps=10 timesolver_tolerance=1.0 timesolver_upper_tolerance=1.2 solution_history_type=file
+# Try using the residual and Jacobian alone to enforce NewtonSolver constraints
+run_example "$example_name" n_timesteps=10 timesolver_tolerance=1.0 timesolver_upper_tolerance=1.2 solution_history_type=memory constrain_in_solver=false
+# Try using the residual and Jacobian alone to enforce PetscDiffSolver constraints
+run_example "$example_name" n_timesteps=10 timesolver_tolerance=1.0 timesolver_upper_tolerance=1.2 solution_history_type=memory constrain_in_solver=false use_petsc_snes=true

--- a/examples/fem_system/fem_system_ex1/fem_system_ex1.C
+++ b/examples/fem_system/fem_system_ex1/fem_system_ex1.C
@@ -104,6 +104,12 @@ int main (int argc, char ** argv)
   const unsigned int dim               = infile("dimension", 2);
   const std::string slvr_type          = infile("solver_type", "newton");
   const std::string mesh_type          = infile("mesh_type"  , "replicated");
+  const bool constrain_in_solver       = infile("constrain_in_solver", true);
+
+  // More desperate debugging options
+  const bool print_solutions           = infile("print_solutions", false);
+  const bool print_residuals           = infile("print_residuals", false);
+  const bool print_jacobians           = infile("print_jacobians", false);
 
 #ifdef LIBMESH_HAVE_EXODUS_API
   const unsigned int write_interval    = infile("write_interval", 5);
@@ -176,6 +182,14 @@ int main (int argc, char ** argv)
   NavierSystem & system =
     equation_systems.add_system<NavierSystem> ("Navier-Stokes");
 
+  // Debug it if requested
+  system.print_solutions = print_solutions;
+  system.print_solution_norms = print_solutions;
+  system.print_residuals = print_residuals;
+  system.print_residual_norms = print_residuals;
+  system.print_jacobians = print_jacobians;
+  system.print_jacobian_norms = print_jacobians;
+
   // Solve this as a time-dependent or steady system
   if (transient)
     system.time_solver = std::make_unique<EulerSolver>(system);
@@ -216,6 +230,8 @@ int main (int argc, char ** argv)
     infile("relative_residual_tolerance", 0.0);
   solver.absolute_residual_tolerance =
     infile("absolute_residual_tolerance", 0.0);
+
+  system.set_constrain_in_solver(constrain_in_solver);
 
   // And the linear solver options
   solver.max_linear_iterations =

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1249,6 +1249,10 @@ public:
    * appropriate for finding linearized updates to a solution in which
    * heterogeneous constraints are already satisfied.
    *
+   * Note the sign difference from the nonlinear heterogeneous constraint
+   * method: Solving u:=K\f has the opposite sign convention from
+   * u:=u_in-J\r, and we apply heterogeneous constraints accordingly.
+   *
    * By default, the constraints for the primal solution of this
    * system are used.  If a non-negative \p qoi_index is passed in,
    * then the constraints for the corresponding adjoint solution are
@@ -1272,7 +1276,67 @@ public:
       (matrix, rhs, elem_dofs, asymmetric_constraint_rows, qoi_index);
   }
 
+  /**
+   * Constrains the element Jacobian and residual.  The element
+   * Jacobian is square, and the elem_dofs should correspond to the
+   * global DOF indices of both the rows and columns of the element
+   * matrix.
+   *
+   * The residual-constraining version of this method creates linear
+   * systems in which heterogeneously constrained degrees of freedom
+   * create non-zero residual terms when not at their correct offset
+   * values, as would be appropriate for finding a solution to a
+   * nonlinear problem in a quasi-Newton solve.
+   *
+   * Note the sign difference from the linear heterogeneous constraint
+   * method: Solving u:=u_in-J\r has the opposite sign convention from
+   * u:=K\f, and we apply heterogeneous constraints accordingly.
+   *
+   * The \p solution vector passed in should be a serialized or
+   * ghosted primal solution
+   */
+  void heterogeneously_constrain_element_jacobian_and_residual (DenseMatrix<Number> & matrix,
+                                                                DenseVector<Number> & rhs,
+                                                                std::vector<dof_id_type> & elem_dofs,
+                                                                NumericVector<Number> & solution_local) const;
 
+  /**
+   * Constrains the element residual.  The element Jacobian is square,
+   * and the elem_dofs should correspond to the global DOF indices of
+   * both the rows and columns of the element matrix.
+   *
+   * The residual-constraining version of this method creates linear
+   * systems in which heterogeneously constrained degrees of freedom
+   * create non-zero residual terms when not at their correct offset
+   * values, as would be appropriate for finding a solution to a
+   * nonlinear problem in a quasi-Newton solve.
+   *
+   * The \p solution vector passed in should be a serialized or
+   * ghosted primal solution
+   */
+  void heterogeneously_constrain_element_residual (DenseVector<Number> & rhs,
+                                                   std::vector<dof_id_type> & elem_dofs,
+                                                   NumericVector<Number> & solution_local) const;
+
+
+  /**
+   * Constrains the element residual.  The element Jacobian is square,
+   * and the elem_dofs should correspond to the global DOF indices of
+   * both the rows and columns of the element matrix, and the dof
+   * constraint should not include any heterogeneous terms.
+   *
+   * The residual-constraining version of this method creates linear
+   * systems in which heterogeneously constrained degrees of freedom
+   * create non-zero residual terms when not at their correct offset
+   * values, as would be appropriate for finding a solution to a
+   * nonlinear problem in a quasi-Newton solve.
+   *
+   * The \p solution vector passed in should be a serialized or
+   * ghosted primal solution
+   */
+  void constrain_element_residual (DenseVector<Number> & rhs,
+                                   std::vector<dof_id_type> & elem_dofs,
+                                   NumericVector<Number> & solution_local) const;
 
   /**
    * Constrains a dyadic element matrix B = v w'.  This method

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1067,18 +1067,33 @@ public:
   bool is_constrained_dof (const dof_id_type dof) const;
 
   /**
-   * \returns \p true if the system has any heterogenous constraints for
+   * \returns \p true if the system has any heterogeneous constraints for
    * adjoint solution \p qoi_num, \p false otherwise.
    */
-  bool has_heterogenous_adjoint_constraints (const unsigned int qoi_num) const;
+  bool has_heterogeneous_adjoint_constraints (const unsigned int qoi_num) const;
+
+  /**
+   * Backwards compatibility with misspelling.
+   */
+  bool has_heterogenous_adjoint_constraints (const unsigned int qoi_num) const {
+    return this->has_heterogeneous_adjoint_constraints (qoi_num);
+  }
 
   /**
    * \returns The heterogeneous constraint value if the degree of
-   * freedom \p dof has a heterogenous constraint for adjoint solution
+   * freedom \p dof has a heterogeneous constraint for adjoint solution
    * \p qoi_num, zero otherwise.
    */
+  Number has_heterogeneous_adjoint_constraint (const unsigned int qoi_num,
+                                               const dof_id_type dof) const;
+
+  /**
+   * Backwards compatibility with misspelling.
+   */
   Number has_heterogenous_adjoint_constraint (const unsigned int qoi_num,
-                                              const dof_id_type dof) const;
+                                              const dof_id_type dof) const {
+    return this->has_heterogeneous_adjoint_constraint (qoi_num, dof);
+  }
 
   /**
    * \returns A reference to the set of right-hand-side values in
@@ -1185,26 +1200,38 @@ public:
    * and columns of the matrix necessarily correspond to variables
    * of the same approximation order.
    *
-   * The heterogenous version of this method creates linear systems in
-   * which heterogenously constrained degrees of freedom will solve to
+   * The heterogeneous version of this method creates linear systems in
+   * which heterogeneously constrained degrees of freedom will solve to
    * their correct offset values, as would be appropriate for finding
    * a solution to a linear problem in a single algebraic solve.  The
-   * non-heterogenous version of this method creates linear systems in
-   * which even heterogenously constrained degrees of freedom are
+   * non-heterogeneous version of this method creates linear systems in
+   * which even heterogeneously constrained degrees of freedom are
    * solved without offset values taken into account, as would be
    * appropriate for finding linearized updates to a solution in which
-   * heterogenous constraints are already satisfied.
+   * heterogeneous constraints are already satisfied.
    *
    * By default, the constraints for the primal solution of this
    * system are used.  If a non-negative \p qoi_index is passed in,
    * then the constraints for the corresponding adjoint solution are
    * used instead.
    */
+  void heterogeneously_constrain_element_matrix_and_vector (DenseMatrix<Number> & matrix,
+                                                            DenseVector<Number> & rhs,
+                                                            std::vector<dof_id_type> & elem_dofs,
+                                                            bool asymmetric_constraint_rows = true,
+                                                            int qoi_index = -1) const;
+
+  /*
+   * Backwards compatibility with misspelling.
+   */
   void heterogenously_constrain_element_matrix_and_vector (DenseMatrix<Number> & matrix,
                                                            DenseVector<Number> & rhs,
                                                            std::vector<dof_id_type> & elem_dofs,
                                                            bool asymmetric_constraint_rows = true,
-                                                           int qoi_index = -1) const;
+                                                           int qoi_index = -1) const {
+    return this->heterogeneously_constrain_element_matrix_and_vector
+      (matrix, rhs, elem_dofs, asymmetric_constraint_rows, qoi_index);
+  }
 
   /**
    * Constrains the element vector.  This method requires
@@ -1212,26 +1239,38 @@ public:
    * case the elem_dofs correspond to the global DOF indices of both
    * the rows and columns of the element matrix.
    *
-   * The heterogenous version of this method creates linear systems in
-   * which heterogenously constrained degrees of freedom will solve to
+   * The heterogeneous version of this method creates linear systems in
+   * which heterogeneously constrained degrees of freedom will solve to
    * their correct offset values, as would be appropriate for finding
    * a solution to a linear problem in a single algebraic solve.  The
-   * non-heterogenous version of this method creates linear systems in
-   * which even heterogenously constrained degrees of freedom are
+   * non-heterogeneous version of this method creates linear systems in
+   * which even heterogeneously constrained degrees of freedom are
    * solved without offset values taken into account, as would be
    * appropriate for finding linearized updates to a solution in which
-   * heterogenous constraints are already satisfied.
+   * heterogeneous constraints are already satisfied.
    *
    * By default, the constraints for the primal solution of this
    * system are used.  If a non-negative \p qoi_index is passed in,
    * then the constraints for the corresponding adjoint solution are
    * used instead.
    */
+  void heterogeneously_constrain_element_vector (const DenseMatrix<Number> & matrix,
+                                                 DenseVector<Number> & rhs,
+                                                 std::vector<dof_id_type> & elem_dofs,
+                                                 bool asymmetric_constraint_rows = true,
+                                                 int qoi_index = -1) const;
+
+  /*
+   * Backwards compatibility with misspelling.
+   */
   void heterogenously_constrain_element_vector (const DenseMatrix<Number> & matrix,
                                                 DenseVector<Number> & rhs,
                                                 std::vector<dof_id_type> & elem_dofs,
                                                 bool asymmetric_constraint_rows = true,
-                                                int qoi_index = -1) const;
+                                                int qoi_index = -1) const {
+    return this->heterogeneously_constrain_element_vector
+      (matrix, rhs, elem_dofs, asymmetric_constraint_rows, qoi_index);
+  }
 
 
 
@@ -1274,7 +1313,7 @@ public:
                                     bool homogeneous = false) const;
 
   /**
-   * Heterogenously constrains the numeric vector \p v, which
+   * Heterogeneously constrains the numeric vector \p v, which
    * represents an adjoint solution defined on the mesh for quantity
    * fo interest \p q.  For homogeneous constraints, use \p
    * enforce_constraints_exactly instead
@@ -1647,7 +1686,7 @@ private:
    * an elements DOFs to be constrained by some other, external DOFs
    * and/or Dirichlet conditions.
    *
-   * The forcing vector will depend on which solution's heterogenous
+   * The forcing vector will depend on which solution's heterogeneous
    * constraints are being applied.  For the default \p qoi_index this
    * will be the primal solution; for \p qoi_index >= 0 the
    * corresponding adjoint solution's constraints will be used.
@@ -2043,7 +2082,7 @@ bool DofMap::is_constrained_dof (const dof_id_type dof) const
 
 
 inline
-bool DofMap::has_heterogenous_adjoint_constraints (const unsigned int qoi_num) const
+bool DofMap::has_heterogeneous_adjoint_constraints (const unsigned int qoi_num) const
 {
   AdjointDofConstraintValues::const_iterator it =
     _adjoint_constraint_values.find(qoi_num);
@@ -2057,7 +2096,7 @@ bool DofMap::has_heterogenous_adjoint_constraints (const unsigned int qoi_num) c
 
 
 inline
-Number DofMap::has_heterogenous_adjoint_constraint (const unsigned int qoi_num,
+Number DofMap::has_heterogeneous_adjoint_constraint (const unsigned int qoi_num,
                                                     const dof_id_type dof) const
 {
   AdjointDofConstraintValues::const_iterator it =
@@ -2110,11 +2149,11 @@ inline void DofMap::constrain_element_matrix_and_vector (DenseMatrix<Number> &,
                                                          std::vector<dof_id_type> &,
                                                          bool) const {}
 
-inline void DofMap::heterogenously_constrain_element_matrix_and_vector
+inline void DofMap::heterogeneously_constrain_element_matrix_and_vector
   (DenseMatrix<Number> &, DenseVector<Number> &,
    std::vector<dof_id_type> &, bool, int) const {}
 
-inline void DofMap::heterogenously_constrain_element_vector
+inline void DofMap::heterogeneously_constrain_element_vector
   (const DenseMatrix<Number> &, DenseVector<Number> &,
    std::vector<dof_id_type> &, bool, int) const {}
 

--- a/include/solvers/diff_solver.h
+++ b/include/solvers/diff_solver.h
@@ -285,7 +285,35 @@ public:
    */
   std::unique_ptr<LinearSolutionMonitor> linear_solution_monitor;
 
+  /**
+   * Enable (or disable; it is \p true by default) exact enforcement
+   * of constraints at the solver level, correcting any constrained
+   * DoF coefficients in \p current_local_solution as well as applying
+   * nonlinear residual and Jacobian terms based on constraint
+   * equations.
+   *
+   * This is probably only safe to disable if user code is setting
+   * nonlinear residual and Jacobian terms based on constraint
+   * equations at an element-by-element level, by combining the
+   * \p asymmetric_constraint_rows option with the
+   * \p residual_constrain_element_vector processing option in
+   * \p DofMap.
+   */
+  virtual void set_exact_constraint_enforcement(bool enable) {
+    _exact_constraint_enforcement = enable;
+  }
+
+  bool exact_constraint_enforcement() {
+    return _exact_constraint_enforcement;
+  }
+
 protected:
+
+  /**
+   * Whether we should enforce exact constraints globally during a
+   * solve.
+   */
+  bool _exact_constraint_enforcement;
 
   /**
    * The largest solution norm which the DiffSolver has yet seen will be stored

--- a/include/solvers/nonlinear_solver.h
+++ b/include/solvers/nonlinear_solver.h
@@ -397,6 +397,10 @@ public:
     _exact_constraint_enforcement = enable;
   }
 
+  bool exact_constraint_enforcement() {
+    return _exact_constraint_enforcement;
+  }
+
 protected:
   /**
    * Whether we should reuse the linear preconditioner

--- a/include/solvers/nonlinear_solver.h
+++ b/include/solvers/nonlinear_solver.h
@@ -379,12 +379,35 @@ public:
    */
   virtual void force_new_preconditioner() {};
 
+  /**
+   * Enable (or disable; it is \p true by default) exact enforcement
+   * of constraints at the solver level, correcting any constrained
+   * DoF coefficients in \p current_local_solution as well as applying
+   * nonlinear residual and Jacobian terms based on constraint
+   * equations.
+   *
+   * This is probably only safe to disable if user code is setting
+   * nonlinear residual and Jacobian terms based on constraint
+   * equations at an element-by-element level, by combining the
+   * \p asymmetric_constraint_rows option with the
+   * \p residual_constrain_element_vector processing option in
+   * \p DofMap.
+   */
+  virtual void set_exact_constraint_enforcement(bool enable) {
+    _exact_constraint_enforcement = enable;
+  }
 
 protected:
   /**
    * Whether we should reuse the linear preconditioner
    */
   bool _reuse_preconditioner;
+
+  /**
+   * Whether we should enforce exact constraints globally during a
+   * solve.
+   */
+  bool _exact_constraint_enforcement;
 
   /**
    * Number of linear iterations to retain the preconditioner
@@ -452,6 +475,7 @@ NonlinearSolver<T>::NonlinearSolver (sys_type & s) :
   minimum_linear_tolerance(0),
   converged(false),
   _reuse_preconditioner(false),
+  _exact_constraint_enforcement(true),
   _reuse_preconditioner_max_linear_its(0),
   _system(s),
   _is_initialized (false),

--- a/include/systems/diff_system.h
+++ b/include/systems/diff_system.h
@@ -378,6 +378,16 @@ public:
    */
   bool print_element_jacobians;
 
+  /**
+   * set_constrain_in_solver to false to apply constraints only via
+   * residual terms in the systems to be solved.
+   */
+  virtual void set_constrain_in_solver(bool enable);
+
+  virtual bool get_constrain_in_solver() {
+    return _constrain_in_solver;
+  }
+
 protected:
 
   /**
@@ -411,6 +421,12 @@ protected:
    */
   void add_dot_var_dirichlet_bcs( unsigned int var_idx, unsigned int dot_var_idx);
 #endif
+
+  /**
+   * _constrain_in_solver defaults to true; if false then we apply
+   * constraints only via residual terms in the systems to be solved.
+   */
+  bool _constrain_in_solver;
 
 private:
   /**

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -2106,7 +2106,7 @@ void DofMap::process_mesh_constraint_rows(const MeshBase & mesh)
                       if (rhsit != vals.end())
                         vals.erase(rhsit);
 
-                      this->heterogenously_constrain_element_matrix_and_vector
+                      this->heterogeneously_constrain_element_matrix_and_vector
                         (K, F, dof_indices, false, q ? (q-1) : -1);
                       if (!q)
                         mat->add_matrix(K, dof_indices);
@@ -2422,7 +2422,7 @@ void DofMap::constrain_element_matrix (DenseMatrix<Number> & matrix,
                 const DofConstraintRow & constraint_row = pos->second;
 
                 // This is an overzealous assertion in the presence of
-                // heterogenous constraints: we now can constrain "u_i = c"
+                // heterogeneous constraints: we now can constrain "u_i = c"
                 // with no other u_j terms involved.
                 //
                 // libmesh_assert (!constraint_row.empty());
@@ -2517,11 +2517,11 @@ void DofMap::constrain_element_matrix_and_vector (DenseMatrix<Number> & matrix,
 
 
 
-void DofMap::heterogenously_constrain_element_matrix_and_vector (DenseMatrix<Number> & matrix,
-                                                                 DenseVector<Number> & rhs,
-                                                                 std::vector<dof_id_type> & elem_dofs,
-                                                                 bool asymmetric_constraint_rows,
-                                                                 int qoi_index) const
+void DofMap::heterogeneously_constrain_element_matrix_and_vector (DenseMatrix<Number> & matrix,
+                                                                  DenseVector<Number> & rhs,
+                                                                  std::vector<dof_id_type> & elem_dofs,
+                                                                  bool asymmetric_constraint_rows,
+                                                                  int qoi_index) const
 {
   libmesh_assert_equal_to (elem_dofs.size(), matrix.m());
   libmesh_assert_equal_to (elem_dofs.size(), matrix.n());
@@ -2623,11 +2623,11 @@ void DofMap::heterogenously_constrain_element_matrix_and_vector (DenseMatrix<Num
 
 
 
-void DofMap::heterogenously_constrain_element_vector (const DenseMatrix<Number> & matrix,
-                                                      DenseVector<Number> & rhs,
-                                                      std::vector<dof_id_type> & elem_dofs,
-                                                      bool asymmetric_constraint_rows,
-                                                      int qoi_index) const
+void DofMap::heterogeneously_constrain_element_vector (const DenseMatrix<Number> & matrix,
+                                                       DenseVector<Number> & rhs,
+                                                       std::vector<dof_id_type> & elem_dofs,
+                                                       bool asymmetric_constraint_rows,
+                                                       int qoi_index) const
 {
   libmesh_assert_equal_to (elem_dofs.size(), matrix.m());
   libmesh_assert_equal_to (elem_dofs.size(), matrix.n());
@@ -3515,7 +3515,7 @@ void DofMap::allgather_recursive_constraints(MeshBase & mesh)
   if (!has_constraints)
     return;
 
-  // If we have heterogenous adjoint constraints we need to
+  // If we have heterogeneous adjoint constraints we need to
   // communicate those too.
   const unsigned int max_qoi_num =
     _adjoint_constraint_values.empty() ?
@@ -4848,7 +4848,7 @@ void DofMap::gather_constraints (MeshBase & /*mesh*/,
 {
   typedef std::set<dof_id_type> DoF_RCSet;
 
-  // If we have heterogenous adjoint constraints we need to
+  // If we have heterogeneous adjoint constraints we need to
   // communicate those too.
   const unsigned int max_qoi_num =
     _adjoint_constraint_values.empty() ?

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -2622,6 +2622,207 @@ void DofMap::heterogeneously_constrain_element_matrix_and_vector (DenseMatrix<Nu
 }
 
 
+void DofMap::heterogeneously_constrain_element_jacobian_and_residual
+  (DenseMatrix<Number> & matrix,
+   DenseVector<Number> & rhs,
+   std::vector<dof_id_type> & elem_dofs,
+   NumericVector<Number> & solution_local) const
+{
+  libmesh_assert_equal_to (elem_dofs.size(), matrix.m());
+  libmesh_assert_equal_to (elem_dofs.size(), matrix.n());
+  libmesh_assert_equal_to (elem_dofs.size(), rhs.size());
+
+  libmesh_assert (solution_local.type() == SERIAL ||
+                  solution_local.type() == GHOSTED);
+
+  // check for easy return
+  if (this->_dof_constraints.empty())
+    return;
+
+  // The constrained matrix is built up as C^T K C.
+  // The constrained RHS is built up as C^T F
+  // Asymmetric residual terms are added if we do not have x = Cx+h
+  DenseMatrix<Number> C;
+  DenseVector<Number> H;
+
+  this->build_constraint_matrix_and_vector (C, H, elem_dofs);
+
+  LOG_SCOPE("hetero_cnstrn_elem_jac_res()", "DofMap");
+
+  // It is possible that the matrix is not constrained at all.
+  if ((C.m() != matrix.m()) ||
+      (C.n() != elem_dofs.size()))
+    return;
+
+  // Compute the matrix-vector product C^T F
+  DenseVector<Number> old_rhs(rhs);
+  C.vector_mult_transpose(rhs, old_rhs);
+
+  // Compute the matrix-matrix-matrix product C^T K C
+  matrix.left_multiply_transpose  (C);
+  matrix.right_multiply (C);
+
+  libmesh_assert_equal_to (matrix.m(), matrix.n());
+  libmesh_assert_equal_to (matrix.m(), elem_dofs.size());
+  libmesh_assert_equal_to (matrix.n(), elem_dofs.size());
+
+  for (unsigned int i=0,
+       n_elem_dofs = cast_int<unsigned int>(elem_dofs.size());
+       i != n_elem_dofs; i++)
+    {
+      const dof_id_type dof_id = elem_dofs[i];
+
+      const DofConstraints::const_iterator
+        pos = _dof_constraints.find(dof_id);
+
+      if (pos != _dof_constraints.end())
+        {
+          for (auto j : make_range(matrix.n()))
+            matrix(i,j) = 0.;
+
+          // If the DOF is constrained
+          matrix(i,i) = 1.;
+
+          // This will put a nonsymmetric entry in the constraint
+          // row to ensure that the linear system produces the
+          // correct value for the constrained DOF.
+          const DofConstraintRow & constraint_row = pos->second;
+
+          for (const auto & item : constraint_row)
+            for (unsigned int j=0; j != n_elem_dofs; j++)
+              if (elem_dofs[j] == item.first)
+                matrix(i,j) = -item.second;
+
+          const DofConstraintValueMap::const_iterator valpos =
+            _primal_constraint_values.find(dof_id);
+
+          Number & rhs_val = rhs(i);
+          rhs_val = (valpos == _primal_constraint_values.end()) ?
+            0 : -valpos->second;
+          for (const auto & [constraining_dof, coef] : constraint_row)
+            rhs_val -= coef * solution_local(constraining_dof);
+          rhs_val += solution_local(dof_id);
+        }
+    }
+}
+
+
+void DofMap::heterogeneously_constrain_element_residual
+  (DenseVector<Number> & rhs,
+   std::vector<dof_id_type> & elem_dofs,
+   NumericVector<Number> & solution_local) const
+{
+  libmesh_assert_equal_to (elem_dofs.size(), rhs.size());
+
+  libmesh_assert (solution_local.type() == SERIAL ||
+                  solution_local.type() == GHOSTED);
+
+  // check for easy return
+  if (this->_dof_constraints.empty())
+    return;
+
+  // The constrained RHS is built up as C^T F
+  // Asymmetric residual terms are added if we do not have x = Cx+h
+  DenseMatrix<Number> C;
+  DenseVector<Number> H;
+
+  this->build_constraint_matrix_and_vector (C, H, elem_dofs);
+
+  LOG_SCOPE("hetero_cnstrn_elem_res()", "DofMap");
+
+  // It is possible that the element is not constrained at all.
+  if ((C.m() != rhs.size()) ||
+      (C.n() != elem_dofs.size()))
+    return;
+
+  // Compute the matrix-vector product C^T F
+  DenseVector<Number> old_rhs(rhs);
+  C.vector_mult_transpose(rhs, old_rhs);
+
+  for (unsigned int i=0,
+       n_elem_dofs = cast_int<unsigned int>(elem_dofs.size());
+       i != n_elem_dofs; i++)
+    {
+      const dof_id_type dof_id = elem_dofs[i];
+
+      const DofConstraints::const_iterator
+        pos = _dof_constraints.find(dof_id);
+
+      if (pos != _dof_constraints.end())
+        {
+          // This will put a nonsymmetric entry in the constraint
+          // row to ensure that the linear system produces the
+          // correct value for the constrained DOF.
+          const DofConstraintRow & constraint_row = pos->second;
+
+          const DofConstraintValueMap::const_iterator valpos =
+            _primal_constraint_values.find(dof_id);
+
+          Number & rhs_val = rhs(i);
+          rhs_val = (valpos == _primal_constraint_values.end()) ?
+            0 : -valpos->second;
+          for (const auto & [constraining_dof, coef] : constraint_row)
+            rhs_val -= coef * solution_local(constraining_dof);
+          rhs_val += solution_local(dof_id);
+        }
+    }
+}
+
+
+void DofMap::constrain_element_residual
+  (DenseVector<Number> & rhs,
+   std::vector<dof_id_type> & elem_dofs,
+   NumericVector<Number> & solution_local) const
+{
+  libmesh_assert_equal_to (elem_dofs.size(), rhs.size());
+
+  libmesh_assert (solution_local.type() == SERIAL ||
+                  solution_local.type() == GHOSTED);
+
+  // check for easy return
+  if (this->_dof_constraints.empty())
+    return;
+
+  // The constrained RHS is built up as C^T F
+  DenseMatrix<Number> C;
+
+  this->build_constraint_matrix (C, elem_dofs);
+
+  LOG_SCOPE("cnstrn_elem_residual()", "DofMap");
+
+  // It is possible that the matrix is not constrained at all.
+  if (C.n() != elem_dofs.size())
+    return;
+
+  // Compute the matrix-vector product C^T F
+  DenseVector<Number> old_rhs(rhs);
+  C.vector_mult_transpose(rhs, old_rhs);
+
+  for (unsigned int i=0,
+       n_elem_dofs = cast_int<unsigned int>(elem_dofs.size());
+       i != n_elem_dofs; i++)
+    {
+      const dof_id_type dof_id = elem_dofs[i];
+
+      const DofConstraints::const_iterator
+        pos = _dof_constraints.find(dof_id);
+
+      if (pos != _dof_constraints.end())
+        {
+          // This will put a nonsymmetric entry in the constraint
+          // row to ensure that the linear system produces the
+          // correct value for the constrained DOF.
+          const DofConstraintRow & constraint_row = pos->second;
+
+          Number & rhs_val = rhs(i);
+          rhs_val = 0;
+          for (const auto & [constraining_dof, coef] : constraint_row)
+            rhs_val -= coef * solution_local(constraining_dof);
+          rhs_val += solution_local(dof_id);
+        }
+    }
+}
+
 
 void DofMap::heterogeneously_constrain_element_vector (const DenseMatrix<Number> & matrix,
                                                        DenseVector<Number> & rhs,

--- a/src/solvers/diff_solver.C
+++ b/src/solvers/diff_solver.C
@@ -41,6 +41,7 @@ DiffSolver::DiffSolver (sys_type & s) :
   relative_step_tolerance(0.),
   initial_linear_tolerance(1e-12),
   minimum_linear_tolerance(TOLERANCE*TOLERANCE),
+  _exact_constraint_enforcement(true),
   max_solution_norm(0.),
   max_residual_norm(0.),
   _outer_iterations(0),

--- a/src/solvers/newton_solver.C
+++ b/src/solvers/newton_solver.C
@@ -83,7 +83,7 @@ Real NewtonSolver::line_search(Real tol,
       _system.update();
 
       // Check residual with fractional Newton step
-      _system.assembly (true, false);
+      _system.assembly(true, false, !this->_exact_constraint_enforcement);
 
       rhs.close();
       current_residual = rhs.l2_norm();
@@ -191,7 +191,7 @@ Real NewtonSolver::line_search(Real tol,
 
       // We may need to localize a parallel solution
       _system.update();
-      _system.assembly (true, false);
+      _system.assembly(true, false, !this->_exact_constraint_enforcement);
 
       rhs.close();
       Real fu = current_residual = rhs.l2_norm();
@@ -317,7 +317,7 @@ unsigned int NewtonSolver::solve()
       if (verbose)
         libMesh::out << "Assembling the System" << std::endl;
 
-      _system.assembly(true, true);
+      _system.assembly(true, true, !this->_exact_constraint_enforcement);
       rhs.close();
       Real current_residual = rhs.l2_norm();
 
@@ -472,7 +472,7 @@ unsigned int NewtonSolver::solve()
           !continue_after_max_iterations)
         {
           _system.update ();
-          _system.assembly(true, false);
+          _system.assembly(true, false, !this->_exact_constraint_enforcement);
 
           rhs.close();
           current_residual = rhs.l2_norm();

--- a/src/solvers/newton_solver.C
+++ b/src/solvers/newton_solver.C
@@ -295,7 +295,8 @@ unsigned int NewtonSolver::solve()
   rhs.close();
 
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
-  _system.get_dof_map().enforce_constraints_exactly(_system);
+  if (this->_exact_constraint_enforcement)
+    _system.get_dof_map().enforce_constraints_exactly(_system);
 #endif
 
   SparseMatrix<Number> & matrix = *(_system.matrix);
@@ -426,8 +427,9 @@ unsigned int NewtonSolver::solve()
       _system.update ();
       // The linear solver may not have fit our constraints exactly
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
-      _system.get_dof_map().enforce_constraints_exactly
-        (_system, &linear_solution, /* homogeneous = */ true);
+      if (this->_exact_constraint_enforcement)
+        _system.get_dof_map().enforce_constraints_exactly
+          (_system, &linear_solution, /* homogeneous = */ true);
 #endif
 
       const unsigned int linear_steps = rval.first;
@@ -553,7 +555,8 @@ unsigned int NewtonSolver::solve()
 
   // The linear solver may not have fit our constraints exactly
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
-  _system.get_dof_map().enforce_constraints_exactly(_system);
+  if (this->_exact_constraint_enforcement)
+    _system.get_dof_map().enforce_constraints_exactly(_system);
 #endif
 
   // We may need to localize a parallel solution

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -115,7 +115,8 @@ extern "C"
     sys.update();
 
     // We may need to correct a non-conforming solution
-    sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
+    if (solver.exact_constraint_enforcement())
+      sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
 
     // Do DiffSystem assembly
     sys.assembly(true, false);
@@ -168,7 +169,8 @@ extern "C"
     sys.update();
 
     // We may need to correct a non-conforming solution
-    sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
+    if (solver.exact_constraint_enforcement())
+      sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
 
     // Do DiffSystem assembly
     sys.assembly(false, true);
@@ -318,7 +320,8 @@ unsigned int PetscDiffSolver::solve()
   LIBMESH_CHKERR(ierr);
 
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
-  _system.get_dof_map().enforce_constraints_exactly(_system);
+  if (this->_exact_constraint_enforcement)
+    _system.get_dof_map().enforce_constraints_exactly(_system);
 #endif
 
   SNESConvergedReason reason;

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -119,7 +119,7 @@ extern "C"
       sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
 
     // Do DiffSystem assembly
-    sys.assembly(true, false);
+    sys.assembly(true, false, !solver.exact_constraint_enforcement());
     R_system.close();
 
     // Swap back
@@ -173,7 +173,7 @@ extern "C"
       sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
 
     // Do DiffSystem assembly
-    sys.assembly(false, true);
+    sys.assembly(false, true, !solver.exact_constraint_enforcement());
     J_system.close();
 
     // Swap back

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -94,7 +94,8 @@ libmesh_petsc_snes_residual_helper (SNES snes, Vec x, void * ctx)
   // current_local_solution.  This is the solution vector that is
   // actually used in the computation of the residual below, and is
   // not locked by debug-enabled PETSc the way that "x" is.
-  sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
+  if (solver->_exact_constraint_enforcement)
+    sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
 
   return ResidualContext(solver, sys, ierr);
 }
@@ -210,8 +211,11 @@ extern "C"
           *rc.sys.current_local_solution.get(), &R, &jac, rc.sys);
 
       jac.close();
-      rc.sys.get_dof_map().enforce_constraints_on_jacobian(rc.sys, &jac);
-      jac.close();
+      if (rc.solver->_exact_constraint_enforcement)
+        {
+          rc.sys.get_dof_map().enforce_constraints_on_jacobian(rc.sys, &jac);
+          jac.close();
+        }
     }
 
     else
@@ -228,9 +232,11 @@ extern "C"
 
     R.close();
 
-    rc.sys.get_dof_map().enforce_constraints_on_residual(rc.sys, &R, rc.sys.current_local_solution.get());
-
-    R.close();
+    if (rc.solver->_exact_constraint_enforcement)
+      {
+        rc.sys.get_dof_map().enforce_constraints_on_residual(rc.sys, &R, rc.sys.current_local_solution.get());
+        R.close();
+      }
 
     return rc.ierr;
   }
@@ -278,9 +284,11 @@ extern "C"
 
     R.close();
 
-    rc.sys.get_dof_map().enforce_constraints_on_residual(rc.sys, &R, rc.sys.current_local_solution.get());
-
-    R.close();
+    if (rc.solver->_exact_constraint_enforcement)
+      {
+        rc.sys.get_dof_map().enforce_constraints_on_residual(rc.sys, &R, rc.sys.current_local_solution.get());
+        R.close();
+      }
 
     return rc.ierr;
   }
@@ -330,9 +338,11 @@ extern "C"
 
     R.close();
 
-    rc.sys.get_dof_map().enforce_constraints_on_residual(rc.sys, &R, rc.sys.current_local_solution.get());
-
-    R.close();
+    if (rc.solver->_exact_constraint_enforcement)
+      {
+        rc.sys.get_dof_map().enforce_constraints_on_residual(rc.sys, &R, rc.sys.current_local_solution.get());
+        R.close();
+      }
 
     return rc.ierr;
   }
@@ -501,7 +511,8 @@ extern "C"
     // current_local_solution.  This is the solution vector that is
     // actually used in the computation of the residual below, and is
     // not locked by debug-enabled PETSc the way that "x" is.
-    sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
+    if (solver->_exact_constraint_enforcement)
+      sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
 
     if (solver->_zero_out_jacobian)
       PC.zero();
@@ -520,9 +531,12 @@ extern "C"
       libmesh_error_msg("Error! Unable to compute residual and/or Jacobian!");
 
     PC.close();
-    sys.get_dof_map().enforce_constraints_on_jacobian(sys, &PC);
+    if (solver->_exact_constraint_enforcement)
+      {
+        sys.get_dof_map().enforce_constraints_on_jacobian(sys, &PC);
+        PC.close();
+      }
 
-    PC.close();
     Jac.close();
 
     return ierr;

--- a/src/solvers/trilinos_nox_nonlinear_solver.C
+++ b/src/solvers/trilinos_nox_nonlinear_solver.C
@@ -107,7 +107,8 @@ bool Problem_Interface::computeF(const Epetra_Vector & x,
   X_global.swap(X_sys);
   R.swap(R_sys);
 
-  sys.get_dof_map().enforce_constraints_exactly(sys);
+  if (_solver->_exact_constraint_enforcement)
+    sys.get_dof_map().enforce_constraints_exactly(sys);
   sys.update();
 
   // Swap back
@@ -165,7 +166,8 @@ bool Problem_Interface::computeJacobian(const Epetra_Vector & x,
   // Use the systems update() to get a good local version of the parallel solution
   X_global.swap(X_sys);
 
-  sys.get_dof_map().enforce_constraints_exactly(sys);
+  if (_solver->_exact_constraint_enforcement)
+    sys.get_dof_map().enforce_constraints_exactly(sys);
   sys.update();
 
   X_global.swap(X_sys);
@@ -229,7 +231,8 @@ bool Problem_Interface::computePreconditioner(const Epetra_Vector & x,
   // Use the systems update() to get a good local version of the parallel solution
   X_global.swap(X_sys);
 
-  sys.get_dof_map().enforce_constraints_exactly(sys);
+  if (this->_exact_constraint_enforcement)
+    sys.get_dof_map().enforce_constraints_exactly(sys);
   sys.update();
 
   X_global.swap(X_sys);

--- a/src/systems/diff_system.C
+++ b/src/systems/diff_system.C
@@ -48,6 +48,7 @@ DifferentiableSystem::DifferentiableSystem(EquationSystems & es,
   print_element_solutions(false),
   print_element_residuals(false),
   print_element_jacobians(false),
+  _constrain_in_solver(true),
   _diff_physics(),
   _diff_qoi()
 {
@@ -417,6 +418,11 @@ void DifferentiableSystem::pop_physics ()
 }
 
 
+void DifferentiableSystem::set_constrain_in_solver(bool enable)
+{
+  _constrain_in_solver = enable;
+  this->time_solver->diff_solver()->set_exact_constraint_enforcement(enable);
+}
 
 
 } // namespace libMesh

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -266,6 +266,18 @@ void add_element_system(FEMSystem & _sys,
       libMesh::out.precision(old_precision);
     }
 
+  if (_get_jacobian && _sys.print_element_jacobians)
+    {
+      std::streamsize old_precision = libMesh::out.precision();
+      libMesh::out.precision(16);
+      if (_femcontext.has_elem())
+        libMesh::out << "Jraw_elem " << _femcontext.get_elem().id();
+      else
+        libMesh::out << "Jraw_scalar ";
+      libMesh::out << " = " << _femcontext.get_elem_jacobian() << std::endl;
+      libMesh::out.precision(old_precision);
+    }
+
   // We turn off the asymmetric constraint application iff we expect
   // enforce_constraints_exactly() to be called in the solver
   const bool constrain_in_solver = _sys.get_constrain_in_solver();

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -272,29 +272,46 @@ void add_element_system(FEMSystem & _sys,
 
   if (_get_residual && _get_jacobian)
     {
-      if (_constrain_heterogeneously)
-        _sys.get_dof_map().heterogenously_constrain_element_matrix_and_vector
-          (_femcontext.get_elem_jacobian(),
-           _femcontext.get_elem_residual(),
-           _femcontext.get_dof_indices(), !constrain_in_solver);
+      if (constrain_in_solver)
+        {
+          if (_constrain_heterogeneously)
+            _sys.get_dof_map().heterogenously_constrain_element_matrix_and_vector
+              (_femcontext.get_elem_jacobian(),
+               _femcontext.get_elem_residual(),
+               _femcontext.get_dof_indices(), false);
+          else if (!_no_constraints)
+            _sys.get_dof_map().constrain_element_matrix_and_vector
+              (_femcontext.get_elem_jacobian(),
+               _femcontext.get_elem_residual(),
+               _femcontext.get_dof_indices(), false);
+        }
       else if (!_no_constraints)
-        _sys.get_dof_map().constrain_element_matrix_and_vector
+        _sys.get_dof_map().heterogeneously_constrain_element_jacobian_and_residual
           (_femcontext.get_elem_jacobian(),
            _femcontext.get_elem_residual(),
-           _femcontext.get_dof_indices(), !constrain_in_solver);
+           _femcontext.get_dof_indices(),
+           *_sys.current_local_solution);
       // Do nothing if (_no_constraints)
     }
   else if (_get_residual)
     {
-      if (_constrain_heterogeneously)
-        _sys.get_dof_map().heterogenously_constrain_element_vector
-          (_femcontext.get_elem_jacobian(),
-           _femcontext.get_elem_residual(),
-           _femcontext.get_dof_indices(), !constrain_in_solver);
+      if (constrain_in_solver)
+        {
+          if (_constrain_heterogeneously)
+            _sys.get_dof_map().heterogenously_constrain_element_vector
+              (_femcontext.get_elem_jacobian(),
+               _femcontext.get_elem_residual(),
+               _femcontext.get_dof_indices(), false);
+          else if (!_no_constraints)
+            _sys.get_dof_map().constrain_element_vector
+              (_femcontext.get_elem_residual(),
+               _femcontext.get_dof_indices(), false);
+        }
       else if (!_no_constraints)
-        _sys.get_dof_map().constrain_element_vector
+        _sys.get_dof_map().heterogeneously_constrain_element_residual
           (_femcontext.get_elem_residual(),
-           _femcontext.get_dof_indices(), !constrain_in_solver);
+           _femcontext.get_dof_indices(),
+           *_sys.current_local_solution);
       // Do nothing if (_no_constraints)
     }
   else if (_get_jacobian)
@@ -307,12 +324,6 @@ void add_element_system(FEMSystem & _sys,
                                                      _femcontext.get_dof_indices(),
                                                      !constrain_in_solver);
     }
-
-  if (_get_residual && !_no_constraints && !constrain_in_solver)
-    _sys.get_dof_map().residual_constrain_element_vector
-      (_femcontext.get_elem_residual(),
-       _femcontext.get_dof_indices(),
-       *_sys.current_local_solution);
 #else
   libmesh_ignore(_constrain_heterogeneously, _no_constraints);
 #endif // #ifdef LIBMESH_ENABLE_CONSTRAINTS


### PR DESCRIPTION
This, combined with updates in app codes, ought to fix #3504.

I'm going to need to retest my corresponding MOOSE branch (it was working before, but I've done a lot of cleanup to the libMesh branch since then) before we merge this, but I'm confident - getting MOOSE problems to work was much easier than getting every combination of adjoints and heterogeneous constraints and NewtonSolver-vs-PetscDiffSolver to work in libMesh examples.