### PR TITLE
GCC 13 workarounds

### DIFF
--- a/include/utils/utility.h
+++ b/include/utils/utility.h
@@ -74,6 +74,22 @@ public:
 };
 
 /**
+ * -Wdangling-reference was nowhere *near* ready to add to -Wall in
+ *  gcc 13.  It's been moved to -Wextra, but we use that too.  :-)
+ *
+ *  See e.g. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109642
+ *
+ *  Our map_find functions trigger it.
+ */
+
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__)
+#if (__GNUC__ > 12)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-reference"
+#endif
+#endif
+
+/**
  * This function should not be called directly (although it can be),
  * instead see the libmesh_map_find() macro.
  *
@@ -155,6 +171,14 @@ map_find(const Map & map,
                        << filename << " on line " << line_number);
   return it->second;
 }
+
+// The map_find functions are our only dangling-reference false positives
+
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__)
+#if (__GNUC__ > 12)
+#pragma GCC diagnostic pop
+#endif
+#endif
 
 
 /**

--- a/src/reduced_basis/rb_assembly_expansion.C
+++ b/src/reduced_basis/rb_assembly_expansion.C
@@ -153,7 +153,7 @@ void RBAssemblyExpansion::attach_output_assembly(std::vector<std::unique_ptr<Ele
 
 void RBAssemblyExpansion::attach_output_assembly(std::vector<ElemAssembly *> output_assembly)
 {
-  _output_assembly_vector.push_back(output_assembly);
+  _output_assembly_vector.push_back(std::move(output_assembly));
 }
 
 void RBAssemblyExpansion::attach_output_assembly(ElemAssembly * output_assembly)

--- a/src/reduced_basis/rb_theta_expansion.C
+++ b/src/reduced_basis/rb_theta_expansion.C
@@ -118,7 +118,7 @@ void RBThetaExpansion::attach_output_theta(std::vector<std::unique_ptr<RBTheta>>
 
 void RBThetaExpansion::attach_output_theta(std::vector<RBTheta *> theta_q_l)
 {
-  _output_theta_vector.push_back(theta_q_l);
+  _output_theta_vector.push_back(std::move(theta_q_l));
 }
 
 void RBThetaExpansion::attach_output_theta(RBTheta * theta_q_l)


### PR DESCRIPTION
I eagerly upgraded my laptop to Ubuntu 23.10, to see if they had a newer no-longer-broken OpenMPI (they do!), only to find out that they also have a newer newly-broken GCC.

These workarounds are enough to get me compiling; hopefully I won't find anything worse at runtime.