### PR TITLE
Remove setting of skip_noncritical_partitioning in copy_nodes_and_elements

### DIFF
--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -503,7 +503,6 @@ void UnstructuredMesh::copy_nodes_and_elements(const MeshBase & other_mesh,
   this->allow_renumbering(other_mesh.allow_renumbering());
   this->allow_remote_element_removal(other_mesh.allow_remote_element_removal());
   this->skip_partitioning(other_mesh.skip_partitioning());
-  this->skip_noncritical_partitioning(other_mesh.skip_noncritical_partitioning());
 }
 
 


### PR DESCRIPTION
Pull #3301 abstracted so that we could use MeshBase objects in `copy_nodes_and_elements`. However, this had the unfortunate effect of conceptually changing the effect that calling the `skip_noncritical_partitioning` setter had. The getter for `skip_noncritical_partitioning` checks three booleans. The setter only sets one. This has consequences for `operator==` comparisons for meshes. Since are not modifying the value of `_skip_noncritical_partitioning` before the `prepare_for_use()` here I really see no need for the setter I'm removing. That doesn't seem like a job for `copy_nodes_and_elements`