### PR TITLE
Add configure support for --with-xdr-include option

### DIFF
--- a/configure
+++ b/configure
@@ -1256,6 +1256,8 @@ enable_strict_lgpl
 enable_nested
 enable_xdr_required
 enable_xdr
+with_xdr_include
+with_xdr_libname
 enable_boost
 with_boost
 with_boost_libdir
@@ -2189,6 +2191,9 @@ Optional Packages:
                           bytes used per unique id [8]
   --with-mapvector-chunk-size=<uint, e.g. 64>
                           objects per DistributedMesh mapvector chunk [1]
+  --with-xdr-include=PATH Specify the path for RPC headers required by XDR
+  --with-xdr-libname=foo  Specify name of the XDR library to be appended to -l
+                          when linking
   --with-boost[=ARG]      use Boost library from a standard location
                           (ARG=yes), from the specified location (ARG=<path>),
                           or disable it (ARG=no) [ARG=yes]
@@ -49677,59 +49682,44 @@ else $as_nop
 fi
 
 
+# Support for --with-xdr-include configure option
+
+# Check whether --with-xdr-include was given.
+if test ${with_xdr_include+y}
+then :
+  withval=$with_xdr_include; withxdrinc=$withval
+else $as_nop
+  withxdrinc=no
+fi
+
+
+# Support for --with-xdr-libname configure option. Note that we currently
+# do not provide a way to specify a library PATH, but that could potentially
+# be added. If the user does not specify this option, it defaults to "tirpc"
+# since that seems to be the current standard way of linking "external" RPC
+# libraries.
+
+# Check whether --with-xdr-libname was given.
+if test ${with_xdr_libname+y}
+then :
+  withval=$with_xdr_libname; withxdrlibname=$withval
+else $as_nop
+  withxdrlibname=tirpc
+fi
+
+
 if test "$enablexdr" != no
 then :
 
