### PR TITLE
global_indices tweaks

### DIFF
--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -742,17 +742,20 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
   hilbert_keys.reserve(n_objects);
   {
     LOG_SCOPE("compute_hilbert_indices()", "MeshCommunication");
+    const processor_id_type my_pid = communicator.rank();
     for (ForwardIterator it=begin; it!=end; ++it)
       {
         const Parallel::DofObjectKey hi(get_dofobject_key (**it, bbox));
         hilbert_keys.push_back(hi);
 
-        if ((*it)->processor_id() == communicator.rank())
+        const processor_id_type pid = (*it)->processor_id();
+
+        if (pid == my_pid)
           sorted_hilbert_keys.push_back(hi);
 
         // someone needs to take care of unpartitioned objects!
-        if ((communicator.rank() == 0) &&
-            ((*it)->processor_id() == DofObject::invalid_processor_id))
+        if ((my_pid == 0) &&
+            (pid == DofObject::invalid_processor_id))
           sorted_hilbert_keys.push_back(hi);
       }
   }

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -56,22 +56,19 @@ void get_hilbert_coords (const Point & p,
 {
   static const Hilbert::inttype max_inttype = static_cast<Hilbert::inttype>(-1);
 
-  const long double // put (x,y,z) in [0,1]^3 (don't divide by 0)
-    x = static_cast<long double>
-        ((bbox.first(0) == bbox.second(0)) ? 0. :
+  const double // put (x,y,z) in [0,1]^3 (don't divide by 0)
+    x = ((bbox.first(0) == bbox.second(0)) ? 0. :
          (p(0)-bbox.first(0))/(bbox.second(0)-bbox.first(0))),
 
 #if LIBMESH_DIM > 1
-    y = static_cast<long double>
-        ((bbox.first(1) == bbox.second(1)) ? 0. :
+    y = ((bbox.first(1) == bbox.second(1)) ? 0. :
          (p(1)-bbox.first(1))/(bbox.second(1)-bbox.first(1))),
 #else
     y = 0.,
 #endif
 
 #if LIBMESH_DIM > 2
-    z = static_cast<long double>
-        ((bbox.first(2) == bbox.second(2)) ? 0. :
+    z = ((bbox.first(2) == bbox.second(2)) ? 0. :
          (p(2)-bbox.first(2))/(bbox.second(2)-bbox.first(2)));
 #else
   z = 0.;


### PR DESCRIPTION
None of these optimizations helped very much, but they didn't hurt either; if CI doesn't show any hiccups I'd just as soon keep them, and if it does (perhaps we really *needed* that `long double` intermediate calculation, at least for `--disable-unique-id` builds?) I'd at least be curious to know about it.