### PR TITLE
Set operators also for unrestricted solve & without preconditioner.

### DIFF
--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -632,6 +632,11 @@ PetscLinearSolver<T>::solve_base (SparseMatrix<T> * matrix,
           ierr = KSPSetOperators(_ksp, mat, const_cast<PetscMatrix<T> *>(precond)->mat());
           LIBMESH_CHKERR(ierr);
         }
+      else
+        {
+          ierr = KSPSetOperators(_ksp, mat, mat);
+          LIBMESH_CHKERR(ierr);
+        }
 
       if (this->_preconditioner)
         {


### PR DESCRIPTION
I have discussed in  #3598, that solving linear systems with `ShellMatrix` makes problems in the current code.
The missing `KSPSetOperators`-call is now added here; for me, this fixes the problems.