### PR TITLE
Avoid using C-style casts in unit tests

### DIFF
--- a/tests/base/dof_object_test.h
+++ b/tests/base/dof_object_test.h
@@ -78,7 +78,7 @@ public:
     DofObject & aobject(*instance);
 
     aobject.processor_id(libMesh::global_processor_id());
-    CPPUNIT_ASSERT_EQUAL( (processor_id_type)libMesh::global_processor_id() , aobject.processor_id() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<processor_id_type>(libMesh::global_processor_id()), aobject.processor_id());
   }
 
   void testValidProcId()
@@ -114,7 +114,7 @@ public:
 
     aobject.set_n_systems (10);
 
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 10, aobject.n_systems() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(10), aobject.n_systems());
   }
 
   void testSetNVariableGroups()
@@ -136,8 +136,8 @@ public:
 
     for (unsigned int s=0; s<2; s++)
       {
-        CPPUNIT_ASSERT_EQUAL( (unsigned int) 60, aobject.n_vars(s) );
-        CPPUNIT_ASSERT_EQUAL( (unsigned int) 3,  aobject.n_var_groups(s) );
+        CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(60), aobject.n_vars(s));
+        CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(3),  aobject.n_var_groups(s));
 
         for (unsigned int vg=0; vg<3; vg++)
           CPPUNIT_ASSERT_EQUAL( nvpg[vg], aobject.n_vars(s,vg) );
@@ -154,7 +154,7 @@ public:
 
     CPPUNIT_ASSERT(aobject.has_extra_integers());
 
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 9, aobject.n_extra_integers() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(9), aobject.n_extra_integers());
 
     unsigned int ints_per_Real = (sizeof(Real)-1)/sizeof(dof_id_type) + 1;
 
@@ -172,7 +172,7 @@ public:
         if (i < 1 || i >= (2 + ints_per_Real))
           {
             aobject.set_extra_integer(i, i);
-            CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+            CPPUNIT_ASSERT_EQUAL( static_cast<dof_id_type>(i), aobject.get_extra_integer(i) );
           }
       }
 
@@ -180,7 +180,7 @@ public:
 
     CPPUNIT_ASSERT(aobject.has_extra_integers());
 
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 6, aobject.n_extra_integers() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(6), aobject.n_extra_integers());
 
     for (unsigned int i=0; i != 6; ++i)
       {
@@ -189,7 +189,7 @@ public:
         if (i == 2 && ints_per_Real <= 4)
           CPPUNIT_ASSERT_EQUAL(aobject.get_extra_datum<Real>(i), pi);
         if (i < 1 || i >= (2 + ints_per_Real))
-          CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+          CPPUNIT_ASSERT_EQUAL( static_cast<dof_id_type>(i), aobject.get_extra_integer(i) );
       }
   }
 
@@ -205,11 +205,9 @@ public:
 
     CPPUNIT_ASSERT(aobject.has_extra_integers());
 
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 1, aobject.n_extra_integers() );
-
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 1, aobject.n_systems() );
-
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 0, aobject.n_vars(0) );
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(1), aobject.n_extra_integers());
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(1), aobject.n_systems());
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(0), aobject.n_vars(0));
 
     aobject.add_extra_integers (4);
 
@@ -217,50 +215,47 @@ public:
 
     CPPUNIT_ASSERT(aobject.has_extra_integers());
 
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 4, aobject.n_extra_integers() );
-
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 2, aobject.n_systems() );
-
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 0, aobject.n_vars(0) );
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 0, aobject.n_vars(1) );
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4), aobject.n_extra_integers());
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(2), aobject.n_systems());
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(0), aobject.n_vars(0));
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(0), aobject.n_vars(1));
 
     for (unsigned int i=0; i != 4; ++i)
       {
         CPPUNIT_ASSERT_EQUAL( DofObject::invalid_id, aobject.get_extra_integer(i) );
         aobject.set_extra_integer(i, i);
-        CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+        CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(i), aobject.get_extra_integer(i));
       }
 
     aobject.add_extra_integers (7);
 
     for (unsigned int i=0; i != 4; ++i)
-      CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+      CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(i), aobject.get_extra_integer(i));
 
     for (unsigned int i=4; i != 7; ++i)
       CPPUNIT_ASSERT_EQUAL( DofObject::invalid_id, aobject.get_extra_integer(i) );
 
     aobject.add_system();
 
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 7, aobject.n_extra_integers() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(7), aobject.n_extra_integers());
 
     for (unsigned int i=0; i != 4; ++i)
