### PR TITLE
Do not throw from ExodusII_IO_Helper::close()

### DIFF
--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -274,8 +274,11 @@ public:
 
   /**
    * Closes the \p ExodusII mesh file.
+   *
+   * This function is called from the ExodusII_IO destructor, so it should
+   * not throw an exception.
    */
-  void close();
+  void close() noexcept;
 
   /**
    * Reads and stores the timesteps in the 'time_steps' array.


### PR DESCRIPTION
Since this function is called from the ExodusII_IO destructor, it should not throw (all destructors should be marked noexcept) because it could be called during stack unwinding.