### PR TITLE
Remove unnecessary indirection from DiffContext

### DIFF
--- a/include/systems/diff_context.h
+++ b/include/systems/diff_context.h
@@ -124,8 +124,7 @@ public:
   const DenseSubVector<Number> & get_elem_solution( unsigned int var ) const
   {
     libmesh_assert_greater(_elem_subsolutions.size(), var);
-    libmesh_assert(_elem_subsolutions[var]);
-    return *(_elem_subsolutions[var]);
+    return _elem_subsolutions[var];
   }
 
   /**
@@ -135,8 +134,7 @@ public:
   DenseSubVector<Number> & get_elem_solution( unsigned int var )
   {
     libmesh_assert_greater(_elem_subsolutions.size(), var);
-    libmesh_assert(_elem_subsolutions[var]);
-    return *(_elem_subsolutions[var]);
+    return _elem_subsolutions[var];
   }
 
   /**
@@ -159,8 +157,7 @@ public:
   const DenseSubVector<Number> & get_elem_solution_rate( unsigned int var ) const
   {
     libmesh_assert_greater(_elem_subsolution_rates.size(), var);
-    libmesh_assert(_elem_subsolution_rates[var]);
-    return *(_elem_subsolution_rates[var]);
+    return _elem_subsolution_rates[var];
   }
 
   /**
@@ -170,8 +167,7 @@ public:
   DenseSubVector<Number> & get_elem_solution_rate( unsigned int var )
   {
     libmesh_assert_greater(_elem_subsolution_rates.size(), var);
-    libmesh_assert(_elem_subsolution_rates[var]);
-    return *(_elem_subsolution_rates[var]);
+    return _elem_subsolution_rates[var];
   }
 
   /**
@@ -194,8 +190,7 @@ public:
   const DenseSubVector<Number> & get_elem_solution_accel( unsigned int var ) const
   {
     libmesh_assert_greater(_elem_subsolution_accels.size(), var);
-    libmesh_assert(_elem_subsolution_accels[var]);
-    return *(_elem_subsolution_accels[var]);
+    return _elem_subsolution_accels[var];
   }
 
   /**
@@ -205,8 +200,7 @@ public:
   DenseSubVector<Number> & get_elem_solution_accel( unsigned int var )
   {
     libmesh_assert_greater(_elem_subsolution_accels.size(), var);
-    libmesh_assert(_elem_subsolution_accels[var]);
-    return *(_elem_subsolution_accels[var]);
+    return _elem_subsolution_accels[var];
   }
 
   /**
@@ -228,8 +222,7 @@ public:
   const DenseSubVector<Number> & get_elem_fixed_solution( unsigned int var ) const
   {
     libmesh_assert_greater(_elem_fixed_subsolutions.size(), var);
-    libmesh_assert(_elem_fixed_subsolutions[var]);
-    return *(_elem_fixed_subsolutions[var]);
+    return _elem_fixed_subsolutions[var];
   }
 
   /**
@@ -239,8 +232,7 @@ public:
   DenseSubVector<Number> & get_elem_fixed_solution( unsigned int var )
   {
     libmesh_assert_greater(_elem_fixed_subsolutions.size(), var);
-    libmesh_assert(_elem_fixed_subsolutions[var]);
-    return *(_elem_fixed_subsolutions[var]);
+    return _elem_fixed_subsolutions[var];
   }
 
   /**
@@ -262,8 +254,7 @@ public:
   const DenseSubVector<Number> & get_elem_residual( unsigned int var ) const
   {
     libmesh_assert_greater(_elem_subresiduals.size(), var);
-    libmesh_assert(_elem_subresiduals[var]);
-    return *(_elem_subresiduals[var]);
+    return _elem_subresiduals[var];
   }
 
   /**
@@ -273,8 +264,7 @@ public:
   DenseSubVector<Number> & get_elem_residual( unsigned int var )
   {
     libmesh_assert_greater(_elem_subresiduals.size(), var);
-    libmesh_assert(_elem_subresiduals[var]);
-    return *(_elem_subresiduals[var]);
+    return _elem_subresiduals[var];
   }
 
   /**
@@ -297,8 +287,7 @@ public:
   {
     libmesh_assert_greater(_elem_subjacobians.size(), var1);
     libmesh_assert_greater(_elem_subjacobians[var1].size(), var2);
-    libmesh_assert(_elem_subjacobians[var1][var2]);
-    return *(_elem_subjacobians[var1][var2]);
+    return _elem_subjacobians[var1][var2];
   }
 
   /**
@@ -309,8 +298,7 @@ public:
   {
     libmesh_assert_greater(_elem_subjacobians.size(), var1);
     libmesh_assert_greater(_elem_subjacobians[var1].size(), var2);
-    libmesh_assert(_elem_subjacobians[var1][var2]);
-    return *(_elem_subjacobians[var1][var2]);
+    return _elem_subjacobians[var1][var2];
   }
 
   /**
@@ -345,8 +333,7 @@ public:
   {
     libmesh_assert_greater(_elem_qoi_subderivatives.size(), qoi);
     libmesh_assert_greater(_elem_qoi_subderivatives[qoi].size(), var);
-    libmesh_assert(_elem_qoi_subderivatives[qoi][var]);
-    return *(_elem_qoi_subderivatives[qoi][var]);
+    return _elem_qoi_subderivatives[qoi][var];
   }
 
   /**
@@ -357,8 +344,7 @@ public:
   {
     libmesh_assert_greater(_elem_qoi_subderivatives.size(), qoi);
     libmesh_assert_greater(_elem_qoi_subderivatives[qoi].size(), var);
-    libmesh_assert(_elem_qoi_subderivatives[qoi][var]);
-    return *(_elem_qoi_subderivatives[qoi][var]);
+    return _elem_qoi_subderivatives[qoi][var];
   }
 
   /**
@@ -541,7 +527,7 @@ public:
   /**
    * Typedef for the localized_vectors iterator
    */