-      CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+      CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(i), aobject.get_extra_integer(i));
 
     for (unsigned int i=4; i != 7; ++i)
       {
         CPPUNIT_ASSERT_EQUAL( DofObject::invalid_id, aobject.get_extra_integer(i) );
         aobject.set_extra_integer(i, i);
-        CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+        CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(i), aobject.get_extra_integer(i));
       }
 
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 3, aobject.n_systems() );
-
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 0, aobject.n_vars(0) );
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 0, aobject.n_vars(1) );
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 0, aobject.n_vars(2) );
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(3), aobject.n_systems());
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(0), aobject.n_vars(0));
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(0), aobject.n_vars(1));
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(0), aobject.n_vars(2));
 
     for (unsigned int i=0; i != 7; ++i)
-      CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+      CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(i), aobject.get_extra_integer(i));
   }
 
   void testSetNSystemsExtraInts()
@@ -275,43 +270,42 @@ public:
 
     CPPUNIT_ASSERT(aobject.has_extra_integers());
 
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 5, aobject.n_extra_integers() );
-
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 10, aobject.n_systems() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(5), aobject.n_extra_integers());
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(10), aobject.n_systems());
 
     for (unsigned int i=0; i != 5; ++i)
       {
         CPPUNIT_ASSERT_EQUAL( DofObject::invalid_id, aobject.get_extra_integer(i) );
         aobject.set_extra_integer(i, i);
-        CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+        CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(i), aobject.get_extra_integer(i));
       }
 
     aobject.add_extra_integers (9);
 
     for (unsigned int i=0; i != 5; ++i)
-      CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+      CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(i), aobject.get_extra_integer(i));
 
     for (unsigned int i=5; i != 9; ++i)
       CPPUNIT_ASSERT_EQUAL( DofObject::invalid_id, aobject.get_extra_integer(i) );
 
     aobject.set_n_systems (6);
 
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 9, aobject.n_extra_integers() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(9), aobject.n_extra_integers());
 
     for (unsigned int i=0; i != 5; ++i)
-      CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+      CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(i), aobject.get_extra_integer(i));
 
     for (unsigned int i=5; i != 9; ++i)
       {
         CPPUNIT_ASSERT_EQUAL( DofObject::invalid_id, aobject.get_extra_integer(i) );
         aobject.set_extra_integer(i, i);
-        CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+        CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(i), aobject.get_extra_integer(i));
       }
 
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 6, aobject.n_systems() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(6), aobject.n_systems());
 
     for (unsigned int i=0; i != 9; ++i)
-      CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+      CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(i), aobject.get_extra_integer(i));
   }
 
   void testSetNVariableGroupsExtraInts()
@@ -328,7 +322,7 @@ public:
       {
         CPPUNIT_ASSERT_EQUAL( DofObject::invalid_id, aobject.get_extra_integer(i) );
         aobject.set_extra_integer(i, i);
-        CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+        CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(i), aobject.get_extra_integer(i));
       }
 
     std::vector<unsigned int> nvpg;
@@ -342,17 +336,17 @@ public:
 
     for (unsigned int s=0; s<2; s++)
       {
-        CPPUNIT_ASSERT_EQUAL( (unsigned int) 60, aobject.n_vars(s) );
-        CPPUNIT_ASSERT_EQUAL( (unsigned int) 3,  aobject.n_var_groups(s) );
+        CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(60), aobject.n_vars(s));
+        CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(3),  aobject.n_var_groups(s));
 
         for (unsigned int vg=0; vg<3; vg++)
           CPPUNIT_ASSERT_EQUAL( nvpg[vg], aobject.n_vars(s,vg) );
       }
 
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 5, aobject.n_extra_integers() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(5), aobject.n_extra_integers());
 
     for (unsigned int i=0; i != 5; ++i)
-      CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+      CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(i), aobject.get_extra_integer(i));
   }
 
 

--- a/tests/base/getpot_test.C
+++ b/tests/base/getpot_test.C
@@ -99,7 +99,7 @@ public:
 
     CPPUNIT_ASSERT( input.have_variable("Section2/Subsection4/var6") );
     unsigned int var6 = input("Section2/Subsection4/var6", 21);
