### PR TITLE
Some clean-up commits for reduced_basis code

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -279,12 +279,7 @@ int main (int argc, char ** argv)
       // since the RBParameters object stores multiple "steps", we
       // take the approach of pre-evaluating the thetas for each
       // parameter while calling the rb_solve() in a loop.
-      //
-      // FIXME: There are some const-correctness issues with the
-      // RBThetaExpansion API here, so this reference is non-const,
-      // but actually we are not changing it so we should be able to
-      // use a const reference here.
-      RBThetaExpansion & rb_theta_expansion = rb_eval.get_rb_theta_expansion();
+      const RBThetaExpansion & rb_theta_expansion = rb_eval.get_rb_theta_expansion();
 
       // Single-entry vector which makes calling the vector-overrides
       // of eval_A_theta(), eval_F_theta(), etc. easier.

--- a/include/reduced_basis/rb_assembly_expansion.h
+++ b/include/reduced_basis/rb_assembly_expansion.h
@@ -59,39 +59,39 @@ public:
    * Perform the specified A interior assembly.
    */
   void perform_A_interior_assembly(unsigned int q,
-                                   FEMContext & context);
+                                   FEMContext & context) const;
 
   /**
    * Perform the specified A boundary assembly.
    */
   void perform_A_boundary_assembly(unsigned int q,
-                                   FEMContext & context);
+                                   FEMContext & context) const;
 
   /**
    * Perform the specified F interior assembly.
    */
   void perform_F_interior_assembly(unsigned int q,
-                                   FEMContext & context);
+                                   FEMContext & context) const;
 
   /**
    * Perform the specified F boundary assembly.
    */
   void perform_F_boundary_assembly(unsigned int q,
-                                   FEMContext & context);
+                                   FEMContext & context) const;
 
   /**
    * Perform the specified output assembly.
    */
   void perform_output_interior_assembly(unsigned int output_index,
                                         unsigned int q_l,
-                                        FEMContext & context);
+                                        FEMContext & context) const;
 
   /**
    * Perform the specified output assembly.
    */
   void perform_output_boundary_assembly(unsigned int output_index,
                                         unsigned int q_l,
-                                        FEMContext & context);
+                                        FEMContext & context) const;
 
   /**
    * Get Q_a, the number of terms in the affine

--- a/include/reduced_basis/rb_assembly_expansion.h
+++ b/include/reduced_basis/rb_assembly_expansion.h
@@ -46,14 +46,14 @@ class RBAssemblyExpansion : public ReferenceCountedObject<RBAssemblyExpansion>
 public:
 
   /**
-   * Constructor.
+   * All special functions can be defaulted for this simple class.
    */
-  RBAssemblyExpansion();
-
-  /**
-   * Destructor.
-   */
-  virtual ~RBAssemblyExpansion() = default;
+  RBAssemblyExpansion() = default;
+  RBAssemblyExpansion (RBAssemblyExpansion &&) = default;
+  RBAssemblyExpansion (const RBAssemblyExpansion &) = default;
+  RBAssemblyExpansion & operator= (const RBAssemblyExpansion &) = default;
+  RBAssemblyExpansion & operator= (RBAssemblyExpansion &&) = default;
+  virtual ~RBAssemblyExpansion () = default;
 
   /**
    * Perform the specified A interior assembly.

--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -217,21 +217,21 @@ public:
    */
   void set_rel_training_tolerance(Real new_training_tolerance)
   {this->rel_training_tolerance = new_training_tolerance; }
-  Real get_rel_training_tolerance() { return rel_training_tolerance; }
+  Real get_rel_training_tolerance() const { return rel_training_tolerance; }
 
   /**
    * Get/set the absolute tolerance for the basis training.
    */
   void set_abs_training_tolerance(Real new_training_tolerance)
   {this->abs_training_tolerance = new_training_tolerance; }
-  Real get_abs_training_tolerance() { return abs_training_tolerance; }
+  Real get_abs_training_tolerance() const { return abs_training_tolerance; }
 
   /**
    * Get/set the boolean to indicate if we normalize the RB error in the greedy.
    */
   void set_normalize_rb_bound_in_greedy(bool normalize_rb_bound_in_greedy_in)
   {this->normalize_rb_bound_in_greedy = normalize_rb_bound_in_greedy_in; }
-  bool get_normalize_rb_bound_in_greedy() { return normalize_rb_bound_in_greedy; }
+  bool get_normalize_rb_bound_in_greedy() const { return normalize_rb_bound_in_greedy; }
 
   /**
    * Get/set the string that determines the training type.
@@ -271,6 +271,7 @@ public:
    * defined in low-memory mode).
    */
   SparseMatrix<Number> * get_inner_product_matrix();
