### PR TITLE
Support interior_parent() in Elem order upgrades

### DIFF
--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1056,7 +1056,8 @@ Elem * Elem::interior_parent ()
 void Elem::set_interior_parent (Elem * p)
 {
   // interior parents make no sense for full-dimensional elements.
-  libmesh_assert_less (this->dim(), LIBMESH_DIM);
+  libmesh_assert (!p ||
+                  this->dim() < LIBMESH_DIM);
 
   // If we have an interior_parent, we USED TO assume it was a
   // one-higher-dimensional interior element, but we now allow e.g.

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -245,7 +245,8 @@ void transfer_elem(Elem & lo_elem,
    * be its exterior child, not the old element.
    */
   Elem * interior_p = lo_elem.interior_parent();
-  hi_elem->set_interior_parent(interior_p);
+  if (interior_p)
+    hi_elem->set_interior_parent(interior_p);
 
   auto parent_exterior_it = exterior_children_of.find(interior_p);
   if (parent_exterior_it != exterior_children_of.end())


### PR DESCRIPTION
This fixes a segfault (or in dbg mode, an assertion failure) in MALAMUTE tests for me.

Refs https://github.com/idaholab/moose/pull/26462