-    CPPUNIT_ASSERT_EQUAL( var6, (unsigned int)42 );
+    CPPUNIT_ASSERT_EQUAL(var6, static_cast<unsigned int>(42));
 
     // We didn't use Section3/unused_var so it should be a UFO
     std::vector<std::string> ufos = input.unidentified_variables();

--- a/tests/base/overlapping_coupling_test.C
+++ b/tests/base/overlapping_coupling_test.C
@@ -47,7 +47,7 @@ class OverlappingCouplingFunctor : public GhostingFunctor
   {
     // This is a highly specalized coupling functor where we are assuming
     // only two subdomains that are overlapping so make sure there's only two.
-    CPPUNIT_ASSERT_EQUAL(2, (int)_mesh.n_subdomains());
+    CPPUNIT_ASSERT_EQUAL(2, static_cast<int>(_mesh.n_subdomains()));
 
     // We're assuming a specific set of subdomain ids
     std::set<subdomain_id_type> ids;
@@ -446,8 +446,8 @@ private:
     dof_id_type n_elems_subdomain_two = std::distance( _mesh->active_subdomain_elements_begin(2),
                                                        _mesh->active_subdomain_elements_end(2) );
 
-    CPPUNIT_ASSERT_EQUAL( n_elems_subdomain_two, (dof_id_type) subdomain_one_couplings.size() );
-    CPPUNIT_ASSERT_EQUAL( dof_id_type(2*n_elems_subdomain_two), (dof_id_type) subdomain_two_couplings.size() );
+    CPPUNIT_ASSERT_EQUAL(n_elems_subdomain_two, static_cast<dof_id_type>(subdomain_one_couplings.size()));
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(2*n_elems_subdomain_two), static_cast<dof_id_type>(subdomain_two_couplings.size()));
   }
 
   void run_partitioner_test(unsigned int n_refinements)
@@ -474,8 +474,8 @@ private:
     // Everyone should be on the same processor if only 1 processor
     if( system.n_processors() == 1 )
       {
-        CPPUNIT_ASSERT_EQUAL( 1, (int)sub_one_proc_ids.size() );
-        CPPUNIT_ASSERT_EQUAL( 1, (int)sub_two_proc_ids.size() );
+        CPPUNIT_ASSERT_EQUAL(1, static_cast<int>(sub_one_proc_ids.size()));
+        CPPUNIT_ASSERT_EQUAL(1, static_cast<int>(sub_two_proc_ids.size()));
         CPPUNIT_ASSERT( sub_one_proc_ids == sub_two_proc_ids );
       }
     // Otherwise these sets should be disjoint
@@ -586,7 +586,7 @@ private:
     for (const auto & elem : _mesh->active_local_subdomain_elements_ptr_range(2))
       {
         // A little extra unit testing on the range iterator
-        CPPUNIT_ASSERT_EQUAL(2, (int)elem->subdomain_id());
+        CPPUNIT_ASSERT_EQUAL(2, static_cast<int>(elem->subdomain_id()));
 
         subdomain_one_context.get_element_fe(u_var)->get_nothing(); // for this unit test
         const std::vector<libMesh::Point> & qpoints = subdomain_two_context.get_element_fe(u_var)->get_xyz();
@@ -735,7 +735,7 @@ private:
     for (const auto & elem : _mesh->active_local_subdomain_elements_ptr_range(2))
       {
         // A little extra unit testing on the range iterator
-        CPPUNIT_ASSERT_EQUAL(2, (int)elem->subdomain_id());
+        CPPUNIT_ASSERT_EQUAL(2, static_cast<int>(elem->subdomain_id()));
 
         const std::vector<libMesh::Point> & qpoints = subdomain_two_context.get_element_fe(u_var)->get_xyz();
 

--- a/tests/geom/elem_test.C
+++ b/tests/geom/elem_test.C
@@ -458,29 +458,29 @@ public:
       for (const auto s : elem->side_index_range())
         {
           if (elem->type() == EDGE2 || elem->type() == EDGE3 || elem->type() == EDGE4)
-            CPPUNIT_ASSERT_EQUAL((unsigned int)s, elem->center_node_on_side(s));
+            CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(s), elem->center_node_on_side(s));
           else if (elem->type() == TRI6 || elem->type() == TRI7)
-            CPPUNIT_ASSERT_EQUAL((unsigned int)(s + 3), elem->center_node_on_side(s));
+            CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(s + 3), elem->center_node_on_side(s));
           else if (elem->type() == QUAD8 || elem->type() == QUAD9 || elem->type() == QUADSHELL8)
-            CPPUNIT_ASSERT_EQUAL((unsigned int)(s + 4), elem->center_node_on_side(s));
+            CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(s + 4), elem->center_node_on_side(s));
           else if (elem->type() == HEX27)
