### PR TITLE
Add MeshRefinement::_allow_unrefined_patches flag and accessor

### DIFF
--- a/include/mesh/mesh_refinement.h
+++ b/include/mesh/mesh_refinement.h
@@ -480,6 +480,16 @@ public:
    */
   signed char & underrefined_boundary_limit();
 
+  /**
+   * This flag defaults to false in order to maintain the original
+   * behavior of the code, which was to always eliminate unrefined
+   * element patches. If you set this flag to true, then the
+   * MeshRefinement::eliminate_unrefined_patches() function
+   * essentially does nothing, allowing such patches to persist. This
+   * may be particularly useful in e.g. 1D meshes where having
+   * unrefined patches does not introduce additional hanging nodes.
+   */
+  bool & allow_unrefined_patches();
 
   /**
    * Copy refinement flags on ghost elements from their
@@ -690,7 +700,9 @@ private:
    * o---o---o---o---o---o---o
    * \endverbatim
    *
-   * by refining the indicated element
+   * by refining the indicated element. If the _allow_unrefined_patches
+   * flag (default false) is set to true, then this function simpy returns
+   * false (indicating that no changes were made).
    */
   bool eliminate_unrefined_patches ();
 
@@ -788,6 +800,8 @@ private:
 
   signed char _overrefined_boundary_limit;
   signed char _underrefined_boundary_limit;
+
+  bool _allow_unrefined_patches;
 
   /**
    * This option enforces the mismatch level prior to refinement by checking
@@ -948,6 +962,11 @@ inline signed char & MeshRefinement::overrefined_boundary_limit()
 inline signed char & MeshRefinement::underrefined_boundary_limit()
 {
   return _underrefined_boundary_limit;
+}
+
+inline bool & MeshRefinement::allow_unrefined_patches()
+{
+  return _allow_unrefined_patches;
 }
 
 #ifdef LIBMESH_ENABLE_DEPRECATED

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -107,6 +107,7 @@ MeshRefinement::MeshRefinement (MeshBase & m) :
   _node_level_mismatch_limit(0),
   _overrefined_boundary_limit(0),
   _underrefined_boundary_limit(0),
+  _allow_unrefined_patches(false),
   _enforce_mismatch_limit_prior_to_refinement(false)
 #ifdef LIBMESH_ENABLE_PERIODIC
   , _periodic_boundaries(nullptr)

--- a/src/mesh/mesh_refinement_smoothing.C
+++ b/src/mesh/mesh_refinement_smoothing.C
@@ -373,6 +373,12 @@ bool MeshRefinement::eliminate_unrefined_patches ()
 
   bool flags_changed = false;
 
+  // Quick return: if unrefined patches are allowed, then we are not
+  // going to do anything here and can simply return that the flags
+  // haven't changed.
+  if (_allow_unrefined_patches)
+    return flags_changed;
+
   // Note: we *cannot* use a reference to the real pointer here, since
   // the pointer may be reseated below and we don't want to reseat
   // pointers held by the Mesh.


### PR DESCRIPTION
This flag defaults to false in order to maintain the original behavior of the code, which was to always eliminate unrefined element patches. If you set it to true, then you can allow such patches to persist, which may be useful in e.g. 1D meshes where having unrefined patches does not introduce additional hanging nodes.