### PR TITLE
Improve handling of mesh stitching for non-conforming meshes

### DIFF
--- a/include/mesh/unstructured_mesh.h
+++ b/include/mesh/unstructured_mesh.h
@@ -192,8 +192,10 @@ public:
    * There is no simple a priori relationship between node IDs in "this" mesh
    * and other_mesh and node IDs in the stitched mesh because the number of nodes (and hence
    * the node IDs) in the stitched mesh depend on how many nodes are stitched.
+   *
+   * \returns true if any coincident nodes were found and merged, and false otherwise,
    */
-  void stitch_meshes (const MeshBase & other_mesh,
+  bool stitch_meshes (const MeshBase & other_mesh,
                       boundary_id_type this_mesh_boundary,
                       boundary_id_type other_mesh_boundary,
                       Real tol=TOLERANCE,
@@ -205,7 +207,7 @@ public:
   /**
    * Similar to stitch_meshes, except that we stitch two adjacent surfaces within this mesh.
    */
-  void stitch_surfaces (boundary_id_type boundary_id_1,
+  bool stitch_surfaces (boundary_id_type boundary_id_1,
                         boundary_id_type boundary_id_2,
                         Real tol=TOLERANCE,
                         bool clear_stitched_boundary_ids=false,
@@ -256,7 +258,7 @@ private:
    * Helper function for stitch_meshes and stitch_surfaces
    * that does the mesh stitching.
    */
-  void stitching_helper (const MeshBase * other_mesh,
+  bool stitching_helper (const MeshBase * other_mesh,
                          boundary_id_type boundary_id_1,
                          boundary_id_type boundary_id_2,
                          Real tol,

--- a/include/mesh/unstructured_mesh.h
+++ b/include/mesh/unstructured_mesh.h
@@ -180,10 +180,16 @@ public:
    * at dealing with slightly misaligned meshes).
    * If \p enforce_all_nodes_match_on_boundaries is true, we throw an error if the number of
    * nodes on the specified boundaries don't match the number of nodes that were merged.
-   * This is a helpful error check in some cases.
+   * This is a helpful error check in some cases. If this is true, it overrides the value of
+   * \p merge_boundary_nodes_all_or_nothing.
    * If \p skip_find_neighbors is true, a faster stitching method is used, where the lists of
    * neighbors for each elements are copied as well and patched, without calling the time-consuming
    * find_neighbors() function. This option is now hard-coded to true.
+   * If \p merge_boundary_nodes_all_or_nothing is true, instead of throwing an error
+   * like \p enforce_all_nodes_match_on_boundaries, the meshes are combined anyway but coincident
+   * nodes are not merged into single nodes. This is useful in cases where you are not sure if the
+   * boundaries are fully conforming beforehand and you want to handle the non-conforming cases
+   * differently.
    *
    * Note that the element IDs for elements in the stitched mesh corresponding to "this" mesh
    * will be unchanged. The IDs for elements corresponding to \p other_mesh will be incremented
@@ -194,6 +200,8 @@ public:
    * the node IDs) in the stitched mesh depend on how many nodes are stitched.
    *
    * \returns true if any coincident nodes were found and merged, and false otherwise,
+   * e.g. in the case of no matching nodes or if \p merge_boundary_nodes_all_or_nothing
+   * was active and relevant.
    */
   bool stitch_meshes (const MeshBase & other_mesh,
                       boundary_id_type this_mesh_boundary,
@@ -202,7 +210,8 @@ public:
                       bool clear_stitched_boundary_ids=false,
                       bool verbose=true,
                       bool use_binary_search=true,
-                      bool enforce_all_nodes_match_on_boundaries=false);
+                      bool enforce_all_nodes_match_on_boundaries=false,
+                      bool merge_boundary_nodes_all_or_nothing=false);
 
   /**
    * Similar to stitch_meshes, except that we stitch two adjacent surfaces within this mesh.
@@ -213,7 +222,8 @@ public:
                         bool clear_stitched_boundary_ids=false,
                         bool verbose=true,
                         bool use_binary_search=true,
-                        bool enforce_all_nodes_match_on_boundaries=false);
+                        bool enforce_all_nodes_match_on_boundaries=false,
+                        bool merge_boundary_nodes_all_or_nothing=false);
 
   /**
    * Deep copy of nodes and elements from another mesh object (used by
@@ -266,7 +276,8 @@ private:
                          bool verbose,
                          bool use_binary_search,
                          bool enforce_all_nodes_match_on_boundaries,
-                         bool skip_find_neighbors);
+                         bool skip_find_neighbors,
+                         bool merge_boundary_nodes_all_or_nothing);
 };
 
 

--- a/include/mesh/unstructured_mesh.h
+++ b/include/mesh/unstructured_mesh.h
@@ -183,7 +183,7 @@ public:
    * This is a helpful error check in some cases.
    * If \p skip_find_neighbors is true, a faster stitching method is used, where the lists of
    * neighbors for each elements are copied as well and patched, without calling the time-consuming
-   * find_neighbors() function.
+   * find_neighbors() function. This option is now hard-coded to true.
    *
    * Note that the element IDs for elements in the stitched mesh corresponding to "this" mesh
    * will be unchanged. The IDs for elements corresponding to \p other_mesh will be incremented

--- a/include/mesh/unstructured_mesh.h
+++ b/include/mesh/unstructured_mesh.h
@@ -199,31 +199,31 @@ public:
    * and other_mesh and node IDs in the stitched mesh because the number of nodes (and hence
    * the node IDs) in the stitched mesh depend on how many nodes are stitched.
    *
-   * \returns true if any coincident nodes were found and merged, and false otherwise,
-   * e.g. in the case of no matching nodes or if \p merge_boundary_nodes_all_or_nothing
-   * was active and relevant.
+   * \returns the count of how many nodes were merged between the two meshes.
+   * This can be zero in the case of no matching nodes or if
+   * \p merge_boundary_nodes_all_or_nothing was active and relevant.
    */
-  bool stitch_meshes (const MeshBase & other_mesh,
-                      boundary_id_type this_mesh_boundary,
-                      boundary_id_type other_mesh_boundary,
-                      Real tol=TOLERANCE,
-                      bool clear_stitched_boundary_ids=false,
-                      bool verbose=true,
-                      bool use_binary_search=true,
-                      bool enforce_all_nodes_match_on_boundaries=false,
-                      bool merge_boundary_nodes_all_or_nothing=false);
+  std::size_t stitch_meshes (const MeshBase & other_mesh,
+                             boundary_id_type this_mesh_boundary,
+                             boundary_id_type other_mesh_boundary,
+                             Real tol=TOLERANCE,
+                             bool clear_stitched_boundary_ids=false,
+                             bool verbose=true,
+                             bool use_binary_search=true,
+                             bool enforce_all_nodes_match_on_boundaries=false,
+                             bool merge_boundary_nodes_all_or_nothing=false);
 
   /**
    * Similar to stitch_meshes, except that we stitch two adjacent surfaces within this mesh.
    */
-  bool stitch_surfaces (boundary_id_type boundary_id_1,
-                        boundary_id_type boundary_id_2,
-                        Real tol=TOLERANCE,
-                        bool clear_stitched_boundary_ids=false,
-                        bool verbose=true,
-                        bool use_binary_search=true,
-                        bool enforce_all_nodes_match_on_boundaries=false,
-                        bool merge_boundary_nodes_all_or_nothing=false);
+  std::size_t stitch_surfaces (boundary_id_type boundary_id_1,
+                               boundary_id_type boundary_id_2,
+                               Real tol=TOLERANCE,
+                               bool clear_stitched_boundary_ids=false,
+                               bool verbose=true,
+                               bool use_binary_search=true,
+                               bool enforce_all_nodes_match_on_boundaries=false,
+                               bool merge_boundary_nodes_all_or_nothing=false);
 
   /**
    * Deep copy of nodes and elements from another mesh object (used by
@@ -268,16 +268,16 @@ private:
    * Helper function for stitch_meshes and stitch_surfaces
    * that does the mesh stitching.
    */
-  bool stitching_helper (const MeshBase * other_mesh,
-                         boundary_id_type boundary_id_1,
-                         boundary_id_type boundary_id_2,
-                         Real tol,
-                         bool clear_stitched_boundary_ids,
-                         bool verbose,
-                         bool use_binary_search,
-                         bool enforce_all_nodes_match_on_boundaries,
-                         bool skip_find_neighbors,
-                         bool merge_boundary_nodes_all_or_nothing);
+  std::size_t stitching_helper (const MeshBase * other_mesh,
+                                boundary_id_type boundary_id_1,
+                                boundary_id_type boundary_id_2,
+                                Real tol,
+                                bool clear_stitched_boundary_ids,
+                                bool verbose,
+                                bool use_binary_search,
+                                bool enforce_all_nodes_match_on_boundaries,
+                                bool skip_find_neighbors,
+                                bool merge_boundary_nodes_all_or_nothing);
 };
 
 

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -1721,15 +1721,16 @@ void UnstructuredMesh::all_complete_order ()
 }
 
 
-bool UnstructuredMesh::stitch_meshes (const MeshBase & other_mesh,
-                                      boundary_id_type this_mesh_boundary_id,
-                                      boundary_id_type other_mesh_boundary_id,
-                                      Real tol,
-                                      bool clear_stitched_boundary_ids,
-                                      bool verbose,
-                                      bool use_binary_search,
-                                      bool enforce_all_nodes_match_on_boundaries,
-                                      bool merge_boundary_nodes_all_or_nothing)
+std::size_t
+UnstructuredMesh::stitch_meshes (const MeshBase & other_mesh,
+                                 boundary_id_type this_mesh_boundary_id,
+                                 boundary_id_type other_mesh_boundary_id,
+                                 Real tol,
+                                 bool clear_stitched_boundary_ids,
+                                 bool verbose,
+                                 bool use_binary_search,
+                                 bool enforce_all_nodes_match_on_boundaries,
+                                 bool merge_boundary_nodes_all_or_nothing)
 {
   LOG_SCOPE("stitch_meshes()", "UnstructuredMesh");
   return stitching_helper(&other_mesh,
@@ -1745,14 +1746,16 @@ bool UnstructuredMesh::stitch_meshes (const MeshBase & other_mesh,
 }
 
 
-bool UnstructuredMesh::stitch_surfaces (boundary_id_type boundary_id_1,
-                                        boundary_id_type boundary_id_2,
-                                        Real tol,
-                                        bool clear_stitched_boundary_ids,
-                                        bool verbose,
-                                        bool use_binary_search,
-                                        bool enforce_all_nodes_match_on_boundaries,
-                                        bool merge_boundary_nodes_all_or_nothing)
+std::size_t
+UnstructuredMesh::stitch_surfaces (boundary_id_type boundary_id_1,
+                                   boundary_id_type boundary_id_2,
+                                   Real tol,
+                                   bool clear_stitched_boundary_ids,
+                                   bool verbose,
+                                   bool use_binary_search,
+                                   bool enforce_all_nodes_match_on_boundaries,
+                                   bool merge_boundary_nodes_all_or_nothing)
+
 {
   return stitching_helper(nullptr,
                           boundary_id_1,
@@ -1767,16 +1770,17 @@ bool UnstructuredMesh::stitch_surfaces (boundary_id_type boundary_id_1,
 }
 
 
-bool UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
-                                         boundary_id_type this_mesh_boundary_id,
-                                         boundary_id_type other_mesh_boundary_id,
-                                         Real tol,
-                                         bool clear_stitched_boundary_ids,
-                                         bool verbose,
-                                         bool use_binary_search,
-                                         bool enforce_all_nodes_match_on_boundaries,
-                                         bool skip_find_neighbors,
-                                         bool merge_boundary_nodes_all_or_nothing)
+std::size_t
+UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
+                                    boundary_id_type this_mesh_boundary_id,
+                                    boundary_id_type other_mesh_boundary_id,
+                                    Real tol,
+                                    bool clear_stitched_boundary_ids,
+                                    bool verbose,
+                                    bool use_binary_search,
+                                    bool enforce_all_nodes_match_on_boundaries,
+                                    bool skip_find_neighbors,
+                                    bool merge_boundary_nodes_all_or_nothing)
 {
 #ifdef DEBUG
   // We rely on neighbor links here
@@ -2421,8 +2425,8 @@ bool UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
           this_mesh_boundary_id, other_mesh_boundary_id, /*clear_nodeset_data=*/true);
     }
 
-  // Return true if some nodes were merged, false otherwise.
-  return !node_to_node_map.empty();
+  // Return the number of nodes which were merged.
+  return node_to_node_map.size();
 }
 
 

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -1721,7 +1721,7 @@ void UnstructuredMesh::all_complete_order ()
 }
 
 