-            CPPUNIT_ASSERT_EQUAL((unsigned int)(s + 20), elem->center_node_on_side(s));
+            CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(s + 20), elem->center_node_on_side(s));
           else if (elem->type() == PRISM18 && s >= 1 && s <= 3)
-            CPPUNIT_ASSERT_EQUAL((unsigned int)(s + 14), elem->center_node_on_side(s));
+            CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(s + 14), elem->center_node_on_side(s));
           else if ((elem->type() == PRISM20 ||
                     elem->type() == PRISM21) && s >= 1 && s <= 3)
-            CPPUNIT_ASSERT_EQUAL((unsigned int)(s + 14), elem->center_node_on_side(s));
+            CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(s + 14), elem->center_node_on_side(s));
           else if (elem->type() == PRISM20 ||
                    elem->type() == PRISM21)
-            CPPUNIT_ASSERT_EQUAL((unsigned int)(18 + (s == 4)), elem->center_node_on_side(s));
+            CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(18 + (s == 4)), elem->center_node_on_side(s));
           else if (elem->type() == PYRAMID14 && s == 4)
-            CPPUNIT_ASSERT_EQUAL((unsigned int)(13), elem->center_node_on_side(s));
+            CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(13), elem->center_node_on_side(s));
           else if (elem->type() == PYRAMID18)
             {
               if (s < 4)
-                CPPUNIT_ASSERT_EQUAL((unsigned int)(s + 14), elem->center_node_on_side(s));
+                CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(s + 14), elem->center_node_on_side(s));
               else
-                CPPUNIT_ASSERT_EQUAL((unsigned int)(13), elem->center_node_on_side(s));
+                CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(13), elem->center_node_on_side(s));
             }
           else
             CPPUNIT_ASSERT_EQUAL(invalid_uint, elem->center_node_on_side(s));

--- a/tests/mesh/boundary_info.C
+++ b/tests/mesh/boundary_info.C
@@ -656,7 +656,7 @@ public:
 
     if (mesh->n_active_local_elem())
     {
-      CPPUNIT_ASSERT_EQUAL((unsigned int) 2, count);
+      CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(2), count);
       CPPUNIT_ASSERT(bi.is_children_on_boundary_side());
     }
 
@@ -838,8 +838,8 @@ public:
       {
         const auto side_5 = bi.side_with_boundary_id(elem, 5);
         const auto side_6 = bi.side_with_boundary_id(elem, 6);
-        CPPUNIT_ASSERT_EQUAL((unsigned int) 1, side_5);
-        CPPUNIT_ASSERT_EQUAL((unsigned int) 1, side_6);
+        CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(1), side_5);
+        CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(1), side_6);
       }
     }
 
@@ -852,9 +852,9 @@ public:
       if (c(0) < 0.5 && c(0) > 0.25 && c(1) > 0.25 && c(1) < 0.5)
       {
         const auto sides = bi.sides_with_boundary_id(elem, 5);
-        CPPUNIT_ASSERT_EQUAL((unsigned long) 2, sides.size());
-        CPPUNIT_ASSERT_EQUAL((unsigned int) 1, sides[0]);
-        CPPUNIT_ASSERT_EQUAL((unsigned int) 2, sides[1]);
+        CPPUNIT_ASSERT_EQUAL(static_cast<unsigned long>(2), sides.size());
+        CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(1), sides[0]);
+        CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(2), sides[1]);
       }
     }
   }

--- a/tests/mesh/mesh_assign.C
+++ b/tests/mesh/mesh_assign.C
@@ -162,7 +162,7 @@ public:
           mesh_two->clear();
 
           // Assert that the moved into mesh has the right number of elements.
-          CPPUNIT_ASSERT_EQUAL(system.get_mesh().n_elem(), dof_id_type(20));
+          CPPUNIT_ASSERT_EQUAL(system.get_mesh().n_elem(), static_cast<dof_id_type>(20));
 
           CPPUNIT_ASSERT(system.get_mesh() == *mesh_two_clone);
 
@@ -193,7 +193,7 @@ public:
           mesh_two->clear();
 
           // Assert that the moved into mesh has the right number of elements.
