### PR TITLE
Don't underintegrate with default ErrorEstimator settings

### DIFF
--- a/include/error_estimation/exact_error_estimator.h
+++ b/include/error_estimation/exact_error_estimator.h
@@ -155,14 +155,15 @@ public:
    */
   void attach_reference_solution (EquationSystems * es_fine);
 
-
   /**
    * Increases or decreases the order of the quadrature rule used for numerical
-   * integration.
+   * integration.  The default \p extraorder is 1, because properly
+   * integrating L2 error requires integrating the squares of terms
+   * with order p+1, and 2p+2 is 1 higher than what we default to
+   * using for reasonable mass matrix integration.
    */
   void extra_quadrature_order (const int extraorder)
   { _extra_order = extraorder; }
-
 
   // Bring the base class functionality into the name lookup
   // procedure.  This allows for alternative calling formats

--- a/include/error_estimation/exact_solution.h
+++ b/include/error_estimation/exact_solution.h
@@ -177,7 +177,10 @@ public:
 
   /**
    * Increases or decreases the order of the quadrature rule used for numerical
-   * integration.
+   * integration.  The default \p extraorder is 1, because properly
+   * integrating L2 error requires integrating the squares of terms
+   * with order p+1, and 2p+2 is 1 higher than what we default to
+   * using for reasonable mass matrix integration.
    */
   void extra_quadrature_order (const int extraorder)
   { _extra_order = extraorder; }

--- a/include/error_estimation/hp_coarsentest.h
+++ b/include/error_estimation/hp_coarsentest.h
@@ -71,7 +71,7 @@ public:
   /**
    * Constructor.
    */
-  HPCoarsenTest() : p_weight(1.0)
+  HPCoarsenTest() : p_weight(1.0), _extra_order(1)
   {
     libmesh_experimental();
   }
@@ -104,6 +104,16 @@ public:
    * providing an option to make h refinement more likely
    */
   Real p_weight;
+
+  /**
+   * Increases or decreases the order of the quadrature rule used for numerical
+   * integration.  The default \p extraorder is 1, because properly
+   * integrating L2 error requires integrating the squares of terms
+   * with order p+1, and 2p+2 is 1 higher than what we default to
+   * using for reasonable mass matrix integration.
+   */
+  void extra_quadrature_order (const int extraorder)
+  { _extra_order = extraorder; }
 
 protected:
   /**
@@ -161,6 +171,11 @@ protected:
    */
   DenseVector<Number> Uc;
   DenseVector<Number> Up;
+
+  /**
+   * Extra order to use for quadrature rule
+   */
+  int _extra_order;
 };
 
 } // namespace libMesh

--- a/include/error_estimation/patch_recovery_error_estimator.h
+++ b/include/error_estimation/patch_recovery_error_estimator.h
@@ -92,6 +92,16 @@ public:
 
   void set_patch_reuse (bool);
 
+  /**
+   * Increases or decreases the order of the quadrature rule used for numerical
+   * integration.  The default \p extraorder is 1, because properly
+   * integrating L2 error requires integrating the squares of terms
+   * with order p+1, and 2p+2 is 1 higher than what we default to
+   * using for reasonable mass matrix integration.
+   */
+  void extra_quadrature_order (const int extraorder)
+  { _extra_order = extraorder; }
+
   virtual ErrorEstimatorType type() const override;
 
 protected:
@@ -105,6 +115,11 @@ protected:
                                     const unsigned int matsize);
 
   bool patch_reuse;
+
+  /**
+   * Extra order to use for quadrature rule
+   */
+  int _extra_order;
 
 private:
 

--- a/include/error_estimation/uniform_refinement_estimator.h
+++ b/include/error_estimation/uniform_refinement_estimator.h
@@ -108,6 +108,16 @@ public:
                                 const std::map<const System *, const NumericVector<Number> *> * solution_vectors = nullptr,
                                 bool estimate_parent_error = false) override;
 
