### PR TITLE
More add_p_level API additions

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1621,6 +1621,11 @@ public:
    */
   bool should_p_refine(unsigned int g) const;
 
+  /**
+   * Whether the given variable should be p-refined
+   */
+  bool should_p_refine_var(unsigned int var) const;
+
   // Prevent bad user implicit conversions
   void should_p_refine(FEFamily, bool) = delete;
   void should_p_refine(Order, bool) = delete;
@@ -2343,6 +2348,18 @@ unsigned int DofMap::var_group_from_var_number(const unsigned int var_num) const
 {
   libmesh_assert(var_num < n_variables());
   return libmesh_map_find(_var_to_vg, var_num);
+}
+
+inline
+bool DofMap::should_p_refine_var(const unsigned int var) const
+{
+#ifdef LIBMESH_ENABLE_AMR
+  const auto vg = this->var_group_from_var_number(var);
+  return !_dont_p_refine.count(vg);
+#else
+  libmesh_ignore(var);
+  return false;
+#endif
 }
 } // namespace libMesh
 

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -364,7 +364,8 @@ public:
    */
   static void nodal_soln(const Elem * elem, const Order o,
                          const std::vector<Number> & elem_soln,
-                         std::vector<Number> & nodal_soln);
+                         std::vector<Number> & nodal_soln,
+                         bool add_p_level = true);
 
   /**
    * Build the nodal soln on one side from the (full) element soln.
@@ -375,7 +376,8 @@ public:
   static void side_nodal_soln(const Elem * elem, const Order o,
                               const unsigned int side,
                               const std::vector<Number> & elem_soln,
-                              std::vector<Number> & nodal_soln_on_side);
+                              std::vector<Number> & nodal_soln_on_side,
+                              bool add_p_level = true);
 
   /**
    * \returns The number of shape functions associated with
@@ -716,7 +718,8 @@ protected:
   static void default_side_nodal_soln(const Elem * elem, const Order o,
                                       const unsigned int side,
                                       const std::vector<Number> & elem_soln,
-                                      std::vector<Number> & nodal_soln_on_side);
+                                      std::vector<Number> & nodal_soln_on_side,
+                                      bool add_p_level = true);
 
   /**
    * An array of the node locations on the last
@@ -1401,7 +1404,8 @@ OutputShape fe_fdm_second_deriv(const ElemType type,
 void lagrange_nodal_soln(const Elem * elem,
                          const Order order,
                          const std::vector<Number> & elem_soln,
-                         std::vector<Number> &       nodal_soln);
+                         std::vector<Number> &       nodal_soln,
+                         bool add_p_level = true);
 
 /**
  * Helper functions for Discontinuous-Pn type basis functions.

--- a/include/fe/fe_abstract.h
+++ b/include/fe/fe_abstract.h
@@ -609,6 +609,11 @@ public:
    */
   void add_p_level_in_reinit(bool value) { _add_p_level_in_reinit = value; }
 
