### PR TITLE
Compute L2 error for the scalar field in Vector FE ex6

### DIFF
--- a/doc/html/examples/vector_fe_ex6.html
+++ b/doc/html/examples/vector_fe_ex6.html
@@ -88,9 +88,12 @@
     DofMap Constraints
       Number of DoF Constraints = 0
 
-L2 error is: 0.134332
-HDiv semi-norm error is: 0.344122
-HDiv error is: 0.369411
+~~ Vector field (u) ~~
+L2 error is: 0.134373
+HDiv semi-norm error is: 0.344042
+HDiv error is: 0.369353
+~~ Scalar field (p) ~~
+L2 error is: 0.0697862
 
 ***************************************************************
 * Done Running Example vector_fe_ex6:
@@ -141,9 +144,12 @@ HDiv error is: 0.369411
     DofMap Constraints
       Number of DoF Constraints = 0
 
-L2 error is: 0.134332
-HDiv semi-norm error is: 0.344122
-HDiv error is: 0.369411
+~~ Vector field (u) ~~
+L2 error is: 0.134373
+HDiv semi-norm error is: 0.344042
+HDiv error is: 0.369353
+~~ Scalar field (p) ~~
+L2 error is: 0.0697862
 
 ***************************************************************
 * Done Running Example vector_fe_ex6:
@@ -194,9 +200,12 @@ HDiv error is: 0.369411
     DofMap Constraints
       Number of DoF Constraints = 0
 
-L2 error is: 0.13447
-HDiv semi-norm error is: 0.4213
-HDiv error is: 0.44224
+~~ Vector field (u) ~~
+L2 error is: 0.134503
+HDiv semi-norm error is: 0.421249
+HDiv error is: 0.442201
+~~ Scalar field (p) ~~
+L2 error is: 0.0854505
 
 ***************************************************************
 * Done Running Example vector_fe_ex6:
@@ -247,9 +256,12 @@ HDiv error is: 0.44224
     DofMap Constraints
       Number of DoF Constraints = 0
 
-L2 error is: 0.13447
-HDiv semi-norm error is: 0.4213
-HDiv error is: 0.44224
+~~ Vector field (u) ~~
+L2 error is: 0.134503
+HDiv semi-norm error is: 0.421249
+HDiv error is: 0.442201
+~~ Scalar field (p) ~~
+L2 error is: 0.0854505
 
 ***************************************************************
 * Done Running Example vector_fe_ex6:
@@ -300,9 +312,12 @@ HDiv error is: 0.44224
     DofMap Constraints
       Number of DoF Constraints = 0
 
-L2 error is: 0.334676
-HDiv semi-norm error is: 0.83716
-HDiv error is: 0.90158
+~~ Vector field (u) ~~
+L2 error is: 0.334771
+HDiv semi-norm error is: 0.836328
+HDiv error is: 0.900842
+~~ Scalar field (p) ~~
+L2 error is: 0.113127
 
 ***************************************************************
 * Done Running Example vector_fe_ex6:
@@ -353,9 +368,12 @@ HDiv error is: 0.90158
     DofMap Constraints
       Number of DoF Constraints = 0
 
-L2 error is: 0.232486
-HDiv semi-norm error is: 0.773271
-HDiv error is: 0.807464
+~~ Vector field (u) ~~
+L2 error is: 0.2325
+HDiv semi-norm error is: 0.773177
+HDiv error is: 0.807378
+~~ Scalar field (p) ~~
+L2 error is: 0.104528
 
 ***************************************************************
 * Done Running Example vector_fe_ex6:
@@ -406,9 +424,12 @@ HDiv error is: 0.807464
     DofMap Constraints
       Number of DoF Constraints = 0
 
-L2 error is: 0.134238
-HDiv semi-norm error is: 0.344122
-HDiv error is: 0.369377
+~~ Vector field (u) ~~
+L2 error is: 0.134279
+HDiv semi-norm error is: 0.344042
+HDiv error is: 0.369318
+~~ Scalar field (p) ~~
+L2 error is: 0.0697398
 
 ***************************************************************
 * Done Running Example vector_fe_ex6:
@@ -459,9 +480,12 @@ HDiv error is: 0.369377
     DofMap Constraints
       Number of DoF Constraints = 0
 
-L2 error is: 0.134238
-HDiv semi-norm error is: 0.344122
-HDiv error is: 0.369377
+~~ Vector field (u) ~~
+L2 error is: 0.134279
+HDiv semi-norm error is: 0.344042
+HDiv error is: 0.369318
+~~ Scalar field (p) ~~
+L2 error is: 0.0697398
 
 ***************************************************************
 * Done Running Example vector_fe_ex6:
