### PR TITLE
Fix missing header, refactor with Threads::DisablePerfLogInScope

### DIFF
--- a/include/parallel/threads.h
+++ b/include/parallel/threads.h
@@ -70,8 +70,8 @@ class DisablePerfLogInScope
 {
 public:
 #ifndef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  DisablePerfLogInScope() {}
-  ~DisablePerfLogInScope() {}
+  DisablePerfLogInScope() = default;
+  ~DisablePerfLogInScope() = default;
 #else
   DisablePerfLogInScope();
   ~DisablePerfLogInScope();

--- a/include/parallel/threads.h
+++ b/include/parallel/threads.h
@@ -61,6 +61,25 @@ private:
   bool & _b;
 };
 
+/**
+ * We use a class to turn perf logging off and on within threads, to
+ * be exception-safe and to avoid forcing indirect inclusion of
+ * libmesh_logging.h everywhere.
+ */
+class DisablePerfLogInScope
+{
+public:
+#ifndef LIBMESH_ENABLE_PERFORMANCE_LOGGING
+  DisablePerfLogInScope() {}
+  ~DisablePerfLogInScope() {}
+#else
+  DisablePerfLogInScope();
+  ~DisablePerfLogInScope();
+private:
+  const bool _logging_was_enabled;
+#endif
+};
+
 
 /**
  * Simple compatibility class for std::thread 'concurrent' execution.

--- a/include/parallel/threads.h
+++ b/include/parallel/threads.h
@@ -65,8 +65,11 @@ private:
  * We use a class to turn perf logging off and on within threads, to
  * be exception-safe and to avoid forcing indirect inclusion of
  * libmesh_logging.h everywhere.
+ *
+ * If we have logging disabled, constructing this class should do
+ * nothing; [[maybe_unused]] disables warnings about that.
  */
-class DisablePerfLogInScope
+class [[maybe_unused]] DisablePerfLogInScope
 {
 public:
 #ifndef LIBMESH_ENABLE_PERFORMANCE_LOGGING

--- a/include/parallel/threads_pthread.h
+++ b/include/parallel/threads_pthread.h
@@ -31,7 +31,6 @@
 # include <thread>
 #endif
 
-#include "libmesh/libmesh_logging.h"
 #include <pthread.h>
 #include <algorithm>
 #include <vector>
@@ -278,12 +277,8 @@ void parallel_for (const Range & range, const Body & body)
     return;
   }
 
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  const bool logging_was_enabled = libMesh::perflog.logging_enabled();
+  DisablePerfLogInScope disable_perf;
 
-  if (libMesh::n_threads() > 1)
-    libMesh::perflog.disable_logging();
-#endif
   unsigned int n_threads = num_pthreads(range);
 
   std::vector<Range *> ranges(n_threads);
@@ -346,11 +341,6 @@ void parallel_for (const Range & range, const Body & body)
   // Clean up
   for (unsigned int i=0; i<n_threads; i++)
     delete ranges[i];
