### PR TITLE
Get a clean `-fsanitize=integer` run of `make check`

### DIFF
--- a/contrib/fparser/util/bytecoderules_parser.cc
+++ b/contrib/fparser/util/bytecoderules_parser.cc
@@ -131,7 +131,7 @@ namespace
                       size_t indent)
         {
             std::string codehash, prevlabel;
-            for(size_t a=chain.size(); a-- > 0; )
+            for(ptrdiff_t a=chain.size(); a-- > 0; )
             {
                 codehash += chain[a];
                 std::string label = GenLabel(codehash);
@@ -509,7 +509,7 @@ namespace
             outstream << "\n" << Indent(indent+1);
 
         outstream << '"';
-        for(size_t a=so_far.size(); a-- > 0; )
+        for(ptrdiff_t a=so_far.size(); a-- > 0; )
         {
             if(a+1 != so_far.size()) outstream << " ";
             outstream << so_far[a].name;
@@ -1269,7 +1269,7 @@ namespace
             }
 
             Node* head = &global_head;
-            for(size_t b=sequence.size(); b-->0; )
+            for(ptrdiff_t b=sequence.size(); b-->0; )
             {
                 const Match& m = sequence[b];
                 bool dup = false;

--- a/fsanitize_ignorelist.txt
+++ b/fsanitize_ignorelist.txt
@@ -7,6 +7,7 @@ fun:*basic_string_view*rfind*
 fun:*basic_string*compare*
 src:*hashing.h
 src:*hashword.h
+src:*libHilbert*SetBits*
 src:*fpoptimizer*
 src:*fp_opcode_add*
 src:*bytecodesynth*

--- a/fsanitize_ignorelist.txt
+++ b/fsanitize_ignorelist.txt
@@ -1,0 +1,14 @@
+# This is a set of exceptions to use in
+# '-fsanitize-ignorelist=yourdir/fsanitize_ignorelist.txt'
+#
+# So far it's been tested and found to be complete for
+# -fsanitize=integer on clang++ 14 with g++ 12.1.0 headers
+fun:*basic_string_view*rfind*
+fun:*basic_string*compare*
+src:*hashing.h
+src:*hashword.h
+src:*fpoptimizer*
+src:*fp_opcode_add*
+src:*bytecodesynth*
+src:*fparser.cc
+src:*Eigen/*

--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -2777,7 +2777,7 @@ GetPot::_DBE_expand_string(const std::string& str)
   unsigned first = 0;
   for (unsigned i = 0;  i<str.size(); i++)
     {
-      if (i < str.size() - 2 && str.substr(i, 2) == "${")
+      if (i + 2 < str.size() && str.substr(i, 2) == "${")
         {
           if (open_brackets == 0)
             first = i+2;

--- a/include/mesh/namebased_io.h
+++ b/include/mesh/namebased_io.h
@@ -125,8 +125,8 @@ NameBasedIO::is_parallel_file_format (std::string_view name)
 {
   return ((name.rfind(".xda") < name.size()) ||
           (name.rfind(".xdr") < name.size()) ||
-          (name.rfind(".nem") + 4 == name.size()) ||
-          (name.rfind(".n") + 2 == name.size()) ||
+          (name.rfind(".nem") == name.size() - 4) ||
+          (name.rfind(".n") == name.size() - 2) ||
           (name.rfind(".cp") < name.size())
           );
 }

--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -422,7 +422,7 @@ public:
    */
   void set_rb_construction_parameters(unsigned int n_training_samples_in,
                                       bool deterministic_training_in,
-                                      unsigned int training_parameters_random_seed_in,
+                                      int training_parameters_random_seed_in,
                                       bool quiet_mode_in,
                                       unsigned int Nmax_in,
                                       Real rel_training_tolerance_in,

--- a/include/reduced_basis/rb_construction_base.h
+++ b/include/reduced_basis/rb_construction_base.h
@@ -156,7 +156,7 @@ public:
   /**
    * Set the seed that is used to randomly generate training parameters.
    */
-  void set_training_random_seed(unsigned int seed);
+  void set_training_random_seed(int seed);
 
   /**
    * In some cases we only want to allow discrete parameter values, instead

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -128,7 +128,7 @@ public:
    */
   void set_rb_construction_parameters(unsigned int n_training_samples_in,
                                       bool deterministic_training_in,
-                                      unsigned int training_parameters_random_seed_in,
+                                      int training_parameters_random_seed_in,
                                       bool quiet_mode_in,
                                       unsigned int Nmax_in,
                                       Real rel_training_tolerance_in,

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2447,7 +2447,7 @@ void DofMap::_dof_indices (const Elem & elem,
                   di.resize(di.size() + nc, DofObject::invalid_id);
                 }
               else
-                for (int i=n_comp-1; i>=dof_offset; i--)
+                for (int i=int(n_comp)-1; i>=dof_offset; i--)
                   {
                     const dof_id_type d =
                       node.dof_number(sys_num, vg, vig, i, n_comp);
@@ -2685,7 +2685,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
                       }
 
                     // Compute the net amount of "extra" order, including Elem::p_level()
-                    int extra_order = elem->p_level() + p_adjustment;
+                    int extra_order = int(elem->p_level()) + p_adjustment;
 
                     FEType fe_type = var.type();
 

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1717,7 +1717,7 @@ dof_id_type DofMap::n_local_constrained_dofs() const
   const DofConstraints::const_iterator lower =
     _dof_constraints.lower_bound(this->first_dof()),
     upper =
-    _dof_constraints.upper_bound(this->end_dof()-1);
+    _dof_constraints.lower_bound(this->end_dof());
 
   return cast_int<dof_id_type>(std::distance(lower, upper));
 }

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -2086,7 +2086,7 @@ void DofMap::process_mesh_constraint_rows(const MeshBase & mesh)
 
               if (was_previously_constrained.count(constrained_id))
                 {
-                  for (auto q : IntRange<unsigned int>(0, n_adjoint_rhs+1))
+                  for (auto q : IntRange<int>(0, n_adjoint_rhs+1))
                     {
                       DenseMatrix<Number> K(1,1);
                       DenseVector<Number> F(1);

--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -157,7 +157,9 @@ void DofObject::set_n_systems (const unsigned int ns)
 
   const unsigned int nei = this->n_extra_integers();
   const dof_id_type header_size = ns + bool(nei);
-  const dof_id_type hdr = nei ? -header_size : header_size;
+  const dof_id_type hdr = nei ?
+    static_cast<dof_id_type>(-static_cast<std::ptrdiff_t>(header_size))
+    : header_size;
   index_buffer_t new_buf(header_size + nei, hdr);
   if (nei)
     {

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -1635,10 +1635,10 @@ FEGenericBase<OutputType>::compute_proj_constraints (DofConstraints & constraint
           // minimum shared p_level
           const unsigned int old_elem_level = elem->p_level();
           if (elem->p_level() != min_p_level)
-            my_fe->set_fe_order(my_fe->get_fe_type().order.get_order() - old_elem_level + min_p_level);
+            my_fe->set_fe_order(my_fe->get_fe_type().order.get_order() + min_p_level - old_elem_level);
           const unsigned int old_neigh_level = neigh->p_level();
           if (old_neigh_level != min_p_level)
-            neigh_fe->set_fe_order(neigh_fe->get_fe_type().order.get_order() - old_neigh_level + min_p_level);
+            neigh_fe->set_fe_order(neigh_fe->get_fe_type().order.get_order() + min_p_level - old_neigh_level);
 
           my_fe->reinit(elem, s);
 
@@ -1668,10 +1668,10 @@ FEGenericBase<OutputType>::compute_proj_constraints (DofConstraints & constraint
           // derivatives for C1 elements) are supported on side nodes
           FEType elem_fe_type = base_fe_type;
           if (old_elem_level != min_p_level)
-            elem_fe_type.order = base_fe_type.order.get_order() - old_elem_level + min_p_level;
+            elem_fe_type.order = base_fe_type.order.get_order() + min_p_level - old_elem_level;
           FEType neigh_fe_type = base_fe_type;
           if (old_neigh_level != min_p_level)
-            neigh_fe_type.order = base_fe_type.order.get_order() - old_neigh_level + min_p_level;
+            neigh_fe_type.order = base_fe_type.order.get_order() + min_p_level - old_neigh_level;
           FEInterface::dofs_on_side(elem,  Dim, elem_fe_type,  s,       my_side_dofs);
           FEInterface::dofs_on_side(neigh, Dim, neigh_fe_type, s_neigh, neigh_side_dofs);
 

--- a/src/mesh/dyna_io.C
+++ b/src/mesh/dyna_io.C
@@ -138,7 +138,7 @@ DynaIO::DynaIO (MeshBase & mesh,
 
 void DynaIO::read (const std::string & name)
 {
-  const bool gzipped_file = (name.size() - name.rfind(".gz")  == 3);
+  const bool gzipped_file = (name.rfind(".gz") == name.size() - 3);
   // These will be handled in unzip_file:
   // const bool bzipped_file = (name.size() - name.rfind(".bz2") == 4);
   // const bool xzipped_file = (name.size() - name.rfind(".xz") == 3);

--- a/src/mesh/mesh_refinement_smoothing.C
+++ b/src/mesh/mesh_refinement_smoothing.C
@@ -424,8 +424,9 @@ bool MeshRefinement::eliminate_unrefined_patches ()
           libmesh_assert_greater (elem->p_level(), 0);
           my_p_adjustment = -1;
         }
-      const unsigned int my_new_p_level = elem->p_level() +
-        my_p_adjustment;
+      const unsigned int my_new_p_level =
+        cast_int<unsigned int>(int(elem->p_level()) +
+                               my_p_adjustment);
 
       // Check all the element neighbors
       for (auto neighbor : elem->neighbor_ptr_range())
@@ -479,7 +480,9 @@ bool MeshRefinement::eliminate_unrefined_patches ()
                       libmesh_assert_greater (neighbor->p_level(), 0);
                       p_adjustment = -1;
                     }
-                  if (my_new_p_level >= neighbor->p_level() + p_adjustment)
+                  if (my_new_p_level >=
+                      cast_int<unsigned int>(int(neighbor->p_level())
+                                             + p_adjustment))
                     {
                       p_flag_me = false;
                       if (!h_flag_me)

--- a/src/mesh/namebased_io.C
+++ b/src/mesh/namebased_io.C
@@ -89,8 +89,8 @@ void NameBasedIO::read (const std::string & name)
 
   // For Nemesis files, the name we try to read will have suffixes
   // identifying processor rank
-  if (basename.rfind(".nem") + 4 == basename.size() ||
-      basename.rfind(".n") + 2 == basename.size())
+  if (basename.rfind(".nem") == basename.size() - 4 ||
+      basename.rfind(".n") == basename.size() - 2)
     {
       std::ostringstream full_name;
 
@@ -189,7 +189,7 @@ void NameBasedIO::read (const std::string & name)
           pid_suffix << '_' << getpid();
           // Nasty hack for reading/writing zipped files
           std::string new_name = name;
-          if (name.size() - name.rfind(".bz2") == 4)
+          if (name.rfind(".bz2") == name.size() - 4)
             {
 #ifdef LIBMESH_HAVE_BZIP
               new_name.erase(new_name.end() - 4, new_name.end());
@@ -203,7 +203,7 @@ void NameBasedIO::read (const std::string & name)
               libmesh_error_msg("ERROR: need bzip2/bunzip2 to open .bz2 file " << name);
 #endif
             }
-          else if (name.size() - name.rfind(".xz") == 3)
+          else if (name.rfind(".xz") == name.size() - 3)
             {
 #ifdef LIBMESH_HAVE_XZ
               new_name.erase(new_name.end() - 3, new_name.end());
@@ -292,9 +292,9 @@ void NameBasedIO::read (const std::string & name)
 
           // If we temporarily decompressed a file, remove the
           // uncompressed version
-          if (name.size() - name.rfind(".bz2") == 4)
+          if (name.rfind(".bz2") == name.size() - 4)
             std::remove(new_name.c_str());
-          if (name.size() - name.rfind(".xz") == 3)
+          if (name.rfind(".xz") == name.size() - 3)
             std::remove(new_name.c_str());
         }
 
@@ -348,12 +348,12 @@ void NameBasedIO::write (const std::string & name)
       std::ostringstream pid_suffix;
       pid_suffix << '_' << pid_0;
 
-      if (name.size() - name.rfind(".bz2") == 4)
+      if (name.rfind(".bz2") == name.size() - 4)
         {
           new_name.erase(new_name.end() - 4, new_name.end());
           new_name += pid_suffix.str();
         }
-      else if (name.size() - name.rfind(".xz") == 3)
+      else if (name.rfind(".xz") == name.size() - 3)
         {
           new_name.erase(new_name.end() - 3, new_name.end());
           new_name += pid_suffix.str();
@@ -432,7 +432,7 @@ void NameBasedIO::write (const std::string & name)
       }
 
       // Nasty hack for reading/writing zipped files
-      if (name.size() - name.rfind(".bz2") == 4)
+      if (name.rfind(".bz2") == name.size() - 4)
         {
           LOG_SCOPE("system(bzip2)", "NameBasedIO");
           if (mymesh.processor_id() == 0)
@@ -445,7 +445,7 @@ void NameBasedIO::write (const std::string & name)
             }
           mymesh.comm().barrier();
         }
-      if (name.size() - name.rfind(".xz") == 3)
+      if (name.rfind(".xz") == name.size() - 3)
         {
           LOG_SCOPE("system(xz)", "NameBasedIO");
           if (mymesh.processor_id() == 0)

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -884,7 +884,7 @@ void UnstructuredMesh::read (const std::string & name,
   // during prepare_for_use() for certain types of mesh files.
   // This is required in cases where there is an associated solution
   // file which expects a certain ordering of the nodes.
-  if (name.rfind(".gmv") + 4 == name.size())
+  if (name.rfind(".gmv") == name.size() - 4)
     this->allow_renumbering(false);
 
   NameBasedIO(*this).read(name);

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -743,7 +743,7 @@ void PetscVector<T>::localize (const numeric_index_type first_local_idx,
   libmesh_assert_less_equal (last_local_idx+1, this->size());
 
   const numeric_index_type my_size       = this->size();
-  const numeric_index_type my_local_size = (last_local_idx - first_local_idx + 1);
+  const numeric_index_type my_local_size = (last_local_idx + 1 - first_local_idx);
   PetscErrorCode ierr=0;
 
   // Don't bother for serial cases

--- a/src/parallel/parallel_bin_sorter.C
+++ b/src/parallel/parallel_bin_sorter.C
@@ -105,7 +105,9 @@ void BinSorter<KeyType,IdxType>::binsort (const IdxType nbins,
 
           // Step through the histogram until we have the
           // desired bin size
-          while ((current_bin_size + histogram[current_histogram_bin] + delta) <= target_bin_size[b])
+          while ((current_bin_size +
+                  cast_int<int>(histogram[current_histogram_bin]) +
+                  delta) <= cast_int<int>(target_bin_size[b]))
             {
               // Don't index out of the histogram!
               if ((current_histogram_bin+1) == phist.n_bins())
@@ -114,7 +116,7 @@ void BinSorter<KeyType,IdxType>::binsort (const IdxType nbins,
               current_bin_size += histogram[current_histogram_bin++];
             }
 
-          delta += current_bin_size - target_bin_size[b];
+          delta += current_bin_size - static_cast<int>(target_bin_size[b]);
 
           // Set the upper bound of the bin
           bin_bounds[b+1] = phist.upper_bound (current_histogram_bin);

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -257,7 +257,7 @@ void RBConstruction::process_parameters_file (const std::string & parameters_fil
   // Set the parameters that have been read in
   set_rb_construction_parameters(n_training_samples,
                                  deterministic_training,
-                                 training_parameters_random_seed_in,
+                                 static_cast<int>(training_parameters_random_seed_in),
                                  quiet_mode_in,
                                  Nmax_in,
                                  rel_training_tolerance_in,
@@ -273,7 +273,7 @@ void RBConstruction::process_parameters_file (const std::string & parameters_fil
 void RBConstruction::set_rb_construction_parameters(
                                                     unsigned int n_training_samples_in,
                                                     bool deterministic_training_in,
-                                                    unsigned int training_parameters_random_seed_in,
+                                                    int training_parameters_random_seed_in,
                                                     bool quiet_mode_in,
                                                     unsigned int Nmax_in,
                                                     Real rel_training_tolerance_in,

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -727,7 +727,7 @@ void RBConstructionBase<Base>::broadcast_parameters(unsigned int proc_id)
 }
 
 template <class Base>
-void RBConstructionBase<Base>::set_training_random_seed(unsigned int seed)
+void RBConstructionBase<Base>::set_training_random_seed(int seed)
 {
   this->training_parameters_random_seed = seed;
 }

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -323,7 +323,7 @@ void RBEIMConstruction::process_parameters_file (const std::string & parameters_
 
 void RBEIMConstruction::set_rb_construction_parameters(unsigned int n_training_samples_in,
                                                        bool deterministic_training_in,
-                                                       unsigned int training_parameters_random_seed_in,
+                                                       int training_parameters_random_seed_in,
                                                        bool quiet_mode_in,
                                                        unsigned int Nmax_in,
                                                        Real rel_training_tolerance_in,

--- a/src/reduced_basis/rb_scm_construction.C
+++ b/src/reduced_basis/rb_scm_construction.C
@@ -96,10 +96,10 @@ void RBSCMConstruction::process_parameters_file(const std::string & parameters_f
   // Read in training_parameters_random_seed value.  This is used to
   // seed the RNG when picking the training parameters.  By default the
   // value is -1, which means use std::time to seed the RNG.
-  unsigned int training_parameters_random_seed_in = static_cast<int>(-1);
+  unsigned int training_parameters_random_seed_in = static_cast<unsigned int>(-1);
   training_parameters_random_seed_in = infile("training_parameters_random_seed",
                                               training_parameters_random_seed_in);
-  set_training_random_seed(training_parameters_random_seed_in);
+  set_training_random_seed(static_cast<int>(training_parameters_random_seed_in));
 
   // SCM Greedy termination tolerance
   const Real SCM_training_tolerance_in = infile("SCM_training_tolerance", SCM_training_tolerance);

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -129,8 +129,8 @@ void FEMContext::attach_quadrature_rules()
           FEType fe_type = sys.variable_type(v);
 
           _element_fe[dim][fe_type]->attach_quadrature_rule(_element_qrule[dim].get());
-          _side_fe[dim][fe_type]->attach_quadrature_rule(_side_qrule[dim].get());
-
+          if (dim)
+            _side_fe[dim][fe_type]->attach_quadrature_rule(_side_qrule[dim].get());
           if (dim == 3)
             _edge_fe[fe_type]->attach_quadrature_rule(_edge_qrule.get());
         };
@@ -157,8 +157,9 @@ void FEMContext::use_default_quadrature_rules(int extra_quadrature_order)
       // Create an adequate quadrature rule
       _element_qrule[dim] =
         hardest_fe_type.default_quadrature_rule(dim, _extra_quadrature_order);
-      _side_qrule[dim] =
-        hardest_fe_type.default_quadrature_rule(dim-1, _extra_quadrature_order);
+      if (dim)
+        _side_qrule[dim] =
+          hardest_fe_type.default_quadrature_rule(dim-1, _extra_quadrature_order);
       if (dim == 3)
         _edge_qrule = hardest_fe_type.default_quadrature_rule(1, _extra_quadrature_order);
     }

--- a/src/utils/utility.C
+++ b/src/utils/utility.C
@@ -159,7 +159,7 @@ std::string Utility::unzip_file (std::string_view name)
   pid_suffix << '_' << getpid();
 
   std::string new_name { name };
-  if (name.size() - name.rfind(".bz2") == 4)
+  if (name.rfind(".bz2") == name.size() - 4)
     {
 #ifdef LIBMESH_HAVE_BZIP
       new_name.erase(new_name.end() - 4, new_name.end());
@@ -174,7 +174,7 @@ std::string Utility::unzip_file (std::string_view name)
       libmesh_error_msg("ERROR: need bzip2/bunzip2 to open .bz2 file " << name);
 #endif
     }
-  else if (name.size() - name.rfind(".xz") == 3)
+  else if (name.rfind(".xz") == name.size() - 3)
     {
 #ifdef LIBMESH_HAVE_XZ
       new_name.erase(new_name.end() - 3, new_name.end());

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -82,13 +82,13 @@ void remove_unzipped_file (std::string_view name)
 
   // If we temporarily decompressed a file, remove the
   // uncompressed version
-  if (name.size() - name.rfind(".bz2") == 4)
+  if (name.rfind(".bz2") == name.size() - 4)
     {
       std::string new_name(name.begin(), name.end()-4);
       new_name += pid_suffix.str();
       std::remove(new_name.c_str());
     }
-  if (name.size() - name.rfind(".xz") == 3)
+  if (name.rfind(".xz") == name.size() - 3)
     {
       std::string new_name(name.begin(), name.end()-3);
       new_name += pid_suffix.str();
@@ -161,9 +161,9 @@ void Xdr::open (std::string name)
 
     case READ:
       {
-        gzipped_file = (file_name.size() - file_name.rfind(".gz")  == 3);
-        bzipped_file = (file_name.size() - file_name.rfind(".bz2") == 4);
-        xzipped_file = (file_name.size() - file_name.rfind(".xz") == 3);
+        gzipped_file = (file_name.rfind(".gz") == file_name.size() - 3);
+        bzipped_file = (file_name.rfind(".bz2") == file_name.size() - 4);
+        xzipped_file = (file_name.rfind(".xz") == file_name.size() - 3);
 
         if (gzipped_file)
           {
@@ -196,9 +196,9 @@ void Xdr::open (std::string name)
 
     case WRITE:
       {
-        gzipped_file = (file_name.size() - file_name.rfind(".gz")  == 3);
-        bzipped_file = (file_name.size() - file_name.rfind(".bz2") == 4);
-        xzipped_file = (file_name.size() - file_name.rfind(".xz")  == 3);
+        gzipped_file = (file_name.rfind(".gz") == file_name.size() - 3);
+        bzipped_file = (file_name.rfind(".bz2") == file_name.size() - 4);
+        xzipped_file = (file_name.rfind(".xz") == file_name.size() - 3);
 
         if (gzipped_file)
           {


### PR DESCRIPTION
Pinging @NamjaeChoi

I just ran in serial and on 4 procs in parallel, but this is runtime behavior checking and it's quite possible that corner cases exist at other processors counts, especially with AMR.

A clean run here requires `-fsanitize-ignorelist=yoursrcdir/fsanitize_ignorelist.txt`.  In the most extreme example, there are a few libstdc++ functions that aren't `-fsanitize=integer` clean and are never going to be.  The GCC team seems to believe that unsigned integer overflow and underflow are not undefined behavior (definitely correct), are necessary for optimal code when doing certain kinds of bit fiddling and looping (probably at least partially correct), and that there's no point in looking for them elsewhere (incorrect, but that's what we have the ignore list for).  In addition to upstream stuff like libstdc++ and Eigen, I've got ignore entries to cover the heavy bit-fiddling in our fparser fork and in some hashing headers.

It would be interesting to add a recipe for this to the devel->master merge, but a quick glance through the commits here should show how annoying it is to fix the lines that fsanitize=integer screams about.  90% are obvious false positives, and perhaps 90% of the rest are subtle false positives.  Oh, and runs with UBSan active are pretty slow, though that's probably my fault for combining it with dbg in my own testing.  Maybe we should add a recipe but it only runs opt mode and we don't make it required to pass?

Longer-term: I love the goal here, but I'm not sure how feasible it's going to be to extend it to MOOSE.  AFAIK nobody's ever even tried to get a `-Wconversion -Werror` build there, and I'm betting the libMesh history of sporadically doing things like that has made this cleanup much easier than it could have been.