-  typedef std::map<const NumericVector<Number> *, std::pair<DenseVector<Number>, std::vector<std::unique_ptr<DenseSubVector<Number>>>>>::iterator localized_vectors_iterator;
+  typedef std::map<const NumericVector<Number> *, std::pair<DenseVector<Number>, std::vector<DenseSubVector<Number>>>>::iterator localized_vectors_iterator;
 
   /**
    * Return a reference to DenseVector localization of localized_vector
@@ -572,28 +558,28 @@ protected:
    * pairs of element localized versions of that vector and per variable views
    */
 
-  std::map<const NumericVector<Number> *, std::pair<DenseVector<Number>, std::vector<std::unique_ptr<DenseSubVector<Number>>>>> _localized_vectors;
+  std::map<const NumericVector<Number> *, std::pair<DenseVector<Number>, std::vector<DenseSubVector<Number>>>> _localized_vectors;
 
   /**
    * Element by element components of nonlinear_solution
    * as adjusted by a time_solver
    */
   DenseVector<Number> _elem_solution;
-  std::vector<std::unique_ptr<DenseSubVector<Number>>> _elem_subsolutions;
+  std::vector<DenseSubVector<Number>> _elem_subsolutions;
 
   /**
    * Element by element components of du/dt
    * as adjusted by a time_solver
    */
   DenseVector<Number> _elem_solution_rate;
-  std::vector<std::unique_ptr<DenseSubVector<Number>>> _elem_subsolution_rates;
+  std::vector<DenseSubVector<Number>> _elem_subsolution_rates;
 
   /**
    * Element by element components of du/dt
    * as adjusted by a time_solver
    */
   DenseVector<Number> _elem_solution_accel;
-  std::vector<std::unique_ptr<DenseSubVector<Number>>> _elem_subsolution_accels;
+  std::vector<DenseSubVector<Number>> _elem_subsolution_accels;
 
   /**
    * Element by element components of nonlinear_solution
@@ -601,7 +587,7 @@ protected:
    * stabilized methods
    */
   DenseVector<Number> _elem_fixed_solution;
-  std::vector<std::unique_ptr<DenseSubVector<Number>>> _elem_fixed_subsolutions;
+  std::vector<DenseSubVector<Number>> _elem_fixed_subsolutions;
 
   /**
    * Element residual vector
@@ -623,13 +609,13 @@ protected:
    * Element quantity of interest derivative contributions
    */
   std::vector<DenseVector<Number>> _elem_qoi_derivative;
-  std::vector<std::vector<std::unique_ptr<DenseSubVector<Number>>>> _elem_qoi_subderivatives;
+  std::vector<std::vector<DenseSubVector<Number>>> _elem_qoi_subderivatives;
 
   /**
    * Element residual subvectors and Jacobian submatrices
    */