-
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  if (libMesh::n_threads() > 1 && logging_was_enabled)
-    libMesh::perflog.enable_logging();
-#endif
 }
 
 /**
@@ -381,12 +371,7 @@ void parallel_reduce (const Range & range, Body & body)
     return;
   }
 
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  const bool logging_was_enabled = libMesh::perflog.logging_enabled();
-
-  if (libMesh::n_threads() > 1)
-    libMesh::perflog.disable_logging();
-#endif
+  DisablePerfLogInScope disable_perf;
 
   unsigned int n_threads = num_pthreads(range);
 
@@ -462,11 +447,6 @@ void parallel_reduce (const Range & range, Body & body)
     delete bodies[i];
   for (unsigned int i=0; i<n_threads; i++)
     delete ranges[i];
-
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  if (libMesh::n_threads() > 1 && logging_was_enabled)
-    libMesh::perflog.enable_logging();
-#endif
 }
 
 /**

--- a/include/parallel/threads_tbb.h
+++ b/include/parallel/threads_tbb.h
@@ -28,8 +28,6 @@
 #ifdef LIBMESH_HAVE_TBB_API
 
 // libMesh includes
-#include "libmesh/libmesh_logging.h"
-
 #include "libmesh/ignore_warnings.h"
 
 // Threading building blocks includes
@@ -88,23 +86,13 @@ void parallel_for (const Range & range, const Body & body)
 {
   BoolAcquire b(in_threads);
 
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  const bool logging_was_enabled = libMesh::perflog.logging_enabled();
-
   if (libMesh::n_threads() > 1)
-    libMesh::perflog.disable_logging();
-#endif
-
-  if (libMesh::n_threads() > 1)
-    tbb::parallel_for (range, body, tbb::auto_partitioner());
-
+    {
+      DisablePerfLogInScope disable_perf;
+      tbb::parallel_for (range, body, tbb::auto_partitioner());
+    }
   else
     body(range);
-
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  if (libMesh::n_threads() > 1 && logging_was_enabled)
-    libMesh::perflog.enable_logging();
-#endif
 }
 
 
@@ -119,23 +107,13 @@ void parallel_for (const Range & range, const Body & body, const Partitioner & p
 {
   BoolAcquire b(in_threads);
 
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  const bool logging_was_enabled = libMesh::perflog.logging_enabled();
-
   if (libMesh::n_threads() > 1)
-    libMesh::perflog.disable_logging();
-#endif
-
-  if (libMesh::n_threads() > 1)
-    tbb::parallel_for (range, body, partitioner);
-
+    {
+      DisablePerfLogInScope disable_perf;
+      tbb::parallel_for (range, body, partitioner);
+    }
   else
     body(range);
-
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  if (libMesh::n_threads() > 1 && logging_was_enabled)
-    libMesh::perflog.enable_logging();
-#endif
 }
 
 
@@ -150,23 +128,13 @@ void parallel_reduce (const Range & range, Body & body)
 {
   BoolAcquire b(in_threads);
 
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  const bool logging_was_enabled = libMesh::perflog.logging_enabled();
-
   if (libMesh::n_threads() > 1)
-    libMesh::perflog.disable_logging();
-#endif
-
-  if (libMesh::n_threads() > 1)
-    tbb::parallel_reduce (range, body, tbb::auto_partitioner());
-
+    {
+      DisablePerfLogInScope disable_perf;
+      tbb::parallel_reduce (range, body, tbb::auto_partitioner());
+    }
   else
     body(range);
-
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  if (libMesh::n_threads() > 1 && logging_was_enabled)
-    libMesh::perflog.enable_logging();
-#endif
 }
 
 
@@ -181,23 +149,13 @@ void parallel_reduce (const Range & range, Body & body, const Partitioner & part
 {
   BoolAcquire b(in_threads);
 
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  const bool logging_was_enabled = libMesh::perflog.logging_enabled();
-
   if (libMesh::n_threads() > 1)
-    libMesh::perflog.disable_logging();
-#endif
-
-  if (libMesh::n_threads() > 1)
-    tbb::parallel_reduce (range, body, partitioner);
-
+    {
+      DisablePerfLogInScope disable_perf;
+      tbb::parallel_reduce (range, body, partitioner);
+    }
   else
     body(range);
-
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  if (libMesh::n_threads() > 1 && logging_was_enabled)
-    libMesh::perflog.enable_logging();
-#endif
 }
 
 

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -28,6 +28,7 @@
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/function_base.h"
 #include "libmesh/hashing.h"
+#include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_serializer.h"
 #include "libmesh/mesh_smoother_laplace.h"
 #include "libmesh/mesh_triangle_holes.h"

--- a/src/parallel/threads.C
+++ b/src/parallel/threads.C
@@ -16,10 +16,10 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// System Includes
-
-// Local Includes
 #include "libmesh/threads.h"
+
+// libMesh includes
+#include "libmesh/libmesh_logging.h"
 
 namespace libMesh
 {
@@ -33,5 +33,20 @@ bool in_threads = false;
 
 void lock_singleton_spin_mutex() { spin_mtx.lock(); }
 void unlock_singleton_spin_mutex() { spin_mtx.unlock(); }
+
+#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
+DisablePerfLogInScope::DisablePerfLogInScope() :
+  _logging_was_enabled(libMesh::perflog.logging_enabled())
+{
+  libMesh::perflog.disable_logging();
+}
+
+DisablePerfLogInScope::~DisablePerfLogInScope()
+{
+  if (_logging_was_enabled)
+    libMesh::perflog.enable_logging();
+}
+#endif
+
 }
 } // namespace libMesh


### PR DESCRIPTION
In poly2tri_triangulator.C we were getting libmesh_logging.h indirectly from threads_foo.h of all places, in a way that broke if neither of TBB and pthreads were available.  See #3659.

After fixing that, I figured I'd avoid the problem happening again, by getting that header out of the threads headers and into threads.C ... which turns out to be a cleaner and more exception-safe solution too.

We should wait on merging this until Logan's done with the CI backend transition.