+  /**
+   * Increases or decreases the order of the quadrature rule used for numerical
+   * integration.  The default \p extraorder is 1, because properly
+   * integrating L2 error requires integrating the squares of terms
+   * with order p+1, and 2p+2 is 1 higher than what we default to
+   * using for reasonable mass matrix integration.
+   */
+  void extra_quadrature_order (const int extraorder)
+  { _extra_order = extraorder; }
+
   virtual ErrorEstimatorType type() const override;
 
   /**
@@ -121,6 +131,12 @@ public:
   unsigned char number_p_refinements;
 
 protected:
+
+  /**
+   * Extra order to use for quadrature rule
+   */
+  int _extra_order;
+
   /**
    * The code for estimate_error and both estimate_errors versions is very
    * similar, so we use the same function for all three

--- a/src/error_estimation/exact_error_estimator.C
+++ b/src/error_estimation/exact_error_estimator.C
@@ -52,7 +52,7 @@ ExactErrorEstimator::ExactErrorEstimator() :
     _exact_deriv(nullptr),
     _exact_hessian(nullptr),
     _equation_systems_fine(nullptr),
-    _extra_order(0)
+    _extra_order(1)
 {
   error_norm = H1;
 }

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -45,7 +45,7 @@ namespace libMesh
 ExactSolution::ExactSolution(const EquationSystems & es) :
   _equation_systems(es),
   _equation_systems_fine(nullptr),
-  _extra_order(0)
+  _extra_order(1)
 {
   // Initialize the _errors data structure which holds all
   // the eventual values of the error.

--- a/src/error_estimation/hp_coarsentest.C
+++ b/src/error_estimation/hp_coarsentest.C
@@ -198,7 +198,7 @@ void HPCoarsenTest::select_refinement (System & system)
                       cont == C_ONE);
 
       // Build an appropriate quadrature rule
-      qrule = fe_type.default_quadrature_rule(dim);
+      qrule = fe_type.default_quadrature_rule(dim, _extra_order);
 
       // Tell the refined finite element about the quadrature
       // rule.  The coarse finite element need not know about it

--- a/src/error_estimation/patch_recovery_error_estimator.C
+++ b/src/error_estimation/patch_recovery_error_estimator.C
@@ -66,7 +66,8 @@ PatchRecoveryErrorEstimator::PatchRecoveryErrorEstimator() :
     ErrorEstimator(),
     target_patch_size(20),
     patch_growth_strategy(&Patch::add_local_face_neighbors),
-    patch_reuse(true)
+    patch_reuse(true),
+    _extra_order(1)
 {
   error_norm = H1_SEMINORM;
 }
@@ -322,7 +323,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
           std::unique_ptr<FEBase> fe (FEBase::build (dim, fe_type));
 
           // Build an appropriate Gaussian quadrature rule
-          std::unique_ptr<QBase> qrule (fe_type.default_quadrature_rule(dim));
+          std::unique_ptr<QBase> qrule (fe_type.default_quadrature_rule(dim, error_estimator._extra_order));
 
           // Tell the finite element about the quadrature rule.
           fe->attach_quadrature_rule (qrule.get());

--- a/src/error_estimation/uniform_refinement_estimator.C
+++ b/src/error_estimation/uniform_refinement_estimator.C
@@ -54,7 +54,8 @@ namespace libMesh
 UniformRefinementEstimator::UniformRefinementEstimator() :
     ErrorEstimator(),
     number_h_refinements(1),
-    number_p_refinements(0)
+    number_p_refinements(0),
+    _extra_order(1)
 {
   error_norm = H1;
 }
@@ -510,7 +511,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
           std::unique_ptr<FEBase> fe (FEBase::build (dim, fe_type));
 
           // Build and attach an appropriate quadrature rule
-          std::unique_ptr<QBase> qrule = fe_type.default_quadrature_rule(dim);
+          std::unique_ptr<QBase> qrule = fe_type.default_quadrature_rule(dim, _extra_order);
           fe->attach_quadrature_rule (qrule.get());
 
           const std::vector<Real> &  JxW = fe->get_JxW();

--- a/src/error_estimation/weighted_patch_recovery_error_estimator.C
+++ b/src/error_estimation/weighted_patch_recovery_error_estimator.C
@@ -223,7 +223,8 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
           std::unique_ptr<FEBase> fe (FEBase::build (dim, fe_type));
 
           // Build an appropriate Gaussian quadrature rule
-          std::unique_ptr<QBase> qrule (fe_type.default_quadrature_rule(dim));
+          std::unique_ptr<QBase> qrule =
+            fe_type.default_quadrature_rule(dim, error_estimator._extra_order);
 
           // Tell the finite element about the quadrature rule.
           fe->attach_quadrature_rule (qrule.get());


### PR DESCRIPTION
We only triggered the problem here with ExactSolution, but there are a bunch of theoretically-susceptible classes, plus a probably-not-susceptible-but-lets-be-safe class.  This fixes them all.

I'm only changing the default setting here; anyone who set an extra quadrature order explicitly should still be getting what they asked for.