### PR TITLE
Add a column API to TypeTensor

### DIFF
--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -179,6 +179,11 @@ public:
   TypeVector<T> row(const unsigned int r) const;
 
   /**
+   * \returns A copy of one column of the tensor as a TypeVector.
+   */
+  TypeVector<T> column(const unsigned int r) const;
+
+  /**
    * Add another tensor to this tensor.
    *
    * \returns A copy of the result, this tensor is unchanged.
@@ -766,6 +771,21 @@ TypeTensor<T>::row(const unsigned int r) const
 
   return return_vector;
 }
+
+
+template <typename T>
+inline
+TypeVector<T>
+TypeTensor<T>::column(const unsigned int r) const
+{
+  TypeVector<T> return_vector;
+
+  for (unsigned int i=0; i<LIBMESH_DIM; i++)
+    return_vector._coords[i] = _coords[i*LIBMESH_DIM + r];
+
+  return return_vector;
+}
+
 
 template <typename T>
 template<typename T2>

--- a/tests/numerics/type_tensor_test.C
+++ b/tests/numerics/type_tensor_test.C
@@ -22,6 +22,7 @@ public:
   CPPUNIT_TEST(testLeftMultiply);
   CPPUNIT_TEST(testRotation);
 #endif
+  CPPUNIT_TEST(testRowCol);
   CPPUNIT_TEST(testIsZero);
 #ifdef LIBMESH_HAVE_METAPHYSICL
   CPPUNIT_TEST(testReplaceAlgebraicType);
@@ -140,6 +141,29 @@ private:
       LIBMESH_ASSERT_FP_EQUAL(1, rotated(2), tol);
     }
   }
+
+  void testRowCol()
+  {
+    LOG_UNIT_TEST;
+
+    TensorValue<Real> t;
+    for (unsigned int i = 0; i < LIBMESH_DIM; i++)
+      for (unsigned int j = 0; j < LIBMESH_DIM; j++)
+        t(i, j) = Real(i * LIBMESH_DIM + j);
+
+    constexpr Real tol = TOLERANCE * TOLERANCE;
+    for (unsigned int k = 0; k < LIBMESH_DIM; k++)
+    {
+      const auto row = t.row(k);
+      for (unsigned int l = 0; l < LIBMESH_DIM; l++)
+        LIBMESH_ASSERT_FP_EQUAL(Real(k * LIBMESH_DIM + l), row(l), tol);
+
+      const auto col = t.column(k);
+      for (unsigned int l = 0; l < LIBMESH_DIM; l++)
+        LIBMESH_ASSERT_FP_EQUAL(Real(l * LIBMESH_DIM + k), col(l), tol);
+    }
+  }
+
 #ifdef LIBMESH_HAVE_METAPHYSICL
   void testReplaceAlgebraicType()
   {


### PR DESCRIPTION
This mimics the `row` API and creates a data copy unlike `slice`