### PR TITLE
Introduced VectorizedEvalInput to encapsulate vectorized evaluate inputs

### DIFF
--- a/contrib/capnproto/rb_data.capnp
+++ b/contrib/capnproto/rb_data.capnp
@@ -122,6 +122,9 @@ struct RBEIMEvaluationReal @0xf8121d2237427a80 {
   interpolationBoundaryId     @15 :List(Integer);
   interpolationSpatialIndices @16 :List(List(Integer));
   interpolationNodeId         @17 :List(Integer);
+  interpolationJxW            @18 :List(Real);
+  interpolationElemVolume     @19 :List(Real);
+  interpolationElemType       @20 :List(Integer);
 }
 struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   nBfs                        @0  :Integer;
@@ -142,4 +145,7 @@ struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   interpolationBoundaryId     @15 :List(Integer);
   interpolationSpatialIndices @16 :List(List(Integer));
   interpolationNodeId         @17 :List(Integer);
+  interpolationJxW            @18 :List(Real);
+  interpolationElemVolume     @19 :List(Real);
+  interpolationElemType       @20 :List(Integer);
 }

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -378,6 +378,9 @@ public:
   void add_interpolation_points_side_index(unsigned int side_index);
   void add_interpolation_points_node_id(dof_id_type node_id);
   void add_interpolation_points_qp(unsigned int qp);
+  void add_interpolation_points_JxW(Real JxW);
+  void add_interpolation_points_elem_volume(Real elem_vol);
+  void add_interpolation_points_elem_type(ElemType elem_type);
   void add_interpolation_points_phi_i_qp(const std::vector<Real> & phi_i_qp);
   void add_interpolation_points_spatial_indices(const std::vector<unsigned int> & spatial_indices);
 
@@ -393,6 +396,9 @@ public:
   unsigned int get_interpolation_points_side_index(unsigned int index) const;
   dof_id_type get_interpolation_points_node_id(unsigned int index) const;
   unsigned int get_interpolation_points_qp(unsigned int index) const;
+  Real get_interpolation_points_JxW(unsigned int index) const;
+  Real get_interpolation_points_elem_volume(unsigned int index) const;
+  ElemType get_interpolation_points_elem_type(unsigned int index) const;
   const std::vector<Real> & get_interpolation_points_phi_i_qp(unsigned int index) const;
   const std::vector<unsigned int> & get_interpolation_points_spatial_indices(unsigned int index) const;
 

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -27,6 +27,7 @@
 #include "libmesh/parallel_object.h"
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
+#include "libmesh/rb_parametrized_function.h"
 
 // C++ includes
 #include <memory>
@@ -655,50 +656,15 @@ private:
   DenseMatrix<Number> _interpolation_matrix;
 
   /**
-   * We need to store interpolation point data in order to
-   * evaluate parametrized functions at the interpolation points.
-   * This requires the xyz locations, the components to evaluate,
-   * and the subdomain IDs.
+   * We store the EIM interpolation point data in this object.
    */
-  std::vector<Point> _interpolation_points_xyz;
+  VectorizedEvalInput _vec_eval_input;
+
+  /**
+   * In the case of a "vector-valued" EIM, this vector determines which
+   * component of the parameterized function we sample at each EIM point.
+   */
   std::vector<unsigned int> _interpolation_points_comp;
