### PR TITLE
Make Metis and Parmetis IGA-aware

### DIFF
--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -202,10 +202,20 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
 
             libmesh_assert_less (elem_global_index, vwgt.size());
 
-            // maybe there is a better weight?
             // The weight is used to define what a balanced graph is
             if (!_weights)
-              vwgt[elem_global_index] = elem->n_nodes();
+              {
+                // Spline nodes are a special case (storing all the
+                // unconstrained DoFs in an IGA simulation), but in
+                // general we'll try to distribute work by expecting
+                // it to be roughly proportional to DoFs, which are
+                // roughly proportional to nodes.
+                if (elem->type() == NODEELEM &&
+                    elem->mapping_type() == RATIONAL_BERNSTEIN_MAP)
+                  vwgt[elem_global_index] = 50;
+                else
+                  vwgt[elem_global_index] = elem->n_nodes();
+              }
             else
               vwgt[elem_global_index] = static_cast<Metis::idx_t>((*_weights)[elem->id()]);
 

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -386,8 +386,16 @@ void ParmetisPartitioner::initialize (const MeshBase & mesh,
         libmesh_assert_less (local_index, n_active_local_elem);
         libmesh_assert_less (local_index, _pmetis->vwgt.size());
 
-        // TODO:[BSK] maybe there is a better weight?
-        _pmetis->vwgt[local_index] = elem->n_nodes();
+        // Spline nodes are a special case (storing all the
+        // unconstrained DoFs in an IGA simulation), but in general
+        // we'll try to distribute work by expecting it to be roughly
+        // proportional to DoFs, which are roughly proportional to
+        // nodes.
+        if (elem->type() == NODEELEM &&
+            elem->mapping_type() == RATIONAL_BERNSTEIN_MAP)
+          _pmetis->vwgt[local_index] = 50;
+        else
+          _pmetis->vwgt[local_index] = elem->n_nodes();
 
         // find the subdomain this element belongs in
         libmesh_assert (global_index_map.count(elem->id()));

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -1142,7 +1142,10 @@ void Partitioner::build_graph (const MeshBase & mesh)
               auto row_it = mesh_constrained_nodes.find(&node);
               if (row_it != end_it)
                 for (auto [pr, coef] : row_it->second)
-                  constraining_elems.insert(pr.first);
+                  {
+                    libmesh_ignore(coef); // avoid gcc 7 warning
+                    constraining_elems.insert(pr.first);
+                  }
             }
           for (const Elem * constraining_elem : constraining_elems)
             elems_constrained_by.emplace(constraining_elem, elem);
@@ -1302,7 +1305,10 @@ void Partitioner::build_graph (const MeshBase & mesh)
               auto row_it = mesh_constrained_nodes.find(&node);
               if (row_it != end_it)
                 for (auto [pr, coef] : row_it->second)
-                  constraining_elems.insert(pr.first);
+                  {
+                    libmesh_ignore(coef); // avoid gcc 7 warning
+                    constraining_elems.insert(pr.first);
+                  }
             }
           for (const Elem * constraining_elem : constraining_elems)
             {

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -1113,6 +1113,7 @@ void Partitioner::build_graph (const MeshBase & mesh)
   LOG_SCOPE("build_graph()", "Partitioner");
 
   const dof_id_type n_active_local_elem  = mesh.n_active_local_elem();
+
   // If we have boundary elements in this mesh, we want to account for
   // the connectivity between them and interior elements.  We can find
   // interior elements from boundary elements, but we need to build up
@@ -1120,20 +1121,44 @@ void Partitioner::build_graph (const MeshBase & mesh)
   typedef std::unordered_multimap<const Elem *, const Elem *> map_type;
   map_type interior_to_boundary_map;
 
-  for (const auto & elem : mesh.active_element_ptr_range())
+  // If we have spline nodes in this mesh, we want to account for the
+  // connectivity between them and integration elements.  We can find
+  // spline nodes from integration elements, but need a reverse map
+  // {integration_elements} = elems_constrained_by[spline_nodeelem]
+  map_type elems_constrained_by;
+
+  const auto & mesh_constrained_nodes = mesh.get_constraint_rows();
+
+  for (const Elem * elem : mesh.active_element_ptr_range())
     {
-      // If we don't have an interior_parent then there's nothing to look us
-      // up.
-      if ((elem->dim() >= LIBMESH_DIM) ||
-          !elem->interior_parent())
-        continue;
+      if (!mesh_constrained_nodes.empty()) // quick test for non-IGA cases
+        {
+          const auto end_it = mesh_constrained_nodes.end();
 
-      // get all relevant interior elements
-      std::set<const Elem *> neighbor_set;
-      elem->find_interior_neighbors(neighbor_set);
+          // Use a set to avoid duplicates
+          std::set<const Elem *> constraining_elems;
+          for (const Node & node : elem->node_ref_range())
+            {
+              auto row_it = mesh_constrained_nodes.find(&node);
+              if (row_it != end_it)
+                for (auto [pr, coef] : row_it->second)
+                  constraining_elems.insert(pr.first);
+            }
+          for (const Elem * constraining_elem : constraining_elems)
+            elems_constrained_by.emplace(constraining_elem, elem);
+        }
 
-      for (const auto & neighbor : neighbor_set)
-        interior_to_boundary_map.emplace(neighbor, elem);
+      // If we don't have an interior_parent and we don't have any
+      // constrained nodes then there's nothing else to look up.
+      if (elem->interior_parent())
+        {
+          // get all relevant interior elements
+          std::set<const Elem *> neighbor_set;
+          elem->find_interior_neighbors(neighbor_set);
+
+          for (const auto & neighbor : neighbor_set)
+            interior_to_boundary_map.emplace(neighbor, elem);
+        }
     }
 
 #ifdef LIBMESH_ENABLE_AMR
@@ -1264,8 +1289,40 @@ void Partitioner::build_graph (const MeshBase & mesh)
 
           graph_row.push_back(neighbor_global_index_by_pid);
         }
