### PR TITLE
Fix for writing XDR files of adaptively refined meshes with extra elem integers

### DIFF
--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -598,7 +598,12 @@ XdrIO::write_serialized_connectivity (Xdr & io,
                     if (write_p_level)
                       output_buffer.push_back(tmp);
 
+                    // connectivity
                     for (xdr_id_type node=0; node<n_nodes; node++)
+                      output_buffer.push_back(*recv_conn_iter++);
+
+                    // Write out the elem extra integers after the connectivity
+                    for (dof_id_type n=0; n<n_elem_integers; n++)
                       output_buffer.push_back(*recv_conn_iter++);
 
                     io.data_stream

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -319,7 +319,8 @@ CLEANFILES = cube_mesh.xda \
              extra_integers.xda \
              extra_integers.xdr \
              write_elemset_data.xda \
-             write_elemset_data.xdr
+             write_elemset_data.xdr \
+             test_helper.xdr
 
 # need to link any data files for VPATH builds
 if LIBMESH_VPATH_BUILD

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -2289,7 +2289,8 @@ CLEANFILES = cube_mesh.xda slit_mesh.xda slit_solution.xda out.e \
 	dist.nem.1.0 repl_with_elem_soln.e test_nemesis_read.nem.1.0 \
 	rep.e repl_with_nodal_soln.e repl_with_elem_vec.e \
 	extra_integers.xda extra_integers.xdr write_elemset_data.xda \
-	write_elemset_data.xdr $(am__append_12) $(am__append_13)
+	write_elemset_data.xdr test_helper.xdr $(am__append_12) \
+	$(am__append_13)
 
 # need to link any data files for VPATH builds
 @LIBMESH_VPATH_BUILD_TRUE@BUILT_SOURCES = .linkstamp

--- a/tests/mesh/extra_integers.C
+++ b/tests/mesh/extra_integers.C
@@ -171,6 +171,18 @@ protected:
     mr.uniformly_refine(1);
 
     test_final_integers(mesh, i1);
+
+    // Test writing an XDR file for a refined mesh with extra elem integers.
+    // Note: without the fix in libMesh/libmesh@de15955c5, this test produced
+    // a segfault for me.
+    // TODO: currently we are only testing writing binary (XDR) files,
+    // should probably also test writing ASCII (XDA) files.
+    // TODO: For now just test writing, should also test reading the mesh back in.
+#ifdef LIBMESH_HAVE_XDR
+    mesh.write("test_helper.xdr");
+    TestCommWorld->barrier();
+#endif
+
 #endif
   }
 

--- a/tests/mesh/extra_integers.C
+++ b/tests/mesh/extra_integers.C
@@ -177,10 +177,16 @@ protected:
     // a segfault for me.
     // TODO: currently we are only testing writing binary (XDR) files,
     // should probably also test writing ASCII (XDA) files.
-    // TODO: For now just test writing, should also test reading the mesh back in.
 #ifdef LIBMESH_HAVE_XDR
-    mesh.write("test_helper.xdr");
+    const std::string xdr_filename = "test_helper.xdr";
+    mesh.write(xdr_filename);
     TestCommWorld->barrier();
+
+   // And test that we can read extra integers from refined XDR/XDA
+   // files. Use a freshly constructed Mesh for this.
+   Mesh mesh2(*TestCommWorld);
+   mesh2.read(xdr_filename);
+   test_final_integers(mesh2, i1);
 #endif
 
 #endif


### PR DESCRIPTION
Also includes a unit test that segfaults for me without the fix in jwpeterson/libmesh@de15955c5.