### PR TITLE
Do same vector operations in solver precheck as resid/jac eval

### DIFF
--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -54,6 +54,7 @@ extern "C"
   PetscErrorCode libmesh_petsc_snes_mffd_residual (SNES snes, Vec x, Vec r, void * ctx);
   PetscErrorCode libmesh_petsc_snes_mffd_interface (void * ctx, Vec x, Vec r);
   PetscErrorCode libmesh_petsc_snes_jacobian (SNES, Vec x, Mat jac, Mat pc, void * ctx);
+  PetscErrorCode libmesh_petsc_snes_precheck(SNESLineSearch, Vec X, Vec Y, PetscBool * changed, void * context);
   PetscErrorCode libmesh_petsc_snes_postcheck(SNESLineSearch, Vec x, Vec y, Vec w, PetscBool * changed_y, PetscBool * changed_w, void * context);
   PetscErrorCode libmesh_petsc_linesearch_shellfunc(SNESLineSearch linesearch, void * ctx);
 
@@ -293,6 +294,11 @@ private:
   friend PetscErrorCode libmesh_petsc_snes_fd_residual (SNES snes, Vec x, Vec r, void * ctx);
   friend PetscErrorCode libmesh_petsc_snes_mffd_residual (SNES snes, Vec x, Vec r, void * ctx);
   friend PetscErrorCode libmesh_petsc_snes_jacobian (SNES snes, Vec x, Mat jac, Mat pc, void * ctx);
+  friend PetscErrorCode libmesh_petsc_snes_precheck (SNESLineSearch,
+                                                     Vec X,
+                                                     Vec Y,
+                                                     PetscBool * changed,
+                                                     void * context);
 };
 
 } // namespace libMesh

--- a/include/systems/nonlinear_implicit_system.h
+++ b/include/systems/nonlinear_implicit_system.h
@@ -212,15 +212,31 @@ public:
                             sys_type & S) = 0;
   };
 
+  /**
+   * Abstract base class to be used for applying user modifications to the Newton search direction
+   * \emph before the solver's line search is called.
+   */
   class ComputePreCheck
   {
   public:
     virtual ~ComputePreCheck () = default;
 
-    virtual void precheck (const NumericVector<Number> & old_soln,
-                           NumericVector<Number> & search_direction,
-                           bool & changed,
-                           sys_type & S) = 0;
+    /**
+     * Abstract precheck method that users must override
+     * @param precheck_soln This is the solution prior to the linesearch (which we have not
+     * performed yet). This will correspond to the system's \p current_local_solution data member,
+     * so it should hold all the information locally that a user might want to query from the vector
+     * (e.g. possibly ghost entries)
+     * @param search_direction The search direction that will be used in the upcoming line search.
+     * \emph Note that this is the \emph negative of the solution update, at least when using PETSc
+     * as the backend. The user may modify this vector
+     * @param changed Whether the user has modified the \p search_direction
+     * @param S The nonlinear implicit system
+     */
+    virtual void precheck(const NumericVector<Number> & precheck_soln,
+                          NumericVector<Number> & search_direction,
+                          bool & changed,
+                          sys_type & S) = 0;
   };
 
   /**


### PR DESCRIPTION
These include
- Most importantly, updating the `current_local_solution` based on the vector passed in by PETSc
- Then performing constraint enforcement on the `current_local_solution`

This should allow a lot more code reuse in MOOSE where it's assumed that any computations using the degrees of freedom in the nonlinear system should use the `current_local_solution` vector. As an indication of the possbility for more code re-use, the library level changes allowed removal of the `ghosted_old_solution` data member in the HDG NS example.

Unrelated to the library changes I also removed the `parallel_increment` data member in the HDG NS example because it's simply not needed. This furthers the example of what I will implement in MOOSE, e.g. the number of new vectors I will need to add for HDG should only be one.