### PR TITLE
Pre-evaluate output thetas in RBConstruction

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -326,10 +326,7 @@ int main (int argc, char ** argv)
 
       // 3.) Evaluate "output" thetas at all steps: in this case, the
       // output is particularly simple (does not depend on mu) so this
-      // should just be a vector of all 1s. Also note that there is no
-      // "vector-valued" version of the RBThetaExpansion::eval_output_theta() API currently,
-      // but this example uses an RBParameters object with multiple steps, so we need to add
-      // that...
+      // should just be a vector of all 1s.
       std::vector<std::vector<Number>> all_outputs(rb_theta_expansion.get_total_n_output_terms());
       {
         unsigned int output_counter = 0;

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -1199,12 +1199,22 @@ void RBEvaluation::read_in_vectors_from_multiple_files(System & sys,
 
 void RBEvaluation::check_evaluated_thetas_size(const std::vector<Number> * evaluated_thetas) const
 {
-  libmesh_error_msg_if((rb_theta_expansion && evaluated_thetas) &&
-                       evaluated_thetas->size() !=
-                       rb_theta_expansion->get_n_A_terms() +
-                       rb_theta_expansion->get_n_F_terms() +
-                       rb_theta_expansion->get_total_n_output_terms(),
-                       "ERROR: Evaluated thetas have wrong size");
+  if (rb_theta_expansion && evaluated_thetas)
+    {
+      auto actual_size = evaluated_thetas->size();
+      auto expected_size =
+        rb_theta_expansion->get_n_A_terms() +
+        rb_theta_expansion->get_n_F_terms() +
+        rb_theta_expansion->get_total_n_output_terms();
+
+      libmesh_error_msg_if(actual_size != expected_size,
+                           "ERROR: Evaluated thetas vector has size " <<
+                           actual_size << ", but we expected " <<
+                           rb_theta_expansion->get_n_A_terms() << " A term(s), " <<
+                           rb_theta_expansion->get_n_F_terms() << " F term(s), and " <<
+                           rb_theta_expansion->get_total_n_output_terms() << " output term(s), " <<
+                           "for a total of " << expected_size << " terms.");
+    }
 }
 
 } // namespace libMesh


### PR DESCRIPTION
This is similar to the change that I made in reduced_basis_ex4 on the "Evaluation" side, except that this is on the "Construction" side. This issue was caught by our internal testing.