### PR TITLE
MeshedHole fixes

### DIFF
--- a/src/mesh/mesh_triangle_holes.C
+++ b/src/mesh/mesh_triangle_holes.C
@@ -719,7 +719,7 @@ TriangulatorInterface::MeshedHole::MeshedHole(const MeshBase & mesh,
         {
           print_areas();
           report_error("MeshedHole found " +
-                       std::to_string(n_positive_areas) +
+                       std::to_string(n_negative_areas) +
                        " clockwise boundaries and cannot choose one!");
         }
 

--- a/src/mesh/mesh_triangle_holes.C
+++ b/src/mesh/mesh_triangle_holes.C
@@ -658,7 +658,7 @@ TriangulatorInterface::MeshedHole::MeshedHole(const MeshBase & mesh,
     if (((twice_this_area > 0) && edge_type == 2) ||
         ((twice_this_area < 0) && edge_type == 1))
       ++n_positive_areas;
-    else
+    else if (edge_type != 0)
       ++n_negative_areas;
 
 #ifdef DEBUG


### PR DESCRIPTION
In some cases with mixes of 2D and 1D elements in the hole mesh, we were first hitting a spurious error message and then giving an *inaccurate* message.

Thanks to @olinwc for the bug report.