@@ -512,9 +536,12 @@ HDiv error is: 0.369377
     DofMap Constraints
       Number of DoF Constraints = 0
 
-L2 error is: 0.134301
-HDiv semi-norm error is: 0.4213
-HDiv error is: 0.442188
+~~ Vector field (u) ~~
+L2 error is: 0.134333
+HDiv semi-norm error is: 0.421249
+HDiv error is: 0.442149
+~~ Scalar field (p) ~~
+L2 error is: 0.0853821
 
 ***************************************************************
 * Done Running Example vector_fe_ex6:
@@ -565,9 +592,12 @@ HDiv error is: 0.442188
     DofMap Constraints
       Number of DoF Constraints = 0
 
-L2 error is: 0.134301
-HDiv semi-norm error is: 0.4213
-HDiv error is: 0.442188
+~~ Vector field (u) ~~
+L2 error is: 0.134333
+HDiv semi-norm error is: 0.421249
+HDiv error is: 0.442149
+~~ Scalar field (p) ~~
+L2 error is: 0.0853821
 
 ***************************************************************
 * Done Running Example vector_fe_ex6:
@@ -618,9 +648,12 @@ HDiv error is: 0.442188
     DofMap Constraints
       Number of DoF Constraints = 0
 
-L2 error is: 0.334634
-HDiv semi-norm error is: 0.83716
-HDiv error is: 0.901564
+~~ Vector field (u) ~~
+L2 error is: 0.33473
+HDiv semi-norm error is: 0.836328
+HDiv error is: 0.900826
+~~ Scalar field (p) ~~
+L2 error is: 0.113105
 
 ***************************************************************
 * Done Running Example vector_fe_ex6:
@@ -671,9 +704,12 @@ HDiv error is: 0.901564
     DofMap Constraints
       Number of DoF Constraints = 0
 
-L2 error is: 0.232356
-HDiv semi-norm error is: 0.773271
-HDiv error is: 0.807426
+~~ Vector field (u) ~~
+L2 error is: 0.23237
+HDiv semi-norm error is: 0.773177
+HDiv error is: 0.807341
+~~ Scalar field (p) ~~
+L2 error is: 0.104476
 
 ***************************************************************
 * Done Running Example vector_fe_ex6:

--- a/examples/vector_fe/vector_fe_ex6/vector_fe_ex6.C
+++ b/examples/vector_fe/vector_fe_ex6/vector_fe_ex6.C
@@ -151,7 +151,7 @@ int main (int argc, char ** argv)
   // Declare the system  "DivGrad" and its variables.
   LinearImplicitSystem & system = equation_systems.add_system<LinearImplicitSystem>("DivGrad");
 
-  // Adds the variable "u" and "p" to "DivGrad". "u" will be our vector field
+  // Adds the variables "u" and "p" to "DivGrad". "u" will be our vector field
   // whereas "p" will be the scalar field.
   system.add_variable("u", FIRST, RAVIART_THOMAS);
   system.add_variable("p", CONSTANT, MONOMIAL);
