### PR TITLE
Add clone method to QBase

### DIFF
--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -74,6 +74,11 @@ public:
   virtual ~QBase() = default;
 
   /**
+   * \returns A copy of this quadrature rule wrapped in a smart pointer.
+   */
+  virtual std::unique_ptr<QBase> clone() const;
+
+  /**
    * \returns The quadrature type in derived classes.
    */
   virtual QuadratureType type() const = 0;

--- a/include/quadrature/quadrature_clough.h
+++ b/include/quadrature/quadrature_clough.h
@@ -61,6 +61,7 @@ public:
    */
   virtual QuadratureType type() const override;
 
+  virtual std::unique_ptr<QBase> clone() const override;
 
 private:
 

--- a/include/quadrature/quadrature_conical.h
+++ b/include/quadrature/quadrature_conical.h
@@ -67,6 +67,8 @@ public:
    */
   virtual QuadratureType type() const override;
 
+  virtual std::unique_ptr<QBase> clone() const override;
+
 private:
 
   /**

--- a/include/quadrature/quadrature_gauss.h
+++ b/include/quadrature/quadrature_gauss.h
@@ -72,6 +72,7 @@ public:
    */
   virtual QuadratureType type() const override;
 
+  virtual std::unique_ptr<QBase> clone() const override;
 
 private:
 

--- a/include/quadrature/quadrature_gauss_lobatto.h
+++ b/include/quadrature/quadrature_gauss_lobatto.h
@@ -63,6 +63,8 @@ public:
    */
   virtual QuadratureType type() const override;
 
+  virtual std::unique_ptr<QBase> clone() const override;
+
 private:
 
   virtual void init_1D (const ElemType, unsigned int) override;

--- a/include/quadrature/quadrature_gm.h
+++ b/include/quadrature/quadrature_gm.h
@@ -120,6 +120,7 @@ public:
    */
   virtual QuadratureType type() const override;
 
+  virtual std::unique_ptr<QBase> clone() const override;
 
 private:
 

--- a/include/quadrature/quadrature_grid.h
+++ b/include/quadrature/quadrature_grid.h
@@ -71,6 +71,7 @@ public:
    */
   virtual QuadratureType type() const override;
 
+  virtual std::unique_ptr<QBase> clone() const override;
 
 private:
 

--- a/include/quadrature/quadrature_jacobi.h
+++ b/include/quadrature/quadrature_jacobi.h
@@ -81,6 +81,8 @@ public:
    */
   virtual QuadratureType type() const override;
 
+  virtual std::unique_ptr<QBase> clone() const override;
+
 private:
   unsigned int _alpha;
   unsigned int _beta;

--- a/include/quadrature/quadrature_monomial.h
+++ b/include/quadrature/quadrature_monomial.h
@@ -82,6 +82,7 @@ public:
    */
   virtual QuadratureType type() const override;
 
+  virtual std::unique_ptr<QBase> clone() const override;
 
 private:
 

--- a/include/quadrature/quadrature_nodal.h
+++ b/include/quadrature/quadrature_nodal.h
@@ -78,6 +78,8 @@ public:
    */
   virtual QuadratureType type() const override;
 
+  virtual std::unique_ptr<QBase> clone() const override;
+
 private:
 
   virtual void init_1D (const ElemType, unsigned int) override;

--- a/include/quadrature/quadrature_simpson.h
+++ b/include/quadrature/quadrature_simpson.h
@@ -72,6 +72,7 @@ public:
    */
   virtual QuadratureType type() const override;
 
+  virtual std::unique_ptr<QBase> clone() const override;
 
 private:
 

--- a/include/quadrature/quadrature_trap.h
+++ b/include/quadrature/quadrature_trap.h
@@ -72,6 +72,8 @@ public:
    */
   virtual QuadratureType type() const override;
 
+  virtual std::unique_ptr<QBase> clone() const override;
+
 private:
 
   virtual void init_1D (const ElemType, unsigned int) override;

--- a/src/quadrature/quadrature.C
+++ b/src/quadrature/quadrature.C
@@ -34,6 +34,10 @@ QBase::QBase(unsigned int d,
   _p_level(0)
 {}
 
+std::unique_ptr<QBase> QBase::clone() const
+{
+  return QBase::build(this->type(), this->get_dim(), this->get_order());
+}
 
 void QBase::print_info(std::ostream & os) const
 {

--- a/src/quadrature/quadrature_clough.C
+++ b/src/quadrature/quadrature_clough.C
@@ -28,6 +28,11 @@ QuadratureType QClough::type() const
   return QCLOUGH;
 }
 
+std::unique_ptr<QBase> QClough::clone() const
+{
+  return std::make_unique<QClough>(*this);
+}
+
 // See the files:
 // quadrature_clough_1D.C
 // quadrature_clough_2D.C

--- a/src/quadrature/quadrature_conical.C
+++ b/src/quadrature/quadrature_conical.C
@@ -35,6 +35,11 @@ QuadratureType QConical::type() const
   return QCONICAL;
 }
 
