### PR TITLE
Add PETSc versioning macros that imitate PETSc's own macros

### DIFF
--- a/include/numerics/petsc_macro.h
+++ b/include/numerics/petsc_macro.h
@@ -34,21 +34,11 @@
   ((LIBMESH_DETECTED_PETSC_VERSION_MAJOR < (major) ||                   \
     (LIBMESH_DETECTED_PETSC_VERSION_MAJOR == (major) && (LIBMESH_DETECTED_PETSC_VERSION_MINOR < (minor) || \
                                                          (LIBMESH_DETECTED_PETSC_VERSION_MINOR == (minor) && \
-                                                          LIBMESH_DETECTED_PETSC_VERSION_SUBMINOR < (subminor))))) ? 1 : 0)
-
-// The PETSC_VERSION_RELEASE constant was introduced just prior to 2.3.0 (ca. Apr 22 2005),
-// so fall back to using PETSC_VERSION_LESS_THAN in case it doesn't exist.
-#ifdef LIBMESH_DETECTED_PETSC_VERSION_RELEASE
-
-#define PETSC_RELEASE_LESS_THAN(major,minor,subminor)                   \
-  (PETSC_VERSION_LESS_THAN(major,minor,subminor) && LIBMESH_DETECTED_PETSC_VERSION_RELEASE)
-
-#else
-
-#define PETSC_RELEASE_LESS_THAN(major,minor,subminor)   \
-  (PETSC_VERSION_LESS_THAN(major,minor,subminor))
-
-#endif
+                                                          LIBMESH_DETECTED_PETSC_VERSION_SUBMINOR < (subminor))))))
+#define PETSC_VERSION_EQUALS(major,minor,subminor)              \
+  ((LIBMESH_DETECTED_PETSC_VERSION_MAJOR == (major)) &&         \
+   (LIBMESH_DETECTED_PETSC_VERSION_MINOR == (minor)) &&         \
+   (LIBMESH_DETECTED_PETSC_VERSION_SUBMINOR == (subminor)))
 
 // We used to have workarounds for missing extern "C" in old PETSc
 // versions.  We no longer support PETSc versions so old, but we do
@@ -243,8 +233,34 @@ const PetscReal * pPR(const T * ptr)
 #else // LIBMESH_HAVE_PETSC
 
 #define PETSC_VERSION_LESS_THAN(major,minor,subminor) 1
-#define PETSC_RELEASE_LESS_THAN(major,minor,subminor) 1
+#define PETSC_VERSION_EQUALS(major,minor,revision) 0
 
 #endif // LIBMESH_HAVE_PETSC
+
+// The PETSC_VERSION_RELEASE constant was introduced just prior to 2.3.0 (ca. Apr 22 2005),
+// so fall back to using PETSC_VERSION_LESS_THAN in case it doesn't exist.
+#ifdef LIBMESH_DETECTED_PETSC_VERSION_RELEASE
+
+#define PETSC_RELEASE_LESS_THAN(major, minor, subminor) \
+  (PETSC_VERSION_LESS_THAN(major, minor, subminor) && LIBMESH_DETECTED_PETSC_VERSION_RELEASE)
+#define PETSC_RELEASE_EQUALS(major, minor, subminor) \
+  (PETSC_VERSION_EQUALS(major, minor, subminor) && LIBMESH_DETECTED_PETSC_VERSION_RELEASE)
+
+#else
+
+#define PETSC_RELEASE_LESS_THAN(major, minor, subminor) \
+  (PETSC_VERSION_LESS_THAN(major, minor, subminor))
+#define PETSC_RELEASE_EQUALS(major, minor, subminor) (PETSC_VERSION_EQUALS(major, minor, subminor))
+
+#endif
+
+#define PETSC_RELEASE_LESS_EQUALS(major, minor, subminor) \
+  (PETSC_RELEASE_LESS_THAN(major, minor, subminor) || PETSC_RELEASE_EQUALS(major, minor, subminor))
+
+#define PETSC_RELEASE_GREATER_EQUALS(major, minor, subminor) \
+  (0 == PETSC_RELEASE_LESS_THAN(major, minor, subminor))
+
+#define PETSC_RELEASE_GREATER_THAN(major, minor, subminor) \
+  (0 == PETSC_RELEASE_LESS_EQUALS(major, minor, subminor))
 
 #endif // LIBMESH_PETSC_MACRO_H