+  const SparseMatrix<Number> * get_inner_product_matrix() const;
 
   /**
    * Get the non-Dirichlet (or more generally no-constraints) version
@@ -278,12 +279,14 @@ public:
    * on vectors that already have constraints enforced.
    */
   SparseMatrix<Number> * get_non_dirichlet_inner_product_matrix();
+  const SparseMatrix<Number> * get_non_dirichlet_inner_product_matrix() const;
 
   /**
    * Get the non-Dirichlet inner-product matrix if it's available,
    * otherwise get the inner-product matrix with constraints.
    */
   SparseMatrix<Number> * get_non_dirichlet_inner_product_matrix_if_avail();
+  const SparseMatrix<Number> * get_non_dirichlet_inner_product_matrix_if_avail() const;
 
   /**
    * Get a pointer to Aq.
@@ -440,14 +443,14 @@ public:
   /**
    * Print out info that describes the current setup of this RBConstruction.
    */
-  virtual void print_info();
+  virtual void print_info() const;
 
   /**
    * Print out a matrix that shows the orthogonality of the RB basis functions.
    * This is a helpful debugging tool, e.g. orthogonality can be degraded
    * due to finite precision arithmetic.
    */
-  void print_basis_function_orthogonality();
+  void print_basis_function_orthogonality() const;
 
   /**
    * Get delta_N, the number of basis functions we
@@ -478,12 +481,12 @@ public:
    * It is sometimes useful to be able to zero vector entries
    * that correspond to constrained dofs.
    */
-  void zero_constrained_dofs_on_vector(NumericVector<Number> & vector);
+  void zero_constrained_dofs_on_vector(NumericVector<Number> & vector) const;
 
   /**
    * @return true if the most recent truth solve gave a zero solution.
    */
-  virtual bool check_if_zero_truth_solve();
+  virtual bool check_if_zero_truth_solve() const;
 
 #ifdef LIBMESH_ENABLE_DIRICHLET
   /**

--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -95,6 +95,7 @@ public:
    * Get a reference to the RBEvaluation object.
    */
   RBEvaluation & get_rb_evaluation();
+  const RBEvaluation & get_rb_evaluation() const;
 
   /**
    * \returns \p true if rb_eval is initialized. False, otherwise.
@@ -106,6 +107,7 @@ public:
    * that belongs to rb_eval.
    */
   RBThetaExpansion & get_rb_theta_expansion();
+  const RBThetaExpansion & get_rb_theta_expansion() const;
 
   /**
    * Set the rb_assembly_expansion object.

--- a/include/reduced_basis/rb_evaluation.h
+++ b/include/reduced_basis/rb_evaluation.h
@@ -58,8 +58,15 @@ public:
   RBEvaluation (const Parallel::Communicator & comm);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class contains unique_ptrs, so it can't be default copy
+   *   constructed/assigned.
+   * - The destructor is defaulted out of line.
    */
+  RBEvaluation (RBEvaluation &&) = default;
+  RBEvaluation (const RBEvaluation &) = delete;
+  RBEvaluation & operator= (const RBEvaluation &) = delete;
+  RBEvaluation & operator= (RBEvaluation &&) = default;
   virtual ~RBEvaluation ();
 
   /**

--- a/include/reduced_basis/rb_evaluation.h
+++ b/include/reduced_basis/rb_evaluation.h
@@ -104,6 +104,7 @@ public:
    * Get a reference to the i^th basis function.
    */
   NumericVector<Number> & get_basis_function(unsigned int i);
+  const NumericVector<Number> & get_basis_function(unsigned int i) const;
 
   /**
    * Perform online solve with the N RB basis functions, for the

--- a/include/reduced_basis/rb_evaluation.h
+++ b/include/reduced_basis/rb_evaluation.h
@@ -126,14 +126,14 @@ public:
    * Compute the dual norm of the residual for the solution
    * saved in RB_solution_vector.
    */
-  virtual Real compute_residual_dual_norm(const unsigned int N);
+  virtual Real compute_residual_dual_norm(const unsigned int N) const;
 
   /**
    * The same as above, except that we pass in evaluated thetas
    * instead of recomputing the theta values.
    */
   virtual Real compute_residual_dual_norm(const unsigned int N,
-                                          const std::vector<Number> * evaluated_thetas);
+                                          const std::vector<Number> * evaluated_thetas) const;
 
   /**
    * Specifies the residual scaling on the denominator to

--- a/include/reduced_basis/rb_evaluation.h
+++ b/include/reduced_basis/rb_evaluation.h
@@ -126,14 +126,14 @@ public:
    * Compute the dual norm of the residual for the solution
    * saved in RB_solution_vector.
    */
