### PR TITLE
Handle not-quite-orphaned DistributedMesh nodes

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -534,7 +534,7 @@ public:
    * and its parent's and children's appropriate pointers
    * to point to null instead of to this.
    *
-   * Used by the library before an element is deleted from a mesh.
+   * To be used before an element is deleted from a mesh.
    */
   void remove_links_to_me ();
 

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -644,6 +644,13 @@ protected:
   bool _is_serial_on_proc_0;
 
   /**
+   * A boolean remembering whether we've recently deleted top-level elements or
+   * not.  If so, we'll need to be extra careful when deleting "unused" nodes
+   * they used to have, because those nodes might still be used by ghost elements.
+   */
+  bool _deleted_coarse_elements;
+
+  /**
    * Cached data from the last renumber_nodes_and_elements call
    */
   dof_id_type _n_nodes, _n_elem, _max_node_id, _max_elem_id;

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -1511,7 +1511,7 @@ void DistributedMesh::renumber_nodes_and_elements ()
         repartitioned_node_sets_to_push;
 
       auto ids_action_functor =
-        [this, &used_nodes, &repartitioned_node_pids,
+        [&used_nodes, &repartitioned_node_pids,
          &repartitioned_node_sets_to_push]
         (processor_id_type pid,
          const std::vector<std::pair<dof_id_type, boolish>> & ids_and_bools)

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -715,10 +715,14 @@ void DistributedMesh::delete_elem(Elem * e)
   // Try to make the cached elem data more accurate
   _n_elem--;
 
-  // Was this a coarse element?  We'll have to be more careful with our nodes
-  // in contract() later; no telling if we just locally orphaned a node that
-  // should be globally retained.
-  if (!e->parent())
+  // Was this a coarse element, not just a coarsening where we still
+  // have some ancestor structure?  Was it a *local* element, that we
+  // might have been depending on as an owner of local nodes?  We'll
+  // have to be more careful with our nodes in contract() later; no
+  // telling if we just locally orphaned a node that should be
+  // globally retained.
+  if (e->processor_id() == this->processor_id() &&
+      !e->parent())
     _deleted_coarse_elements = true;
 
   // Delete the element from the BoundaryInfo object

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -1516,14 +1516,14 @@ void DistributedMesh::renumber_nodes_and_elements ()
         (processor_id_type pid,
          const std::vector<std::pair<dof_id_type, boolish>> & ids_and_bools)
         {
-          for (auto [n, local_to_pid] : ids_and_bools)
+          for (auto [n, sender_could_become_owner] : ids_and_bools)
             {
               // If we don't see a use for our own node, but someone
               // else does, better figure out who should own it next.
               if (!used_nodes.count(n))
                 {
                   auto it = repartitioned_node_pids.find(n);
-                  if (local_to_pid)
+                  if (sender_could_become_owner)
                     {
                       if (it != repartitioned_node_pids.end() &&
                           pid < it->second)

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -1472,7 +1472,7 @@ void DistributedMesh::renumber_nodes_and_elements ()
   std::set<dof_id_type> used_nodes;
 
   // What used node info should we send from our proc?  Could we take ownership
-  // of each if we needed to?
+  // of each node if we needed to?
   std::map<processor_id_type, std::map<dof_id_type, bool>>
     used_nodes_on_proc;
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -64,6 +64,7 @@ unit_tests_sources = \
   mesh/mesh_assign.C \
   mesh/mesh_base_test.C \
   mesh/mesh_collection.C \
+  mesh/mesh_deletions.C \
   mesh/mesh_extruder.C \
   mesh/mesh_function.C \
   mesh/mesh_function_dfem.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -213,10 +213,10 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/boundary_points.C mesh/checkpoint.C mesh/contains_point.C \
 	mesh/extra_integers.C mesh/mesh_assign.C mesh/mesh_base_test.C \
-	mesh/mesh_collection.C mesh/mesh_extruder.C \
-	mesh/mesh_function.C mesh/mesh_function_dfem.C \
-	mesh/mesh_generation_test.C mesh/mesh_input.C \
-	mesh/mesh_stitch.C mesh/mesh_triangulation.C \
+	mesh/mesh_collection.C mesh/mesh_deletions.C \
+	mesh/mesh_extruder.C mesh/mesh_function.C \
+	mesh/mesh_function_dfem.C mesh/mesh_generation_test.C \
+	mesh/mesh_input.C mesh/mesh_stitch.C mesh/mesh_triangulation.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/libmesh_poly2tri.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
@@ -312,6 +312,7 @@ am__objects_3 = unit_tests_dbg-driver.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_assign.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_base_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_collection.$(OBJEXT) \
+	mesh/unit_tests_dbg-mesh_deletions.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_function.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_function_dfem.$(OBJEXT) \
@@ -404,10 +405,10 @@ am__unit_tests_devel_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/boundary_points.C mesh/checkpoint.C mesh/contains_point.C \
 	mesh/extra_integers.C mesh/mesh_assign.C mesh/mesh_base_test.C \
-	mesh/mesh_collection.C mesh/mesh_extruder.C \
-	mesh/mesh_function.C mesh/mesh_function_dfem.C \
-	mesh/mesh_generation_test.C mesh/mesh_input.C \
-	mesh/mesh_stitch.C mesh/mesh_triangulation.C \
+	mesh/mesh_collection.C mesh/mesh_deletions.C \
+	mesh/mesh_extruder.C mesh/mesh_function.C \
+	mesh/mesh_function_dfem.C mesh/mesh_generation_test.C \
+	mesh/mesh_input.C mesh/mesh_stitch.C mesh/mesh_triangulation.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/libmesh_poly2tri.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
@@ -501,6 +502,7 @@ am__objects_5 = unit_tests_devel-driver.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_assign.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_base_test.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_collection.$(OBJEXT) \
+	mesh/unit_tests_devel-mesh_deletions.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_function.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_function_dfem.$(OBJEXT) \
@@ -589,10 +591,10 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/boundary_points.C mesh/checkpoint.C mesh/contains_point.C \
 	mesh/extra_integers.C mesh/mesh_assign.C mesh/mesh_base_test.C \
-	mesh/mesh_collection.C mesh/mesh_extruder.C \
-	mesh/mesh_function.C mesh/mesh_function_dfem.C \
-	mesh/mesh_generation_test.C mesh/mesh_input.C \
-	mesh/mesh_stitch.C mesh/mesh_triangulation.C \
+	mesh/mesh_collection.C mesh/mesh_deletions.C \
+	mesh/mesh_extruder.C mesh/mesh_function.C \
+	mesh/mesh_function_dfem.C mesh/mesh_generation_test.C \
+	mesh/mesh_input.C mesh/mesh_stitch.C mesh/mesh_triangulation.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/libmesh_poly2tri.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
@@ -686,6 +688,7 @@ am__objects_7 = unit_tests_oprof-driver.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_assign.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_base_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_collection.$(OBJEXT) \
+	mesh/unit_tests_oprof-mesh_deletions.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_function.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_function_dfem.$(OBJEXT) \
@@ -774,10 +777,10 @@ am__unit_tests_opt_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/boundary_points.C mesh/checkpoint.C mesh/contains_point.C \
 	mesh/extra_integers.C mesh/mesh_assign.C mesh/mesh_base_test.C \
-	mesh/mesh_collection.C mesh/mesh_extruder.C \
-	mesh/mesh_function.C mesh/mesh_function_dfem.C \
-	mesh/mesh_generation_test.C mesh/mesh_input.C \
-	mesh/mesh_stitch.C mesh/mesh_triangulation.C \
+	mesh/mesh_collection.C mesh/mesh_deletions.C \
+	mesh/mesh_extruder.C mesh/mesh_function.C \
+	mesh/mesh_function_dfem.C mesh/mesh_generation_test.C \
+	mesh/mesh_input.C mesh/mesh_stitch.C mesh/mesh_triangulation.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/libmesh_poly2tri.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
@@ -871,6 +874,7 @@ am__objects_9 = unit_tests_opt-driver.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_assign.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_base_test.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_collection.$(OBJEXT) \
+	mesh/unit_tests_opt-mesh_deletions.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_function.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_function_dfem.$(OBJEXT) \
@@ -959,10 +963,10 @@ am__unit_tests_prof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/boundary_points.C mesh/checkpoint.C mesh/contains_point.C \
 	mesh/extra_integers.C mesh/mesh_assign.C mesh/mesh_base_test.C \
-	mesh/mesh_collection.C mesh/mesh_extruder.C \
-	mesh/mesh_function.C mesh/mesh_function_dfem.C \
-	mesh/mesh_generation_test.C mesh/mesh_input.C \
-	mesh/mesh_stitch.C mesh/mesh_triangulation.C \
+	mesh/mesh_collection.C mesh/mesh_deletions.C \
+	mesh/mesh_extruder.C mesh/mesh_function.C \
+	mesh/mesh_function_dfem.C mesh/mesh_generation_test.C \
+	mesh/mesh_input.C mesh/mesh_stitch.C mesh/mesh_triangulation.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/libmesh_poly2tri.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
@@ -1056,6 +1060,7 @@ am__objects_11 = unit_tests_prof-driver.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_assign.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_base_test.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_collection.$(OBJEXT) \
+	mesh/unit_tests_prof-mesh_deletions.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_function.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_function_dfem.$(OBJEXT) \
@@ -1308,6 +1313,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_assign.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_base_test.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_collection.Po \
+	mesh/$(DEPDIR)/unit_tests_dbg-mesh_deletions.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Po \
@@ -1338,6 +1344,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_assign.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_base_test.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_collection.Po \
+	mesh/$(DEPDIR)/unit_tests_devel-mesh_deletions.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Po \
@@ -1368,6 +1375,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_assign.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_base_test.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_collection.Po \
+	mesh/$(DEPDIR)/unit_tests_oprof-mesh_deletions.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Po \
@@ -1398,6 +1406,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_assign.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_base_test.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_collection.Po \
+	mesh/$(DEPDIR)/unit_tests_opt-mesh_deletions.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Po \
@@ -1428,6 +1437,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_assign.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_base_test.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_collection.Po \
+	mesh/$(DEPDIR)/unit_tests_prof-mesh_deletions.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Po \
@@ -2128,10 +2138,10 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/boundary_points.C mesh/checkpoint.C mesh/contains_point.C \
 	mesh/extra_integers.C mesh/mesh_assign.C mesh/mesh_base_test.C \
-	mesh/mesh_collection.C mesh/mesh_extruder.C \
-	mesh/mesh_function.C mesh/mesh_function_dfem.C \
-	mesh/mesh_generation_test.C mesh/mesh_input.C \
-	mesh/mesh_stitch.C mesh/mesh_triangulation.C \
+	mesh/mesh_collection.C mesh/mesh_deletions.C \
+	mesh/mesh_extruder.C mesh/mesh_function.C \
+	mesh/mesh_function_dfem.C mesh/mesh_generation_test.C \
+	mesh/mesh_input.C mesh/mesh_stitch.C mesh/mesh_triangulation.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/libmesh_poly2tri.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
@@ -2397,6 +2407,8 @@ mesh/unit_tests_dbg-mesh_base_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-mesh_collection.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_dbg-mesh_deletions.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-mesh_extruder.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-mesh_function.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -2661,6 +2673,8 @@ mesh/unit_tests_devel-mesh_base_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-mesh_collection.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_devel-mesh_deletions.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-mesh_extruder.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-mesh_function.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -2876,6 +2890,8 @@ mesh/unit_tests_oprof-mesh_assign.$(OBJEXT): mesh/$(am__dirstamp) \
 mesh/unit_tests_oprof-mesh_base_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-mesh_collection.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_oprof-mesh_deletions.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-mesh_extruder.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
@@ -3093,6 +3109,8 @@ mesh/unit_tests_opt-mesh_base_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-mesh_collection.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_opt-mesh_deletions.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-mesh_extruder.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-mesh_function.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -3308,6 +3326,8 @@ mesh/unit_tests_prof-mesh_assign.$(OBJEXT): mesh/$(am__dirstamp) \
 mesh/unit_tests_prof-mesh_base_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-mesh_collection.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_prof-mesh_deletions.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-mesh_extruder.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
@@ -3631,6 +3651,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_assign.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_base_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_collection.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_deletions.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Po@am__quote@ # am--include-marker
@@ -3661,6 +3682,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_assign.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_base_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_collection.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_deletions.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Po@am__quote@ # am--include-marker
@@ -3691,6 +3713,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_assign.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_base_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_collection.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_deletions.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Po@am__quote@ # am--include-marker
@@ -3721,6 +3744,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_assign.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_base_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_collection.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_deletions.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Po@am__quote@ # am--include-marker
@@ -3751,6 +3775,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_assign.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_base_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_collection.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_deletions.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Po@am__quote@ # am--include-marker
@@ -4595,6 +4620,20 @@ mesh/unit_tests_dbg-mesh_collection.obj: mesh/mesh_collection.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_collection.C' object='mesh/unit_tests_dbg-mesh_collection.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mesh_collection.obj `if test -f 'mesh/mesh_collection.C'; then $(CYGPATH_W) 'mesh/mesh_collection.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_collection.C'; fi`
+
+mesh/unit_tests_dbg-mesh_deletions.o: mesh/mesh_deletions.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mesh_deletions.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mesh_deletions.Tpo -c -o mesh/unit_tests_dbg-mesh_deletions.o `test -f 'mesh/mesh_deletions.C' || echo '$(srcdir)/'`mesh/mesh_deletions.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-mesh_deletions.Tpo mesh/$(DEPDIR)/unit_tests_dbg-mesh_deletions.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_deletions.C' object='mesh/unit_tests_dbg-mesh_deletions.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mesh_deletions.o `test -f 'mesh/mesh_deletions.C' || echo '$(srcdir)/'`mesh/mesh_deletions.C
+
+mesh/unit_tests_dbg-mesh_deletions.obj: mesh/mesh_deletions.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mesh_deletions.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mesh_deletions.Tpo -c -o mesh/unit_tests_dbg-mesh_deletions.obj `if test -f 'mesh/mesh_deletions.C'; then $(CYGPATH_W) 'mesh/mesh_deletions.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_deletions.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-mesh_deletions.Tpo mesh/$(DEPDIR)/unit_tests_dbg-mesh_deletions.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_deletions.C' object='mesh/unit_tests_dbg-mesh_deletions.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mesh_deletions.obj `if test -f 'mesh/mesh_deletions.C'; then $(CYGPATH_W) 'mesh/mesh_deletions.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_deletions.C'; fi`
 
 mesh/unit_tests_dbg-mesh_extruder.o: mesh/mesh_extruder.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mesh_extruder.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Tpo -c -o mesh/unit_tests_dbg-mesh_extruder.o `test -f 'mesh/mesh_extruder.C' || echo '$(srcdir)/'`mesh/mesh_extruder.C
@@ -6038,6 +6077,20 @@ mesh/unit_tests_devel-mesh_collection.obj: mesh/mesh_collection.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mesh_collection.obj `if test -f 'mesh/mesh_collection.C'; then $(CYGPATH_W) 'mesh/mesh_collection.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_collection.C'; fi`
 
+mesh/unit_tests_devel-mesh_deletions.o: mesh/mesh_deletions.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mesh_deletions.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mesh_deletions.Tpo -c -o mesh/unit_tests_devel-mesh_deletions.o `test -f 'mesh/mesh_deletions.C' || echo '$(srcdir)/'`mesh/mesh_deletions.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mesh_deletions.Tpo mesh/$(DEPDIR)/unit_tests_devel-mesh_deletions.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_deletions.C' object='mesh/unit_tests_devel-mesh_deletions.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mesh_deletions.o `test -f 'mesh/mesh_deletions.C' || echo '$(srcdir)/'`mesh/mesh_deletions.C
+
+mesh/unit_tests_devel-mesh_deletions.obj: mesh/mesh_deletions.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mesh_deletions.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mesh_deletions.Tpo -c -o mesh/unit_tests_devel-mesh_deletions.obj `if test -f 'mesh/mesh_deletions.C'; then $(CYGPATH_W) 'mesh/mesh_deletions.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_deletions.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mesh_deletions.Tpo mesh/$(DEPDIR)/unit_tests_devel-mesh_deletions.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_deletions.C' object='mesh/unit_tests_devel-mesh_deletions.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mesh_deletions.obj `if test -f 'mesh/mesh_deletions.C'; then $(CYGPATH_W) 'mesh/mesh_deletions.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_deletions.C'; fi`
+
 mesh/unit_tests_devel-mesh_extruder.o: mesh/mesh_extruder.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mesh_extruder.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Tpo -c -o mesh/unit_tests_devel-mesh_extruder.o `test -f 'mesh/mesh_extruder.C' || echo '$(srcdir)/'`mesh/mesh_extruder.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Tpo mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po
@@ -7479,6 +7532,20 @@ mesh/unit_tests_oprof-mesh_collection.obj: mesh/mesh_collection.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_collection.C' object='mesh/unit_tests_oprof-mesh_collection.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mesh_collection.obj `if test -f 'mesh/mesh_collection.C'; then $(CYGPATH_W) 'mesh/mesh_collection.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_collection.C'; fi`
+
+mesh/unit_tests_oprof-mesh_deletions.o: mesh/mesh_deletions.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mesh_deletions.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mesh_deletions.Tpo -c -o mesh/unit_tests_oprof-mesh_deletions.o `test -f 'mesh/mesh_deletions.C' || echo '$(srcdir)/'`mesh/mesh_deletions.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-mesh_deletions.Tpo mesh/$(DEPDIR)/unit_tests_oprof-mesh_deletions.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_deletions.C' object='mesh/unit_tests_oprof-mesh_deletions.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mesh_deletions.o `test -f 'mesh/mesh_deletions.C' || echo '$(srcdir)/'`mesh/mesh_deletions.C
+
+mesh/unit_tests_oprof-mesh_deletions.obj: mesh/mesh_deletions.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mesh_deletions.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mesh_deletions.Tpo -c -o mesh/unit_tests_oprof-mesh_deletions.obj `if test -f 'mesh/mesh_deletions.C'; then $(CYGPATH_W) 'mesh/mesh_deletions.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_deletions.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-mesh_deletions.Tpo mesh/$(DEPDIR)/unit_tests_oprof-mesh_deletions.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_deletions.C' object='mesh/unit_tests_oprof-mesh_deletions.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mesh_deletions.obj `if test -f 'mesh/mesh_deletions.C'; then $(CYGPATH_W) 'mesh/mesh_deletions.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_deletions.C'; fi`
 
 mesh/unit_tests_oprof-mesh_extruder.o: mesh/mesh_extruder.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mesh_extruder.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Tpo -c -o mesh/unit_tests_oprof-mesh_extruder.o `test -f 'mesh/mesh_extruder.C' || echo '$(srcdir)/'`mesh/mesh_extruder.C
@@ -8922,6 +8989,20 @@ mesh/unit_tests_opt-mesh_collection.obj: mesh/mesh_collection.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mesh_collection.obj `if test -f 'mesh/mesh_collection.C'; then $(CYGPATH_W) 'mesh/mesh_collection.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_collection.C'; fi`
 
+mesh/unit_tests_opt-mesh_deletions.o: mesh/mesh_deletions.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mesh_deletions.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mesh_deletions.Tpo -c -o mesh/unit_tests_opt-mesh_deletions.o `test -f 'mesh/mesh_deletions.C' || echo '$(srcdir)/'`mesh/mesh_deletions.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mesh_deletions.Tpo mesh/$(DEPDIR)/unit_tests_opt-mesh_deletions.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_deletions.C' object='mesh/unit_tests_opt-mesh_deletions.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mesh_deletions.o `test -f 'mesh/mesh_deletions.C' || echo '$(srcdir)/'`mesh/mesh_deletions.C
+
+mesh/unit_tests_opt-mesh_deletions.obj: mesh/mesh_deletions.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mesh_deletions.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mesh_deletions.Tpo -c -o mesh/unit_tests_opt-mesh_deletions.obj `if test -f 'mesh/mesh_deletions.C'; then $(CYGPATH_W) 'mesh/mesh_deletions.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_deletions.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mesh_deletions.Tpo mesh/$(DEPDIR)/unit_tests_opt-mesh_deletions.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_deletions.C' object='mesh/unit_tests_opt-mesh_deletions.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mesh_deletions.obj `if test -f 'mesh/mesh_deletions.C'; then $(CYGPATH_W) 'mesh/mesh_deletions.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_deletions.C'; fi`
+
 mesh/unit_tests_opt-mesh_extruder.o: mesh/mesh_extruder.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mesh_extruder.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Tpo -c -o mesh/unit_tests_opt-mesh_extruder.o `test -f 'mesh/mesh_extruder.C' || echo '$(srcdir)/'`mesh/mesh_extruder.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Tpo mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po
@@ -10364,6 +10445,20 @@ mesh/unit_tests_prof-mesh_collection.obj: mesh/mesh_collection.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mesh_collection.obj `if test -f 'mesh/mesh_collection.C'; then $(CYGPATH_W) 'mesh/mesh_collection.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_collection.C'; fi`
 
+mesh/unit_tests_prof-mesh_deletions.o: mesh/mesh_deletions.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mesh_deletions.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mesh_deletions.Tpo -c -o mesh/unit_tests_prof-mesh_deletions.o `test -f 'mesh/mesh_deletions.C' || echo '$(srcdir)/'`mesh/mesh_deletions.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mesh_deletions.Tpo mesh/$(DEPDIR)/unit_tests_prof-mesh_deletions.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_deletions.C' object='mesh/unit_tests_prof-mesh_deletions.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mesh_deletions.o `test -f 'mesh/mesh_deletions.C' || echo '$(srcdir)/'`mesh/mesh_deletions.C
+
+mesh/unit_tests_prof-mesh_deletions.obj: mesh/mesh_deletions.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mesh_deletions.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mesh_deletions.Tpo -c -o mesh/unit_tests_prof-mesh_deletions.obj `if test -f 'mesh/mesh_deletions.C'; then $(CYGPATH_W) 'mesh/mesh_deletions.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_deletions.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mesh_deletions.Tpo mesh/$(DEPDIR)/unit_tests_prof-mesh_deletions.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_deletions.C' object='mesh/unit_tests_prof-mesh_deletions.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mesh_deletions.obj `if test -f 'mesh/mesh_deletions.C'; then $(CYGPATH_W) 'mesh/mesh_deletions.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_deletions.C'; fi`
+
 mesh/unit_tests_prof-mesh_extruder.o: mesh/mesh_extruder.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mesh_extruder.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Tpo -c -o mesh/unit_tests_prof-mesh_extruder.o `test -f 'mesh/mesh_extruder.C' || echo '$(srcdir)/'`mesh/mesh_extruder.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Tpo mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po
@@ -11749,6 +11844,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_assign.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_collection.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_deletions.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Po
@@ -11779,6 +11875,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_assign.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_collection.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_deletions.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Po
@@ -11809,6 +11906,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_assign.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_collection.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_deletions.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Po
@@ -11839,6 +11937,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_assign.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_collection.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_deletions.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Po
@@ -11869,6 +11968,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_assign.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_collection.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_deletions.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Po
@@ -12311,6 +12411,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_assign.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_collection.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_deletions.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Po
@@ -12341,6 +12442,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_assign.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_collection.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_deletions.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Po
@@ -12371,6 +12473,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_assign.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_collection.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_deletions.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Po
@@ -12401,6 +12504,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_assign.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_collection.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_deletions.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Po
@@ -12431,6 +12535,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_assign.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_base_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_collection.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_deletions.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Po

--- a/tests/mesh/mesh_deletions.C
+++ b/tests/mesh/mesh_deletions.C
@@ -1,0 +1,91 @@
+#include <libmesh/distributed_mesh.h>
+#include <libmesh/elem.h>
+#include "libmesh/enum_partitioner_type.h"
+#include <libmesh/mesh_generation.h>
+#include <libmesh/parallel.h>
+#include <libmesh/partitioner.h>
+#include <libmesh/replicated_mesh.h>
+
+#include "test_comm.h"
+#include "libmesh_cppunit.h"
+
+using namespace libMesh;
+
+class MeshDeletionsTest : public CppUnit::TestCase {
+  /**
+   * This test ensures operations like delete_elem don't cause
+   * problems with later mesh preparation
+   */
+public:
+  LIBMESH_CPPUNIT_TEST_SUITE( MeshDeletionsTest );
+
+#if LIBMESH_DIM > 1
+  CPPUNIT_TEST( testDeleteElemReplicated );
+  CPPUNIT_TEST( testDeleteElemDistributed );
+#endif
+
+  CPPUNIT_TEST_SUITE_END();
+
+protected:
+
+public:
+  void setUp()
+  {
+  }
+
+  void tearDown()
+  {
+  }
+
+  void testDeleteElem(UnstructuredMesh & mesh)
+  {
+    LOG_UNIT_TEST;
+
+    // Let's not trust Metis or Parmetis to give us a replicable test
+    // case.
+    mesh.partitioner() = Partitioner::build(LINEAR_PARTITIONER);
+
+    MeshTools::Generation::build_square(mesh,
+                                        3, 3,
+                                        0., 1.,
+                                        0., 1.,
+                                        QUAD4);
+
+    std::vector<std::vector<int>> deletions =
+      {{1, 2, 4}, {0, 3}, {0, 2}, {1}};
+    dof_id_type n_elem = 9;
+    for (auto deletionset : deletions)
+      {
+        for (int e : deletionset)
+          {
+            --n_elem;
+            Elem * elem = mesh.query_elem_ptr(e);
+            if (elem)
+              {
+                elem->remove_links_to_me();
+                mesh.delete_elem(elem);
+              }
+          }
+
+        mesh.prepare_for_use();
+
+        CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), n_elem);
+      }
+  }
+
+  void testDeleteElemReplicated()
+  {
+    LOG_UNIT_TEST;
+    ReplicatedMesh mesh(*TestCommWorld);
+    testDeleteElem(mesh);
+  }
+
+  void testDeleteElemDistributed()
+  {
+    LOG_UNIT_TEST;
+    DistributedMesh mesh(*TestCommWorld);
+    testDeleteElem(mesh);
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( MeshDeletionsTest );


### PR DESCRIPTION
The MOOSE test case that triggered a `--distributed-mesh` failure here was working on 15 or fewer processors, on 16 processors it was working on my own workstation, and it was working 80% of the time (are some Parmetis versions not deterministic?) on INL servers.

I'll see if I can come up with a more reproduceable unit test, but in the meantime this at least fixes the issue for me.