--- a/src/solvers/petscdmlibmeshimpl.C
+++ b/src/solvers/petscdmlibmeshimpl.C
@@ -180,7 +180,11 @@ PetscErrorCode DMlibMeshGetBlocks(DM dm, PetscInt * n, char *** blocknames)
   CHKERRQ(ierr);
   if (!islibmesh) LIBMESH_SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
+#if PETSC_RELEASE_GREATER_EQUALS(3,20,0)
+  PetscAssertPointer(n,2);
+#else
   PetscValidPointer(n,2);
+#endif
   *n = cast_int<unsigned int>(dlm->blockids->size());
   if (!blocknames) PetscFunctionReturn(0);
   ierr = PetscMalloc(*n*sizeof(char *), blocknames); CHKERRQ(ierr);
@@ -206,7 +210,11 @@ PetscErrorCode DMlibMeshGetVariables(DM dm, PetscInt * n, char *** varnames)
   CHKERRQ(ierr);
   if (!islibmesh) LIBMESH_SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
+#if PETSC_RELEASE_GREATER_EQUALS(3,20,0)
+  PetscAssertPointer(n,2);
+#else
   PetscValidPointer(n,2);
+#endif
   *n = cast_int<unsigned int>(dlm->varids->size());
   if (!varnames) PetscFunctionReturn(0);
   ierr = PetscMalloc(*n*sizeof(char *), varnames); CHKERRQ(ierr);
@@ -494,7 +502,11 @@ PetscErrorCode DMlibMeshCreateFieldDecompositionDM(DM dm, PetscInt dnumber, Pets
   CHKERRQ(ierr);
   if (!islibmesh) LIBMESH_SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
   if (dnumber < 0) LIBMESH_SETERRQ1(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Negative number %" LIBMESH_PETSCINT_FMT " of decomposition parts", dnumber);
+#if PETSC_RELEASE_GREATER_EQUALS(3,20,0)
+  PetscAssertPointer(ddm,5);
+#else
   PetscValidPointer(ddm,5);
+#endif
   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
   ierr = DMCreate(((PetscObject)dm)->comm, ddm); CHKERRQ(ierr);
   ierr = DMSetType(*ddm, DMLIBMESH);             CHKERRQ(ierr);
@@ -547,7 +559,11 @@ PetscErrorCode DMlibMeshCreateDomainDecompositionDM(DM dm, PetscInt dnumber, Pet
   CHKERRQ(ierr);
   if (!islibmesh) LIBMESH_SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
   if (dnumber < 0) LIBMESH_SETERRQ1(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Negative number %" LIBMESH_PETSCINT_FMT " of decomposition parts", dnumber);
+#if PETSC_RELEASE_GREATER_EQUALS(3,20,0)
+  PetscAssertPointer(ddm,5);
+#else
   PetscValidPointer(ddm,5);
+#endif
   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
   ierr = DMCreate(((PetscObject)dm)->comm, ddm); CHKERRQ(ierr);
   ierr = DMSetType(*ddm, DMLIBMESH);             CHKERRQ(ierr);


### PR DESCRIPTION
The release macros match PETSc's own version macros. Their version macros ensure that a non-release PETSc is equivalent to an "inifinite" version, e.g. it will compare greater than any petsc version release. Our "release" macros will do the same. This allows me to easily update libMesh and downstream code as I'm working with PETSc main

Closes #3610 