### PR TITLE
FE optimization

### DIFF
--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -249,6 +249,22 @@ public:
                            std::vector<OutputShape> & v,
                            const bool add_p_level = true);
 
+  /**
+   * Fills \p comps with dphidxi (and in higher dimensions, eta/zeta)
+   * derivative component values for all shape functions, evaluated at
+   * all points in p.  You must specify element order directly.
+   * Output component arrays in \p comps should already be the
+   * appropriate size.
+   *
+   * On a p-refined element, \p o should be the base order of the
+   * element if \p add_p_level is left \p true, or can be the base
+   * order of the element if \p add_p_level is set to \p false.
+   */
+  static void all_shape_derivs(const Elem * elem,
+                               const Order o,
+                               const std::vector<Point> & p,
+                               std::vector<std::vector<OutputShape>> * comps[3],
+                               const bool add_p_level = true);
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   /**
@@ -614,29 +630,13 @@ protected:
                                     const Elem * e);
 
   /**
-   * Fills \p dphidxi (and in higher dimensions, eta/zeta) derivative
-   * component values for all shape functions, evaluated at all points
-   * in p.  You must specify element order directly.  Output
-   * component arrays in \p comps should already be the appropriate size.
-   *
-   * On a p-refined element, \p o should be the base order of the
-   * element if \p add_p_level is left \p true, or can be the base
-   * order of the element if \p add_p_level is set to \p false.
-   */
-  void all_shape_derivs(const Elem * elem,
-                        const Order o,
-                        const std::vector<Point> & p,
-                        std::vector<std::vector<OutputShape>> * comps[3],
-                        const bool add_p_level = true);
-
-  /**
    * A default implementation for all_shape_derivs
    */
