### PR TITLE
Keep track of command line queries

### DIFF
--- a/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
+++ b/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
@@ -79,11 +79,7 @@ int main(int argc, char ** argv)
   // default MPI communicator.
   Mesh mesh(init.comm());
 
-  GetPot command_line (argc, argv);
-
-  int n = 4;
-  if (command_line.search(1, "-n"))
-    n = command_line.next(n);
+  const int n = libMesh::command_line_next("-n", 4);
 
   // Build a 1D mesh with 4 elements from x=0 to x=1, using
   // EDGE3 (i.e. quadratic) 1D elements. They are called EDGE3 elements

--- a/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
+++ b/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
@@ -151,30 +151,24 @@ int main (int argc, char ** argv)
 
   libMesh::out << std::endl << std::endl;
 
-  // Create a GetPot object to parse the command line
-  GetPot command_line (argc, argv);
-
-
   // This boolean value is obtained from the command line, it is true
   // if the flag "-read_solution" is present, false otherwise.
   // It indicates whether we are going to read in
   // the mesh and solution files "saved_mesh.xda" and "saved_solution.xda"
   // or whether we are going to start from scratch by just reading
   // "mesh.xda"
-  const bool read_solution = command_line.search("-read_solution");
+  const bool read_solution = libMesh::on_command_line("-read_solution");
 
   // This value is also obtained from the commandline and it specifies the
   // initial value for the t_step looping variable. We must
   // distinguish between the two cases here, whether we read in the
   // solution or we started from scratch, so that we do not overwrite the
   // gmv output files.
-  unsigned int init_timestep = 0;
+  const unsigned int init_timestep =
+    libMesh::command_line_next("-init_timestep",
+                               libMesh::invalid_uint);
 
-  // Search the command line for the "init_timestep" flag and if it is
-  // present, set init_timestep accordingly.
-  if (command_line.search("-init_timestep"))
-    init_timestep = command_line.next(0);
-  else
+  if (init_timestep == libMesh::invalid_uint)
     {
       // This handy function will print the file name, line number,
       // specified message, and then throw an exception.
@@ -182,18 +176,16 @@ int main (int argc, char ** argv)
     }
 
   // This command line value specifies how many time steps to take.
-  unsigned int n_timesteps = 0;
+  const unsigned int n_timesteps =
+    libMesh::command_line_next("-n_timesteps",
+                               libMesh::invalid_uint);
 
-  if (command_line.search("-n_timesteps"))
-    n_timesteps = command_line.next(0);
-  else
+  if (n_timesteps == libMesh::invalid_uint)
     libmesh_error_msg("ERROR: Number of timesteps not specified");
 
   // This command line value specifies how far to allow refinement
-  unsigned int max_h_level = 5;
-  if (command_line.search("-max_h_level"))
-    max_h_level = command_line.next(n_timesteps);
-
+  const unsigned int max_h_level =
+    libMesh::command_line_next("-max_h_level", 5);
 
   // Skip this 2D example if libMesh was compiled as 1D-only.
   libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");
@@ -214,9 +206,8 @@ int main (int argc, char ** argv)
       mesh.read ("mesh.xda");
 
       // Again do a search on the command line for an argument
-      unsigned int n_refinements = 5;
-      if (command_line.search("-n_refinements"))
-        n_refinements = command_line.next(0);
+      const unsigned int n_refinements = 5;
+        libMesh::command_line_next("-n_refinements", 5);
 
       // Uniformly refine the mesh 5 times
       if (!read_solution)
@@ -422,9 +413,8 @@ int main (int argc, char ** argv)
         }
 
       // Again do a search on the command line for an argument
-      unsigned int output_freq = 10;
-      if (command_line.search("-output_freq"))
-        output_freq = command_line.next(0);
+      const unsigned int output_freq =
+        libMesh::command_line_next("-output_freq", 10);
 
       // Output every 10 timesteps to file.
       if ((t_step+1)%output_freq == 0)

--- a/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
+++ b/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
@@ -171,30 +171,24 @@ int main (int argc, char ** argv)
 
   libMesh::out << std::endl << std::endl;
 
-  // Create a GetPot object to parse the command line
-  GetPot command_line (argc, argv);
-
-
   // This boolean value is obtained from the command line, it is true
   // if the flag "-read_solution" is present, false otherwise.
   // It indicates whether we are going to read in
   // the mesh and solution files "saved_mesh.xda" and "saved_solution.xda"
   // or whether we are going to start from scratch by just reading
   // "mesh.xda"
-  const bool read_solution = command_line.search("-read_solution");
+  const bool read_solution = libMesh::on_command_line("-read_solution");
 
   // This value is also obtained from the commandline and it specifies the
   // initial value for the t_step looping variable. We must
   // distinguish between the two cases here, whether we read in the
   // solution or we started from scratch, so that we do not overwrite the
   // gmv output files.
-  unsigned int init_timestep = 0;
+  const unsigned int init_timestep =
+    libMesh::command_line_next("-init_timestep",
+                               libMesh::invalid_uint);
 
