### PR TITLE
Average side nodal solutions for H_DIV elements

### DIFF
--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -1489,7 +1489,7 @@ EquationSystems::build_discontinuous_solution_vector
                                   FEInterface::get_continuity(fe_type);
                                 const Elem * const neigh = elem->neighbor_ptr(s);
 
-                                if ((cont == DISCONTINUOUS || cont == H_CURL) &&
+                                if ((cont == DISCONTINUOUS || cont == H_CURL || cont == H_DIV) &&
                                     neigh &&
                                     neigh->level() == elem->level() &&
                                     var_description.active_on_subdomain(neigh->subdomain_id()))


### PR DESCRIPTION
Forgot this when we initially implemented H(div) conforming elements, but I'm pretty sure the tangential component would need to be averaged in the same way the normal component needs to for H(curl) elements.

Cheers,
-Nuno