-  std::vector<std::unique_ptr<DenseSubVector<Number>>> _elem_subresiduals;
-  std::vector<std::vector<std::unique_ptr<DenseSubMatrix<Number>>>> _elem_subjacobians;
+  std::vector<DenseSubVector<Number>> _elem_subresiduals;
+  std::vector<std::vector<DenseSubMatrix<Number>>> _elem_subjacobians;
 
   /**
    * Global Degree of freedom index lists

--- a/src/systems/diff_context.C
+++ b/src/systems/diff_context.C
@@ -63,10 +63,10 @@ DiffContext::DiffContext (const System & sys) :
 
   for (unsigned int i=0; i != nv; ++i)
     {
-      _elem_subsolutions.emplace_back(std::make_unique<DenseSubVector<Number>>(_elem_solution));
-      _elem_subresiduals.emplace_back(std::make_unique<DenseSubVector<Number>>(_elem_residual));
+      _elem_subsolutions.emplace_back(_elem_solution);
+      _elem_subresiduals.emplace_back(_elem_residual);
       for (std::size_t q=0; q != n_qoi; ++q)
-        _elem_qoi_subderivatives[q].emplace_back(std::make_unique<DenseSubVector<Number>>(_elem_qoi_derivative[q]));
+        _elem_qoi_subderivatives[q].emplace_back(_elem_qoi_derivative[q]);
       _elem_subjacobians[i].reserve(nv);
 
       // Only make space for these if we're using DiffSystem
@@ -77,21 +77,21 @@ DiffContext::DiffContext (const System & sys) :
           // Now, we only need these if the solver is unsteady
           if (!diff_system->get_time_solver().is_steady())
             {
-              _elem_subsolution_rates.emplace_back(std::make_unique<DenseSubVector<Number>>(_elem_solution_rate));
+              _elem_subsolution_rates.emplace_back(_elem_solution_rate);
 
               // We only need accel space if the TimeSolver is second order
               const UnsteadySolver & time_solver = cast_ref<const UnsteadySolver &>(diff_system->get_time_solver());
 
               if (time_solver.time_order() >= 2 || !diff_system->get_second_order_vars().empty())
-                _elem_subsolution_accels.emplace_back(std::make_unique<DenseSubVector<Number>>(_elem_solution_accel));
+                _elem_subsolution_accels.emplace_back(_elem_solution_accel);
             }
         }
 
       if (sys.use_fixed_solution)
-        _elem_fixed_subsolutions.emplace_back(std::make_unique<DenseSubVector<Number>>(_elem_fixed_solution));
+        _elem_fixed_subsolutions.emplace_back(_elem_fixed_solution);
 
       for (unsigned int j=0; j != nv; ++j)
-        _elem_subjacobians[i].emplace_back(std::make_unique<DenseSubMatrix<Number>>(_elem_jacobian));
+        _elem_subjacobians[i].emplace_back(_elem_jacobian);
     }
 }
 
@@ -119,7 +119,7 @@ Real DiffContext::get_deltat_value()
 void DiffContext::add_localized_vector (NumericVector<Number> & localized_vector, const System & sys)
 {
   // Make an empty pair keyed with a reference to this _localized_vector
-  _localized_vectors[&localized_vector] = std::make_pair(DenseVector<Number>(), std::vector<std::unique_ptr<DenseSubVector<Number>>>());
+  _localized_vectors[&localized_vector] = std::make_pair(DenseVector<Number>(), std::vector<DenseSubVector<Number>>());
 
   unsigned int nv = sys.n_vars();
 
@@ -127,7 +127,7 @@ void DiffContext::add_localized_vector (NumericVector<Number> & localized_vector
 
   // Fill the DenseSubVector with nv copies of DenseVector
   for (unsigned int i=0; i != nv; ++i)
-    _localized_vectors[&localized_vector].second.emplace_back(std::make_unique<DenseSubVector<Number>>(_localized_vectors[&localized_vector].first));
+    _localized_vectors[&localized_vector].second.emplace_back(_localized_vectors[&localized_vector].first);
 }
 
 
@@ -147,7 +147,7 @@ const DenseVector<Number> & DiffContext::get_localized_vector (const NumericVect
 
 DenseSubVector<Number> & DiffContext::get_localized_subvector (const NumericVector<Number> & localized_vector, unsigned int var)
 {
-  return *_localized_vectors[&localized_vector].second[var];
+  return _localized_vectors[&localized_vector].second[var];
 }
 
 
@@ -155,7 +155,7 @@ const DenseSubVector<Number> & DiffContext::get_localized_subvector (const Numer
 {
   auto localized_vectors_it = _localized_vectors.find(&localized_vector);
   libmesh_assert(localized_vectors_it != _localized_vectors.end());
-  return *localized_vectors_it->second.second[var];
+  return localized_vectors_it->second.second[var];
 }
 
 } // namespace libMesh

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -1868,7 +1868,7 @@ void FEMContext::pre_fe_reinit(const System & sys, const Elem * e)
               // This is redundant with earlier initialization, isn't it? - RHS
               // sys.get_dof_map().dof_indices (&(this->get_elem()), this->get_dof_indices(i), i);
 
-              localized_vec_it->second.second[i]->reposition
+              localized_vec_it->second.second[i].reposition
                 (sub_dofs, n_dofs_var);
 
               sub_dofs += n_dofs_var;


### PR DESCRIPTION
This gives us a little bit of speedup and a surprisingly large reduction in memory use, especially when we have thousands of variables as in https://github.com/idaholab/moose/issues/25007