+  /**
+   * Whether to add p-refinement levels in init/reinit methods
+   */
+  bool add_p_level_in_reinit() const { return _add_p_level_in_reinit; }
+
 protected:
 
   /**

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -95,7 +95,8 @@ public:
    * Non-deprecated version of function above.
    */
   static unsigned int n_shape_functions(const FEType & fe_t,
-                                        const Elem * elem);
+                                        const Elem * elem,
+                                        const bool add_p_level = true);
 
   /**
    * Same as above, but ignores the elem->p_level() and uses the
@@ -226,7 +227,8 @@ public:
    * The non-deprecated version of the function above.
    */
   static unsigned int n_dofs_per_elem(const FEType & fe_t,
-                                      const Elem * elem);
+                                      const Elem * elem,
+                                      bool add_p_level = true);
 
   /**
    * Same thing but internally elem->p_level() is ignored and extra_order is used instead.
@@ -289,7 +291,8 @@ public:
                          const FEType & fe_t,
                          const Elem * elem,
                          const std::vector<Number> & elem_soln,
-                         std::vector<Number> & nodal_soln);
+                         std::vector<Number> & nodal_soln,
+                         bool add_p_level = true);
 
 
   /**
@@ -304,7 +307,8 @@ public:
                               const Elem * elem,
                               const unsigned int side,
                               const std::vector<Number> & elem_soln,
-                              std::vector<Number> & nodal_soln);
+                              std::vector<Number> & nodal_soln,
+                              bool add_p_level = true);
 
   /**
    * This is now deprecated; use FEMap::map instead.
@@ -386,12 +390,13 @@ public:
 
   /**
    * Non-deprecated version of the shape() function. The
-   * Elem::p_level() is accounted for internally.
+   * Elem::p_level() is accounted for internally if \p add_p_level
    */
   static Real shape(const FEType & fe_t,
                     const Elem * elem,
                     const unsigned int i,
-                    const Point & p);
+                    const Point & p,
+                    const bool add_p_level = true);
 
   /**
    * Non-deprecated version of the shape() function. The

--- a/include/fe/fe_macro.h
+++ b/include/fe/fe_macro.h
@@ -51,7 +51,7 @@
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::init_shape_functions(const std::vector<Point> &, const Elem *); \
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::init_dual_shape_functions(unsigned int, unsigned int); \
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::default_all_shape_derivs (const Elem * elem, const Order o, const std::vector<Point> & p, std::vector<std::vector<Real>> * comps[3], const bool add_p_level); \
-  template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::default_side_nodal_soln(const Elem * elem, const Order o, const unsigned int side, const std::vector<Number> & elem_soln, std::vector<Number> & nodal_soln_on_side)
+  template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::default_side_nodal_soln(const Elem * elem, const Order o, const unsigned int side, const std::vector<Number> & elem_soln, std::vector<Number> & nodal_soln_on_side, bool add_p_level)
 
 #else // LIBMESH_ENABLE_INFINITE_ELEMENTS
 
@@ -64,7 +64,7 @@
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::init_shape_functions(const std::vector<Point> &, const Elem *); \
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::init_dual_shape_functions(unsigned int, unsigned int); \
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::default_all_shape_derivs (const Elem * elem, const Order o, const std::vector<Point> & p, std::vector<std::vector<Real>> * comps[3], const bool add_p_level); \
-  template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::default_side_nodal_soln(const Elem * elem, const Order o, const unsigned int side, const std::vector<Number> & elem_soln, std::vector<Number> & nodal_soln_on_side)
+  template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::default_side_nodal_soln(const Elem * elem, const Order o, const unsigned int side, const std::vector<Number> & elem_soln, std::vector<Number> & nodal_soln_on_side, bool add_p_level)
 
 #endif // LIBMESH_ENABLE_INFINITE_ELEMENTS
 
@@ -116,8 +116,9 @@ template <>                                                             \
 void FE<_dim,_fetype>::nodal_soln(const Elem * elem,                    \
                                   const Order order,                    \
                                   const std::vector<Number> & elem_soln,\
-                                  std::vector<Number> & nodal_soln)     \
-{ _funcname(elem, order, elem_soln, nodal_soln); }
+                                  std::vector<Number> & nodal_soln,     \
+                                  const bool add_p_level)               \
+{ _funcname(elem, order, elem_soln, nodal_soln, add_p_level); }
 
 #define LIBMESH_FE_NODAL_SOLN(fetype, _funcname)                        \
 LIBMESH_FE_NODAL_SOLN_DIM(fetype, _funcname, 0)                         \
@@ -132,8 +133,9 @@ void FE<_dim,_fetype>::side_nodal_soln(const Elem * elem,               \
                                        const Order order,               \
                                        const unsigned int side,         \
                                        const std::vector<Number> & elem_soln,\
-                                       std::vector<Number> & nodal_soln)\
-{ default_side_nodal_soln(elem, order, side, elem_soln, nodal_soln); }
+                                       std::vector<Number> & nodal_soln, \
+                                       const bool add_p_level)          \
+{ default_side_nodal_soln(elem, order, side, elem_soln, nodal_soln, add_p_level); }
 
 #define LIBMESH_FE_SIDE_NODAL_SOLN(fetype)                              \
 LIBMESH_FE_SIDE_NODAL_SOLN_DIM(fetype, 0)                               \

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -2549,10 +2549,12 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectSide
             continue;
 
           FEType fe_type = base_fe_type;
+          const auto & dof_map = system.get_dof_map();
+          const bool add_p_level = dof_map.should_p_refine_var(var);
 
           // This may be a p refined element
           fe_type.order =
-            libMesh::Order (fe_type.order + elem.p_level());
+            libMesh::Order (fe_type.order + add_p_level*elem.p_level());
 
           // If this is a Lagrange element with DoFs on sides then by
           // convention we interpolate at the node rather than project
@@ -2664,7 +2666,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectSide
 
           std::vector<unsigned int> side_dofs;
           FEInterface::dofs_on_side(&elem, dim, base_fe_type,
-                                    context.side, side_dofs);
+                                    context.side, side_dofs, add_p_level);
 
           this->construct_projection
             (dof_indices, side_dofs, var_component,

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -1656,7 +1656,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::SortAndCopy
                       }
             }
 
-          if (FEInterface::n_dofs_per_elem(fe_type, elem) ||
+          if (FEInterface::n_dofs_per_elem(fe_type, elem, add_p_level) ||
               (has_interior_nodes &&
                FEInterface::n_dofs_at_node(fe_type, elem, n_nodes-1, add_p_level)))
             {
@@ -2708,10 +2708,13 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectInte
           context.get_element_fe( var, fe, dim );
 
           FEType fe_type = base_fe_type;
+          const auto & dof_map = system.get_dof_map();
+          const auto vg = dof_map.var_group_from_var_number(var);
+          const bool add_p_level = dof_map.should_p_refine(vg);
 
           // This may be a p refined element
           fe_type.order =
-            libMesh::Order (fe_type.order + elem->p_level());
+            libMesh::Order (fe_type.order + add_p_level * elem->p_level());
 
           const unsigned int var_component =
             system.variable_scalar_number(var, 0);

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -813,7 +813,7 @@ void DofMap::reinit(MeshBase & mesh)
             }
           // Allocate the element DOFs
           const unsigned int dofs_per_elem =
-            FEInterface::n_dofs_per_elem(base_fe_type, elem);
+            FEInterface::n_dofs_per_elem(base_fe_type, elem, add_p_level);
 
           elem->set_n_comp_group(sys_num, vg, dofs_per_elem);
 
@@ -2509,7 +2509,7 @@ void DofMap::_dof_indices (const Elem & elem,
         }
 
       // If there are any element-based DOF numbers, get them
-      const unsigned int nc = FEInterface::n_dofs_per_elem(fe_type, p_level, &elem);
+      const unsigned int nc = FEInterface::n_dofs_per_elem(fe_type, add_p_level*p_level, &elem);
 
       // We should never have fewer dofs than necessary on an
       // element unless we're getting indices on a parent element

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -706,10 +706,11 @@ void
 FE<Dim,T>::default_side_nodal_soln(const Elem * elem, const Order o,
                                    const unsigned int side,
                                    const std::vector<Number> & elem_soln,
-                                   std::vector<Number> & nodal_soln_on_side)
+                                   std::vector<Number> & nodal_soln_on_side,
+                                   const bool add_p_level)
 {
   std::vector<Number> full_nodal_soln;
-  nodal_soln(elem, o, elem_soln, full_nodal_soln);
+  nodal_soln(elem, o, elem_soln, full_nodal_soln, add_p_level);
   const std::vector<unsigned int> side_nodes =
     elem->nodes_on_side(side);
 

--- a/src/fe/fe_bernstein.C
+++ b/src/fe/fe_bernstein.C
@@ -40,7 +40,8 @@ namespace {
 void bernstein_nodal_soln(const Elem * elem,
                           const Order order,
                           const std::vector<Number> & elem_soln,
-                          std::vector<Number> & nodal_soln)
+                          std::vector<Number> & nodal_soln,
+                          const bool add_p_level)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -48,7 +49,7 @@ void bernstein_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = static_cast<Order>(order + elem->p_level());
+  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, BERNSTEIN);

--- a/src/fe/fe_clough.C
+++ b/src/fe/fe_clough.C
@@ -36,7 +36,8 @@ namespace {
 void clough_nodal_soln(const Elem * elem,
                        const Order order,
                        const std::vector<Number> & elem_soln,
-                       std::vector<Number> &       nodal_soln)
+                       std::vector<Number> &       nodal_soln,
+                       const bool add_p_level)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -44,7 +45,7 @@ void clough_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = static_cast<Order>(order + elem->p_level());
+  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, CLOUGH);

--- a/src/fe/fe_hermite.C
+++ b/src/fe/fe_hermite.C
@@ -36,7 +36,8 @@ namespace {
 void hermite_nodal_soln(const Elem * elem,
                         const Order order,
                         const std::vector<Number> & elem_soln,
-                        std::vector<Number> & nodal_soln)
+                        std::vector<Number> & nodal_soln,
+                        const bool add_p_level)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -48,7 +49,7 @@ void hermite_nodal_soln(const Elem * elem,
   FEType fe_type(order, HERMITE);
 
   const unsigned int n_sf =
-    FEInterface::n_shape_functions(fe_type, elem);
+    FEInterface::n_shape_functions(fe_type, elem, add_p_level);
 
   std::vector<Point> refspace_nodes;
   FEBase::get_refspace_nodes(elem_type,refspace_nodes);
@@ -64,7 +65,7 @@ void hermite_nodal_soln(const Elem * elem,
       // u_i = Sum (alpha_i phi_i)
       for (unsigned int i=0; i<n_sf; i++)
         nodal_soln[n] += elem_soln[i] *
-          FEInterface::shape(fe_type, elem, i, refspace_nodes[n]);
+          FEInterface::shape(fe_type, elem, i, refspace_nodes[n], add_p_level);
     }
 } // hermite_nodal_soln()
 

--- a/src/fe/fe_hierarchic.C
+++ b/src/fe/fe_hierarchic.C
@@ -36,7 +36,8 @@ namespace {
 void hierarchic_nodal_soln(const Elem * elem,
                            const Order order,
                            const std::vector<Number> & elem_soln,
-                           std::vector<Number> & nodal_soln)
+                           std::vector<Number> & nodal_soln,
+                           const bool add_p_level)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -44,7 +45,7 @@ void hierarchic_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = static_cast<Order>(order + elem->p_level());
+  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, HIERARCHIC);

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -501,7 +501,8 @@ unsigned int FEInterface::n_shape_functions(const unsigned int dim,
 
 unsigned int
 FEInterface::n_shape_functions(const FEType & fe_t,
-                               const Elem * elem)
+                               const Elem * elem,
+                               const bool add_p_level)
 {
   // dim is required by the fe_with_vec_switch macro
   auto dim = elem->dim();
@@ -519,7 +520,7 @@ FEInterface::n_shape_functions(const FEType & fe_t,
 #endif
 
   // Account for Elem::p_level() when computing total_order
-  auto total_order = static_cast<Order>(fe_t.order + elem->p_level());
+  auto total_order = static_cast<Order>(fe_t.order + add_p_level*elem->p_level());
 
   fe_with_vec_switch(n_shape_functions(elem->type(), total_order));
 }
@@ -752,7 +753,8 @@ unsigned int FEInterface::n_dofs_per_elem(const unsigned int dim,
 
 unsigned int
 FEInterface::n_dofs_per_elem(const FEType & fe_t,
-                             const Elem * elem)
+                             const Elem * elem,
+                             const bool add_p_level)
 {
   // dim is required by the fe_with_vec_switch macro
   auto dim = elem->dim();
@@ -765,7 +767,7 @@ FEInterface::n_dofs_per_elem(const FEType & fe_t,
 #endif
 
   // Account for Elem::p_level() when computing total_order
-  auto total_order = static_cast<Order>(fe_t.order + elem->p_level());
+  auto total_order = static_cast<Order>(fe_t.order + add_p_level*elem->p_level());
 
   fe_with_vec_switch(n_dofs_per_elem(elem->type(), total_order));
 }
@@ -828,7 +830,8 @@ void FEInterface::nodal_soln(const unsigned int dim,
                              const FEType & fe_t,
                              const Elem * elem,
                              const std::vector<Number> & elem_soln,
-                             std::vector<Number> &       nodal_soln)
+                             std::vector<Number> &       nodal_soln,
+                             const bool add_p_level)
 {
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
@@ -842,7 +845,7 @@ void FEInterface::nodal_soln(const unsigned int dim,
 
   const Order order = fe_t.order;
 
-  void_fe_with_vec_switch(nodal_soln(elem, order, elem_soln, nodal_soln));
+  void_fe_with_vec_switch(nodal_soln(elem, order, elem_soln, nodal_soln, add_p_level));
 }
 
 
@@ -851,7 +854,8 @@ void FEInterface::side_nodal_soln(const FEType & fe_t,
                                   const Elem * elem,
                                   const unsigned int side,
                                   const std::vector<Number> & elem_soln,
-                                  std::vector<Number> &       nodal_soln)
+                                  std::vector<Number> &       nodal_soln,
+                                  const bool add_p_level)
 {
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
@@ -866,7 +870,7 @@ void FEInterface::side_nodal_soln(const FEType & fe_t,
   const Order order = fe_t.order;
   const unsigned int dim = elem->dim();
 
-  void_fe_with_vec_switch(side_nodal_soln(elem, order, side, elem_soln, nodal_soln));
+  void_fe_with_vec_switch(side_nodal_soln(elem, order, side, elem_soln, nodal_soln, add_p_level));
 }
 
 
@@ -1002,7 +1006,8 @@ Real
 FEInterface::shape(const FEType & fe_t,
                    const Elem * elem,
                    const unsigned int i,
-                   const Point & p)
+                   const Point & p,
+                   const bool add_p_level)
 {
   // dim is required by the fe_switch macro
   auto dim = elem->dim();
@@ -1018,9 +1023,8 @@ FEInterface::shape(const FEType & fe_t,
   //
   // FE<X,Y>::shape(Elem *, Order, unsigned, Point, true)
   //
-  // with the last parameter set to "true" so that the Elem::p_level()
-  // is accounted for internally. See fe.h for more details.
-  fe_switch(shape(elem, fe_t.order, i, p, true));
+  // See fe.h for more details.
+  fe_switch(shape(elem, fe_t.order, i, p, add_p_level));
 }
 
 

--- a/src/fe/fe_l2_hierarchic.C
+++ b/src/fe/fe_l2_hierarchic.C
@@ -36,7 +36,8 @@ namespace {
 void l2_hierarchic_nodal_soln(const Elem * elem,
                               const Order order,
                               const std::vector<Number> & elem_soln,
-                              std::vector<Number> & nodal_soln)
+                              std::vector<Number> & nodal_soln,
+                              const bool add_p_level)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -44,7 +45,7 @@ void l2_hierarchic_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = static_cast<Order>(order + elem->p_level());
+  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, L2_HIERARCHIC);

--- a/src/fe/fe_lagrange.C
+++ b/src/fe/fe_lagrange.C
@@ -43,12 +43,13 @@ namespace libMesh
 void lagrange_nodal_soln(const Elem * elem,
                          const Order order,
                          const std::vector<Number> & elem_soln,
-                         std::vector<Number> &       nodal_soln)
+                         std::vector<Number> &       nodal_soln,
+                         const bool add_p_level)
 {
   const unsigned int n_nodes = elem->n_nodes();
   const ElemType type        = elem->type();
 
-  const Order totalorder = static_cast<Order>(order+elem->p_level());
+  const Order totalorder = static_cast<Order>(order+add_p_level*elem->p_level());
 
   nodal_soln.resize(n_nodes);
 

--- a/src/fe/fe_lagrange_vec.C
+++ b/src/fe/fe_lagrange_vec.C
@@ -47,12 +47,13 @@ void lagrange_vec_nodal_soln(const Elem * elem,
                              const Order order,
                              const std::vector<Number> & elem_soln,
                              const int dim,
-                             std::vector<Number> &       nodal_soln)
+                             std::vector<Number> &       nodal_soln,
+                             const bool add_p_level)
 {
   const unsigned int n_nodes = elem->n_nodes();
   const ElemType type        = elem->type();
 
-  const Order totalorder = static_cast<Order>(order+elem->p_level());
+  const Order totalorder = static_cast<Order>(order+add_p_level*elem->p_level());
 
   nodal_soln.resize(dim*n_nodes);
 
@@ -632,29 +633,33 @@ template <>
 void FE<0,LAGRANGE_VEC>::nodal_soln(const Elem * elem,
                                     const Order order,
                                     const std::vector<Number> & elem_soln,
-                                    std::vector<Number> & nodal_soln)
-{ FE<0,LAGRANGE>::nodal_soln(elem, order, elem_soln, nodal_soln); }
+                                    std::vector<Number> & nodal_soln,
+                                    const bool add_p_level)
+{ FE<0,LAGRANGE>::nodal_soln(elem, order, elem_soln, nodal_soln, add_p_level); }
 
 template <>
 void FE<1,LAGRANGE_VEC>::nodal_soln(const Elem * elem,
                                     const Order order,
                                     const std::vector<Number> & elem_soln,
-                                    std::vector<Number> & nodal_soln)
-{ FE<1,LAGRANGE>::nodal_soln(elem, order, elem_soln, nodal_soln); }
+                                    std::vector<Number> & nodal_soln,
+                                    const bool add_p_level)
+{ FE<1,LAGRANGE>::nodal_soln(elem, order, elem_soln, nodal_soln, add_p_level); }
 
 template <>
 void FE<2,LAGRANGE_VEC>::nodal_soln(const Elem * elem,
                                     const Order order,
                                     const std::vector<Number> & elem_soln,
-                                    std::vector<Number> & nodal_soln)
-{ lagrange_vec_nodal_soln(elem, order, elem_soln, 2 /*dimension*/, nodal_soln); }
+                                    std::vector<Number> & nodal_soln,
+                                    const bool add_p_level)
+{ lagrange_vec_nodal_soln(elem, order, elem_soln, 2 /*dimension*/, nodal_soln, add_p_level); }
 
 template <>
 void FE<3,LAGRANGE_VEC>::nodal_soln(const Elem * elem,
                                     const Order order,
                                     const std::vector<Number> & elem_soln,
-                                    std::vector<Number> & nodal_soln)
-{ lagrange_vec_nodal_soln(elem, order, elem_soln, 3 /*dimension*/, nodal_soln); }
+                                    std::vector<Number> & nodal_soln,
+                                    const bool add_p_level)
+{ lagrange_vec_nodal_soln(elem, order, elem_soln, 3 /*dimension*/, nodal_soln, add_p_level); }
 
 LIBMESH_FE_SIDE_NODAL_SOLN(LAGRANGE_VEC)
 

