### PR TITLE
Make VTK preserve ids when reading

### DIFF
--- a/src/mesh/namebased_io.C
+++ b/src/mesh/namebased_io.C
@@ -246,7 +246,8 @@ void NameBasedIO::read (const std::string & name)
           else if (basename.rfind(".gmv") < basename.size())
             GMVIO(mymesh).read (new_name);
 
-          else if (basename.rfind(".vtu") < basename.size())
+          else if (basename.rfind(".pvtu") < basename.size() ||
+                   basename.rfind(".vtu") < basename.size())
             VTKIO(mymesh).read(new_name);
 
           else if (basename.rfind(".inp") < basename.size())
@@ -279,6 +280,7 @@ void NameBasedIO::read (const std::string & name)
                                 << "     *.off  -- OOGL OFF surface format\n" \
                                 << "     *.ogl  -- OOGL OFF surface format\n" \
                                 << "     *.oogl -- OOGL OFF surface format\n" \
+                                << "     *.pvtu  -- Paraview VTK format\n" \
                                 << "     *.ucd  -- AVS's ASCII UCD format\n" \
                                 << "     *.unv  -- I-deas Universal format\n" \
                                 << "     *.vtu  -- Paraview VTK format\n" \
@@ -400,8 +402,8 @@ void NameBasedIO::write (const std::string & name)
         else if (basename.rfind(".fro") < basename.size())
           FroIO(mymesh).write (new_name);
 