-void UnstructuredMesh::stitch_meshes (const MeshBase & other_mesh,
+bool UnstructuredMesh::stitch_meshes (const MeshBase & other_mesh,
                                       boundary_id_type this_mesh_boundary_id,
                                       boundary_id_type other_mesh_boundary_id,
                                       Real tol,
@@ -1731,19 +1731,19 @@ void UnstructuredMesh::stitch_meshes (const MeshBase & other_mesh,
                                       bool enforce_all_nodes_match_on_boundaries)
 {
   LOG_SCOPE("stitch_meshes()", "UnstructuredMesh");
-  stitching_helper(&other_mesh,
-                   this_mesh_boundary_id,
-                   other_mesh_boundary_id,
-                   tol,
-                   clear_stitched_boundary_ids,
-                   verbose,
-                   use_binary_search,
-                   enforce_all_nodes_match_on_boundaries,
-                   true);
+  return stitching_helper(&other_mesh,
+                          this_mesh_boundary_id,
+                          other_mesh_boundary_id,
+                          tol,
+                          clear_stitched_boundary_ids,
+                          verbose,
+                          use_binary_search,
+                          enforce_all_nodes_match_on_boundaries,
+                          true);
 }
 
 
-void UnstructuredMesh::stitch_surfaces (boundary_id_type boundary_id_1,
+bool UnstructuredMesh::stitch_surfaces (boundary_id_type boundary_id_1,
                                         boundary_id_type boundary_id_2,
                                         Real tol,
                                         bool clear_stitched_boundary_ids,
@@ -1751,19 +1751,19 @@ void UnstructuredMesh::stitch_surfaces (boundary_id_type boundary_id_1,
                                         bool use_binary_search,
                                         bool enforce_all_nodes_match_on_boundaries)
 {
-  stitching_helper(nullptr,
-                   boundary_id_1,
-                   boundary_id_2,
-                   tol,
-                   clear_stitched_boundary_ids,
-                   verbose,
-                   use_binary_search,
-                   enforce_all_nodes_match_on_boundaries,
-                   true);
+  return stitching_helper(nullptr,
+                          boundary_id_1,
+                          boundary_id_2,
+                          tol,
+                          clear_stitched_boundary_ids,
+                          verbose,
+                          use_binary_search,
+                          enforce_all_nodes_match_on_boundaries,
+                          true);
 }
 
 
-void UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
+bool UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
                                          boundary_id_type this_mesh_boundary_id,
                                          boundary_id_type other_mesh_boundary_id,
                                          Real tol,
@@ -2395,6 +2395,9 @@ void UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
       this->get_boundary_info().clear_stitched_boundary_side_ids(
           this_mesh_boundary_id, other_mesh_boundary_id, /*clear_nodeset_data=*/true);
     }
+
+  // Return true if some nodes were merged, false otherwise.
+  return !node_to_node_map.empty();
 }
 
 


### PR DESCRIPTION
This adds a new flag "merge_boundary_nodes_all_or_nothing" (open to better names?) to `stitch_meshes` and `stitch_surfaces`, which can help to avoid scenarios where you would otherwise create a mix of merged and unmerged nodes at a stitched interface.

I've also add a boolean return value to help identify if nodes were actually stitched; I think this should help with #3580 .