@@ -179,8 +179,8 @@ int main (int argc, char ** argv)
 
   if (dimension == 2)
     {
-      SolutionFunction<2> soln_func(system.variable_number("u"));
-      SolutionGradient<2> soln_grad(system.variable_number("u"));
+      SolutionFunction<2> soln_func;
+      SolutionGradient<2> soln_grad;
 
       // Build FunctionBase* containers to attach to the ExactSolution object.
       std::vector<FunctionBase<Number> *> sols(1, &soln_func);
@@ -191,8 +191,8 @@ int main (int argc, char ** argv)
     }
   else if (dimension == 3)
     {
-      SolutionFunction<3> soln_func(system.variable_number("u"));
-      SolutionGradient<3> soln_grad(system.variable_number("u"));
+      SolutionFunction<3> soln_func;
+      SolutionGradient<3> soln_grad;
 
       // Build FunctionBase* containers to attach to the ExactSolution object.
       std::vector<FunctionBase<Number> *> sols(1, &soln_func);
@@ -208,8 +208,11 @@ int main (int argc, char ** argv)
 
   // Compute the error.
   exact_sol.compute_error("DivGrad", "u");
+  exact_sol.compute_error("DivGrad", "p");
 
   // Print out the error values.
+  libMesh::out << "~~ Vector field (u) ~~"
+               << std::endl;
   libMesh::out << "L2 error is: "
                << exact_sol.l2_error("DivGrad", "u")
                << std::endl;
@@ -218,6 +221,11 @@ int main (int argc, char ** argv)
                << std::endl;
   libMesh::out << "HDiv error is: "
                << exact_sol.hdiv_error("DivGrad", "u")
+               << std::endl;
+  libMesh::out << "~~ Scalar field (p) ~~"
+               << std::endl;
+  libMesh::out << "L2 error is: "
+               << exact_sol.l2_error("DivGrad", "p")
                << std::endl;
 
 #ifdef LIBMESH_HAVE_EXODUS_API

--- a/examples/vector_fe/vector_fe_ex6/vector_fe_ex6.in
+++ b/examples/vector_fe/vector_fe_ex6/vector_fe_ex6.in
@@ -8,7 +8,7 @@ element_type = TRI6
 grid_size = 15
 
 # Higher quadrature order for more accurate error results
-extra_error_quadrature = 0
+extra_error_quadrature = 2
 
 # Whether the boundary condition applied for p corresponds to a Dirichlet or
 # Neumann condition. Note that a Neumann condition for p in the mixed

--- a/include/numerics/function_base.h
+++ b/include/numerics/function_base.h
@@ -48,9 +48,10 @@ class Point;
  * allow the convenient and libMesh-common usage through a \p FunctionBase *.
  *
  * \note For functor objects for vector-valued variables, it is
- * assumed each component is indexed contiguously; i.e. if u_var is
- * index 3, then libMesh expects the x-component of u_var is index 3,
- * the y-component is index 4, and the z-component is index 5.
+ * assumed each component is indexed contiguously; e.g. if u_var is a
+ * 3d vector-valued variable at index 3, following some scalar-valued variables
+ * at indices 0, 1, and 2, then libMesh expects the x-component of u_var to be
+ * at index 3, the y-component at index 4, and the z-component at index 5.
  *
  * \note For 2-D elements in 3 spatial dimensions, libMesh is expecting
  * 2 components (i.e. mesh_dimension() number of components).
@@ -136,6 +137,10 @@ public:
    * \note Subclasses are recommended to override this, since the default
    * implementation is based on a vector evaluation, which is usually
    * unnecessarily inefficient.
+   *
+   * \note The default implementation calls operator() with a DenseVector of
+   * size \p i+1 which will result in unexpected behaviour if operator()
+   * makes any access beyond that limit.
    */
   virtual Output component(unsigned int i,
                            const Point & p,

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -469,12 +469,19 @@ void ExactSolution::_compute_error(std::string_view sys_name,
     _equation_systems_fine->get_system(sys_name) :
     _equation_systems.get_system (sys_name);
 
+  const MeshBase & mesh = computed_system.get_mesh();
+
   const Real time = _equation_systems.get_system(sys_name).time;
 
   const unsigned int sys_num = computed_system.number();
   const unsigned int var = computed_system.variable_number(unknown_name);
-  const unsigned int var_component =
-    computed_system.variable_scalar_number(var, 0);
+  unsigned int var_component = 0;
+  for (const auto var_num : make_range(var))
+  {
+    const auto & var_fe_type = computed_system.variable_type(var_num);
+    const auto var_vec_dim = FEInterface::n_vec_dim(mesh, var_fe_type);
+    var_component += var_vec_dim;
+  }
 
   // Prepare a global solution, a serialized mesh, and a MeshFunction
   // of the coarse system, if we need them for fine-system integration
@@ -517,8 +524,6 @@ void ExactSolution::_compute_error(std::string_view sys_name,
 
   // Get a reference to the dofmap and mesh for that system
   const DofMap & computed_dof_map = computed_system.get_dof_map();
-
-  const MeshBase & mesh = computed_system.get_mesh();
 
   // Grab which element dimensions are present in the mesh
   const std::set<unsigned char> & elem_dims = mesh.elem_dimensions();


### PR DESCRIPTION
I was curious about what Alex (@lindsayad) noted yesterday in #3638 and couldn't resist trying to reproduce it.
My observations are exactly the same, and upping the quadrature order for the error computation does bring back the linear trend (phew.....).

I've done this the lazy way, i.e., I'm just creating new `ExactSolution` and `FunctionBase` objects... It seems that if I reverse the order in which I add the vector and scalar variables to the system, add thus the way in which I assemble the system as well, that I could then use the same `ExactSolution` and `FunctionBase` objects we already have... But what if I had more than one vector variable in the system? If I understand the following correctly,

https://github.com/libMesh/libmesh/blob/edc105866bac6e574ddc182352fcd032bda19b0e/include/numerics/function_base.h#L50-L53

I can only have one vector variable, and it must be the last one to be added to the system?
I'll update the html file with the new outputs if you're both happy with this. If Alex already has a better implementation, I'm happy to drop this as well, no worries. :)

Cheers,
-Nuno