-  std::vector<subdomain_id_type> _interpolation_points_subdomain_id;
-
-  /**
-   * We also store perturbations of the xyz locations that may be
-   * needed to evaluate finite difference approximations to derivatives.
-   */
-  std::vector<std::vector<Point>> _interpolation_points_xyz_perturbations;
-
-  /**
-   * We also store the element ID and qp index of each interpolation
-   * point so that we can evaluate our basis functions at these
-   * points by simply looking up the appropriate stored values.
-   * This data is only needed during the EIM training.
-   */
-  std::vector<dof_id_type> _interpolation_points_elem_id;
-  std::vector<unsigned int> _interpolation_points_qp;
-
-  /**
-   * If the EIM approximation applies to element sides, then we need to
-   * store the side index and boundary ID for each quadrature point.
-   */
-  std::vector<unsigned int> _interpolation_points_side_index;
-  std::vector<boundary_id_type> _interpolation_points_boundary_id;
-
-  /**
-   * If the EIM approximation applies to element nodes (e.g. from a nodeset),
-   * then we need to store the ID for each node. We also store the associated
-   * boundary ID in this case, using _interpolation_points_boundary_id.
-   */
-  std::vector<dof_id_type> _interpolation_points_node_id;
-
-  /**
-   * We store the shape function values at the qp as well. These values
-   * allows us to evaluate parametrized functions that depend on nodal
-   * data.
-   */
-  std::vector<std::vector<Real>> _interpolation_points_phi_i_qp;
 
   /**
    * Here we store the spatial indices that were initialized by

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -22,6 +22,7 @@
 
 // libMesh includes
 #include "libmesh/libmesh_common.h"
+#include "libmesh/enum_elem_type.h"
 
 // C++ includes
 #include <unordered_map>
@@ -70,6 +71,9 @@ struct VectorizedEvalInput
   std::vector<unsigned int> side_indices;
   std::vector<boundary_id_type> boundary_ids;
   std::vector<dof_id_type> node_ids;
+  std::vector<Real> JxWs;
+  std::vector<Real> elem_volumes;
+  std::vector<ElemType> elem_types;
 };
 
 /**

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -37,6 +37,42 @@ class Point;
 class System;
 
 /**
+ * Define a struct for the input to the "vectorized evaluate" functions below.
+ * This encapsulates the arguments into a class to prevent having many function
+ * arguments, and also makes it easier to make API changes in the future because
+ * we can change these structs without changing the function arguments.
+ */
+struct VectorizedEvalInput
+{
+  VectorizedEvalInput () = default;
+  VectorizedEvalInput (const VectorizedEvalInput &) = default;
+  VectorizedEvalInput & operator= (const VectorizedEvalInput &) = default;
+  VectorizedEvalInput (VectorizedEvalInput &&) = default;
+  VectorizedEvalInput & operator= (VectorizedEvalInput &&) = default;
+  virtual ~VectorizedEvalInput() = default;
+
+  /**
+   * Clear all the members.
+   */
+  void clear();
+
+  /**
+   * The members that define the inputs to the vectorized evaluate functions. Note
+   * that some of these members may be unused, for example when we call the "interior"
+   * vectorized evaluate function, we do not use node_ids.
+   */
+  std::vector<Point> all_xyz;
+  std::vector<dof_id_type> elem_ids;
+  std::vector<unsigned int> qps;
+  std::vector<subdomain_id_type> sbd_ids;
+  std::vector<std::vector<Point>> all_xyz_perturb;
+  std::vector<std::vector<Real>> phi_i_qp;
+  std::vector<unsigned int> side_indices;
+  std::vector<boundary_id_type> boundary_ids;
+  std::vector<dof_id_type> node_ids;
+};
+
+/**
  * A simple functor class that provides a RBParameter-dependent function.
  *
  * \author David Knezevic
@@ -157,12 +193,7 @@ public:
    * evaluate() function may be overridden in derived classes.
    */
   virtual void vectorized_evaluate(const std::vector<RBParameters> & mus,
-                                   const std::vector<Point> & all_xyz,
-                                   const std::vector<dof_id_type> & elem_ids,
-                                   const std::vector<unsigned int> & qps,
-                                   const std::vector<subdomain_id_type> & sbd_ids,
-                                   const std::vector<std::vector<Point>> & all_xyz_perturb,
-                                   const std::vector<std::vector<Real>> & phi_i_qp,
+                                   const VectorizedEvalInput & v,
                                    std::vector<std::vector<std::vector<Number>>> & output);
 
   /**
@@ -173,14 +204,7 @@ public:
    * side_evaluate() function may be overridden in derived classes.
    */
   virtual void side_vectorized_evaluate(const std::vector<RBParameters> & mus,
-                                        const std::vector<Point> & all_xyz,
-                                        const std::vector<dof_id_type> & elem_ids,
-                                        const std::vector<unsigned int> & side_indices,
-                                        const std::vector<unsigned int> & qps,
-                                        const std::vector<subdomain_id_type> & sbd_ids,
-                                        const std::vector<boundary_id_type> & boundary_ids,
-                                        const std::vector<std::vector<Point>> & all_xyz_perturb,
-                                        const std::vector<std::vector<Real>> & phi_i_qp,
+                                        const VectorizedEvalInput & v,
                                         std::vector<std::vector<std::vector<Number>>> & output);
 
   /**
@@ -191,9 +215,7 @@ public:
    * node_evaluate() function may be overridden in derived classes.
    */
   virtual void node_vectorized_evaluate(const std::vector<RBParameters> & mus,
-                                        const std::vector<Point> & all_xyz,
-                                        const std::vector<dof_id_type> & node_ids,
-                                        const std::vector<boundary_id_type> & boundary_ids,
+                                        const VectorizedEvalInput & v,
                                         std::vector<std::vector<std::vector<Number>>> & output);
 
   /**

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -327,7 +327,7 @@ public:
    * can handle the case where the spatial function evaluation requires us to have
    * indices from all nodes of an element, since in that case we need a vector of
    * indices (one per node) for each point. Other cases, such as when we define
-   * the paramtrized function based on the element index only, only require a
+   * the parametrized function based on the element index only, only require a
    * singly-nested vector which we handle as a special case of the doubly-nested
    * vector.
    *
@@ -338,12 +338,7 @@ public:
    * to provide the relevant behavior.
    */
   virtual void get_spatial_indices(std::vector<std::vector<unsigned int>> & spatial_indices,
-                                   const std::vector<dof_id_type> & elem_ids,
-                                   const std::vector<unsigned int> & side_indices,
-                                   const std::vector<dof_id_type> & node_ids,
-                                   const std::vector<unsigned int> & qps,
-                                   const std::vector<subdomain_id_type> & sbd_ids,
-                                   const std::vector<boundary_id_type> & boundary_ids);
+                                   const VectorizedEvalInput & v);
 
   /**
    * The Online stage counterpart of get_spatial_indices(). This method
@@ -351,12 +346,7 @@ public:
    * we can evaluate it during an Online solve.
    */
   virtual void initialize_spatial_indices(const std::vector<std::vector<unsigned int>> & spatial_indices,
-                                          const std::vector<dof_id_type> & elem_ids,
-                                          const std::vector<unsigned int> & side_indices,
-                                          const std::vector<dof_id_type> & node_ids,
-                                          const std::vector<unsigned int> & qps,
-                                          const std::vector<subdomain_id_type> & sbd_ids,
-                                          const std::vector<boundary_id_type> & boundary_ids);
+                                          const VectorizedEvalInput & v);
 
   /**
    * Virtual function that performs cleanup after each

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -833,6 +833,48 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
       }
   }
 
+  // Interpolation points JxW values
+  {
+    auto interpolation_points_JxW_list =
+      rb_eim_evaluation_reader.getInterpolationJxW();
+
+    libmesh_error_msg_if(interpolation_points_JxW_list.size() != n_bfs,
+                         "Size error while reading the eim interpolation JxW values.");
+
+    for (unsigned int i=0; i<n_bfs; ++i)
+      {
+        rb_eim_evaluation.add_interpolation_points_JxW(interpolation_points_JxW_list[i]);
+      }
+  }
+
+  // Interpolation points element volume values
+  {
+    auto interpolation_points_elem_volume_list =
+      rb_eim_evaluation_reader.getInterpolationElemVolume();
+
+    libmesh_error_msg_if(interpolation_points_elem_volume_list.size() != n_bfs,
+                         "Size error while reading the eim interpolation element volumes.");
+
+    for (unsigned int i=0; i<n_bfs; ++i)
+      {
+        rb_eim_evaluation.add_interpolation_points_elem_volume(interpolation_points_elem_volume_list[i]);
+      }
+  }
+
+  // Interpolation points element types
+  {
+    auto interpolation_points_elem_type_list =
+      rb_eim_evaluation_reader.getInterpolationElemType();
+
+    libmesh_error_msg_if(interpolation_points_elem_type_list.size() != n_bfs,
+                         "Size error while reading the eim interpolation element types.");
+
+    for (unsigned int i=0; i<n_bfs; ++i)
+      {
+        rb_eim_evaluation.add_interpolation_points_elem_type(static_cast<ElemType>(interpolation_points_elem_type_list[i]));
+      }
+  }
+
   // Interpolation points perturbations
   {
     auto interpolation_points_list_outer =

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -713,6 +713,33 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
       }
   }
 
+  // Interpolation points JxW values at each qp
+  {
+    auto interpolation_points_JxW_list =
+      rb_eim_evaluation_builder.initInterpolationJxW(n_bfs);
+    for (unsigned int i=0; i<n_bfs; ++i)
+      interpolation_points_JxW_list.set(i,
+                                        rb_eim_evaluation.get_interpolation_points_JxW(i));
+  }
+
+  // Element volume for the element that contains each interpolation point
+  {
+    auto interpolation_points_elem_volume_list =
+      rb_eim_evaluation_builder.initInterpolationElemVolume(n_bfs);
+    for (unsigned int i=0; i<n_bfs; ++i)
+      interpolation_points_elem_volume_list.set(i,
+                                                rb_eim_evaluation.get_interpolation_points_elem_volume(i));
+  }
+
+  // Element type for the element that contains each interpolation point
+  {
+    auto interpolation_points_elem_type_list =
+      rb_eim_evaluation_builder.initInterpolationElemType(n_bfs);
+    for (unsigned int i=0; i<n_bfs; ++i)
+      interpolation_points_elem_type_list.set(i,
+                                              rb_eim_evaluation.get_interpolation_points_elem_type(i));
+  }
+
   // Optionally store EIM solutions for the training set
   if (rb_eim_evaluation.get_parametrized_function().is_lookup_table)
     {

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -324,23 +324,13 @@ void RBEIMEvaluation::initialize_interpolation_points_spatial_indices()
   _interpolation_points_spatial_indices.clear();
 
   get_parametrized_function().get_spatial_indices(_interpolation_points_spatial_indices,
-                                                  _vec_eval_input.elem_ids,
-                                                  _vec_eval_input.side_indices,
-                                                  _vec_eval_input.node_ids,
-                                                  _vec_eval_input.qps,
-                                                  _vec_eval_input.sbd_ids,
-                                                  _vec_eval_input.boundary_ids);
+                                                  _vec_eval_input);
 }
 
 void RBEIMEvaluation::initialize_param_fn_spatial_indices()
 {
   get_parametrized_function().initialize_spatial_indices(_interpolation_points_spatial_indices,
-                                                         _vec_eval_input.elem_ids,
-                                                         _vec_eval_input.side_indices,
-                                                         _vec_eval_input.node_ids,
-                                                         _vec_eval_input.qps,
-                                                         _vec_eval_input.sbd_ids,
-                                                         _vec_eval_input.boundary_ids);
+                                                         _vec_eval_input);
 }
 
 unsigned int RBEIMEvaluation::get_n_basis_functions() const

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -771,6 +771,21 @@ void RBEIMEvaluation::add_interpolation_points_qp(unsigned int qp)
   _vec_eval_input.qps.emplace_back(qp);
 }
 
+void RBEIMEvaluation::add_interpolation_points_JxW(Real JxW)
+{
+  _vec_eval_input.JxWs.emplace_back(JxW);
+}
+
+void RBEIMEvaluation::add_interpolation_points_elem_volume(Real elem_vol)
+{
+  _vec_eval_input.elem_volumes.emplace_back(elem_vol);
+}
+
+void RBEIMEvaluation::add_interpolation_points_elem_type(ElemType elem_type)
+{
+  _vec_eval_input.elem_types.emplace_back(elem_type);
+}
+
 void RBEIMEvaluation::add_interpolation_points_phi_i_qp(const std::vector<Real> & phi_i_qp)
 {
   _vec_eval_input.phi_i_qp.emplace_back(phi_i_qp);
@@ -842,6 +857,27 @@ unsigned int RBEIMEvaluation::get_interpolation_points_qp(unsigned int index) co
   libmesh_error_msg_if(index >= _vec_eval_input.qps.size(), "Error: Invalid index");
 
   return _vec_eval_input.qps[index];
+}
+
+Real RBEIMEvaluation::get_interpolation_points_JxW(unsigned int index) const
+{
+  libmesh_error_msg_if(index >= _vec_eval_input.JxWs.size(), "Error: Invalid index");
+
+  return _vec_eval_input.JxWs[index];
+}
+
+Real RBEIMEvaluation::get_interpolation_points_elem_volume(unsigned int index) const
+{
+  libmesh_error_msg_if(index >= _vec_eval_input.elem_volumes.size(), "Error: Invalid index");
+
+  return _vec_eval_input.elem_volumes[index];
+}
+
+ElemType RBEIMEvaluation::get_interpolation_points_elem_type(unsigned int index) const
+{
+  libmesh_error_msg_if(index >= _vec_eval_input.elem_types.size(), "Error: Invalid index");
+
+  return _vec_eval_input.elem_types[index];
 }
 
 const std::vector<Real> & RBEIMEvaluation::get_interpolation_points_phi_i_qp(unsigned int index) const

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -31,6 +31,19 @@
 namespace libMesh
 {
 
+void VectorizedEvalInput::clear()
+{
+  all_xyz.clear();
+  elem_ids.clear();
+  qps.clear();
+  sbd_ids.clear();
+  all_xyz_perturb.clear();
+  phi_i_qp.clear();
+  side_indices.clear();
+  boundary_ids.clear();
+  node_ids.clear();
+}
+
 RBParametrizedFunction::RBParametrizedFunction()
 :
 requires_xyz_perturbations(false),
@@ -136,21 +149,16 @@ RBParametrizedFunction::node_evaluate(const RBParameters & /*mu*/,
 }
 
 void RBParametrizedFunction::vectorized_evaluate(const std::vector<RBParameters> & mus,
-                                                 const std::vector<Point> & all_xyz,
-                                                 const std::vector<dof_id_type> & elem_ids,
-                                                 const std::vector<unsigned int> & qps,
-                                                 const std::vector<subdomain_id_type> & sbd_ids,
-                                                 const std::vector<std::vector<Point>> & all_xyz_perturb,
-                                                 const std::vector<std::vector<Real>> & phi_i_qp,
+                                                 const VectorizedEvalInput & v,
                                                  std::vector<std::vector<std::vector<Number>>> & output)
 {
   LOG_SCOPE("vectorized_evaluate()", "RBParametrizedFunction");
 
   output.clear();
-  unsigned int n_points = all_xyz.size();
+  unsigned int n_points = v.all_xyz.size();
 
-  libmesh_error_msg_if(sbd_ids.size() != n_points, "Error: invalid vector sizes");
-  libmesh_error_msg_if(requires_xyz_perturbations && (all_xyz_perturb.size() != n_points), "Error: invalid vector sizes");
+  libmesh_error_msg_if(v.sbd_ids.size() != n_points, "Error: invalid vector sizes");
+  libmesh_error_msg_if(requires_xyz_perturbations && (v.all_xyz_perturb.size() != n_points), "Error: invalid vector sizes");
 
   // Dummy vector to be used when xyz perturbations are not required
   std::vector<Point> empty_perturbs;
@@ -173,12 +181,12 @@ void RBParametrizedFunction::vectorized_evaluate(const std::vector<RBParameters>
           // Evaluate all steps for the current mu at the current interpolation point
           all_evals[mu_index][point_index] =
             this->evaluate(mus[mu_index],
-                           all_xyz[point_index],
-                           elem_ids[point_index],
-                           qps[point_index],
-                           sbd_ids[point_index],
-                           requires_xyz_perturbations ? all_xyz_perturb[point_index] : empty_perturbs,
-                           phi_i_qp[point_index]);
+                           v.all_xyz[point_index],
+                           v.elem_ids[point_index],
+                           v.qps[point_index],
+                           v.sbd_ids[point_index],
+                           requires_xyz_perturbations ? v.all_xyz_perturb[point_index] : empty_perturbs,
+                           v.phi_i_qp[point_index]);
 
           // The vector returned by evaluate() should contain:
           // n_components * mus[mu_index].n_steps()
@@ -225,23 +233,16 @@ void RBParametrizedFunction::vectorized_evaluate(const std::vector<RBParameters>
 }
 
 void RBParametrizedFunction::side_vectorized_evaluate(const std::vector<RBParameters> & mus,
-                                                      const std::vector<Point> & all_xyz,
-                                                      const std::vector<dof_id_type> & elem_ids,
-                                                      const std::vector<unsigned int> & side_indices,
-                                                      const std::vector<unsigned int> & qps,
-                                                      const std::vector<subdomain_id_type> & sbd_ids,
-                                                      const std::vector<boundary_id_type> & boundary_ids,
-                                                      const std::vector<std::vector<Point>> & all_xyz_perturb,
-                                                      const std::vector<std::vector<Real>> & phi_i_qp,
+                                                      const VectorizedEvalInput & v,
                                                       std::vector<std::vector<std::vector<Number>>> & output)
 {
   LOG_SCOPE("side_vectorized_evaluate()", "RBParametrizedFunction");
 
   output.clear();
-  unsigned int n_points = all_xyz.size();
+  unsigned int n_points = v.all_xyz.size();
 
-  libmesh_error_msg_if(sbd_ids.size() != n_points, "Error: invalid vector sizes");
-  libmesh_error_msg_if(requires_xyz_perturbations && (all_xyz_perturb.size() != n_points), "Error: invalid vector sizes");
+  libmesh_error_msg_if(v.sbd_ids.size() != n_points, "Error: invalid vector sizes");
+  libmesh_error_msg_if(requires_xyz_perturbations && (v.all_xyz_perturb.size() != n_points), "Error: invalid vector sizes");
 
   // Dummy vector to be used when xyz perturbations are not required
   std::vector<Point> empty_perturbs;
@@ -264,14 +265,14 @@ void RBParametrizedFunction::side_vectorized_evaluate(const std::vector<RBParame
           // Evaluate all steps for the current mu at the current interpolation point
           all_evals[mu_index][point_index] =
             this->side_evaluate(mus[mu_index],
-                                all_xyz[point_index],
-                                elem_ids[point_index],
-                                side_indices[point_index],
-                                qps[point_index],
-                                sbd_ids[point_index],
-                                boundary_ids[point_index],
-                                requires_xyz_perturbations ? all_xyz_perturb[point_index] : empty_perturbs,
-                                phi_i_qp[point_index]);
+                                v.all_xyz[point_index],
+                                v.elem_ids[point_index],
+                                v.side_indices[point_index],
+                                v.qps[point_index],
+                                v.sbd_ids[point_index],
+                                v.boundary_ids[point_index],
+                                requires_xyz_perturbations ? v.all_xyz_perturb[point_index] : empty_perturbs,
+                                v.phi_i_qp[point_index]);
 
           // The vector returned by side_evaluate() should contain:
           // n_components * mus[mu_index].n_steps()
@@ -318,15 +319,13 @@ void RBParametrizedFunction::side_vectorized_evaluate(const std::vector<RBParame
 }
 
 void RBParametrizedFunction::node_vectorized_evaluate(const std::vector<RBParameters> & mus,
-                                                      const std::vector<Point> & all_xyz,
-                                                      const std::vector<dof_id_type> & node_ids,
-                                                      const std::vector<boundary_id_type> & boundary_ids,
+                                                      const VectorizedEvalInput & v,
                                                       std::vector<std::vector<std::vector<Number>>> & output)
 {
   LOG_SCOPE("node_vectorized_evaluate()", "RBParametrizedFunction");
 
   output.clear();
-  unsigned int n_points = all_xyz.size();
+  unsigned int n_points = v.all_xyz.size();
 
   // The number of components returned by this RBParametrizedFunction
   auto n_components = this->get_n_components();
@@ -346,9 +345,9 @@ void RBParametrizedFunction::node_vectorized_evaluate(const std::vector<RBParame
           // Evaluate all steps for the current mu at the current interpolation point
           all_evals[mu_index][point_index] =
             this->node_evaluate(mus[mu_index],
-                                all_xyz[point_index],
-                                node_ids[point_index],
-                                boundary_ids[point_index]);
+                                v.all_xyz[point_index],
+                                v.node_ids[point_index],
+                                v.boundary_ids[point_index]);
 
           // The vector returned by node_evaluate() should contain:
           // n_components * mus[mu_index].n_steps()
@@ -409,12 +408,13 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh(const RBP
     n_points += xyz_vec.size();
   }
 
-  std::vector<Point> all_xyz_vec(n_points);
-  std::vector<dof_id_type> elem_ids_vec(n_points);
-  std::vector<unsigned int> qps_vec(n_points);
-  std::vector<subdomain_id_type> sbd_ids_vec(n_points);
-  std::vector<std::vector<Point>> all_xyz_perturb_vec(n_points);
-  std::vector<std::vector<Real>> phi_i_qp_vec(n_points);
+  VectorizedEvalInput v;
+  v.all_xyz.resize(n_points);
+  v.elem_ids.resize(n_points);
+  v.qps.resize(n_points);
+  v.sbd_ids.resize(n_points);
+  v.all_xyz_perturb.resize(n_points);
+  v.phi_i_qp.resize(n_points);
 
   // Empty vector to be used when xyz perturbations are not required
   std::vector<Point> empty_perturbs;
@@ -449,14 +449,14 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh(const RBP
         {
           mesh_to_preevaluated_values_map[elem_id][qp] = counter;
 
-          all_xyz_vec[counter] = xyz_vec[qp];
-          elem_ids_vec[counter] = elem_id;
-          qps_vec[counter] = qp;
-          sbd_ids_vec[counter] = subdomain_id;
+          v.all_xyz[counter] = xyz_vec[qp];
+          v.elem_ids[counter] = elem_id;
+          v.qps[counter] = qp;
+          v.sbd_ids[counter] = subdomain_id;
 
-          phi_i_qp_vec[counter].resize(phi.size());
+          v.phi_i_qp[counter].resize(phi.size());
           for(auto i : index_range(phi))
-            phi_i_qp_vec[counter][i] = phi[i][qp];
+            v.phi_i_qp[counter][i] = phi[i][qp];
 
           if (requires_xyz_perturbations)
             {
@@ -464,11 +464,11 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh(const RBP
                 libmesh_map_find(all_xyz_perturb, elem_id);
               libmesh_error_msg_if(qp >= qps_and_perturbs.size(), "Error: Invalid qp");
 
-              all_xyz_perturb_vec[counter] = qps_and_perturbs[qp];
+              v.all_xyz_perturb[counter] = qps_and_perturbs[qp];
             }
           else
             {
-              all_xyz_perturb_vec[counter] = empty_perturbs;
+              v.all_xyz_perturb[counter] = empty_perturbs;
             }
 
           counter++;
@@ -476,14 +476,7 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh(const RBP
     }
 
   std::vector<RBParameters> mus {mu};
-  vectorized_evaluate(mus,
-                      all_xyz_vec,
-                      elem_ids_vec,
-                      qps_vec,
-                      sbd_ids_vec,
-                      all_xyz_perturb_vec,
-                      phi_i_qp_vec,
-                      preevaluated_values);
+  vectorized_evaluate(mus, v, preevaluated_values);
 
   preevaluate_parametrized_function_cleanup();
 }
@@ -505,14 +498,15 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh_sides(con
     n_points += xyz_vec.size();
   }
 
-  std::vector<Point> all_xyz_vec(n_points);
-  std::vector<dof_id_type> elem_ids_vec(n_points);
-  std::vector<unsigned int> side_indices_vec(n_points);
-  std::vector<unsigned int> qps_vec(n_points);
-  std::vector<subdomain_id_type> sbd_ids_vec(n_points);
-  std::vector<boundary_id_type> boundary_ids_vec(n_points);
-  std::vector<std::vector<Point>> all_xyz_perturb_vec(n_points);
-  std::vector<std::vector<Real>> phi_i_qp_vec(n_points);
+  VectorizedEvalInput v;
+  v.all_xyz.resize(n_points);
+  v.elem_ids.resize(n_points);
+  v.side_indices.resize(n_points);
+  v.qps.resize(n_points);
+  v.sbd_ids.resize(n_points);
+  v.boundary_ids.resize(n_points);
+  v.all_xyz_perturb.resize(n_points);
+  v.phi_i_qp.resize(n_points);
 
   // Empty vector to be used when xyz perturbations are not required
   std::vector<Point> empty_perturbs;
@@ -563,16 +557,16 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh_sides(con
             {
               mesh_to_preevaluated_side_values_map[elem_side_pair][qp] = counter;
 
-              all_xyz_vec[counter] = xyz_vec[qp];
-              elem_ids_vec[counter] = elem_side_pair.first;
-              side_indices_vec[counter] = elem_side_pair.second;
-              qps_vec[counter] = qp;
-              sbd_ids_vec[counter] = subdomain_id;
-              boundary_ids_vec[counter] = boundary_id;
+              v.all_xyz[counter] = xyz_vec[qp];
+              v.elem_ids[counter] = elem_side_pair.first;
+              v.side_indices[counter] = elem_side_pair.second;
+              v.qps[counter] = qp;
+              v.sbd_ids[counter] = subdomain_id;
+              v.boundary_ids[counter] = boundary_id;
 
-              phi_i_qp_vec[counter].resize(phi.size());
+              v.phi_i_qp[counter].resize(phi.size());
               for(auto i : index_range(phi))
-                phi_i_qp_vec[counter][i] = phi[i][qp];
+                v.phi_i_qp[counter][i] = phi[i][qp];
 
               if (requires_xyz_perturbations)
                 {
@@ -580,11 +574,11 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh_sides(con
                     libmesh_map_find(side_all_xyz_perturb, elem_side_pair);
                   libmesh_error_msg_if(qp >= qps_and_perturbs.size(), "Error: Invalid qp");
 
-                  all_xyz_perturb_vec[counter] = qps_and_perturbs[qp];
+                  v.all_xyz_perturb[counter] = qps_and_perturbs[qp];
                 }
               else
                 {
-                  all_xyz_perturb_vec[counter] = empty_perturbs;
+                  v.all_xyz_perturb[counter] = empty_perturbs;
                 }
               counter++;
             }
@@ -600,16 +594,16 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh_sides(con
             {
               mesh_to_preevaluated_side_values_map[elem_side_pair][qp] = counter;
 
-              all_xyz_vec[counter] = xyz_vec[qp];
-              elem_ids_vec[counter] = elem_side_pair.first;
-              side_indices_vec[counter] = elem_side_pair.second;
-              qps_vec[counter] = qp;
-              sbd_ids_vec[counter] = subdomain_id;
-              boundary_ids_vec[counter] = boundary_id;
+              v.all_xyz[counter] = xyz_vec[qp];
+              v.elem_ids[counter] = elem_side_pair.first;
+              v.side_indices[counter] = elem_side_pair.second;
+              v.qps[counter] = qp;
+              v.sbd_ids[counter] = subdomain_id;
+              v.boundary_ids[counter] = boundary_id;
 
-              phi_i_qp_vec[counter].resize(phi.size());
+              v.phi_i_qp[counter].resize(phi.size());
               for(auto i : index_range(phi))
-                phi_i_qp_vec[counter][i] = phi[i][qp];
+                v.phi_i_qp[counter][i] = phi[i][qp];
 
               if (requires_xyz_perturbations)
                 {
@@ -617,11 +611,11 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh_sides(con
                     libmesh_map_find(side_all_xyz_perturb, elem_side_pair);
                   libmesh_error_msg_if(qp >= qps_and_perturbs.size(), "Error: Invalid qp");
 
-                  all_xyz_perturb_vec[counter] = qps_and_perturbs[qp];
+                  v.all_xyz_perturb[counter] = qps_and_perturbs[qp];
                 }
               else
                 {
-                  all_xyz_perturb_vec[counter] = empty_perturbs;
+                  v.all_xyz_perturb[counter] = empty_perturbs;
                 }
               counter++;
             }
@@ -631,16 +625,7 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh_sides(con
     }
 
   std::vector<RBParameters> mus {mu};
-  side_vectorized_evaluate(mus,
-                           all_xyz_vec,
-                           elem_ids_vec,
-                           side_indices_vec,
-                           qps_vec,
-                           sbd_ids_vec,
-                           boundary_ids_vec,
-                           all_xyz_perturb_vec,
-                           phi_i_qp_vec,
-                           preevaluated_values);
+  side_vectorized_evaluate(mus, v, preevaluated_values);
 
   preevaluate_parametrized_function_cleanup();
 }
@@ -654,9 +639,10 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh_nodes(con
 
   unsigned int n_points = all_xyz.size();
 
-  std::vector<Point> all_xyz_vec(n_points);
-  std::vector<dof_id_type> node_ids_vec(n_points);
-  std::vector<boundary_id_type> boundary_ids_vec(n_points);
+  VectorizedEvalInput v;
+  v.all_xyz.resize(n_points);
+  v.node_ids.resize(n_points);
+  v.boundary_ids.resize(n_points);
 
   // Empty vector to be used when xyz perturbations are not required
   std::vector<Point> empty_perturbs;
@@ -668,19 +654,15 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh_nodes(con
 
       mesh_to_preevaluated_node_values_map[node_id] = counter;
 
-      all_xyz_vec[counter] = p;
-      node_ids_vec[counter] = node_id;
-      boundary_ids_vec[counter] = boundary_id;
+      v.all_xyz[counter] = p;
+      v.node_ids[counter] = node_id;
+      v.boundary_ids[counter] = boundary_id;
 
       counter++;
     }
 
   std::vector<RBParameters> mus {mu};
-  node_vectorized_evaluate(mus,
-                           all_xyz_vec,
-                           node_ids_vec,
-                           boundary_ids_vec,
-                           preevaluated_values);
+  node_vectorized_evaluate(mus, v, preevaluated_values);
 
   preevaluate_parametrized_function_cleanup();
 }
@@ -752,8 +734,12 @@ std::vector<std::vector<Number>> RBParametrizedFunction::evaluate_at_observation
   if (n_points == 0)
     return std::vector<std::vector<Number>>();
 
-  const std::vector<unsigned int> qps_vec(n_points);
-  std::vector<std::vector<Real>> phi_i_qp_vec(n_points);
+  VectorizedEvalInput v;
+  v.all_xyz = observation_points;
+  v.elem_ids = elem_ids;
+  v.sbd_ids = sbd_ids;
+  v.qps.resize(n_points);
+  v.phi_i_qp.resize(n_points);
 
   // In order to compute phi_i_qp, we initialize a FEMContext
   FEMContext con(sys);
@@ -788,21 +774,13 @@ std::vector<std::vector<Number>> RBParametrizedFunction::evaluate_at_observation
       con.pre_fe_reinit(sys, &elem_ref);
       con.get_element_fe(/*var*/ 0, elem_ref.dim())->reinit(&elem_ref, &obs_pt_ref_coords_vec);
 
-      phi_i_qp_vec[obs_pt_idx].resize(phi.size());
+      v.phi_i_qp[obs_pt_idx].resize(phi.size());
       for(auto i : index_range(phi))
-        phi_i_qp_vec[obs_pt_idx][i] = phi[i][/*qp*/ 0];
+        v.phi_i_qp[obs_pt_idx][i] = phi[i][/*qp*/ 0];
     }
 
   std::vector<std::vector<std::vector<Number>>> obs_pt_values;
-
-  vectorized_evaluate({mu},
-                      observation_points,
-                      elem_ids,
-                      qps_vec,
-                      sbd_ids,
-                      /*all_xyz_perturb_vec*/ {},
-                      phi_i_qp_vec,
-                      obs_pt_values);
+  vectorized_evaluate({mu}, v, obs_pt_values);
 
   return obs_pt_values[0];
 }

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -786,23 +786,13 @@ std::vector<std::vector<Number>> RBParametrizedFunction::evaluate_at_observation
 }
 
 void RBParametrizedFunction::get_spatial_indices(std::vector<std::vector<unsigned int>> & /*spatial_indices*/,
-                                                 const std::vector<dof_id_type> & /*elem_ids*/,
-                                                 const std::vector<unsigned int> & /*side_indices*/,
-                                                 const std::vector<dof_id_type> & /*node_ids*/,
-                                                 const std::vector<unsigned int> & /*qps*/,
-                                                 const std::vector<subdomain_id_type> & /*sbd_ids*/,
-                                                 const std::vector<boundary_id_type> & /*boundary_ids*/)
+                                                 const VectorizedEvalInput & /*v*/)
 {
   // No-op by default
 }
 
 void RBParametrizedFunction::initialize_spatial_indices(const std::vector<std::vector<unsigned int>> & /*spatial_indices*/,
-                                                        const std::vector<dof_id_type> & /*elem_ids*/,
-                                                        const std::vector<unsigned int> & /*side_indices*/,
-                                                        const std::vector<dof_id_type> & /*node_ids*/,
-                                                        const std::vector<unsigned int> & /*qps*/,
-                                                        const std::vector<subdomain_id_type> & /*sbd_ids*/,
-                                                        const std::vector<boundary_id_type> & /*boundary_ids*/)
+                                                        const VectorizedEvalInput & /*v*/)
 {
   // No-op by default
 }

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -415,6 +415,9 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh(const RBP
   v.sbd_ids.resize(n_points);
   v.all_xyz_perturb.resize(n_points);
   v.phi_i_qp.resize(n_points);
+  v.JxWs.resize(n_points);
+  v.elem_volumes.resize(n_points);
+  v.elem_types.resize(n_points);
 
   // Empty vector to be used when xyz perturbations are not required
   std::vector<Point> empty_perturbs;
@@ -424,6 +427,7 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh(const RBP
   for (auto dim : con.elem_dimensions())
     {
       auto fe = con.get_element_fe(/*var=*/0, dim);
+      fe->get_JxW();
       fe->get_phi();
     }
 
@@ -442,6 +446,7 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh(const RBP
 
       auto elem_fe = con.get_element_fe(/*var=*/0, elem_ref.dim());
       const std::vector<std::vector<Real>> & phi = elem_fe->get_phi();
+      const std::vector<Real> & JxW = elem_fe->get_JxW();
 
       elem_fe->reinit(&elem_ref);
 
@@ -453,6 +458,10 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh(const RBP
           v.elem_ids[counter] = elem_id;
           v.qps[counter] = qp;
           v.sbd_ids[counter] = subdomain_id;
+
+          v.JxWs[counter] = JxW[qp];
+          v.elem_volumes[counter] = elem_ref.volume();
+          v.elem_types[counter] = elem_ref.type();
 
           v.phi_i_qp[counter].resize(phi.size());
           for(auto i : index_range(phi))


### PR DESCRIPTION
Previously the RB EIM "vectorized evaluate" functions had a large number of separate inputs, which was tedious to deal with and means that it is an API change any time we want to enable more data to be passed to these functions. This update encapsulates these inputs in the `VectorizedEvalInput` class.