### PR TITLE
Never go above the max order when computing FEs

### DIFF
--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -1247,21 +1247,22 @@ void FEInterface::shapes<Real>(const unsigned int dim,
     }
 #endif
 
-  const Order o = fe_t.order;
+  const auto o = Order(std::min(static_cast<int>(fe_t.order + add_p_level * elem->p_level()),
+                                static_cast<int>(FEInterface::max_order(fe_t, elem->type()))));
 
   switch(dim)
     {
     case 0:
-      fe_scalar_vec_error_switch(0, shapes(elem,o,i,p,phi,add_p_level), , ; return;);
+      fe_scalar_vec_error_switch(0, shapes(elem,o,i,p,phi,false), , ; return;);
       break;
     case 1:
-      fe_scalar_vec_error_switch(1, shapes(elem,o,i,p,phi,add_p_level), , ; return;);
+      fe_scalar_vec_error_switch(1, shapes(elem,o,i,p,phi,false), , ; return;);
       break;
     case 2:
-      fe_scalar_vec_error_switch(2, shapes(elem,o,i,p,phi,add_p_level), , ; return;);
+      fe_scalar_vec_error_switch(2, shapes(elem,o,i,p,phi,false), , ; return;);
       break;
     case 3:
-      fe_scalar_vec_error_switch(3, shapes(elem,o,i,p,phi,add_p_level), , ; return;);
+      fe_scalar_vec_error_switch(3, shapes(elem,o,i,p,phi,false), , ; return;);
       break;
     default:
       libmesh_error_msg("Invalid dimension = " << dim);
@@ -1289,21 +1290,22 @@ void FEInterface::all_shapes<Real>(const unsigned int dim,
     }
 #endif
 
-  const Order o = fe_t.order;
+  const auto o = Order(std::min(static_cast<int>(fe_t.order + add_p_level * elem->p_level()),
+                                static_cast<int>(FEInterface::max_order(fe_t, elem->type()))));
 
   switch(dim)
     {
     case 0:
-      fe_scalar_vec_error_switch(0, all_shapes(elem,o,p,phi,add_p_level), , ; return;);
+      fe_scalar_vec_error_switch(0, all_shapes(elem,o,p,phi,false), , ; return;);
       break;
     case 1:
-      fe_scalar_vec_error_switch(1, all_shapes(elem,o,p,phi,add_p_level), , ; return;);
+      fe_scalar_vec_error_switch(1, all_shapes(elem,o,p,phi,false), , ; return;);
       break;
     case 2:
-      fe_scalar_vec_error_switch(2, all_shapes(elem,o,p,phi,add_p_level), , ; return;);
+      fe_scalar_vec_error_switch(2, all_shapes(elem,o,p,phi,false), , ; return;);
       break;
     case 3:
-      fe_scalar_vec_error_switch(3, all_shapes(elem,o,p,phi,add_p_level), , ; return;);
+      fe_scalar_vec_error_switch(3, all_shapes(elem,o,p,phi,false), , ; return;);
       break;
     default:
       libmesh_error_msg("Invalid dimension = " << dim);


### PR DESCRIPTION
I started going down the road of modifying APIs but wound up here. I personally think running with the maximum order is better than erroring with a requested order that is too high, but I can definitely understand someone arguing the other way. These changes were enough to make @YaqiWang's test in idaholab/moose#24180 run and show good results (shown below).

When I initially started off modifying APIs and adding more `add_p_level` arguments, I wound up staring at our MOOSE `Assembly` helpers and thinking that if I disabled p refinement for those, then I would be implicitly disabling p refinement for actual user Lagrange variables of the same order. And that would be sad for a user who does want to p-refine a Lagrange basis up to second order from a mesh order of unity and initial variable order of unity.
```
Postprocessor Values:
+----------------+----------------+----------------+----------------+
| time           | dofs           | h              | l2_err         |
+----------------+----------------+----------------+----------------+
|   0.000000e+00 |   0.000000e+00 |   0.000000e+00 |   0.000000e+00 |
|   1.000000e+00 |   1.200000e+01 |   7.071068e-01 |   1.012842e-02 |
|   2.000000e+00 |   2.400000e+01 |   7.071068e-01 |   1.963216e-03 |
|   3.000000e+00 |   4.000000e+01 |   7.071068e-01 |   2.547371e-04 |
+----------------+----------------+----------------+----------------+
```