--- a/src/fe/fe_monomial.C
+++ b/src/fe/fe_monomial.C
@@ -296,7 +296,8 @@ namespace {
 void monomial_nodal_soln(const Elem * elem,
                          const Order order,
                          const std::vector<Number> & elem_soln,
-                         std::vector<Number> & nodal_soln)
+                         std::vector<Number> & nodal_soln,
+                         const bool add_p_level)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -304,7 +305,7 @@ void monomial_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = static_cast<Order>(order+elem->p_level());
+  const Order totalorder = static_cast<Order>(order+add_p_level*elem->p_level());
 
   switch (totalorder)
     {

--- a/src/fe/fe_monomial_vec.C
+++ b/src/fe/fe_monomial_vec.C
@@ -45,7 +45,8 @@ monomial_vec_nodal_soln(const Elem * elem,
                         const Order order,
                         const std::vector<Number> & elem_soln,
                         const int dim,
-                        std::vector<Number> & nodal_soln)
+                        std::vector<Number> & nodal_soln,
+                        const bool add_p_level)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -53,7 +54,7 @@ monomial_vec_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(dim * n_nodes);
 
-  const Order totalorder = static_cast<Order>(order + elem->p_level());
+  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
 
   switch (totalorder)
   {
@@ -130,9 +131,10 @@ void
 FE<0, MONOMIAL_VEC>::nodal_soln(const Elem * elem,
                                 const Order order,
                                 const std::vector<Number> & elem_soln,
-                                std::vector<Number> & nodal_soln)
+                                std::vector<Number> & nodal_soln,
+                                const bool add_p_level)
 {
-  FE<0, MONOMIAL>::nodal_soln(elem, order, elem_soln, nodal_soln);
+  FE<0, MONOMIAL>::nodal_soln(elem, order, elem_soln, nodal_soln, add_p_level);
 }
 
 template <>