-          CPPUNIT_ASSERT_EQUAL(system.get_mesh().n_elem(), dof_id_type(42));
+          CPPUNIT_ASSERT_EQUAL(system.get_mesh().n_elem(), static_cast<dof_id_type>(42));
 
           CPPUNIT_ASSERT(system.get_mesh() == *mesh_two_clone);
 

--- a/tests/mesh/mesh_extruder.C
+++ b/tests/mesh/mesh_extruder.C
@@ -79,7 +79,7 @@ public:
         // Retrieve the element from the mesh by ID to guarantee proper ordering instead of with iterators
         Elem & elem = dest_mesh.elem_ref(i);
 
-        CPPUNIT_ASSERT_EQUAL((unsigned int)elem.subdomain_id(), i%n_elems_per_layer + i/n_elems_per_layer /* integer division */);
+        CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(elem.subdomain_id()), i%n_elems_per_layer + i/n_elems_per_layer /* integer division */);
       }
   }
 };

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -302,9 +302,9 @@ public:
     mesh.prepare_for_use();
 
     // 5^3 spline nodes + 7^3 Rational Bezier nodes
-    CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(), dof_id_type(468));
+    CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(), static_cast<dof_id_type>(468));
     // 5^3 spline elements + 3^3 Rational Bezier elements
-    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(),  dof_id_type(152));
+    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(),  static_cast<dof_id_type>(152));
 
     // Check that we see the boundary ids we expect
     BoundaryInfo & bi = mesh.get_boundary_info();
@@ -1236,8 +1236,8 @@ public:
 
       nem.read("test_nemesis_read.nem");
       mesh.prepare_for_use();
-      CPPUNIT_ASSERT_EQUAL(mesh.n_elem(),  dof_id_type(9));
-      CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(), dof_id_type(16));
+      CPPUNIT_ASSERT_EQUAL(mesh.n_elem(),  static_cast<dof_id_type>(9));
+      CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(), static_cast<dof_id_type>(16));
     }
   }
 
@@ -1350,8 +1350,8 @@ public:
 
     // We have 1 QUAD9 finite element, attached via a trivial map to 9
     // spline Node+NodeElem objects
-    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), dof_id_type(10));
-    CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(), dof_id_type(18));
+    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(),  static_cast<dof_id_type>(10));
+    CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(), static_cast<dof_id_type>(18));
 
     helperTestingDynaQuad(mesh);
   }
@@ -1372,8 +1372,8 @@ public:
     mesh.prepare_for_use();
 
     // Mesh should contain 1 TET10 finite element
-    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), dof_id_type(1));
-    CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(), dof_id_type(10));
+    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(),  static_cast<dof_id_type>(1));
+    CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(), static_cast<dof_id_type>(10));
 
     // Element should have TET10 reference element volume
     const Elem * const elem = mesh.query_elem_ptr(0);
@@ -1411,8 +1411,8 @@ public:
     mesh.prepare_for_use();
 
     // We have 1 QUAD9 finite element
-    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), dof_id_type(1));
-    CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(), dof_id_type(9));
+    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(),  static_cast<dof_id_type>(1));
+    CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(), static_cast<dof_id_type>(9));
 
     helperTestingDynaQuad(mesh);
   }
@@ -1433,8 +1433,8 @@ public:
 
     // We have 5^2 QUAD9 elements, with 11^2 nodes,
     // tied to 49 Node/NodeElem spline nodes
-    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), dof_id_type(25+49));
-    CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(), dof_id_type(121+49));
+    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(),  static_cast<dof_id_type>(25+49));
+    CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(), static_cast<dof_id_type>(121+49));
 
     CPPUNIT_ASSERT_EQUAL(mesh.default_mapping_type(),
                          RATIONAL_BERNSTEIN_MAP);
@@ -1477,7 +1477,7 @@ public:
     es.init();
 
     // We should have a constraint on every FE dof
-    CPPUNIT_ASSERT_EQUAL(sys.get_dof_map().n_constrained_dofs(), dof_id_type(121));
+    CPPUNIT_ASSERT_EQUAL(sys.get_dof_map().n_constrained_dofs(), static_cast<dof_id_type>(121));
 #endif // LIBMESH_ENABLE_CONSTRAINTS
 #endif // LIBMESH_HAVE_SOLVER
   }

