### PR TITLE
Add support for multi-step RBParameters objects in reduced_basis_ex4

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex4/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex4/assembly.h
@@ -69,9 +69,6 @@ struct ShiftedGaussian : public RBParametrizedFunction
     // Real center_y = mu.get_value("center_y");
     // return std::vector<Number> { std::exp(-2. * (pow<2>(center_x - p(0)) + pow<2>(center_y - p(1)))) };
 
-    // Debugging: print number of steps stored for each parameter
-    // libMesh::out << "Called ShiftedGaussian::evaluate() with " << mu.n_steps << " step(s) for each parameter." << std::endl;
-
     // New way, there are get_n_components() * mu.n_steps() entries in
     // the return vector.  In debug mode, we verify that the same
     // number of steps are provided for all parameters when

--- a/examples/reduced_basis/reduced_basis_ex4/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex4/assembly.h
@@ -86,7 +86,36 @@ struct ShiftedGaussian : public RBParametrizedFunction
 };
 
 // Expansion of the PDE operator
-struct ThetaA0 : RBTheta { virtual Number evaluate(const RBParameters &) { return 0.05;  } };
+struct ThetaA0 : RBTheta
+{
+  /**
+   * Evaluate theta for a single scalar-valued RBParameters object.
+   * In this case, Theta(mu) does not depend on mu
+   */
+  virtual Number evaluate(const RBParameters &) override
+  {
+    return 0.05;
+  }
+
+  /**
+   * Evaluate theta for multiple mu values, each of which may have multiple "steps".
+   * This theta still doesn't depend on mu, but the output vector must be sized appropriately.
+   */
+  virtual std::vector<Number> evaluate_vec(const std::vector<RBParameters> & mus) override
+  {
+    // Compute the number of values to be returned in the vector. For
+    // scalar-valued RBParameters objects, there would be mus.size()
+    // values returned in the vector. For step-valued RBParameters
+    // objects, there are:
+    // sum_i mus[i].max_n_values()
+    // total Thetas, i.e. one Theta per step.
+    unsigned int count = 0;
+    for (const auto & mu : mus)
+      count += mu.max_n_values();
+
+    return std::vector<Number>(count, /*value=*/0.05);
+  }
+};
 
 struct A0 : ElemAssembly
 {

--- a/examples/reduced_basis/reduced_basis_ex4/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex4/assembly.h
@@ -72,7 +72,7 @@ struct ShiftedGaussian : public RBParametrizedFunction
     libmesh_error_msg_if(n_values_x != n_values_y, "Must specify same number of values for all parameters.");
 
     // Debugging: print number of values
-    libMesh::out << "Called ShiftedGaussian::evaluate() with " << n_values_x << " value(s) for each parameter." << std::endl;
+    // libMesh::out << "Called ShiftedGaussian::evaluate() with " << n_values_x << " value(s) for each parameter." << std::endl;
 
     std::vector<Number> ret(this->get_n_components() * n_values_x);
     for (std::size_t i=0; i<n_values_x; ++i)

--- a/examples/reduced_basis/reduced_basis_ex4/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex4/assembly.h
@@ -13,6 +13,7 @@
 #include "libmesh/fe_interface.h"
 #include "libmesh/elem.h"
 #include "libmesh/utility.h"
+#include "libmesh/print_trace.h"
 
 // rbOOmit includes
 #include "libmesh/rb_assembly_expansion.h"
@@ -59,6 +60,9 @@ struct ShiftedGaussian : public RBParametrizedFunction
            const std::vector<Point> & /*p_perturb*/,
            const std::vector<Real> & /*phi_i_qp*/) override
   {
+    // Debugging - to figure out where this function is called from
+    // libMesh::print_trace();
+
     Real center_x = mu.get_value("center_x");
     Real center_y = mu.get_value("center_y");
     return std::vector<Number> { std::exp(-2. * (pow<2>(center_x - p(0)) + pow<2>(center_y - p(1)))) };

--- a/examples/reduced_basis/reduced_basis_ex4/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex4/assembly.h
@@ -286,8 +286,9 @@ struct EimTestRBThetaExpansion : RBThetaExpansion
     // Note: there are no Thetas associated with the RHS since we use
     // an EIM approximation for the forcing term.
 
-    // Attach an RBTheta object for the output. Here we just use the
+    // Attach an RBTheta object for each output. Here we just use the
     // ThetaConstant class again, but this time with a value of 1.0.
+    attach_output_theta(&output_theta);
     attach_output_theta(&output_theta);
   }
 
@@ -303,18 +304,22 @@ struct EimTestRBAssemblyExpansion : RBAssemblyExpansion
    * Constructor.
    */
   EimTestRBAssemblyExpansion():
-    L0(BoundingBox(/*min=*/Point(-0.2, -0.2),
-                   /*max=*/Point(0.2, 0.2)))
+    L0(BoundingBox(/*min=*/Point(-0.2, -0.2), /*max=*/Point(0.0, 0.0))),
+    L1(BoundingBox(/*min=*/Point(0.0, 0.0), /*max=*/Point(0.2, 0.2)))
   {
     attach_A_assembly(&A0_assembly);
+
+    // Attach output assembly objects
     attach_output_assembly(&L0);
+    attach_output_assembly(&L1);
   }
 
   // A0 assembly object
   A0 A0_assembly;
 
-  // Assembly object associated with the output functional
+  // Assembly objects associated with the output functionals
   OutputAssembly L0;
+  OutputAssembly L1;
 };
 
 #endif

--- a/examples/reduced_basis/reduced_basis_ex4/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex4/assembly.h
@@ -79,8 +79,8 @@ struct ShiftedGaussian : public RBParametrizedFunction
     std::vector<Number> ret(this->get_n_components() * mu.n_steps());
     for (auto i : make_range(mu.n_steps()))
       {
-        Real center_x = mu.get_value("center_x", static_cast<std::size_t>(i));
-        Real center_y = mu.get_value("center_y", static_cast<std::size_t>(i));
+        Real center_x = mu.get_step_value("center_x", i);
+        Real center_y = mu.get_step_value("center_y", i);
         ret[i] = std::exp(-2. * (pow<2>(center_x - p(0)) + pow<2>(center_y - p(1))));
       }
     return ret;

--- a/examples/reduced_basis/reduced_basis_ex4/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex4/assembly.h
@@ -15,6 +15,7 @@
 #include "libmesh/utility.h"
 #include "libmesh/print_trace.h"
 #include "libmesh/int_range.h"
+#include "libmesh/bounding_box.h"
 
 // rbOOmit includes
 #include "libmesh/rb_assembly_expansion.h"
@@ -45,6 +46,7 @@ using libMesh::subdomain_id_type;
 using libMesh::dof_id_type;
 using libMesh::Utility::pow;
 using libMesh::make_range;