@@ -140,9 +142,10 @@ void
 FE<1, MONOMIAL_VEC>::nodal_soln(const Elem * elem,
                                 const Order order,
                                 const std::vector<Number> & elem_soln,
-                                std::vector<Number> & nodal_soln)
+                                std::vector<Number> & nodal_soln,
+                                const bool add_p_level)
 {
-  FE<1, MONOMIAL>::nodal_soln(elem, order, elem_soln, nodal_soln);
+  FE<1, MONOMIAL>::nodal_soln(elem, order, elem_soln, nodal_soln, add_p_level);
 }
 
 template <>
@@ -150,9 +153,10 @@ void
 FE<2, MONOMIAL_VEC>::nodal_soln(const Elem * elem,
                                 const Order order,
                                 const std::vector<Number> & elem_soln,
-                                std::vector<Number> & nodal_soln)
+                                std::vector<Number> & nodal_soln,
+                                const bool add_p_level)
 {
-  monomial_vec_nodal_soln(elem, order, elem_soln, 2 /*dimension*/, nodal_soln);
+  monomial_vec_nodal_soln(elem, order, elem_soln, 2 /*dimension*/, nodal_soln, add_p_level);
 }
 
 template <>
@@ -160,9 +164,10 @@ void
 FE<3, MONOMIAL_VEC>::nodal_soln(const Elem * elem,
                                 const Order order,
                                 const std::vector<Number> & elem_soln,
-                                std::vector<Number> & nodal_soln)
+                                std::vector<Number> & nodal_soln,
+                                const bool add_p_level)
 {
-  monomial_vec_nodal_soln(elem, order, elem_soln, 3 /*dimension*/, nodal_soln);
+  monomial_vec_nodal_soln(elem, order, elem_soln, 3 /*dimension*/, nodal_soln, add_p_level);
 }
 
 LIBMESH_FE_SIDE_NODAL_SOLN(MONOMIAL_VEC)