-  virtual Real compute_residual_dual_norm(const unsigned int N) const;
+  virtual Real compute_residual_dual_norm(const unsigned int N);
 
   /**
    * The same as above, except that we pass in evaluated thetas
    * instead of recomputing the theta values.
    */
   virtual Real compute_residual_dual_norm(const unsigned int N,
-                                          const std::vector<Number> * evaluated_thetas) const;
+                                          const std::vector<Number> * evaluated_thetas);
 
   /**
    * Specifies the residual scaling on the denominator to

--- a/include/reduced_basis/rb_evaluation.h
+++ b/include/reduced_basis/rb_evaluation.h
@@ -77,6 +77,7 @@ public:
    * Get a reference to the rb_theta_expansion.
    */
   RBThetaExpansion & get_rb_theta_expansion();
+  const RBThetaExpansion & get_rb_theta_expansion() const;
 
   /**
    * \returns \p true if the theta expansion has been initialized.

--- a/include/reduced_basis/rb_temporal_discretization.h
+++ b/include/reduced_basis/rb_temporal_discretization.h
@@ -47,6 +47,15 @@ public:
   RBTemporalDiscretization();
 
   /**
+   * Special functions can all be defaulted for this simple class.
+   */
+  RBTemporalDiscretization (RBTemporalDiscretization &&) = default;
+  RBTemporalDiscretization (const RBTemporalDiscretization &) = default;
+  RBTemporalDiscretization & operator= (const RBTemporalDiscretization &) = default;
+  RBTemporalDiscretization & operator= (RBTemporalDiscretization &&) = default;
+  virtual ~RBTemporalDiscretization () = default;
+
+  /**
    * Get/set delta_t, the time-step size.
    */
   Real get_delta_t() const;
@@ -119,7 +128,6 @@ private:
    * See Martin Grepl's thesis
    */
   std::vector<Real> _control;
-
 };
 
 }

--- a/include/reduced_basis/rb_theta_expansion.h
+++ b/include/reduced_basis/rb_theta_expansion.h
@@ -46,14 +46,14 @@ class RBThetaExpansion : public ReferenceCountedObject<RBThetaExpansion>
 public:
 
   /**
-   * Constructor.
+   * All special functions can be defaulted for this simple class.
    */
-  RBThetaExpansion();
-
-  /**
-   * Destructor.
-   */
-  virtual ~RBThetaExpansion() = default;
+  RBThetaExpansion() = default;
+  RBThetaExpansion (RBThetaExpansion &&) = default;
+  RBThetaExpansion (const RBThetaExpansion &) = default;
+  RBThetaExpansion & operator= (const RBThetaExpansion &) = default;
+  RBThetaExpansion & operator= (RBThetaExpansion &&) = default;
+  virtual ~RBThetaExpansion () = default;
 
   /**
    * Evaluate theta_q_a at the current parameter. Override
@@ -172,7 +172,6 @@ public:
    */
   virtual void attach_output_theta(RBTheta * theta_q_l);
 
-
 private:
 
   /**
@@ -189,7 +188,6 @@ private:
    * Vector storing the RBTheta functors for the affine expansion of the outputs.
    */
   std::vector<std::vector<RBTheta *>> _output_theta_vector;
-
 };
 
 }

--- a/include/reduced_basis/rb_theta_expansion.h
+++ b/include/reduced_basis/rb_theta_expansion.h
@@ -61,39 +61,39 @@ public:
    * in subclasses.
    */
   virtual Number eval_A_theta(unsigned int q,
-                              const RBParameters & mu);
+                              const RBParameters & mu) const;
 
   /**
    * Evaluate theta_q_a at multiple parameters simultaneously.
    */
   virtual std::vector<Number> eval_A_theta(unsigned int q,
-                                           const std::vector<RBParameters> & mus);
+                                           const std::vector<RBParameters> & mus) const;
 
   /**
    * Evaluate theta_q_f at the current parameter.
    */
   virtual Number eval_F_theta(unsigned int q,
-                              const RBParameters & mu);
+                              const RBParameters & mu) const;
 
   /**
    * Evaluate theta_q_f at multiple parameters simultaneously.
    */
   virtual std::vector<Number> eval_F_theta(unsigned int q,
-                                           const std::vector<RBParameters> & mus);
+                                           const std::vector<RBParameters> & mus) const;
 
   /**
    * Evaluate theta_q_l at the current parameter.
    */
   virtual Number eval_output_theta(unsigned int output_index,
                                    unsigned int q_l,
-                                   const RBParameters & mu);
+                                   const RBParameters & mu) const;
 
   /**
    * Evaluate theta_q_l at multiple parameters simultaneously.
    */
   virtual std::vector<Number> eval_output_theta(unsigned int output_index,
                                                 unsigned int q_l,
-                                                const std::vector<RBParameters> & mus);
+                                                const std::vector<RBParameters> & mus) const;
 
   /**
    * Get Q_a, the number of terms in the affine
@@ -128,7 +128,7 @@ public:
    * pre-evaluated theta arrays, which store the pre-evaluated output theta
    * values in this order following the "A" and "F" theta values.
    */
