### PR TITLE
Avoid using `new` in unit tests

### DIFF
--- a/tests/fe/dual_shape_verification_test.C
+++ b/tests/fe/dual_shape_verification_test.C
@@ -24,9 +24,9 @@ public:
   CPPUNIT_TEST_SUITE_END();
 
 private:
-  Mesh * _mesh;
-  QGauss * _qrule;
-  FEBase * _fe;
+  std::unique_ptr<Mesh> _mesh;
+  std::unique_ptr<QGauss> _qrule;
+  std::unique_ptr<FEBase> _fe;
   Elem * _elem;
 
 public:
@@ -71,27 +71,22 @@ public:
   void setUp()
     {
       FEType fe_type(FIRST, LAGRANGE);
-      _fe = FEBase::build(1, fe_type).release();
+      _fe = FEBase::build(1, fe_type);
       _fe->get_phi();
       _fe->get_dual_phi();
 
-      _mesh = new Mesh(*TestCommWorld);
+      _mesh = std::make_unique<Mesh>(*TestCommWorld);
 
       MeshTools::Generation::build_line(*_mesh, 1, -1, 1, EDGE2);
 
       auto rng = _mesh->active_local_element_ptr_range();
       _elem = rng.begin() == rng.end() ? nullptr : *(rng.begin());
 
-      _qrule = new QGauss(1, fe_type.default_quadrature_order());
-      _fe->attach_quadrature_rule(_qrule);
+      _qrule = std::make_unique<QGauss>(1, fe_type.default_quadrature_order());
+      _fe->attach_quadrature_rule(_qrule.get());
     }
 
-  void tearDown()
-    {
-      delete _mesh;
-      delete _fe;
-      delete _qrule;
-    }
+  void tearDown() {}
 
 };
 