+std::unique_ptr<QBase> QConical::clone() const
+{
+  return std::make_unique<QConical>(*this);
+}
+
 void QConical::init_1D(const ElemType, unsigned int)
 {
   QGauss gauss1D(1, get_order());

--- a/src/quadrature/quadrature_gauss.C
+++ b/src/quadrature/quadrature_gauss.C
@@ -35,6 +35,11 @@ QuadratureType QGauss::type() const
   return QGAUSS;
 }
 
+std::unique_ptr<QBase> QGauss::clone() const
+{
+  return std::make_unique<QGauss>(*this);
+}
+
 void QGauss::keast_rule(const Real rule_data[][4],
                         const unsigned int n_pts)
 {

--- a/src/quadrature/quadrature_gauss_lobatto.C
+++ b/src/quadrature/quadrature_gauss_lobatto.C
@@ -48,4 +48,9 @@ QuadratureType QGaussLobatto::type() const
   return QGAUSS_LOBATTO;
 }
 
+std::unique_ptr<QBase> QGaussLobatto::clone() const
+{
+  return std::make_unique<QGaussLobatto>(*this);
+}
+
 } // namespace libMesh

--- a/src/quadrature/quadrature_gm.C
+++ b/src/quadrature/quadrature_gm.C
@@ -35,6 +35,11 @@ QuadratureType QGrundmann_Moller::type() const
 }
 
 
+std::unique_ptr<QBase> QGrundmann_Moller::clone() const
+{
+  return std::make_unique<QGrundmann_Moller>(*this);
+}
+
 
 void QGrundmann_Moller::init_1D(const ElemType, unsigned int)
 {

--- a/src/quadrature/quadrature_grid.C
+++ b/src/quadrature/quadrature_grid.C
@@ -28,6 +28,11 @@ QuadratureType QGrid::type() const
   return QGRID;
 }
 
+std::unique_ptr<QBase> QGrid::clone() const
+{
+  return std::make_unique<QGrid>(*this);
+}
+
 // See the files:
 // quadrature_grid_1D.C
 // quadrature_grid_2D.C

--- a/src/quadrature/quadrature_jacobi.C
+++ b/src/quadrature/quadrature_jacobi.C
@@ -39,4 +39,9 @@ QuadratureType QJacobi::type() const
     libmesh_error_msg("Invalid Jacobi quadrature rule: alpha = " << _alpha << ", beta = " << _beta);
 }
 
+std::unique_ptr<QBase> QJacobi::clone() const
+{
+  return std::make_unique<QJacobi>(*this);
+}
+
 }

--- a/src/quadrature/quadrature_monomial.C
+++ b/src/quadrature/quadrature_monomial.C
@@ -34,6 +34,11 @@ QuadratureType QMonomial::type() const
   return QMONOMIAL;
 }
 
+std::unique_ptr<QBase> QMonomial::clone() const
+{
+  return std::make_unique<QMonomial>(*this);
+}
+
 void QMonomial::wissmann_rule(const Real rule_data[][3],
                               const unsigned int n_pts)
 {

--- a/src/quadrature/quadrature_nodal.C
+++ b/src/quadrature/quadrature_nodal.C
@@ -28,6 +28,11 @@ QuadratureType QNodal::type() const
   return QNODAL;
 }
 
+std::unique_ptr<QBase> QNodal::clone() const
+{
+  return std::make_unique<QNodal>(*this);
+}
+
 // See the files:
 // quadrature_nodal_1D.C
 // quadrature_nodal_2D.C

--- a/src/quadrature/quadrature_simpson.C
+++ b/src/quadrature/quadrature_simpson.C
@@ -28,6 +28,11 @@ QuadratureType QSimpson::type() const
   return QSIMPSON;
 }
 
+std::unique_ptr<QBase> QSimpson::clone() const
+{
+  return std::make_unique<QSimpson>(*this);
+}
+
 // See the files:
 // quadrature_simpson_1D.C
 // quadrature_simpson_2D.C

--- a/src/quadrature/quadrature_trap.C
+++ b/src/quadrature/quadrature_trap.C
@@ -28,6 +28,11 @@ QuadratureType QTrap::type() const
   return QTRAP;
 }
 
+std::unique_ptr<QBase> QTrap::clone() const
+{
+  return std::make_unique<QTrap>(*this);
+}
+
 // See the files:
 // quadrature_trap_1D.C
 // quadrature_trap_2D.C


### PR DESCRIPTION
This will allow us to build copies of quadrature rules that are defined in MOOSE. This is also the reason for the base class implementation (instead of a pure virtual) to allow CI to not be broken. Once clone gets implemented in the MOOSE class we can come back and make the base class implementation pure virtual