### PR TITLE
Fix unused var warning with --disable-mpi

### DIFF
--- a/include/parallel/parallel_fe_type.h
+++ b/include/parallel/parallel_fe_type.h
@@ -148,6 +148,7 @@ public:
   explicit
   StandardType(const libMesh::FEType * example=nullptr)
   {
+#ifdef LIBMESH_HAVE_MPI
     using libMesh::FEType;
 
     // We need an example for MPI_Address to use
@@ -161,7 +162,6 @@ public:
         ex = temp.get();
       }
 
-#ifdef LIBMESH_HAVE_MPI
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
     constexpr std::size_t structsize = 5;
 #else
@@ -223,6 +223,8 @@ public:
 
     timpi_call_mpi
       (MPI_Type_free (&tmptype));
+#else
+    libmesh_ignore(example);
 #endif // #ifdef LIBMESH_HAVE_MPI
   }
 


### PR DESCRIPTION
I was basically tweaking parallel_algebra.h code here, but I guess in that case it was templated code that wasn't getting instantiated and so wasn't triggering the warning?

That warning (with --enable-werror) is currently blocking devel->master merges, so I intend to merge this ASAP.