-        else if (basename.rfind(".vtu") < basename.size())
-          VTKIO(mymesh).write (new_name);
+        else if (basename.rfind(".pvtu") < basename.size())
+          VTKIO(mymesh).write (name);
 
         else
           {
@@ -421,9 +423,9 @@ void NameBasedIO::write (const std::string & name)
               << "     *.nem   -- Sandia's Nemesis format\n"
               << "     *.plt   -- Tecplot binary file\n"
               << "     *.poly  -- TetGen ASCII file\n"
+              << "     *.pvtu   -- VTK (paraview-readable) format\n"
               << "     *.ucd   -- AVS's ASCII UCD format\n"
               << "     *.unv   -- I-deas Universal format\n"
-              << "     *.vtu   -- VTK (paraview-readable) format\n"
               << "     *.xda   -- libMesh ASCII format\n"
               << "     *.xdr   -- libMesh binary format,\n"
               << std::endl

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -422,6 +422,9 @@ void ReplicatedMesh::renumber_elem(const dof_id_type old_id,
   Elem * el = _elements[old_id];
   libmesh_assert (el);
 
+  if (new_id >= _elements.size())
+    _elements.resize(new_id+1, nullptr);
+
   el->set_id(new_id);
   libmesh_assert (!_elements[new_id]);
   _elements[new_id] = el;
@@ -635,6 +638,9 @@ void ReplicatedMesh::renumber_node(const dof_id_type old_id,
   // This doesn't get used in serial yet
   Node * nd = _nodes[old_id];
   libmesh_assert (nd);
+
+  if (new_id >= _nodes.size())
+    _nodes.resize(new_id+1, nullptr);
 
   nd->set_id(new_id);
   libmesh_assert (!_nodes[new_id]);

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -34,6 +34,7 @@
 #include "libmesh/ignore_warnings.h"
 
 #include "vtkXMLUnstructuredGridReader.h"
+#include "vtkXMLPUnstructuredGridReader.h"
 #include "vtkXMLUnstructuredGridWriter.h"
 #include "vtkXMLPUnstructuredGridWriter.h"
 #include "vtkUnstructuredGrid.h"
@@ -193,7 +194,7 @@ void VTKIO::read (const std::string & name)
   elems_of_dimension.resize(4, false);
 
   // Use a typedef, because these names are just crazy
-  typedef vtkSmartPointer<vtkXMLUnstructuredGridReader> MyReader;
+  typedef vtkSmartPointer<vtkXMLPUnstructuredGridReader> MyReader;
   MyReader reader = MyReader::New();
 
   // Pass the filename along to the reader

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -212,8 +212,43 @@ void VTKIO::read (const std::string & name)
   // Clear out any pre-existing data from the Mesh
   mesh.clear();
 
+  // Try to preserve any libMesh ids and subdomain ids we find in the
+  // file.  This will be null if there are none, e.g. if a non-libMesh
+  // program wrote this file.
+
+  vtkAbstractArray * abstract_elem_id =
+    _vtk_grid->GetCellData()->GetAbstractArray("libmesh_elem_id");
+  vtkAbstractArray * abstract_node_id =
+    _vtk_grid->GetPointData()->GetAbstractArray("libmesh_node_id");
+  vtkAbstractArray * abstract_subdomain_id =
+    _vtk_grid->GetCellData()->GetAbstractArray("subdomain_id");
+
+  // Get ids as integers.  This will be null if they are another data
+  // type, e.g. if a non-libMesh program used the names we thought
+  // were unique for different data.
+  vtkIntArray * elem_id = vtkIntArray::SafeDownCast(abstract_elem_id);
+  vtkIntArray * node_id = vtkIntArray::SafeDownCast(abstract_node_id);
+  vtkIntArray * subdomain_id = vtkIntArray::SafeDownCast(abstract_subdomain_id);
+
+  if (abstract_elem_id && !elem_id)
+    libmesh_warning("Found non-integral libmesh_elem_id array; forced to ignore it.\n"
+                    "This is technically valid but probably broken.");
+
+  if (abstract_node_id && !node_id)
+    libmesh_warning("Found non-integral libmesh_node_id array; forced to ignore it.\n"
+                    "This is technically valid but probably broken.");
+
+  if (abstract_subdomain_id && !subdomain_id)
+    libmesh_warning("Found non-integral subdomain_id array; forced to ignore it.\n"
+                    "This is technically valid but probably broken.");
+
   // Get the number of points from the _vtk_grid object
   const unsigned int vtk_num_points = static_cast<unsigned int>(_vtk_grid->GetNumberOfPoints());
+
+  // Map from VTK indexing to libMesh id if necessary
+  std::vector<dof_id_type> vtk_node_to_libmesh;
+  if (node_id)
+    vtk_node_to_libmesh.resize(vtk_num_points);
 
   // always numbered nicely so we can loop like this
   for (unsigned int i=0; i<vtk_num_points; ++i)
@@ -223,34 +258,25 @@ void VTKIO::read (const std::string & name)
       double pnt[3];
       _vtk_grid->GetPoint(static_cast<vtkIdType>(i), pnt);
       Point xyz(pnt[0], pnt[1], pnt[2]);
-      mesh.add_point(xyz, i);
+
+      if (node_id)
+        {
+          auto id = node_id->GetValue(i);
+
+          // It would nice to distinguish between "duplicate nodes
+          // because one was ghosted in a parallel file segment" and
+          // "duplicate nodes because there was a bug", but I'm not
+          // sure how to do that with vtkXMLPUnstructuredGridReader
+          if (!mesh.query_node_ptr(id))
+            mesh.add_point(xyz, id);
+          vtk_node_to_libmesh[i] = id;
+        }
+      else
+        mesh.add_point(xyz, i);
     }
 
   // Get the number of cells from the _vtk_grid object
   const unsigned int vtk_num_cells = static_cast<unsigned int>(_vtk_grid->GetNumberOfCells());
-
-  // Try to preserve any libMesh ids and subdomain ids we find in the
-  // file.  This will be null if there are none, e.g. if a non-libMesh
-  // program wrote this file.
-
-  vtkAbstractArray * abstract_elem_id =
-    _vtk_grid->GetCellData()->GetAbstractArray("libmesh_elem_id");
-  vtkAbstractArray * abstract_subdomain_id =
-    _vtk_grid->GetCellData()->GetAbstractArray("subdomain_id");
-
-  // Get ids as integers.  This will be null if they are another data
-  // type, e.g. if a non-libMesh program used the names we thought
-  // were unique for different data.
-  vtkIntArray * elem_id = vtkIntArray::SafeDownCast(abstract_elem_id);
-  vtkIntArray * subdomain_id = vtkIntArray::SafeDownCast(abstract_subdomain_id);
-
-  if (abstract_elem_id && !elem_id)
-    libmesh_warning("Found non-integral libmesh_elem_id array; forced to ignore it.\n"
-                    "This is technically valid but probably broken.");
-
-  if (abstract_subdomain_id && !subdomain_id)
-    libmesh_warning("Found non-integral subdomain_id array; forced to ignore it.\n"
-                    "This is technically valid but probably broken.");
 
   auto& element_map = libmesh_map_find(_element_maps, mesh.default_mapping_type());
 
@@ -265,8 +291,13 @@ void VTKIO::read (const std::string & name)
 
       // get the straightforward numbering from the VTK cells
       for (auto j : elem->node_index_range())
-        elem->set_node(j) =
-          mesh.node_ptr(cast_int<dof_id_type>(cell->GetPointId(j)));
+        {
+          const auto vtk_point_id = cell->GetPointId(j);
+          const dof_id_type libmesh_node_id = node_id ?
+            vtk_node_to_libmesh[vtk_point_id] : vtk_point_id;
+
+          elem->set_node(j) = mesh.node_ptr(libmesh_node_id);
+        }
 
       // then get the connectivity
       std::vector<dof_id_type> conn;
@@ -478,6 +509,10 @@ void VTKIO::nodes_to_vtk()
   }
 #endif
 
+  vtkSmartPointer<vtkIntArray> node_id = vtkSmartPointer<vtkIntArray>::New();
+  node_id->SetName("libmesh_node_id");
+  node_id->SetNumberOfComponents(1);
+
   unsigned int local_node_counter = 0;
 
   for (const auto & node_ptr : mesh.local_node_ptr_range())
@@ -505,6 +540,8 @@ void VTKIO::nodes_to_vtk()
       }
 #endif
 