-            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for built-in XDR support" >&5
-printf %s "checking for built-in XDR support... " >&6; }
-
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <stdio.h>
-                                   #include <rpc/rpc.h>
-                                   #include <rpc/xdr.h>
-int
-main (void)
-{
-
-                                    XDR * xdr;
-                                    FILE * fp;
-                                    xdrstdio_create(xdr, fp, XDR_ENCODE);
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_link "$LINENO"
+                        if test "x$withxdrinc" != "xno"
 then :
 
-                   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-
-printf "%s\n" "#define HAVE_XDR 1" >>confdefs.h
-
-                   enablexdr=yes
-
-else $as_nop
-
-                   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-                   enablexdr=no
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext
-
-
-            if test "x$enablexdr" = "xno"
-then :
-
-              { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for XDR support in /usr/include/tirpc" >&5
-printf %s "checking for XDR support in /usr/include/tirpc... " >&6; }
+              { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for XDR support in $withxdrinc" >&5
+printf %s "checking for XDR support in $withxdrinc... " >&6; }
               old_CPPFLAGS="$CPPFLAGS"
               old_LIBS="$LIBS"
-              CPPFLAGS="$CPPFLAGS -I/usr/include/tirpc"
-              LIBS="$LIBS -ltirpc"
+              CPPFLAGS="$CPPFLAGS -I$withxdrinc"
+              LIBS="$LIBS -l$withxdrlibname"
 
 
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -49773,17 +49763,124 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
                             if test "x$enablexdr" = "xyes"
 then :
 
-                      libmesh_optional_INCLUDES="$libmesh_optional_INCLUDES -I/usr/include/tirpc"
-                      libmesh_optional_LIBS="$libmesh_optional_LIBS -ltirpc"
+                      libmesh_optional_INCLUDES="$libmesh_optional_INCLUDES -I$withxdrinc"
+                      libmesh_optional_LIBS="$libmesh_optional_LIBS -l$withxdrlibname"
 
 fi
 
                             CPPFLAGS="$old_CPPFLAGS"
               LIBS="$old_LIBS"
 
+elif test "x$withxdrinc" = "xno"
+then :
+
+                                                                      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for built-in XDR support" >&5
+printf %s "checking for built-in XDR support... " >&6; }
+
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdio.h>
+                                   #include <rpc/rpc.h>
+                                   #include <rpc/xdr.h>
+int
+main (void)
+{
+
+                                    XDR * xdr;
+                                    FILE * fp;
+                                    xdrstdio_create(xdr, fp, XDR_ENCODE);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"
+then :
+
+                   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+
+printf "%s\n" "#define HAVE_XDR 1" >>confdefs.h
+
+                   enablexdr=yes
+
+else $as_nop
+
+                   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+                   enablexdr=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+
+
+                            if test "x$enablexdr" = "xno"
+then :
+
+                      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for XDR support in /usr/include/tirpc" >&5
+printf %s "checking for XDR support in /usr/include/tirpc... " >&6; }
+                      old_CPPFLAGS="$CPPFLAGS"
+                      old_LIBS="$LIBS"
+                      CPPFLAGS="$CPPFLAGS -I/usr/include/tirpc"
+                      LIBS="$LIBS -ltirpc"
+
+
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdio.h>
+                                   #include <rpc/rpc.h>
+                                   #include <rpc/xdr.h>
+int
+main (void)
+{
+
+                                    XDR * xdr;
+                                    FILE * fp;
+                                    xdrstdio_create(xdr, fp, XDR_ENCODE);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"
+then :
+
+                   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+
+printf "%s\n" "#define HAVE_XDR 1" >>confdefs.h
+
+                   enablexdr=yes
+
+else $as_nop
+
+                   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+                   enablexdr=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+
+
+                                            if test "x$enablexdr" = "xyes"
+then :
+
+                              libmesh_optional_INCLUDES="$libmesh_optional_INCLUDES -I/usr/include/tirpc"
+                              libmesh_optional_LIBS="$libmesh_optional_LIBS -ltirpc"
+
+fi
+
+                                            CPPFLAGS="$old_CPPFLAGS"
+                      LIBS="$old_LIBS"
+
 fi
 
 fi
+
+fi
+
 if test "x$enablexdr" = "xno" && test "x$xdrrequired" = "xyes"
 then :
   as_fn_error 4 "*** XDR was not found, but --enable-xdr-required was specified." "$LINENO" 5

--- a/configure
+++ b/configure
@@ -49682,6 +49682,13 @@ else $as_nop
 fi
 
 
+if test "x${TIRPC_DIR}" != "x"
+then :
+  withxdrinc_default=${TIRPC_DIR}
+else $as_nop
+  withxdrinc_default=no
+fi
+
 # Support for --with-xdr-include configure option
 
 # Check whether --with-xdr-include was given.
@@ -49689,7 +49696,7 @@ if test ${with_xdr_include+y}
 then :
   withval=$with_xdr_include; withxdrinc=$withval
 else $as_nop
-  withxdrinc=no
+  withxdrinc=$withxdrinc_default
 fi
 
 

--- a/m4/libmesh_optional_packages.m4
+++ b/m4/libmesh_optional_packages.m4
@@ -122,35 +122,82 @@ AC_ARG_ENABLE(xdr,
               enablexdr=$enableval,
               enablexdr=yes)
 
+# Support for --with-xdr-include configure option
+AC_ARG_WITH(xdr-include,
+            AS_HELP_STRING([--with-xdr-include=PATH],[Specify the path for RPC headers required by XDR]),
+            withxdrinc=$withval,
+            withxdrinc=no)
+
+# Support for --with-xdr-libname configure option. Note that we currently
+# do not provide a way to specify a library PATH, but that could potentially
+# be added. If the user does not specify this option, it defaults to "tirpc"
+# since that seems to be the current standard way of linking "external" RPC
+# libraries.
+AC_ARG_WITH(xdr-libname,
+            AS_HELP_STRING([--with-xdr-libname=foo],[Specify name of the XDR library to be appended to -l when linking]),
+            withxdrlibname=$withval,
+            withxdrlibname=tirpc)
+
 AS_IF([test "$enablexdr" != no],
       [
-      dnl Check whether the system/compiler has xdr.h in /usr/include and glibc.
-      AC_MSG_CHECKING([for built-in XDR support])
-      CONFIGURE_XDR
-
-      dnl Check for headers in /usr/include/tirpc. (Fedora 28 does this.)
-      AS_IF([test "x$enablexdr" = "xno"],
+      dnl If there is a user-provided XDR include/library provided, then we only
+      dnl try compiling/linking against those, to avoid accidentally bringing in
+      dnl any unwanted system RPC headers.
+      AS_IF([test "x$withxdrinc" != "xno"],
             [
-              AC_MSG_CHECKING([for XDR support in /usr/include/tirpc])
+              AC_MSG_CHECKING([for XDR support in $withxdrinc])
               old_CPPFLAGS="$CPPFLAGS"
               old_LIBS="$LIBS"
-              CPPFLAGS="$CPPFLAGS -I/usr/include/tirpc"
-              LIBS="$LIBS -ltirpc"
+              CPPFLAGS="$CPPFLAGS -I$withxdrinc"
+              LIBS="$LIBS -l$withxdrlibname"
 
               CONFIGURE_XDR
 
               dnl If that worked, append the required include paths and libraries as necessary.
               AS_IF([test "x$enablexdr" = "xyes"],
                     [
-                      libmesh_optional_INCLUDES="$libmesh_optional_INCLUDES -I/usr/include/tirpc"
-                      libmesh_optional_LIBS="$libmesh_optional_LIBS -ltirpc"
+                      libmesh_optional_INCLUDES="$libmesh_optional_INCLUDES -I$withxdrinc"
+                      libmesh_optional_LIBS="$libmesh_optional_LIBS -l$withxdrlibname"
                     ])
 
               dnl Reset flags after testing
               CPPFLAGS="$old_CPPFLAGS"
               LIBS="$old_LIBS"
-           ])
+            ],
+            [test "x$withxdrinc" = "xno"],
+            [
+              dnl The user did not provide a custom XDR include/header path, so we
+              dnl instead check whether the system/compiler has built-in support for
+              dnl compiling/linking a code that includes xdr.h, followed by checking
+              dnl other known locations.
+              AC_MSG_CHECKING([for built-in XDR support])
+              CONFIGURE_XDR
+
+              dnl Check for headers in /usr/include/tirpc. (Fedora 28 does this.)
+              AS_IF([test "x$enablexdr" = "xno"],
+                    [
+                      AC_MSG_CHECKING([for XDR support in /usr/include/tirpc])
+                      old_CPPFLAGS="$CPPFLAGS"
+                      old_LIBS="$LIBS"
+                      CPPFLAGS="$CPPFLAGS -I/usr/include/tirpc"
+                      LIBS="$LIBS -ltirpc"
+
+                      CONFIGURE_XDR
+
+                      dnl If that worked, append the required include paths and libraries as necessary.
+                      AS_IF([test "x$enablexdr" = "xyes"],
+                            [
+                              libmesh_optional_INCLUDES="$libmesh_optional_INCLUDES -I/usr/include/tirpc"
+                              libmesh_optional_LIBS="$libmesh_optional_LIBS -ltirpc"
+                            ])
+
+                      dnl Reset flags after testing
+                      CPPFLAGS="$old_CPPFLAGS"
+                      LIBS="$old_LIBS"
+                   ])
+            ])
       ])
