### PR TITLE
Fix -Wimplicit-function-declaration warning coming from Metis source

### DIFF
--- a/contrib/metis/GKlib/string.c
+++ b/contrib/metis/GKlib/string.c
@@ -13,6 +13,10 @@ of standard functions (but with enhanced functionality).
 */
 /************************************************************************/
 
+// On GCC, strptime is only defined in <time.h> if the _XOPEN_SOURCE macro
+// is defined. See also: the Stack Overflow dicussion here:
+// https://stackoverflow.com/questions/43460876/trouble-including-function-declaration-for-strptime
+#define _XOPEN_SOURCE 700
 #include <GKlib.h>
 #include <time.h> // strptime
 


### PR DESCRIPTION
For more information, see the Stack Overflow discussion here: https://stackoverflow.com/questions/43460876/trouble-including-function-declaration-for-strptime

The full warning from my compiler (GCC 11.4) is:
```
../../../contrib/metis/GKlib/string.c: In function 'gk_str2time': ../../../contrib/metis/GKlib/string.c:506:8: warning: implicit declaration of function 'strptime'; did you mean 'strftime'? [-Wimplicit-function-declaration]
  506 |   if (!strptime(str, "%m/%d/%Y %H:%M:%S", &time))
      |        ^~~~~~~~
      |        strftime
```