-    }
 
+      // Check for any constraining elements
+      if (!mesh_constrained_nodes.empty()) // quick test for non-IGA cases
+        {
+          const auto end_it = mesh_constrained_nodes.end();
+
+          // Use a set to avoid duplicates
+          std::set<const Elem *> constraining_elems;
+          for (const Node & node : elem->node_ref_range())
+            {
+              auto row_it = mesh_constrained_nodes.find(&node);
+              if (row_it != end_it)
+                for (auto [pr, coef] : row_it->second)
+                  constraining_elems.insert(pr.first);
+            }
+          for (const Elem * constraining_elem : constraining_elems)
+            {
+              const dof_id_type constraining_global_index_by_pid =
+                _global_index_by_pid_map[constraining_elem->id()];
+
+              graph_row.push_back(constraining_global_index_by_pid);
+            }
+        }
+
+      // Check for any constrained elements
+      for (const auto & pr : as_range(elems_constrained_by.equal_range(elem)))
+        {
+          const Elem * constrained = pr.second;
+          const dof_id_type constrained_global_index_by_pid =
+            _global_index_by_pid_map[constrained->id()];
+
+          graph_row.push_back(constrained_global_index_by_pid);
+        }
+    }
 }
 
 void Partitioner::assign_partitioning (MeshBase & mesh, const std::vector<dof_id_type> & parts)

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1906,10 +1906,16 @@ std::string System::get_info() const
   oss << '\n';
 
   oss << "    n_dofs()="             << this->n_dofs()             << '\n';
-  oss << "    n_local_dofs()="       << this->n_local_dofs()       << '\n';
+  dof_id_type local_dofs = this->n_local_dofs();
+  oss << "    n_local_dofs()="       << local_dofs                 << '\n';
+  this->comm().max(local_dofs);
+  oss << "    max(n_local_dofs())="       << local_dofs                 << '\n';
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
   oss << "    n_constrained_dofs()=" << this->n_constrained_dofs() << '\n';
   oss << "    n_local_constrained_dofs()=" << this->n_local_constrained_dofs() << '\n';
+  dof_id_type local_unconstrained_dofs = this->n_local_dofs() - this->n_local_constrained_dofs();
+  this->comm().max(local_unconstrained_dofs);
+  oss << "    max(local unconstrained dofs)=" << local_unconstrained_dofs << '\n';
 #endif
 
   oss << "    " << "n_vectors()="  << this->n_vectors()  << '\n';


### PR DESCRIPTION
I'm not sure how to add regression tests for this sort of thing, since those partitioners are somewhat black boxes as far as we're concerned and there are always legitimate cases where they can't come up with a good partitioning ... but the newly-output `max(local unconstrained dofs)` numbers from Metis on `fem_example_ex5` on 16 ranks go down from 208 pre-partitioner-modifications to 94 post-modifications, on a problem where the theoretical optimum would be 80, and that's good enough for me for now.  With Parmetis the numbers go from 80 to 84, which is less good, but at least we're not clearly regressing ... and if I bump up the number of ranks then the `master` behavior degrades badly while the `parmetis_iga` behavior doesn't.