+using libMesh::BoundingBox;
 
 struct ShiftedGaussian : public RBParametrizedFunction
 {
@@ -98,8 +100,9 @@ struct ThetaConstant : RBTheta
   /**
    * Evaluate theta for a single scalar-valued RBParameters object.
    * In this case, Theta(mu) does not depend on mu explicitly, except
-   * to determine the number of "steps" (aka n_steps()) which mu
-   * has, so that the output vector is sized appropriately.
+   * to throw an error in case a multi-step RBParameters object has
+   * been provided, since the evaluate() interface does not support
+   * multi-step RBParameters objects.
    */
   virtual Number evaluate(const RBParameters & mu) override
   {
@@ -110,14 +113,17 @@ struct ThetaConstant : RBTheta
   }
 
   /**
-   * Evaluate theta for multiple mu values, each of which may have multiple "steps".
-   * This theta still doesn't depend on mu, but the output vector must be sized appropriately.
+   * Evaluate theta for multiple mu values, each of which may have
+   * multiple "steps".  In this case, Theta(mu) does not depend on mu
+   * explicitly, except to determine the number of "steps" (aka
+   * n_steps()) which mu has, so that the output vector is sized
+   * appropriately.
    */
   virtual std::vector<Number> evaluate_vec(const std::vector<RBParameters> & mus) override
   {
     // Compute the number of values to be returned in the vector. For
-    // scalar-valued RBParameters objects, there would be mus.size()
-    // values returned in the vector. For step-valued RBParameters
+    // single-step RBParameters objects, there would be mus.size()
+    // values returned in the vector. For multi-step RBParameters
     // objects, there are:
     // sum_i mus[i].n_steps()
     // total Thetas, i.e. one Theta per step.
@@ -226,20 +232,13 @@ struct EIM_F : RBEIMAssembly
 
 /**
  * Output assembly object which computes the average value of the
- * solution variable inside a BoundingBox defined by lower corner
- * [min_x_in, min_y_in] and upper corner [max_x_in, max_y_in].
- * OutputAssembly is copied from reduced_basis_ex1 where it is also
- * used.
+ * solution variable inside a user-provided BoundingBox.
+ * OutputAssembly is also used in reduced_basis_ex1.
  */
 struct OutputAssembly : ElemAssembly
 {
-  OutputAssembly(Real min_x_in, Real max_x_in,
-                 Real min_y_in, Real max_y_in)
-    :
-    min_x(min_x_in),
-    max_x(max_x_in),
-    min_y(min_y_in),
-    max_y(max_y_in)
+  OutputAssembly(const BoundingBox & bbox_in) :
+    bbox(bbox_in)
   {}
 
   // Output: Average value over the region [min_x,max_x]x[min_y,max_y]
@@ -259,18 +258,17 @@ struct OutputAssembly : ElemAssembly
     // Now we will build the affine operator
     unsigned int n_qpoints = c.get_element_qrule().n_points();
 
-    Real output_area = (max_x-min_x) * (max_y-min_y);
+    // TODO: BoundingBox should be able to compute and return its area/volume
+    Real output_area = (bbox.max()(0) - bbox.min()(0)) * (bbox.max()(1) - bbox.min()(1));
 
-    Point avg = c.get_elem().vertex_average();
-    if ((min_x <= avg(0)) && (avg(0) <= max_x) &&
-        (min_y <= avg(1)) && (avg(1) <= max_y))
+    if (bbox.contains_point(c.get_elem().vertex_average()))
       for (unsigned int qp=0; qp != n_qpoints; qp++)
         for (unsigned int i=0; i != n_u_dofs; i++)
           c.get_elem_residual()(i) += JxW[qp] * phi[i][qp] / output_area;
   }
 
   // Member variables that define the output region in 2D
-  Real min_x, max_x, min_y, max_y;
+  BoundingBox bbox;
 };
 
 // Define an RBThetaExpansion class for this PDE
@@ -305,8 +303,8 @@ struct EimTestRBAssemblyExpansion : RBAssemblyExpansion
    * Constructor.
    */
   EimTestRBAssemblyExpansion():
-    L0(/*min_x=*/-0.2, /*max_x=*/0.2,
-       /*min_y=*/-0.2, /*max_x=*/0.2)
+    L0(BoundingBox(/*min=*/Point(-0.2, -0.2),
+                   /*max=*/Point(0.2, 0.2)))
   {
     attach_A_assembly(&A0_assembly);
     attach_output_assembly(&L0);

--- a/examples/reduced_basis/reduced_basis_ex4/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex4/assembly.h
@@ -288,9 +288,8 @@ struct EimTestRBThetaExpansion : RBThetaExpansion
     // Note: there are no Thetas associated with the RHS since we use
     // an EIM approximation for the forcing term.
 
-    // Attach a default RBTheta object for the output which just
-    // returns 1.  We just need the default RBTheta in this case
-    // because the output functional does not depend on mu.
+    // Attach an RBTheta object for the output. Here we just use the
+    // ThetaConstant class again, but this time with a value of 1.0.
     attach_output_theta(&output_theta);
   }
 

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -232,7 +232,7 @@ int main (int argc, char ** argv)
                                                                       "rb_data");
       }
     }