--- a/src/fe/fe_nedelec_one.C
+++ b/src/fe/fe_nedelec_one.C
@@ -43,12 +43,13 @@ void nedelec_one_nodal_soln(const Elem * elem,
                             const Order order,
                             const std::vector<Number> & elem_soln,
                             const int dim,
-                            std::vector<Number> & nodal_soln)
+                            std::vector<Number> & nodal_soln,
+                            const bool add_p_level)
 {
   const unsigned int n_nodes = elem->n_nodes();
   const ElemType elem_type   = elem->type();
 
-  const Order totalorder = static_cast<Order>(order + elem->p_level());
+  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
 
   nodal_soln.resize(n_nodes*dim);
 
@@ -444,29 +445,33 @@ template <>
 void FE<0,NEDELEC_ONE>::nodal_soln(const Elem *,
                                    const Order,
                                    const std::vector<Number> &,
-                                   std::vector<Number> &)
+                                   std::vector<Number> &,
+                                   bool)
 { NEDELEC_LOW_D_ERROR_MESSAGE }
 
 template <>
 void FE<1,NEDELEC_ONE>::nodal_soln(const Elem *,
                                    const Order,
                                    const std::vector<Number> &,
-                                   std::vector<Number> &)
+                                   std::vector<Number> &,
+                                   bool)
 { NEDELEC_LOW_D_ERROR_MESSAGE }
 
 template <>
 void FE<2,NEDELEC_ONE>::nodal_soln(const Elem * elem,
                                    const Order order,
                                    const std::vector<Number> & elem_soln,
-                                   std::vector<Number> & nodal_soln)
-{ nedelec_one_nodal_soln(elem, order, elem_soln, 2 /*dim*/, nodal_soln); }
+                                   std::vector<Number> & nodal_soln,
+                                   const bool add_p_level)
+{ nedelec_one_nodal_soln(elem, order, elem_soln, 2 /*dim*/, nodal_soln, add_p_level); }
 
 template <>
 void FE<3,NEDELEC_ONE>::nodal_soln(const Elem * elem,
                                    const Order order,
                                    const std::vector<Number> & elem_soln,
-                                   std::vector<Number> & nodal_soln)
-{ nedelec_one_nodal_soln(elem, order, elem_soln, 3 /*dim*/, nodal_soln); }
+                                   std::vector<Number> & nodal_soln,
+                                   const bool add_p_level)
+{ nedelec_one_nodal_soln(elem, order, elem_soln, 3 /*dim*/, nodal_soln, add_p_level); }
 
 LIBMESH_FE_SIDE_NODAL_SOLN(NEDELEC_ONE)
 

