### PR TITLE
Added RBParametrizedFunction::preevaluate_parametrized_function_cleanup()

### DIFF
--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -337,6 +337,14 @@ public:
                                           const std::vector<boundary_id_type> & boundary_ids);
 
   /**
+   * Virtual function that performs cleanup after each
+   * "preevaluate parametrized function" evaluation. This function
+   * is a no-op by default, but it can be overridden in subclasses
+   * in order to do necessary cleanup, such as clearing cached data.
+   */
+  virtual void preevaluate_parametrized_function_cleanup();
+
+  /**
    * Storage for pre-evaluated values. The indexing is given by:
    *   parameter index --> point index --> component index --> value.
    */

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -484,6 +484,8 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh(const RBP
                       all_xyz_perturb_vec,
                       phi_i_qp_vec,
                       preevaluated_values);
+
+  preevaluate_parametrized_function_cleanup();
 }
 
 void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh_sides(const RBParameters & mu,
@@ -639,6 +641,8 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh_sides(con
                            all_xyz_perturb_vec,
                            phi_i_qp_vec,
                            preevaluated_values);
+
+  preevaluate_parametrized_function_cleanup();
 }
 
 void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh_nodes(const RBParameters & mu,
@@ -677,6 +681,8 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh_nodes(con
                            node_ids_vec,
                            boundary_ids_vec,
                            preevaluated_values);
+
+  preevaluate_parametrized_function_cleanup();
 }
 
 Number RBParametrizedFunction::lookup_preevaluated_value_on_mesh(unsigned int comp,
@@ -819,6 +825,11 @@ void RBParametrizedFunction::initialize_spatial_indices(const std::vector<std::v
                                                         const std::vector<unsigned int> & /*qps*/,
                                                         const std::vector<subdomain_id_type> & /*sbd_ids*/,
                                                         const std::vector<boundary_id_type> & /*boundary_ids*/)
+{
+  // No-op by default
+}
+
+void RBParametrizedFunction::preevaluate_parametrized_function_cleanup()
 {
   // No-op by default
 }


### PR DESCRIPTION
Added RBParametrizedFunction::preevaluate_parametrized_function_cleanup(), which is a no-op by default. It can be overridden in subclasses in order to do relevant cleanup during EIM training, such as clearing cached data.