--- a/tests/mesh/mesh_stitch.C
+++ b/tests/mesh/mesh_stitch.C
@@ -78,8 +78,8 @@ public:
 
     mesh0.stitch_meshes(mesh1, 2, 10, TOLERANCE, true, true, false, false);
 
-    CPPUNIT_ASSERT_EQUAL(mesh0.n_elem(), dof_id_type(16));
-    CPPUNIT_ASSERT_EQUAL(mesh0.n_nodes(), dof_id_type(45));
+    CPPUNIT_ASSERT_EQUAL(mesh0.n_elem(),  static_cast<dof_id_type>(16));
+    CPPUNIT_ASSERT_EQUAL(mesh0.n_nodes(), static_cast<dof_id_type>(45));
 
     const BoundaryInfo & bi = mesh0.get_boundary_info();
     const auto & sbi = bi.get_side_boundary_ids();
@@ -176,8 +176,8 @@ public:
     mesh2.stitch_meshes(mesh3, 2, 4, TOLERANCE, true, true, false, false);
     mesh0.stitch_meshes(mesh2, 1, 3, TOLERANCE, true, true, false, false);
 
-    CPPUNIT_ASSERT_EQUAL(mesh0.n_elem(), dof_id_type(32));
-    CPPUNIT_ASSERT_EQUAL(mesh0.n_nodes(), dof_id_type(405));
+    CPPUNIT_ASSERT_EQUAL(mesh0.n_elem(),  static_cast<dof_id_type>(32));
+    CPPUNIT_ASSERT_EQUAL(mesh0.n_nodes(), static_cast<dof_id_type>(405));
     CPPUNIT_ASSERT_EQUAL(mesh0.n_elem_integers(), 5u); // that pair counts 2x
     CPPUNIT_ASSERT_EQUAL(mesh0.n_node_integers(), 5u);
     std::vector<std::string> all_names {"foo", "bar", "baz", "qux"};
@@ -196,7 +196,7 @@ public:
         CPPUNIT_ASSERT_EQUAL(elem->n_extra_integers(), 5u);
         const Point c = elem->vertex_average();
         if (c(0) > 0 && c(1) > 0) // this came from mesh1
-          CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(foo0e_idx), dof_id_type(2));
+          CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(foo0e_idx), static_cast<dof_id_type>(2));
         else
           CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(foo0e_idx), DofObject::invalid_id);
       }
@@ -209,8 +209,8 @@ public:
           node->template get_extra_datum<trivially_copyable_pair>(qux0n_idx);
         if ((*node)(0) <= 0 && (*node)(1) < 0) // this came from mesh2
           {
-            CPPUNIT_ASSERT_EQUAL(datum.first, dof_id_type(3));
-            CPPUNIT_ASSERT_EQUAL(datum.second, dof_id_type(4));
+            CPPUNIT_ASSERT_EQUAL(datum.first,  static_cast<dof_id_type>(3));
+            CPPUNIT_ASSERT_EQUAL(datum.second, static_cast<dof_id_type>(4));
           }
         else
           {

--- a/tests/mesh/mesh_subdomain_id.C
+++ b/tests/mesh/mesh_subdomain_id.C
@@ -60,7 +60,7 @@ public:
     std::set<subdomain_id_type> actual_ids;
     for (auto & elem : mesh->active_element_ptr_range())
       {
-        CPPUNIT_ASSERT(elem->id() < (dof_id_type)Elem::invalid_subdomain_id);
+        CPPUNIT_ASSERT(elem->id() < static_cast<dof_id_type>(Elem::invalid_subdomain_id));
         actual_ids.insert((subdomain_id_type)elem->id());
         elem->subdomain_id() = (subdomain_id_type)elem->id();
       }

--- a/tests/mesh/mesh_triangulation.C
+++ b/tests/mesh/mesh_triangulation.C
@@ -278,7 +278,7 @@ public:
 
     triangulator.triangulate();
 
-    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), dof_id_type(2));
+    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), static_cast<dof_id_type>(2));
     for (const auto & elem : mesh.element_ptr_range())
       {
         CPPUNIT_ASSERT_EQUAL(elem->type(), TRI3);
@@ -452,7 +452,7 @@ public:
 
     triangulator.triangulate();
 
-    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), dof_id_type(8));
+    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), static_cast<dof_id_type>(8));
 
     // Center coordinates for all the elements we expect
     Real r2p2o6 = (std::sqrt(Real(2))+2)/6;
