### PR TITLE
A few more minor improvements for multi-step RBParameters objects

### DIFF
--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -284,22 +284,20 @@ public:
   /**
    * Fill \p param_names with the names of the parameters.
    *
-   * \deprecated to avoid making it too easy to create copies that in
-   * most circumstances aren't needed.  If you really need a list of
-   * the parameter names, the best approach is to iterate over this
-   * object using the begin()/end() APIs and build a std::set that
-   * way.
+   * Note: this function was previously deprecated, but now that
+   * multi-step RBParameters objects are possible, this is actually
+   * the most efficient way to get a list of the parameter names
+   * stored on this object.
    */
   void get_parameter_names(std::set<std::string> & param_names) const;
 
   /**
    * Fill \p param_names with the names of the extra parameters.
    *
-   * \deprecated to avoid making it too easy to create copies that in
-   * most circumstances aren't needed.  If you really need a list of
-   * the parameter names, the best approach is to iterate over this
-   * object using the extra_begin()/extra_end() APIs and build a std::set that
-   * way.
+   * Note: this function was previously deprecated, but now that
+   * multi-step RBParameters objects are possible, this is actually
+   * the most efficient way to get a list of the parameter names
+   * stored on this object.
    */
   void get_extra_parameter_names(std::set<std::string> & param_names) const;
 

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -239,8 +239,7 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
   {
   unsigned int counter = 0;
   for (auto mu_index : index_range(mus))
-    // Do at least one solve even if there are no parameters (hence no steps) defined on this mu
-    for (auto step_index : make_range(std::max(1u, mus[mu_index].n_steps())))
+    for (auto step_index : make_range(mus[mu_index].n_steps()))
     {
       // Ignore compiler warnings about unused loop index
       libmesh_ignore(step_index);
@@ -278,8 +277,7 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
   {
   unsigned int counter = 0;
   for (auto mu_index : index_range(mus))
-    // Do at least one solve even if there are no parameters (hence no steps) defined on this mu
-    for (auto step_index : make_range(std::max(1u, mus[mu_index].n_steps())))
+    for (auto step_index : make_range(mus[mu_index].n_steps()))
     {
       // Ignore compiler warnings about unused loop index
       libmesh_ignore(step_index);

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -192,8 +192,6 @@ unsigned int RBParameters::n_steps() const
 
 void RBParameters::get_parameter_names(std::set<std::string> & param_names) const
 {
-  libmesh_deprecated();
-
   param_names.clear();
   for (const auto & pr : _parameters)
     param_names.insert(pr.first);
@@ -201,8 +199,6 @@ void RBParameters::get_parameter_names(std::set<std::string> & param_names) cons
 
 void RBParameters::get_extra_parameter_names(std::set<std::string> & param_names) const
 {
-  libmesh_deprecated();
-
   param_names.clear();
   for (const auto & pr : _extra_parameters)
     param_names.insert(pr.first);


### PR DESCRIPTION
* The fix in #3571 makes the max(1, n_steps) checks added previously unnecessary
* Un-deprecate the `RBParameters::get_parameter_names()` APIs