### PR TITLE
Poly2TriTriangulator refinement fixes

### DIFF
--- a/include/geom/cell_hex.h
+++ b/include/geom/cell_hex.h
@@ -172,7 +172,7 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 24; }
 
-  virtual void orient(BoundaryInfo *) override final;
+  virtual bool is_flipped() const override final;
 
   /**
    * This maps each edge to the sides that contain said edge.

--- a/include/geom/cell_inf_hex.h
+++ b/include/geom/cell_inf_hex.h
@@ -187,7 +187,7 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 4; }
 
-  virtual void orient(BoundaryInfo *) override final;
+  virtual bool is_flipped() const override final;
 
   /**
    * This maps each edge to the sides that contain said edge.

--- a/include/geom/cell_inf_prism.h
+++ b/include/geom/cell_inf_prism.h
@@ -171,7 +171,7 @@ public:
 
   std::vector<unsigned int> sides_on_edge(const unsigned int e) const override final;
 
-  virtual void orient(BoundaryInfo *) override final;
+  virtual bool is_flipped() const override final;
 
   /**
    * This maps each edge to the sides that contain said edge.

--- a/include/geom/cell_prism.h
+++ b/include/geom/cell_prism.h
@@ -151,7 +151,7 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 6; }
 
-  virtual void orient(BoundaryInfo *) override final;
+  virtual bool is_flipped() const override final;
 
   /**
    * This maps each edge to the sides that contain said edge.

--- a/include/geom/cell_pyramid.h
+++ b/include/geom/cell_pyramid.h
@@ -175,7 +175,7 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 4; }
 
-  virtual void orient(BoundaryInfo *) override final;
+  virtual bool is_flipped() const override final;
 
   /**
    * This maps each edge to the sides that contain said edge.

--- a/include/geom/cell_tet.h
+++ b/include/geom/cell_tet.h
@@ -196,7 +196,7 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 12; }
 
-  virtual void orient(BoundaryInfo *) override final;
+  virtual bool is_flipped() const override final;
 
   /**
    * This maps each edge to the sides that contain said edge.

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -202,7 +202,7 @@ public:
 
   virtual void permute(unsigned int) override final { libmesh_error(); }
 
-  virtual void orient(BoundaryInfo *) override final;
+  virtual bool is_flipped() const override final;
 
   unsigned int center_node_on_side(const unsigned short side) const override final;
 

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -1799,12 +1799,24 @@ public:
   virtual void flip(BoundaryInfo * boundary_info) = 0;
 
   /**
+   * \returns Whether the element is flipped compared to standard
+   * libMesh (e.g. clockwise for 2D elements) node orientations.
+   *
+   * Always returns \p false if a 2D element is not in the XY plane or
+   * a 1D element is not on the X axis; user code designed to work for
+   * embedded manifolds should handle any consistent orientation, and
+   * determining whether an orientation is consistent is not a local
+   * operation.
+   */
+   virtual bool is_flipped() const = 0;
+
+  /**
    * Flips the element (by swapping node and neighbor pointers) to
    * have a mapping Jacobian of opposite sign, iff we find a negative
    * orientation.  This only fixes flipped elements; for tangled
    * elements the only fixes possible are non-local.
    */
-  virtual void orient(BoundaryInfo * boundary_info) = 0;
+  void orient(BoundaryInfo * boundary_info);
 
 #ifdef LIBMESH_ENABLE_AMR
 
@@ -3077,6 +3089,14 @@ void Elem::hack_p_level_and_refinement_flag (unsigned int p,
 }
 
 #endif // ifdef LIBMESH_ENABLE_AMR
+
+
+inline
+void Elem::orient(BoundaryInfo * boundary_info)
+{
+  if (this->is_flipped())
+    this->flip(boundary_info);
+}
 
 
 inline

--- a/include/geom/face_inf_quad.h
+++ b/include/geom/face_inf_quad.h
@@ -231,7 +231,7 @@ public:
 
   virtual void permute(unsigned int) override final { libmesh_error(); }
 
-  virtual void orient(BoundaryInfo *) override final;
+  virtual bool is_flipped() const override final;
 
 protected:
 

--- a/include/geom/face_quad.h
+++ b/include/geom/face_quad.h
@@ -188,7 +188,7 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 4; }
 
-  virtual void orient(BoundaryInfo *) override final;
+  virtual bool is_flipped() const override final;
 
 protected:
 

--- a/include/geom/face_tri.h
+++ b/include/geom/face_tri.h
@@ -175,7 +175,7 @@ public:
    */
   virtual unsigned int n_permutations() const override final { return 3; }
 
-  virtual void orient(BoundaryInfo *) override final;
+  virtual bool is_flipped() const override final;
 
 protected:
 

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -266,7 +266,7 @@ public:
   virtual void permute(unsigned int) override final { libmesh_error(); }
 
   virtual void flip(BoundaryInfo *) override final { libmesh_error(); }