-  // Search the command line for the "init_timestep" flag and if it is
-  // present, set init_timestep accordingly.
-  if (command_line.search("-init_timestep"))
-    init_timestep = command_line.next(0);
-  else
+  if (init_timestep == libMesh::invalid_uint)
     {
       // This handy function will print the file name, line number,
       // specified message, and then throw an exception.
@@ -203,23 +197,23 @@ int main (int argc, char ** argv)
 
   // This value is also obtained from the command line, and specifies
   // the number of time steps to take.
-  unsigned int n_timesteps = 0;
+  const unsigned int n_timesteps =
+    libMesh::command_line_next("-n_timesteps",
+                               libMesh::invalid_uint);
 
-  // Again do a search on the command line for the argument
-  if (command_line.search("-n_timesteps"))
-    n_timesteps = command_line.next(0);
-  else
+  if (n_timesteps == libMesh::invalid_uint)
     libmesh_error_msg("ERROR: Number of timesteps not specified");
 
   // The user can specify a different exact solution on the command
   // line, if we have an expression parser compiled in
 #ifdef LIBMESH_HAVE_FPARSER
-  const bool have_expression = command_line.search("-exact_solution");
+  const bool have_expression = libMesh::on_command_line("-exact_solution");
 #else
   const bool have_expression = false;
 #endif
   if (have_expression)
-    parsed_solution = std::make_unique<ParsedFunction<Number>>(command_line.next(std::string()));
+    parsed_solution = std::make_unique<ParsedFunction<Number>>
+      (libMesh::command_line_next("-exact_solution", std::string()));
 
   // Skip this 2D example if libMesh was compiled as 1D-only.
   libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");
@@ -277,9 +271,8 @@ int main (int argc, char ** argv)
       MeshTools::Generation::build_square(mesh, 2, 2, 0., 2., 0., 2., QUAD4);
 
       // Again do a search on the command line for an argument
-      unsigned int n_refinements = 5;
-      if (command_line.search("-n_refinements"))
-        n_refinements = command_line.next(0);
+      const unsigned int n_refinements =
+        libMesh::command_line_next("-n_refinements", 5);
 
       // Uniformly refine the mesh 5 times
       if (!read_solution)
@@ -420,9 +413,8 @@ int main (int argc, char ** argv)
       *system.old_local_solution = *system.current_local_solution;
 
       // The number of refinement steps per time step.
-      unsigned int max_r_steps = 1;
-      if (command_line.search("-max_r_steps"))
-        max_r_steps = command_line.next(0);
+      const unsigned int max_r_steps =
+        libMesh::command_line_next("-max_r_steps", 1);
 
       // A refinement loop.
       for (unsigned int r_step=0; r_step<max_r_steps+1; r_step++)
@@ -489,9 +481,8 @@ int main (int argc, char ** argv)
         }
 
       // Again do a search on the command line for an argument
-      unsigned int output_freq = 10;
-      if (command_line.search("-output_freq"))
-        output_freq = command_line.next(0);
+      const unsigned int output_freq =
+        libMesh::command_line_next("-output_freq", 10);
 
       // Output every 10 timesteps to file.
       if ((t_step+1)%output_freq == 0)

--- a/examples/adjoints/adjoints_ex2/adjoints_ex2.C
+++ b/examples/adjoints/adjoints_ex2/adjoints_ex2.C
@@ -573,6 +573,9 @@ int main (int argc, char ** argv)
         // performance benchmarks.
         const bool forward_sensitivity = infile("--forward_sensitivity", true);
 
