### PR TITLE
Don't try to cache when using non-Lagrange mapping

### DIFF
--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -190,9 +190,12 @@ void FE<Dim,T>::reinit(const Elem * elem,
           if (this->qrule->shapes_need_reinit())
             this->shapes_on_quadrature = false;
 
+          // We're not going to bother trying to cache nodal
+          // points *and* weights for fancier mapping types.
           if (this->elem_type != elem->type() ||
               this->_elem_p_level != elem->p_level() ||
-              !this->shapes_on_quadrature)
+              !this->shapes_on_quadrature ||
+              elem->mapping_type() != LAGRANGE_MAP)
             {
               // Set the type and p level for this element
               this->elem_type = elem->type();


### PR DESCRIPTION
Most IGA problems hit a different reason to invalidate FE caches, so this bug wasn't triggering ... but the simple meshes I was using to test discontinuous-Bezier-extraction IGA were setting it off.

And the most obvious symptom was simply that we were getting different results in parallel in a new MOOSE discontinuous-IGA test, which sent me chasing after a dozen red herrings before finding the non-parallel non-MOOSE non-discontinuous-extraction bug.  The ratio of "work spent finding the problem" to "work spent fixing the problem" here was insane.