--- a/src/fe/fe_rational.C
+++ b/src/fe/fe_rational.C
@@ -37,7 +37,8 @@ static const FEFamily _underlying_fe_family = BERNSTEIN;
 void rational_nodal_soln(const Elem * elem,
                          const Order order,
                          const std::vector<Number> & elem_soln,
-                         std::vector<Number> & nodal_soln)
+                         std::vector<Number> & nodal_soln,
+                         const bool add_p_level)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -45,7 +46,7 @@ void rational_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = static_cast<Order>(order + elem->p_level());
+  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, _underlying_fe_family);

--- a/src/fe/fe_raviart.C
+++ b/src/fe/fe_raviart.C
@@ -43,12 +43,13 @@ void raviart_thomas_nodal_soln(const Elem * elem,
                                const Order order,
                                const std::vector<Number> & elem_soln,
                                const int dim,
-                               std::vector<Number> & nodal_soln)
+                               std::vector<Number> & nodal_soln,
+                               const bool add_p_level)
 {
   const unsigned int n_nodes = elem->n_nodes();
   const ElemType elem_type   = elem->type();
 
-  const Order totalorder = static_cast<Order>(order + elem->p_level());
+  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
 
   nodal_soln.resize(n_nodes*dim);
 
@@ -379,29 +380,33 @@ template <>
 void FE<0,RAVIART_THOMAS>::nodal_soln(const Elem *,
                                       const Order,
                                       const std::vector<Number> &,
-                                      std::vector<Number> &)
+                                      std::vector<Number> &,
+                                      bool)
 { RAVIART_LOW_D_ERROR_MESSAGE }
 
 template <>
 void FE<1,RAVIART_THOMAS>::nodal_soln(const Elem *,
                                       const Order,
                                       const std::vector<Number> &,
-                                      std::vector<Number> &)
+                                      std::vector<Number> &,
+                                      bool)
 { RAVIART_LOW_D_ERROR_MESSAGE }
 
 template <>
 void FE<2,RAVIART_THOMAS>::nodal_soln(const Elem * elem,
                                       const Order order,
                                       const std::vector<Number> & elem_soln,
-                                      std::vector<Number> & nodal_soln)
-{ raviart_thomas_nodal_soln(elem, order, elem_soln, 2 /*dim*/, nodal_soln); }
+                                      std::vector<Number> & nodal_soln,
+                                      const bool add_p_level)
+{ raviart_thomas_nodal_soln(elem, order, elem_soln, 2 /*dim*/, nodal_soln, add_p_level); }
 
 template <>
 void FE<3,RAVIART_THOMAS>::nodal_soln(const Elem * elem,
                                       const Order order,
                                       const std::vector<Number> & elem_soln,
-                                      std::vector<Number> & nodal_soln)
-{ raviart_thomas_nodal_soln(elem, order, elem_soln, 3 /*dim*/, nodal_soln); }
+                                      std::vector<Number> & nodal_soln,
+                                      const bool add_p_level)
+{ raviart_thomas_nodal_soln(elem, order, elem_soln, 3 /*dim*/, nodal_soln, add_p_level); }
 
 LIBMESH_FE_SIDE_NODAL_SOLN(RAVIART_THOMAS)
 