-  else
+  else // online mode
     {
       SimpleEIMEvaluation eim_rb_eval(mesh.comm());
       SimpleRBEvaluation rb_eval(mesh.comm());
@@ -268,6 +268,9 @@ int main (int argc, char ** argv)
 
       rb_eval.set_parameters(online_mu);
       rb_eval.print_parameters();
+
+      // FIXME: Here we need to pre-evaluate the thetas and call rb_solve in a loop while
+      // passing in the pre-evaluated thetas.
       rb_eval.rb_solve(rb_eval.get_n_basis_functions());
 
       EquationSystems equation_systems (mesh);

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -260,6 +260,12 @@ int main (int argc, char ** argv)
       online_mu.push_back_value("center_x", 0.5);
       online_mu.push_back_value("center_y", 0.5);
 
+      // Add 3rd (center_x, center_y) values. For debugging purposes,
+      // we want the number of "steps" (3) to be different from the
+      // number of parameters (2).
+      online_mu.push_back_value("center_x", -0.25);
+      online_mu.push_back_value("center_y", -0.25);
+
       rb_eval.set_parameters(online_mu);
       rb_eval.print_parameters();
       rb_eval.rb_solve(rb_eval.get_n_basis_functions());

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -300,7 +300,7 @@ int main (int argc, char ** argv)
           all_A[q_a] = rb_theta_expansion.eval_A_theta(q_a, mu_vec);
 
           // This size of each A_q vector here is:
-          // sum_i mu_vec[i].max_n_values()
+          // sum_i mu_vec[i].n_steps()
           // and it contains
           // the logically 2D array of values:
           // according to: {Theta(mu_vec[0], step_0), Theta(mu_vec[1], step_0), ... Theta(mu_vec[M], step_0),
@@ -381,7 +381,7 @@ int main (int argc, char ** argv)
       rb_eval.read_in_basis_functions(rb_construction, "rb_data");
 
       // Loop over each step, fill the evaluated_thetas array, call rb_solve()
-      for (unsigned step=0; step<online_mu.max_n_values(); ++step)
+      for (unsigned step=0; step<online_mu.n_steps(); ++step)
         {
           unsigned int counter = 0;
 

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -254,6 +254,12 @@ int main (int argc, char ** argv)
       RBParameters online_mu;
       online_mu.push_back_value("center_x", online_center_x);
       online_mu.push_back_value("center_y", online_center_y);
+
+      // Testing: Add secondary center_x and center_y values,
+      // corresponding to e.g. a different time step or load step.
+      online_mu.push_back_value("center_x", 0.5);
+      online_mu.push_back_value("center_y", 0.5);
+
       rb_eval.set_parameters(online_mu);
       rb_eval.print_parameters();
       rb_eval.rb_solve(rb_eval.get_n_basis_functions());

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -252,8 +252,8 @@ int main (int argc, char ** argv)
       Real online_center_x = infile("online_center_x", 0.);
       Real online_center_y = infile("online_center_y", 0.);
       RBParameters online_mu;
-      online_mu.set_value("center_x", online_center_x);
-      online_mu.set_value("center_y", online_center_y);
+      online_mu.push_back_value("center_x", online_center_x);
+      online_mu.push_back_value("center_y", online_center_y);
       rb_eval.set_parameters(online_mu);
       rb_eval.print_parameters();
       rb_eval.rb_solve(rb_eval.get_n_basis_functions());

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -328,9 +328,28 @@ int main (int argc, char ** argv)
           libMesh::out << std::endl;
         }
 
-      // 3.) Evaluate "output" thetas at all steps: in this case there are no outputs and there
-      // is no "vector-valued" version of the RBThetaExpansion::eval_output_theta() API, so we
-      // skip this step for now.
+      // 3.) Evaluate "output" thetas at all steps: in this case, the
+      // output is particularly simple (does not depend on mu) so this
+      // should just be a vector of all 1s. Also note that there is no
+      // "vector-valued" version of the RBThetaExpansion::eval_output_theta() API currently,
+      // but this example uses an RBParameters object with multiple steps, so we need to add
+      // that...
+      std::vector<std::vector<Number>> all_outputs(rb_theta_expansion.get_total_n_output_terms());
+      {
+        unsigned int output_counter = 0;
+        for (unsigned int n=0; n<rb_theta_expansion.get_n_outputs(); n++)
+          for (unsigned int q_l=0; q_l<rb_theta_expansion.get_n_output_terms(n); q_l++)
+            {
+              all_outputs[output_counter++] =
+                rb_theta_expansion.eval_output_theta(n, q_l, mu_vec); // TODO: Add vector-valued API
+
+              // Debugging:
+              libMesh::out << "output(" << n << ", " << q_l << ") = ";
+              for (const auto & val : all_outputs.back())
+                libMesh::out << val << ", ";
+              libMesh::out << std::endl;
+            }
+      }
 
       // The total number of thetas is the sum of the "A", "F", and
       // "output" thetas.

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -278,7 +278,7 @@ int main (int argc, char ** argv)
       // support single-valued RBParameters objects.  In this case,
       // since the RBParameters object stores multiple "steps", we
       // take the approach of pre-evaluating the thetas for each
-      // parameter while calling the rb_solve in a loop.
+      // parameter while calling the rb_solve() in a loop.
       //
       // FIXME: There are some const-correctness issues with the
       // RBThetaExpansion API here, so this reference is non-const,
@@ -341,7 +341,7 @@ int main (int argc, char ** argv)
           for (unsigned int q_l=0; q_l<rb_theta_expansion.get_n_output_terms(n); q_l++)
             {
               all_outputs[output_counter++] =
-                rb_theta_expansion.eval_output_theta(n, q_l, mu_vec); // TODO: Add vector-valued API
+                rb_theta_expansion.eval_output_theta(n, q_l, mu_vec);
 
               // Debugging:
               libMesh::out << "output(" << n << ", " << q_l << ") = ";
@@ -405,6 +405,12 @@ int main (int argc, char ** argv)
           libMesh::out << "Performing solve for step " << step << std::endl;
           rb_eval.rb_solve(rb_eval.get_n_basis_functions(), &evaluated_thetas);
 
+          // Print the output as well as the corresponding output error bound
+          libMesh::out << "Output value = " << rb_eval.RB_outputs[0]
+                       << ", error bound = " << rb_eval.RB_output_error_bounds[0]
+                       << std::endl;
+
+      // Write an exo file to visualize this solution
           rb_construction.load_rb_solution();
 #ifdef LIBMESH_HAVE_EXODUS_API
           ExodusII_IO(mesh).write_equation_systems("RB_sol_" + std::to_string(step) + ".e", equation_systems);

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -380,7 +380,7 @@ int main (int argc, char ** argv)
       rb_construction.set_rb_evaluation(rb_eval);
       rb_eval.read_in_basis_functions(rb_construction, "rb_data");
 
-      // Loop over each step, fill the evaluated_thetas array, call rb_solve
+      // Loop over each step, fill the evaluated_thetas array, call rb_solve()
       for (unsigned step=0; step<online_mu.max_n_values(); ++step)
         {
           unsigned int counter = 0;
@@ -394,7 +394,12 @@ int main (int argc, char ** argv)
             evaluated_thetas[counter++] = all_F[q_f][step];
 
           // Set output Theta values for current step
-          // TODO: add some outputs since currently there are none in this example
+          {
+            unsigned int output_counter = 0;
+            for (unsigned int n=0; n<rb_theta_expansion.get_n_outputs(); n++)
+              for (unsigned int q_l=0; q_l<rb_theta_expansion.get_n_output_terms(n); q_l++)
+                evaluated_thetas[counter++] = all_outputs[output_counter++][step];
+          }
 
           // Call rb_solve() for the current thetas
           libMesh::out << "Performing solve for step " << step << std::endl;

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -406,11 +406,12 @@ int main (int argc, char ** argv)
           rb_eval.rb_solve(rb_eval.get_n_basis_functions(), &evaluated_thetas);
 
           // Print the output as well as the corresponding output error bound
-          libMesh::out << "Output value = " << rb_eval.RB_outputs[0]
-                       << ", error bound = " << rb_eval.RB_output_error_bounds[0]
-                       << std::endl;
+          for (auto i : index_range(rb_eval.RB_outputs))
+            libMesh::out << "Output value " << i << " = " << rb_eval.RB_outputs[i]
+                         << ", error bound " << i << " = " << rb_eval.RB_output_error_bounds[i]
+                         << std::endl;
 
-      // Write an exo file to visualize this solution
+          // Write an exo file to visualize this solution
           rb_construction.load_rb_solution();
 #ifdef LIBMESH_HAVE_EXODUS_API
           ExodusII_IO(mesh).write_equation_systems("RB_sol_" + std::to_string(step) + ".e", equation_systems);

--- a/include/reduced_basis/rb_evaluation.h
+++ b/include/reduced_basis/rb_evaluation.h
@@ -142,10 +142,23 @@ public:
   virtual Real residual_scaling_denom(Real alpha_LB);
 
   /**
-   * Evaluate the dual norm of output \p n
-   * for the current parameters.
+   * Evaluate the dual norm of output \p n for the current parameters.
+   *
+   * This function is \deprecated, since you should either evaluate
+   * the output dual norm using a vector of pre-evaluated thetas, or
+   * by using the RBParameters object returned by calling
+   * get_parameters() on this class. Instead call the version of this
+   * function that takes an option pointer to a vector of evalauted
+   * theta values.
    */
   Real eval_output_dual_norm(unsigned int n, const RBParameters & mu);
+
+  /**
+   * Evaluate the dual norm of output \p n for the current parameters,
+   * or using the pre-evaluted theta values provided in the "evaluated_thetas"
+   * array.
+   */
+  Real eval_output_dual_norm(unsigned int n, const std::vector<Number> * evaluated_thetas);
 
   /**
    * Get a lower bound for the stability constant (e.g. coercivity constant or

--- a/include/reduced_basis/rb_evaluation.h
+++ b/include/reduced_basis/rb_evaluation.h
@@ -370,6 +370,12 @@ private:
    */
   RBThetaExpansion * rb_theta_expansion;
 
+  /**
+   * For interfaces like rb_solve() and compute_residual_dual_norm() that optinally
+   * take a vector of "pre-evaluated" theta values, this function checks to make sure
+   * that, when provided, it is the right size.
+   */
+  void check_evaluated_thetas_size(const std::vector<Number> * evaluated_thetas) const;
 };
 
 }

--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -184,8 +184,27 @@ public:
   /**
    * Set the value of the specified parameter. If param_name
    * doesn't already exist, it is added to the RBParameters object.
+   * For backwards compatibility, calling this function sets up
+   * "param_name" to be a single-entry vector with "value" as the
+   * only entry.
    */
   void set_value(const std::string & param_name, Real value);
+
+  /**
+   * Set the value of the specified parameter at the specified vector
+   * index.  Note: each parameter is now allowed to be vector-valued,
+   * it is up to the user to organize what the vector indices refer to
+   * (e.g. load or time steps).
+   */
+  void set_value(const std::string & param_name, std::size_t index, Real value);
+
+  /**
+   * Similar to set_value(name, index, value) but instead of specifying a particular
+   * index, just appends one more. Calling push_back_value() many times is more efficient
+   * than calling set_value(name, index, value) many times because it takes advantage
+   * of the std::vector's size-doubling t reduce allocations.
+   */
+  void push_back_value(const std::string & param_name, Real value);
 
   /**
    * Get the value of the specified extra parameter, throwing an error

--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -182,17 +182,17 @@ public:
   Real get_value(const std::string & param_name, const Real & default_val) const;
 
   /**
-   * Get the value of the specified parameter at the specified index,
+   * Get the value of the specified parameter at the specified step,
    * throwing an error if it does not exist.
    */
-  Real get_value(const std::string & param_name, std::size_t index) const;
+  Real get_step_value(const std::string & param_name, std::size_t index) const;
 
   /**
-   * Get the value of the specified parameter at the specified index,
+   * Get the value of the specified parameter at the specified step,
    * returning the provided default value if either the parameter is
-   * not defined or the index is invalid.
+   * not defined or the step is invalid.
    */
-  Real get_value(const std::string & param_name, std::size_t index, const Real & default_val) const;
+  Real get_step_value(const std::string & param_name, std::size_t index, const Real & default_val) const;
 
   /**
    * Set the value of the specified parameter. If param_name

--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -243,22 +243,12 @@ public:
   unsigned int n_parameters() const;
 
   /**
-   * Returns the number of values stored for param_name, or 0 if
-   * param_name is not present. Each parameter stored in an
-   * RBParameters object can have one value for time step or load
-   * step, and n_values() gives the number of such values.
+   * Returns the number of steps stored for all parameters. For
+   * simplicity, we require all parameters to store the same number of
+   * steps ("step" here may refer to time step or load step) and in
+   * debug mode we actually verify that is the case.
    */
-  unsigned int n_values(const std::string & param_name) const;
-
-  /**
-   * Returns the maximum number of values stored for any
-   * parameter. Note: we generally expect all parameters to store the
-   * same number of values (e.g. one per time step or one per load
-   * step) but there is nothing which requires that to be the case
-   * currently, so this function may be helpful in sizing output data
-   * structures.
-   */
-  unsigned int max_n_values() const;
+  unsigned int n_steps() const;
 
   /**
    * Fill \p param_names with the names of the parameters.

--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -243,6 +243,24 @@ public:
   unsigned int n_parameters() const;
 
   /**
+   * Returns the number of values stored for param_name, or 0 if
+   * param_name is not present. Each parameter stored in an
+   * RBParameters object can have one value for time step or load
+   * step, and n_values() gives the number of such values.
+   */
+  unsigned int n_values(const std::string & param_name) const;
+
+  /**
+   * Returns the maximum number of values stored for any
+   * parameter. Note: we generally expect all parameters to store the
+   * same number of values (e.g. one per time step or one per load
+   * step) but there is nothing which requires that to be the case
+   * currently, so this function may be helpful in sizing output data
+   * structures.
+   */
+  unsigned int max_n_values() const;
+
+  /**
    * Fill \p param_names with the names of the parameters.
    *
    * \deprecated to avoid making it too easy to create copies that in

--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -182,6 +182,19 @@ public:
   Real get_value(const std::string & param_name, const Real & default_val) const;
 
   /**
+   * Get the value of the specified parameter at the specified index,
+   * throwing an error if it does not exist.
+   */
+  Real get_value(const std::string & param_name, std::size_t index) const;
+
+  /**
+   * Get the value of the specified parameter at the specified index,
+   * returning the provided default value if either the parameter is
+   * not defined or the index is invalid.
+   */
+  Real get_value(const std::string & param_name, std::size_t index, const Real & default_val) const;
+
+  /**
    * Set the value of the specified parameter. If param_name
    * doesn't already exist, it is added to the RBParameters object.
    * For backwards compatibility, calling this function sets up

--- a/include/reduced_basis/rb_theta_expansion.h
+++ b/include/reduced_basis/rb_theta_expansion.h
@@ -89,6 +89,13 @@ public:
                                    const RBParameters & mu);
 
   /**
+   * Evaluate theta_q_l at multiple parameters simultaneously.
+   */
+  virtual std::vector<Number> eval_output_theta(unsigned int output_index,
+                                                unsigned int q_l,
+                                                const std::vector<RBParameters> & mus);
+
+  /**
    * Get Q_a, the number of terms in the affine
    * expansion for the bilinear form.
    */

--- a/include/reduced_basis/rb_theta_expansion.h
+++ b/include/reduced_basis/rb_theta_expansion.h
@@ -111,6 +111,11 @@ public:
   unsigned int get_n_output_terms(unsigned int output_index) const;
 
   /**
+   * Returns the total number of affine terms associated with all outputs.
+   */
+  unsigned int get_total_n_output_terms() const;
+
+  /**
    * Attach a pointer to a functor object that defines one
    * of the theta_q_a terms.
    */

--- a/include/reduced_basis/rb_theta_expansion.h
+++ b/include/reduced_basis/rb_theta_expansion.h
@@ -116,6 +116,14 @@ public:
   unsigned int get_total_n_output_terms() const;
 
   /**
+   * Computes the one-dimensional index for output n, term q_l implied by
+   * a "row-major" ordering of the outputs. This is useful for indexing into
+   * pre-evaluated theta arrays, which store the pre-evaluated output theta
+   * values in this order following the "A" and "F" theta values.
+   */
+  unsigned int output_index_1D(unsigned int n, unsigned int q_l);
+
+  /**
    * Attach a pointer to a functor object that defines one
    * of the theta_q_a terms.
    */

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -230,14 +230,14 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
   // one RB-EIM solve per input mu, per step. In order for this to
   // work, we require that all the input mu objects have the same
   // number of steps.
-  auto n_vals_0 = mus[0].max_n_values();
+  auto n_steps_0 = mus[0].n_steps();
   for (const auto & mu : mus)
-    libmesh_error_msg_if(mu.max_n_values() != n_vals_0, "All RBParameters objects must have same max_n_values()");
+    libmesh_error_msg_if(mu.n_steps() != n_steps_0, "All RBParameters objects must have same n_steps()");
 
   // After we verified that all mus have the same number of values,
   // the total number of RB-EIM solves is simply the number of mus
   // times the number of steps.
-  unsigned int num_rb_eim_solves = mus.size() * n_vals_0;
+  unsigned int num_rb_eim_solves = mus.size() * n_steps_0;
 
   // Debugging:
   // std::cout << "num_rb_eim_solves = " << num_rb_eim_solves << std::endl;
@@ -250,7 +250,7 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
   {
   unsigned int counter = 0;
   for (auto mu_index : index_range(mus))
-    for (auto step_index : make_range(mus[mu_index].max_n_values()))
+    for (auto step_index : make_range(mus[mu_index].n_steps()))
     {
       evaluated_values_at_interp_points[counter].resize(N); // N is number of RB basis functions
 
@@ -297,7 +297,7 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
   {
   unsigned int counter = 0;
   for (auto mu_index : index_range(mus))
-    for (auto step_index : make_range(mus[mu_index].max_n_values()))
+    for (auto step_index : make_range(mus[mu_index].n_steps()))
     {
       DenseVector<Number> EIM_rhs = evaluated_values_at_interp_points[counter];
       interpolation_matrix_N.lu_solve(EIM_rhs, _rb_eim_solutions[counter]);

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -207,25 +207,6 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
                                                     _interpolation_points_phi_i_qp,
                                                     output_all_comps);
 
-  // Debugging: This should be equal to mus.size()
-  // libMesh::out << "output_all_comps.size()=" << output_all_comps.size() << std::endl;
-
-  // Debugging
-  // The size of output_all_comps[i][j] should now be 3 in our test
-  // for (auto i : index_range(output_all_comps))
-  //   for (auto j : index_range(output_all_comps[i]))
-  //     libMesh::out << "output_all_comps["<<i<<"]["<<j<<"].size() = " << output_all_comps[i][j].size() << std::endl;
-
-  // Debugging print output_all_comps[i][j]
-  // for (auto i : index_range(output_all_comps))
-  //   for (auto j : index_range(output_all_comps[i]))
-  //     {
-  //       libMesh::out << "output_all_comps["<<i<<"]["<<j<<"] = ";
-  //       for (auto k : index_range(output_all_comps[i][j]))
-  //         libMesh::out << output_all_comps[i][j][k] << ", ";
-  //       libMesh::out << std::endl;
-  //     }
-
   // Previously we did one RB-EIM solve per input mu, but now we do
   // one RB-EIM solve per input mu, per step. In order for this to
   // work, we require that all the input mu objects have the same
@@ -238,9 +219,6 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
   // the total number of RB-EIM solves is simply the number of mus
   // times the number of steps.
   unsigned int num_rb_eim_solves = mus.size() * n_steps_0;
-
-  // Debugging:
-  // std::cout << "num_rb_eim_solves = " << num_rb_eim_solves << std::endl;
 
   std::vector<std::vector<Number>> evaluated_values_at_interp_points(num_rb_eim_solves);
 
@@ -258,12 +236,6 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
         {
           unsigned int comp = _interpolation_points_comp[interp_pt_index];
 
-          // Debugging
-          // libMesh::out << "mu_index = " << mu_index
-          //              << ", interp_pt_index = " << interp_pt_index
-          //              << ", comp = " << comp
-          //              << std::endl;
-
           // For vector-valued functions, the output_all_comps vectors are indexed first by component, then by step.
           // For example, if there are 2 components and 3 steps, the output entries will be:
           // [(comp0, step0), (comp1, step0),  (comp0, step1), (comp1, step1),  (comp0, step2), (comp1, step2)]
@@ -276,15 +248,6 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
       counter++;
     }
   }
-
-  // Debugging: print the contents of evaluated_values_at_interp_points
-  // for (auto i : index_range(evaluated_values_at_interp_points))
-  //   {
-  //     libMesh::out << "evaluated_values_at_interp_points["<<i<<"] = ";
-  //     for (auto j : index_range(evaluated_values_at_interp_points[i]))
-  //       libMesh::out << evaluated_values_at_interp_points[i][j] << ", ";
-  //     libMesh::out << std::endl;
-  //   }
 
   DenseMatrix<Number> interpolation_matrix_N;
   _interpolation_matrix.get_principal_submatrix(N, interpolation_matrix_N);

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -208,23 +208,23 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
                                                     output_all_comps);
 
   // Debugging: This should be equal to mus.size()
-  libMesh::out << "output_all_comps.size()=" << output_all_comps.size() << std::endl;
+  // libMesh::out << "output_all_comps.size()=" << output_all_comps.size() << std::endl;
 
   // Debugging
   // The size of output_all_comps[i][j] should now be 3 in our test
-  for (auto i : index_range(output_all_comps))
-    for (auto j : index_range(output_all_comps[i]))
-      libMesh::out << "output_all_comps["<<i<<"]["<<j<<"].size() = " << output_all_comps[i][j].size() << std::endl;
+  // for (auto i : index_range(output_all_comps))
+  //   for (auto j : index_range(output_all_comps[i]))
+  //     libMesh::out << "output_all_comps["<<i<<"]["<<j<<"].size() = " << output_all_comps[i][j].size() << std::endl;
 
   // Debugging print output_all_comps[i][j]
-  for (auto i : index_range(output_all_comps))
-    for (auto j : index_range(output_all_comps[i]))
-      {
-        libMesh::out << "output_all_comps["<<i<<"]["<<j<<"] = ";
-        for (auto k : index_range(output_all_comps[i][j]))
-          libMesh::out << output_all_comps[i][j][k] << ", ";
-        libMesh::out << std::endl;
-      }
+  // for (auto i : index_range(output_all_comps))
+  //   for (auto j : index_range(output_all_comps[i]))
+  //     {
+  //       libMesh::out << "output_all_comps["<<i<<"]["<<j<<"] = ";
+  //       for (auto k : index_range(output_all_comps[i][j]))
+  //         libMesh::out << output_all_comps[i][j][k] << ", ";
+  //       libMesh::out << std::endl;
+  //     }
 
   // Previously we did one RB-EIM solve per input mu, but now we do
   // one RB-EIM solve per input mu, per step. In order for this to
@@ -240,7 +240,7 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
   unsigned int num_rb_eim_solves = mus.size() * n_vals_0;
 
   // Debugging:
-  std::cout << "num_rb_eim_solves = " << num_rb_eim_solves << std::endl;
+  // std::cout << "num_rb_eim_solves = " << num_rb_eim_solves << std::endl;
 
   std::vector<std::vector<Number>> evaluated_values_at_interp_points(num_rb_eim_solves);
 
@@ -278,13 +278,13 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
   }
 
   // Debugging: print the contents of evaluated_values_at_interp_points
-  for (auto i : index_range(evaluated_values_at_interp_points))
-    {
-      libMesh::out << "evaluated_values_at_interp_points["<<i<<"] = ";
-      for (auto j : index_range(evaluated_values_at_interp_points[i]))
-        libMesh::out << evaluated_values_at_interp_points[i][j] << ", ";
-      libMesh::out << std::endl;
-    }
+  // for (auto i : index_range(evaluated_values_at_interp_points))
+  //   {
+  //     libMesh::out << "evaluated_values_at_interp_points["<<i<<"] = ";
+  //     for (auto j : index_range(evaluated_values_at_interp_points[i]))
+  //       libMesh::out << evaluated_values_at_interp_points[i][j] << ", ";
+  //     libMesh::out << std::endl;
+  //   }
 
   DenseMatrix<Number> interpolation_matrix_N;
   _interpolation_matrix.get_principal_submatrix(N, interpolation_matrix_N);

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -262,6 +262,9 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
   for (auto mu_index : index_range(mus))
     for (auto step_index : make_range(mus[mu_index].n_steps()))
     {
+      // Ignore compiler warnings about unused loop index
+      libmesh_ignore(step_index);
+
       DenseVector<Number> EIM_rhs = evaluated_values_at_interp_points[counter];
       interpolation_matrix_N.lu_solve(EIM_rhs, _rb_eim_solutions[counter]);
       counter++;

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -207,14 +207,57 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
                                                     _interpolation_points_phi_i_qp,
                                                     output_all_comps);
 
+  // Debugging
+  libMesh::out << "output_all_comps.size()=" << output_all_comps.size() << std::endl;
+
+  // Debugging
+  // The size of output_all_comps[i][j] should now be 2 in our test
+  for (auto i : index_range(output_all_comps))
+    for (auto j : index_range(output_all_comps[i]))
+      libMesh::out << "output_all_comps["<<i<<"]["<<j<<"].size() = " << output_all_comps[i][j].size() << std::endl;
+
+  // Debugging print output_all_comps[i][j]
+  for (auto i : index_range(output_all_comps))
+    for (auto j : index_range(output_all_comps[i]))
+      {
+        libMesh::out << "output_all_comps["<<i<<"]["<<j<<"] = ";
+        for (auto k : index_range(output_all_comps[i][j]))
+          libMesh::out << output_all_comps[i][j][k] << ", ";
+        libMesh::out << std::endl;
+      }
+
+  // The size of this array should depend on the number of steps
+  // stored within each mu object somehow, e.g. it should instead be
+  // something like:
+  // sum_i mus[i].max_n_values()
+  // where the sum goes over all entries of mus.
+  unsigned int evaluated_values_at_interp_points_size = 0;
+  for (const auto & mu : mus)
+    evaluated_values_at_interp_points_size += mu.max_n_values();
+
+  // Debugging:
+  std::cout << "evaluated_values_at_interp_points_size = "
+            << evaluated_values_at_interp_points_size
+            << std::endl;
+
   std::vector<std::vector<Number>> evaluated_values_at_interp_points(output_all_comps.size());
 
+  // In this loop, mu_index does not just refer to the ith
+  // RBParameters object, but also the jth step within the ith
+  // RBParameters object.
   for (unsigned int mu_index : index_range(evaluated_values_at_interp_points))
     {
-      evaluated_values_at_interp_points[mu_index].resize(N);
+      evaluated_values_at_interp_points[mu_index].resize(N); // N is number of RB basis functions
       for (unsigned int interp_pt_index=0; interp_pt_index<N; interp_pt_index++)
         {
+          // FIXME: We need to index into output_all_comps[i][j] using more than just comp now...
           unsigned int comp = _interpolation_points_comp[interp_pt_index];
+
+          // Debugging
+          // libMesh::out << "mu_index = " << mu_index
+          //              << ", interp_pt_index = " << interp_pt_index
+          //              << ", comp = " << comp
+          //              << std::endl;
 
           evaluated_values_at_interp_points[mu_index][interp_pt_index] =
             output_all_comps[mu_index][interp_pt_index][comp];

--- a/src/reduced_basis/rb_eim_theta.C
+++ b/src/reduced_basis/rb_eim_theta.C
@@ -36,11 +36,6 @@ Number RBEIMTheta::evaluate(const RBParameters & mu)
   std::vector<RBParameters> mus {mu};
   std::vector<Number> values = evaluate_vec(mus);
 
-  // Debugging:
-  // for (const auto & val : values)
-  //   libMesh::out << val << ", ";
-  // libMesh::out << std::endl;
-
   libmesh_error_msg_if(values.size() != 1, "Error: should have one value");
   return values[0];
 }

--- a/src/reduced_basis/rb_eim_theta.C
+++ b/src/reduced_basis/rb_eim_theta.C
@@ -37,9 +37,9 @@ Number RBEIMTheta::evaluate(const RBParameters & mu)
   std::vector<Number> values = evaluate_vec(mus);
 
   // Debugging:
-  for (const auto & val : values)
-    libMesh::out << val << ", ";
-  libMesh::out << std::endl;
+  // for (const auto & val : values)
+  //   libMesh::out << val << ", ";
+  // libMesh::out << std::endl;
 
   libmesh_error_msg_if(values.size() != 1, "Error: should have one value");
   return values[0];

--- a/src/reduced_basis/rb_eim_theta.C
+++ b/src/reduced_basis/rb_eim_theta.C
@@ -36,6 +36,11 @@ Number RBEIMTheta::evaluate(const RBParameters & mu)
   std::vector<RBParameters> mus {mu};
   std::vector<Number> values = evaluate_vec(mus);
 
+  // Debugging:
+  for (const auto & val : values)
+    libMesh::out << val << ", ";
+  libMesh::out << std::endl;
+
   libmesh_error_msg_if(values.size() != 1, "Error: should have one value");
   return values[0];
 }

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -218,12 +218,7 @@ Real RBEvaluation::rb_solve(unsigned int N,
   // In case the theta functions have been pre-evaluated, first check the size for consistency. The
   // size of the input "evaluated_thetas" vector must match the sum of the "A", "F", and "output" terms
   // in the expansion.
-  libmesh_error_msg_if(evaluated_thetas &&
-                       evaluated_thetas->size() !=
-                       rb_theta_expansion->get_n_A_terms() +
-                       rb_theta_expansion->get_n_F_terms() +
-                       rb_theta_expansion->get_total_n_output_terms(),
-                       "ERROR: Evaluated thetas have wrong size");
+  this->check_evaluated_thetas_size(evaluated_thetas);
 
   const RBParameters & mu = get_parameters();
 
@@ -348,9 +343,7 @@ Real RBEvaluation::compute_residual_dual_norm(const unsigned int N,
   LOG_SCOPE("compute_residual_dual_norm()", "RBEvaluation");
 
   // In case the theta functions have been pre-evaluated, first check the size for consistency
-  libmesh_error_msg_if(evaluated_thetas &&
-                       evaluated_thetas->size() != rb_theta_expansion->get_n_A_terms() + rb_theta_expansion->get_n_F_terms(),
-                       "ERROR: Evaluated thetas have wrong size");
+  this->check_evaluated_thetas_size(evaluated_thetas);
 
   // If evaluated_thetas is provided, then mu is not actually used for anything
   const RBParameters & mu = get_parameters();
@@ -1187,6 +1180,16 @@ void RBEvaluation::read_in_vectors_from_multiple_files(System & sys,
 
   // Undo the temporary renumbering
   sys.get_mesh().fix_broken_node_and_element_numbering();
+}
+
+void RBEvaluation::check_evaluated_thetas_size(const std::vector<Number> * evaluated_thetas) const
+{
+  libmesh_error_msg_if((rb_theta_expansion && evaluated_thetas) &&
+                       evaluated_thetas->size() !=
+                       rb_theta_expansion->get_n_A_terms() +
+                       rb_theta_expansion->get_n_F_terms() +
+                       rb_theta_expansion->get_total_n_output_terms(),
+                       "ERROR: Evaluated thetas have wrong size");
 }
 
 } // namespace libMesh

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -54,31 +54,31 @@ bool RBParameters::has_extra_value(const std::string & param_name) const
 
 Real RBParameters::get_value(const std::string & param_name) const
 {
-  // This version of get_value() does not take an index and is provided
-  // for backwards compatibility. It simply returns the [0]th entry of
-  // the vector if it can, throwing an error otherwise.
-  return this->get_value(param_name, /*index=*/static_cast<std::size_t>(0));
+  // get_value() is maintained for backwards compatibility. It simply
+  // returns the [0]th entry of the vector if it can, throwing an
+  // error otherwise.
+  return this->get_step_value(param_name, /*step=*/0);
 }
 
 Real RBParameters::get_value(const std::string & param_name, const Real & default_val) const
 {
-  // This version of get_value() does not take an index and is provided
-  // for backwards compatibility. It simply returns the [0]th entry of
-  // the vector if it can, or the default value otherwise.
-  return this->get_value(param_name, /*index=*/0, default_val);
+  // get_value() is maintained for backwards compatibility. It simply
+  // returns the [0]th entry of the vector if it can, or the default
+  // value otherwise.
+  return this->get_step_value(param_name, /*step=*/0, default_val);
 }
 
-Real RBParameters::get_value(const std::string & param_name, std::size_t index) const
+Real RBParameters::get_step_value(const std::string & param_name, std::size_t step) const
 {
   const auto & vec = libmesh_map_find(_parameters, param_name);
-  libmesh_error_msg_if(index >= vec.size(), "Error getting value for parameter " << param_name);
-  return vec[index];
+  libmesh_error_msg_if(step >= vec.size(), "Error getting value for parameter " << param_name);
+  return vec[step];
 }
 
-Real RBParameters::get_value(const std::string & param_name, std::size_t index, const Real & default_val) const
+Real RBParameters::get_step_value(const std::string & param_name, std::size_t step, const Real & default_val) const
 {
   auto it = _parameters.find(param_name);
-  return ((it != _parameters.end() && index < it->second.size()) ? it->second[index] : default_val);
+  return ((it != _parameters.end() && step < it->second.size()) ? it->second[step] : default_val);
 }
 
 void RBParameters::set_value(const std::string & param_name, Real value)

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -133,8 +133,21 @@ void RBParameters::set_extra_value(const std::string & param_name, Real value)
 
 unsigned int RBParameters::n_parameters() const
 {
-  return cast_int<unsigned int>
-    (_parameters.size());
+  return cast_int<unsigned int>(_parameters.size());
+}
+
+unsigned int RBParameters::n_values(const std::string & param_name) const
+{
+  auto it = _parameters.find(param_name);
+  return (it != _parameters.end() ? it->second.size() : 0);
+}
+
+unsigned int RBParameters::max_n_values() const
+{
+  std::size_t ret = 0;
+  for (const auto & pr : _parameters)
+    ret = std::max(ret, pr.second.size());
+  return cast_int<unsigned int>(ret);
 }
 
 void RBParameters::get_parameter_names(std::set<std::string> & param_names) const

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -136,18 +136,24 @@ unsigned int RBParameters::n_parameters() const
   return cast_int<unsigned int>(_parameters.size());
 }
 
-unsigned int RBParameters::n_values(const std::string & param_name) const
+unsigned int RBParameters::n_steps() const
 {
-  auto it = _parameters.find(param_name);
-  return (it != _parameters.end() ? it->second.size() : 0);
-}
+  // Quick return if there are no parameters
+  if (_parameters.empty())
+    return 0;
 
-unsigned int RBParameters::max_n_values() const
-{
-  std::size_t ret = 0;
+  // If _parameters is not empty, we can check the number of steps in the first param
+  auto size_first = _parameters.begin()->second.size();
+
+#ifdef DEBUG
+  // In debug mode, verify that all parameters have the same number of steps
   for (const auto & pr : _parameters)
-    ret = std::max(ret, pr.second.size());
-  return cast_int<unsigned int>(ret);
+    libmesh_assert_msg(pr.second.size() == size_first, "All parameters must have the same number of steps.");
+#endif
+
+  // If we made it here in DEBUG mode, then all parameters were
+  // verified to have the same number of steps.
+  return size_first;
 }
 
 void RBParameters::get_parameter_names(std::set<std::string> & param_names) const

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -57,9 +57,7 @@ Real RBParameters::get_value(const std::string & param_name) const
   // This version of get_value() does not take an index and is provided
   // for backwards compatibility. It simply returns the [0]th entry of
   // the vector if it can, throwing an error otherwise.
-  const auto & vec = libmesh_map_find(_parameters, param_name);
-  libmesh_error_msg_if(vec.size() == 0, "Error getting value for parameter " << param_name);
-  return vec[0];
+  return this->get_value(param_name, /*index=*/static_cast<std::size_t>(0));
 }
 
 Real RBParameters::get_value(const std::string & param_name, const Real & default_val) const
