### PR TITLE
Add Elem-independent `quality(ASPECT_RATIO)` implementation

### DIFF
--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1581,8 +1581,34 @@ Real Elem::quality (const ElemQuality q) const
 {
   switch (q)
     {
+      // Aspect Ratio: Maximum edge length ratios
+    case ASPECT_RATIO:
+      {
+        if (this->dim() < 2)
+          return 1;
+
+        std::vector<Real> edge_lengths;
+        for (auto e : make_range(this->n_edges()))
+          {
+            const Point p0 = this->point(this->local_edge_node(e,0)),
+                        p1 = this->point(this->local_edge_node(e,1));
+
+            edge_lengths.push_back((p1-p0).norm());
+          }
+
+        const Real max = *std::max_element(edge_lengths.begin(),
+                                           edge_lengths.end()),
+                   min = *std::min_element(edge_lengths.begin(),
+                                           edge_lengths.end());
+
+        if (min == 0.)
+          return 0.;
+        else
+          return max / min;
+      }
       /**
-       * I don't know what to do for this metric.
+       * I don't know what to do for any other metric in general;
+       * subclasses may have specific overrides.
        */
     default:
       {

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1614,10 +1614,12 @@ Real Elem::quality (const ElemQuality q) const
       {
         libmesh_do_once( libmesh_here();
 
-                         libMesh::err << "ERROR:  unknown quality metric: "
+                         libMesh::err << "ERROR: quality metric "
                          << Utility::enum_to_string(q)
+                         << " not implemented on element type "
+                         << Utility::enum_to_string(this->type())
                          << std::endl
-                         << "Cowardly returning 1."
+                         << "Returning 1."
                          << std::endl; );
 
         return 1.;

--- a/src/geom/face_inf_quad.C
+++ b/src/geom/face_inf_quad.C
@@ -183,9 +183,9 @@ InfQuad::is_flipped() const
 }
 
 
-Real InfQuad::quality (const ElemQuality) const
+Real InfQuad::quality (const ElemQuality q) const
 {
-  return 0.; // Not implemented
+  return Elem::quality(q); // Not implemented
 }
 
 

--- a/tests/geom/elem_test.C
+++ b/tests/geom/elem_test.C
@@ -2,6 +2,7 @@
 
 #include <libmesh/boundary_info.h>
 #include <libmesh/elem.h>
+#include <libmesh/enum_elem_quality.h>
 #include <libmesh/enum_elem_type.h>
 #include <libmesh/elem_side_builder.h>
 #include <libmesh/mesh.h>
@@ -173,6 +174,28 @@ public:
             CPPUNIT_ASSERT(!bbox.contains_point(wide_bbox.min()));
             CPPUNIT_ASSERT(!bbox.contains_point(wide_bbox.max()));
           }
+      }
+  }
+
+  void test_quality()
+  {
+    LOG_UNIT_TEST;
+
+    for (const auto & elem : _mesh->active_local_element_ptr_range())
+      {
+        // We only have one metric defined on all elements
+        const Real q = elem->quality(ASPECT_RATIO);
+
+        // We use "0" to mean infinity rather than inf or NaN, and
+        // every quality other than that should be 1 or larger (worse)
+        CPPUNIT_ASSERT_LESSEQUAL(q, Real(1)); // 1 <= q
+
+        // We're building isotropic meshes, where even elements
+        // dissected from cubes ought to have tolerable quality.
+        //
+        // Worst I see is 2 on tets, but let's add a little tolerance
+        // in case we decide to play with rotated meshes here later
+        CPPUNIT_ASSERT_LESSEQUAL(Real(2+TOLERANCE), q); // q <= 2
       }
   }
 
@@ -532,6 +555,7 @@ public:
 
 #define ELEMTEST                                \
   CPPUNIT_TEST( test_bounding_box );            \
+  CPPUNIT_TEST( test_quality );                 \
   CPPUNIT_TEST( test_maps );                    \
   CPPUNIT_TEST( test_permute );                 \
   CPPUNIT_TEST( test_flip );                    \


### PR DESCRIPTION
It's not `SHAPE`, but hopefully it's good enough for https://github.com/idaholab/moose/issues/25121 for now.