--- a/src/fe/fe_scalar.C
+++ b/src/fe/fe_scalar.C
@@ -35,7 +35,8 @@ namespace {
 void scalar_nodal_soln(const Elem * elem,
                        const Order order,
                        const std::vector<Number> & elem_soln,
-                       std::vector<Number> &       nodal_soln)
+                       std::vector<Number> &       nodal_soln,
+                       const bool /*add_p_level*/)
 {
   const unsigned int n_nodes = elem->n_nodes();
   nodal_soln.resize(n_nodes);

--- a/src/fe/fe_side_hierarchic.C
+++ b/src/fe/fe_side_hierarchic.C
@@ -36,7 +36,8 @@ namespace {
 void side_hierarchic_nodal_soln(const Elem * elem,
                                 const Order /* order */,
                                 const std::vector<Number> & /* elem_soln */,
-                                std::vector<Number> & nodal_soln)
+                                std::vector<Number> & nodal_soln,
+                                const bool /*add_p_level*/)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -54,7 +55,8 @@ void side_hierarchic_side_nodal_soln
   (const Elem * elem, const Order o,
    const unsigned int side,
    const std::vector<Number> & elem_soln,
-   std::vector<Number> & nodal_soln_on_side)
+   std::vector<Number> & nodal_soln_on_side,
+   const bool /*add_p_level*/)
 {
   // Cheat here for now: perturb vertices toward the side center so as
   // to make the values well-defined.
@@ -186,7 +188,8 @@ void FE<0, SIDE_HIERARCHIC>::side_nodal_soln
   (const Elem *, const Order,
    const unsigned int,
    const std::vector<Number> &,
-   std::vector<Number> &)
+   std::vector<Number> &,
+   bool)
 {
   libmesh_error_msg("No side variables in 0D!");
 }
