### PR TITLE
Have ExactSolution properly handle vector variables

### DIFF
--- a/examples/vector_fe/vector_fe_ex6/solution_function.h
+++ b/examples/vector_fe/vector_fe_ex6/solution_function.h
@@ -71,6 +71,8 @@ void SolutionFunction<2>::operator() (const Point & p,
   // contiguously.
   output(_u_var)   = soln(x, y)(0);
   output(_u_var+1) = soln(x, y)(1);
+  // scalar solution
+  output(_u_var+2) = soln.scalar(x, y);
 }
 
 template<>
@@ -85,6 +87,8 @@ void SolutionFunction<3>::operator() (const Point & p,
   output(_u_var)   = soln(x, y, z)(0);
   output(_u_var+1) = soln(x, y, z)(1);
   output(_u_var+2) = soln(x, y, z)(2);
+  // scalar solution
+  output(_u_var+3) = soln.scalar(x, y);
 }
 
 template<>
@@ -93,7 +97,10 @@ Number SolutionFunction<2>::component(unsigned int component_in,
                                       const Real)
 {
   const Real x=p(0), y=p(1);
-  return soln(x, y)(component_in);
+  if (component_in == 2)
+    return soln.scalar(x, y);
+  else
+    return soln(x, y)(component_in);
 }
 
 template<>
@@ -102,7 +109,10 @@ Number SolutionFunction<3>::component(unsigned int component_in,
                                       const Real)
 {
   const Real x=p(0), y=p(1), z=p(2);
-  return soln(x, y, z)(component_in);
+  if (component_in == 3)
+    return soln.scalar(x, y);
+  else
+    return soln(x, y, z)(component_in);
 }
 
 template<unsigned int dim>
@@ -164,7 +174,11 @@ Gradient SolutionGradient<2>::component(unsigned int component_in,
                                         const Real)
 {
   const Real x=p(0), y=p(1);
-  return soln.grad(x, y).row(component_in);
+  if (component_in == 2)
+    // Only interested in L2 norms for the scalar field
+    return {};
+  else
+    return soln.grad(x, y).row(component_in);
 }
 
 template<>
@@ -173,6 +187,9 @@ Gradient SolutionGradient<3>::component(unsigned int component_in,
                                         const Real)
 {
   const Real x=p(0), y=p(1), z=p(2);
+  if (component_in == 3)
+    // Only interested in L2 norms for the scalar field
+    return {};
   return soln.grad(x, y, z).row(component_in);
 }
 

--- a/examples/vector_fe/vector_fe_ex6/solution_function.h
+++ b/examples/vector_fe/vector_fe_ex6/solution_function.h
@@ -34,9 +34,7 @@ class SolutionFunction : public FunctionBase<Number>
 {
 public:
 
-  SolutionFunction(const unsigned int u_var)
-    : _u_var(u_var) {}
-
+  SolutionFunction() = default;
   ~SolutionFunction() = default;
 
   virtual Number operator() (const Point &,
@@ -52,11 +50,10 @@ public:
                            const Real);
 
   virtual std::unique_ptr<FunctionBase<Number>> clone() const
-  { return std::make_unique<SolutionFunction>(_u_var); }
+  { return std::make_unique<SolutionFunction>(); }
 
 private:
 
-  const unsigned int _u_var;
   DivGradExactSolution soln;
 };
 
@@ -69,10 +66,10 @@ void SolutionFunction<2>::operator() (const Point & p,
   const Real x=p(0), y=p(1);
   // libMesh assumes each component of the vector-valued variable is stored
   // contiguously.
-  output(_u_var)   = soln(x, y)(0);
-  output(_u_var+1) = soln(x, y)(1);
+  output(0) = soln(x, y)(0);
+  output(1) = soln(x, y)(1);
   // scalar solution
-  output(_u_var+2) = soln.scalar(x, y);
+  output(2) = soln.scalar(x, y);
 }
 
 template<>
@@ -84,11 +81,11 @@ void SolutionFunction<3>::operator() (const Point & p,
   const Real x=p(0), y=p(1), z=p(2);
   // libMesh assumes each component of the vector-valued variable is stored
   // contiguously.
-  output(_u_var)   = soln(x, y, z)(0);
-  output(_u_var+1) = soln(x, y, z)(1);
-  output(_u_var+2) = soln(x, y, z)(2);
+  output(0) = soln(x, y, z)(0);
+  output(1) = soln(x, y, z)(1);
+  output(2) = soln(x, y, z)(2);
   // scalar solution
-  output(_u_var+3) = soln.scalar(x, y);
+  output(3) = soln.scalar(x, y);
 }
 
 template<>