@@ -498,7 +498,7 @@ public:
 
     triangulator.triangulate();
 
-    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), dof_id_type(12));
+    CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), static_cast<dof_id_type>(12));
 
     // Center coordinates for all the elements we expect
     std::vector <Point> expected_centers

--- a/tests/mesh/mixed_dim_mesh_test.C
+++ b/tests/mesh/mixed_dim_mesh_test.C
@@ -107,10 +107,10 @@ public:
     LOG_UNIT_TEST;
 
     // There'd better be 3 elements
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)3, _mesh->n_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(3), _mesh->n_elem());
 
     // There'd better be only 6 nodes
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)6, _mesh->n_nodes() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(6), _mesh->n_nodes());
 
     /* The nodes for the EDGE2 element should have the same global ids
        as the bottom edge of the top QUAD4 element */
@@ -176,14 +176,14 @@ public:
     CPPUNIT_ASSERT(top_elem);
 
     // We should have gotten back the top quad
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)0, top_elem->id() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(0), top_elem->id());
 
     Point bottom_point(0.5, -0.5);
     const Elem* bottom_elem = (*locator)(bottom_point);
     CPPUNIT_ASSERT(bottom_elem);
 
     // We should have gotten back the bottom quad
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)1, bottom_elem->id() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(1), bottom_elem->id());
 
     // Test getting back the edge
     {
@@ -193,7 +193,7 @@ public:
       CPPUNIT_ASSERT(interface_elem);
 
       // We should have gotten back the overlapping edge element
-      CPPUNIT_ASSERT_EQUAL( (dof_id_type)2, interface_elem->id() );
+      CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(2), interface_elem->id());
     }
   }
 
@@ -251,11 +251,11 @@ public:
     LOG_UNIT_TEST;
 
     // We should have 13 total and 10 active elements.
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)13, _mesh->n_elem() );
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)10, _mesh->n_active_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(13), _mesh->n_elem());
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(10), _mesh->n_active_elem());
 
     // We should have 15 nodes
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)15, _mesh->n_nodes() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(15), _mesh->n_nodes());
 
     // EDGE2,id=11 should have same nodes of bottom of QUAD4, id=3
     CPPUNIT_ASSERT_EQUAL( _mesh->elem_ref(11).node_id(0),
@@ -509,11 +509,11 @@ public:
     LOG_UNIT_TEST;
 
     // We should have 13 total and 10 active elements.
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)15, _mesh->n_elem() );
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)12, _mesh->n_active_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(15), _mesh->n_elem());
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(12), _mesh->n_active_elem());
 
     // We should have 15 nodes
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)19, _mesh->n_nodes() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(19), _mesh->n_nodes());
 
     // EDGE2,id=13 should have same nodes of bottom of QUAD4, id=5
     CPPUNIT_ASSERT_EQUAL( _mesh->elem_ref(13).node_id(0),
@@ -735,11 +735,11 @@ public:
     LOG_UNIT_TEST;
 
     // We should have 15 total and 12 active elements.
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)15, _mesh->n_elem() );
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)12, _mesh->n_active_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(15), _mesh->n_elem());
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(12), _mesh->n_active_elem());
 
     // We should have 15 nodes
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)11, _mesh->n_nodes() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(11), _mesh->n_nodes());
 
     // EDGE2,id=13 should have same nodes of the base of TRI3, id=5
     CPPUNIT_ASSERT_EQUAL( _mesh->elem_ref(13).node_id(0),
@@ -962,11 +962,11 @@ public:
     LOG_UNIT_TEST;
 
     // We should have 57 total and 54 active elements.
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)57, _mesh->n_elem() );
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)54, _mesh->n_active_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(57), _mesh->n_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(54), _mesh->n_active_elem() );
 
     // We should have 113 nodes
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)113, _mesh->n_nodes() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(113), _mesh->n_nodes() );
 
     // QUAD4,id=53 should have same nodes as a face in HEX8, id=39
     CPPUNIT_ASSERT_EQUAL( _mesh->elem_ref(53).node_id(0),

--- a/tests/mesh/slit_mesh_test.C
+++ b/tests/mesh/slit_mesh_test.C
@@ -192,10 +192,10 @@ public:
     LOG_UNIT_TEST;
 
     // There'd better be 8 elements
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)8, _mesh->n_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(8), _mesh->n_elem());
 
     // There'd better still be a full 16 nodes
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)16, _mesh->n_nodes() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(16), _mesh->n_nodes());
 
     /* The middle nodes should still be distinct between the top and
      * bottom elements */