-  unsigned int output_index_1D(unsigned int n, unsigned int q_l);
+  unsigned int output_index_1D(unsigned int n, unsigned int q_l) const;
 
   /**
    * Attach a pointer to a functor object that defines one

--- a/include/reduced_basis/transient_rb_assembly_expansion.h
+++ b/include/reduced_basis/transient_rb_assembly_expansion.h
@@ -42,9 +42,14 @@ class TransientRBAssemblyExpansion : public RBAssemblyExpansion
 public:
 
   /**
-   * Constructor.
+   * All special functions can be defaulted for this simple class.
    */
-  TransientRBAssemblyExpansion();
+  TransientRBAssemblyExpansion() = default;
+  TransientRBAssemblyExpansion (TransientRBAssemblyExpansion &&) = default;
+  TransientRBAssemblyExpansion (const TransientRBAssemblyExpansion &) = default;
+  TransientRBAssemblyExpansion & operator= (const TransientRBAssemblyExpansion &) = default;
+  TransientRBAssemblyExpansion & operator= (TransientRBAssemblyExpansion &&) = default;
+  virtual ~TransientRBAssemblyExpansion () = default;
 
   /**
    * Perform the specified M interior assembly.

--- a/include/reduced_basis/transient_rb_assembly_expansion.h
+++ b/include/reduced_basis/transient_rb_assembly_expansion.h
@@ -55,13 +55,13 @@ public:
    * Perform the specified M interior assembly.
    */
   void perform_M_interior_assembly(unsigned int q,
-                                   FEMContext & context);
+                                   FEMContext & context) const;
 
   /**
    * Perform the specified M boundary assembly.
    */
   void perform_M_boundary_assembly(unsigned int q,
-                                   FEMContext & context);
+                                   FEMContext & context) const;
 
   /**
    * Get Q_m, the number of terms in the affine

--- a/include/reduced_basis/transient_rb_construction.h
+++ b/include/reduced_basis/transient_rb_construction.h
@@ -58,8 +58,14 @@ public:
                            const unsigned int number);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class has the same restrictions/defaults as its base class.
+   * - Destructor is defaulted out-of-line
    */
+  TransientRBConstruction (TransientRBConstruction &&) = default;
+  TransientRBConstruction (const TransientRBConstruction &) = delete;
+  TransientRBConstruction & operator= (const TransientRBConstruction &) = delete;
+  TransientRBConstruction & operator= (TransientRBConstruction &&) = delete;
   virtual ~TransientRBConstruction ();
 
   /**

--- a/include/reduced_basis/transient_rb_construction.h
+++ b/include/reduced_basis/transient_rb_construction.h
@@ -118,7 +118,7 @@ public:
   /**
    * Print out info that describes the current setup of this RBConstruction.
    */
-  virtual void print_info() override;
+  virtual void print_info() const override;
 
   /**
    * Function that indicates when to terminate the Greedy

--- a/include/reduced_basis/transient_rb_evaluation.h
+++ b/include/reduced_basis/transient_rb_evaluation.h
@@ -57,9 +57,16 @@ public:
   TransientRBEvaluation (const Parallel::Communicator & comm_in);
 
   /**
-   * Destructor.
+   * Special functions.
+   * - This class contains unique_ptrs, so it can't be default copy
+   *   constructed/assigned.
+   * - The destructor is defaulted out of line.
    */
-  ~TransientRBEvaluation ();
+  TransientRBEvaluation (TransientRBEvaluation &&) = default;
+  TransientRBEvaluation (const TransientRBEvaluation &) = delete;
+  TransientRBEvaluation & operator= (const TransientRBEvaluation &) = delete;
+  TransientRBEvaluation & operator= (TransientRBEvaluation &&) = default;
+  virtual ~TransientRBEvaluation ();
 
   /**
    * The type of the parent.

--- a/include/reduced_basis/transient_rb_theta_expansion.h
+++ b/include/reduced_basis/transient_rb_theta_expansion.h
@@ -43,9 +43,14 @@ class TransientRBThetaExpansion : public RBThetaExpansion
 public:
 
   /**
-   * Constructor.
+   * All special functions can be defaulted for this simple class.
    */
-  TransientRBThetaExpansion();
+  TransientRBThetaExpansion() = default;
+  TransientRBThetaExpansion (TransientRBThetaExpansion &&) = default;
+  TransientRBThetaExpansion (const TransientRBThetaExpansion &) = default;
+  TransientRBThetaExpansion & operator= (const TransientRBThetaExpansion &) = default;
+  TransientRBThetaExpansion & operator= (TransientRBThetaExpansion &&) = default;
+  virtual ~TransientRBThetaExpansion () = default;
 
   /**
    * The type of the parent.

--- a/include/reduced_basis/transient_rb_theta_expansion.h
+++ b/include/reduced_basis/transient_rb_theta_expansion.h
@@ -64,8 +64,7 @@ public:
    * Get Q_m, the number of terms in the affine
    * expansion for the mass operator.
    */