--- a/tests/fe/fe_side_test.C
+++ b/tests/fe/fe_side_test.C
@@ -41,8 +41,8 @@ template <Order order, FEFamily family, ElemType elem_type>
 class FESideTest : public FETestBase<order, family, elem_type, N_x> {
 
 private:
-  FEBase * _fe_side;
-  QGauss * _qrule_side;
+  std::unique_ptr<FEBase> _fe_side;
+  std::unique_ptr<QGauss> _qrule_side;
 
 public:
   void setUp()
@@ -50,10 +50,10 @@ public:
     FETestBase<order,family,elem_type,N_x>::setUp();
 
     FEType fe_type = this->_sys->variable_type(0);
-    _fe_side = FEBase::build(this->_dim, fe_type).release();
+    _fe_side = FEBase::build(this->_dim, fe_type);
 
-    _qrule_side = new QGauss(this->_dim-1, fe_type.default_quadrature_order());
-    _fe_side->attach_quadrature_rule(this->_qrule_side);
+    _qrule_side = std::make_unique<QGauss>(this->_dim-1, fe_type.default_quadrature_order());
+    _fe_side->attach_quadrature_rule(this->_qrule_side.get());
 
     _fe_side->get_xyz();
     _fe_side->get_normals();
@@ -94,8 +94,6 @@ public:
 
   void tearDown()
   {
-    delete _fe_side;
-    delete _qrule_side;
     FETestBase<order,family,elem_type,N_x>::tearDown();
   }
 

--- a/tests/fe/fe_test.h
+++ b/tests/fe/fe_test.h
@@ -1,5 +1,5 @@
-#ifndef __fe_test_h__
-#define __fe_test_h__
+#ifndef FE_TEST_H
+#define FE_TEST_H
 
 #include "test_comm.h"
 
@@ -903,4 +903,4 @@ public:
                                                                         \
   CPPUNIT_TEST_SUITE_REGISTRATION( FETest_##order##_##family##_##elemtype );
 
-#endif // #ifdef __fe_test_h__
+#endif

--- a/tests/geom/node_test.C
+++ b/tests/geom/node_test.C
@@ -24,7 +24,7 @@ public:
 
 private:
 
-  Node * dof_object_instance;
+  std::unique_ptr<Node> dof_object_instance;
 
 public:
 
@@ -32,15 +32,13 @@ public:
   {
     PointTestBase<Node>::setUp();
 
-    dof_object_instance = new Node(1,1,1);
-    DofObjectTest<Node>::setUp(dof_object_instance);
+    dof_object_instance = std::make_unique<Node>(1,1,1);
+    DofObjectTest<Node>::setUp(dof_object_instance.get());
   }
 
   virtual void tearDown()
   {
     PointTestBase<Node>::tearDown();
-
-    delete dof_object_instance;
   }
 
 };

--- a/tests/mesh/boundary_points.C
+++ b/tests/mesh/boundary_points.C
@@ -25,11 +25,11 @@ public:
 
 protected:
 
-  ReplicatedMesh* _mesh;
+  std::unique_ptr<ReplicatedMesh> _mesh;
 
   void build_mesh()
   {
-    _mesh = new ReplicatedMesh(*TestCommWorld, 2);
+    _mesh = std::make_unique<ReplicatedMesh>(*TestCommWorld, 2);
 
     // (0,1)           (1,1)           (2,1) (3,1)       (4,1)       (5,1)       (6,1)
     // x---------------x---------------x     x-----------x-----------x-----------x
@@ -175,10 +175,7 @@ public:
 #endif
   }
 
-  void tearDown()
-  {
-    delete _mesh;
-  }
+  void tearDown() {}
 
   void testMesh()
   {

--- a/tests/mesh/mesh_function_dfem.C
+++ b/tests/mesh/mesh_function_dfem.C
@@ -59,12 +59,12 @@ public:
   CPPUNIT_TEST_SUITE_END();
 
 protected:
-  ReplicatedMesh * _mesh;
+  std::unique_ptr<ReplicatedMesh> _mesh;
   std::unique_ptr<PointLocatorBase> _point_locator;
 
   void build_mesh()
   {
-    _mesh = new ReplicatedMesh(*TestCommWorld);
+    _mesh = std::make_unique<ReplicatedMesh>(*TestCommWorld);
 
     // (0,1)           (1,1)
     // x---------------x
@@ -120,12 +120,7 @@ public:
 #endif
   }
 
-  void tearDown()
-  {
-#if LIBMESH_DIM > 1
-    delete _mesh;
-#endif
-  }
+  void tearDown() {}
 
   // test that point locator works correctly
   void test_point_locator_dfem()

--- a/tests/mesh/mixed_dim_mesh_test.C
+++ b/tests/mesh/mixed_dim_mesh_test.C
@@ -36,11 +36,11 @@ public:
 
 protected:
 
-  ReplicatedMesh* _mesh;
+  std::unique_ptr<ReplicatedMesh> _mesh;
 
   void build_mesh()
   {
-    _mesh = new ReplicatedMesh(*TestCommWorld);
+    _mesh = std::make_unique<ReplicatedMesh>(*TestCommWorld);
 
     // (0,1)           (1,1)
     // x---------------x
@@ -100,10 +100,7 @@ public:
 #endif
   }
 
-  void tearDown()
-  {
-    delete _mesh;
-  }
+  void tearDown() {}
 
   void testMesh()
   {
@@ -371,11 +368,11 @@ public:
   // Yes, this is necessary. Somewhere in those macros is a protected/private
 protected:
 
-  ReplicatedMesh* _mesh;
+  std::unique_ptr<ReplicatedMesh> _mesh;
 
   void build_mesh()
   {
-    _mesh = new ReplicatedMesh(*TestCommWorld);
+    _mesh = std::make_unique<ReplicatedMesh>(*TestCommWorld);
     // We start with this
     //
     //
@@ -504,12 +501,7 @@ public:
 #endif
   }
 
-  void tearDown()
-  {
-#if LIBMESH_DIM > 1
-    delete _mesh;
-#endif
-  }
+  void tearDown() {}
 
   void testMesh()
   {
@@ -632,11 +624,11 @@ public:
 
 protected:
 
-  ReplicatedMesh* _mesh;
+  std::unique_ptr<ReplicatedMesh> _mesh;
 
   void build_mesh()
   {
-    _mesh = new ReplicatedMesh(*TestCommWorld);
+    _mesh = std::make_unique<ReplicatedMesh>(*TestCommWorld);
 
     /**
      * We start with this
@@ -735,12 +727,7 @@ public:
 #endif
   }
 
-  void tearDown()
-  {
-#if LIBMESH_DIM > 1
-    delete _mesh;
-#endif
-  }
+  void tearDown() {}
 
   void testMesh()
   {
@@ -898,11 +885,11 @@ public:
   // Yes, this is necessary. Somewhere in those macros is a protected/private
 protected:
 
-  ReplicatedMesh* _mesh;
+  std::unique_ptr<ReplicatedMesh> _mesh;
 
   void build_mesh()
   {
-    _mesh = new ReplicatedMesh(*TestCommWorld);
+    _mesh = std::make_unique<ReplicatedMesh>(*TestCommWorld);
 
     _mesh->set_mesh_dimension(3);
 
@@ -967,12 +954,7 @@ public:
 #endif
   }
 
-  void tearDown()
-  {
-#if LIBMESH_DIM > 2
-    delete _mesh;
-#endif
-  }
+  void tearDown() {}
 
   void testMesh()
   {

--- a/tests/mesh/slit_mesh_test.C
+++ b/tests/mesh/slit_mesh_test.C
@@ -81,11 +81,11 @@ public:
 
 protected:
 
-  Mesh* _mesh;
+  std::unique_ptr<Mesh> _mesh;
 
   void build_mesh()
   {
-    _mesh = new Mesh(*TestCommWorld);
+    _mesh = std::make_unique<Mesh>(*TestCommWorld);
 
     // (-1,1)     (0,1)      (1,1)      (2,1)      (3,1)
     // o----------o----------o----------o----------o
@@ -185,10 +185,7 @@ public:
 #endif
   }
 
-  void tearDown()
-  {
-    delete _mesh;
-  }
+  void tearDown() {}
 
   void testMesh()
   {
@@ -288,7 +285,7 @@ public:
 protected:
 
   System* _sys;
-  EquationSystems* _es;
+  std::unique_ptr<EquationSystems> _es;
 
 public:
 
@@ -301,7 +298,7 @@ public:
     // have contiguous ids, which is a requirement to write xda files.
     _mesh->allow_renumbering(true);
 
-    _es = new EquationSystems(*_mesh);
+    _es = std::make_unique<EquationSystems>(*_mesh);
     _sys = &_es->add_system<System> ("SimpleSystem");
     _sys->add_variable("u", FIRST);
 
@@ -318,12 +315,7 @@ public:
 #endif
   }
 
-  void tearDown()
-  {
-    delete _es;
-    // _sys is owned by _es
-    delete _mesh;
-  }
+  void tearDown() {}
 
   void testMesh()
   {

--- a/tests/numerics/eigen_sparse_vector_test.C
+++ b/tests/numerics/eigen_sparse_vector_test.C
@@ -8,20 +8,26 @@
 using namespace libMesh;
 
 class EigenSparseVectorTest : public NumericVectorTest<EigenSparseVector<Number>> {
+private:
+  // This class manages the memory for the communicator it uses,
+  // providing a dumb pointer to the managed resource for the base
+  // class.
+  std::unique_ptr<Parallel::Communicator> _managed_comm;
+
 public:
   void setUp()
   {
     // Eigen doesn't support distributed parallel vectors, but we can
     // build a serial vector on each processor
-    my_comm = new Parallel::Communicator();
+    _managed_comm = std::make_unique<Parallel::Communicator>();
+
+    // Base class communicator points to our managed communicator
+    my_comm = _managed_comm.get();
 
     this->NumericVectorTest<EigenSparseVector<Number>>::setUp();
   }
 
-  void tearDown()
-  {
-    delete my_comm;
-  }
+  void tearDown() {}
 
   EigenSparseVectorTest() :
     NumericVectorTest<EigenSparseVector<Number>>() {

--- a/tests/numerics/laspack_vector_test.C
+++ b/tests/numerics/laspack_vector_test.C
@@ -9,20 +9,26 @@ using namespace libMesh;
 
 class LaspackVectorTest : public NumericVectorTest<LaspackVector<Number>>
 {
+private:
+  // This class manages the memory for the communicator it uses,
+  // providing a dumb pointer to the managed resource for the base
+  // class.
+  std::unique_ptr<Parallel::Communicator> _managed_comm;
+
 public:
   void setUp()
   {
     // Laspack doesn't support distributed parallel vectors, but we
     // can build a serial vector on each processor
-    my_comm = new Parallel::Communicator();
+    _managed_comm = std::make_unique<Parallel::Communicator>();
+
+    // Base class communicator points to our managed communicator
+    my_comm = _managed_comm.get();
 
     this->NumericVectorTest<LaspackVector<Number>>::setUp();
   }
 
-  void tearDown()
-  {
-    delete my_comm;
-  }
+  void tearDown() {}
 
   LaspackVectorTest() :
     NumericVectorTest<LaspackVector<Number>>() {

--- a/tests/numerics/numeric_vector_test.h
+++ b/tests/numerics/numeric_vector_test.h
@@ -1,5 +1,5 @@
-#ifndef __numeric_vector_test_h__
-#define __numeric_vector_test_h__
+#ifndef NUMERIC_VECTOR_TEST_H
+#define NUMERIC_VECTOR_TEST_H
 
 // test includes
 #include "test_comm.h"
@@ -344,4 +344,4 @@ public:
   }
 };
 
-#endif // #ifdef __numeric_vector_test_h__
+#endif

--- a/tests/numerics/type_vector_test.h
+++ b/tests/numerics/type_vector_test.h
@@ -1,5 +1,5 @@
-#ifndef __type_vector_test_h__
-#define __type_vector_test_h__
+#ifndef TYPE_VECTOR_TEST_H
+#define TYPE_VECTOR_TEST_H
 
 #include <libmesh/type_vector.h>
 
@@ -505,4 +505,4 @@ public:
   }
 };
 
-#endif // #ifdef __type_vector_test_h__
+#endif

--- a/tests/numerics/type_vector_test.h
+++ b/tests/numerics/type_vector_test.h
@@ -64,14 +64,15 @@ protected:
   std::string libmesh_suite_name;
 
 private:
-  DerivedClass *m_1_1_1, *m_n1_1_n1;
+  std::unique_ptr<DerivedClass> m_1_1_1;
+  std::unique_ptr<DerivedClass> m_n1_1_n1;
   TypeVector<T>   *basem_1_1_1, *basem_n1_1_n1;
 
 public:
   virtual void setUp()
   {
-    m_1_1_1 = new DerivedClass(1);
-    m_n1_1_n1 = new DerivedClass(-1);
+    m_1_1_1 = std::make_unique<DerivedClass>(1);
+    m_n1_1_n1 = std::make_unique<DerivedClass>(-1);
 
 #if LIBMESH_DIM > 1
     (*m_1_1_1)(1) = 1;
@@ -83,15 +84,11 @@ public:
 #endif
 
 
-    basem_1_1_1 = m_1_1_1;
-    basem_n1_1_n1 = m_n1_1_n1;
+    basem_1_1_1 = m_1_1_1.get();
+    basem_n1_1_n1 = m_n1_1_n1.get();
   }
 
-  virtual void tearDown()
-  {
-    delete m_1_1_1;
-    delete m_n1_1_n1;
-  }
+  virtual void tearDown() {}
 
   void testValue()
   {

--- a/tests/partitioning/partitioner_test.h
+++ b/tests/partitioning/partitioner_test.h
@@ -1,5 +1,5 @@
-#ifndef __fe_test_h__
-#define __fe_test_h__
+#ifndef PARTITIONER_TEST_H
+#define PARTITIONER_TEST_H
 
 #include <libmesh/distributed_mesh.h>
 #include <libmesh/elem.h>
@@ -159,4 +159,4 @@ public:
                                                                             \
   CPPUNIT_TEST_SUITE_REGISTRATION( PartitionerTest_##partitionersubclass##_##meshclass );
 
-#endif // #ifdef __fe_test_h__
+#endif


### PR DESCRIPTION
Similar to #3529, clean up some pre-C++14 code using `std::make_unique` in the unit tests. This saves a few lines by obviating the need for manual `tearDown()` implementations.