### PR TITLE
Avoid using direct `new` calls in examples

### DIFF
--- a/examples/adjoints/adjoints_ex2/adjoints_ex2.C
+++ b/examples/adjoints/adjoints_ex2/adjoints_ex2.C
@@ -191,16 +191,15 @@ void set_system_parameters(LaplaceSystem & system, FEMParameters & param)
   if (param.use_petsc_snes)
   {
 #ifdef LIBMESH_HAVE_PETSC
-    PetscDiffSolver *solver = new PetscDiffSolver(system);
-    system.time_solver->diff_solver().reset(solver);
+    system.time_solver->diff_solver() = std::make_unique<PetscDiffSolver>(system);
 #else
     libmesh_error_msg("This example requires libMesh to be compiled with PETSc support.");
 #endif
   }
   else
   {
-    NewtonSolver * solver = new NewtonSolver(system);
-    system.time_solver->diff_solver() = std::unique_ptr<DiffSolver>(solver);
+    system.time_solver->diff_solver() = std::make_unique<NewtonSolver>(system);
+    auto solver = cast_ptr<NewtonSolver*>(system.time_solver->diff_solver().get());
 
     solver->quiet                       = param.solver_quiet;
     solver->max_nonlinear_iterations    = param.max_nonlinear_iterations;
@@ -230,7 +229,7 @@ void set_system_parameters(LaplaceSystem & system, FEMParameters & param)
 std::unique_ptr<MeshRefinement> build_mesh_refinement(MeshBase & mesh,
                                                       FEMParameters & param)
 {
-  MeshRefinement * mesh_refinement = new MeshRefinement(mesh);
+  auto mesh_refinement = std::make_unique<MeshRefinement>(mesh);
   mesh_refinement->coarsen_by_parents() = true;
   mesh_refinement->absolute_global_tolerance() = param.global_tolerance;
   mesh_refinement->nelem_target()      = param.nelem_target;
@@ -238,7 +237,7 @@ std::unique_ptr<MeshRefinement> build_mesh_refinement(MeshBase & mesh,
   mesh_refinement->coarsen_fraction()  = param.coarsen_fraction;
   mesh_refinement->coarsen_threshold() = param.coarsen_threshold;
 
-  return std::unique_ptr<MeshRefinement>(mesh_refinement);
+  return mesh_refinement;
 }
 
 #endif // LIBMESH_ENABLE_AMR
@@ -262,21 +261,17 @@ std::unique_ptr<ErrorEstimator> build_error_estimator(FEMParameters & param)
     {
       libMesh::out << "Using Adjoint Residual Error Estimator with Patch Recovery Weights" << std::endl << std::endl;
 
-      AdjointResidualErrorEstimator * adjoint_residual_estimator = new AdjointResidualErrorEstimator;
+      auto adjoint_residual_estimator = std::make_unique<AdjointResidualErrorEstimator>();
 
       adjoint_residual_estimator->error_plot_suffix = "error.gmv";
 
-      PatchRecoveryErrorEstimator * p1 = new PatchRecoveryErrorEstimator;
-      adjoint_residual_estimator->primal_error_estimator().reset(p1);
-
-      PatchRecoveryErrorEstimator * p2 = new PatchRecoveryErrorEstimator;
-      adjoint_residual_estimator->dual_error_estimator().reset(p2);
-
+      adjoint_residual_estimator->primal_error_estimator() = std::make_unique<PatchRecoveryErrorEstimator>();
       adjoint_residual_estimator->primal_error_estimator()->error_norm.set_type(0, H1_SEMINORM);
 
+      adjoint_residual_estimator->dual_error_estimator() = std::make_unique<PatchRecoveryErrorEstimator>();
       adjoint_residual_estimator->dual_error_estimator()->error_norm.set_type(0, H1_SEMINORM);
 
-      return std::unique_ptr<ErrorEstimator>(adjoint_residual_estimator);
+      return adjoint_residual_estimator;
     }
   else
     libmesh_error_msg("Unknown indicator_type = " << param.indicator_type);

--- a/examples/adjoints/adjoints_ex3/H-qoi.h
+++ b/examples/adjoints/adjoints_ex3/H-qoi.h
@@ -16,6 +16,7 @@ class CoupledSystemQoI : public DifferentiableQoI
 {
 public:
   CoupledSystemQoI() = default;
+  CoupledSystemQoI(const CoupledSystemQoI &) = default;
   virtual ~CoupledSystemQoI() = default;
 
   virtual void init_qoi_count(System & sys);
@@ -31,9 +32,8 @@ public:
 
   virtual std::unique_ptr<DifferentiableQoI> clone()
   {
-    DifferentiableQoI * my_clone = new CoupledSystemQoI;
-    *my_clone = *this;
-    return std::unique_ptr<DifferentiableQoI>(my_clone);
+    // Calls defaulted copy constructor for this class
+    return std::make_unique<CoupledSystemQoI>(*this);
   }
 
 protected:

--- a/examples/adjoints/adjoints_ex4/adjoints_ex4.C
+++ b/examples/adjoints/adjoints_ex4/adjoints_ex4.C
@@ -181,16 +181,15 @@ void set_system_parameters(LaplaceSystem & system,
   if (param.use_petsc_snes)
   {
 #ifdef LIBMESH_HAVE_PETSC
-    PetscDiffSolver *solver = new PetscDiffSolver(system);
-    system.time_solver->diff_solver().reset(solver);
+    system.time_solver->diff_solver() = std::make_unique<PetscDiffSolver>(system);
 #else
     libmesh_error_msg("This example requires libMesh to be compiled with PETSc support.");
 #endif
   }
   else
   {
-    NewtonSolver * solver = new NewtonSolver(system);
-    system.time_solver->diff_solver() = std::unique_ptr<DiffSolver>(solver);
+    system.time_solver->diff_solver() = std::make_unique<NewtonSolver>(system);
+    auto solver = cast_ptr<NewtonSolver*>(system.time_solver->diff_solver().get());
 
     solver->quiet                       = param.solver_quiet;
     solver->max_nonlinear_iterations    = param.max_nonlinear_iterations;
@@ -220,7 +219,7 @@ void set_system_parameters(LaplaceSystem & system,
 std::unique_ptr<MeshRefinement> build_mesh_refinement(MeshBase & mesh,
                                                       FEMParameters & param)
 {
-  MeshRefinement * mesh_refinement = new MeshRefinement(mesh);
+  auto mesh_refinement = std::make_unique<MeshRefinement>(mesh);
   mesh_refinement->coarsen_by_parents() = true;
   mesh_refinement->absolute_global_tolerance() = param.global_tolerance;
   mesh_refinement->nelem_target()      = param.nelem_target;
@@ -228,7 +227,7 @@ std::unique_ptr<MeshRefinement> build_mesh_refinement(MeshBase & mesh,
   mesh_refinement->coarsen_fraction()  = param.coarsen_fraction;
   mesh_refinement->coarsen_threshold() = param.coarsen_threshold;
 
-  return std::unique_ptr<MeshRefinement>(mesh_refinement);
+  return mesh_refinement;
 }
 
 // This is where declare the adjoint refined error estimator. This estimator builds an error bound
@@ -238,14 +237,14 @@ std::unique_ptr<AdjointRefinementEstimator> build_adjoint_refinement_error_estim
 {
   libMesh::out << "Computing the error estimate using the Adjoint Refinement Error Estimator" << std::endl << std::endl;
 
-  AdjointRefinementEstimator *adjoint_refinement_estimator = new AdjointRefinementEstimator;
+  auto adjoint_refinement_estimator = std::make_unique<AdjointRefinementEstimator>();
 
   adjoint_refinement_estimator->qoi_set() = qois;
 
   // We enrich the FE space for the dual problem by doing 2 uniform h refinements
   adjoint_refinement_estimator->number_h_refinements = 2;
 
-  return std::unique_ptr<AdjointRefinementEstimator>(adjoint_refinement_estimator);
+  return adjoint_refinement_estimator;
 }
 
 #endif // LIBMESH_ENABLE_AMR

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -202,41 +202,32 @@ void set_system_parameters(HeatSystem &system, FEMParameters &param)
   // Solve this as a time-dependent or steady system
   if (param.transient)
     {
-      UnsteadySolver *innersolver;
+      std::unique_ptr<UnsteadySolver> innersolver;
       if (param.timesolver_core == "euler2")
         {
-          Euler2Solver *euler2solver =
-            new Euler2Solver(system);
-
+          auto euler2solver = std::make_unique<Euler2Solver>(system);
           euler2solver->theta = param.timesolver_theta;
-          innersolver = euler2solver;
+          innersolver = std::move(euler2solver);
         }
       else if (param.timesolver_core == "euler")
         {
-          EulerSolver *eulersolver =
-            new EulerSolver(system);
-
+          auto eulersolver = std::make_unique<EulerSolver>(system);
           eulersolver->theta = param.timesolver_theta;
-          innersolver = eulersolver;
+          innersolver = std::move(eulersolver);
         }
       else
         libmesh_error_msg("This example (and unsteady adjoints in libMesh) only support Backward Euler and explicit methods.");
 
       if (param.timesolver_tolerance)
         {
-          TwostepTimeSolver *timesolver =
-            new TwostepTimeSolver(system);
+          system.time_solver = std::make_unique<TwostepTimeSolver>(system);
+          auto timesolver = cast_ptr<TwostepTimeSolver *>(system.time_solver.get());
 
           timesolver->max_growth       = param.timesolver_maxgrowth;
           timesolver->target_tolerance = param.timesolver_tolerance;
           timesolver->upper_tolerance  = param.timesolver_upper_tolerance;
           timesolver->component_norm   = SystemNorm(param.timesolver_norm);
-
-          timesolver->core_time_solver =
-            std::unique_ptr<UnsteadySolver>(innersolver);
-
-          system.time_solver =
-            std::unique_ptr<UnsteadySolver>(timesolver);
+          timesolver->core_time_solver = std::move(innersolver);
 
           // The Memory/File Solution History object we will set the system SolutionHistory object to
           if(param.solution_history_type == "memory")
@@ -250,13 +241,11 @@ void set_system_parameters(HeatSystem &system, FEMParameters &param)
             system.time_solver->set_solution_history(heatsystem_solution_history);
           }
           else
-          libmesh_error_msg("Unrecognized solution history type: " << param.solution_history_type);
-
+            libmesh_error_msg("Unrecognized solution history type: " << param.solution_history_type);
         }
       else
       {
-        system.time_solver =
-          std::unique_ptr<TimeSolver>(innersolver);
+        system.time_solver = std::move(innersolver);
 
         // The Memory/File Solution History object we will set the system SolutionHistory object to
         if(param.solution_history_type == "memory")
@@ -270,17 +259,14 @@ void set_system_parameters(HeatSystem &system, FEMParameters &param)
           system.time_solver->set_solution_history(heatsystem_solution_history);
         }
         else
-        libmesh_error_msg("Unrecognized solution history type: " << param.solution_history_type);
-
+          libmesh_error_msg("Unrecognized solution history type: " << param.solution_history_type);
       }
     }
-  else
-    system.time_solver =
-      std::unique_ptr<TimeSolver>(new SteadySolver(system));
+  else // !param.transient
+    system.time_solver = std::make_unique<SteadySolver>(system);
 
-  system.time_solver->reduce_deltat_on_diffsolver_failure =
-                                        param.deltat_reductions;
-  system.time_solver->quiet           = param.time_solver_quiet;
+  system.time_solver->reduce_deltat_on_diffsolver_failure = param.deltat_reductions;
+  system.time_solver->quiet = param.time_solver_quiet;
 
  #ifdef LIBMESH_ENABLE_DIRICHLET
   // Create any Dirichlet boundary conditions
@@ -315,16 +301,15 @@ void set_system_parameters(HeatSystem &system, FEMParameters &param)
   if (param.use_petsc_snes)
     {
 #ifdef LIBMESH_HAVE_PETSC
-      PetscDiffSolver *solver = new PetscDiffSolver(system);
-      system.time_solver->diff_solver() = std::unique_ptr<DiffSolver>(solver);
+      system.time_solver->diff_solver() = std::make_unique<PetscDiffSolver>(system);
 #else
       libmesh_error_msg("This example requires libMesh to be compiled with PETSc support.");
 #endif
     }
   else
     {
-      NewtonSolver *solver = new NewtonSolver(system);
-      system.time_solver->diff_solver() = std::unique_ptr<DiffSolver>(solver);
+      system.time_solver->diff_solver() = std::make_unique<NewtonSolver>(system);
+      auto solver = cast_ptr<NewtonSolver *>(system.time_solver->diff_solver().get());
 
       solver->quiet                       = param.solver_quiet;
       solver->verbose                     = param.solver_verbose;

--- a/examples/adjoints/adjoints_ex7/adjoints_ex7.C
+++ b/examples/adjoints/adjoints_ex7/adjoints_ex7.C
@@ -390,7 +390,7 @@ int main (int argc, char ** argv)
   set_system_parameters(system, param);
 
   // Also build an FEMPhysics to provide the residual definition for the adjoint activities
-  SigmaPhysics* sigma_physics = new SigmaPhysics();
+  auto sigma_physics = std::make_unique<SigmaPhysics>();
   sigma_physics->init_data(system);
 
   libMesh::out << "Initializing systems" << std::endl;
@@ -739,7 +739,7 @@ int main (int argc, char ** argv)
 
       // The adjoint refinement error estimator object (which also computed model error)
       auto adjoint_refinement_error_estimator =
-        build_adjoint_refinement_error_estimator(qois, dynamic_cast<FEMPhysics *>(sigma_physics), param);
+        build_adjoint_refinement_error_estimator(qois, dynamic_cast<FEMPhysics *>(sigma_physics.get()), param);
 
       // Error Vector to be filled by the error estimator at each timestep
       ErrorVector QoI_elementwise_error;

--- a/examples/fem_system/fem_system_ex4/fem_system_ex4.C
+++ b/examples/fem_system/fem_system_ex4/fem_system_ex4.C
@@ -217,14 +217,12 @@ int main (int argc, char ** argv)
           // size at once
           libmesh_assert_equal_to (nelem_target, 0);
 
-          UniformRefinementEstimator * u =
-            new UniformRefinementEstimator;
+          auto u = std::make_unique<UniformRefinementEstimator>();
 
           // The lid-driven cavity problem isn't in H1, so
           // lets estimate L2 error
           u->error_norm = L2;
-
-          error_estimator.reset(u);
+          error_estimator = std::move(u);
         }
       else
         {

--- a/examples/miscellaneous/miscellaneous_ex6/miscellaneous_ex6.C
+++ b/examples/miscellaneous/miscellaneous_ex6/miscellaneous_ex6.C
@@ -310,7 +310,7 @@ void add_cube_convex_hull_to_mesh(MeshBase & mesh,
   for (auto & old_elem : cube_mesh.element_ptr_range())
     if (old_elem->type() == TRI3)
       {
-        Elem * new_elem = mesh.add_elem(new Tri3);
+        Elem * new_elem = mesh.add_elem(Elem::build(TRI3));
 
         // Assign nodes in new elements.  Since this is an example,
         // we'll do it in several steps.


### PR DESCRIPTION
As mentioned on #3519, we still had some instances of pre-C++14 std::unique_ptr use in the examples; this branch cleans up all the ones I could find.