+      node_id->InsertTuple1(local_node_counter, node.id());
+
       ++local_node_counter;
     }
 
@@ -513,6 +550,8 @@ void VTKIO::nodes_to_vtk()
 
   // add points to grid
   _vtk_grid->SetPoints(points);
+  _vtk_grid->GetPointData()->AddArray(node_id);
+
 #if !VTK_VERSION_LESS_THAN(9,0,0)
   if (have_weights)
     _vtk_grid->GetPointData()->SetRationalWeights(rational_weights);
@@ -531,6 +570,13 @@ void VTKIO::cells_to_vtk()
   vtkSmartPointer<vtkIdList> pts = vtkSmartPointer<vtkIdList>::New();
 
   std::vector<int> types(mesh.n_active_local_elem());
+
+  // We already created this but we need to add more if we have any
+  // ghost nodes
+  vtkAbstractArray * abstract_node_id =
+    _vtk_grid->GetPointData()->GetAbstractArray("libmesh_node_id");
+  vtkIntArray * node_id = vtkIntArray::SafeDownCast(abstract_node_id);
+  libmesh_assert(node_id);
 
   vtkSmartPointer<vtkIntArray> elem_id = vtkSmartPointer<vtkIntArray>::New();
   elem_id->SetName("libmesh_elem_id");
@@ -581,6 +627,8 @@ void VTKIO::cells_to_vtk()
               // Update the _local_node_map with the ID returned by VTK
               _local_node_map[global_node_id] =
                 cast_int<dof_id_type>(local);
+
+              node_id->InsertTuple1(local, global_node_id);
             }
 
           // Otherwise, the node ID was found in the _local_node_map, so


### PR DESCRIPTION
Also, make VTK reading work robustly again, and add unit tests to make it (including id preservation) less likely to regress again, and make MeshBase::renumber_* more robust along the way.

This should close #3756