### PR TITLE
Add EIM error indicator

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
@@ -29,6 +29,12 @@ public:
   {
     set_parametrized_function(std::make_unique<ShiftedGaussian>());
   }
+
+  virtual bool use_eim_error_indicator() const override
+  {
+    // Indicate that we do use the EIM error indicator here.
+    return true;
+  }
 };
 
 // A simple subclass of RBEIMConstruction.

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -324,6 +324,15 @@ int main (int argc, char ** argv)
       for (unsigned int q_f=0; q_f<rb_theta_expansion.get_n_F_terms(); q_f++)
         all_F[q_f] = rb_theta_expansion.eval_F_theta(q_f, mu_vec);
 
+      // The eval_F_theta() calls above use "EIM solves" from eim_rb_eval, hence we
+      // can now print out the EIM error indicator values.
+      const auto & eim_error_indicators =
+        eim_rb_eval.get_rb_eim_error_indicators();
+      for (auto idx : index_range(eim_error_indicators))
+        std::cout << "EIM error indicator for step: " << idx << ": "
+                  << std::scientific << eim_error_indicators[idx] << std::endl;
+      std::cout << std::endl;
+
       // 3.) Evaluate "output" thetas at all steps: in this case, the
       // output is particularly simple (does not depend on mu) so this
       // should just be a vector of all 1s.

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -329,9 +329,9 @@ int main (int argc, char ** argv)
       const auto & eim_error_indicators =
         eim_rb_eval.get_rb_eim_error_indicators();
       for (auto idx : index_range(eim_error_indicators))
-        std::cout << "EIM error indicator for step: " << idx << ": "
-                  << std::scientific << eim_error_indicators[idx] << std::endl;
-      std::cout << std::endl;
+        libMesh::out << "EIM error indicator for step: " << idx << ": "
+                     << std::scientific << eim_error_indicators[idx] << std::endl;
+      libMesh::out << std::endl;
 
       // 3.) Evaluate "output" thetas at all steps: in this case, the
       // output is particularly simple (does not depend on mu) so this

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -543,6 +543,12 @@ public:
 
   /**
    * Virtual function to indicate if we use the EIM error indicator in this case.
+   * This indicates if we will generate the data during the Offline training for
+   * the EIM error indicator. In EIM solves, the error indicator will only
+   * be used if set_eim_error_indicator_active() is set to true, since we want
+   * to be able to enable or disable the error indicator depending on the type
+   * of solve we are doing (e.g. EIM solves during training do not need the
+   * error indicator).
    */
   virtual bool use_eim_error_indicator() const;
 

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -361,6 +361,11 @@ public:
   std::vector<DenseVector<Number>> & get_eim_solutions_for_training_set();
 
   /**
+   * Return the EIM error indicator values from the most recent call to rb_eim_solves().
+   */
+  const std::vector<Real> & get_rb_eim_error_indicators() const;
+
+  /**
    * Set the data associated with EIM interpolation points.
    */
   void add_interpolation_points_xyz(Point p);

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -147,6 +147,13 @@ public:
   unsigned int get_n_basis_functions() const;
 
   /**
+   * Return the number of interpolation points. If we're not using the EIM error
+   * indicator, then this matches get_n_basis_functions(), but if we are using
+   * the EIM error indicator then we should have one extra interpolation point.
+   */
+  unsigned int get_n_interpolation_points() const;
+
+  /**
    * Set the number of basis functions. Useful when reading in
    * stored data.
    */

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -541,6 +541,18 @@ public:
    */
   virtual bool scale_components_in_enrichment() const;
 
+  /**
+   * Virtual function to indicate if we use the EIM error indicator in this case.
+   */
+  virtual bool use_eim_error_indicator() const;
+
+  /**
+   * Activate/decative the error indicator in EIM solves. We need this option since
+   * in some cases (e.g. during EIM training) we do not want to activate the EIM
+   * error indicator, whereas in "online solves" we do want to activate it.
+   */
+  void set_eim_error_indicator_active(bool is_active);
+
 private:
 
   /**
@@ -592,6 +604,12 @@ private:
    * The EIM solution coefficients from the most recent call to rb_eim_solves().
    */
   std::vector<DenseVector<Number>> _rb_eim_solutions;
+
+  /**
+   * If we're using the EIM error indicator, then we store the error indicator
+   * values corresponding to _rb_eim_solutions here.
+   */
+  std::vector<Real> _rb_eim_error_indicators;
 
   /**
    * Storage for EIM solutions from the training set. This is typically used in
@@ -780,6 +798,17 @@ private:
    * want to avoid changing it.
    */
   bool _preserve_rb_eim_solutions;