-  virtual void orient(BoundaryInfo *) override final {};
+  virtual bool is_flipped() const override final { return false; }
 
   virtual ElemType side_type (const unsigned int) const override
   {

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -231,7 +231,7 @@ public:
   virtual void permute(unsigned int) override { libmesh_error(); }
 
   virtual void flip(BoundaryInfo *) override final { libmesh_error(); }
-  virtual void orient(BoundaryInfo *) override final { libmesh_error(); }
+  virtual bool is_flipped() const override final { libmesh_error(); return false; }
 
   virtual unsigned int center_node_on_side(const unsigned short) const override
   { libmesh_error(); return invalid_uint; }

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -484,6 +484,17 @@ void libmesh_assert_no_links_to_elem(const MeshBase & mesh,
                                      const Elem * bad_elem);
 
 /**
+ * A function for testing that node locations match across processors.
+ */
+void libmesh_assert_equal_points (const MeshBase & mesh);
+
+/**
+ * A function for testing that element nodal connectivities match
+ * across processors.
+ */
+void libmesh_assert_equal_connectivity (const MeshBase & mesh);
+
+/**
  * A function for verifying that all nodes are connected to at least
  * one element.
  *

--- a/include/parallel/parallel_algebra.h
+++ b/include/parallel/parallel_algebra.h
@@ -19,10 +19,6 @@
 #ifndef LIBMESH_PARALLEL_ALGEBRA_H
 #define LIBMESH_PARALLEL_ALGEBRA_H
 
-// This class contains all the functionality for bin sorting
-// Templated on the type of keys you will be sorting and the
-// type of iterator you will be using.
-
 
 // libMesh includes
 #include "libmesh/libmesh_config.h"
@@ -31,6 +27,7 @@
 #include "libmesh/vector_value.h"
 
 // TIMPI includes
+#include "timpi/attributes.h"
 #include "timpi/op_function.h"
 #include "timpi/standard_type.h"
 
@@ -39,223 +36,7 @@
 #include <memory>
 #include <type_traits>
 
-namespace TIMPI {
-
-using libMesh::TypeVector;
-using libMesh::TypeTensor;
-using libMesh::VectorValue;
-using libMesh::TensorValue;
-using libMesh::Point;
-
-// StandardType<> specializations to return a derived MPI datatype
-// to handle communication of LIBMESH_DIM-vectors.
-//
-// We use MPI_Create_struct here because our vector classes might
-// have vptrs, and I'd rather not have the datatype break in those
-// cases.
-template <typename T>
-class StandardType<TypeVector<T>, typename std::enable_if<StandardType<T>::is_fixed_type>::type>
-  : public DataType
-{
-public:
-  explicit
-  StandardType(const TypeVector<T> * example=nullptr)
-  {
-    // We need an example for MPI_Address to use
-    TypeVector<T> * ex;
-    std::unique_ptr<TypeVector<T>> temp;
-    if (example)
-      ex = const_cast<TypeVector<T> *>(example);
-    else
-      {
-        temp = std::make_unique<TypeVector<T>>();
-        ex = temp.get();
-      }
-
-#ifdef LIBMESH_HAVE_MPI
-    StandardType<T> T_type(&((*ex)(0)));
-
-    // We require MPI-2 here:
-    int blocklength = LIBMESH_DIM;
-    MPI_Aint displs, start;
-    MPI_Datatype tmptype, type = T_type;
-
-    timpi_call_mpi
-      (MPI_Get_address (ex, &start));
-    timpi_call_mpi
-      (MPI_Get_address (&((*ex)(0)), &displs));
-
-    // subtract off offset to first value from the beginning of the structure
-    displs -= start;
-
-    // create a prototype structure
-    timpi_call_mpi
-      (MPI_Type_create_struct (1, &blocklength, &displs, &type,
-                               &tmptype));
-    timpi_call_mpi
-      (MPI_Type_commit (&tmptype));
-
-    // resize the structure type to account for padding, if any
-    timpi_call_mpi
-      (MPI_Type_create_resized (tmptype, 0, sizeof(TypeVector<T>),
-                                &_datatype));
-
-    timpi_call_mpi
-      (MPI_Type_commit (&_datatype));
-
-    timpi_call_mpi
-      (MPI_Type_free (&tmptype));
-#endif // #ifdef LIBMESH_HAVE_MPI
-  }
-
-  StandardType(const StandardType<TypeVector<T>> & timpi_mpi_var(t))
-    : DataType()
-  {
-    timpi_call_mpi (MPI_Type_dup (t._datatype, &_datatype));
-  }
-
-  ~StandardType() { this->free(); }
-
-  static const bool is_fixed_type = true;
-};
-
-
-template <typename T>
-class StandardType<VectorValue<T>, typename std::enable_if<StandardType<T>::is_fixed_type>::type>
-  : public DataType
-{
-public:
-  explicit
-  StandardType(const VectorValue<T> * example=nullptr)
-  {
-    // We need an example for MPI_Address to use
-    VectorValue<T> * ex;
-    std::unique_ptr<VectorValue<T>> temp;
-    if (example)
-      ex = const_cast<VectorValue<T> *>(example);
-    else
-      {
-        temp = std::make_unique<VectorValue<T>>();
-        ex = temp.get();
-      }
-
-#ifdef LIBMESH_HAVE_MPI
-    StandardType<T> T_type(&((*ex)(0)));
-
-    int blocklength = LIBMESH_DIM;
-    MPI_Aint displs, start;
-    MPI_Datatype tmptype, type = T_type;
-
-    timpi_call_mpi
-      (MPI_Get_address (ex, &start));
-    timpi_call_mpi
-      (MPI_Get_address (&((*ex)(0)), &displs));
-
-    // subtract off offset to first value from the beginning of the structure
-    displs -= start;
-
-    // create a prototype structure
-    timpi_call_mpi
-      (MPI_Type_create_struct (1, &blocklength, &displs, &type,
-                               &tmptype));
-    timpi_call_mpi
-      (MPI_Type_commit (&tmptype));
-
-    // resize the structure type to account for padding, if any
-    timpi_call_mpi
-      (MPI_Type_create_resized (tmptype, 0,
-                                sizeof(VectorValue<T>),
-                                &_datatype));
-
-    timpi_call_mpi
-      (MPI_Type_commit (&_datatype));
-
-    timpi_call_mpi
-      (MPI_Type_free (&tmptype));
-#endif // #ifdef LIBMESH_HAVE_MPI
-  }
-
-  StandardType(const StandardType<VectorValue<T>> & timpi_mpi_var(t))
-    : DataType()
-  {
-#ifdef LIBMESH_HAVE_MPI
-    timpi_call_mpi (MPI_Type_dup (t._datatype, &_datatype));
-#endif
-  }
-
-  ~StandardType() { this->free(); }
-
-  static const bool is_fixed_type = true;
-};
-
-template <>
-class StandardType<Point> : public DataType
-{
-public:
-  explicit
-  StandardType(const Point * example=nullptr)
-  {
-    // Prevent unused variable warnings when !LIBMESH_HAVE_MPI
-    libmesh_ignore(example);
-
-#ifdef LIBMESH_HAVE_MPI
-
-    // We need an example for MPI_Address to use
-    Point * ex;
-
-    std::unique_ptr<Point> temp;
-    if (example)
-      ex = const_cast<Point *>(example);
-    else
-      {
-        temp = std::make_unique<Point>();
-        ex = temp.get();
-      }
-
-    StandardType<libMesh::Real> T_type(&((*ex)(0)));
-
-    int blocklength = LIBMESH_DIM;
-    MPI_Aint displs, start;
-    MPI_Datatype tmptype, type = T_type;
-
-    timpi_call_mpi
-      (MPI_Get_address (ex, &start));
-    timpi_call_mpi
-      (MPI_Get_address (&((*ex)(0)), &displs));
-
-    // subtract off offset to first value from the beginning of the structure
-    displs -= start;
-
-    // create a prototype structure
-    timpi_call_mpi
-      (MPI_Type_create_struct (1, &blocklength, &displs, &type,
-                               &tmptype));
-    timpi_call_mpi
-      (MPI_Type_commit (&tmptype));
-
-    // resize the structure type to account for padding, if any
-    timpi_call_mpi
-      (MPI_Type_create_resized (tmptype, 0, sizeof(Point),
-                                &_datatype));
-
-    timpi_call_mpi
-      (MPI_Type_commit (&_datatype));
-
-    timpi_call_mpi
-      (MPI_Type_free (&tmptype));
-#endif // #ifdef LIBMESH_HAVE_MPI
-  }
-
-  StandardType(const StandardType<Point> & timpi_mpi_var(t))
-    : DataType()
-  {
-    timpi_call_mpi (MPI_Type_dup (t._datatype, &_datatype));
-  }
-
-  ~StandardType() { this->free(); }
-
-  static const bool is_fixed_type = true;
-};
+namespace libMesh {
 
 // OpFunction<> specializations to return an MPI_Op version of the
 // reduction operations on LIBMESH_DIM-vectors.
@@ -268,6 +49,7 @@ public:
 //
 // min() and max() are applied component-wise; this makes them useful
 // for bounding box reduction operations.
+
 template <typename V>
 class TypeVectorOpFunction
 {
@@ -355,26 +137,273 @@ public:
 #endif // LIBMESH_HAVE_MPI
 };
 
+
+template <typename V>
+struct TypeVectorAttributes
+{
+  static const bool has_min_max = true;
+  static void set_lowest(V & x) {
+    for (int d=0; d != LIBMESH_DIM; ++d)
+      TIMPI::Attributes<decltype(x(d))>::set_lowest(x(d));
+  }
+  static void set_highest(V & x) {
+    for (int d=0; d != LIBMESH_DIM; ++d)
+      TIMPI::Attributes<decltype(x(d))>::set_highest(x(d));
+  }
+};
+
+} // namespace libMesh
+
+
+namespace TIMPI {
+
+// StandardType<> specializations to return a derived MPI datatype
+// to handle communication of LIBMESH_DIM-vectors.
+//
+// We use MPI_Create_struct here because our vector classes might
+// have vptrs, and I'd rather not have the datatype break in those
+// cases.
 template <typename T>
-class OpFunction<TypeVector<T>> : public TypeVectorOpFunction<TypeVector<T>> {};
+class StandardType<libMesh::TypeVector<T>, typename std::enable_if<StandardType<T>::is_fixed_type>::type>
+  : public DataType
+{
+public:
+  explicit
+  StandardType(const libMesh::TypeVector<T> * example=nullptr)
+  {
+    using libMesh::TypeVector;
+
+    // We need an example for MPI_Address to use
+    TypeVector<T> * ex;
+    std::unique_ptr<TypeVector<T>> temp;
+    if (example)
+      ex = const_cast<TypeVector<T> *>(example);
+    else
+      {
+        temp = std::make_unique<TypeVector<T>>();
+        ex = temp.get();
+      }
+
+#ifdef LIBMESH_HAVE_MPI
+    StandardType<T> T_type(&((*ex)(0)));
+
+    // We require MPI-2 here:
+    int blocklength = LIBMESH_DIM;
+    MPI_Aint displs, start;
+    MPI_Datatype tmptype, type = T_type;
+
+    timpi_call_mpi
+      (MPI_Get_address (ex, &start));
+    timpi_call_mpi
+      (MPI_Get_address (&((*ex)(0)), &displs));
+
+    // subtract off offset to first value from the beginning of the structure
+    displs -= start;
+
+    // create a prototype structure
+    timpi_call_mpi
+      (MPI_Type_create_struct (1, &blocklength, &displs, &type,
+                               &tmptype));
+    timpi_call_mpi
+      (MPI_Type_commit (&tmptype));
+
+    // resize the structure type to account for padding, if any
+    timpi_call_mpi
+      (MPI_Type_create_resized (tmptype, 0, sizeof(TypeVector<T>),
+                                &_datatype));
+
+    timpi_call_mpi
+      (MPI_Type_commit (&_datatype));
+
+    timpi_call_mpi
+      (MPI_Type_free (&tmptype));
+#endif // #ifdef LIBMESH_HAVE_MPI
+  }
+
+  StandardType(const StandardType<libMesh::TypeVector<T>> & timpi_mpi_var(t))
+    : DataType()
+  {
+    timpi_call_mpi (MPI_Type_dup (t._datatype, &_datatype));
+  }
+
+  ~StandardType() { this->free(); }
+
+  static const bool is_fixed_type = true;
+};
+
 
 template <typename T>
-class OpFunction<VectorValue<T>> : public TypeVectorOpFunction<VectorValue<T>> {};
+class StandardType<libMesh::VectorValue<T>, typename std::enable_if<StandardType<T>::is_fixed_type>::type>
+  : public DataType
+{
+public:
+  explicit
+  StandardType(const libMesh::VectorValue<T> * example=nullptr)
+  {
+    using libMesh::VectorValue;
+
+    // We need an example for MPI_Address to use
+    VectorValue<T> * ex;
+    std::unique_ptr<VectorValue<T>> temp;
+    if (example)
+      ex = const_cast<VectorValue<T> *>(example);
+    else
+      {
+        temp = std::make_unique<VectorValue<T>>();
+        ex = temp.get();
+      }
+
+#ifdef LIBMESH_HAVE_MPI
+    StandardType<T> T_type(&((*ex)(0)));
+
+    int blocklength = LIBMESH_DIM;
+    MPI_Aint displs, start;
+    MPI_Datatype tmptype, type = T_type;
+
+    timpi_call_mpi
+      (MPI_Get_address (ex, &start));
+    timpi_call_mpi
+      (MPI_Get_address (&((*ex)(0)), &displs));
+
+    // subtract off offset to first value from the beginning of the structure
+    displs -= start;
+
+    // create a prototype structure
+    timpi_call_mpi
+      (MPI_Type_create_struct (1, &blocklength, &displs, &type,
+                               &tmptype));
+    timpi_call_mpi
+      (MPI_Type_commit (&tmptype));
+
+    // resize the structure type to account for padding, if any
+    timpi_call_mpi
+      (MPI_Type_create_resized (tmptype, 0,
+                                sizeof(VectorValue<T>),
+                                &_datatype));
+
+    timpi_call_mpi
+      (MPI_Type_commit (&_datatype));
+
+    timpi_call_mpi
+      (MPI_Type_free (&tmptype));
+#endif // #ifdef LIBMESH_HAVE_MPI
+  }
+
+  StandardType(const StandardType<libMesh::VectorValue<T>> & timpi_mpi_var(t))
+    : DataType()
+  {
+#ifdef LIBMESH_HAVE_MPI
+    timpi_call_mpi (MPI_Type_dup (t._datatype, &_datatype));
+#endif
+  }
+
+  ~StandardType() { this->free(); }
+
+  static const bool is_fixed_type = true;
+};
 
 template <>
-class OpFunction<Point> : public TypeVectorOpFunction<Point> {};
+class StandardType<libMesh::Point> : public DataType
+{
+public:
+  explicit
+  StandardType(const libMesh::Point * example=nullptr)
+  {
+    using libMesh::Point;
+
+    // Prevent unused variable warnings when !LIBMESH_HAVE_MPI
+    libmesh_ignore(example);
+
+#ifdef LIBMESH_HAVE_MPI
+
+    // We need an example for MPI_Address to use
+    Point * ex;
+
+    std::unique_ptr<Point> temp;
+    if (example)
+      ex = const_cast<Point *>(example);
+    else
+      {
+        temp = std::make_unique<Point>();
+        ex = temp.get();
+      }
+
+    StandardType<libMesh::Real> T_type(&((*ex)(0)));
+
+    int blocklength = LIBMESH_DIM;
+    MPI_Aint displs, start;
+    MPI_Datatype tmptype, type = T_type;
+
+    timpi_call_mpi
+      (MPI_Get_address (ex, &start));
+    timpi_call_mpi
+      (MPI_Get_address (&((*ex)(0)), &displs));
+
+    // subtract off offset to first value from the beginning of the structure
+    displs -= start;
+
+    // create a prototype structure
+    timpi_call_mpi
+      (MPI_Type_create_struct (1, &blocklength, &displs, &type,
+                               &tmptype));
+    timpi_call_mpi
+      (MPI_Type_commit (&tmptype));
+
+    // resize the structure type to account for padding, if any
+    timpi_call_mpi
+      (MPI_Type_create_resized (tmptype, 0, sizeof(Point),
+                                &_datatype));
+
+    timpi_call_mpi
+      (MPI_Type_commit (&_datatype));
+
+    timpi_call_mpi
+      (MPI_Type_free (&tmptype));
+#endif // #ifdef LIBMESH_HAVE_MPI
+  }
+
+  StandardType(const StandardType<libMesh::Point> & timpi_mpi_var(t))
+    : DataType()
+  {
+    timpi_call_mpi (MPI_Type_dup (t._datatype, &_datatype));
+  }
+
+  ~StandardType() { this->free(); }
+
+  static const bool is_fixed_type = true;
+};
+
+template <typename T>
+class OpFunction<libMesh::TypeVector<T>> : public libMesh::TypeVectorOpFunction<libMesh::TypeVector<T>> {};
+
+template <typename T>
+class OpFunction<libMesh::VectorValue<T>> : public libMesh::TypeVectorOpFunction<libMesh::VectorValue<T>> {};
+
+template <>
+class OpFunction<libMesh::Point> : public libMesh::TypeVectorOpFunction<libMesh::Point> {};
+
+
+template <typename T>
+class Attributes<libMesh::TypeVector<T>> : public libMesh::TypeVectorAttributes<libMesh::TypeVector<T>> {};
+
+template <typename T>
+class Attributes<libMesh::VectorValue<T>> : public libMesh::TypeVectorAttributes<libMesh::VectorValue<T>> {};
+
+template <>
+class Attributes<libMesh::Point> : public libMesh::TypeVectorAttributes<libMesh::Point> {};
+
 
 // StandardType<> specializations to return a derived MPI datatype
 // to handle communication of LIBMESH_DIM*LIBMESH_DIM-tensors.
 //
 // We assume contiguous storage here
 template <typename T>
-class StandardType<TypeTensor<T>, typename std::enable_if<StandardType<T>::is_fixed_type>::type>
+class StandardType<libMesh::TypeTensor<T>, typename std::enable_if<StandardType<T>::is_fixed_type>::type>
   : public DataType
 {
 public:
   explicit
-  StandardType(const TypeTensor<T> * example=nullptr) :
+  StandardType(const libMesh::TypeTensor<T> * example=nullptr) :
     DataType(StandardType<T>(example ?  &((*example)(0,0)) : nullptr), LIBMESH_DIM*LIBMESH_DIM) {}
 
   inline ~StandardType() { this->free(); }
@@ -383,12 +412,12 @@ public:
 };
 
 template <typename T>
-class StandardType<TensorValue<T>, typename std::enable_if<StandardType<T>::is_fixed_type>::type>
+class StandardType<libMesh::TensorValue<T>, typename std::enable_if<StandardType<T>::is_fixed_type>::type>
   : public DataType
 {
 public:
   explicit
-  StandardType(const TensorValue<T> * example=nullptr) :
+  StandardType(const libMesh::TensorValue<T> * example=nullptr) :
     DataType(StandardType<T>(example ?  &((*example)(0,0)) : nullptr), LIBMESH_DIM*LIBMESH_DIM) {}
 
   inline ~StandardType() { this->free(); }

--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -226,13 +226,12 @@ unsigned int Hex::opposite_node(const unsigned int node_in,
 
 
 
-void
-Hex::orient(BoundaryInfo * boundary_info)
+bool
+Hex::is_flipped() const
 {
-  if (triple_product(this->point(1)-this->point(0),
-                     this->point(3)-this->point(0),
-                     this->point(4)-this->point(0)) < 0)
-    this->flip(boundary_info);
+  return (triple_product(this->point(1)-this->point(0),
+                         this->point(3)-this->point(0),
+                         this->point(4)-this->point(0)) < 0);
 }
 
 

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -245,13 +245,12 @@ std::vector<unsigned int> InfHex::sides_on_edge(const unsigned int e) const
 }
 
 
-void
-InfHex::orient(BoundaryInfo * boundary_info)
+bool
+InfHex::is_flipped() const
 {
-  if (triple_product(this->point(1)-this->point(0),
-                     this->point(3)-this->point(0),
-                     this->point(4)-this->point(0)) < 0)
-    this->flip(boundary_info);
+  return (triple_product(this->point(1)-this->point(0),
+                         this->point(3)-this->point(0),
+                         this->point(4)-this->point(0)) < 0);
 }
 
 

--- a/src/geom/cell_inf_prism.C
+++ b/src/geom/cell_inf_prism.C
@@ -303,13 +303,12 @@ InfPrism::sides_on_edge(const unsigned int e) const
 }
 
 
-void
-InfPrism::orient(BoundaryInfo * boundary_info)
+bool
+InfPrism::is_flipped() const
 {
-  if (triple_product(this->point(1)-this->point(0),
-                     this->point(2)-this->point(0),
-                     this->point(3)-this->point(0)) < 0)
-    this->flip(boundary_info);
+  return (triple_product(this->point(1)-this->point(0),
+                         this->point(2)-this->point(0),
+                         this->point(3)-this->point(0)) < 0);
 }
 
 

--- a/src/geom/cell_prism.C
+++ b/src/geom/cell_prism.C
@@ -236,13 +236,12 @@ std::vector<unsigned int> Prism::sides_on_edge(const unsigned int e) const
 }
 
 
-void
-Prism::orient(BoundaryInfo * boundary_info)
+bool
+Prism::is_flipped() const
 {
-  if (triple_product(this->point(1)-this->point(0),
-                     this->point(2)-this->point(0),
-                     this->point(3)-this->point(0)) < 0)
-    this->flip(boundary_info);
+  return (triple_product(this->point(1)-this->point(0),
+                        this->point(2)-this->point(0),
+                        this->point(3)-this->point(0)) < 0);
 }
 
 

--- a/src/geom/cell_pyramid.C
+++ b/src/geom/cell_pyramid.C
@@ -229,13 +229,12 @@ std::vector<unsigned int> Pyramid::sides_on_edge(const unsigned int e) const
 }
 
 
-void
-Pyramid::orient(BoundaryInfo * boundary_info)
+bool
+Pyramid::is_flipped() const
 {
-  if (triple_product(this->point(1)-this->point(0),
-                     this->point(3)-this->point(0),
-                     this->point(4)-this->point(0)) < 0)
-    this->flip(boundary_info);
+  return (triple_product(this->point(1)-this->point(0),
+                         this->point(3)-this->point(0),
+                         this->point(4)-this->point(0)) < 0);
 }
 
 

--- a/src/geom/cell_tet.C
+++ b/src/geom/cell_tet.C
@@ -220,13 +220,12 @@ std::vector<unsigned int> Tet::sides_on_edge(const unsigned int e) const
 
 
 
-void
-Tet::orient(BoundaryInfo * boundary_info)
+bool
+Tet::is_flipped() const
 {
-  if (triple_product(this->point(1)-this->point(0),
-                     this->point(2)-this->point(0),
-                     this->point(3)-this->point(0)) < 0)
-    this->flip(boundary_info);
+  return (triple_product(this->point(1)-this->point(0),
+                        this->point(2)-this->point(0),
+                        this->point(3)-this->point(0)) < 0);
 }
 
 

--- a/src/geom/edge.C
+++ b/src/geom/edge.C
@@ -149,19 +149,18 @@ ElemType Edge::side_type (const unsigned int libmesh_dbg_var(s)) const
 }
 
 
-void
-Edge::orient(BoundaryInfo * boundary_info)
+bool
+Edge::is_flipped() const
 {
-  // Don't bother on 1D elements embedded in 2D/3D
-  if (
+  // Don't trigger on 1D elements embedded in 2D/3D
+  return (
 #if LIBMESH_DIM > 2
-      !this->point(0)(2) && !this->point(1)(2) &&
+          !this->point(0)(2) && !this->point(1)(2) &&
 #endif
 #if LIBMESH_DIM > 1
-      !this->point(0)(1) && !this->point(1)(1) &&
+          !this->point(0)(1) && !this->point(1)(1) &&
 #endif
-      this->point(0)(0) > this->point(1)(0))
-    this->flip(boundary_info);
+          this->point(0)(0) > this->point(1)(0));
 }
 
 

--- a/src/geom/face_inf_quad.C
+++ b/src/geom/face_inf_quad.C
@@ -167,20 +167,19 @@ bool InfQuad::is_child_on_side(const unsigned int c,
 }
 
 
-void
-InfQuad::orient(BoundaryInfo * boundary_info)
+bool
+InfQuad::is_flipped() const
 {
-  if (
+  return (
 #if LIBMESH_DIM > 2
-      // Don't bother outside the XY plane
-      this->point(0)(2) && this->point(1)(2) &&
-      this->point(2)(2) && this->point(3)(2) &&
+          // Don't bother outside the XY plane
+          this->point(0)(2) && this->point(1)(2) &&
+          this->point(2)(2) && this->point(3)(2) &&
 #endif
-      ((this->point(1)(0)-this->point(0)(0))*
-       (this->point(2)(1)-this->point(0)(1)) >
-       (this->point(2)(0)-this->point(0)(0))*
-       (this->point(1)(1)-this->point(0)(1))))
-    this->flip(boundary_info);
+          ((this->point(1)(0)-this->point(0)(0))*
+           (this->point(2)(1)-this->point(0)(1)) >
+           (this->point(2)(0)-this->point(0)(0))*
+           (this->point(1)(1)-this->point(0)(1))));
 }
 
 

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -163,19 +163,18 @@ unsigned int Quad::opposite_node(const unsigned int node_in,
 }
 
 
-void Quad::orient(BoundaryInfo * boundary_info)
+bool Quad::is_flipped() const
 {
-  if (
+  return (
 #if LIBMESH_DIM > 2
-      // Don't bother outside the XY plane
-      !this->point(0)(2) && !this->point(1)(2) &&
-      !this->point(2)(2) && !this->point(3)(2) &&
+          // Don't bother outside the XY plane
+          !this->point(0)(2) && !this->point(1)(2) &&
+          !this->point(2)(2) && !this->point(3)(2) &&
 #endif
-      ((this->point(1)(0)-this->point(0)(0))*
-       (this->point(3)(1)-this->point(0)(1)) <
-       (this->point(3)(0)-this->point(0)(0))*
-       (this->point(1)(1)-this->point(0)(1))))
-    this->flip(boundary_info);
+          ((this->point(1)(0)-this->point(0)(0))*
+           (this->point(3)(1)-this->point(0)(1)) <
+           (this->point(3)(0)-this->point(0)(0))*
+           (this->point(1)(1)-this->point(0)(1))));
 }
 
 

--- a/src/geom/face_tri.C
+++ b/src/geom/face_tri.C
@@ -121,19 +121,18 @@ bool Tri::is_child_on_side(const unsigned int c,
 }
 
 
-void Tri::orient(BoundaryInfo * boundary_info)
+bool Tri::is_flipped() const
 {
-  if (
+  return (
 #if LIBMESH_DIM > 2
-      // Don't bother outside the XY plane
-      !this->point(0)(2) && !this->point(1)(2) &&
-      !this->point(2)(2) &&
+          // Don't bother outside the XY plane
+          !this->point(0)(2) && !this->point(1)(2) &&
+          !this->point(2)(2) &&
 #endif
-      ((this->point(1)(0)-this->point(0)(0))*
-       (this->point(2)(1)-this->point(0)(1)) <
-       (this->point(2)(0)-this->point(0)(0))*
-       (this->point(1)(1)-this->point(0)(1))))
-    this->flip(boundary_info);
+          ((this->point(1)(0)-this->point(0)(0))*
+           (this->point(2)(1)-this->point(0)(1)) <
+           (this->point(2)(0)-this->point(0)(0))*
+           (this->point(1)(1)-this->point(0)(1))));
 }
 
 

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -193,6 +193,12 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
 
   const Parallel::Communicator & communicator (mesh.comm());
 
+#ifdef DEBUG
+  // This is going to be a mess if geometry is out of sync
+  MeshTools::libmesh_assert_equal_points(mesh);
+  MeshTools::libmesh_assert_equal_connectivity(mesh);
+#endif
+
   // Global bounding box.  We choose the nodal bounding box for
   // backwards compatibility; the element bounding box may be looser
   // on curved elements.

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1451,6 +1451,7 @@ void libmesh_assert_valid_refinement_tree(const MeshBase &)
 
 
 #ifdef DEBUG
+
 void libmesh_assert_no_links_to_elem(const MeshBase & mesh,
                                      const Elem * bad_elem)
 {
@@ -1469,6 +1470,42 @@ void libmesh_assert_no_links_to_elem(const MeshBase & mesh,
     }
 }
 
+
+void libmesh_assert_equal_points (const MeshBase & mesh)
+{
+  LOG_SCOPE("libmesh_assert_equal_points()", "MeshTools");
+
+  dof_id_type pmax_node_id = mesh.max_node_id();
+  mesh.comm().max(pmax_node_id);
+
+  for (dof_id_type i=0; i != pmax_node_id; ++i)
+    {
+      const Point * p = mesh.query_node_ptr(i);
+
+      mesh.comm().semiverify(p);
+    }
+}
+
+
+void libmesh_assert_equal_connectivity (const MeshBase & mesh)
+{
+  LOG_SCOPE("libmesh_assert_equal_connectivity()", "MeshTools");
+
+  dof_id_type pmax_elem_id = mesh.max_elem_id();
+  mesh.comm().max(pmax_elem_id);
+
+  for (dof_id_type i=0; i != pmax_elem_id; ++i)
+    {
+      const Elem * e = mesh.query_elem_ptr(i);
+
+      std::vector<dof_id_type> nodes;
+      if (e)
+        for (auto n : e->node_index_range())
+          nodes.push_back(e->node_id(n));
+
+      mesh.comm().semiverify(e ? &nodes : nullptr);
+    }
+}
 
 
 void libmesh_assert_connected_nodes (const MeshBase & mesh)

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -63,11 +63,26 @@ p2t::Point to_p2t(const libMesh::Point & p)
   return {p(0), p(1)};
 }
 
-bool in_circumcircle(const libMesh::Elem & elem,
-                     const libMesh::Point & p)
+Real distance_from_circumcircle(const Elem & elem,
+                                const Point & p)
 {
-  using namespace libMesh;
+  libmesh_assert_equal_to(elem.n_vertices(), 3);
 
+  const Point circumcenter = elem.quasicircumcenter();
+  const Real radius = (elem.point(0) - circumcenter).norm();
+  const Real p_dist = (p - circumcenter).norm();
+
+  return p_dist - radius;
+}
+
+
+bool in_circumcircle(const Elem & elem,
+                     const Point & p,
+                     const Real tol = 0)
+{
+  return (distance_from_circumcircle(elem, p) < tol);
+
+  /*
   libmesh_assert_equal_to(elem.n_vertices(), 3);
 
   const Point pv0 = elem.point(0) - p;
@@ -77,6 +92,7 @@ bool in_circumcircle(const libMesh::Elem & elem,
   return ((pv0.norm_sq() * (pv1(0)*pv2(1)-pv2(0)*pv1(1))) -
           (pv1.norm_sq() * (pv0(0)*pv2(1)-pv2(0)*pv0(1))) +
           (pv2.norm_sq() * (pv0(0)*pv1(1)-pv1(0)*pv0(1)))) > 0;
+  */
 }
 
 unsigned int segment_intersection(const libMesh::Elem & elem,

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -697,8 +697,24 @@ bool Poly2TriTriangulator::insert_refinement_points()
                 }
               else
                 {
+                  // Should we just add the vertex average of the
+                  // boundary element, to minimize the number of
+                  // slivers created?
+                  //
+                  // new_pt = cavity_elem->vertex_average();
+                  //
+                  // That works for a while, but it
+                  // seems to be able to "run away" and leave us with
+                  // crazy slivers on boundaries if we push interior
+                  // refinement too far while disabling boundary
+                  // refinement.
+                  //
+                  // Let's go back to refining our original problem
+                  // element.
+                  cavity_elem = elem;
                   new_pt = cavity_elem->vertex_average();
                   new_node = mesh.add_point(new_pt, nn++);
+
                   // This was going to be a side refinement but it's
                   // now an internal refinement
                   side = invalid_uint;

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -903,6 +903,7 @@ bool Poly2TriTriangulator::insert_refinement_points()
                   new_elem->set_node(0) = new_node;
                   new_elem->set_node(1) = node_CW;
                   new_elem->set_node(2) = node_CCW;
+                  libmesh_assert(!new_elem->is_flipped());
 
                   // Set in-and-out-of-cavity neighbor pointers
                   new_elem->set_neighbor(1, neigh);

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -396,7 +396,8 @@ void Poly2TriTriangulator::triangulate_current_points()
 
           // We're not going to support overlapping nodes on the boundary
           if (point_node_map.count(*pt))
-            libmesh_not_implemented();
+            libmesh_not_implemented_msg
+              ("Triangulating overlapping boundary nodes is unsupported");
 
           point_node_map.emplace(*pt, node);
         }

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -838,7 +838,7 @@ bool Poly2TriTriangulator::insert_refinement_points()
                       cavity.end())
                     continue;
 
