### PR TITLE
Add option for removing global boundary ID in remove_id

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -373,9 +373,12 @@ public:
    * \p id's existence from the BoundaryInfo object.  That is, after
    * calling remove_id(), \p id will no longer be in the sets returned by
    * get_boundary_ids(), get_side_boundary_ids(), etc., and will not
-   * be in the bc_id_list vector returned by build_side_list(), etc.
+   * be in the bc_id_list vector returned by build_side_list(), etc. Set
+   * the \p global parameter to true if this is being called for all processes
+   * in the object's communicator, in which case we will remove the id from
+   * the global boundary ID container
    */
-  void remove_id (boundary_id_type id);
+  void remove_id (boundary_id_type id, bool global = false);
 
   /**
    * Changes all entities (nodes, sides, edges, shellfaces) with boundary

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1779,7 +1779,7 @@ void BoundaryInfo::remove_side (const Elem * elem,
 
 
 
-void BoundaryInfo::remove_id (boundary_id_type id)
+void BoundaryInfo::remove_id (boundary_id_type id, const bool global)
 {
   // Erase id from ids containers
   _boundary_ids.erase(id);
@@ -1790,6 +1790,8 @@ void BoundaryInfo::remove_id (boundary_id_type id)
   _ss_id_to_name.erase(id);
   _ns_id_to_name.erase(id);
   _es_id_to_name.erase(id);
+  if (global)
+    _global_boundary_ids.erase(id);
 
   // Erase (*, id) entries from map.
   erase_if(_boundary_node_id,


### PR DESCRIPTION
This was inspired by the discussion starting at
https://github.com/idaholab/moose/pull/25386#discussion_r1318084095. If the user knows they're calling `remove_id` globally, then they can remove the ID from the global container and potentially remove a need to call `set_isnt_prepared()` on the mesh object because global cache data has gone out of sync