+
+  /**
+   * Indicate if the EIM error indicator is active in RB EIM solves. Note that
+   * this is distinct from use_eim_error_indicator(), since use_eim_error_indicator()
+   * indicates if this RBEIMEvaluation has an EIM error indicator defined,
+   * whereas _is_eim_error_indicator_active is used to turn on or off the
+   * error indicator. This primary purpose of _is_eim_error_indicator_active
+   * is to turn the error indicator off during EIM training (when it is not relevant)
+   * and to turn it on during "online solves".
+   */
+  bool _is_eim_error_indicator_active;
 
 };
 

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -151,6 +151,10 @@ public:
 
   /**
    * Vectorized version of evaluate. If requires_xyz_perturbations==false, then all_xyz_perturb will not be used.
+   *
+   * The base class implementation of this function loops over the
+   * input "mus" vector and calls evaluate() for each entry. The
+   * evaluate() function may be overridden in derived classes.
    */
   virtual void vectorized_evaluate(const std::vector<RBParameters> & mus,
                                    const std::vector<Point> & all_xyz,

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -185,6 +185,10 @@ public:
 
   /**
    * Same as vectorized_evaluate() but on element nodes.
+   *
+   * The base class implementation of this function loops over the
+   * input "mus" vector and calls node_evaluate() for each entry. The
+   * node_evaluate() function may be overridden in derived classes.
    */
   virtual void node_vectorized_evaluate(const std::vector<RBParameters> & mus,
                                         const std::vector<Point> & all_xyz,

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -167,6 +167,10 @@ public:
 
   /**
    * Same as vectorized_evaluate() but on element sides.
+   *
+   * The base class implementation of this function loops over the
+   * input "mus" vector and calls side_evaluate() for each entry. The
+   * side_evaluate() function may be overridden in derived classes.
    */
   virtual void side_vectorized_evaluate(const std::vector<RBParameters> & mus,
                                         const std::vector<Point> & all_xyz,

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -677,7 +677,8 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
   // If we're using the EIM error indicator then we store one extra
   // interpolation point and associated data, hence we increment n_bfs
   // here so that we write out the extra data below.
-  if (rb_eim_evaluation.use_eim_error_indicator())
+  if (rb_eim_evaluation.use_eim_error_indicator() &&
+      (rb_eim_evaluation_reader.getInterpolationXyz().size() > n_bfs))
     n_bfs++;
 
   rb_eim_evaluation.resize_data_structures(n_bfs);

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -674,6 +674,12 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
   unsigned int n_bfs = rb_eim_evaluation_reader.getNBfs();
   rb_eim_evaluation.set_n_basis_functions(n_bfs);
 
+  // If we're using the EIM error indicator then we store one extra
+  // interpolation point and associated data, hence we increment n_bfs
+  // here so that we write out the extra data below.
+  if (rb_eim_evaluation.use_eim_error_indicator())
+    n_bfs++;
+
   rb_eim_evaluation.resize_data_structures(n_bfs);
 
   auto parameter_ranges =

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -677,8 +677,13 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
   // If we're using the EIM error indicator then we store one extra
   // interpolation point and associated data, hence we increment n_bfs
   // here so that we write out the extra data below.
-  if (rb_eim_evaluation.use_eim_error_indicator() &&
-      (rb_eim_evaluation_reader.getInterpolationXyz().size() > n_bfs))
+  //
+  // Note that we do not check rb_eim_evaluation.use_eim_error_indicator()
+  // below because it can be false in some cases when we're reading in
+  // data (e.g. if we're using a base class RBEIMEvaluation to do the
+  // reading). The check below will still give the right behavior whether
+  // regardless of the value of use_eim_error_indicator().
+  if (rb_eim_evaluation_reader.getInterpolationXyz().size() > n_bfs)
     n_bfs++;
 
   rb_eim_evaluation.resize_data_structures(n_bfs);

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -586,8 +586,12 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
   // If we're using the EIM error indicator then we store one extra
   // interpolation point and associated data, hence we increment n_bfs
   // here so that we write out the extra data below.
-  if (rb_eim_evaluation.use_eim_error_indicator())
+  if (rb_eim_evaluation.use_eim_error_indicator() &&
+      (rb_eim_evaluation.get_n_interpolation_points() > n_bfs))
     n_bfs++;
+
+  libmesh_error_msg_if(n_bfs != rb_eim_evaluation.get_n_interpolation_points(),
+    "Number of basis functions should match number of interpolation points");
 
   auto parameter_ranges_list =
     rb_eim_evaluation_builder.initParameterRanges();

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -580,8 +580,14 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
                                            RBEIMEvaluationBuilderNumber & rb_eim_evaluation_builder)
 {
   // Number of basis functions
-    unsigned int n_bfs = rb_eim_evaluation.get_n_basis_functions();
+  unsigned int n_bfs = rb_eim_evaluation.get_n_basis_functions();
   rb_eim_evaluation_builder.setNBfs(n_bfs);
+
+  // If we're using the EIM error indicator then we store one extra
+  // interpolation point and associated data, hence we increment n_bfs
+  // here so that we write out the extra data below.
+  if (rb_eim_evaluation.use_eim_error_indicator())
+    n_bfs++;
 
   auto parameter_ranges_list =
     rb_eim_evaluation_builder.initParameterRanges();

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -504,13 +504,6 @@ Real RBEIMConstruction::train_eim_approximation_with_greedy()
             exit_condition_satisfied = true;
           }
 
-        if (rbe.get_n_basis_functions() >= this->get_Nmax())
-          {
-            libMesh::out << "Maximum number of basis functions reached: Nmax = "
-                         << get_Nmax() << std::endl;
-            exit_condition_satisfied = true;
-          }
-
         {
           bool do_exit = false;
           for (auto & param : greedy_param_list)

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -475,7 +475,11 @@ Real RBEIMConstruction::train_eim_approximation_with_greedy()
       if (exit_on_next_iteration)
         {
           libMesh::out << "Extra EIM iteration for error indicator is complete, hence exiting EIM training now" << std::endl;
-          get_rb_eim_evaluation().set_eim_error_indicator_active(false);
+
+          // Before we exit we remove the "final" EIM basis function, since it was only added in order
+          // to create data for the EIM error indicator.
+          rbe.set_n_basis_functions(rbe.get_n_basis_functions()-1);
+
           break;
         }
 
@@ -528,11 +532,6 @@ Real RBEIMConstruction::train_eim_approximation_with_greedy()
             if (get_rb_eim_evaluation().use_eim_error_indicator())
               {
                 exit_on_next_iteration = true;
-
-                // We set eim_error_indicator_active to true so that we skip
-                // adding the basis function for the "final" interpolation point,
-                // since we only need the interpolation point data in that case.
-                get_rb_eim_evaluation().set_eim_error_indicator_active(true);
                 libMesh::out << "EIM error indicator is active, hence we will run one extra EIM iteration before exiting"
                              << std::endl;
               }
@@ -660,7 +659,11 @@ Real RBEIMConstruction::train_eim_approximation_with_POD()
       if (exit_on_next_iteration)
         {
           libMesh::out << "Extra EIM iteration for error indicator is complete, hence exiting EIM training now" << std::endl;
-          get_rb_eim_evaluation().set_eim_error_indicator_active(false);
+
+          // Before we exit we remove the "final" EIM basis function, since it was only added in order
+          // to create data for the EIM error indicator.
+          get_rb_eim_evaluation().set_n_basis_functions(get_rb_eim_evaluation().get_n_basis_functions()-1);
+
           break;
         }
 
@@ -679,11 +682,6 @@ Real RBEIMConstruction::train_eim_approximation_with_POD()
           if (get_rb_eim_evaluation().use_eim_error_indicator())
             {
               exit_on_next_iteration = true;
-
-              // We set eim_error_indicator_active to true so that we skip
-              // adding the basis function for the "final" interpolation point,
-              // since we only need the interpolation point data in that case.
-              get_rb_eim_evaluation().set_eim_error_indicator_active(true);
               libMesh::out << "EIM error indicator is active, hence we will run one extra EIM iteration before exiting"
                             << std::endl;
             }

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -649,7 +649,10 @@ Real RBEIMConstruction::train_eim_approximation_with_POD()
                    << ", POD error norm: " << rel_err << std::endl;
 
       if (exit_on_next_iteration)
+      {
         libMesh::out << "Extra EIM iteration for error indicator is complete, hence exiting EIM training now" << std::endl;
+        break;
+      }
 
       bool exit_condition_satisfied = false;
       if (rel_err < get_rel_training_tolerance())

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -417,9 +417,13 @@ Real RBEIMConstruction::train_eim_approximation_with_greedy()
 {
   LOG_SCOPE("train_eim_approximation_with_greedy()", "RBEIMConstruction");
 
-  _eim_projection_matrix.resize(get_Nmax(),get_Nmax());
-
   RBEIMEvaluation & rbe = get_rb_eim_evaluation();
+
+  // We need space for one extra interpolation point if we're using the
+  // EIM error indicator.
+  unsigned int max_matrix_size = rbe.use_eim_error_indicator() ? get_Nmax()+1 : get_Nmax();
+  _eim_projection_matrix.resize(max_matrix_size,max_matrix_size);
+
   rbe.initialize_parameters(*this);
   rbe.resize_data_structures(get_Nmax());
 
@@ -556,11 +560,15 @@ Real RBEIMConstruction::train_eim_approximation_with_POD()
 {
   LOG_SCOPE("train_eim_approximation_with_POD()", "RBEIMConstruction");
 
+  RBEIMEvaluation & rbe = get_rb_eim_evaluation();
+
   // _eim_projection_matrix is not used in the POD case, but we resize it here in any case
   // to be consistent with what we do in train_eim_approximation_with_greedy().
-  _eim_projection_matrix.resize(get_Nmax(),get_Nmax());
+  // We need space for one extra interpolation point if we're using the
+  // EIM error indicator.
+  unsigned int max_matrix_size = rbe.use_eim_error_indicator() ? get_Nmax()+1 : get_Nmax();
+  _eim_projection_matrix.resize(max_matrix_size,max_matrix_size);
 
-  RBEIMEvaluation & rbe = get_rb_eim_evaluation();
   rbe.initialize_parameters(*this);
   rbe.resize_data_structures(get_Nmax());
 
@@ -943,7 +951,12 @@ unsigned int RBEIMConstruction::get_n_parametrized_functions_for_training() cons
 
 void RBEIMConstruction::reinit_eim_projection_matrix()
 {
-  _eim_projection_matrix.resize(get_Nmax(),get_Nmax());
+  RBEIMEvaluation & rbe = get_rb_eim_evaluation();
+
+  // We need space for one extra interpolation point if we're using the
+  // EIM error indicator.
+  unsigned int max_matrix_size = rbe.use_eim_error_indicator() ? get_Nmax()+1 : get_Nmax();
+  _eim_projection_matrix.resize(max_matrix_size,max_matrix_size);
 }
 
 std::pair<Real,unsigned int> RBEIMConstruction::compute_max_eim_error()

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -473,7 +473,11 @@ Real RBEIMConstruction::train_eim_approximation_with_greedy()
       libMesh::out << "Maximum EIM error is " << greedy_error << std::endl << std::endl;
 
       if (exit_on_next_iteration)
-        libMesh::out << "Extra EIM iteration for error indicator is complete, hence exiting EIM training now" << std::endl;
+        {
+          libMesh::out << "Extra EIM iteration for error indicator is complete, hence exiting EIM training now" << std::endl;
+          get_rb_eim_evaluation().set_eim_error_indicator_active(false);
+          break;
+        }
 
       // Convergence and/or termination tests
       {
@@ -531,6 +535,11 @@ Real RBEIMConstruction::train_eim_approximation_with_greedy()
             if (get_rb_eim_evaluation().use_eim_error_indicator())
               {
                 exit_on_next_iteration = true;
+
+                // We set eim_error_indicator_active to true so that we skip
+                // adding the basis function for the "final" interpolation point,
+                // since we only need the interpolation point data in that case.
+                get_rb_eim_evaluation().set_eim_error_indicator_active(true);
                 libMesh::out << "EIM error indicator is active, hence we will run one extra EIM iteration before exiting"
                              << std::endl;
               }
@@ -649,10 +658,11 @@ Real RBEIMConstruction::train_eim_approximation_with_POD()
                    << ", POD error norm: " << rel_err << std::endl;
 
       if (exit_on_next_iteration)
-      {
-        libMesh::out << "Extra EIM iteration for error indicator is complete, hence exiting EIM training now" << std::endl;
-        break;
-      }
+        {
+          libMesh::out << "Extra EIM iteration for error indicator is complete, hence exiting EIM training now" << std::endl;
+          get_rb_eim_evaluation().set_eim_error_indicator_active(false);
+          break;
+        }
 
       bool exit_condition_satisfied = false;
       if (rel_err < get_rel_training_tolerance())
@@ -670,6 +680,11 @@ Real RBEIMConstruction::train_eim_approximation_with_POD()
           if (get_rb_eim_evaluation().use_eim_error_indicator())
             {
               exit_on_next_iteration = true;
+
+              // We set eim_error_indicator_active to true so that we skip
+              // adding the basis function for the "final" interpolation point,
+              // since we only need the interpolation point data in that case.
+              get_rb_eim_evaluation().set_eim_error_indicator_active(true);
               libMesh::out << "EIM error indicator is active, hence we will run one extra EIM iteration before exiting"
                             << std::endl;
             }
@@ -2380,13 +2395,13 @@ void RBEIMConstruction::enrich_eim_approximation_on_interiors(const QpDataMap & 
   // Add local_pf as the new basis function and store data
   // associated with the interpolation point.
   eim_eval.add_basis_function_and_interpolation_data(local_pf,
-                                                    optimal_point,
-                                                    optimal_comp,
-                                                    optimal_elem_id,
-                                                    optimal_subdomain_id,
-                                                    optimal_qp,
-                                                    optimal_point_perturbs,
-                                                    optimal_point_phi_i_qp);
+                                                     optimal_point,
+                                                     optimal_comp,
+                                                     optimal_elem_id,
+                                                     optimal_subdomain_id,
+                                                     optimal_qp,
+                                                     optimal_point_perturbs,
+                                                     optimal_point_phi_i_qp);
 
   if (has_obs_vals)
     {

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -643,10 +643,17 @@ Real RBEIMConstruction::train_eim_approximation_with_POD()
   Real rel_err = 0.;
   while (true)
     {
-      if (j >= get_Nmax() || j >= n_snapshots)
+      if (j >= n_snapshots)
+        {
+          libMesh::out << "Number of basis functions (" << j << ") equals number of training samples, hence exiting." << std::endl;
+          break;
+        }
+
+      bool exit_condition_satisfied = false;
+      if (j >= get_Nmax())
         {
           libMesh::out << "Maximum number of basis functions (" << j << ") reached." << std::endl;
-          break;
+          exit_condition_satisfied = true;
         }
 
       // The "energy" error in the POD approximation is determined by the first omitted
@@ -664,7 +671,6 @@ Real RBEIMConstruction::train_eim_approximation_with_POD()
           break;
         }
 
-      bool exit_condition_satisfied = false;
       if (rel_err < get_rel_training_tolerance())
         {
           libMesh::out << "Training tolerance reached." << std::endl;

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -324,7 +324,13 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
         if (_is_eim_error_indicator_active && (n_interp_pts_in_solve > N))
           {
             Number rb_eim_error_indicator_val = _rb_eim_solutions[counter](N);
+
+            // Drop the last entry from the solution vector since it is only used
+            // for the error indicator value, which we already obtained above.
+            auto rb_eim_sol_copy = _rb_eim_solutions[counter];
             _rb_eim_solutions[counter].resize(N);
+            for (auto sol_idx : make_range(N))
+              _rb_eim_solutions[counter](sol_idx) = rb_eim_sol_copy(sol_idx);
 
             // Normalize the error indicator based on the norm of the coefficient vector
             _rb_eim_error_indicators[counter] =

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -944,6 +944,8 @@ void RBEIMEvaluation::add_basis_function_and_interpolation_data(
       // function since we only need the interpolation point data.
       _local_eim_basis_functions.emplace_back(bf);
     }
+  else
+    std::cout << "Skip storing extra basis function since it is not needed to evaluate the error indicator" << std::endl;
 
   _interpolation_points_xyz.emplace_back(p);
   _interpolation_points_comp.emplace_back(comp);
@@ -974,6 +976,8 @@ void RBEIMEvaluation::add_side_basis_function_and_interpolation_data(
       // function since we only need the interpolation point data.
       _local_side_eim_basis_functions.emplace_back(side_bf);
     }
+  else
+    std::cout << "Skip storing extra basis function since it is not needed to evaluate the error indicator" << std::endl;
 
   _interpolation_points_xyz.emplace_back(p);
   _interpolation_points_comp.emplace_back(comp);
@@ -1001,6 +1005,8 @@ void RBEIMEvaluation::add_node_basis_function_and_interpolation_data(
       // function since we only need the interpolation point data.
       _local_node_eim_basis_functions.emplace_back(node_bf);
     }
+  else
+    std::cout << "Skip storing extra basis function since it is not needed to evaluate the error indicator" << std::endl;
 
   _interpolation_points_xyz.emplace_back(p);
   _interpolation_points_comp.emplace_back(comp);

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -754,6 +754,11 @@ std::vector<DenseVector<Number>> & RBEIMEvaluation::get_eim_solutions_for_traini
   return _eim_solutions_for_training_set;
 }
 
+const std::vector<Real> & RBEIMEvaluation::get_rb_eim_error_indicators() const
+{
+  return _rb_eim_error_indicators;
+}
+
 void RBEIMEvaluation::add_interpolation_points_xyz(Point p)
 {
   _interpolation_points_xyz.emplace_back(p);

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -324,7 +324,7 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
         if (_is_eim_error_indicator_active && (n_interp_pts_in_solve > N))
           {
             Number rb_eim_error_indicator_val = _rb_eim_solutions[counter](N);
-            _rb_eim_solutions[counter](N) = 0.;
+            _rb_eim_solutions[counter].resize(N);
 
             // Normalize the error indicator based on the norm of the coefficient vector
             _rb_eim_error_indicators[counter] =

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -951,17 +951,7 @@ void RBEIMEvaluation::add_basis_function_and_interpolation_data(
   const std::vector<Point> & perturbs,
   const std::vector<Real> & phi_i_qp)
 {
-  if (!_is_eim_error_indicator_active)
-    {
-      // We use the _is_eim_error_indicator_active to indicate
-      // when we are adding data associated with the error indicator
-      // only, and in that case we should skip adding the basis
-      // function since we only need the interpolation point data.
-      _local_eim_basis_functions.emplace_back(bf);
-    }
-  else
-    std::cout << "Skip storing extra basis function since it is not needed to evaluate the error indicator" << std::endl;
-
+  _local_eim_basis_functions.emplace_back(bf);
   _interpolation_points_xyz.emplace_back(p);
   _interpolation_points_comp.emplace_back(comp);
   _interpolation_points_elem_id.emplace_back(elem_id);
@@ -983,17 +973,7 @@ void RBEIMEvaluation::add_side_basis_function_and_interpolation_data(
   const std::vector<Point> & perturbs,
   const std::vector<Real> & phi_i_qp)
 {
-  if (!_is_eim_error_indicator_active)
-    {
-      // We use the _is_eim_error_indicator_active to indicate
-      // when we are adding data associated with the error indicator
-      // only, and in that case we should skip adding the basis
-      // function since we only need the interpolation point data.
-      _local_side_eim_basis_functions.emplace_back(side_bf);
-    }
-  else
-    std::cout << "Skip storing extra basis function since it is not needed to evaluate the error indicator" << std::endl;
-
+  _local_side_eim_basis_functions.emplace_back(side_bf);
   _interpolation_points_xyz.emplace_back(p);
   _interpolation_points_comp.emplace_back(comp);
   _interpolation_points_elem_id.emplace_back(elem_id);
@@ -1012,17 +992,7 @@ void RBEIMEvaluation::add_node_basis_function_and_interpolation_data(
   dof_id_type node_id,
   boundary_id_type boundary_id)
 {
-  if (!_is_eim_error_indicator_active)
-    {
-      // We use the _is_eim_error_indicator_active to indicate
-      // when we are adding data associated with the error indicator
-      // only, and in that case we should skip adding the basis
-      // function since we only need the interpolation point data.
-      _local_node_eim_basis_functions.emplace_back(node_bf);
-    }
-  else
-    std::cout << "Skip storing extra basis function since it is not needed to evaluate the error indicator" << std::endl;
-
+  _local_node_eim_basis_functions.emplace_back(node_bf);
   _interpolation_points_xyz.emplace_back(p);
   _interpolation_points_comp.emplace_back(comp);
   _interpolation_points_node_id.emplace_back(node_id);

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -936,7 +936,14 @@ void RBEIMEvaluation::add_basis_function_and_interpolation_data(
   const std::vector<Point> & perturbs,
   const std::vector<Real> & phi_i_qp)
 {
-  _local_eim_basis_functions.emplace_back(bf);
+  if (!_is_eim_error_indicator_active)
+    {
+      // We use the _is_eim_error_indicator_active to indicate
+      // when we are adding data associated with the error indicator
+      // only, and in that case we should skip adding the basis
+      // function since we only need the interpolation point data.
+      _local_eim_basis_functions.emplace_back(bf);
+    }
 
   _interpolation_points_xyz.emplace_back(p);
   _interpolation_points_comp.emplace_back(comp);
@@ -959,7 +966,14 @@ void RBEIMEvaluation::add_side_basis_function_and_interpolation_data(
   const std::vector<Point> & perturbs,
   const std::vector<Real> & phi_i_qp)
 {
-  _local_side_eim_basis_functions.emplace_back(side_bf);
+  if (!_is_eim_error_indicator_active)
+    {
+      // We use the _is_eim_error_indicator_active to indicate
+      // when we are adding data associated with the error indicator
+      // only, and in that case we should skip adding the basis
+      // function since we only need the interpolation point data.
+      _local_side_eim_basis_functions.emplace_back(side_bf);
+    }
 
   _interpolation_points_xyz.emplace_back(p);
   _interpolation_points_comp.emplace_back(comp);
@@ -979,7 +993,14 @@ void RBEIMEvaluation::add_node_basis_function_and_interpolation_data(
   dof_id_type node_id,
   boundary_id_type boundary_id)
 {
-  _local_node_eim_basis_functions.emplace_back(node_bf);
+  if (!_is_eim_error_indicator_active)
+    {
+      // We use the _is_eim_error_indicator_active to indicate
+      // when we are adding data associated with the error indicator
+      // only, and in that case we should skip adding the basis
+      // function since we only need the interpolation point data.
+      _local_node_eim_basis_functions.emplace_back(node_bf);
+    }
 
   _interpolation_points_xyz.emplace_back(p);
   _interpolation_points_comp.emplace_back(comp);

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -293,7 +293,7 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
   // earlier.
   _rb_eim_solutions.resize(num_rb_eim_solves);
   if (_is_eim_error_indicator_active)
-    _rb_eim_error_indicators.resize(mus.size());
+    _rb_eim_error_indicators.resize(num_rb_eim_solves);
 
   {
     unsigned int counter = 0;

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -90,7 +90,11 @@ void RBEIMEvaluation::resize_data_structures(const unsigned int Nmax)
   _interpolation_points_phi_i_qp.clear();
   _interpolation_points_spatial_indices.clear();
 
-  _interpolation_matrix.resize(Nmax,Nmax);
+  // We need space for one extra interpolation point if we're using the
+  // EIM error indicator.
+  unsigned int max_matrix_size = use_eim_error_indicator() ? Nmax+1 : Nmax;
+
+  _interpolation_matrix.resize(max_matrix_size,max_matrix_size);
 }
 
 void RBEIMEvaluation::set_parametrized_function(std::unique_ptr<RBParametrizedFunction> pf)

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -370,6 +370,11 @@ unsigned int RBEIMEvaluation::get_n_basis_functions() const
     return _local_eim_basis_functions.size();
 }
 
+unsigned int RBEIMEvaluation::get_n_interpolation_points() const
+{
+  return _interpolation_points_xyz.size();
+}
+
 void RBEIMEvaluation::set_n_basis_functions(unsigned int n_bfs)
 {
   if (get_parametrized_function().on_mesh_sides())

--- a/src/reduced_basis/rb_eim_theta.C
+++ b/src/reduced_basis/rb_eim_theta.C
@@ -42,7 +42,10 @@ Number RBEIMTheta::evaluate(const RBParameters & mu)
 
 std::vector<Number> RBEIMTheta::evaluate_vec(const std::vector<RBParameters> & mus)
 {
+  rb_eim_eval.set_eim_error_indicator_active(true);
   rb_eim_eval.rb_eim_solves(mus, rb_eim_eval.get_n_basis_functions());
+  rb_eim_eval.set_eim_error_indicator_active(false);
+
   return rb_eim_eval.get_rb_eim_solutions_entries(index);
 }
 

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -155,20 +155,71 @@ void RBParametrizedFunction::vectorized_evaluate(const std::vector<RBParameters>
   // Dummy vector to be used when xyz perturbations are not required
   std::vector<Point> empty_perturbs;
 
-  output.resize(mus.size());
+  // The number of components returned by this RBParametrizedFunction
+  auto n_components = this->get_n_components();
+
+  // We first loop over all mus and all n_points, calling evaluate()
+  // for each and storing the results.  It is easier to first
+  // pre-compute all the values before filling output, since, in the
+  // case of multi-step RBParameters, the ordering of the loops is a
+  // bit complicated otherwise.
+  std::vector<std::vector<std::vector<Number>>> all_evals(mus.size());
   for (auto mu_index : index_range(mus))
     {
-      output[mu_index].resize(n_points);
-      for (unsigned int point_index=0; point_index<n_points; point_index++)
+      // Allocate enough space to store all points for the current mu
+      all_evals[mu_index].resize(n_points);
+      for (auto point_index : index_range(all_evals[mu_index]))
         {
-          output[mu_index][point_index] =
-            evaluate(mus[mu_index],
-                     all_xyz[point_index],
-                     elem_ids[point_index],
-                     qps[point_index],
-                     sbd_ids[point_index],
-                     requires_xyz_perturbations ? all_xyz_perturb[point_index] : empty_perturbs,
-                     phi_i_qp[point_index]);
+          // Evaluate all steps for the current mu at the current interpolation point
+          all_evals[mu_index][point_index] =
+            this->evaluate(mus[mu_index],
+                           all_xyz[point_index],
+                           elem_ids[point_index],
+                           qps[point_index],
+                           sbd_ids[point_index],
+                           requires_xyz_perturbations ? all_xyz_perturb[point_index] : empty_perturbs,
+                           phi_i_qp[point_index]);
+
+          // The vector returned by evaluate() should contain:
+          // n_components * mus[mu_index].n_steps()
+          // entries. That is, for multi-step RBParameters objects,
+          // the vector will be packed with entries as follows:
+          // [step0_component0, step0_component1, ..., step0_componentN,
+          //  step1_component0, step1_component1, ..., step1_componentN,
+          //  ...
+          //  stepM_component0, stepM_component1, ..., stepM_componentN]
+          auto n_steps = mus[mu_index].n_steps();
+          auto received_data = all_evals[mu_index][point_index].size();
+          libmesh_error_msg_if(received_data != n_components * n_steps,
+                               "Recieved " << received_data <<
+                               " evaluated values but expected to receive " << n_components * n_steps);
+        }
+    }
+
+  // TODO: move this code for computing the total number of "steps"
+  // represented by a std::vector of RBParameters objects to a helper
+  // function.
+  unsigned int output_size = 0;
+  for (const auto & mu : mus)
+    output_size += mu.n_steps();
+
+  output.resize(output_size);
+
+  // We use traditional for-loops here (rather than range-based) so that we can declare and
+  // increment multiple loop counters all within the local scope of the for-loop.
+  for (auto [mu_index, output_index] = std::make_tuple(0u, 0u); mu_index < mus.size(); ++mu_index)
+    {
+      auto n_steps = mus[mu_index].n_steps();
+      for (auto mu_step = 0u; mu_step < n_steps; ++mu_step, ++output_index)
+        {
+          output[output_index].resize(n_points);
+          for (auto point_index : make_range(n_points))
+            {
+              output[output_index][point_index].resize(n_components);
+
+              for (auto comp : make_range(n_components))
+                output[output_index][point_index][comp] = all_evals[mu_index][point_index][n_components*mu_step + comp];
+            }
         }
     }
 }

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -246,22 +246,73 @@ void RBParametrizedFunction::side_vectorized_evaluate(const std::vector<RBParame
   // Dummy vector to be used when xyz perturbations are not required
   std::vector<Point> empty_perturbs;
 
-  output.resize(mus.size());
+  // The number of components returned by this RBParametrizedFunction
+  auto n_components = this->get_n_components();
+
+  // We first loop over all mus and all n_points, calling side_evaluate()
+  // for each and storing the results.  It is easier to first
+  // pre-compute all the values before filling output, since, in the
+  // case of multi-step RBParameters, the ordering of the loops is a
+  // bit complicated otherwise.
+  std::vector<std::vector<std::vector<Number>>> all_evals(mus.size());
   for (auto mu_index : index_range(mus))
     {
-      output[mu_index].resize(n_points);
-      for (unsigned int point_index=0; point_index<n_points; point_index++)
+      // Allocate enough space to store all points for the current mu
+      all_evals[mu_index].resize(n_points);
+      for (auto point_index : index_range(all_evals[mu_index]))
         {
-          output[mu_index][point_index] =
-            side_evaluate(mus[mu_index],
-                          all_xyz[point_index],
-                          elem_ids[point_index],
-                          side_indices[point_index],
-                          qps[point_index],
-                          sbd_ids[point_index],
-                          boundary_ids[point_index],
-                          requires_xyz_perturbations ? all_xyz_perturb[point_index] : empty_perturbs,
-                          phi_i_qp[point_index]);
+          // Evaluate all steps for the current mu at the current interpolation point
+          all_evals[mu_index][point_index] =
+            this->side_evaluate(mus[mu_index],
+                                all_xyz[point_index],
+                                elem_ids[point_index],
+                                side_indices[point_index],
+                                qps[point_index],
+                                sbd_ids[point_index],
+                                boundary_ids[point_index],
+                                requires_xyz_perturbations ? all_xyz_perturb[point_index] : empty_perturbs,
+                                phi_i_qp[point_index]);
+
+          // The vector returned by side_evaluate() should contain:
+          // n_components * mus[mu_index].n_steps()
+          // entries. That is, for multi-step RBParameters objects,
+          // the vector will be packed with entries as follows:
+          // [step0_component0, step0_component1, ..., step0_componentN,
+          //  step1_component0, step1_component1, ..., step1_componentN,
+          //  ...
+          //  stepM_component0, stepM_component1, ..., stepM_componentN]
+          auto n_steps = mus[mu_index].n_steps();
+          auto received_data = all_evals[mu_index][point_index].size();
+          libmesh_error_msg_if(received_data != n_components * n_steps,
+                               "Recieved " << received_data <<
+                               " evaluated values but expected to receive " << n_components * n_steps);
+        }
+    }
+
+  // TODO: move this code for computing the total number of "steps"
+  // represented by a std::vector of RBParameters objects to a helper
+  // function.
+  unsigned int output_size = 0;
+  for (const auto & mu : mus)
+    output_size += mu.n_steps();
+
+  output.resize(output_size);
+
+  // We use traditional for-loops here (rather than range-based) so that we can declare and
+  // increment multiple loop counters all within the local scope of the for-loop.
+  for (auto [mu_index, output_index] = std::make_tuple(0u, 0u); mu_index < mus.size(); ++mu_index)
+    {
+      auto n_steps = mus[mu_index].n_steps();
+      for (auto mu_step = 0u; mu_step < n_steps; ++mu_step, ++output_index)
+        {
+          output[output_index].resize(n_points);
+          for (auto point_index : make_range(n_points))
+            {
+              output[output_index][point_index].resize(n_components);
+
+              for (auto comp : make_range(n_components))
+                output[output_index][point_index][comp] = all_evals[mu_index][point_index][n_components*mu_step + comp];
+            }
         }
     }
 }

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -328,16 +328,68 @@ void RBParametrizedFunction::node_vectorized_evaluate(const std::vector<RBParame
   output.clear();
   unsigned int n_points = all_xyz.size();
 
-  output.resize(mus.size());
+  // The number of components returned by this RBParametrizedFunction
+  auto n_components = this->get_n_components();
+
+  // We first loop over all mus and all n_points, calling node_evaluate()
+  // for each and storing the results.  It is easier to first
+  // pre-compute all the values before filling output, since, in the
+  // case of multi-step RBParameters, the ordering of the loops is a
+  // bit complicated otherwise.
+  std::vector<std::vector<std::vector<Number>>> all_evals(mus.size());
   for (auto mu_index : index_range(mus))
     {
-      output[mu_index].resize(n_points);
-      for (unsigned int point_index=0; point_index<n_points; point_index++)
+      // Allocate enough space to store all points for the current mu
+      all_evals[mu_index].resize(n_points);
+      for (auto point_index : index_range(all_evals[mu_index]))
         {
-          output[mu_index][point_index] = node_evaluate(mus[mu_index],
-                                                        all_xyz[point_index],
-                                                        node_ids[point_index],
-                                                        boundary_ids[point_index]);
+          // Evaluate all steps for the current mu at the current interpolation point
+          all_evals[mu_index][point_index] =
+            this->node_evaluate(mus[mu_index],
+                                all_xyz[point_index],
+                                node_ids[point_index],
+                                boundary_ids[point_index]);
+
+          // The vector returned by node_evaluate() should contain:
+          // n_components * mus[mu_index].n_steps()
+          // entries. That is, for multi-step RBParameters objects,
+          // the vector will be packed with entries as follows:
+          // [step0_component0, step0_component1, ..., step0_componentN,
+          //  step1_component0, step1_component1, ..., step1_componentN,
+          //  ...
+          //  stepM_component0, stepM_component1, ..., stepM_componentN]
+          auto n_steps = mus[mu_index].n_steps();
+          auto received_data = all_evals[mu_index][point_index].size();
+          libmesh_error_msg_if(received_data != n_components * n_steps,
+                               "Recieved " << received_data <<
+                               " evaluated values but expected to receive " << n_components * n_steps);
+        }
+    }
+
+  // TODO: move this code for computing the total number of "steps"
+  // represented by a std::vector of RBParameters objects to a helper
+  // function.
+  unsigned int output_size = 0;
+  for (const auto & mu : mus)
+    output_size += mu.n_steps();
+
+  output.resize(output_size);
+
+  // We use traditional for-loops here (rather than range-based) so that we can declare and
+  // increment multiple loop counters all within the local scope of the for-loop.
+  for (auto [mu_index, output_index] = std::make_tuple(0u, 0u); mu_index < mus.size(); ++mu_index)
+    {
+      auto n_steps = mus[mu_index].n_steps();
+      for (auto mu_step = 0u; mu_step < n_steps; ++mu_step, ++output_index)
+        {
+          output[output_index].resize(n_points);
+          for (auto point_index : make_range(n_points))
+            {
+              output[output_index][point_index].resize(n_components);
+
+              for (auto comp : make_range(n_components))
+                output[output_index][point_index][comp] = all_evals[mu_index][point_index][n_components*mu_step + comp];
+            }
         }
     }
 }


### PR DESCRIPTION
This branch is by @dknez with a rebase and a few fixes for multi-step `RBParameters` added by me. The EIM error indicator is computed (so the new code is tested) in reduced_basis_ex4 which now outputs the following during the online stage:
```
center_x: -6.000000e-01, 5.000000e-01, -2.500000e-01
center_y: 7.000000e-01, 5.000000e-01, -2.500000e-01
EIM error indicator for step: 0: 2.423799e-02
EIM error indicator for step: 1: 1.293180e-02
EIM error indicator for step: 2: 2.458400e-02

Performing solve for step 0
Output value 0 = 1.826706e+00, error bound 0 = 2.234035e-03
Output value 1 = 1.865210e+00, error bound 1 = 2.234035e-03
Performing solve for step 1
Output value 0 = 2.473697e+00, error bound 0 = 1.732261e-03
Output value 1 = 3.150812e+00, error bound 1 = 1.732261e-03
Performing solve for step 2
Output value 0 = 4.683464e+00, error bound 0 = 3.246956e-03
Output value 1 = 4.134760e+00, error bound 1 = 3.246956e-03
```