### PR TITLE
Fix missing _n_steps initialization in RBParameters compatibility constructor

### DIFF
--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -32,7 +32,8 @@ RBParameters::RBParameters() :
 {
 }
 
-RBParameters::RBParameters(const std::map<std::string, Real> & parameter_map)
+RBParameters::RBParameters(const std::map<std::string, Real> & parameter_map) :
+  _n_steps(1)
 {
   // Backwards compatible support for constructing an RBParameters
   // object from a map<string, Real>. We store a single entry in each

--- a/tests/utils/rb_parameters_test.C
+++ b/tests/utils/rb_parameters_test.C
@@ -65,6 +65,10 @@ public:
     CPPUNIT_ASSERT_EQUAL(params.get_value("a"), 1.);
     CPPUNIT_ASSERT_EQUAL(params.get_value("b"), 2.);
     CPPUNIT_ASSERT_EQUAL(params.get_value("c"), 3.);
+
+    // Test that RBParameters objects constructed with the old
+    // constructor have the correct number of steps.
+    CPPUNIT_ASSERT_EQUAL(params.n_steps(), 1u);
   }
 
   void testIterators()


### PR DESCRIPTION
This was only causing one test to fail for us, since we don't use this particular approach much any more.