### PR TITLE
Updates to RBParameters interface

### DIFF
--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -86,9 +86,16 @@ public:
   const std::map<std::string, Real> & get_extra_parameters_map() const;
 
   /**
-   * Get the value of the specific parameter.
+   * Get the value of the specified parameter, throwing an error if it
+   * does not exist.
    */
   Real get_value(const std::string & param_name) const;
+
+  /**
+   * Get the value of the specified parameter, returning the provided
+   * default value if it does not exist.
+   */
+  Real get_value(const std::string & param_name, const Real & default_val) const;
 
   /**
    * Set the value of the specified parameter. If param_name
@@ -97,9 +104,16 @@ public:
   void set_value(const std::string & param_name, Real value);
 
   /**
-   * Get the value of the specific extra parameter.
+   * Get the value of the specified extra parameter, throwing an error
+   * if it does not exist.
    */
   Real get_extra_value(const std::string & param_name) const;
+
+  /**
+   * Get the value of the specified extra parameter, returning the
+   * provided default value if it does not exist.
+   */
+  Real get_extra_value(const std::string & param_name, const Real & default_val) const;
 
   /**
    * Set the value of the specified extra parameter. If param_name

--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -69,11 +69,19 @@ public:
 
   /**
    * Get a const reference to the map that stores all of the values.
+   *
+   * This interface is \deprecated and will be removed soon. To iterate over
+   * the parameters map, you should instead use the begin/end APIs provided
+   * by this class.
    */
   const std::map<std::string, Real> & get_parameters_map() const;
 
   /**
    * Get a const reference to the map that stores all of the "extra" values.
+   *
+   * This interface is \deprecated and will be removed soon. To iterate over
+   * the parameters map, you should instead use the begin/end APIs provided
+   * by this class.
    */
   const std::map<std::string, Real> & get_extra_parameters_map() const;
 

--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -96,6 +96,12 @@ public:
   bool has_value(const std::string & param_name) const;
 
   /**
+   * \returns true if there is an extra parameter named "param_name" present
+   * in this class, false otherwise.
+   */
+  bool has_extra_value(const std::string & param_name) const;
+
+  /**
    * Get the value of the specified parameter, throwing an error if it
    * does not exist.
    */

--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -56,6 +56,10 @@ public:
 
   /**
    * Constructor. Set parameters based on the std::map \p parameter_map.
+   *
+   * This constructor will still be supported once we switch over to
+   * the vector-based storage for RBParameters objects. It will just set
+   * the 0th entry of the vector corresponding to each parameter name.
    */
   RBParameters(const std::map<std::string, Real> & parameter_map);
 