@@ -252,11 +252,11 @@ public:
 
 #ifdef LIBMESH_ENABLE_AMR
     // We should have 40 total and 32 active elements.
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)40, _mesh->n_elem() );
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)32, _mesh->n_active_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(40), _mesh->n_elem());
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(32), _mesh->n_active_elem());
 
     // We should have 48 nodes, not 45 or 46
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)48, _mesh->n_nodes() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(48), _mesh->n_nodes());
 #endif
   }
 };
@@ -323,11 +323,11 @@ public:
 
 #ifdef LIBMESH_ENABLE_AMR
     // We should have 168 total and 128 active elements.
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)(8+32+128), _mesh->n_elem() );
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)128, _mesh->n_active_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(8+32+128), _mesh->n_elem());
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(128), _mesh->n_active_elem());
 
     // We should have 160 nodes
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)160, _mesh->n_nodes() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(160), _mesh->n_nodes());
 #endif
   }
 

--- a/tests/numerics/coupling_matrix_test.C
+++ b/tests/numerics/coupling_matrix_test.C
@@ -169,7 +169,7 @@ private:
         for (unsigned int pj = 0; pj != sizeof(jvals)/isize; ++pj)
           {
             CPPUNIT_ASSERT(ccr_it != ccr.end());
-            CPPUNIT_ASSERT_EQUAL((unsigned int) *ccr_it, jvals[pj]);
+            CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(*ccr_it), jvals[pj]);
             ++ccr_it;
           }
 

--- a/tests/numerics/petsc_vector_test.C
+++ b/tests/numerics/petsc_vector_test.C
@@ -74,7 +74,7 @@ public:
     // Test getting a read only array after getting a writable array
     values = v.get_array();
     read_only_values = v.get_array_read();
-    CPPUNIT_ASSERT_EQUAL((intptr_t)read_only_values, (intptr_t)values);
+    CPPUNIT_ASSERT_EQUAL(read_only_values, const_cast<const PetscScalar *>(values));
 
     v.restore_array();
 

--- a/tests/numerics/tensor_traits_test.C
+++ b/tests/numerics/tensor_traits_test.C
@@ -18,13 +18,13 @@ public:
     {
       LOG_UNIT_TEST;
 
-      CPPUNIT_ASSERT_EQUAL((unsigned char)0, TensorTraits<Real>::rank);
-      CPPUNIT_ASSERT_EQUAL((unsigned char)1, TensorTraits<VectorValue<Real>>::rank);
-      CPPUNIT_ASSERT_EQUAL((unsigned char)1, TensorTraits<TypeVector<Real>>::rank);
-      CPPUNIT_ASSERT_EQUAL((unsigned char)2, TensorTraits<TensorValue<Real>>::rank);
-      CPPUNIT_ASSERT_EQUAL((unsigned char)2, TensorTraits<TypeTensor<Real>>::rank);
+      CPPUNIT_ASSERT_EQUAL(static_cast<unsigned char>(0), TensorTraits<Real>::rank);
+      CPPUNIT_ASSERT_EQUAL(static_cast<unsigned char>(1), TensorTraits<VectorValue<Real>>::rank);
+      CPPUNIT_ASSERT_EQUAL(static_cast<unsigned char>(1), TensorTraits<TypeVector<Real>>::rank);
+      CPPUNIT_ASSERT_EQUAL(static_cast<unsigned char>(2), TensorTraits<TensorValue<Real>>::rank);
+      CPPUNIT_ASSERT_EQUAL(static_cast<unsigned char>(2), TensorTraits<TypeTensor<Real>>::rank);
       typedef TypeNTensor<3, Real> TypeNTensorTestType;
-      CPPUNIT_ASSERT_EQUAL((unsigned char)3, TensorTraits<TypeNTensorTestType>::rank);
+      CPPUNIT_ASSERT_EQUAL(static_cast<unsigned char>(3), TensorTraits<TypeNTensorTestType>::rank);
     }
 };
 


### PR DESCRIPTION
I'm not sure exactly how this pattern got started and spread so much in the unit tests, but let's use C++ style casts when writing C++.

I also ended up updating code like "dof_id_type(i)" which I guess is technically C++ (constructing a temporary) and not a C-style cast, however I think using the cast syntax still gives the most clarity.