### PR TITLE
Remove possibly bad "copying" of id to name maps

### DIFF
--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -178,23 +178,6 @@ DistributedMesh::DistributedMesh (const DistributedMesh & other_mesh) :
 
   this->set_subdomain_name_map() = other_mesh.get_subdomain_name_map();
 
-  // Use the first BoundaryInfo object to build the list of side boundary ids
-  std::vector<boundary_id_type> side_boundaries;
-  other_boundary_info.build_side_boundary_ids(side_boundaries);
-
-  // Assign those boundary ids in our BoundaryInfo object
-  for (const auto & side_bnd_id : side_boundaries)
-    this_boundary_info.sideset_name(side_bnd_id) =
-      other_boundary_info.get_sideset_name(side_bnd_id);
-
-  // Do the same thing for node boundary ids
-  std::vector<boundary_id_type> node_boundaries;
-  other_boundary_info.build_node_boundary_ids(node_boundaries);
-
-  for (const auto & node_bnd_id : node_boundaries)
-    this_boundary_info.nodeset_name(node_bnd_id) =
-      other_boundary_info.get_nodeset_name(node_bnd_id);
-
   // Need to copy extra_ghost_elems
   for (auto & elem : other_mesh._extra_ghost_elems)
     _extra_ghost_elems.insert(this->elem_ptr(elem->id()));
@@ -219,23 +202,6 @@ DistributedMesh::DistributedMesh (const UnstructuredMesh & other_mesh) :
   this_boundary_info = other_boundary_info;
 
   this->set_subdomain_name_map() = other_mesh.get_subdomain_name_map();
-
-  // Use the first BoundaryInfo object to build the list of side boundary ids
-  std::vector<boundary_id_type> side_boundaries;
-  other_boundary_info.build_side_boundary_ids(side_boundaries);
-
-  // Assign those boundary ids in our BoundaryInfo object
-  for (const auto & side_bnd_id : side_boundaries)
-    this_boundary_info.sideset_name(side_bnd_id) =
-      other_boundary_info.get_sideset_name(side_bnd_id);
-
-  // Do the same thing for node boundary ids
-  std::vector<boundary_id_type> node_boundaries;
-  other_boundary_info.build_node_boundary_ids(node_boundaries);
-
-  for (const auto & node_bnd_id : node_boundaries)
-    this_boundary_info.nodeset_name(node_bnd_id) =
-      other_boundary_info.get_nodeset_name(node_bnd_id);
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
   _next_unique_id = other_mesh.parallel_max_unique_id() +

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -99,23 +99,6 @@ ReplicatedMesh::ReplicatedMesh (const ReplicatedMesh & other_mesh) :
 
   this->set_subdomain_name_map() = other_mesh.get_subdomain_name_map();
 
-  // Use the first BoundaryInfo object to build the list of side boundary ids
-  std::vector<boundary_id_type> side_boundaries;
-  other_boundary_info.build_side_boundary_ids(side_boundaries);
-
-  // Assign those boundary ids in our BoundaryInfo object
-  for (const auto & side_bnd_id : side_boundaries)
-    this_boundary_info.sideset_name(side_bnd_id) =
-      other_boundary_info.get_sideset_name(side_bnd_id);
-
-  // Do the same thing for node boundary ids
-  std::vector<boundary_id_type> node_boundaries;
-  other_boundary_info.build_node_boundary_ids(node_boundaries);
-
-  for (const auto & node_bnd_id : node_boundaries)
-    this_boundary_info.nodeset_name(node_bnd_id) =
-      other_boundary_info.get_nodeset_name(node_bnd_id);
-
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
   this->_next_unique_id = other_mesh._next_unique_id;
 #endif
@@ -134,23 +117,6 @@ ReplicatedMesh::ReplicatedMesh (const UnstructuredMesh & other_mesh) :
   this_boundary_info = other_boundary_info;
 
   this->set_subdomain_name_map() = other_mesh.get_subdomain_name_map();
-
-  // Use the first BoundaryInfo object to build the list of side boundary ids
-  std::vector<boundary_id_type> side_boundaries;
-  other_boundary_info.build_side_boundary_ids(side_boundaries);
-
-  // Assign those boundary ids in our BoundaryInfo object
-  for (const auto & side_bnd_id : side_boundaries)
-    this_boundary_info.sideset_name(side_bnd_id) =
-      other_boundary_info.get_sideset_name(side_bnd_id);
-
-  // Do the same thing for node boundary ids
-  std::vector<boundary_id_type> node_boundaries;
-  other_boundary_info.build_node_boundary_ids(node_boundaries);
-
-  for (const auto & node_bnd_id : node_boundaries)
-    this_boundary_info.nodeset_name(node_bnd_id) =
-      other_boundary_info.get_nodeset_name(node_bnd_id);
 }
 
 ReplicatedMesh & ReplicatedMesh::operator= (ReplicatedMesh && other_mesh)


### PR DESCRIPTION
The lines I'm removing will iterate over all the boundary IDs in the boundary info and then add to the map from id to name after querying the boundary info we're copying from. However, methods like `get_sideset_name` will happily return an empty string if the query ID doesn't have a corresponding name. And then we insert the empty string into the boundary info we're copy assigning. This pedantically makes the boundary info non-equal. I added these bad lines back in #2028. Roy added the correct fix in #2634. Let's just rely on that.

Refs #3516