### PR TITLE
Add and use copy_constraint_rows

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1863,8 +1863,14 @@ public:
   const std::map<subdomain_id_type, std::string> & get_subdomain_name_map () const
   { return _block_id_to_name; }
 
-  typedef std::map<const Node *, std::vector<std::pair<std::pair<const Elem *, unsigned int>, Real>>>
-    constraint_rows_type;
+  typedef std::vector<std::pair<std::pair<const Elem *, unsigned int>, Real>> constraint_rows_mapped_type;
+  typedef std::map<const Node *, constraint_rows_mapped_type> constraint_rows_type;
+
+
+  /**
+   * Copy the constraints from the other mesh to this mesh
+   */
+  void copy_constraint_rows(const MeshBase & other_mesh);
 
   constraint_rows_type & get_constraint_rows()
   { return _constraint_rows; }
@@ -2162,7 +2168,7 @@ protected:
   // constrained in terms of values on spline control nodes.
   //
   // _constraint_rows[constrained_node_id][i].first.first is an
-  // element id,
+  // element,
   // _constraint_rows[constrained_node_id][i].first.second is the
   // local node id of that element which is a constraining node,
   // _constraint_rows[constrained_node_id][i].second is that node's

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -152,6 +152,7 @@ DistributedMesh::DistributedMesh (const DistributedMesh & other_mesh) :
   _next_free_unpartitioned_elem_id(this->n_processors())
 {
   this->copy_nodes_and_elements(other_mesh, true);
+  this->copy_constraint_rows(other_mesh);
   _n_nodes = other_mesh.n_nodes();
   _n_elem  = other_mesh.n_elem();
   _max_node_id = other_mesh.max_node_id();
@@ -195,6 +196,7 @@ DistributedMesh::DistributedMesh (const UnstructuredMesh & other_mesh) :
   _next_free_unpartitioned_elem_id(this->n_processors())
 {
   this->copy_nodes_and_elements(other_mesh, true);
+  this->copy_constraint_rows(other_mesh);
 
   auto & this_boundary_info = this->get_boundary_info();
   const auto & other_boundary_info = other_mesh.get_boundary_info();

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -1925,5 +1925,22 @@ bool MeshBase::nodes_and_elements_equal(const MeshBase & other_mesh) const
   return true;
 }
 
+void
+MeshBase::copy_constraint_rows(const MeshBase & other_mesh)
+{
+  const auto & other_constraint_rows = other_mesh.get_constraint_rows();
+  for (const auto & [other_node, other_node_constraints] : other_constraint_rows)
+  {
+    const Node * const our_node = this->node_ptr(other_node->id());
+    constraint_rows_mapped_type our_node_constraints;
+    for (const auto & [other_inner_key_pair, constraint_value] : other_node_constraints)
+    {
+      const auto & [other_elem, local_node_id] = other_inner_key_pair;
+      const Elem * const our_elem = this->elem_ptr(other_elem->id());
+      our_node_constraints.emplace_back(std::make_pair(our_elem, local_node_id), constraint_value);
+    }
+    _constraint_rows[our_node] = std::move(our_node_constraints);
+  }
+}
 
 } // namespace libMesh

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -91,6 +91,7 @@ ReplicatedMesh::ReplicatedMesh (const ReplicatedMesh & other_mesh) :
   _n_nodes(0), _n_elem(0) // copy_* will increment this
 {
   this->copy_nodes_and_elements(other_mesh, true);
+  this->copy_constraint_rows(other_mesh);
 
   auto & this_boundary_info = this->get_boundary_info();
   const auto & other_boundary_info = other_mesh.get_boundary_info();
@@ -110,6 +111,7 @@ ReplicatedMesh::ReplicatedMesh (const UnstructuredMesh & other_mesh) :
   _n_nodes(0), _n_elem(0) // copy_* will increment this
 {
   this->copy_nodes_and_elements(other_mesh, true);
+  this->copy_constraint_rows(other_mesh);
 
   auto & this_boundary_info = this->get_boundary_info();
   const auto & other_boundary_info = other_mesh.get_boundary_info();


### PR DESCRIPTION
With constraint comparison occurring when we call `MeshTools::valid_is_prepared`, we need to ensure that we copy constraint rows when copy constructing meshes