### PR TITLE
Fix expanded $CC detection

### DIFF
--- a/configure
+++ b/configure
@@ -5957,7 +5957,7 @@ else $as_nop
 then :
 
 else $as_nop
-                          CC_TRY_LIST="mpicc $CXX_TRY_LIST"
+                          CC_TRY_LIST="mpicc $CC_TRY_LIST"
 fi
 
 fi
@@ -5974,7 +5974,7 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 if test -n "$ac_tool_prefix"; then
-  for ac_prog in $CXX_TRY_LIST
+  for ac_prog in $CC_TRY_LIST
   do
     # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
 set dummy $ac_tool_prefix$ac_prog; ac_word=$2
@@ -6023,7 +6023,7 @@ fi
 fi
 if test -z "$CC"; then
   ac_ct_CC=$CC
-  for ac_prog in $CXX_TRY_LIST
+  for ac_prog in $CC_TRY_LIST
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -40,7 +40,7 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
                   AS_IF([test x"$PETSC_HAVE_MPI" = x1 && test x"$PETSC_CC" != x],
                         [],
                         dnl PETSc doesn't define a CC so we'll just try to pull one from the environment
-                        [CC_TRY_LIST="mpicc $CXX_TRY_LIST"])
+                        [CC_TRY_LIST="mpicc $CC_TRY_LIST"])
                 ]) dnl AS_IF([test x"$MPI" != x])
         ])
 
@@ -55,7 +55,7 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
         [CC="$PETSC_CC"])
 
   dnl If we still don't have a CC set then we will try to pick one up from CC_TRY_LIST
-  AC_PROG_CC([$CXX_TRY_LIST])
+  AC_PROG_CC([$CC_TRY_LIST])
 
 
   # --------------------------------------------------------------


### PR DESCRIPTION
This should fix the "libMesh no longer configures without PETSc" bug that's currently preventing devel->master merges.