### PR TITLE
Add way to disable use of p-refinement when doing FE::reinit

### DIFF
--- a/include/fe/fe_abstract.h
+++ b/include/fe/fe_abstract.h
@@ -501,7 +501,8 @@ public:
   /**
    * \returns The approximation order of the finite element.
    */
-  Order get_order()  const { return static_cast<Order>(fe_type.order + _p_level); }
+  Order get_order(bool add_p_level = true) const
+  { return static_cast<Order>(fe_type.order + add_p_level * _p_level); }
 
   /**
    * Sets the *base* FE order of the finite element.
@@ -602,6 +603,11 @@ public:
    * set calculate_default_dual_coeff as needed
    */
   void set_calculate_default_dual_coeff(const bool val){calculate_default_dual_coeff = val; }
+
+  /**
+   * Indicate whether to add p-refinement levels in init/reinit methods
+   */
+  void add_p_level_in_reinit(bool value) { _add_p_level_in_reinit = value; }
 
 protected:
 
@@ -728,6 +734,10 @@ protected:
    */
   virtual bool shapes_need_reinit() const = 0;
 
+  /**
+   * Whether to add p-refinement levels in init/reinit methods
+   */
+  bool _add_p_level_in_reinit;
 };
 
 } // namespace libMesh

--- a/include/fe/fe_transformation_base.h
+++ b/include/fe/fe_transformation_base.h
@@ -74,7 +74,8 @@ public:
                        const Elem * const elem,
                        const std::vector<Point> & qp,
                        const FEGenericBase<OutputShape> & fe,
-                       std::vector<std::vector<OutputShape>> & phi) const = 0;
+                       std::vector<std::vector<OutputShape>> & phi,
+                       bool add_p_level = true) const = 0;
 
   /**
    * Evaluates shape function gradients in physical coordinates based on proper

--- a/include/fe/h1_fe_transformation.h
+++ b/include/fe/h1_fe_transformation.h
@@ -69,7 +69,8 @@ public:
                        const Elem * const,
                        const std::vector<Point> &,
                        const FEGenericBase<OutputShape> &,
-                       std::vector<std::vector<OutputShape>> &) const override;
+                       std::vector<std::vector<OutputShape>> &,
+                       bool add_p_level = true) const override;
 
   /**
    * Evaluates shape function gradients in physical coordinates for H1

--- a/include/fe/hcurl_fe_transformation.h
+++ b/include/fe/hcurl_fe_transformation.h
@@ -69,7 +69,8 @@ public:
                        const Elem * const elem,
                        const std::vector<Point> & qp,
                        const FEGenericBase<OutputShape> & fe,
-                       std::vector<std::vector<OutputShape>> & phi) const override;
+                       std::vector<std::vector<OutputShape>> & phi,
+                       bool add_p_level = true) const override;
 
   /**
    * Evaluates shape function gradients in physical coordinates for

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -64,7 +64,8 @@ FEAbstract::FEAbstract(const unsigned int d,
   elem_type(INVALID_ELEM),
   _p_level(0),
   qrule(nullptr),
-  shapes_on_quadrature(false)
+  shapes_on_quadrature(false),
+  _add_p_level_in_reinit(true)
 {
 }
 

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -725,7 +725,7 @@ void FEGenericBase<OutputType>::compute_shape_functions (const Elem * elem,
   this->determine_calculations();
 
   if (calculate_phi)
-    this->_fe_trans->map_phi(this->dim, elem, qp, (*this), this->phi);
+    this->_fe_trans->map_phi(this->dim, elem, qp, (*this), this->phi, this->_add_p_level_in_reinit);
 
   if (calculate_dphi)
     this->_fe_trans->map_dphi(this->dim, elem, qp, (*this), this->dphi,

--- a/src/fe/h1_fe_transformation.C
+++ b/src/fe/h1_fe_transformation.C
@@ -53,9 +53,10 @@ void H1FETransformation<OutputShape>::map_phi( const unsigned int dim,
                                                const Elem * const elem,
                                                const std::vector<Point> & qp,
                                                const FEGenericBase<OutputShape> & fe,
-                                               std::vector<std::vector<OutputShape>> & phi ) const
+                                               std::vector<std::vector<OutputShape>> & phi,
+                                               const bool add_p_level) const
 {
-  FEInterface::all_shapes<OutputShape>(dim, fe.get_fe_type(), elem, qp, phi);
+  FEInterface::all_shapes<OutputShape>(dim, fe.get_fe_type(), elem, qp, phi, add_p_level);
 }
 
 

--- a/src/fe/hcurl_fe_transformation.C
+++ b/src/fe/hcurl_fe_transformation.C
@@ -54,7 +54,8 @@ void HCurlFETransformation<OutputShape>::map_phi(const unsigned int dim,
                                                  const Elem * const elem,
                                                  const std::vector<Point> & qp,
                                                  const FEGenericBase<OutputShape> & fe,
-                                                 std::vector<std::vector<OutputShape>> & phi) const
+                                                 std::vector<std::vector<OutputShape>> & phi,
+                                                 const bool /*add_p_level*/) const
 {
   switch (dim)
     {
@@ -278,7 +279,8 @@ void HCurlFETransformation<Real>::map_phi(const unsigned int,
                                           const Elem * const,
                                           const std::vector<Point> &,
                                           const FEGenericBase<Real> &,
-                                          std::vector<std::vector<Real>> &) const
+                                          std::vector<std::vector<Real>> &,
+                                          bool) const
 {
   libmesh_error_msg("HCurl transformations only make sense for vector-valued elements.");
 }


### PR DESCRIPTION
I think this is the better way to handle this compared to #3570. With some new `Assembly` code I have this working for @YaqiWang's https://github.com/idaholab/moose/pull/24180