-  void default_all_shape_derivs (const Elem * elem,
-                                 const Order o,
-                                 const std::vector<Point> & p,
-                                 std::vector<std::vector<OutputShape>> * comps[3],
-                                 const bool add_p_level = true);
+  static void default_all_shape_derivs (const Elem * elem,
+                                        const Order o,
+                                        const std::vector<Point> & p,
+                                        std::vector<std::vector<OutputShape>> * comps[3],
+                                        const bool add_p_level = true);
 
 
   /**
@@ -1482,7 +1482,7 @@ void FE<MyDim,MyType>::all_shape_derivs              \
    std::vector<std::vector<OutputShape>> * comps[3], \
    const bool add_p_level)                           \
 {                                                    \
-  this->default_all_shape_derivs                     \
+  FE<MyDim,MyType>::default_all_shape_derivs         \
     (elem,o,p,comps,add_p_level);                    \
 }
 

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -615,9 +615,9 @@ protected:
 
   /**
    * Fills \p dphidxi (and in higher dimensions, eta/zeta) derivative
-   * values for all shape functions, evaluated at all points in p.
-   * You must specify element order directly.  \p Internal arrays
-   * should already be the appropriate size.
+   * component values for all shape functions, evaluated at all points
+   * in p.  You must specify element order directly.  Output
+   * component arrays in \p comps should already be the appropriate size.
    *
    * On a p-refined element, \p o should be the base order of the
    * element if \p add_p_level is left \p true, or can be the base
@@ -626,6 +626,7 @@ protected:
   void all_shape_derivs(const Elem * elem,
                         const Order o,
                         const std::vector<Point> & p,
+                        std::vector<std::vector<OutputShape>> * comps[3],
                         const bool add_p_level = true);
 
   /**
@@ -634,6 +635,7 @@ protected:
   void default_all_shape_derivs (const Elem * elem,
                                  const Order o,
                                  const std::vector<Point> & p,
+                                 std::vector<std::vector<OutputShape>> * comps[3],
                                  const bool add_p_level = true);
 
 
@@ -1423,10 +1425,11 @@ void rational_all_shapes (const Elem & elem,
                           std::vector<std::vector<Real>> & v,
                           const bool add_p_level);
 
+template <typename OutputShape>
 void rational_all_shape_derivs (const Elem & elem,
                                 const FEType underlying_fe_type,
                                 const std::vector<Point> & p,
-                                std::vector<std::vector<Real>> * comps[3],
+                                std::vector<std::vector<OutputShape>> * comps[3],
                                 const bool add_p_level);
 
 } // namespace libMesh
@@ -1476,10 +1479,11 @@ void FE<MyDim,MyType>::all_shape_derivs              \
   (const Elem * elem,                                \
    const Order o,                                    \
    const std::vector<Point> & p,                     \
+   std::vector<std::vector<OutputShape>> * comps[3], \
    const bool add_p_level)                           \
 {                                                    \
   this->default_all_shape_derivs                     \
-    (elem,o,p,add_p_level);                          \
+    (elem,o,p,comps,add_p_level);                    \
 }
 
 

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -598,6 +598,14 @@ public:
                            std::vector<OutputType> & dphi,
                            const bool add_p_level = true);
 
+  template<typename OutputType>
+  static void all_shape_derivs(const unsigned int dim,
+                               const FEType & fe_t,
+                               const Elem * elem,
+                               const std::vector<Point> & p,
+                               std::vector<std::vector<OutputType>> * comps[3],
+                               const bool add_p_level = true);
+
   /**
    * Typedef for pointer to a function that returns FE shape function derivative values.
    * The \p p_level() of the passed-in \p elem is accounted for internally when

--- a/include/fe/fe_macro.h
+++ b/include/fe/fe_macro.h
@@ -50,7 +50,7 @@
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::init_base_shape_functions(const std::vector<Point> &, const Elem *); \
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::init_shape_functions(const std::vector<Point> &, const Elem *); \
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::init_dual_shape_functions(unsigned int, unsigned int); \
-  template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::default_all_shape_derivs (const Elem * elem, const Order o, const std::vector<Point> & p, const bool add_p_level); \
+  template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::default_all_shape_derivs (const Elem * elem, const Order o, const std::vector<Point> & p, std::vector<std::vector<Real>> * comps[3], const bool add_p_level); \
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::default_side_nodal_soln(const Elem * elem, const Order o, const unsigned int side, const std::vector<Number> & elem_soln, std::vector<Number> & nodal_soln_on_side)
 
 #else // LIBMESH_ENABLE_INFINITE_ELEMENTS
@@ -63,7 +63,7 @@
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::reinit(const Elem *,const std::vector<Point> * const,const std::vector<Real> * const); \
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::init_shape_functions(const std::vector<Point> &, const Elem *); \
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::init_dual_shape_functions(unsigned int, unsigned int); \
-  template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::default_all_shape_derivs (const Elem * elem, const Order o, const std::vector<Point> & p, const bool add_p_level); \
+  template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::default_all_shape_derivs (const Elem * elem, const Order o, const std::vector<Point> & p, std::vector<std::vector<Real>> * comps[3], const bool add_p_level); \
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::default_side_nodal_soln(const Elem * elem, const Order o, const unsigned int side, const std::vector<Number> & elem_soln, std::vector<Number> & nodal_soln_on_side)
 
 #endif // LIBMESH_ENABLE_INFINITE_ELEMENTS

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -1064,12 +1064,14 @@ void rational_fe_weighted_shapes_derivs(const Elem * elem,
 
   shapes.resize(n_sf);
   for (unsigned int i=0; i != n_sf; ++i)
+    shapes[i].resize(n_p, 0);
+
+  FEInterface::all_shapes(dim, fe_type, elem, p, shapes, add_p_level);
+
+  for (unsigned int i=0; i != n_sf; ++i)
     {
       auto & shapes_i = shapes[i];
 
-      shapes_i.resize(n_p, 0);
-
-      FEInterface::shapes(dim, fe_type, elem, i, p, shapes_i, add_p_level);
       for (auto & s : shapes_i)
         s *= node_weights[i];
 

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -579,6 +579,14 @@ void FE<Dim,T>::init_shape_functions(const std::vector<Point> & qp,
   }
 #endif // ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
+        // Compute the values of the shape function derivatives
+  if (this->calculate_dphiref && Dim > 0)
+    {
+      std::vector<std::vector<OutputShape>> * comps[3]
+        { &this->dphidxi, &this->dphideta, &this->dphidzeta };
+      FE<Dim,T>::all_shape_derivs(elem, this->fe_type.order, qp, comps);
+    }
+
   switch (Dim)
     {
 
@@ -593,10 +601,6 @@ void FE<Dim,T>::init_shape_functions(const std::vector<Point> & qp,
       // 1D
     case 1:
       {
-        // Compute the values of the shape function derivatives
-        if (this->calculate_dphiref)
-          FE<Dim,T>::all_shape_derivs(elem, this->fe_type.order, qp);
-
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
         // Compute the value of shape function i Hessians at quadrature point p
         if (this->calculate_d2phi)
@@ -614,10 +618,6 @@ void FE<Dim,T>::init_shape_functions(const std::vector<Point> & qp,
       // 2D
     case 2:
       {
-        // Compute the values of the shape function derivatives
-        if (this->calculate_dphiref)
-          FE<Dim,T>::all_shape_derivs(elem, this->fe_type.order, qp);
-
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
         // Compute the value of shape function i Hessians at quadrature point p
         if (this->calculate_d2phi)
@@ -640,10 +640,6 @@ void FE<Dim,T>::init_shape_functions(const std::vector<Point> & qp,
       // 3D
     case 3:
       {
-        // Compute the values of the shape function derivatives
-        if (this->calculate_dphiref)
-          FE<Dim,T>::all_shape_derivs(elem, this->fe_type.order, qp);
-
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
         // Compute the value of shape function i Hessians at quadrature point p
         if (this->calculate_d2phi)
@@ -676,10 +672,9 @@ void
 FE<Dim,T>::default_all_shape_derivs (const Elem * elem,
                                      const Order o,
                                      const std::vector<Point> & p,
+                                     std::vector<std::vector<OutputShape>> * comps[3],
                                      const bool add_p_level)
 {
-  std::vector<std::vector<OutputShape>> * comps[3]
-    { &this->dphidxi, &this->dphideta, &this->dphidzeta };
   for (unsigned int d=0; d != Dim; ++d)
     {
       auto & comps_d = *comps[d];
@@ -1306,10 +1301,11 @@ void rational_all_shapes (const Elem & elem,
 }
 
 
+template <typename OutputShape>
 void rational_all_shape_derivs (const Elem & elem,
                                 const FEType underlying_fe_type,
                                 const std::vector<Point> & p,
-                                std::vector<std::vector<Real>> * comps[3],
+                                std::vector<std::vector<OutputShape>> * comps[3],
                                 const bool add_p_level)
 {
   const int my_dim = elem.dim();
@@ -1418,4 +1414,5 @@ INSTANTIATE_FE(3);
 
 INSTANTIATE_SUBDIVISION_FE;
 
+template LIBMESH_EXPORT void rational_all_shape_derivs<double> (const Elem & elem, const FEType underlying_fe_type, const std::vector<Point> & p, std::vector<std::vector<Real>> * comps[3], const bool add_p_level);
 } // namespace libMesh

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -1734,6 +1734,52 @@ void FEInterface::shape_derivs<Real>(const FEType & fe_t,
 
 
 
+// Only instantiating Real because we don't expect vector-valued
+// mapping functions, and that's what's using this interface.
+template<>
+void FEInterface::all_shape_derivs<Real>(const unsigned int dim,
+                                         const FEType & fe_t,
+                                         const Elem * elem,
+                                         const std::vector<Point> & p,
+                                         std::vector<std::vector<Real>> * comps[3],
+                                         const bool add_p_level)
+{
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+  if (elem && is_InfFE_elem(elem->type()))
+    {
+      for (auto j : make_range(dim))
+        for (auto i : index_range(*comps[j]))
+          FEInterface::shape_derivs<Real>(fe_t, elem, i, j, p, (*comps[j])[i], add_p_level);
+      return;
+    }
+#endif
+
+  const Order o = fe_t.order;
+
+  switch(dim)
+    {
+    case 0:
+      fe_scalar_vec_error_switch(0, all_shape_derivs(elem,o,p,comps,add_p_level), , ; return;);
+      break;
+    case 1:
+      fe_scalar_vec_error_switch(1, all_shape_derivs(elem,o,p,comps,add_p_level), , ; return;);
+      break;
+    case 2:
+      fe_scalar_vec_error_switch(2, all_shape_derivs(elem,o,p,comps,add_p_level), , ; return;);
+      break;
+    case 3:
+      fe_scalar_vec_error_switch(3, all_shape_derivs(elem,o,p,comps,add_p_level), , ; return;);
+      break;
+    default:
+      libmesh_error_msg("Invalid dimension = " << dim);
+    }
+
+  return;
+}
+
+
+
 template<>
 void FEInterface::shape_derivs<RealGradient>(const FEType & fe_t,
                                              const Elem * elem,

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -258,6 +258,8 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
     case 1:
       {
         // Compute gradients of mapping shape functions i at quadrature points p
+
+        // TODO: optimizations for the RATIONAL_BERNSTEIN+linear case
         if (is_linear)
           {
             for (unsigned int i=0; i<n_mapping_shape_functions; i++)
@@ -283,17 +285,19 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
           }
         else
           {
-            for (unsigned int i=0; i<n_mapping_shape_functions; i++)
+            if (calculate_dxyz)
               {
-                if (calculate_dxyz)
-                  for (std::size_t p=0; p<n_qp; p++)
-                    this->dphidxi_map[i][p]  = shape_deriv_ptr (map_fe_type, elem, i, 0, qp[p], false);
-#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
-                if (calculate_d2xyz)
-                  for (std::size_t p=0; p<n_qp; p++)
-                    this->d2phidxi2_map[i][p] = shape_second_deriv_ptr (map_fe_type, elem, i, 0, qp[p], false);
-#endif // ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+                std::vector<std::vector<Real>> * comps[3]
+                  { &this->dphidxi_map, &this->dphideta_map, &this->dphidzeta_map };
+                FEInterface::all_shape_derivs(Dim, map_fe_type, elem, qp, comps, false);
               }
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+            if (calculate_d2xyz)
+              for (unsigned int i=0; i<n_mapping_shape_functions; i++)
+                for (std::size_t p=0; p<n_qp; p++)
+                  this->d2phidxi2_map[i][p] = shape_second_deriv_ptr (map_fe_type, elem, i, 0, qp[p], false);
+#endif // ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
           }
 
         break;
@@ -303,6 +307,8 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
     case 2:
       {
         // Compute gradients of mapping shape functions i at quadrature points p
+
+        // TODO: optimizations for the RATIONAL_BERNSTEIN+linear case
         if (is_linear)
           {
             for (unsigned int i=0; i<n_mapping_shape_functions; i++)
@@ -335,24 +341,23 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
           }
         else
           {
-            for (unsigned int i=0; i<n_mapping_shape_functions; i++)
+            if (calculate_dxyz)
               {
-                if (calculate_dxyz)
-                  for (std::size_t p=0; p<n_qp; p++)
-                    {
-                      this->dphidxi_map[i][p]  = shape_deriv_ptr (map_fe_type, elem, i, 0, qp[p], false);
-                      this->dphideta_map[i][p] = shape_deriv_ptr (map_fe_type, elem, i, 1, qp[p], false);
-                    }
-#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
-                if (calculate_d2xyz)
-                  for (std::size_t p=0; p<n_qp; p++)
-                    {
-                      this->d2phidxi2_map[i][p] = shape_second_deriv_ptr (map_fe_type, elem, i, 0, qp[p], false);
-                      this->d2phidxideta_map[i][p] = shape_second_deriv_ptr (map_fe_type, elem, i, 1, qp[p], false);
-                      this->d2phideta2_map[i][p] = shape_second_deriv_ptr (map_fe_type, elem, i, 2, qp[p], false);
-                    }
-#endif // ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+                std::vector<std::vector<Real>> * comps[3]
+                  { &this->dphidxi_map, &this->dphideta_map, &this->dphidzeta_map };
+                FEInterface::all_shape_derivs(Dim, map_fe_type, elem, qp, comps, false);
               }
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+            if (calculate_d2xyz)
+              for (unsigned int i=0; i<n_mapping_shape_functions; i++)
+                for (std::size_t p=0; p<n_qp; p++)
+                  {
+                    this->d2phidxi2_map[i][p] = shape_second_deriv_ptr (map_fe_type, elem, i, 0, qp[p], false);
+                    this->d2phidxideta_map[i][p] = shape_second_deriv_ptr (map_fe_type, elem, i, 1, qp[p], false);
+                    this->d2phideta2_map[i][p] = shape_second_deriv_ptr (map_fe_type, elem, i, 2, qp[p], false);
+                  }
+#endif // ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
           }
 
         break;
@@ -363,6 +368,8 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
     case 3:
       {
         // Compute gradients of mapping shape functions i at quadrature points p
+
+        // TODO: optimizations for the RATIONAL_BERNSTEIN+linear case
         if (is_linear)
           {
             for (unsigned int i=0; i<n_mapping_shape_functions; i++)
@@ -405,28 +412,26 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
           }
         else
           {
-            for (unsigned int i=0; i<n_mapping_shape_functions; i++)
+            if (calculate_dxyz)
               {
-                if (calculate_dxyz)
-                  for (std::size_t p=0; p<n_qp; p++)
-                    {
-                      this->dphidxi_map[i][p]   = shape_deriv_ptr (map_fe_type, elem, i, 0, qp[p], false);
-                      this->dphideta_map[i][p]  = shape_deriv_ptr (map_fe_type, elem, i, 1, qp[p], false);
-                      this->dphidzeta_map[i][p] = shape_deriv_ptr (map_fe_type, elem, i, 2, qp[p], false);
-                    }
-#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
-                if (calculate_d2xyz)
-                  for (std::size_t p=0; p<n_qp; p++)
-                    {
-                      this->d2phidxi2_map[i][p]      = shape_second_deriv_ptr (map_fe_type, elem, i, 0, qp[p], false);
-                      this->d2phidxideta_map[i][p]   = shape_second_deriv_ptr (map_fe_type, elem, i, 1, qp[p], false);
-                      this->d2phideta2_map[i][p]     = shape_second_deriv_ptr (map_fe_type, elem, i, 2, qp[p], false);
-                      this->d2phidxidzeta_map[i][p]  = shape_second_deriv_ptr (map_fe_type, elem, i, 3, qp[p], false);
-                      this->d2phidetadzeta_map[i][p] = shape_second_deriv_ptr (map_fe_type, elem, i, 4, qp[p], false);
-                      this->d2phidzeta2_map[i][p]    = shape_second_deriv_ptr (map_fe_type, elem, i, 5, qp[p], false);
-                    }
-#endif // ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+                std::vector<std::vector<Real>> * comps[3]
+                  { &this->dphidxi_map, &this->dphideta_map, &this->dphidzeta_map };
+                FEInterface::all_shape_derivs(Dim, map_fe_type, elem, qp, comps, false);
               }
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+            if (calculate_d2xyz)
+              for (unsigned int i=0; i<n_mapping_shape_functions; i++)
+                for (std::size_t p=0; p<n_qp; p++)
+                  {
+                    this->d2phidxi2_map[i][p]      = shape_second_deriv_ptr (map_fe_type, elem, i, 0, qp[p], false);
+                    this->d2phidxideta_map[i][p]   = shape_second_deriv_ptr (map_fe_type, elem, i, 1, qp[p], false);
+                    this->d2phideta2_map[i][p]     = shape_second_deriv_ptr (map_fe_type, elem, i, 2, qp[p], false);
+                    this->d2phidxidzeta_map[i][p]  = shape_second_deriv_ptr (map_fe_type, elem, i, 3, qp[p], false);
+                    this->d2phidetadzeta_map[i][p] = shape_second_deriv_ptr (map_fe_type, elem, i, 4, qp[p], false);
+                    this->d2phidzeta2_map[i][p]    = shape_second_deriv_ptr (map_fe_type, elem, i, 5, qp[p], false);
+                  }
+#endif // ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
           }
 
         break;

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -267,9 +267,7 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
               {
                 if (calculate_xyz)
                   {
-                    this->phi_map[i][0] =
-                      shape_ptr(map_fe_type, elem, i, qp[0], false);
-                    for (std::size_t p=1; p<n_qp; p++)
+                    for (std::size_t p=0; p<n_qp; p++)
                       this->phi_map[i][p] =
                         shape_ptr(map_fe_type, elem, i, qp[p], false);
                   }
@@ -325,9 +323,7 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
               {
                 if (calculate_xyz)
                   {
-                    this->phi_map[i][0] =
-                      shape_ptr (map_fe_type, elem, i, qp[0], false);
-                    for (std::size_t p=1; p<n_qp; p++)
+                    for (std::size_t p=0; p<n_qp; p++)
                       this->phi_map[i][p] =
                         shape_ptr (map_fe_type, elem, i, qp[p], false);
                   }
@@ -397,10 +393,7 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
               {
                 if (calculate_xyz)
                   {
-                    this->phi_map[i][0] =
-                      shape_ptr (map_fe_type, elem, i, qp[0], false);
-
-                    for (std::size_t p=1; p<n_qp; p++)
+                    for (std::size_t p=0; p<n_qp; p++)
                       this->phi_map[i][p] =
                         shape_ptr (map_fe_type, elem, i, qp[p], false);
                   }

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -232,9 +232,6 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
   // Optimize for the *linear* geometric elements case:
   bool is_linear = elem->is_linear();
 
-  FEInterface::shape_ptr shape_ptr =
-    FEInterface::shape_function(map_fe_type, elem);
-
   FEInterface::shape_deriv_ptr shape_deriv_ptr =
     FEInterface::shape_deriv_function(map_fe_type, elem);
 
@@ -243,15 +240,16 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
     FEInterface::shape_second_deriv_function(map_fe_type, elem);
 #endif // ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
+  if (calculate_xyz)
+    FEInterface::all_shapes(Dim, map_fe_type, elem, qp, this->phi_map, false);
+
   switch (Dim)
     {
       //------------------------------------------------------------
       // 0D
     case 0:
       {
-        if (calculate_xyz)
-          FEInterface::all_shapes(0, map_fe_type, elem, qp, this->phi_map, false);
-
+        // No mapping derivatives here
         break;
       }
 
@@ -259,19 +257,11 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
       // 1D
     case 1:
       {
-        // Compute the value of the mapping shape function i at quadrature point p
-        // (Lagrange shape functions are used for mapping)
+        // Compute gradients of mapping shape functions i at quadrature points p
         if (is_linear)
           {
             for (unsigned int i=0; i<n_mapping_shape_functions; i++)
               {
-                if (calculate_xyz)
-                  {
-                    for (std::size_t p=0; p<n_qp; p++)
-                      this->phi_map[i][p] =
-                        shape_ptr(map_fe_type, elem, i, qp[p], false);
-                  }
-
                 if (calculate_dxyz)
                   {
                     this->dphidxi_map[i][0] =
@@ -293,9 +283,6 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
           }
         else
           {
-            if (calculate_xyz)
-              FEInterface::all_shapes(1, map_fe_type, elem, qp, this->phi_map, false);
-
             for (unsigned int i=0; i<n_mapping_shape_functions; i++)
               {
                 if (calculate_dxyz)
@@ -315,18 +302,11 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
       // 2D
     case 2:
       {
-        // Compute the value of the mapping shape function i at quadrature point p
-        // (Lagrange shape functions are used for mapping)
+        // Compute gradients of mapping shape functions i at quadrature points p
         if (is_linear)
           {
             for (unsigned int i=0; i<n_mapping_shape_functions; i++)
               {
-                if (calculate_xyz)
-                  {
-                    for (std::size_t p=0; p<n_qp; p++)
-                      this->phi_map[i][p] =
-                        shape_ptr (map_fe_type, elem, i, qp[p], false);
-                  }
                 if (calculate_dxyz)
                   {
                     this->dphidxi_map[i][0]  = shape_deriv_ptr (map_fe_type, elem, i, 0, qp[0], false);
@@ -355,9 +335,6 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
           }
         else
           {
-            if (calculate_xyz)
-              FEInterface::all_shapes(2, map_fe_type, elem, qp, this->phi_map, false);
-
             for (unsigned int i=0; i<n_mapping_shape_functions; i++)
               {
                 if (calculate_dxyz)
@@ -385,18 +362,11 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
       // 3D
     case 3:
       {
-        // Compute the value of the mapping shape function i at quadrature point p
-        // (Lagrange shape functions are used for mapping)
+        // Compute gradients of mapping shape functions i at quadrature points p
         if (is_linear)
           {
             for (unsigned int i=0; i<n_mapping_shape_functions; i++)
               {
-                if (calculate_xyz)
-                  {
-                    for (std::size_t p=0; p<n_qp; p++)
-                      this->phi_map[i][p] =
-                        shape_ptr (map_fe_type, elem, i, qp[p], false);
-                  }
                 if (calculate_dxyz)
                   {
                     this->dphidxi_map[i][0]  = shape_deriv_ptr (map_fe_type, elem, i, 0, qp[0], false);
@@ -435,9 +405,6 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
           }
         else
           {
-            if (calculate_xyz)
-              FEInterface::all_shapes(3, map_fe_type, elem, qp, this->phi_map, false);
-
             for (unsigned int i=0; i<n_mapping_shape_functions; i++)
               {
                 if (calculate_dxyz)

--- a/src/fe/fe_rational_shape_1D.C
+++ b/src/fe/fe_rational_shape_1D.C
@@ -224,12 +224,10 @@ void
 FE<1,RATIONAL_BERNSTEIN>::all_shape_derivs (const Elem * elem,
                                             const Order o,
                                             const std::vector<Point> & p,
+                                            std::vector<std::vector<Real>> * comps[3],
                                             const bool add_p_level)
 {
   FEType underlying_fe_type(o, _underlying_fe_family);
-
-  std::vector<std::vector<Real>> * comps[3]
-    { &this->dphidxi, &this->dphideta, &this->dphidzeta };
 
   rational_all_shape_derivs (*elem, underlying_fe_type, p,
                              comps, add_p_level);

--- a/src/fe/fe_rational_shape_2D.C
+++ b/src/fe/fe_rational_shape_2D.C
@@ -222,12 +222,10 @@ void
 FE<2,RATIONAL_BERNSTEIN>::all_shape_derivs (const Elem * elem,
                                             const Order o,
                                             const std::vector<Point> & p,
+                                            std::vector<std::vector<Real>> * comps[3],
                                             const bool add_p_level)
 {
   FEType underlying_fe_type(o, _underlying_fe_family);
-
-  std::vector<std::vector<Real>> * comps[3]
-    { &this->dphidxi, &this->dphideta, &this->dphidzeta };
 
   rational_all_shape_derivs (*elem, underlying_fe_type, p,
                              comps, add_p_level);

--- a/src/fe/fe_rational_shape_3D.C
+++ b/src/fe/fe_rational_shape_3D.C
@@ -218,12 +218,10 @@ void
 FE<3,RATIONAL_BERNSTEIN>::all_shape_derivs (const Elem * elem,
                                             const Order o,
                                             const std::vector<Point> & p,
+                                            std::vector<std::vector<Real>> * comps[3],
                                             const bool add_p_level)
 {
   FEType underlying_fe_type(o, _underlying_fe_family);
-
-  std::vector<std::vector<Real>> * comps[3]
-    { &this->dphidxi, &this->dphideta, &this->dphidzeta };
 
   rational_all_shape_derivs (*elem, underlying_fe_type, p,
                              comps, add_p_level);

--- a/src/fe/h1_fe_transformation.C
+++ b/src/fe/h1_fe_transformation.C
@@ -55,11 +55,7 @@ void H1FETransformation<OutputShape>::map_phi( const unsigned int dim,
                                                const FEGenericBase<OutputShape> & fe,
                                                std::vector<std::vector<OutputShape>> & phi ) const
 {
-  for (auto i : index_range(phi))
-    {
-      libmesh_assert_equal_to ( qp.size(), phi[i].size() );
-      FEInterface::shapes<OutputShape>(dim, fe.get_fe_type(), elem, i, qp, phi[i]);
-    }
+  FEInterface::all_shapes<OutputShape>(dim, fe.get_fe_type(), elem, qp, phi);
 }
 
 


### PR DESCRIPTION
More all_shape* specializations (and more usage of them) enables us to take advantage of tensor products in LAGRANGE HEX evaluations and of the special structure of `RATIONAL_BERNSTEIN`.  Overall I've only shaved a couple percent off of `LIBMESH_BENCHMARK`, but it doesn't hit those cases super hard.  IGA is *much* less slow now.