+
 AS_IF([test "x$enablexdr" = "xno" && test "x$xdrrequired" = "xyes"],
       [AC_MSG_ERROR([*** XDR was not found, but --enable-xdr-required was specified.], 4)])
 

--- a/m4/libmesh_optional_packages.m4
+++ b/m4/libmesh_optional_packages.m4
@@ -122,11 +122,15 @@ AC_ARG_ENABLE(xdr,
               enablexdr=$enableval,
               enablexdr=yes)
 
+dnl If the user sets ${TIRPC_DIR} in their environment, then use that as the
+dnl default value for --with-xdr-include
+AS_IF([test "x${TIRPC_DIR}" != "x"], [withxdrinc_default=${TIRPC_DIR}], [withxdrinc_default=no])
+
 # Support for --with-xdr-include configure option
 AC_ARG_WITH(xdr-include,
             AS_HELP_STRING([--with-xdr-include=PATH],[Specify the path for RPC headers required by XDR]),
             withxdrinc=$withval,
-            withxdrinc=no)
+            withxdrinc=$withxdrinc_default)
 
 # Support for --with-xdr-libname configure option. Note that we currently
 # do not provide a way to specify a library PATH, but that could potentially


### PR DESCRIPTION
RPC headers can be installed in places other than `/usr/include/tirpc` so let the user specify the correct PATH.

Closes #3709.