+        // Don't confuse PETSc with our custom GetPot's arguments
+        libMesh::add_command_line_names(infile);
+
         if (forward_sensitivity)
           {
             // This will require two linear solves (one per parameter)

--- a/examples/eigenproblems/eigenproblems_ex1/eigenproblems_ex1.C
+++ b/examples/eigenproblems/eigenproblems_ex1/eigenproblems_ex1.C
@@ -84,19 +84,9 @@ int main (int argc, char ** argv)
   // Get the number of eigen values to be computed from "-n", and
   // possibly the mesh size from -nx and -ny
 
-  GetPot command_line (argc, argv);
-
-  int nev = 5;
-  if (command_line.search(1, "-n"))
-    nev = command_line.next(nev);
-
-  int nx = 20;
-  if (command_line.search(1, "-nx"))
-    nx = command_line.next(nx);
-
-  int ny = 20;
-  if (command_line.search(1, "-ny"))
-    ny = command_line.next(ny);
+  const int nev = libMesh::command_line_next("-n", 5),
+            nx = libMesh::command_line_next("-nx", 20),
+            ny = libMesh::command_line_next("-ny", 20);
 
   // Skip this 2D example if libMesh was compiled as 1D-only.
   libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");

--- a/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
+++ b/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
@@ -96,19 +96,9 @@ int main (int argc, char ** argv)
   // Get the number of eigen values to be computed from "-n", and
   // possibly the mesh size from -nx and -ny
 
-  GetPot command_line (argc, argv);
-
-  int nev = 5;
-  if (command_line.search(1, "-n"))
-    nev = command_line.next(nev);
-
-  int nx = 20;
-  if (command_line.search(1, "-nx"))
-    nx = command_line.next(nx);
-
-  int ny = 20;
-  if (command_line.search(1, "-ny"))
-    ny = command_line.next(ny);
+  const int nev = libMesh::command_line_next("-n", 5),
+            nx = libMesh::command_line_next("-nx", 20),
+            ny = libMesh::command_line_next("-ny", 20);
 
 
   // Skip this 2D example if libMesh was compiled as 1D-only.

--- a/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
+++ b/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
@@ -140,20 +140,17 @@ int main (int argc, char ** argv)
   GetPot command_line (argc, argv);
 
   // Read the mesh name from the command line
-  std::string mesh_name = "";
-  if (command_line.search(1, "-mesh_name"))
-    mesh_name = command_line.next(mesh_name);
+  const std::string mesh_name =
+    libMesh::command_line_next("-mesh_name", std::string());
 
   // Also, read in the index of the eigenvector that we should plot
   // (zero-based indexing, as usual!)
-  unsigned int plotting_index = 0;
-  if (command_line.search(1, "-plotting_index"))
-    plotting_index = command_line.next(plotting_index);
+  const unsigned int plotting_index =
+    libMesh::command_line_next("-plotting_index", 0u);
 
   // Finally, read in the number of eigenpairs we want to compute!
-  unsigned int n_evals = 0;
-  if (command_line.search(1, "-n_evals"))
-    n_evals = command_line.next(n_evals);
+  const unsigned int n_evals =
+    libMesh::command_line_next("-n_evals", 0u);
 
   // Append the .e to mesh_name
   std::ostringstream mesh_name_exodus;

--- a/examples/introduction/introduction_ex1/introduction_ex1.C
+++ b/examples/introduction/introduction_ex1/introduction_ex1.C
@@ -52,8 +52,10 @@ int main (int argc, char ** argv)
   // a filename to write the mesh into.
   libmesh_error_msg_if(argc < 4, "Usage: " << argv[0] << " -d 2 in.mesh [-o out.mesh]");
 
-  // Get the dimensionality of the mesh from argv[2]
-  const unsigned int dim = std::atoi(argv[2]);
+  // Get the dimensionality of the mesh from the "-d" argument
+  const unsigned int dim =
+    libMesh::command_line_next("-d", libMesh::invalid_uint);
+  libmesh_error_msg_if(dim > 3, "Usage: " << argv[0] << " -d 2 in.mesh [-o out.mesh]");
 
   // Skip higher-dimensional examples on a lower-dimensional libMesh build
   libmesh_example_requires(dim <= LIBMESH_DIM, "2D/3D support");
@@ -63,30 +65,31 @@ int main (int argc, char ** argv)
   Mesh mesh(init.comm());
 
   // We may need XDR support compiled in to read binary .xdr files
-  std::string input_filename = argv[3];
+  const std::string input_filename = argv[3];
 #ifndef LIBMESH_HAVE_XDR
   libmesh_example_requires(input_filename.rfind(".xdr") >=
                            input_filename.size(), "XDR support");
 #endif
 
   // Read the input mesh.
-  mesh.read (argv[3]);
+  mesh.read (input_filename);
 
   // Print information about the mesh to the screen.
   mesh.print_info();
 
   // Write the output mesh if the user specified an
   // output file name.
-  if (argc >= 6 && std::string("-o") == argv[4])
+  if (libMesh::on_command_line("-o"))
     {
       // We may need XDR support compiled in to read binary .xdr files
-      std::string output_filename = argv[5];
+      const std::string output_filename =
+        libMesh::command_line_next("-o",std::string());
 #ifndef LIBMESH_HAVE_XDR
       libmesh_example_requires(output_filename.rfind(".xdr") >=
                                output_filename.size(), "XDR support");
 #endif
 
-      mesh.write (argv[5]);
+      mesh.write (output_filename);
     }
 
   // All done.  libMesh objects are destroyed here.  Because the

--- a/examples/introduction/introduction_ex4/introduction_ex4.C
+++ b/examples/introduction/introduction_ex4/introduction_ex4.C
@@ -126,9 +126,6 @@ int main (int argc, char ** argv)
   // Declare a performance log for the main program
   // PerfLog perf_main("Main Program");
 
-  // Create a GetPot object to parse the command line
-  GetPot command_line (argc, argv);
-
   // Check for proper calling arguments.
   libmesh_error_msg_if(argc < 3, "Usage:\n" << "\t " << argv[0] << " -d 2(3)" << " -n 15");
 
@@ -144,9 +141,7 @@ int main (int argc, char ** argv)
   // Read problem dimension from command line.  Use int
   // instead of unsigned since the GetPot overload is ambiguous
   // otherwise.
-  int dim = 2;
-  if (command_line.search(1, "-d"))
-    dim = command_line.next(dim);
+  const int dim = libMesh::command_line_next("-d", 2);
 
   // Skip higher-dimensional examples on a lower-dimensional libMesh build
   libmesh_example_requires(dim <= LIBMESH_DIM, "2D/3D support");
@@ -158,19 +153,17 @@ int main (int argc, char ** argv)
 
   // Create a mesh with user-defined dimension.
   // Read number of elements from command line
-  int ps = 15;
-  if (command_line.search(1, "-n"))
-    ps = command_line.next(ps);
+  const int ps = libMesh::command_line_next("-n", 15);
 
   // Read FE order from command line
   std::string order = "SECOND";
-  if (command_line.search(2, "-Order", "-o"))
-    order = command_line.next(order);
+  order = libMesh::command_line_next("-o", order);
+  order = libMesh::command_line_next("-Order", order);
 
   // Read FE Family from command line
   std::string family = "LAGRANGE";
-  if (command_line.search(2, "-FEFamily", "-f"))
-    family = command_line.next(family);
+  family = libMesh::command_line_next("-f", family);
+  family = libMesh::command_line_next("-Order", family);
 
   // Cannot use discontinuous basis.
   libmesh_error_msg_if((family == "MONOMIAL") || (family == "XYZ"),

--- a/examples/introduction/introduction_ex5/introduction_ex5.C
+++ b/examples/introduction/introduction_ex5/introduction_ex5.C
@@ -120,8 +120,9 @@ int main (int argc, char ** argv)
 
   libMesh::out << std::endl << std::endl;
 
-  // Set the quadrature rule type that the user wants from argv[2]
-  quad_type = static_cast<QuadratureType>(std::atoi(argv[2]));
+  // Set the quadrature rule type that the user wants
+  quad_type = string_to_enum<QuadratureType>
+    (libMesh::command_line_next("-q", std::string("QGAUSS")));
 
   // Skip this 3D example if libMesh was compiled as 1D-only.
   libmesh_example_requires(3 <= LIBMESH_DIM, "3D support");

--- a/examples/introduction/introduction_ex5/introduction_ex5.C
+++ b/examples/introduction/introduction_ex5/introduction_ex5.C
@@ -66,7 +66,10 @@
 // The definition of a geometric element
 #include "libmesh/elem.h"
 #include "libmesh/enum_solver_package.h"
+
+// Reading a quadrature rule from user arguments
 #include "libmesh/enum_quadrature_type.h"
+#include "libmesh/string_to_enum.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/introduction/introduction_ex5/introduction_ex5.C
+++ b/examples/introduction/introduction_ex5/introduction_ex5.C
@@ -124,7 +124,7 @@ int main (int argc, char ** argv)
   libMesh::out << std::endl << std::endl;
 
   // Set the quadrature rule type that the user wants
-  quad_type = string_to_enum<QuadratureType>
+  quad_type = Utility::string_to_enum<QuadratureType>
     (libMesh::command_line_next("-q", std::string("QGAUSS")));
 
   // Skip this 3D example if libMesh was compiled as 1D-only.

--- a/examples/introduction/introduction_ex5/run.sh
+++ b/examples/introduction/introduction_ex5/run.sh
@@ -6,6 +6,6 @@ source $LIBMESH_DIR/examples/run_common.sh
 
 example_name=introduction_ex5
 
-options="-q 0"
+options="-q QGAUSS"
 
 run_example "$example_name" "$options"

--- a/examples/miscellaneous/miscellaneous_ex10/miscellaneous_ex10.C
+++ b/examples/miscellaneous/miscellaneous_ex10/miscellaneous_ex10.C
@@ -77,9 +77,6 @@ int main (int argc, char ** argv)
   libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
                            "--enable-petsc, --enable-trilinos, or --enable-eigen");
 
-  // Create a GetPot object to parse the command line
-  GetPot command_line (argc, argv);
-
   // Check for proper calling arguments.
   libmesh_error_msg_if(argc < 3, "Usage:\n" << "\t " << argv[0] << " -n 15");
 
@@ -104,9 +101,7 @@ int main (int argc, char ** argv)
 #endif
 
   // Read number of elements used in each cube from command line
-  int ps = 10;
-  if (command_line.search(1, "-n"))
-    ps = command_line.next(ps);
+  const int ps = libMesh::command_line_next("-n", 10);
 
   // Generate eight meshes that will be stitched
   Mesh mesh (init.comm());

--- a/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
+++ b/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
@@ -116,10 +116,8 @@ int main (int argc, char ** argv)
   MeshTools::Modification::scale(mesh, L, L, L);
 
   // Get the number of mesh refinements from the command line
-  GetPot command_line (argc, argv);
-  int n_refinements = 3;
-  if (command_line.search(1, "-n_refinements"))
-    n_refinements = command_line.next(n_refinements);
+  const int n_refinements =
+    libMesh::command_line_next("-n_refinements", 3);
 
   // Quadrisect the mesh triangles a few times to obtain a
   // finer mesh.  Subdivision surface elements require the

--- a/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
+++ b/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
@@ -124,10 +124,8 @@ int main (int argc, char ** argv)
 #endif
 
   // Read the "distributed_load" flag from the command line
-  GetPot command_line (argc, argv);
-  int distributed_load = 0;
-  if (command_line.search(1, "-distributed_load"))
-    distributed_load = command_line.next(distributed_load);
+  const int distributed_load =
+    libMesh::command_line_next("-distributed_load", 0);
 
   {
     Mesh mesh (init.comm(), 3);
@@ -143,9 +141,8 @@ int main (int argc, char ** argv)
   mesh.read("cylinder.xdr");
 
   // Get the number of mesh refinements from the command line
-  int n_refinements = 0;
-  if (command_line.search(1, "-n_refinements"))
-    n_refinements = command_line.next(n_refinements);
+  const int n_refinements =
+    libMesh::command_line_next("-n_refinements", 0);
 
   // Refine the mesh if requested
   // Skip adaptive runs on a non-adaptive libMesh build

--- a/examples/miscellaneous/miscellaneous_ex13/miscellaneous_ex13.C
+++ b/examples/miscellaneous/miscellaneous_ex13/miscellaneous_ex13.C
@@ -125,10 +125,7 @@ int main (int argc, char ** argv)
 #endif
 
   // Read the "distributed_load" flag from the command line
-  GetPot command_line (argc, argv);
-  int distributed_load = 0;
-  if (command_line.search(1, "-distributed_load"))
-    distributed_load = command_line.next(distributed_load);
+  const int distributed_load = libMesh::command_line_next("-distributed_load", 0);
 
   {
     Mesh mesh (init.comm(), 3);

--- a/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
+++ b/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
@@ -169,25 +169,23 @@ int main (int argc, char ** argv)
   libMesh::out << std::endl << std::endl;
 
   // Read number of refinements
-  int nr = 2;
-  if (command_line.search(1, "-r"))
-    nr = command_line.next(nr);
+  const int nr = libMesh::command_line_next("-r", 2);
 
   // Read FE order from command line
   std::string order = "FIRST";
-  if (command_line.search(2, "-Order", "-o"))
-    order = command_line.next(order);
+  order = libMesh::command_line_next("-o", order);
+  order = libMesh::command_line_next("-Order", order);
 
   // Read FE Family from command line
   std::string family = "LAGRANGE";
-  if (command_line.search(2, "-FEFamily", "-f"))
-    family = command_line.next(family);
+  family = libMesh::command_line_next("-f", family);
+  family = libMesh::command_line_next("-Order", family);
 
   // Cannot use discontinuous basis.
   libmesh_error_msg_if((family == "MONOMIAL") || (family == "XYZ"),
                        "This example requires a C^0 (or higher) FE basis.");
 
-  if (command_line.search(1, "-pre"))
+  if (libMesh::on_command_line("-pre"))
     {
 #ifdef LIBMESH_HAVE_PETSC
       //Use the jacobian for preconditioning.

--- a/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
+++ b/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
@@ -113,11 +113,7 @@ int main (int argc, char ** argv)
   libmesh_example_requires(false, "--enable-dirichlet");
 #endif
 
-  GetPot command_line (argc, argv);
-
-  Real R = 2.;
-  if (command_line.search(1, "-R"))
-    R = command_line.next(R);
+  const Real R = libMesh::command_line_next("-R", 2.);
 
   Mesh mesh(init.comm());
 
@@ -174,9 +170,8 @@ int main (int argc, char ** argv)
 #ifdef LIBMESH_ENABLE_AMR
   // Possibly solve on a refined mesh next.
   MeshRefinement mesh_refinement (mesh);
-  unsigned int n_refinements = 0;
-  if (command_line.search("-n_refinements"))
-    n_refinements = command_line.next(0);
+  unsigned int n_refinements =
+    libMesh::command_line_next("-n_refinements", 0);
 
   for (unsigned int r = 0; r != n_refinements; ++r)
     {

--- a/examples/reduced_basis/reduced_basis_ex1/reduced_basis_ex1.C
+++ b/examples/reduced_basis/reduced_basis_ex1/reduced_basis_ex1.C
@@ -114,10 +114,7 @@ int main (int argc, char ** argv)
   bool store_basis_functions = infile("store_basis_functions", true); // Do we write the RB basis functions to disk?
 
   // Read the "online_mode" flag from the command line
-  GetPot command_line (argc, argv);
-  int online_mode = 0;
-  if (command_line.search(1, "-online_mode"))
-    online_mode = command_line.next(online_mode);
+  const int online_mode = libMesh::command_line_next("-online_mode", 0);
 
   // Build a mesh on the default MPI communicator.
   Mesh mesh (init.comm(), dim);

--- a/examples/reduced_basis/reduced_basis_ex2/reduced_basis_ex2.C
+++ b/examples/reduced_basis/reduced_basis_ex2/reduced_basis_ex2.C
@@ -115,10 +115,7 @@ int main (int argc, char ** argv)
   bool store_basis_functions = infile("store_basis_functions", true); // Do we write the RB basis functions to disk?
 
   // Read the "online_mode" flag from the command line
-  GetPot command_line (argc, argv);
-  int online_mode = 0;
-  if (command_line.search(1, "-online_mode"))
-    online_mode = command_line.next(online_mode);
+  const int online_mode = libMesh::command_line_next("-online_mode", 0);
 
   // Build a mesh on the default MPI communicator.
   Mesh mesh (init.comm(), dim);

--- a/examples/reduced_basis/reduced_basis_ex3/reduced_basis_ex3.C
+++ b/examples/reduced_basis/reduced_basis_ex3/reduced_basis_ex3.C
@@ -91,10 +91,7 @@ int main (int argc, char** argv)
   bool store_basis_functions = infile("store_basis_functions", true); // Do we write the RB basis functions to disk?
 
   // Read the "online_mode" flag from the command line
-  GetPot command_line (argc, argv);
-  int online_mode = 0;
-  if (command_line.search(1, "-online_mode"))
-    online_mode = command_line.next(online_mode);
+  const int online_mode = libMesh::command_line_next("-online_mode", 0);
 
   // Build a mesh on the default MPI communicator.
   Mesh mesh (init.comm(), dim);

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -94,18 +94,12 @@ int main (int argc, char ** argv)
   const unsigned int dim = 2;                      // The number of spatial dimensions
 
   // Read the "online_mode" flag from the command line
-  GetPot command_line (argc, argv);
-  int online_mode = 0;
-  if (command_line.search(1, "-online_mode"))
-    online_mode = command_line.next(online_mode);
-
-  int eim_training_function_to_plot = 0;
-  if (command_line.search(1, "-eim_training_function_to_plot"))
-    eim_training_function_to_plot = command_line.next(eim_training_function_to_plot);
-
-  int eim_basis_function_to_plot = 0;
-  if (command_line.search(1, "-eim_basis_function_to_plot"))
-    eim_basis_function_to_plot = command_line.next(eim_basis_function_to_plot);
+  const int online_mode =
+    libMesh::command_line_next("-online_mode", 0),
+            eim_training_function_to_plot =
+    libMesh::command_line_next("-eim_training_function_to_plot", 0),
+            eim_basis_function_to_plot =
+    libMesh::command_line_next("-eim_basis_function_to_plot", 0);
 
   ReplicatedMesh mesh (init.comm(), dim);
   MeshTools::Generation::build_square (mesh,

--- a/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
+++ b/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
@@ -134,11 +134,7 @@ int main(int argc, char ** argv)
   bool store_basis_functions = infile("store_basis_functions", true);
 
   // Read the "online_mode" flag from the command line
-  GetPot command_line(argc, argv);
-  int online_mode = 0;
-  if (command_line.search(1, "-online_mode"))
-    online_mode = command_line.next(online_mode);
-
+  const int online_mode = libMesh::command_line_next("-online_mode", 0);
 
   Mesh mesh (init.comm());
 

--- a/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
+++ b/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
@@ -151,10 +151,8 @@ int main (int argc, char ** argv)
   unsigned int n_elem_z  = infile("n_elem_z", 1);
 
   // Read the "online_mode" flag from the command line
-  GetPot command_line (argc, argv);
-  int online_mode = 0;
-  if (command_line.search(1, "-online_mode"))
-    online_mode = command_line.next(online_mode);
+  const int online_mode =
+    libMesh::command_line_next("-online_mode", 0);
 
   // Create a mesh, with dimension to be overridden by build_cube, on
   // the default MPI communicator.  We currently have to create a

--- a/examples/reduced_basis/reduced_basis_ex7/reduced_basis_ex7.C
+++ b/examples/reduced_basis/reduced_basis_ex7/reduced_basis_ex7.C
@@ -146,10 +146,8 @@ int main (int argc, char** argv)
   bool store_basis_functions = infile("store_basis_functions", true); // Do we write the RB basis functions to disk?
 
   // Read the "online_mode" flag from the command line
-  GetPot command_line (argc, argv);
-  int online_mode = 0;
-  if (command_line.search(1, "-online_mode"))
-    online_mode = command_line.next(online_mode);
+  const int online_mode =
+    libMesh::command_line_next("-online_mode", 0);
 
   // Create a mesh on the default MPI communicator.
   Mesh mesh(init.comm(), dim);

--- a/examples/subdomains/subdomains_ex1/subdomains_ex1.C
+++ b/examples/subdomains/subdomains_ex1/subdomains_ex1.C
@@ -129,28 +129,24 @@ int main (int argc, char ** argv)
   // Read problem dimension from command line.  Use int
   // instead of unsigned since the GetPot overload is ambiguous
   // otherwise.
-  int dim = 2;
-  if (command_line.search(1, "-d"))
-    dim = command_line.next(dim);
+  const int dim = libMesh::command_line_next("-d", 2);
 
   // Skip higher-dimensional examples on a lower-dimensional libMesh build
   libmesh_example_requires(dim <= LIBMESH_DIM, "2D/3D support");
 
   // Create a mesh with user-defined dimension.
   // Read number of elements from command line
-  int ps = 15;
-  if (command_line.search(1, "-n"))
-    ps = command_line.next(ps);
+  const int ps = libMesh::command_line_next("-n", 15);
 
   // Read FE order from command line
   std::string order = "FIRST";
-  if (command_line.search(2, "-Order", "-o"))
-    order = command_line.next(order);
+  order = libMesh::command_line_next("-o", order);
+  order = libMesh::command_line_next("-Order", order);
 
   // Read FE Family from command line
   std::string family = "LAGRANGE";
-  if (command_line.search(2, "-FEFamily", "-f"))
-    family = command_line.next(family);
+  family = libMesh::command_line_next("-f", family);
+  family = libMesh::command_line_next("-Order", family);
 
   // Cannot use discontinuous basis.
   libmesh_error_msg_if((family == "MONOMIAL") || (family == "XYZ"),

--- a/examples/subdomains/subdomains_ex2/subdomains_ex2.C
+++ b/examples/subdomains/subdomains_ex2/subdomains_ex2.C
@@ -119,9 +119,7 @@ int main (int argc, char ** argv)
   // Read problem dimension from command line.  Use int
   // instead of unsigned since the GetPot overload is ambiguous
   // otherwise.
-  int dim = 2;
-  if (command_line.search(1, "-d"))
-    dim = command_line.next(dim);
+  const int dim = libMesh::command_line_next("-d", 2);
 
   // Skip higher-dimensional examples on a lower-dimensional libMesh build
   libmesh_example_requires(dim <= LIBMESH_DIM, "2D/3D support");
@@ -131,19 +129,17 @@ int main (int argc, char ** argv)
   Mesh mesh (init.comm(), dim);
 
   // Read number of elements from command line
-  int ps = 15;
-  if (command_line.search(1, "-n"))
-    ps = command_line.next(ps);
+  const int ps = libMesh::command_line_next("-n", 15);
 
   // Read FE order from command line
   std::string order = "SECOND";
-  if (command_line.search(2, "-Order", "-o"))
-    order = command_line.next(order);
+  order = libMesh::command_line_next("-o", order);
+  order = libMesh::command_line_next("-Order", order);
 
   // Read FE Family from command line
   std::string family = "LAGRANGE";
-  if (command_line.search(2, "-FEFamily", "-f"))
-    family = command_line.next(family);
+  family = libMesh::command_line_next("-f", family);
+  family = libMesh::command_line_next("-Order", family);
 
   // Cannot use discontinuous basis.
   libmesh_error_msg_if(((family == "MONOMIAL") || (family == "XYZ")) &&

--- a/examples/subdomains/subdomains_ex3/subdomains_ex3.C
+++ b/examples/subdomains/subdomains_ex3/subdomains_ex3.C
@@ -86,13 +86,11 @@ int main (int argc, char ** argv)
   Mesh mesh(init.comm());
 
   {
-    unsigned int dim=2;
+    const unsigned int dim =
+      libMesh::command_line_next("-d", 2);
 
-    if (argc == 3 && std::atoi(argv[2]) == 3)
-      {
-        std::cout << "Running in 3D" << std::endl;
-        dim=3;
-      }
+    if (dim == 3)
+      std::cout << "Running in 3D" << std::endl;
 
     mesh.read ((dim==2) ? "mesh.xda" : "hybrid_3d.xda");
   }
@@ -101,12 +99,9 @@ int main (int argc, char ** argv)
   // This class handles all the details of mesh refinement and coarsening.
   MeshRefinement mesh_refinement (mesh);
 
-  GetPot command_line (argc, argv);
-
   // Uniformly refine the mesh, by default 4 times.
-  int n_refinements = 4;
-  if (command_line.search(1, "-n_refinements"))
-    n_refinements = command_line.next(n_refinements);
+  const int n_refinements =
+    libMesh::command_line_next("-n_refinements", 4);
 
   mesh_refinement.uniformly_refine (n_refinements);
 

--- a/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
+++ b/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
@@ -90,11 +90,8 @@ int main (int argc, char ** argv)
   Mesh mesh(init.comm());
 
   // Get the mesh size from the command line.
-  GetPot command_line (argc, argv);
-
-  int n_elem = 15;
-  if (command_line.search(1, "-n_elem"))
-    n_elem = command_line.next(n_elem);
+  const int n_elem =
+    libMesh::command_line_next("-n_elem", 15);
 
   // Use the MeshTools::Generation mesh generator to create a uniform
   // 2D grid on the square [-1,1]^2.  We instruct the mesh generator

--- a/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
+++ b/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
@@ -119,11 +119,7 @@ int main (int argc, char** argv)
   Mesh mesh(init.comm());
 
   // Get the mesh size from the command line.
-  GetPot command_line (argc, argv);
-
-  int n_elem = 20;
-  if (command_line.search(1, "-n_elem"))
-    n_elem = command_line.next(n_elem);
+  const int n_elem = libMesh::command_line_next("-n_elem", 20);
 
   // Use the MeshTools::Generation mesh generator to create a uniform
   // 2D grid on the square [-1,1]^2.  We instruct the mesh generator
@@ -192,9 +188,7 @@ int main (int argc, char** argv)
 
   // We also set a standard linear solver flag in the EquationSystems object
   // which controls the maximum number of linear solver iterations allowed.
-  int max_iter = 25;
-  if (command_line.search(1, "-max_iter"))
-    max_iter = command_line.next(max_iter);
+  const int max_iter = libMesh::command_line_next("-max_iter", 25);
 
   equation_systems.parameters.set<unsigned int>("linear solver maximum iterations") = max_iter;
 

--- a/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
+++ b/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
@@ -106,11 +106,7 @@ int main (int argc, char ** argv)
   Mesh mesh(init.comm());
 
   // Get the mesh size from the command line.
-  GetPot command_line (argc, argv);
-
-  int n_elem = 20;
-  if (command_line.search(1, "-n_elem"))
-    n_elem = command_line.next(n_elem);
+  const int n_elem = libMesh::command_line_next("-n_elem", 20);
 
   // Use the MeshTools::Generation mesh generator to create a uniform
   // 2D grid on the square [-1,1]^2.  We instruct the mesh generator
@@ -181,10 +177,7 @@ int main (int argc, char ** argv)
 
   // We also set a standard linear solver flag in the EquationSystems object
   // which controls the maximum number of linear solver iterations allowed.
-
-  int max_iter = 250;
-  if (command_line.search(1, "-max_iter"))
-    max_iter = command_line.next(max_iter);
+  const int max_iter = libMesh::command_line_next("-max_iter", 250);
 
   equation_systems.parameters.set<unsigned int>("linear solver maximum iterations") = max_iter;
 

--- a/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
+++ b/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
@@ -97,13 +97,8 @@ int main (int argc, char ** argv)
   Mesh mesh(init.comm(), dim);
 
   // Get the mesh size from the command line.
-  GetPot command_line (argc, argv);
-
-  int nx = 50, ny = 10;
-  if (command_line.search(1, "-nx"))
-    nx = command_line.next(nx);
-  if (command_line.search(1, "-ny"))
-    ny = command_line.next(ny);
+  const int nx = libMesh::command_line_next("-nx", 50),
+            ny = libMesh::command_line_next("-ny", 10);
 
   MeshTools::Generation::build_square (mesh,
                                        nx, ny,

--- a/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
+++ b/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
@@ -103,7 +103,7 @@ int main (int argc, char ** argv)
   // Get the mesh size from the command line.
   GetPot command_line (argc, argv);
 
-  const int nx = libMesh::command_line_next("-nx", 50), 
+  const int nx = libMesh::command_line_next("-nx", 50),
             ny = libMesh::command_line_next("-ny", 10);
 
   // Create a 2D mesh distributed across the default MPI communicator.

--- a/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
+++ b/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
@@ -103,11 +103,8 @@ int main (int argc, char ** argv)
   // Get the mesh size from the command line.
   GetPot command_line (argc, argv);
 
-  int nx = 50, ny = 10;
-  if (command_line.search(1, "-nx"))
-    nx = command_line.next(nx);
-  if (command_line.search(1, "-ny"))
-    ny = command_line.next(ny);
+  const int nx = libMesh::command_line_next("-nx", 50), 
+            ny = libMesh::command_line_next("-ny", 10);
 
   // Create a 2D mesh distributed across the default MPI communicator.
   Mesh mesh(init.comm(), dim);

--- a/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
+++ b/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
@@ -432,16 +432,9 @@ int main (int argc, char ** argv)
 #endif
 
   // Get the mesh size from the command line.
-  GetPot command_line (argc, argv);
-
-  int nx = 32, ny = 8, nz = 4;
-  if (command_line.search(1, "-nx"))
-    nx = command_line.next(nx);
-  if (command_line.search(1, "-ny"))
-    ny = command_line.next(ny);
-  if (command_line.search(1, "-nz"))
-    nz = command_line.next(nz);
-
+  const int nx = libMesh::command_line_next("-nx", 32),
+            ny = libMesh::command_line_next("-ny", 8),
+            nz = libMesh::command_line_next("-nz", 4);
 
   // Create a 3D mesh distributed across the default MPI communicator.
   Mesh mesh(init.comm(), dim);

--- a/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
+++ b/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
@@ -101,11 +101,8 @@ int main (int argc, char ** argv)
   // Get the mesh size from the command line.
   GetPot command_line (argc, argv);
 
-  int nx = 15, ny = 15;
-  if (command_line.search(1, "-nx"))
-    nx = command_line.next(nx);
-  if (command_line.search(1, "-ny"))
-    ny = command_line.next(ny);
+  const int nx = libMesh::command_line_next("-nx", 15),
+            ny = libMesh::command_line_next("-ny", 15);
 
   // Create a mesh, with dimension to be overridden later, on the
   // default MPI communicator.

--- a/include/base/libmesh.h
+++ b/include/base/libmesh.h
@@ -22,8 +22,9 @@
 
 
 // Local includes
-#include "libmesh/libmesh_common.h"
 #include "libmesh/libmesh_base.h"
+#include "libmesh/libmesh_common.h"
+#include "libmesh/libmesh_config.h"
 
 // C++ includes
 #include <string>
@@ -38,6 +39,14 @@ class vtkMPIController;
 namespace TIMPI {
   class TIMPIInit;
 }
+
+#ifdef GETPOT_NAMESPACE
+namespace GETPOT_NAMESPACE {
+#endif
+class GetPot;
+#ifdef GETPOT_NAMESPACE
+}
+#endif
 
 /**
  * The \p libMesh namespace provides an interface to certain functionality
@@ -55,6 +64,7 @@ namespace libMesh
 namespace Parallel {
   class Communicator;
 }
+
 enum SolverPackage : int;
 
 /**
@@ -233,6 +243,13 @@ std::vector<std::string> command_line_names();
  * Add a name to the set of queried command-line names
  */
 void add_command_line_name(const std::string & name);
+
+/**
+ * Merge a GetPot object's requested names into the set of queried
+ * command-line names
+ */
+void add_command_line_names(const GetPot & getpot);
+
 
 /**
  * The imaginary unit, \f$ \sqrt{-1} \f$.

--- a/include/base/libmesh.h
+++ b/include/base/libmesh.h
@@ -220,6 +220,21 @@ template <typename T>
 void command_line_vector (const std::string &, std::vector<T> &);
 
 /**
+ * \returns The set of names which this program has queried or
+ * expected to query via the libMesh command line interface.
+ *
+ * This is useful for detecting any future conflicts with other
+ * packages (such as PETSc) which manage command line values, and for
+ * avoiding UFO warnings from such packages.
+ */
+std::vector<std::string> command_line_names();
+
+/**
+ * Add a name to the set of queried command-line names
+ */
+void add_command_line_name(const std::string & name);
+
+/**
  * The imaginary unit, \f$ \sqrt{-1} \f$.
  */
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -894,6 +894,17 @@ void add_command_line_name(const std::string & name)
 }
 
 
+
+void add_command_line_names(const GetPot & getpot)
+{
+  for (auto & getter : {&GetPot::get_requested_arguments,
+                        &GetPot::get_requested_variables,
+                        &GetPot::get_requested_sections})
+    for (const std::string & name : (getpot.*getter)())
+      add_command_line_name(name);
+}
+
+
 std::vector<std::string> command_line_names()
 {
   return std::vector<std::string>(command_line_name_set.begin(),

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -762,6 +762,13 @@ LibMeshInit::~LibMeshInit()
     libMesh::enableFPE(false);
 
 #if defined(LIBMESH_HAVE_PETSC)
+  // Let PETSc know about all the command line objects that we
+  // consumed without asking them, so we don't get unused option
+  // warnings abou those.
+  std::vector<std::string> cli_names = command_line_names();
+  for (const auto & name : cli_names)
+    PetscOptionsClearValue(NULL, name.c_str());
+
   // Allow the user to bypass PETSc finalization
   if (!libMesh::on_command_line ("--disable-petsc")
 #if defined(LIBMESH_HAVE_MPI)


### PR DESCRIPTION
This gives us a mechanism by which we can tell PETSc to ignore them (right before PetscFinalize), so user codes can avoid spurious PETSc unused-option warnings.

I've tested this a bit by hand but only in one configuration; I'll throw the CI kitchen sink at it before we think about merging.