--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -86,6 +86,12 @@ public:
   const std::map<std::string, Real> & get_extra_parameters_map() const;
 
   /**
+   * \returns true if there is a parameter named "param_name" present
+   * in this class, false otherwise.
+   */
+  bool has_value(const std::string & param_name) const;
+
+  /**
    * Get the value of the specified parameter, throwing an error if it
    * does not exist.
    */

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -258,7 +258,7 @@ void add_parameter_ranges_to_builder(const RBParametrized & rb_evaluation,
 
     // We could loop over either parameters_min or parameters_max, they should have the same keys.
     unsigned int count = 0;
-    for (const auto & [key, val] : parameters_min.get_parameters_map())
+    for (const auto & [key, val] : parameters_min)
       if (!rb_evaluation.is_discrete_parameter(key))
         {
           names.set(count, key);

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -50,6 +50,11 @@ const std::map<std::string, Real> & RBParameters::get_extra_parameters_map() con
   return _extra_parameters;
 }
 
+bool RBParameters::has_value(const std::string & param_name) const
+{
+  return _parameters.count(param_name);
+}
+
 Real RBParameters::get_value(const std::string & param_name) const
 {
   // find the parameter value, throwing an error if it doesn't exist.

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -17,19 +17,19 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-// C++ includes
-#include <sstream>
-
 // libmesh includes
 #include "libmesh/rb_parameters.h"
 #include "libmesh/utility.h"
 
+// C++ includes
+#include <sstream>
+
 namespace libMesh
 {
 
-RBParameters::RBParameters(const std::map<std::string, Real> & parameter_map)
+RBParameters::RBParameters(const std::map<std::string, Real> & parameter_map) :
+  _parameters(parameter_map)
 {
-  _parameters = parameter_map;
 }
 
 void RBParameters::clear()

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -55,6 +55,11 @@ bool RBParameters::has_value(const std::string & param_name) const
   return _parameters.count(param_name);
 }
 
+bool RBParameters::has_extra_value(const std::string & param_name) const
+{
+  return _extra_parameters.count(param_name);
+}
+
 Real RBParameters::get_value(const std::string & param_name) const
 {
   // find the parameter value, throwing an error if it doesn't exist.

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -56,6 +56,12 @@ Real RBParameters::get_value(const std::string & param_name) const
   return libmesh_map_find(_parameters, param_name);
 }
 
+Real RBParameters::get_value(const std::string & param_name, const Real & default_val) const
+{
+  auto it = _parameters.find(param_name);
+  return (it != _parameters.end() ? it->second : default_val);
+}
+
 void RBParameters::set_value(const std::string & param_name, Real value)
 {
   _parameters[param_name] = value;
@@ -65,6 +71,12 @@ Real RBParameters::get_extra_value(const std::string & param_name) const
 {
   // find the parameter value, throwing an error if it doesn't exist.
   return libmesh_map_find(_extra_parameters, param_name);
+}
+
+Real RBParameters::get_extra_value(const std::string & param_name, const Real & default_val) const
+{
+  auto it = _extra_parameters.find(param_name);
+  return (it != _extra_parameters.end() ? it->second : default_val);
 }
 
 void RBParameters::set_extra_value(const std::string & param_name, Real value)

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -140,12 +140,9 @@ std::string RBParameters::get_string(unsigned int precision) const
   std::stringstream param_stringstream;
   param_stringstream.precision(precision);
 
-  const_iterator it     = _parameters.begin();
-  const_iterator it_end = _parameters.end();
-  for ( ; it != it_end; ++it)
-    {
-      param_stringstream << it->first << ": " << std::scientific <<  it->second << std::endl;
-    }
+  for (const auto & [key, value] : _parameters)
+    param_stringstream << key << ": " << std::scientific <<  value << std::endl;
+
   return param_stringstream.str();
 }
 

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -40,11 +40,13 @@ void RBParameters::clear()
 
 const std::map<std::string, Real> & RBParameters::get_parameters_map() const
 {
+  libmesh_deprecated();
   return _parameters;
 }
 
 const std::map<std::string, Real> & RBParameters::get_extra_parameters_map() const
 {
+  libmesh_deprecated();
   return _extra_parameters;
 }
 

--- a/src/reduced_basis/rb_parametrized.C
+++ b/src/reduced_basis/rb_parametrized.C
@@ -124,8 +124,7 @@ std::set<std::string> RBParametrized::get_parameter_names() const
   libmesh_error_msg_if(!parameters_initialized, "Error: parameters not initialized in RBParametrized::get_parameter_names");
 
   std::set<std::string> parameter_names;
-  const auto & params_map = parameters_min.get_parameters_map();
-  for (const auto & pr : params_map)
+  for (const auto & pr : parameters_min)
     parameter_names.insert(pr.first);
 
   return parameter_names;


### PR DESCRIPTION
We are working on generalizing the `RBParameters` class in a mostly backwards-compatible way so that it stores a `map<string, vector<Real>>` instead of the current `map<string, Real>`. The prior "scalar" use cases will continue to be supported by using single-entry vectors in the map, but the point is that our various `vectorized_evaluate` routines should become much more memory efficient if we can switch from a vector-of-maps to a map-containing-vectors approach.

This change doesn't affect much libMesh code, but we previously used the deprecated APIs a lot in our internal codebase. The new APIs in this PR are the result of working around calling the deprecated APIs, so they should hopefully be sufficient for anyone else that was actually using `RBParameters::get_parameters_map()` extensively. Follow-up PRs will deal with the actual update to `vector<Real>`
