### PR TITLE
Example option typo fixes

### DIFF
--- a/examples/introduction/introduction_ex4/introduction_ex4.C
+++ b/examples/introduction/introduction_ex4/introduction_ex4.C
@@ -163,7 +163,7 @@ int main (int argc, char ** argv)
   // Read FE Family from command line
   std::string family = "LAGRANGE";
   family = libMesh::command_line_next("-f", family);
-  family = libMesh::command_line_next("-Order", family);
+  family = libMesh::command_line_next("-FEFamily", family);
 
   // Cannot use discontinuous basis.
   libmesh_error_msg_if((family == "MONOMIAL") || (family == "XYZ"),

--- a/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
+++ b/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
@@ -179,7 +179,7 @@ int main (int argc, char ** argv)
   // Read FE Family from command line
   std::string family = "LAGRANGE";
   family = libMesh::command_line_next("-f", family);
-  family = libMesh::command_line_next("-Order", family);
+  family = libMesh::command_line_next("-FEFamily", family);
 
   // Cannot use discontinuous basis.
   libmesh_error_msg_if((family == "MONOMIAL") || (family == "XYZ"),

--- a/examples/subdomains/subdomains_ex1/subdomains_ex1.C
+++ b/examples/subdomains/subdomains_ex1/subdomains_ex1.C
@@ -146,7 +146,7 @@ int main (int argc, char ** argv)
   // Read FE Family from command line
   std::string family = "LAGRANGE";
   family = libMesh::command_line_next("-f", family);
-  family = libMesh::command_line_next("-Order", family);
+  family = libMesh::command_line_next("-FEFamily", family);
 
   // Cannot use discontinuous basis.
   libmesh_error_msg_if((family == "MONOMIAL") || (family == "XYZ"),

--- a/examples/subdomains/subdomains_ex2/subdomains_ex2.C
+++ b/examples/subdomains/subdomains_ex2/subdomains_ex2.C
@@ -139,7 +139,7 @@ int main (int argc, char ** argv)
   // Read FE Family from command line
   std::string family = "LAGRANGE";
   family = libMesh::command_line_next("-f", family);
-  family = libMesh::command_line_next("-Order", family);
+  family = libMesh::command_line_next("-FEFamily", family);
 
   // Cannot use discontinuous basis.
   libmesh_error_msg_if(((family == "MONOMIAL") || (family == "XYZ")) &&


### PR DESCRIPTION
This is embarrassing.  Fixes for mistakes in the #3736 refactoring.

We never use this option in our `run.sh` scripts, so CI didn't scream about the screwup.