### PR TITLE
Delete dangerous implicit conversions for should_p_refine

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1621,6 +1621,12 @@ public:
    */
   bool should_p_refine(unsigned int g) const;
 
+  // Prevent bad user implicit conversions
+  void should_p_refine(FEFamily, bool) = delete;
+  void should_p_refine(Order, bool) = delete;
+  bool should_p_refine(FEFamily) const = delete;
+  bool should_p_refine(Order) const = delete;
+
 private:
 
   /**


### PR DESCRIPTION
I immediately shot myself in the foot with my own code per https://github.com/idaholab/moose/pull/25108#discussion_r1294127650. Let's not let myself nor anyone else do that in the future