### PR TITLE
Get the proper rational weights for nodal_soln

### DIFF
--- a/src/fe/fe_rational.C
+++ b/src/fe/fe_rational.C
@@ -83,8 +83,11 @@ void rational_nodal_soln(const Elem * elem,
 
         std::vector<Real> node_weights(n_nodes);
 
+        const unsigned char weight_index = elem->mapping_data();
+
         for (unsigned int n=0; n<n_nodes; n++)
-          node_weights[n] = elem->node_ref(n).get_extra_integer(0);
+          node_weights[n] =
+            elem->node_ref(n).get_extra_datum<Real>(weight_index);
 
         for (unsigned int n=0; n<n_nodes; n++)
           {


### PR DESCRIPTION
Good news: this way we get the same answer from visualizations on 32-bit and 64-bit, and it should be the correct answer to boot!

Bad news: I've had to disable the MOOSE IGA regression tests (at least the ones with non-trivial bex_weight meshes) to get this to pass, because neither answer was correct before.

Refs idaholab/moose#25819