### PR TITLE
Fix missing libmesh_logging.h includes

### DIFF
--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -31,6 +31,7 @@
 #include "libmesh/rb_eim_evaluation.h"
 #include "libmesh/rb_scm_evaluation.h"
 #include "libmesh/rb_parametrized_function.h"
+#include "libmesh/libmesh_logging.h"
 
 // Cap'n'Proto includes
 #include "capnp/serialize.h"

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -32,6 +32,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/int_range.h"
 #include "libmesh/rb_parametrized_function.h"
+#include "libmesh/libmesh_logging.h"
 
 // Cap'n'Proto includes
 #include <capnp/serialize.h>


### PR DESCRIPTION
These were not caught by CI because we don't have any CIVET recipes that define `LIBMESH_HAVE_CAPNPROTO`.
