### PR TITLE
Respect Abaqus node and element numbers a little

### DIFF
--- a/include/mesh/abaqus_io.h
+++ b/include/mesh/abaqus_io.h
@@ -212,23 +212,6 @@ private:
   std::set<ElemType> _elem_types;
 
   /**
-   * Map from libmesh element number -> abaqus element number,
-   * and the converse.
-   */
-  // std::map<dof_id_type, dof_id_type> _libmesh_to_abaqus_elem_mapping;
-  std::map<dof_id_type, dof_id_type> _abaqus_to_libmesh_elem_mapping;
-
-  /**
-   * Map from abaqus node number -> sequential, 0-based libmesh node numbering.
-   *
-   * \note In every Abaqus file I've ever seen the node numbers were 1-based,
-   * sequential, and all in order, so that this map is probably overkill.
-   * Nevertheless, it is the most general solution in case we come across a
-   * weird Abaqus file some day.
-   */
-  std::map<dof_id_type, dof_id_type> _abaqus_to_libmesh_node_mapping;
-
-  /**
    * This flag gets set to true after the first "*PART" section
    * we see.  If it is still true when we see a second PART
    * section, we will print an error message... we don't currently

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -479,12 +479,6 @@ void AbaqusIO::read_nodes(std::string nset_name)
   char c;
   std::string line;
 
-  // Defines the sequential node numbering used by libmesh.  Since
-  // there can be multiple *NODE sections in an Abaqus file, we always
-  // start our numbering with the number of nodes currently in the
-  // Mesh.
-  dof_id_type libmesh_node_id = the_mesh.n_nodes();
-
   // We need to duplicate some of the read_ids code if this *NODE
   // section also defines an NSET.  We'll set up the id_storage
   // pointer and push back IDs into this vector in the loop below...
@@ -527,13 +521,17 @@ void AbaqusIO::read_nodes(std::string nset_name)
       if (id_storage)
         id_storage->push_back(abaqus_node_id);
 
-      // Set up the abaqus -> libmesh node mapping.  This is usually just the
-      // "off-by-one" map, but it doesn't have to be.
-      _abaqus_to_libmesh_node_mapping[abaqus_node_id] = libmesh_node_id;
+      // Convert from Abaqus 1-based to libMesh 0-based numbering
+      libmesh_error_msg_if(abaqus_node_id < 1,
+                           "Invalid Abaqus node ID found");
+      const dof_id_type libmesh_node_id = abaqus_node_id-1;
+
+      libmesh_error_msg_if(the_mesh.query_node_ptr(libmesh_node_id),
+                           "Duplicate Abaqus node ID found");
 
       // Add the point to the mesh using libmesh's numbering,
       // and post-increment the libmesh node counter.
-      the_mesh.add_point(Point(x,y,z), libmesh_node_id++);
+      the_mesh.add_point(Point(x,y,z), libmesh_node_id);
     } // while
 }
 
@@ -678,12 +676,12 @@ void AbaqusIO::read_elements(std::string upper, std::string elset_name)
       char c;
       _in >> abaqus_elem_id >> c;
 
-      // Add an element of the appropriate type to the Mesh.
-      Elem * elem = the_mesh.add_elem(Elem::build(elem_type));
+      // Add an element of the appropriate type to the Mesh, with the
+      // abaqus element ID.
+      std::unique_ptr<Elem> new_elem = Elem::build(elem_type);
+      new_elem->set_id() = abaqus_elem_id;
 
-      // Associate the ID returned from libmesh with the abaqus element ID
-      //_libmesh_to_abaqus_elem_mapping[elem->id()] = abaqus_elem_id;
-      _abaqus_to_libmesh_elem_mapping[abaqus_elem_id] = elem->id();
+      Elem * elem = the_mesh.add_elem(std::move(new_elem));
 
       // The count of the total number of IDs read for the current element.
       unsigned id_count=0;
@@ -707,8 +705,10 @@ void AbaqusIO::read_elements(std::string upper, std::string elset_name)
 
               if (success)
                 {
-                  // Use the global node number mapping to determine the corresponding libmesh global node id
-                  dof_id_type libmesh_global_node_id = _abaqus_to_libmesh_node_mapping[abaqus_global_node_id];
+                  // Map the id'th element ID (Abaqus 1-based numbering) to LibMesh numbering
+                  libmesh_error_msg_if(abaqus_global_node_id < 1,
+                                       "Invalid Abaqus node ID found");
+                  const dof_id_type libmesh_global_node_id = abaqus_global_node_id-1;
 
                   // Grab the node pointer from the mesh for this ID
                   Node * node = the_mesh.node_ptr(libmesh_global_node_id);
@@ -993,8 +993,10 @@ void AbaqusIO::assign_subdomain_ids()
         // Loop over this vector
         for (const auto & id : id_vector)
           {
-            // Map the id'th element ID (Abaqus numbering) to LibMesh numbering
-            dof_id_type libmesh_elem_id = _abaqus_to_libmesh_elem_mapping[id];
+            // Map the id'th element ID (Abaqus 1-based numbering) to LibMesh numbering
+            libmesh_error_msg_if(id < 1,
+                                 "Invalid Abaqus element ID found");
+            const dof_id_type libmesh_elem_id = id-1;
 
             // Get reference to that element
             Elem & elem = the_mesh.elem_ref(libmesh_elem_id);
@@ -1047,8 +1049,10 @@ void AbaqusIO::assign_boundary_node_ids()
 
       for (const auto & id : nodeset_ids)
         {
-          // Map the Abaqus global node ID to the libmesh node ID
-          dof_id_type libmesh_global_node_id = _abaqus_to_libmesh_node_mapping[id];
+          // Map the id'th element ID (Abaqus 1-based numbering) to LibMesh numbering
+          libmesh_error_msg_if(id < 1,
+                               "Invalid Abaqus node ID found");
+          const dof_id_type libmesh_global_node_id = id-1;
 
           // Get node pointer from the mesh
           Node * node = the_mesh.node_ptr(libmesh_global_node_id);
@@ -1087,8 +1091,10 @@ void AbaqusIO::assign_sideset_ids()
 
         for (const auto & [abaqus_elem_id, abaqus_side_number] : sideset_ids)
           {
-            // Map the Abaqus element ID to LibMesh numbering
-            dof_id_type libmesh_elem_id = _abaqus_to_libmesh_elem_mapping[ abaqus_elem_id ];
+            // Map the id'th element ID (Abaqus 1-based numbering) to LibMesh numbering
+            libmesh_error_msg_if(abaqus_elem_id < 1,
+                                 "Invalid Abaqus element ID found");
+            const dof_id_type libmesh_elem_id = abaqus_elem_id-1;
 
             // Get a reference to that element
             Elem & elem = the_mesh.elem_ref(libmesh_elem_id);
@@ -1143,8 +1149,10 @@ void AbaqusIO::assign_sideset_ids()
         // Loop over this vector
         for (const auto & id : id_vector)
           {
-            // Map the id_vector[i]'th element ID (Abaqus numbering) to LibMesh numbering
-            dof_id_type libmesh_elem_id = _abaqus_to_libmesh_elem_mapping[id];
+            // Map the id'th element ID (Abaqus 1-based numbering) to LibMesh numbering
+            libmesh_error_msg_if(id < 1,
+                                 "Invalid Abaqus element ID found");
+            const dof_id_type libmesh_elem_id = id-1;
 
             // Get a reference to that element
             Elem & elem = the_mesh.elem_ref(libmesh_elem_id);


### PR DESCRIPTION
We're not going to respect them enough to not convert from 1-based to 0-based, of course[0], but we can at least stick to just that conversion and not give them whatever (sequential for nodes and replicated meshes, sequential with spacing for distributed meshes) ids we choose instead.

[0] Dijkstra, E.W. "Why numbering should start at zero"

This is my crack at making life easier for @Traiwit in https://github.com/idaholab/moose/discussions/25440 ... who I'm really hoping can help test it, because it looks like we have *zero* test coverage of AbaqusIO right now?