@@ -120,9 +117,7 @@ class SolutionGradient : public FunctionBase<Gradient>
 {
 public:
 
-  SolutionGradient(const unsigned int u_var)
-    : _u_var(u_var) {}
-
+  SolutionGradient() = default;
   ~SolutionGradient() = default;
 
   virtual Gradient operator() (const Point &, const Real = 0)
@@ -137,11 +132,10 @@ public:
                              const Real);
 
   virtual std::unique_ptr<FunctionBase<Gradient>> clone() const
-  { return std::make_unique<SolutionGradient>(_u_var); }
+  { return std::make_unique<SolutionGradient>(); }
 
 private:
 
-  const unsigned int _u_var;
   DivGradExactSolution soln;
 };
 
@@ -152,8 +146,8 @@ void SolutionGradient<2>::operator() (const Point & p,
 {
   output.zero();
   const Real x=p(0), y=p(1);
-  output(_u_var)   = soln.grad(x, y).row(0);
-  output(_u_var+1) = soln.grad(x, y).row(1);
+  output(0) = soln.grad(x, y).row(0);
+  output(1) = soln.grad(x, y).row(1);
 }
 
 template<>
@@ -163,9 +157,9 @@ void SolutionGradient<3>::operator() (const Point & p,
 {
   output.zero();
   const Real x=p(0), y=p(1), z=p(2);
-  output(_u_var)   = soln.grad(x, y, z).row(0);
-  output(_u_var+1) = soln.grad(x, y, z).row(1);
-  output(_u_var+2) = soln.grad(x, y, z).row(2);
+  output(0) = soln.grad(x, y, z).row(0);
+  output(1) = soln.grad(x, y, z).row(1);
+  output(2) = soln.grad(x, y, z).row(2);
 }
 
 template<>

--- a/examples/vector_fe/vector_fe_ex6/vector_fe_ex6.C
+++ b/examples/vector_fe/vector_fe_ex6/vector_fe_ex6.C
@@ -179,8 +179,8 @@ int main (int argc, char ** argv)
 
   if (dimension == 2)
     {
-      SolutionFunction<2> soln_func(system.variable_number("u"));
-      SolutionGradient<2> soln_grad(system.variable_number("u"));
+      SolutionFunction<2> soln_func;
+      SolutionGradient<2> soln_grad;
 
       // Build FunctionBase* containers to attach to the ExactSolution object.
       std::vector<FunctionBase<Number> *> sols(1, &soln_func);
@@ -191,8 +191,8 @@ int main (int argc, char ** argv)
     }
   else if (dimension == 3)
     {
-      SolutionFunction<3> soln_func(system.variable_number("u"));
-      SolutionGradient<3> soln_grad(system.variable_number("u"));
+      SolutionFunction<3> soln_func;
+      SolutionGradient<3> soln_grad;
 
       // Build FunctionBase* containers to attach to the ExactSolution object.
       std::vector<FunctionBase<Number> *> sols(1, &soln_func);

--- a/examples/vector_fe/vector_fe_ex6/vector_fe_ex6.C
+++ b/examples/vector_fe/vector_fe_ex6/vector_fe_ex6.C
@@ -208,6 +208,7 @@ int main (int argc, char ** argv)
 
   // Compute the error.
   exact_sol.compute_error("DivGrad", "u");
+  exact_sol.compute_error("DivGrad", "p");
 
   // Print out the error values.
   libMesh::out << "L2 error is: "
@@ -218,6 +219,9 @@ int main (int argc, char ** argv)
                << std::endl;
   libMesh::out << "HDiv error is: "
                << exact_sol.hdiv_error("DivGrad", "u")
+               << std::endl;
+  libMesh::out << "L2 error for p is: "
+               << exact_sol.l2_error("DivGrad", "p")
                << std::endl;
 
 #ifdef LIBMESH_HAVE_EXODUS_API


### PR DESCRIPTION
This enables L2 error calculations for the scalar (at least the way I implemented it) in the RT example. I'd be fine dropping the second commit if the L2 scalar field error calculation in #3674 is better implemented