### PR TITLE
PETSC_RELEASE_LESS_THAN -> PETSC_VERSION_LESS_THAN

### DIFF
--- a/include/numerics/petsc_macro.h
+++ b/include/numerics/petsc_macro.h
@@ -88,7 +88,7 @@
 #define ISCreateLibMesh(comm,n,idx,mode,is) ISCreateGeneral((comm),(n),(idx),(mode),(is))
 
 // As of release 3.8.0, MatGetSubMatrix was renamed to MatCreateSubMatrix.
-#if PETSC_RELEASE_LESS_THAN(3,8,0)
+#if PETSC_VERSION_LESS_THAN(3,8,0)
 # define LibMeshCreateSubMatrix MatGetSubMatrix
 #else
 # define LibMeshCreateSubMatrix MatCreateSubMatrix
@@ -108,7 +108,7 @@
 
 // As of 3.18, %D is no longer supported in format strings, but the
 // replacement PetscInt_FMT didn't get added until 3.7.2
-#if PETSC_RELEASE_LESS_THAN(3,8,0)
+#if PETSC_VERSION_LESS_THAN(3,8,0)
 # define LIBMESH_PETSCINT_FMT "D"
 #else
 # define LIBMESH_PETSCINT_FMT PetscInt_FMT

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -254,7 +254,7 @@ DiffSolver::SolveResult convert_solve_result(SNESConvergedReason r)
       // SNES_CONVERGED_TR_DELTA was changed to a diverged condition,
       // SNES_DIVERGED_TR_DELTA, in PETSc 1c6b2ff8df. This change will
       // likely be in 3.12 and later releases.
-#if PETSC_RELEASE_LESS_THAN(3,12,0)
+#if PETSC_VERSION_LESS_THAN(3,12,0)
     case SNES_CONVERGED_TR_DELTA:
 #endif
       return DiffSolver::CONVERGED_NO_REASON;

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -746,7 +746,7 @@ void PetscLinearSolver<T>::get_residual_history(std::vector<double> & hist)
 
   // Recent versions of PETSc require the residual
   // history vector pointer to be declared as const.
-#if PETSC_RELEASE_LESS_THAN(3,15,0)
+#if PETSC_VERSION_LESS_THAN(3,15,0)
   PetscReal * p;
 #else
   const PetscReal * p;
@@ -787,7 +787,7 @@ Real PetscLinearSolver<T>::get_initial_residual()
 
   // Recent versions of PETSc require the residual
   // history vector pointer to be declared as const.
-#if PETSC_RELEASE_LESS_THAN(3,15,0)
+#if PETSC_VERSION_LESS_THAN(3,15,0)
   PetscReal * p;
 #else
   const PetscReal * p;

--- a/src/solvers/petscdmlibmesh.C
+++ b/src/solvers/petscdmlibmesh.C
@@ -21,7 +21,7 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 
-#if !PETSC_RELEASE_LESS_THAN(3,6,0)
+#if !PETSC_VERSION_LESS_THAN(3,6,0)
 # include <petsc/private/petscimpl.h>
 #else
 # include <petsc-private/petscimpl.h>

--- a/src/solvers/petscdmlibmeshimpl.C
+++ b/src/solvers/petscdmlibmeshimpl.C
@@ -24,7 +24,7 @@
 #include "libmesh/ignore_warnings.h"
 
 // PETSc includes
-#if !PETSC_RELEASE_LESS_THAN(3,6,0)
+#if !PETSC_VERSION_LESS_THAN(3,6,0)
 # include <petsc/private/dmimpl.h>
 #else
 # include <petsc-private/dmimpl.h>
@@ -796,7 +796,7 @@ static PetscErrorCode DMCreateGlobalVector_libMesh(DM dm, Vec *x)
     ierr = VecDuplicate(v,x); CHKERRQ(ierr);
   }
 
-#if PETSC_RELEASE_LESS_THAN(3,13,0)
+#if PETSC_VERSION_LESS_THAN(3,13,0)
   ierr = PetscObjectCompose((PetscObject)*x,"DM",(PetscObject)dm); CHKERRQ(ierr);
 #else
   ierr = VecSetDM(*x, dm);CHKERRQ(ierr);
@@ -983,7 +983,7 @@ PetscErrorCode  DMCreate_libMesh(DM dm)
   // * dm->ops->getinjection was renamed to dm->ops->createinjection in PETSc 5a84ad338 (5 Jul 2019)
   // * dm->ops-getaggregates was removed in PETSc 97779f9a (5 Jul 2019)
   // * Both changes were merged into PETSc master in 94aad3ce (7 Jul 2019).
-#if PETSC_RELEASE_LESS_THAN(3,12,0)
+#if PETSC_VERSION_LESS_THAN(3,12,0)
   dm->ops->getinjection       = 0; // DMGetInjection_libMesh;
   dm->ops->getaggregates      = 0; // DMGetAggregates_libMesh;
 #else

--- a/src/solvers/tao_optimization_solver.C
+++ b/src/solvers/tao_optimization_solver.C
@@ -496,7 +496,7 @@ void TaoOptimizationSolver<T>::solve ()
   // ||g(X)|| / ||g(X0)||                <= gttol
   // Command line equivalents: -tao_fatol, -tao_frtol, -tao_gatol, -tao_grtol, -tao_gttol
   ierr = TaoSetTolerances(_tao,
-#if PETSC_RELEASE_LESS_THAN(3,7,0)
+#if PETSC_VERSION_LESS_THAN(3,7,0)
                           // Releases up to 3.X.Y had fatol and frtol, after that they were removed.
                           // Hopefully we'll be able to know X and Y soon. Guessing at 3.7.0.
                           /*fatol=*/PETSC_DEFAULT,


### PR DESCRIPTION
The former macro was only ever intended to be used temporarily, and it has the weird side effect of causing incompatibility with future non-release PETSc hashes if it's kept around too long.

This was aimed at #3589 but turned out to be a total red herring there.  I still think it's worth merging.