### PR TITLE
Small RB EIM update

### DIFF
--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -450,6 +450,13 @@ Real RBEIMConstruction::train_eim_approximation_with_greedy()
 
   while (true)
     {
+      if (rbe.get_n_basis_functions() >= get_n_training_samples())
+        {
+          libMesh::out << "Number of basis functions (" << rbe.get_n_basis_functions()
+            << ") equals number of training samples, hence exiting." << std::endl;
+          break;
+        }
+
       libMesh::out << "Greedily selected parameter vector:" << std::endl;
       print_parameters();
       greedy_param_list.emplace_back(get_parameters());

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -336,9 +336,14 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
             for (auto sol_idx : make_range(N))
               _rb_eim_solutions[counter](sol_idx) = rb_eim_sol_copy(sol_idx);
 
-            // Normalize the error indicator based on the norm of the coefficient vector
+            // Normalize the error indicator based on the norm of the EIM coefficient vector,
+            // but also check for the case that the EIM coefficient vector is zero in order
+            // to handle that separately.
+            Real eim_coeff_norm = _rb_eim_solutions[counter].linfty_norm();
+            Real normalization = (eim_coeff_norm > 0.) ? eim_coeff_norm : 1.;
+
             _rb_eim_error_indicators[counter] =
-              std::abs(rb_eim_error_indicator_val) / _rb_eim_solutions[counter].linfty_norm();
+              std::abs(rb_eim_error_indicator_val) / normalization;
           }
 
         counter++;


### PR DESCRIPTION
Check for zero solution when defining normalization in RBEIMEvaluation::rb_eim_solves().

Also, exit EIM greedy if the number of basis functions equals the number of training samples.