### PR TITLE
Change error to warning for constraints in EigenSystem

### DIFF
--- a/src/systems/eigen_system.C
+++ b/src/systems/eigen_system.C
@@ -209,9 +209,10 @@ void EigenSystem::reinit ()
 void EigenSystem::solve ()
 {
   if (get_dof_map().n_constrained_dofs())
-    libmesh_error_msg("EigenSystem does not support constrained degrees of freedom. If you wish to "
-                      "perform a solve on a system with constraints, then please use the "
-                      "CondensedEigenSystem class instead");
+    libmesh_warning("EigenSystem does not have first-class support for constrained degrees of "
+                    "freedom. You may see spurious effects of the constrained degrees of freedom "
+                    "in a given eigenvector. If you wish to perform a reliable solve on a system "
+                    "with constraints, please use the CondensedEigenSystem class instead");
 
   // A reference to the EquationSystems
   EquationSystems & es = this->get_equation_systems();


### PR DESCRIPTION
There is a VTB model that relies on periodic BCs in which the solution (selected eigenvector) is not perturbed by the periodic dofs. Until we can update MOOSE to use the `CondensedEigenSystem` we need this to be a warning in order to not break downstream CI.

VTB failure [here](https://civet.inl.gov/job/1606703/)