### PR TITLE
Warnings fixes

### DIFF
--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -45,6 +45,8 @@
 #pragma clang diagnostic ignored "-Woverloaded-virtual"
 #pragma clang diagnostic ignored "-Wmacro-redefined"
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#pragma clang diagnostic ignored "-Winvalid-utf8"
 // Ignore warnings from code that does "if (foo) bar();"
 #pragma clang diagnostic ignored "-Wmisleading-indentation"
 #pragma clang diagnostic ignored "-Wint-in-bool-context"

--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -79,6 +79,7 @@
 // And these are for Eigen
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wstack-protector"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 // And this for VTK
 #pragma GCC diagnostic ignored "-Wlogical-op"
 // Ignore warnings from code that uses deprecated members of std, like std::auto_ptr.

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -35,7 +35,9 @@
 #include "libmesh/utility.h"
 
 // poly2tri includes
+#include "libmesh/ignore_warnings.h" // utf-8 comments should be fine...
 #include "poly2tri/poly2tri.h"
+#include "libmesh/restore_warnings.h"
 
 // Anonymous namespace - poly2tri doesn't define operator<(Point,Point)
 namespace

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -698,7 +698,9 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id,
   std::vector<std::vector<dof_id_type>> recv_ids   (this->n_processors());
   std::vector<std::vector<Real>>         recv_coords(this->n_processors());
 
+#ifndef NDEBUG
   std::size_t n_written=0;
+#endif
 
   // Note: do not be tempted to replace the node loops below with
   // range-based iterators, these iterators must be defined outside
@@ -837,7 +839,9 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id,
                 coords[3*local_idx+2] = 0.;
 #endif
 
+#ifndef NDEBUG
                 n_written++;
+#endif
               }
 
           io.data_stream (coords.empty() ? nullptr : coords.data(),
@@ -864,8 +868,10 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id,
   std::vector<xdr_id_type> & unique_ids=xfer_unique_ids;
   std::vector<std::vector<xdr_id_type>> recv_unique_ids (this->n_processors());
 
+#ifndef NDEBUG
   // Reset write counter
   n_written = 0;
+#endif
 
   // Return node iterator to the beginning
   node_iter = mesh.local_nodes_begin();
@@ -976,7 +982,9 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id,
 
                 unique_ids[local_idx] = recv_unique_ids[pid][idx];
 
+#ifndef NDEBUG
                 n_written++;
+#endif
               }
 
           io.data_stream (unique_ids.empty() ? nullptr : unique_ids.data(),
@@ -992,8 +1000,10 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id,
   // Next: do "block"-based I/O for the extra node integers (if necessary)
   if (n_node_integers)
     {
+#ifndef NDEBUG
       // Reset write counter
       n_written = 0;
+#endif
 
       // Return node iterator to the beginning
       node_iter = mesh.local_nodes_begin();
@@ -1127,7 +1137,9 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id,
                     for (unsigned int i=0; i != n_node_integers; ++i)
                       node_integers[n_node_integers*local_idx + i] = recv_node_integers[pid][n_node_integers*idx + i];
 
+#ifndef NDEBUG
                     n_written++;
+#endif
                   }
 
               io.data_stream (node_integers.empty() ? nullptr : node_integers.data(),

--- a/src/utils/point_locator_nanoflann.C
+++ b/src/utils/point_locator_nanoflann.C
@@ -319,7 +319,7 @@ PointLocatorNanoflann::operator() (const Point & p,
   candidate_elements.clear();
 
   // Keep track of the number of elements checked in detail
-  unsigned int n_elems_checked = 0;
+  // unsigned int n_elems_checked = 0;
 
   // Do the KD-Tree search
   auto result_set = this->kd_tree_find_neighbors(p, _num_results);
@@ -350,7 +350,7 @@ PointLocatorNanoflann::operator() (const Point & p,
         candidate_elem->contains_point(p);
 
       // Increment the number of elements checked
-      n_elems_checked++;
+      // n_elems_checked++;
 
       // If the point is contained in/close to an Elem from an
       // allowed subdomain, add it to the list.

--- a/tests/mesh/libmesh_poly2tri.C
+++ b/tests/mesh/libmesh_poly2tri.C
@@ -2,7 +2,9 @@
 #include "libmesh_cppunit.h"
 
 #ifdef LIBMESH_HAVE_POLY2TRI
+#  include "libmesh/ignore_warnings.h" // utf-8 comments should be fine...
 #  include "poly2tri/poly2tri.h"
+#  include "libmesh/restore_warnings.h"
 #endif
 
 #include <numeric>


### PR DESCRIPTION
I'm seeing some troubling issues with clang 15.0.7 and MetaPhysicL, but this fixes everything else it complained about, as well as warnings from g++ 12.2.0