### PR TITLE
Don't die in volume() on a twisted element

### DIFF
--- a/include/base/libmesh_exceptions.h
+++ b/include/base/libmesh_exceptions.h
@@ -146,12 +146,14 @@ public:
 #define libmesh_noexcept noexcept
 
 #define LIBMESH_THROW(e) do { throw e; } while (0)
+#define libmesh_rethrow throw
 #define libmesh_try try
 #define libmesh_catch(e) catch(e)
 
 #else
 
 #define LIBMESH_THROW(e) do { libMesh::err << e.what(); std::abort(); } while (0)
+#define libmesh_rethrow
 #define libmesh_try
 #define libmesh_catch(e) if (0)
 

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -974,6 +974,10 @@ public:
 
   /**
    * \returns The (length/area/volume) of the geometric element.
+   *
+   * If the element is twisted or inverted such that the mapping
+   * Jacobian is singular at any point, implementations of this method
+   * may return a "net" volume or may simply return NaN.
    */
   virtual Real volume () const;
 

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -887,7 +887,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
 
             const Real det = (g11*g22 - g12*g21);
 
-            if (det <= 0.)
+            if (det <= jacobian_tolerance)
               {
                 // Don't call print_info() recursively if we're already
                 // failing.  print_info() calls Elem::volume() which may

--- a/tests/geom/volume_test.C
+++ b/tests/geom/volume_test.C
@@ -176,9 +176,10 @@ public:
     prism6->point(1) *= -1;
     prism6->point(1) += 2*prism6->point(0);
 
-    // Its volume should now be NaN and shouldn't throw an error.
-    Real vol = prism6->volume();
-    CPPUNIT_ASSERT(libmesh_isnan(vol));
+    // The real test here is that volume() doesn't throw
+    const Real vol = prism6->volume();
+    const Real gold_vol = 3+Real(5)/9;
+    CPPUNIT_ASSERT_LESS(TOLERANCE, std::abs(vol-gold_vol));
   }
 
   void testEdge3Volume()

--- a/tests/geom/volume_test.C
+++ b/tests/geom/volume_test.C
@@ -24,6 +24,7 @@ class VolumeTest : public CppUnit::TestCase
 
 public:
   LIBMESH_CPPUNIT_TEST_SUITE( VolumeTest );
+  CPPUNIT_TEST( testTwistedVolume );
   CPPUNIT_TEST( testEdge3Volume );
   CPPUNIT_TEST( testEdge3Invertible );
   CPPUNIT_TEST( testEdge4Invertible );
@@ -153,6 +154,31 @@ public:
       LIBMESH_ASSERT_FP_EQUAL(0, true_centroid(2), TOLERANCE*TOLERANCE);
 #endif // LIBMESH_ENABLE_AMR
     }
+  }
+
+  void testTwistedVolume()
+  {
+    LOG_UNIT_TEST;
+
+    ReplicatedMesh mesh(*TestCommWorld);
+
+    // Build an element type that will fall back on our generic
+    // quadrature-based Elem::volume()
+    MeshTools::Generation::build_cube(mesh,
+                                      /*nelem=*/1, /*nelem=*/1, /*nelem=*/1,
+                                      /*xmin=*/-1, /*xmax=*/1,
+                                      /*ymin=*/-1, /*ymax=*/1,
+                                      /*zmin=*/-1, /*zmax=*/1,
+                                      PRISM21);
+
+    // Pick an element and twist it
+    Elem * prism6 = mesh.elem_ptr(0);
+    prism6->point(1) *= -1;
+    prism6->point(1) += 2*prism6->point(0);
+
+    // Its volume should now be NaN and shouldn't throw an error.
+    Real vol = prism6->volume();
+    CPPUNIT_ASSERT(libmesh_isnan(vol));
   }
 
   void testEdge3Volume()


### PR DESCRIPTION
I started out by trying to return NaN when we detected a twisted element, but that was weirdly inconsistent between `Elem::volume()` and it's various specializations, so instead I'm just returning the same "net volume" that we should be getting from the specialized `volume()` functions when they're called on a twisted element.  I'll leave the NaN stuff in our git history just in case we change our minds in the future; it would be tedious to detect twisted elements in every specialization, but not impossible.