-  virtual unsigned int get_n_M_terms()
-  { return cast_int<unsigned int>(_M_theta_vector.size()); }
+  virtual unsigned int get_n_M_terms() const;
 
   /**
    * Attach a pointer to a functor object that defines one

--- a/include/reduced_basis/transient_rb_theta_expansion.h
+++ b/include/reduced_basis/transient_rb_theta_expansion.h
@@ -58,7 +58,7 @@ public:
    * in subclasses.
    */
   virtual Number eval_M_theta(unsigned int q,
-                              const RBParameters & mu);
+                              const RBParameters & mu) const;
 
   /**
    * Get Q_m, the number of terms in the affine

--- a/src/reduced_basis/rb_assembly_expansion.C
+++ b/src/reduced_basis/rb_assembly_expansion.C
@@ -25,7 +25,7 @@ namespace libMesh
 {
 
 void RBAssemblyExpansion::perform_A_interior_assembly(unsigned int q,
-                                                      FEMContext & context)
+                                                      FEMContext & context) const
 {
   libmesh_error_msg_if(q >= get_n_A_terms(),
                        "Error: We must have q < get_n_A_terms in perform_A_interior_assembly.");
@@ -36,7 +36,7 @@ void RBAssemblyExpansion::perform_A_interior_assembly(unsigned int q,
 }
 
 void RBAssemblyExpansion::perform_A_boundary_assembly(unsigned int q,
-                                                      FEMContext & context)
+                                                      FEMContext & context) const
 {
   libmesh_error_msg_if(q >= get_n_A_terms(),
                        "Error: We must have q < get_n_A_terms in perform_A_boundary_assembly.");
@@ -47,7 +47,7 @@ void RBAssemblyExpansion::perform_A_boundary_assembly(unsigned int q,
 }
 
 void RBAssemblyExpansion::perform_F_interior_assembly(unsigned int q,
-                                                      FEMContext & context)
+                                                      FEMContext & context) const
 {
   libmesh_error_msg_if(q >= get_n_F_terms(),
                        "Error: We must have q < get_n_F_terms in perform_F_interior_assembly.");
@@ -58,7 +58,7 @@ void RBAssemblyExpansion::perform_F_interior_assembly(unsigned int q,
 }
 
 void RBAssemblyExpansion::perform_F_boundary_assembly(unsigned int q,
-                                                      FEMContext & context)
+                                                      FEMContext & context) const
 {
   libmesh_error_msg_if(q >= get_n_F_terms(),
                        "Error: We must have q < get_n_F_terms in perform_F_interior_assembly.");
@@ -70,7 +70,7 @@ void RBAssemblyExpansion::perform_F_boundary_assembly(unsigned int q,
 
 void RBAssemblyExpansion::perform_output_interior_assembly(unsigned int output_index,
                                                            unsigned int q_l,
-                                                           FEMContext & context)
+                                                           FEMContext & context) const
 {
   libmesh_error_msg_if((output_index >= get_n_outputs()) || (q_l >= get_n_output_terms(output_index)),
                        "Error: We must have output_index < n_outputs and "
@@ -83,7 +83,7 @@ void RBAssemblyExpansion::perform_output_interior_assembly(unsigned int output_i
 
 void RBAssemblyExpansion::perform_output_boundary_assembly(unsigned int output_index,
                                                            unsigned int q_l,
-                                                           FEMContext & context)
+                                                           FEMContext & context) const
 {
   libmesh_error_msg_if((output_index >= get_n_outputs()) || (q_l >= get_n_output_terms(output_index)),
                        "Error: We must have output_index < n_outputs and "

--- a/src/reduced_basis/rb_assembly_expansion.C
+++ b/src/reduced_basis/rb_assembly_expansion.C
@@ -24,13 +24,6 @@
 namespace libMesh
 {
 
-// ------------------------------------------------------------
-// RBAssemblyExpansion implementation
-
-RBAssemblyExpansion::RBAssemblyExpansion()
-{
-}
-
 void RBAssemblyExpansion::perform_A_interior_assembly(unsigned int q,
                                                       FEMContext & context)
 {

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -333,7 +333,7 @@ void RBConstruction::set_rb_construction_parameters(
     }
 }
 
-void RBConstruction::print_info()
+void RBConstruction::print_info() const
 {
   // Print out info that describes the current setup
   libMesh::out << std::endl << "RBConstruction parameters:" << std::endl;
@@ -370,7 +370,7 @@ void RBConstruction::print_info()
   libMesh::out << std::endl;
 }
 
-void RBConstruction::print_basis_function_orthogonality()
+void RBConstruction::print_basis_function_orthogonality() const
 {
   std::unique_ptr<NumericVector<Number>> temp = solution->clone();
 
@@ -423,7 +423,7 @@ void RBConstruction::set_energy_inner_product(const std::vector<Number> & energy
   energy_inner_product_coeffs = energy_inner_product_coeffs_in;
 }
 
-void RBConstruction::zero_constrained_dofs_on_vector(NumericVector<Number> & vector)
+void RBConstruction::zero_constrained_dofs_on_vector(NumericVector<Number> & vector) const
 {
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
   const DofMap & dof_map = get_dof_map();
@@ -440,7 +440,7 @@ void RBConstruction::zero_constrained_dofs_on_vector(NumericVector<Number> & vec
   vector.close();
 }
 
-bool RBConstruction::check_if_zero_truth_solve()
+bool RBConstruction::check_if_zero_truth_solve() const
 {
   return (solution->l2_norm() == 0.);
 }
@@ -2265,6 +2265,11 @@ SparseMatrix<Number> * RBConstruction::get_inner_product_matrix()
   return inner_product_matrix.get();
 }
 
+const SparseMatrix<Number> * RBConstruction::get_inner_product_matrix() const
+{
+  return inner_product_matrix.get();
+}
+
 SparseMatrix<Number> * RBConstruction::get_non_dirichlet_inner_product_matrix()
 {
   libmesh_error_msg_if(!store_non_dirichlet_operators,
@@ -2273,7 +2278,25 @@ SparseMatrix<Number> * RBConstruction::get_non_dirichlet_inner_product_matrix()
   return non_dirichlet_inner_product_matrix.get();
 }
 
+const SparseMatrix<Number> * RBConstruction::get_non_dirichlet_inner_product_matrix() const
+{
+  libmesh_error_msg_if(!store_non_dirichlet_operators,
+                       "Error: Must have store_non_dirichlet_operators==true to access non_dirichlet_inner_product_matrix.");
+
+  return non_dirichlet_inner_product_matrix.get();
+}
+
 SparseMatrix<Number> * RBConstruction::get_non_dirichlet_inner_product_matrix_if_avail()
+{
+  if (store_non_dirichlet_operators)
+    {
+      return get_non_dirichlet_inner_product_matrix();
+    }
+
+  return get_inner_product_matrix();
+}
+
+const SparseMatrix<Number> * RBConstruction::get_non_dirichlet_inner_product_matrix_if_avail() const
 {
   if (store_non_dirichlet_operators)
     {

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -178,12 +178,24 @@ RBEvaluation & RBConstruction::get_rb_evaluation()
   return *rb_eval;
 }
 
+const RBEvaluation & RBConstruction::get_rb_evaluation() const
+{
+  libmesh_error_msg_if(!rb_eval, "Error: RBEvaluation object hasn't been initialized yet");
+
+  return *rb_eval;
+}
+
 bool RBConstruction::is_rb_eval_initialized() const
 {
   return (rb_eval != nullptr);
 }
 
 RBThetaExpansion & RBConstruction::get_rb_theta_expansion()
+{
+  return get_rb_evaluation().get_rb_theta_expansion();
+}
+
+const RBThetaExpansion & RBConstruction::get_rb_theta_expansion() const
 {
   return get_rb_evaluation().get_rb_theta_expansion();
 }

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -340,13 +340,13 @@ Real RBEvaluation::get_error_bound_normalization()
   return normalization;
 }
 
-Real RBEvaluation::compute_residual_dual_norm(const unsigned int N) const
+Real RBEvaluation::compute_residual_dual_norm(const unsigned int N)
 {
   return compute_residual_dual_norm(N, nullptr);
 }
 
 Real RBEvaluation::compute_residual_dual_norm(const unsigned int N,
-                                              const std::vector<Number> * evaluated_thetas) const
+                                              const std::vector<Number> * evaluated_thetas)
 {
   LOG_SCOPE("compute_residual_dual_norm()", "RBEvaluation");
 

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -340,13 +340,13 @@ Real RBEvaluation::get_error_bound_normalization()
   return normalization;
 }
 
-Real RBEvaluation::compute_residual_dual_norm(const unsigned int N)
+Real RBEvaluation::compute_residual_dual_norm(const unsigned int N) const
 {
   return compute_residual_dual_norm(N, nullptr);
 }
 
 Real RBEvaluation::compute_residual_dual_norm(const unsigned int N,
-                                              const std::vector<Number> * evaluated_thetas)
+                                              const std::vector<Number> * evaluated_thetas) const
 {
   LOG_SCOPE("compute_residual_dual_norm()", "RBEvaluation");
 

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -89,6 +89,14 @@ RBThetaExpansion & RBEvaluation::get_rb_theta_expansion()
   return *rb_theta_expansion;
 }
 
+const RBThetaExpansion & RBEvaluation::get_rb_theta_expansion() const
+{
+  libmesh_error_msg_if(!is_rb_theta_expansion_initialized(),
+                       "Error: rb_theta_expansion hasn't been initialized yet");
+
+  return *rb_theta_expansion;
+}
+
 bool RBEvaluation::is_rb_theta_expansion_initialized() const
 {
   if (rb_theta_expansion)

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -210,6 +210,13 @@ NumericVector<Number> & RBEvaluation::get_basis_function(unsigned int i)
   return *(basis_functions[i]);
 }
 
+const NumericVector<Number> & RBEvaluation::get_basis_function(unsigned int i) const
+{
+  libmesh_assert_less (i, basis_functions.size());
+
+  return *(basis_functions[i]);
+}
+
 Real RBEvaluation::rb_solve(unsigned int N)
 {
   return rb_solve(N, nullptr);

--- a/src/reduced_basis/rb_theta_expansion.C
+++ b/src/reduced_basis/rb_theta_expansion.C
@@ -69,7 +69,7 @@ unsigned int RBThetaExpansion::get_total_n_output_terms() const
   return sum;
 }
 
-unsigned int RBThetaExpansion::output_index_1D(unsigned int n, unsigned int q_l)
+unsigned int RBThetaExpansion::output_index_1D(unsigned int n, unsigned int q_l) const
 {
   // Start with index of the current term
   unsigned int index = q_l;
@@ -139,7 +139,7 @@ void RBThetaExpansion::attach_output_theta(RBTheta * theta_q_l)
 }
 
 Number RBThetaExpansion::eval_A_theta(unsigned int q,
-                                      const RBParameters & mu)
+                                      const RBParameters & mu) const
 {
   libmesh_error_msg_if(q >= get_n_A_terms(), "Error: We must have q < get_n_A_terms in eval_A_theta.");
   libmesh_assert(_A_theta_vector[q]);
@@ -148,7 +148,7 @@ Number RBThetaExpansion::eval_A_theta(unsigned int q,
 }
 
 std::vector<Number> RBThetaExpansion::eval_A_theta(unsigned int q,
-                                                   const std::vector<RBParameters> & mus)
+                                                   const std::vector<RBParameters> & mus) const
 {
   libmesh_error_msg_if(q >= get_n_A_terms(), "Error: We must have q < get_n_A_terms in eval_A_theta.");
   libmesh_assert(_A_theta_vector[q]);
@@ -157,7 +157,7 @@ std::vector<Number> RBThetaExpansion::eval_A_theta(unsigned int q,
 }
 
 Number RBThetaExpansion::eval_F_theta(unsigned int q,
-                                      const RBParameters & mu)
+                                      const RBParameters & mu) const
 {
   libmesh_error_msg_if(q >= get_n_F_terms(), "Error: We must have q < get_n_F_terms in eval_F_theta.");
   libmesh_assert(_F_theta_vector[q]);
@@ -166,7 +166,7 @@ Number RBThetaExpansion::eval_F_theta(unsigned int q,
 }
 
 std::vector<Number> RBThetaExpansion::eval_F_theta(unsigned int q,
-                                                   const std::vector<RBParameters> & mus)
+                                                   const std::vector<RBParameters> & mus) const
 {
   libmesh_error_msg_if(q >= get_n_F_terms(), "Error: We must have q < get_n_F_terms in eval_F_theta.");
   libmesh_assert(_F_theta_vector[q]);
@@ -176,7 +176,7 @@ std::vector<Number> RBThetaExpansion::eval_F_theta(unsigned int q,
 
 Number RBThetaExpansion::eval_output_theta(unsigned int output_index,
                                            unsigned int q_l,
-                                           const RBParameters & mu)
+                                           const RBParameters & mu) const
 {
   libmesh_error_msg_if((output_index >= get_n_outputs()) || (q_l >= get_n_output_terms(output_index)),
                        "Error: We must have output_index < n_outputs and "
@@ -190,7 +190,7 @@ Number RBThetaExpansion::eval_output_theta(unsigned int output_index,
 std::vector<Number>
 RBThetaExpansion::eval_output_theta(unsigned int output_index,
                                     unsigned int q_l,
-                                    const std::vector<RBParameters> & mus)
+                                    const std::vector<RBParameters> & mus) const
 {
   libmesh_error_msg_if((output_index >= get_n_outputs()) || (q_l >= get_n_output_terms(output_index)),
                        "Error: We must have output_index < n_outputs and "

--- a/src/reduced_basis/rb_theta_expansion.C
+++ b/src/reduced_basis/rb_theta_expansion.C
@@ -28,13 +28,6 @@
 namespace libMesh
 {
 
-// ------------------------------------------------------------
-// RBThetaExpansion implementation
-
-RBThetaExpansion::RBThetaExpansion()
-{
-}
-
 unsigned int RBThetaExpansion::get_n_A_terms() const
 {
   return cast_int<unsigned int>

--- a/src/reduced_basis/transient_rb_assembly_expansion.C
+++ b/src/reduced_basis/transient_rb_assembly_expansion.C
@@ -24,13 +24,6 @@
 namespace libMesh
 {
 
-// ------------------------------------------------------------
-// TransientRBAssemblyExpansion implementation
-
-TransientRBAssemblyExpansion::TransientRBAssemblyExpansion()
-{
-}
-
 void TransientRBAssemblyExpansion::perform_M_interior_assembly(unsigned int q,
                                                                FEMContext & context)
 {

--- a/src/reduced_basis/transient_rb_assembly_expansion.C
+++ b/src/reduced_basis/transient_rb_assembly_expansion.C
@@ -25,7 +25,7 @@ namespace libMesh
 {
 
 void TransientRBAssemblyExpansion::perform_M_interior_assembly(unsigned int q,
-                                                               FEMContext & context)
+                                                               FEMContext & context) const
 {
   libmesh_error_msg_if(q >= get_n_M_terms(), "Error: We must have q < get_n_M_terms in perform_M_interior_assembly.");
   libmesh_assert(_M_assembly_vector[q]);
@@ -34,7 +34,7 @@ void TransientRBAssemblyExpansion::perform_M_interior_assembly(unsigned int q,
 }
 
 void TransientRBAssemblyExpansion::perform_M_boundary_assembly(unsigned int q,
-                                                               FEMContext & context)
+                                                               FEMContext & context) const
 {
   libmesh_error_msg_if(q >= get_n_M_terms(), "Error: We must have q < get_n_M_terms in perform_M_boundary_assembly.");
   libmesh_assert(_M_assembly_vector[q]);

--- a/src/reduced_basis/transient_rb_construction.C
+++ b/src/reduced_basis/transient_rb_construction.C
@@ -140,7 +140,7 @@ void TransientRBConstruction::process_parameters_file (const std::string & param
   trans_rb_eval.pull_temporal_discretization_data( *this );
 }
 
-void TransientRBConstruction::print_info()
+void TransientRBConstruction::print_info() const
 {
   Parent::print_info();
 
@@ -149,8 +149,8 @@ void TransientRBConstruction::print_info()
   if (is_rb_eval_initialized())
     {
       // Print out info that describes the current setup
-      TransientRBThetaExpansion & trans_theta_expansion =
-        cast_ref<TransientRBThetaExpansion &>(get_rb_theta_expansion());
+      auto & trans_theta_expansion =
+        cast_ref<const TransientRBThetaExpansion &>(get_rb_theta_expansion());
       libMesh::out << "Q_m: " << trans_theta_expansion.get_n_M_terms() << std::endl;
     }
   else

--- a/src/reduced_basis/transient_rb_theta_expansion.C
+++ b/src/reduced_basis/transient_rb_theta_expansion.C
@@ -39,6 +39,11 @@ Number TransientRBThetaExpansion::eval_M_theta(unsigned int q,
   return _M_theta_vector[q]->evaluate( mu );
 }
 
+unsigned int TransientRBThetaExpansion::get_n_M_terms() const
+{
+  return cast_int<unsigned int>(_M_theta_vector.size());
+}
+
 void TransientRBThetaExpansion::attach_M_theta(RBTheta * theta_q_m)
 {
   libmesh_assert(theta_q_m);

--- a/src/reduced_basis/transient_rb_theta_expansion.C
+++ b/src/reduced_basis/transient_rb_theta_expansion.C
@@ -31,7 +31,7 @@ TransientRBThetaExpansion::TransientRBThetaExpansion()
 }
 
 Number TransientRBThetaExpansion::eval_M_theta(unsigned int q,
-                                               const RBParameters & mu)
+                                               const RBParameters & mu) const
 {
   libmesh_error_msg_if(q >= get_n_M_terms(), "Error: We must have q < get_n_M_terms in eval_M_theta.");
   libmesh_assert(_M_theta_vector[q]);

--- a/src/reduced_basis/transient_rb_theta_expansion.C
+++ b/src/reduced_basis/transient_rb_theta_expansion.C
@@ -23,13 +23,6 @@
 namespace libMesh
 {
 
-// ------------------------------------------------------------
-// RBThetaExpansion implementation
-
-TransientRBThetaExpansion::TransientRBThetaExpansion()
-{
-}
-
 Number TransientRBThetaExpansion::eval_M_theta(unsigned int q,
                                                const RBParameters & mu) const
 {


### PR DESCRIPTION
* Make APIs `const` when possible
* Default/delete special member functions.

I believe there's still some additional APIs that can be made `const` here, especially `RBConstruction`'s matrix accessors, but this is a decent chunk for now.