@@ -67,8 +65,20 @@ Real RBParameters::get_value(const std::string & param_name, const Real & defaul
   // This version of get_value() does not take an index and is provided
   // for backwards compatibility. It simply returns the [0]th entry of
   // the vector if it can, or the default value otherwise.
+  return this->get_value(param_name, /*index=*/0, default_val);
+}
+
+Real RBParameters::get_value(const std::string & param_name, std::size_t index) const
+{
+  const auto & vec = libmesh_map_find(_parameters, param_name);
+  libmesh_error_msg_if(index >= vec.size(), "Error getting value for parameter " << param_name);
+  return vec[index];
+}
+
+Real RBParameters::get_value(const std::string & param_name, std::size_t index, const Real & default_val) const
+{
   auto it = _parameters.find(param_name);
-  return ((it != _parameters.end() && it->second.size() != 0) ? it->second[0] : default_val);
+  return ((it != _parameters.end() && index < it->second.size()) ? it->second[index] : default_val);
 }
 
 void RBParameters::set_value(const std::string & param_name, Real value)

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -79,6 +79,27 @@ void RBParameters::set_value(const std::string & param_name, Real value)
   _parameters[param_name] = {value};
 }
 
+void RBParameters::set_value(const std::string & param_name, std::size_t index, Real value)
+{
+  // Get reference to vector of values for this parameter, creating it
+  // if it does not already exist.
+  auto & vec = _parameters[param_name];
+
+  // Allocate more space (padding with 0s) if vector is not big enough
+  // to fit the user's requested index.
+  if (vec.size() < index+1)
+    vec.resize(index+1);
+
+  vec[index] = value;
+}
+
+void RBParameters::push_back_value(const std::string & param_name, Real value)
+{
+  // Get reference to vector of values for this parameter, creating it
+  // if it does not already exist, and push back the specified value.
+  _parameters[param_name].push_back(value);
+}
+
 Real RBParameters::get_extra_value(const std::string & param_name) const
 {
   // Same as get_value(param_name) but for the map of extra parameters

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -155,6 +155,10 @@ void RBParametrizedFunction::vectorized_evaluate(const std::vector<RBParameters>
   // Dummy vector to be used when xyz perturbations are not required
   std::vector<Point> empty_perturbs;
 
+  // Debugging
+  libMesh::out << "mus.size() = " << mus.size() << std::endl;
+  libMesh::out << "n_points = " << n_points << std::endl;
+
   output.resize(mus.size());
   for ( unsigned int mu_index : index_range(mus))
     {

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -159,6 +159,22 @@ void RBParametrizedFunction::vectorized_evaluate(const std::vector<RBParameters>
   libMesh::out << "mus.size() = " << mus.size() << std::endl;
   libMesh::out << "n_points = " << n_points << std::endl;
 
+  // Debugging: A new feature is that each parameter stored in an
+  // RBParameters object can have multiple values defined in a vector.
+  // The following code iterates over each RBParameters object and
+  // checks the number of values it has.
+  {
+    std::map<std::string, unsigned int> num_values_per_param;
+    for (const auto & mu : mus)
+    {
+      for (const auto & pr : mu)
+        num_values_per_param[pr.first]++;
+    }
+
+    for (const auto & [param_name, nvals] : num_values_per_param)
+      libMesh::out << "Parameter " << param_name << " has " << nvals << " value(s)" << std::endl;
+  }
+
   output.resize(mus.size());
   for ( unsigned int mu_index : index_range(mus))
     {

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -155,26 +155,6 @@ void RBParametrizedFunction::vectorized_evaluate(const std::vector<RBParameters>
   // Dummy vector to be used when xyz perturbations are not required
   std::vector<Point> empty_perturbs;
 
-  // Debugging
-  // libMesh::out << "mus.size() = " << mus.size() << std::endl;
-  // libMesh::out << "n_points = " << n_points << std::endl;
-
-  // Debugging: A new feature is that each parameter stored in an
-  // RBParameters object can have multiple values defined in a vector.
-  // The following code iterates over each RBParameters object and
-  // checks the number of values it has.
-  // {
-  //   std::map<std::string, unsigned int> num_values_per_param;
-  //   for (const auto & mu : mus)
-  //   {
-  //     for (const auto & pr : mu)
-  //       num_values_per_param[pr.first]++;
-  //   }
-  //
-  //   for (const auto & [param_name, nvals] : num_values_per_param)
-  //     libMesh::out << "Parameter " << param_name << " has " << nvals << " value(s)" << std::endl;
-  // }
-
   output.resize(mus.size());
   for (auto mu_index : index_range(mus))
     {
@@ -189,12 +169,6 @@ void RBParametrizedFunction::vectorized_evaluate(const std::vector<RBParameters>
                      sbd_ids[point_index],
                      requires_xyz_perturbations ? all_xyz_perturb[point_index] : empty_perturbs,
                      phi_i_qp[point_index]);
-
-          // Debugging
-          // libMesh::out << "mu_index = " << mu_index
-          //              << ", point_index = " << point_index
-          //              << ", output[mu_index][point_index].size() = " << output[mu_index][point_index].size()
-          //              << std::endl;
         }
     }
 }

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -156,51 +156,45 @@ void RBParametrizedFunction::vectorized_evaluate(const std::vector<RBParameters>
   std::vector<Point> empty_perturbs;
 
   // Debugging
-  libMesh::out << "mus.size() = " << mus.size() << std::endl;
-  libMesh::out << "n_points = " << n_points << std::endl;
+  // libMesh::out << "mus.size() = " << mus.size() << std::endl;
+  // libMesh::out << "n_points = " << n_points << std::endl;
 
   // Debugging: A new feature is that each parameter stored in an
   // RBParameters object can have multiple values defined in a vector.
   // The following code iterates over each RBParameters object and
   // checks the number of values it has.
-  {
-    std::map<std::string, unsigned int> num_values_per_param;
-    for (const auto & mu : mus)
-    {
-      for (const auto & pr : mu)
-        num_values_per_param[pr.first]++;
-    }
-
-    for (const auto & [param_name, nvals] : num_values_per_param)
-      libMesh::out << "Parameter " << param_name << " has " << nvals << " value(s)" << std::endl;
-  }
+  // {
+  //   std::map<std::string, unsigned int> num_values_per_param;
+  //   for (const auto & mu : mus)
+  //   {
+  //     for (const auto & pr : mu)
+  //       num_values_per_param[pr.first]++;
+  //   }
+  //
+  //   for (const auto & [param_name, nvals] : num_values_per_param)
+  //     libMesh::out << "Parameter " << param_name << " has " << nvals << " value(s)" << std::endl;
+  // }
 
   output.resize(mus.size());
-  for ( unsigned int mu_index : index_range(mus))
+  for (auto mu_index : index_range(mus))
     {
       output[mu_index].resize(n_points);
       for (unsigned int point_index=0; point_index<n_points; point_index++)
         {
-          if (requires_xyz_perturbations)
-            {
-              output[mu_index][point_index] = evaluate(mus[mu_index],
-                                                       all_xyz[point_index],
-                                                       elem_ids[point_index],
-                                                       qps[point_index],
-                                                       sbd_ids[point_index],
-                                                       all_xyz_perturb[point_index],
-                                                       phi_i_qp[point_index]);
-            }
-          else
-            {
-              output[mu_index][point_index] = evaluate(mus[mu_index],
-                                                       all_xyz[point_index],
-                                                       elem_ids[point_index],
-                                                       qps[point_index],
-                                                       sbd_ids[point_index],
-                                                       empty_perturbs,
-                                                       phi_i_qp[point_index]);
-            }
+          output[mu_index][point_index] =
+            evaluate(mus[mu_index],
+                     all_xyz[point_index],
+                     elem_ids[point_index],
+                     qps[point_index],
+                     sbd_ids[point_index],
+                     requires_xyz_perturbations ? all_xyz_perturb[point_index] : empty_perturbs,
+                     phi_i_qp[point_index]);
+
+          // Debugging
+          // libMesh::out << "mu_index = " << mu_index
+          //              << ", point_index = " << point_index
+          //              << ", output[mu_index][point_index].size() = " << output[mu_index][point_index].size()
+          //              << std::endl;
         }
     }
 }
@@ -228,35 +222,21 @@ void RBParametrizedFunction::side_vectorized_evaluate(const std::vector<RBParame
   std::vector<Point> empty_perturbs;
 
   output.resize(mus.size());
-  for ( unsigned int mu_index : index_range(mus))
+  for (auto mu_index : index_range(mus))
     {
       output[mu_index].resize(n_points);
       for (unsigned int point_index=0; point_index<n_points; point_index++)
         {
-          if (requires_xyz_perturbations)
-            {
-              output[mu_index][point_index] = side_evaluate(mus[mu_index],
-                                                            all_xyz[point_index],
-                                                            elem_ids[point_index],
-                                                            side_indices[point_index],
-                                                            qps[point_index],
-                                                            sbd_ids[point_index],
-                                                            boundary_ids[point_index],
-                                                            all_xyz_perturb[point_index],
-                                                            phi_i_qp[point_index]);
-            }
-          else
-            {
-              output[mu_index][point_index] = side_evaluate(mus[mu_index],
-                                                            all_xyz[point_index],
-                                                            elem_ids[point_index],
-                                                            side_indices[point_index],
-                                                            qps[point_index],
-                                                            sbd_ids[point_index],
-                                                            boundary_ids[point_index],
-                                                            empty_perturbs,
-                                                            phi_i_qp[point_index]);
-            }
+          output[mu_index][point_index] =
+            side_evaluate(mus[mu_index],
+                          all_xyz[point_index],
+                          elem_ids[point_index],
+                          side_indices[point_index],
+                          qps[point_index],
+                          sbd_ids[point_index],
+                          boundary_ids[point_index],
+                          requires_xyz_perturbations ? all_xyz_perturb[point_index] : empty_perturbs,
+                          phi_i_qp[point_index]);
         }
     }
 }
@@ -273,7 +253,7 @@ void RBParametrizedFunction::node_vectorized_evaluate(const std::vector<RBParame
   unsigned int n_points = all_xyz.size();
 
   output.resize(mus.size());
-  for ( unsigned int mu_index : index_range(mus))
+  for (auto mu_index : index_range(mus))
     {
       output[mu_index].resize(n_points);
       for (unsigned int point_index=0; point_index<n_points; point_index++)

--- a/src/reduced_basis/rb_theta_expansion.C
+++ b/src/reduced_basis/rb_theta_expansion.C
@@ -58,6 +58,14 @@ unsigned int RBThetaExpansion::get_n_output_terms(unsigned int index) const
     (_output_theta_vector[index].size());
 }
 
+unsigned int RBThetaExpansion::get_total_n_output_terms() const
+{
+  unsigned int sum = 0;
+  for (const auto & vec : _output_theta_vector)
+    sum += vec.size();
+  return sum;
+}
+
 void RBThetaExpansion::attach_A_theta(RBTheta * theta_q_a)
 {
   libmesh_assert(theta_q_a);

--- a/src/reduced_basis/rb_theta_expansion.C
+++ b/src/reduced_basis/rb_theta_expansion.C
@@ -22,6 +22,9 @@
 #include "libmesh/rb_theta.h"
 #include "libmesh/rb_parameters.h"
 
+// libMesh includes
+#include "libmesh/int_range.h" // make_range
+
 namespace libMesh
 {
 
@@ -64,6 +67,18 @@ unsigned int RBThetaExpansion::get_total_n_output_terms() const
   for (const auto & vec : _output_theta_vector)
     sum += vec.size();
   return sum;
+}
+
+unsigned int RBThetaExpansion::output_index_1D(unsigned int n, unsigned int q_l)
+{
+  // Start with index of the current term
+  unsigned int index = q_l;
+
+  // Add to it the number of terms for all outputs prior to n
+  for (auto i : make_range(n))
+    index += _output_theta_vector[i].size();
+
+  return index;
 }
 
 void RBThetaExpansion::attach_A_theta(RBTheta * theta_q_a)

--- a/src/reduced_basis/rb_theta_expansion.C
+++ b/src/reduced_basis/rb_theta_expansion.C
@@ -187,5 +187,18 @@ Number RBThetaExpansion::eval_output_theta(unsigned int output_index,
   return _output_theta_vector[output_index][q_l]->evaluate( mu );
 }
 
+std::vector<Number>
+RBThetaExpansion::eval_output_theta(unsigned int output_index,
+                                    unsigned int q_l,
+                                    const std::vector<RBParameters> & mus)
+{
+  libmesh_error_msg_if((output_index >= get_n_outputs()) || (q_l >= get_n_output_terms(output_index)),
+                       "Error: We must have output_index < n_outputs and "
+                       "q_l < get_n_output_terms(output_index) in eval_output_theta.");
+
+  libmesh_assert(_output_theta_vector[output_index][q_l]);
+
+  return _output_theta_vector[output_index][q_l]->evaluate_vec(mus);
+}
 
 }


### PR DESCRIPTION
This PR updates one of the `reduced_basis` examples to use the new capabilities provided in #3552. We previously had partial support for using "pre-evaluated thetas" in `RBEvaluation::rb_solve()`, and this PR extends that support to the computation of outputs and error bounds. The "pre-evaluated thetas" codepath is relevant to the multi-step `RBParameters` approach because the `RBEvaluation` class itself does not need to know that the `RBParameters` it is using has multiple steps... it just uses the pre-evaluated thetas, and the looping over steps can be handled at a higher level of the code, as is now done in reduced_basis_ex4.