### PR TITLE
Add "WEDGE6" to ExodusII helper

### DIFF
--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -508,6 +508,7 @@ void ExodusII_IO_Helper::init_element_equivalence_map()
 
   // PRISM6 equivalences
   element_equivalence_map["WEDGE"] = PRISM6;
+  element_equivalence_map["WEDGE6"] = PRISM6;
 
   // PRISM15 equivalences
   element_equivalence_map["WEDGE15"] = PRISM15;


### PR DESCRIPTION
I guess we've only seen these referenced as "WEDGE" in files, but there's a user with a "WEDGE6" that isn't readable, and the ExodusII standards say it should be.