### PR TITLE
Provide STL iterator typedefs for RBParameters::const_iterator

### DIFF
--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -71,6 +71,13 @@ public:
   class const_iterator
   {
   public:
+    // Typedefs needed for interoperating with other STL algorithms and containers.
+    typedef std::forward_iterator_tag iterator_category;
+    typedef std::pair<std::string, Real> value_type;
+    typedef std::ptrdiff_t difference_type;
+    typedef value_type* pointer;
+    typedef value_type& reference;
+
     // Underlying iterator type, must match the container type of _parameters.
     typedef std::map<std::string, std::vector<Real>>::const_iterator MapIter;
 
@@ -115,7 +122,7 @@ public:
     // compatibility but it is not the most efficient thing since we
     // need to construct a std::pair every time we dereference a
     // const_iterator.
-    const std::pair<std::string, Real> &
+    const value_type &
     operator*() const
     {
       _emulator = std::make_pair(_it->first, _it->second[_vec_index]);
@@ -148,8 +155,8 @@ public:
     std::size_t _vec_index;
 
     // Returned by the operator* function. Emulates dereferencing a
-    // map<sring, Real> iterator.
-    mutable std::pair<std::string, Real> _emulator;
+    // map<string, Real> iterator.
+    mutable value_type _emulator;
   };
 
   /**

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -126,6 +126,7 @@ unit_tests_sources = \
   systems/systems_test.C \
   utils/parameters_test.C \
   utils/point_locator_test.C \
+  utils/rb_parameters_test.C \
   utils/transparent_comparator.C \
   utils/vectormap_test.C \
   utils/xdr_test.C

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -253,9 +253,10 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/periodic_bc_test.C \
 	systems/systems_test.C utils/parameters_test.C \
-	utils/point_locator_test.C utils/transparent_comparator.C \
-	utils/vectormap_test.C utils/xdr_test.C meshes/1_quad.bxt.gz \
-	meshes/25_quad.bxt.gz meshes/BlockWithHole_Patch9.bxt.gz \
+	utils/point_locator_test.C utils/rb_parameters_test.C \
+	utils/transparent_comparator.C utils/vectormap_test.C \
+	utils/xdr_test.C meshes/1_quad.bxt.gz meshes/25_quad.bxt.gz \
+	meshes/BlockWithHole_Patch9.bxt.gz \
 	meshes/PlateWithHole_Patch8.bxt.gz \
 	meshes/PressurizedCyl3d_Patch1_8Elem.bxt.gz \
 	meshes/PressurizedCyl_Patch6_256Elem.bxt.gz \
@@ -370,6 +371,7 @@ am__objects_3 = unit_tests_dbg-driver.$(OBJEXT) \
 	systems/unit_tests_dbg-systems_test.$(OBJEXT) \
 	utils/unit_tests_dbg-parameters_test.$(OBJEXT) \
 	utils/unit_tests_dbg-point_locator_test.$(OBJEXT) \
+	utils/unit_tests_dbg-rb_parameters_test.$(OBJEXT) \
 	utils/unit_tests_dbg-transparent_comparator.$(OBJEXT) \
 	utils/unit_tests_dbg-vectormap_test.$(OBJEXT) \
 	utils/unit_tests_dbg-xdr_test.$(OBJEXT) $(am__objects_1) \
@@ -445,9 +447,10 @@ am__unit_tests_devel_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/periodic_bc_test.C \
 	systems/systems_test.C utils/parameters_test.C \
-	utils/point_locator_test.C utils/transparent_comparator.C \
-	utils/vectormap_test.C utils/xdr_test.C meshes/1_quad.bxt.gz \
-	meshes/25_quad.bxt.gz meshes/BlockWithHole_Patch9.bxt.gz \
+	utils/point_locator_test.C utils/rb_parameters_test.C \
+	utils/transparent_comparator.C utils/vectormap_test.C \
+	utils/xdr_test.C meshes/1_quad.bxt.gz meshes/25_quad.bxt.gz \
+	meshes/BlockWithHole_Patch9.bxt.gz \
 	meshes/PlateWithHole_Patch8.bxt.gz \
 	meshes/PressurizedCyl3d_Patch1_8Elem.bxt.gz \
 	meshes/PressurizedCyl_Patch6_256Elem.bxt.gz \
@@ -560,6 +563,7 @@ am__objects_5 = unit_tests_devel-driver.$(OBJEXT) \
 	systems/unit_tests_devel-systems_test.$(OBJEXT) \
 	utils/unit_tests_devel-parameters_test.$(OBJEXT) \
 	utils/unit_tests_devel-point_locator_test.$(OBJEXT) \
+	utils/unit_tests_devel-rb_parameters_test.$(OBJEXT) \
 	utils/unit_tests_devel-transparent_comparator.$(OBJEXT) \
 	utils/unit_tests_devel-vectormap_test.$(OBJEXT) \
 	utils/unit_tests_devel-xdr_test.$(OBJEXT) $(am__objects_1) \
@@ -631,9 +635,10 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/periodic_bc_test.C \
 	systems/systems_test.C utils/parameters_test.C \
-	utils/point_locator_test.C utils/transparent_comparator.C \
-	utils/vectormap_test.C utils/xdr_test.C meshes/1_quad.bxt.gz \
-	meshes/25_quad.bxt.gz meshes/BlockWithHole_Patch9.bxt.gz \
+	utils/point_locator_test.C utils/rb_parameters_test.C \
+	utils/transparent_comparator.C utils/vectormap_test.C \
+	utils/xdr_test.C meshes/1_quad.bxt.gz meshes/25_quad.bxt.gz \
+	meshes/BlockWithHole_Patch9.bxt.gz \
 	meshes/PlateWithHole_Patch8.bxt.gz \
 	meshes/PressurizedCyl3d_Patch1_8Elem.bxt.gz \
 	meshes/PressurizedCyl_Patch6_256Elem.bxt.gz \
@@ -746,6 +751,7 @@ am__objects_7 = unit_tests_oprof-driver.$(OBJEXT) \
 	systems/unit_tests_oprof-systems_test.$(OBJEXT) \
 	utils/unit_tests_oprof-parameters_test.$(OBJEXT) \
 	utils/unit_tests_oprof-point_locator_test.$(OBJEXT) \
+	utils/unit_tests_oprof-rb_parameters_test.$(OBJEXT) \
 	utils/unit_tests_oprof-transparent_comparator.$(OBJEXT) \
 	utils/unit_tests_oprof-vectormap_test.$(OBJEXT) \
 	utils/unit_tests_oprof-xdr_test.$(OBJEXT) $(am__objects_1) \
@@ -817,9 +823,10 @@ am__unit_tests_opt_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/periodic_bc_test.C \
 	systems/systems_test.C utils/parameters_test.C \
-	utils/point_locator_test.C utils/transparent_comparator.C \
-	utils/vectormap_test.C utils/xdr_test.C meshes/1_quad.bxt.gz \
-	meshes/25_quad.bxt.gz meshes/BlockWithHole_Patch9.bxt.gz \
+	utils/point_locator_test.C utils/rb_parameters_test.C \
+	utils/transparent_comparator.C utils/vectormap_test.C \
+	utils/xdr_test.C meshes/1_quad.bxt.gz meshes/25_quad.bxt.gz \
+	meshes/BlockWithHole_Patch9.bxt.gz \
 	meshes/PlateWithHole_Patch8.bxt.gz \
 	meshes/PressurizedCyl3d_Patch1_8Elem.bxt.gz \
 	meshes/PressurizedCyl_Patch6_256Elem.bxt.gz \
@@ -932,6 +939,7 @@ am__objects_9 = unit_tests_opt-driver.$(OBJEXT) \
 	systems/unit_tests_opt-systems_test.$(OBJEXT) \
 	utils/unit_tests_opt-parameters_test.$(OBJEXT) \
 	utils/unit_tests_opt-point_locator_test.$(OBJEXT) \
+	utils/unit_tests_opt-rb_parameters_test.$(OBJEXT) \
 	utils/unit_tests_opt-transparent_comparator.$(OBJEXT) \
 	utils/unit_tests_opt-vectormap_test.$(OBJEXT) \
 	utils/unit_tests_opt-xdr_test.$(OBJEXT) $(am__objects_1) \
@@ -1003,9 +1011,10 @@ am__unit_tests_prof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/periodic_bc_test.C \
 	systems/systems_test.C utils/parameters_test.C \
-	utils/point_locator_test.C utils/transparent_comparator.C \
-	utils/vectormap_test.C utils/xdr_test.C meshes/1_quad.bxt.gz \
-	meshes/25_quad.bxt.gz meshes/BlockWithHole_Patch9.bxt.gz \
+	utils/point_locator_test.C utils/rb_parameters_test.C \
+	utils/transparent_comparator.C utils/vectormap_test.C \
+	utils/xdr_test.C meshes/1_quad.bxt.gz meshes/25_quad.bxt.gz \
+	meshes/BlockWithHole_Patch9.bxt.gz \
 	meshes/PlateWithHole_Patch8.bxt.gz \
 	meshes/PressurizedCyl3d_Patch1_8Elem.bxt.gz \
 	meshes/PressurizedCyl_Patch6_256Elem.bxt.gz \
@@ -1118,6 +1127,7 @@ am__objects_11 = unit_tests_prof-driver.$(OBJEXT) \
 	systems/unit_tests_prof-systems_test.$(OBJEXT) \
 	utils/unit_tests_prof-parameters_test.$(OBJEXT) \
 	utils/unit_tests_prof-point_locator_test.$(OBJEXT) \
+	utils/unit_tests_prof-rb_parameters_test.$(OBJEXT) \
 	utils/unit_tests_prof-transparent_comparator.$(OBJEXT) \
 	utils/unit_tests_prof-vectormap_test.$(OBJEXT) \
 	utils/unit_tests_prof-xdr_test.$(OBJEXT) $(am__objects_1) \
@@ -1641,26 +1651,31 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	systems/$(DEPDIR)/unit_tests_prof-systems_test.Po \
 	utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po \
+	utils/$(DEPDIR)/unit_tests_dbg-rb_parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_dbg-transparent_comparator.Po \
 	utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Po \
 	utils/$(DEPDIR)/unit_tests_dbg-xdr_test.Po \
 	utils/$(DEPDIR)/unit_tests_devel-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po \
+	utils/$(DEPDIR)/unit_tests_devel-rb_parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_devel-transparent_comparator.Po \
 	utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po \
 	utils/$(DEPDIR)/unit_tests_devel-xdr_test.Po \
 	utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po \
+	utils/$(DEPDIR)/unit_tests_oprof-rb_parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_oprof-transparent_comparator.Po \
 	utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Po \
 	utils/$(DEPDIR)/unit_tests_oprof-xdr_test.Po \
 	utils/$(DEPDIR)/unit_tests_opt-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po \
+	utils/$(DEPDIR)/unit_tests_opt-rb_parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_opt-transparent_comparator.Po \
 	utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po \
 	utils/$(DEPDIR)/unit_tests_opt-xdr_test.Po \
 	utils/$(DEPDIR)/unit_tests_prof-parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po \
+	utils/$(DEPDIR)/unit_tests_prof-rb_parameters_test.Po \
 	utils/$(DEPDIR)/unit_tests_prof-transparent_comparator.Po \
 	utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po \
 	utils/$(DEPDIR)/unit_tests_prof-xdr_test.Po
@@ -2178,9 +2193,9 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/periodic_bc_test.C \
 	systems/systems_test.C utils/parameters_test.C \
-	utils/point_locator_test.C utils/transparent_comparator.C \
-	utils/vectormap_test.C utils/xdr_test.C $(data) \
-	$(am__append_1)
+	utils/point_locator_test.C utils/rb_parameters_test.C \
+	utils/transparent_comparator.C utils/vectormap_test.C \
+	utils/xdr_test.C $(data) $(am__append_1)
 data = meshes/1_quad.bxt.gz \
        meshes/25_quad.bxt.gz \
        meshes/BlockWithHole_Patch9.bxt.gz \
@@ -2573,6 +2588,8 @@ utils/unit_tests_dbg-parameters_test.$(OBJEXT): utils/$(am__dirstamp) \
 	utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_dbg-point_locator_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_dbg-rb_parameters_test.$(OBJEXT):  \
+	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_dbg-transparent_comparator.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_dbg-vectormap_test.$(OBJEXT): utils/$(am__dirstamp) \
@@ -2797,6 +2814,8 @@ utils/unit_tests_devel-parameters_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_devel-point_locator_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_devel-rb_parameters_test.$(OBJEXT):  \
+	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_devel-transparent_comparator.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_devel-vectormap_test.$(OBJEXT):  \
@@ -3014,6 +3033,8 @@ systems/unit_tests_oprof-systems_test.$(OBJEXT):  \
 utils/unit_tests_oprof-parameters_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_oprof-point_locator_test.$(OBJEXT):  \
+	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_oprof-rb_parameters_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_oprof-transparent_comparator.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
@@ -3233,6 +3254,8 @@ utils/unit_tests_opt-parameters_test.$(OBJEXT): utils/$(am__dirstamp) \
 	utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_opt-point_locator_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_opt-rb_parameters_test.$(OBJEXT):  \
+	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_opt-transparent_comparator.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_opt-vectormap_test.$(OBJEXT): utils/$(am__dirstamp) \
@@ -3450,6 +3473,8 @@ systems/unit_tests_prof-systems_test.$(OBJEXT):  \
 utils/unit_tests_prof-parameters_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_prof-point_locator_test.$(OBJEXT):  \
+	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_prof-rb_parameters_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_prof-transparent_comparator.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
@@ -3979,26 +4004,31 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@systems/$(DEPDIR)/unit_tests_prof-systems_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-rb_parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-transparent_comparator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-xdr_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-rb_parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-transparent_comparator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-xdr_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-rb_parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-transparent_comparator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-xdr_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-rb_parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-transparent_comparator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-xdr_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-rb_parameters_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-transparent_comparator.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-xdr_test.Po@am__quote@ # am--include-marker
@@ -5432,6 +5462,20 @@ utils/unit_tests_dbg-point_locator_test.obj: utils/point_locator_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/point_locator_test.C' object='utils/unit_tests_dbg-point_locator_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_dbg-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
+
+utils/unit_tests_dbg-rb_parameters_test.o: utils/rb_parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_dbg-rb_parameters_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_dbg-rb_parameters_test.Tpo -c -o utils/unit_tests_dbg-rb_parameters_test.o `test -f 'utils/rb_parameters_test.C' || echo '$(srcdir)/'`utils/rb_parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_dbg-rb_parameters_test.Tpo utils/$(DEPDIR)/unit_tests_dbg-rb_parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/rb_parameters_test.C' object='utils/unit_tests_dbg-rb_parameters_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_dbg-rb_parameters_test.o `test -f 'utils/rb_parameters_test.C' || echo '$(srcdir)/'`utils/rb_parameters_test.C
+
+utils/unit_tests_dbg-rb_parameters_test.obj: utils/rb_parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_dbg-rb_parameters_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_dbg-rb_parameters_test.Tpo -c -o utils/unit_tests_dbg-rb_parameters_test.obj `if test -f 'utils/rb_parameters_test.C'; then $(CYGPATH_W) 'utils/rb_parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/rb_parameters_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_dbg-rb_parameters_test.Tpo utils/$(DEPDIR)/unit_tests_dbg-rb_parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/rb_parameters_test.C' object='utils/unit_tests_dbg-rb_parameters_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_dbg-rb_parameters_test.obj `if test -f 'utils/rb_parameters_test.C'; then $(CYGPATH_W) 'utils/rb_parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/rb_parameters_test.C'; fi`
 
 utils/unit_tests_dbg-transparent_comparator.o: utils/transparent_comparator.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_dbg-transparent_comparator.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_dbg-transparent_comparator.Tpo -c -o utils/unit_tests_dbg-transparent_comparator.o `test -f 'utils/transparent_comparator.C' || echo '$(srcdir)/'`utils/transparent_comparator.C
@@ -6889,6 +6933,20 @@ utils/unit_tests_devel-point_locator_test.obj: utils/point_locator_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_devel-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
 
+utils/unit_tests_devel-rb_parameters_test.o: utils/rb_parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_devel-rb_parameters_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_devel-rb_parameters_test.Tpo -c -o utils/unit_tests_devel-rb_parameters_test.o `test -f 'utils/rb_parameters_test.C' || echo '$(srcdir)/'`utils/rb_parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_devel-rb_parameters_test.Tpo utils/$(DEPDIR)/unit_tests_devel-rb_parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/rb_parameters_test.C' object='utils/unit_tests_devel-rb_parameters_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_devel-rb_parameters_test.o `test -f 'utils/rb_parameters_test.C' || echo '$(srcdir)/'`utils/rb_parameters_test.C
+
+utils/unit_tests_devel-rb_parameters_test.obj: utils/rb_parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_devel-rb_parameters_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_devel-rb_parameters_test.Tpo -c -o utils/unit_tests_devel-rb_parameters_test.obj `if test -f 'utils/rb_parameters_test.C'; then $(CYGPATH_W) 'utils/rb_parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/rb_parameters_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_devel-rb_parameters_test.Tpo utils/$(DEPDIR)/unit_tests_devel-rb_parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/rb_parameters_test.C' object='utils/unit_tests_devel-rb_parameters_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_devel-rb_parameters_test.obj `if test -f 'utils/rb_parameters_test.C'; then $(CYGPATH_W) 'utils/rb_parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/rb_parameters_test.C'; fi`
+
 utils/unit_tests_devel-transparent_comparator.o: utils/transparent_comparator.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_devel-transparent_comparator.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_devel-transparent_comparator.Tpo -c -o utils/unit_tests_devel-transparent_comparator.o `test -f 'utils/transparent_comparator.C' || echo '$(srcdir)/'`utils/transparent_comparator.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_devel-transparent_comparator.Tpo utils/$(DEPDIR)/unit_tests_devel-transparent_comparator.Po
@@ -8344,6 +8402,20 @@ utils/unit_tests_oprof-point_locator_test.obj: utils/point_locator_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/point_locator_test.C' object='utils/unit_tests_oprof-point_locator_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_oprof-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
+
+utils/unit_tests_oprof-rb_parameters_test.o: utils/rb_parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_oprof-rb_parameters_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_oprof-rb_parameters_test.Tpo -c -o utils/unit_tests_oprof-rb_parameters_test.o `test -f 'utils/rb_parameters_test.C' || echo '$(srcdir)/'`utils/rb_parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_oprof-rb_parameters_test.Tpo utils/$(DEPDIR)/unit_tests_oprof-rb_parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/rb_parameters_test.C' object='utils/unit_tests_oprof-rb_parameters_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_oprof-rb_parameters_test.o `test -f 'utils/rb_parameters_test.C' || echo '$(srcdir)/'`utils/rb_parameters_test.C
+
+utils/unit_tests_oprof-rb_parameters_test.obj: utils/rb_parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_oprof-rb_parameters_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_oprof-rb_parameters_test.Tpo -c -o utils/unit_tests_oprof-rb_parameters_test.obj `if test -f 'utils/rb_parameters_test.C'; then $(CYGPATH_W) 'utils/rb_parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/rb_parameters_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_oprof-rb_parameters_test.Tpo utils/$(DEPDIR)/unit_tests_oprof-rb_parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/rb_parameters_test.C' object='utils/unit_tests_oprof-rb_parameters_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_oprof-rb_parameters_test.obj `if test -f 'utils/rb_parameters_test.C'; then $(CYGPATH_W) 'utils/rb_parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/rb_parameters_test.C'; fi`
 
 utils/unit_tests_oprof-transparent_comparator.o: utils/transparent_comparator.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_oprof-transparent_comparator.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_oprof-transparent_comparator.Tpo -c -o utils/unit_tests_oprof-transparent_comparator.o `test -f 'utils/transparent_comparator.C' || echo '$(srcdir)/'`utils/transparent_comparator.C
@@ -9801,6 +9873,20 @@ utils/unit_tests_opt-point_locator_test.obj: utils/point_locator_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_opt-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
 
+utils/unit_tests_opt-rb_parameters_test.o: utils/rb_parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_opt-rb_parameters_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_opt-rb_parameters_test.Tpo -c -o utils/unit_tests_opt-rb_parameters_test.o `test -f 'utils/rb_parameters_test.C' || echo '$(srcdir)/'`utils/rb_parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_opt-rb_parameters_test.Tpo utils/$(DEPDIR)/unit_tests_opt-rb_parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/rb_parameters_test.C' object='utils/unit_tests_opt-rb_parameters_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_opt-rb_parameters_test.o `test -f 'utils/rb_parameters_test.C' || echo '$(srcdir)/'`utils/rb_parameters_test.C
+
+utils/unit_tests_opt-rb_parameters_test.obj: utils/rb_parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_opt-rb_parameters_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_opt-rb_parameters_test.Tpo -c -o utils/unit_tests_opt-rb_parameters_test.obj `if test -f 'utils/rb_parameters_test.C'; then $(CYGPATH_W) 'utils/rb_parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/rb_parameters_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_opt-rb_parameters_test.Tpo utils/$(DEPDIR)/unit_tests_opt-rb_parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/rb_parameters_test.C' object='utils/unit_tests_opt-rb_parameters_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_opt-rb_parameters_test.obj `if test -f 'utils/rb_parameters_test.C'; then $(CYGPATH_W) 'utils/rb_parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/rb_parameters_test.C'; fi`
+
 utils/unit_tests_opt-transparent_comparator.o: utils/transparent_comparator.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_opt-transparent_comparator.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_opt-transparent_comparator.Tpo -c -o utils/unit_tests_opt-transparent_comparator.o `test -f 'utils/transparent_comparator.C' || echo '$(srcdir)/'`utils/transparent_comparator.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_opt-transparent_comparator.Tpo utils/$(DEPDIR)/unit_tests_opt-transparent_comparator.Po
@@ -11257,6 +11343,20 @@ utils/unit_tests_prof-point_locator_test.obj: utils/point_locator_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_prof-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
 
+utils/unit_tests_prof-rb_parameters_test.o: utils/rb_parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_prof-rb_parameters_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_prof-rb_parameters_test.Tpo -c -o utils/unit_tests_prof-rb_parameters_test.o `test -f 'utils/rb_parameters_test.C' || echo '$(srcdir)/'`utils/rb_parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_prof-rb_parameters_test.Tpo utils/$(DEPDIR)/unit_tests_prof-rb_parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/rb_parameters_test.C' object='utils/unit_tests_prof-rb_parameters_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_prof-rb_parameters_test.o `test -f 'utils/rb_parameters_test.C' || echo '$(srcdir)/'`utils/rb_parameters_test.C
+
+utils/unit_tests_prof-rb_parameters_test.obj: utils/rb_parameters_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_prof-rb_parameters_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_prof-rb_parameters_test.Tpo -c -o utils/unit_tests_prof-rb_parameters_test.obj `if test -f 'utils/rb_parameters_test.C'; then $(CYGPATH_W) 'utils/rb_parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/rb_parameters_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_prof-rb_parameters_test.Tpo utils/$(DEPDIR)/unit_tests_prof-rb_parameters_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/rb_parameters_test.C' object='utils/unit_tests_prof-rb_parameters_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_prof-rb_parameters_test.obj `if test -f 'utils/rb_parameters_test.C'; then $(CYGPATH_W) 'utils/rb_parameters_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/rb_parameters_test.C'; fi`
+
 utils/unit_tests_prof-transparent_comparator.o: utils/transparent_comparator.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_prof-transparent_comparator.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_prof-transparent_comparator.Tpo -c -o utils/unit_tests_prof-transparent_comparator.o `test -f 'utils/transparent_comparator.C' || echo '$(srcdir)/'`utils/transparent_comparator.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_prof-transparent_comparator.Tpo utils/$(DEPDIR)/unit_tests_prof-transparent_comparator.Po
@@ -12172,26 +12272,31 @@ distclean: distclean-am
 	-rm -f systems/$(DEPDIR)/unit_tests_prof-systems_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_dbg-rb_parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_devel-rb_parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_oprof-rb_parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_opt-rb_parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_prof-rb_parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-xdr_test.Po
@@ -12739,26 +12844,31 @@ maintainer-clean: maintainer-clean-am
 	-rm -f systems/$(DEPDIR)/unit_tests_prof-systems_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_dbg-rb_parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_dbg-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_devel-rb_parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_devel-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_oprof-rb_parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_oprof-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_opt-rb_parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_opt-xdr_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po
+	-rm -f utils/$(DEPDIR)/unit_tests_prof-rb_parameters_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-transparent_comparator.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po
 	-rm -f utils/$(DEPDIR)/unit_tests_prof-xdr_test.Po

--- a/tests/utils/rb_parameters_test.C
+++ b/tests/utils/rb_parameters_test.C
@@ -1,0 +1,48 @@
+// libMesh includes
+#include "libmesh/rb_parameters.h"
+
+// CPPUnit includes
+#include "libmesh_cppunit.h"
+
+using namespace libMesh;
+
+class RBParametersTest : public CppUnit::TestCase
+{
+public:
+  LIBMESH_CPPUNIT_TEST_SUITE ( RBParametersTest );
+  CPPUNIT_TEST( testScalar );
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  // virtual void setUp()
+  // {}
+
+  // virtual void tearDown()
+  // {}
+
+  void testScalar()
+  {
+    LOG_UNIT_TEST;
+
+    // Test scalar-valued interfaces
+    RBParameters params;
+    params.set_value("a", 1.);
+    params.set_value("b", 2.);
+    params.set_value("c", 3.);
+
+    // Expected result
+    // a: 1.000000e+00
+    // b: 2.000000e+00
+    // c: 3.000000e+00
+    CPPUNIT_ASSERT(params.has_value("a"));
+    CPPUNIT_ASSERT(params.has_value("b"));
+    CPPUNIT_ASSERT(params.has_value("c"));
+    CPPUNIT_ASSERT_EQUAL(params.get_value("a"), 1.);
+    CPPUNIT_ASSERT_EQUAL(params.get_value("b"), 2.);
+    CPPUNIT_ASSERT_EQUAL(params.get_value("c"), 3.);
+  }
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION ( RBParametersTest );

--- a/tests/utils/rb_parameters_test.C
+++ b/tests/utils/rb_parameters_test.C
@@ -11,6 +11,8 @@ class RBParametersTest : public CppUnit::TestCase
 public:
   LIBMESH_CPPUNIT_TEST_SUITE ( RBParametersTest );
   CPPUNIT_TEST( testScalar );
+  CPPUNIT_TEST( testOldConstructor );
+  CPPUNIT_TEST( testIterators );
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -41,6 +43,51 @@ public:
     CPPUNIT_ASSERT_EQUAL(params.get_value("a"), 1.);
     CPPUNIT_ASSERT_EQUAL(params.get_value("b"), 2.);
     CPPUNIT_ASSERT_EQUAL(params.get_value("c"), 3.);
+  }
+
+  void testOldConstructor()
+  {
+    LOG_UNIT_TEST;
+
+    // Test constructing an RBParameters object from a std::map
+    std::map<std::string, Real> in = {{"a", 1.}, {"b", 2.}, {"c", 3.}};
+    RBParameters params(in);
+
+    // Expected result
+    // a: 1.000000e+00
+    // b: 2.000000e+00
+    // c: 3.000000e+00
+    CPPUNIT_ASSERT(params.has_value("a"));
+    CPPUNIT_ASSERT(params.has_value("b"));
+    CPPUNIT_ASSERT(params.has_value("c"));
+    CPPUNIT_ASSERT_EQUAL(params.get_value("a"), 1.);
+    CPPUNIT_ASSERT_EQUAL(params.get_value("b"), 2.);
+    CPPUNIT_ASSERT_EQUAL(params.get_value("c"), 3.);
+  }
+
+  void testIterators()
+  {
+    LOG_UNIT_TEST;
+
+    // Test creating a std::map using RBParameters iterators
+    RBParameters params;
+    params.set_value("a", 1.);
+    params.set_value("b", 2.);
+    params.set_value("c", 3.);
+
+    std::map<std::string, Real> m;
+    m.insert(params.begin(), params.end());
+
+    // Expected result
+    // a: 1.000000e+00
+    // b: 2.000000e+00
+    // c: 3.000000e+00
+    CPPUNIT_ASSERT(m.count("a"));
+    CPPUNIT_ASSERT(m.count("b"));
+    CPPUNIT_ASSERT(m.count("c"));
+    CPPUNIT_ASSERT_EQUAL(m["a"], 1.);
+    CPPUNIT_ASSERT_EQUAL(m["b"], 2.);
+    CPPUNIT_ASSERT_EQUAL(m["c"], 3.);
   }
 
 };


### PR DESCRIPTION
Older compilers apparently allowed us to get away without these typedefs, but GCC 11 does not. Also added a unit test of the case that was previously failing to compile under GCC 11.