-                  if (in_circumcircle(*neigh, new_pt))
+                  if (in_circumcircle(*neigh, new_pt, TOLERANCE*TOLERANCE))
                     {
                       unchecked_cavity.insert(neigh);
                       for (auto v : make_range(3u))

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -541,7 +541,7 @@ void Poly2TriTriangulator::triangulate_current_points()
         {
           const p2t::Point & vertex = *ptri.GetPoint(v);
 
-          Node * node = point_node_map[vertex];
+          Node * node = libmesh_map_find(point_node_map, vertex);
           libmesh_assert(node);
           elem->set_node(v) = node;
         }

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -723,6 +723,7 @@ bool Poly2TriTriangulator::insert_refinement_points()
       // What side are we coming from, and what side are we going to?
       unsigned int source_side = invalid_uint;
       unsigned int side = invalid_uint;
+
       while (!cavity_elem->contains_point(new_pt))
         {
           side = segment_intersection(*cavity_elem, ray_start, new_pt, source_side);
@@ -835,10 +836,10 @@ bool Poly2TriTriangulator::insert_refinement_points()
       else
         libmesh_assert(new_node);
 
-
       // Find the Delaunay cavity around the new point.
-      std::set<Elem *> unchecked_cavity {cavity_elem};
       std::set<Elem *> cavity;
+
+      std::set<Elem *> unchecked_cavity {cavity_elem};
       std::set<Node *> cavity_nodes {cavity_elem->node_ptr(0),
                                      cavity_elem->node_ptr(1),
                                      cavity_elem->node_ptr(2)};

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -808,8 +808,10 @@ bool Poly2TriTriangulator::insert_refinement_points()
   // element ids ... but we can set a temporary element id to use for
   // the purpose.
   struct cmp {
-    bool operator()(Elem * a, Elem * b) const
-    { return (a->id() < b->id()); }
+    bool operator()(Elem * a, Elem * b) const {
+      libmesh_assert(a == b || a->id() != b->id());
+      return (a->id() < b->id());
+    }
   } comp;
 
   std::map<Elem *, std::unique_ptr<Elem>, decltype(comp)> new_elems(comp);

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -118,13 +118,13 @@ unsigned int segment_intersection(const libMesh::Elem & elem,
                          targetsdy * raydx;
       const Real t = t_num * one_over_denom;
 
-      if (t < -TOLERANCE || t > 1 + TOLERANCE)
+      if (t < -TOLERANCE*TOLERANCE || t > 1 + TOLERANCE*TOLERANCE)
         continue;
 
       const Real u_num = targetsdx * edgedy - targetsdy * edgedx;
       const Real u = u_num * one_over_denom;
 
-      if (u < -TOLERANCE || u > 1 + TOLERANCE)
+      if (u < -TOLERANCE*TOLERANCE || u > 1 + TOLERANCE*TOLERANCE)
         continue;
 
 /*

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -172,6 +172,8 @@ Poly2TriTriangulator::~Poly2TriTriangulator() = default;
 // Primary function responsible for performing the triangulation
 void Poly2TriTriangulator::triangulate()
 {
+  LOG_SCOPE("triangulate()", "Poly2TriTriangulator");
+
   // We only operate on serialized meshes.  And it's not safe to
   // serialize earlier, because it would then be possible for the user
   // to re-parallelize the mesh in between there and here.
@@ -280,6 +282,8 @@ bool Poly2TriTriangulator::is_refine_boundary_allowed
 
 void Poly2TriTriangulator::triangulate_current_points()
 {
+  LOG_SCOPE("triangulate_current_points()", "Poly2TriTriangulator");
+
   // Will the triangulation have holes?
   const std::size_t n_holes = _holes != nullptr ? _holes->size() : 0;
 
@@ -571,6 +575,8 @@ void Poly2TriTriangulator::triangulate_current_points()
 
 bool Poly2TriTriangulator::insert_refinement_points()
 {
+  LOG_SCOPE("insert_refinement_points()", "Poly2TriTriangulator");
+
   if (this->minimum_angle() != 0)
     libmesh_not_implemented();
 

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -1055,9 +1055,6 @@ bool Poly2TriTriangulator::insert_refinement_points()
       std::set<Elem *> cavity;
 
       std::set<Elem *> unchecked_cavity {cavity_elem};
-      std::set<Node *> cavity_nodes {cavity_elem->node_ptr(0),
-                                     cavity_elem->node_ptr(1),
-                                     cavity_elem->node_ptr(2)};
       while (!unchecked_cavity.empty())
         {
           std::set<Elem *> checking_cavity;
@@ -1077,11 +1074,7 @@ bool Poly2TriTriangulator::insert_refinement_points()
                     continue;
 
                   if (in_circumcircle(*neigh, new_pt, TOLERANCE*TOLERANCE))
-                    {
-                      unchecked_cavity.insert(neigh);
-                      for (auto v : make_range(3u))
-                        cavity_nodes.insert(neigh->node_ptr(v));
-                    }
+                    unchecked_cavity.insert(neigh);
                 }
             }
 

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -144,7 +144,7 @@ can_delaunay_swap(const Elem & elem,
 }
 
 
-void libmesh_assert_locally_delaunay(const Elem & elem)
+[[maybe_unused]] void libmesh_assert_locally_delaunay(const Elem & elem)
 {
   libmesh_ignore(elem);
 
@@ -156,12 +156,10 @@ void libmesh_assert_locally_delaunay(const Elem & elem)
 #endif
 }
 
-void libmesh_assert_delaunay(MeshBase & mesh,
+void libmesh_assert_delaunay(MeshBase & libmesh_dbg_var(mesh),
                              std::unordered_map<Elem *, std::unique_ptr<Elem>> & new_elems)
 {
   libmesh_ignore(new_elems);
-  if (0) // Keep gcc from complaining about an unused function in opt
-    libmesh_assert_locally_delaunay(**mesh.elements_begin());
 #ifndef NDEBUG
   LOG_SCOPE("libmesh_assert_delaunay()", "Poly2TriTriangulator");
 
@@ -1437,6 +1435,7 @@ bool Poly2TriTriangulator::insert_refinement_points()
     {
       libmesh_assert_equal_to(raw_elem, unique_elem.get());
       libmesh_assert(!raw_elem->is_flipped());
+      libmesh_ignore(raw_elem); // Old gcc warns "unused variable"
       mesh.add_elem(std::move(unique_elem));
     }
 

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -159,12 +159,12 @@ void libmesh_assert_locally_delaunay(const Elem & elem)
 void libmesh_assert_delaunay(MeshBase & mesh,
                              std::unordered_map<Elem *, std::unique_ptr<Elem>> & new_elems)
 {
-  LOG_SCOPE("libmesh_assert_delaunay", "Poly2TriTriangulator");
-
   libmesh_ignore(new_elems);
   if (0) // Keep gcc from complaining about an unused function in opt
     libmesh_assert_locally_delaunay(**mesh.elements_begin());
 #ifndef NDEBUG
+  LOG_SCOPE("libmesh_assert_delaunay()", "Poly2TriTriangulator");
+
   for (auto & elem : mesh.element_ptr_range())
     libmesh_assert_locally_delaunay(*elem);
 

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -546,6 +546,9 @@ void Poly2TriTriangulator::triangulate_current_points()
           elem->set_node(v) = node;
         }
 
+      // We expect a consistent triangle orientation
+      libmesh_assert(!elem->is_flipped());
+
       Elem * added_elem = _mesh.add_elem(std::move(elem));
 
       for (auto v : make_range(3))
@@ -1160,8 +1163,12 @@ bool Poly2TriTriangulator::insert_refinement_points()
     }
 
   // Okay, *now* we can add the new elements.
-  for (auto & new_elem_pair : new_elems)
-    mesh.add_elem(std::move(new_elem_pair.second));
+  for (auto & [raw_elem, unique_elem] : new_elems)
+    {
+      libmesh_assert_equal_to(raw_elem, unique_elem.get());
+      libmesh_assert(!raw_elem->is_flipped());
+      mesh.add_elem(std::move(unique_elem));
+    }
 
   // Did we add anything?
   return !new_elems.empty();

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -1088,7 +1088,8 @@ bool Poly2TriTriangulator::insert_refinement_points()
       // Set of elements that might need Delaunay swaps
       std::unordered_set<Elem *> check_delaunay_on;
 
-      // Keep maps for doing neighbor pointer assignment
+      // Keep maps for doing neighbor pointer assignment.  Not going
+      // to iterate through these so hashing pointers is fine.
       std::unordered_map<Node *, std::pair<Elem *, boundary_id_type>>
         neighbors_CCW, neighbors_CW;
 

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -156,8 +156,10 @@ can_delaunay_swap(const Elem & elem,
 #endif
 }
 
+template <typename Container>
+inline
 void libmesh_assert_delaunay(MeshBase & libmesh_dbg_var(mesh),
-                             std::unordered_map<Elem *, std::unique_ptr<Elem>> & new_elems)
+                             Container & new_elems)
 {
   libmesh_ignore(new_elems);
 #ifndef NDEBUG
@@ -175,12 +177,13 @@ void libmesh_assert_delaunay(MeshBase & libmesh_dbg_var(mesh),
 // Restore a triangulation's Delaunay property, starting with a set of
 // all triangles that might initially not be locally Delaunay with
 // their neighbors.
-void restore_delaunay(std::unordered_set<Elem *> & check_delaunay_on,
+template <typename Container>
+inline
+void restore_delaunay(Container & check_delaunay_on,
                       BoundaryInfo & boundary_info)
 {
   LOG_SCOPE("restore_delaunay()", "Poly2TriTriangulator");
 
-  std::unordered_set<Elem *> newly_flipped;
   while (!check_delaunay_on.empty())
     {
       Elem & elem = **check_delaunay_on.begin();

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -877,7 +877,7 @@ bool Poly2TriTriangulator::insert_refinement_points()
       // cavity will be a source of one new triangle.
 
       // Keep maps for doing neighbor pointer assignment
-      std::map<Node *, std::pair<Elem *, boundary_id_type>>
+      std::unordered_map<Node *, std::pair<Elem *, boundary_id_type>>
         neighbors_CCW, neighbors_CW;
 
       for (Elem * old_elem : cavity)

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -402,11 +402,19 @@ void Poly2TriTriangulator::triangulate()
   // if that is requested and reasonable
   this->insert_any_extra_boundary_points();
 
+  // Triangulate the points we have, then see if we need to add more;
+  // repeat until we don't need to add more.
+  //
+  // This is currently done redundantly in parallel; make sure no
+  // processor quits before the others.
   do
     {
+      libmesh_parallel_only(_mesh.comm());
       this->triangulate_current_points();
     }
   while (this->insert_refinement_points());
+
+  libmesh_parallel_only(_mesh.comm());
 
   // Okay, we really do need to support boundary ids soon, but we
   // don't yet

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -42,6 +42,8 @@
 // Anonymous namespace - poly2tri doesn't define operator<(Point,Point)
 namespace
 {
+using namespace libMesh;
+
 struct P2TPointCompare
 {
   bool operator()(const p2t::Point & a, const p2t::Point & b) const

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -812,7 +812,7 @@ bool Poly2TriTriangulator::insert_refinement_points()
     { return (a->id() < b->id()); }
   } comp;
 
-  std::unordered_map<Elem *, std::unique_ptr<Elem>> new_elems;
+  std::map<Elem *, std::unique_ptr<Elem>, decltype(comp)> new_elems(comp);
 
   // We should already be Delaunay when we get here, otherwise we
   // won't be able to stay Delaunay later.  But we're *not* always

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -1086,7 +1086,7 @@ bool Poly2TriTriangulator::insert_refinement_points()
       // cavity will be a source of one new triangle.
 
       // Set of elements that might need Delaunay swaps
-      std::unordered_set<Elem *> check_delaunay_on;
+      std::set<Elem *, decltype(comp)> check_delaunay_on(comp);
 
       // Keep maps for doing neighbor pointer assignment.  Not going
       // to iterate through these so hashing pointers is fine.

--- a/tests/geom/elem_test.C
+++ b/tests/geom/elem_test.C
@@ -362,10 +362,16 @@ public:
             boundary_info.boundary_ids(elem, s, bcids[s]);
           }
 
+        CPPUNIT_ASSERT(!elem->is_flipped());
+
         if (elem->id()%2)
-          elem->flip(&boundary_info);
+          {
+            elem->flip(&boundary_info);
+            CPPUNIT_ASSERT(elem->is_flipped());
+          }
 
         elem->orient(&boundary_info);
+        CPPUNIT_ASSERT(!elem->is_flipped());
 
         // Our map should still be affine.
         // ... except for stupid singular pyramid maps
@@ -417,7 +423,10 @@ public:
           continue;
 #endif
         if (elem->id()%2)
-          elem->flip(&boundary_info);
+          {
+            elem->flip(&boundary_info);
+            CPPUNIT_ASSERT(elem->is_flipped());
+          }
       }
 
     MeshTools::Modification::orient_elements(*_mesh);
@@ -426,6 +435,8 @@ public:
     for (const auto & elem : _mesh->active_local_element_ptr_range())
       {
         const Elem & old_elem = old_mesh.elem_ref(elem->id());
+
+        CPPUNIT_ASSERT(!elem->is_flipped());
 
         // Elem::operator==() uses node ids to compare
         CPPUNIT_ASSERT(*elem == old_elem);


### PR DESCRIPTION
This fixes some failure cases where triangulation refinement runs away creating sliver elements ... and it fixes more failure cases where it turns out we can't trust poly2tri to give us a true Delaunay triangulation.

The more careful behavior at boundaries will probably force us to regold tests in MOOSE.  Here's hoping it doesn't force too much of that further downstream.

This fixes https://github.com/idaholab/moose/issues/24474 for me.