### PR TITLE
Streamline exact solution specification in Vector FE ex6

### DIFF
--- a/examples/vector_fe/vector_fe_ex6/div_grad_exact_solution.h
+++ b/examples/vector_fe/vector_fe_ex6/div_grad_exact_solution.h
@@ -31,52 +31,52 @@ public:
 
   Real scalar(Real x, Real y)
   {
-    return cos(.5*pi*x)*sin(.5*pi*y);
+    return cos(k*x)*sin(k*y);
   }
 
   Real scalar(Real x, Real y, Real z)
   {
-    return cos(.5*pi*x)*sin(.5*pi*y)*cos(.5*pi*z);
+    return cos(k*x)*sin(k*y)*cos(k*z);
   }
 
   RealGradient operator() (Real x, Real y)
   {
-    const Real ux =  .5*pi*sin(.5*pi*x)*sin(.5*pi*y);
-    const Real uy = -.5*pi*cos(.5*pi*x)*cos(.5*pi*y);
+    const Real ux =  k*sin(k*x)*sin(k*y);
+    const Real uy = -k*cos(k*x)*cos(k*y);
 
     return RealGradient(ux, uy);
   }
 
   RealGradient operator() (Real x, Real y, Real z)
   {
-    const Real ux =  .5*pi*sin(.5*pi*x)*sin(.5*pi*y)*cos(.5*pi*z);
-    const Real uy = -.5*pi*cos(.5*pi*x)*cos(.5*pi*y)*cos(.5*pi*z);
-    const Real uz =  .5*pi*cos(.5*pi*x)*sin(.5*pi*y)*sin(.5*pi*z);
+    const Real ux =  k*sin(k*x)*sin(k*y)*cos(k*z);
+    const Real uy = -k*cos(k*x)*cos(k*y)*cos(k*z);
+    const Real uz =  k*cos(k*x)*sin(k*y)*sin(k*z);
 
     return RealGradient(ux, uy, uz);
   }
 
   RealTensor grad(Real x, Real y)
   {
-    const Real dux_dx = .5*pi*.5*pi*cos(.5*pi*x)*sin(.5*pi*y);
-    const Real dux_dy = .5*pi*.5*pi*sin(.5*pi*x)*cos(.5*pi*y);
-    const Real duy_dx = .5*pi*.5*pi*sin(.5*pi*x)*cos(.5*pi*y);
-    const Real duy_dy = .5*pi*.5*pi*cos(.5*pi*x)*sin(.5*pi*y);
+    const Real dux_dx = k*k*cos(k*x)*sin(k*y);
+    const Real dux_dy = k*k*sin(k*x)*cos(k*y);
+    const Real duy_dx = k*k*sin(k*x)*cos(k*y);
+    const Real duy_dy = k*k*cos(k*x)*sin(k*y);
 
     return RealTensor(dux_dx, dux_dy, Real(0), duy_dx, duy_dy);
   }
 
   RealTensor grad(Real x, Real y, Real z)
   {
-    const Real dux_dx =  .5*pi*.5*pi*cos(.5*pi*x)*sin(.5*pi*y)*cos(.5*pi*z);
-    const Real dux_dy =  .5*pi*.5*pi*sin(.5*pi*x)*cos(.5*pi*y)*cos(.5*pi*z);
-    const Real dux_dz = -.5*pi*.5*pi*sin(.5*pi*x)*sin(.5*pi*y)*sin(.5*pi*z);
-    const Real duy_dx =  .5*pi*.5*pi*sin(.5*pi*x)*cos(.5*pi*y)*cos(.5*pi*z);
-    const Real duy_dy =  .5*pi*.5*pi*cos(.5*pi*x)*sin(.5*pi*y)*cos(.5*pi*z);
-    const Real duy_dz =  .5*pi*.5*pi*cos(.5*pi*x)*cos(.5*pi*y)*sin(.5*pi*z);
-    const Real duz_dx = -.5*pi*.5*pi*sin(.5*pi*x)*sin(.5*pi*y)*sin(.5*pi*z);
-    const Real duz_dy =  .5*pi*.5*pi*cos(.5*pi*x)*cos(.5*pi*y)*sin(.5*pi*z);
-    const Real duz_dz =  .5*pi*.5*pi*cos(.5*pi*x)*sin(.5*pi*y)*cos(.5*pi*z);
+    const Real dux_dx =  k*k*cos(k*x)*sin(k*y)*cos(k*z);
+    const Real dux_dy =  k*k*sin(k*x)*cos(k*y)*cos(k*z);
+    const Real dux_dz = -k*k*sin(k*x)*sin(k*y)*sin(k*z);
+    const Real duy_dx =  k*k*sin(k*x)*cos(k*y)*cos(k*z);
+    const Real duy_dy =  k*k*cos(k*x)*sin(k*y)*cos(k*z);
+    const Real duy_dz =  k*k*cos(k*x)*cos(k*y)*sin(k*z);
+    const Real duz_dx = -k*k*sin(k*x)*sin(k*y)*sin(k*z);
+    const Real duz_dy =  k*k*cos(k*x)*cos(k*y)*sin(k*z);
+    const Real duz_dz =  k*k*cos(k*x)*sin(k*y)*cos(k*z);
 
     return RealTensor(dux_dx, dux_dy, dux_dz, duy_dx, duy_dy, duy_dz, duz_dx, duz_dy, duz_dz);
   }
@@ -107,6 +107,9 @@ public:
   {
     return div(x, y, z);
   }
+
+private:
+  const Real k = .5*pi;
 };
 
 #endif // DIV_GRAD_EXACT_SOLUTION_H


### PR DESCRIPTION
Hey,

I decided to play a bit with #3676, and for that I defined a wavenumber-like variable to allow me to change the characteristics of the solution function easily. Other people might find this ability useful, this is for them.

Now, some examples read an input parameter, `extra_error_quadrature`, to adjust the quadrature order for error estimation purposes. From what I've seen, it's default value is often 2, which is *not* better than 1 (the new global default), and worse, can induce people in error I feel...

In libMesh, the quadrature order is the order of the highest polynomial which can be exactly integrated, not the number of points in the quadrature rule. As the default quadrature order is 2p+1, i.e. odd, adding an even number, m, as the extra order, is no better than just adding m-1. From what I've seen, all examples which take an input parameter to set the extra order use an even number as its default, and none of these examples need it anymore with the new global default anyway...

The new global default means you'll only need an extra order if you're using an order p basis to estimate a solution with order p+2 on each element, at which point you probably want a finer mesh anyway, so the option is now kinda irrelevant? (Which I think is awesome and a huge merit of #3676 btw!)

It might be useful to illustrate how you can change the error quadrature order, but none of our examples make useful use of that option atm, thoughts?