### PR TITLE
Delete non-ASCII characters from header

### DIFF
--- a/include/solvers/time_solver.h
+++ b/include/solvers/time_solver.h
@@ -265,9 +265,9 @@ public:
   void set_solution_history(const SolutionHistory & _solution_history);
 
   /**
-￼   * A getter function that returns a reference to the solution history
-￼   * object owned by TimeSolver
-￼   * */
+   * A getter function that returns a reference to the solution history
+   * object owned by TimeSolver
+   */
   SolutionHistory & get_solution_history();
 
   /**


### PR DESCRIPTION
This is kind of a real fix, but also a test of whether CIVET is working again.