@@ -196,7 +199,8 @@ void FE<1, SIDE_HIERARCHIC>::side_nodal_soln
   (const Elem *, const Order,
    const unsigned int side,
    const std::vector<Number> & elem_soln,
-   std::vector<Number> & nodal_soln_on_side)
+   std::vector<Number> & nodal_soln_on_side,
+   const bool /*add_p_level*/)
 {
   libmesh_assert_less(side, 2);
   nodal_soln_on_side.resize(1);
@@ -209,11 +213,13 @@ void FE<2, SIDE_HIERARCHIC>::side_nodal_soln
   (const Elem * elem, const Order o,
    const unsigned int side,
    const std::vector<Number> & elem_soln,
-   std::vector<Number> & nodal_soln_on_side)
+   std::vector<Number> & nodal_soln_on_side,
+   const bool add_p_level)
 {
   libmesh_assert_equal_to(elem->dim(), 2);
   side_hierarchic_side_nodal_soln(elem, o, side, elem_soln,
-                                  nodal_soln_on_side);
+                                  nodal_soln_on_side,
+                                  add_p_level);
 }
 
 
@@ -222,11 +228,13 @@ void FE<3, SIDE_HIERARCHIC>::side_nodal_soln
   (const Elem * elem, const Order o,
    const unsigned int side,
    const std::vector<Number> & elem_soln,
-   std::vector<Number> & nodal_soln_on_side)
+   std::vector<Number> & nodal_soln_on_side,
+   const bool add_p_level)
 {
   libmesh_assert_equal_to(elem->dim(), 3);
   side_hierarchic_side_nodal_soln(elem, o, side, elem_soln,
-                                  nodal_soln_on_side);
+                                  nodal_soln_on_side,
+                                  add_p_level);
 }
 
 

--- a/src/fe/fe_subdivision_2D.C
+++ b/src/fe/fe_subdivision_2D.C
@@ -882,7 +882,8 @@ template <>
 void FE<2,SUBDIVISION>::nodal_soln(const Elem * elem,
                                    const Order,
                                    const std::vector<Number> & elem_soln,
-                                   std::vector<Number> & nodal_soln)
+                                   std::vector<Number> & nodal_soln,
+                                   const bool /*add_p_level*/)
 {
   libmesh_assert(elem);
   libmesh_assert_equal_to(elem->type(), TRI3SUBDIVISION);

--- a/src/fe/fe_szabab.C
+++ b/src/fe/fe_szabab.C
@@ -39,7 +39,8 @@ namespace {
 void szabab_nodal_soln(const Elem * elem,
                        const Order order,
                        const std::vector<Number> & elem_soln,
-                       std::vector<Number> & nodal_soln)
+                       std::vector<Number> & nodal_soln,
+                       const bool add_p_level)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
@@ -47,7 +48,7 @@ void szabab_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = static_cast<Order>(order + elem->p_level());
+  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, SZABAB);

--- a/src/fe/fe_xyz.C
+++ b/src/fe/fe_xyz.C
@@ -38,13 +38,14 @@ namespace {
 void xyz_nodal_soln(const Elem * elem,
                     const Order order,
                     const std::vector<Number> & elem_soln,
-                    std::vector<Number> & nodal_soln)
+                    std::vector<Number> & nodal_soln,
+                    const bool add_p_level)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = static_cast<Order>(order + elem->p_level());
+  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
 
   switch (totalorder)
     {

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -2025,13 +2025,14 @@ FEMContext::build_new_fe( const FEGenericBase<OutputShape>* fe,
   libmesh_assert(this->has_elem() || fe_type.family == SCALAR);
 
 #ifdef LIBMESH_ENABLE_AMR
+  const bool add_p_level = fe->add_p_level_in_reinit();
   if ((algebraic_type() == OLD) &&
       this->has_elem())
     {
       if (this->get_elem().p_refinement_flag() == Elem::JUST_REFINED)
-        fe_type.order = static_cast<Order>(fe_type.order - 1);
+        fe_type.order = static_cast<Order>(fe_type.order - add_p_level);
       else if (this->get_elem().p_refinement_flag() == Elem::JUST_COARSENED)
-        fe_type.order = static_cast<Order>(fe_type.order + 1);
+        fe_type.order = static_cast<Order>(fe_type.order + add_p_level);
     }
 #endif // LIBMESH_ENABLE_AMR
 
@@ -2039,6 +2040,9 @@ FEMContext::build_new_fe( const FEGenericBase<OutputShape>* fe,
 
   FEGenericBase<OutputShape>* fe_new =
     cached_fe<OutputShape>(elem_dim, fe_type, get_derivative_level);
+#ifdef LIBMESH_ENABLE_AMR
+  fe_new->add_p_level_in_reinit(add_p_level);
+#endif // LIBMESH_ENABLE_AMR
 
   // Map the physical co-ordinates to the master co-ordinates using the inverse_map from fe_interface.h
   // Build a vector of point co-ordinates to send to reinit


### PR DESCRIPTION
Disabling p refinement now working for these explicit test cases
- first order Lagrange on first order mesh
- first order Lagrange on second order mesh
- third order Hermite on first order mesh
- third order Hermite on second order mesh
- first order hierarchic on first order mesh
- first order hierarchic on second order mesh
- first order Lagrange vec on first order mesh
- first order Lagrange vec on second order mesh
- first order monomial vec on first order mesh
- first order monomial vec on second order mesh
- first order Nedelec on second order mesh

Refs idaholab/moose#25108