### PR TITLE
Optional local matrices in DiffContext

### DIFF
--- a/include/systems/diff_context.h
+++ b/include/systems/diff_context.h
@@ -61,7 +61,8 @@ public:
    * data structures.
    */
   explicit
-  DiffContext (const System &);
+  DiffContext (const System &,
+               bool allocate_local_matrices = true);
 
   /**
    * Destructor.
@@ -271,13 +272,19 @@ public:
    * Const accessor for element Jacobian.
    */
   const DenseMatrix<Number> & get_elem_jacobian() const
-  { return _elem_jacobian; }
+  {
+    libmesh_assert(_have_local_matrices);
+    return _elem_jacobian;
+  }
 
   /**
    * Non-const accessor for element Jacobian.
    */
   DenseMatrix<Number> & get_elem_jacobian()
-  { return _elem_jacobian; }
+  {
+    libmesh_assert(_have_local_matrices);
+    return _elem_jacobian;
+  }
 
   /**
    * Const accessor for element Jacobian of particular variables corresponding
@@ -285,6 +292,7 @@ public:
    */
   const DenseSubMatrix<Number> & get_elem_jacobian( unsigned int var1, unsigned int var2 ) const
   {
+    libmesh_assert(_have_local_matrices);
     libmesh_assert_greater(_elem_subjacobians.size(), var1);
     libmesh_assert_greater(_elem_subjacobians[var1].size(), var2);
     return _elem_subjacobians[var1][var2];
@@ -292,10 +300,12 @@ public:
 
   /**
    * Non-const accessor for element Jacobian of particular variables corresponding
-   * to the variable index arguments.
+   * to the variable index arguments.  Only available if \p
+   * _have_local_matrices
    */
   DenseSubMatrix<Number> & get_elem_jacobian( unsigned int var1, unsigned int var2 )
   {
+    libmesh_assert(_have_local_matrices);
     libmesh_assert_greater(_elem_subjacobians.size(), var1);
     libmesh_assert_greater(_elem_subjacobians[var1].size(), var2);
     return _elem_subjacobians[var1][var2];
@@ -561,6 +571,11 @@ protected:
   std::map<const NumericVector<Number> *, std::pair<DenseVector<Number>, std::vector<DenseSubVector<Number>>>> _localized_vectors;
 
   /**
+   * Whether we have local matrices allocated/initialized
+   */
+  const bool _have_local_matrices;
+
+  /**
    * Element by element components of nonlinear_solution
    * as adjusted by a time_solver
    */
@@ -596,7 +611,7 @@ protected:
 
   /**
    * Element jacobian: derivatives of elem_residual with respect to
-   * elem_solution
+   * elem_solution.  Only initialized if \p _have_local_matrices
    */
   DenseMatrix<Number> _elem_jacobian;
 
@@ -612,7 +627,8 @@ protected:
   std::vector<std::vector<DenseSubVector<Number>>> _elem_qoi_subderivatives;
 
   /**
-   * Element residual subvectors and Jacobian submatrices
+   * Element residual subvectors and (if \p _have_local_matrices)
+   * Jacobian submatrices
    */
   std::vector<DenseSubVector<Number>> _elem_subresiduals;
   std::vector<std::vector<DenseSubMatrix<Number>>> _elem_subjacobians;

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -72,7 +72,8 @@ public:
    */
   explicit
   FEMContext (const System & sys,
-              const std::vector<unsigned int> * active_vars = nullptr);
+              const std::vector<unsigned int> * active_vars = nullptr,
+              bool allocate_local_matrices = true);
 
   /**
    * Constructor.  Specify the extra quadrature order instead
@@ -85,7 +86,8 @@ public:
   explicit
   FEMContext (const System & sys,
               int extra_quadrature_order,
-              const std::vector<unsigned int> * active_vars = nullptr);
+              const std::vector<unsigned int> * active_vars = nullptr,
+              bool allocate_local_matrices = true);
 
 
   /**

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -532,7 +532,7 @@ public:
                   const std::vector<unsigned int> * vars) :
     last_elem(nullptr),
     sys(sys_in),
-    old_context(sys_in, vars)
+    old_context(sys_in, vars, /* allocate_local_matrices= */ false)
   {
     // We'll be queried for components but we'll typically be looking
     // up data by variables, and those indices don't always match
@@ -555,7 +555,7 @@ public:
   OldSolutionBase(const OldSolutionBase & in) :
     last_elem(nullptr),
     sys(in.sys),
-    old_context(sys, in.old_context.active_vars()),
+    old_context(sys, in.old_context.active_vars(), /* allocate_local_matrices= */ false),
     component_to_var(in.component_to_var)
   {
   }
@@ -1267,8 +1267,11 @@ template <typename FFunctor, typename GFunctor,
           typename FValue, typename ProjectionAction>
 GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::SubFunctor::SubFunctor
   (GenericProjector & p) :
-  projector(p), action(p.master_action), f(p.master_f),
-  context(p.system, &p.variables), conts(p.system.n_vars()),
+  projector(p),
+  action(p.master_action),
+  f(p.master_f),
+  context(p.system, &p.variables, /* allocate_local_matrices= */ false),
+  conts(p.system.n_vars()),
   field_types(p.system.n_vars()), system(p.system)
 {
   // Loop over all the variables we've been requested to project, to

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -632,14 +632,17 @@ private:
 
     // If our supplied functions require a FEMContext, and if we have
     // an initialized solution to use with that FEMContext, then
-    // create one
+    // create one.  We're not going to use elem_jacobian or
+    // subjacobians here so don't allocate them.
     std::unique_ptr<FEMContext> context;
     if (f_fem)
       {
         libmesh_assert(f_system);
         if (f_system->current_local_solution->initialized())
           {
-            context = std::make_unique<FEMContext>(*f_system);
+            context = std::make_unique<FEMContext>
+              (*f_system, nullptr,
+               /* allocate local_matrices = */ false);
             f_fem->init_context(*context);
           }
       }
@@ -812,14 +815,17 @@ private:
 
     // If our supplied functions require a FEMContext, and if we have
     // an initialized solution to use with that FEMContext, then
-    // create one
+    // create one.  We're not going to use elem_jacobian or
+    // subjacobians here so don't allocate them.
     std::unique_ptr<FEMContext> context;
     if (f_fem)
       {
         libmesh_assert(f_system);
         if (f_system->current_local_solution->initialized())
           {
-            context = std::make_unique<FEMContext>(*f_system);
+            context = std::make_unique<FEMContext>
+              (*f_system, nullptr,
+               /* allocate local_matrices = */ false);
             f_fem->init_context(*context);
             if (g_fem)
               g_fem->init_context(*context);
@@ -1610,7 +1616,10 @@ public:
     // Construct a FEMContext object for the System on which the
     // Variables in our DirichletBoundary objects are defined. This
     // will be used in the apply_dirichlet_impl() function.
-    auto fem_context = std::make_unique<FEMContext>(*system);
+    // We're not going to use elem_jacobian or subjacobians here so
+    // don't allocate them.
+    auto fem_context = std::make_unique<FEMContext>
+      (*system, nullptr, /* allocate local_matrices = */ false);
 
     // At the time we are using this FEMContext, the current_local_solution
     // vector is not initialized, but also we don't need it, so set

--- a/src/error_estimation/jump_error_estimator.C
+++ b/src/error_estimation/jump_error_estimator.C
@@ -142,8 +142,11 @@ void JumpErrorEstimator::estimate_error (const System & system,
       sys.update();
     }
 
-  fine_context = std::make_unique<FEMContext>(system);
-  coarse_context = std::make_unique<FEMContext>(system);
+  // We don't use full elem_jacobian or subjacobians here.
+  fine_context = std::make_unique<FEMContext>
+    (system, nullptr, /* allocate_local_matrices = */ false);
+  coarse_context = std::make_unique<FEMContext>
+    (system, nullptr, /* allocate_local_matrices = */ false);
 
   // Don't overintegrate - we're evaluating differences of FE values,
   // not products of them.

--- a/src/error_estimation/weighted_patch_recovery_error_estimator.C
+++ b/src/error_estimation/weighted_patch_recovery_error_estimator.C
@@ -578,8 +578,10 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
           // seminorm, otherwise just compute it for the current element
 
           // Get an FEMContext for this system, this will help us in
-          // obtaining the weights from the user code
-          FEMContext femcontext(system);
+          // obtaining the weights from the user code.
+          // We don't use full elem_jacobian or subjacobians here.
+          FEMContext femcontext(system, nullptr,
+                                /* allocate_local_matrices = */ false);
           error_estimator.weight_functions[var]->init_context(femcontext);
 
           // Loop over every element in the patch


### PR DESCRIPTION
Another optimization for the sake of https://github.com/idaholab/moose/issues/25007 with wider benefits - we don't need to be allocating `N_var^2` submatrices except when we expect to use them.

Pinging @jwpeterson - at first glance it looks to me like `rb_eim_construction.C` and/or `rb_parameterized_function.C` might also benefit from setting this to `false` in the context objects constructed there, but I'm not certain.