### PR TITLE
Error in EigenSystem::solve if we have constraints

### DIFF
--- a/src/systems/eigen_system.C
+++ b/src/systems/eigen_system.C
@@ -208,6 +208,10 @@ void EigenSystem::reinit ()
 
 void EigenSystem::solve ()
 {
+  if (get_dof_map().n_constrained_dofs())
+    libmesh_error_msg("EigenSystem does not support constrained degrees of freedom. If you wish to "
+                      "perform a solve on a system with constraints, then please use the "
+                      "CondensedEigenSystem class instead");
 
   // A reference to the EquationSystems
   EquationSystems & es = this->get_equation_systems();


### PR DESCRIPTION
At least with SLEPc's eigen solver and the assembly routines in MOOSE, the result of a solve does not honor constraints such as hanging nodes/the solve is totally hosed. We do have `CondensedEigenSystem` which is a class intended for use with constraints. Unrelated to this PR that class will need to be updated in order to support shell matrices if MOOSE is to be able to use it

Here is the result of running `moose/test/tests/problems/eigen_problem/eigensolvers/ne.i` with half of the domain refined

![Screenshot from 2023-06-13 12-10-15](https://github.com/libMesh/libmesh/assets/10248304/078ec111-6ec0-4e69-9a30-5591c1d0c9c4)
