### PR TITLE
Introduce scaling into POD in EIM

### DIFF
--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -375,11 +375,8 @@ private:
 
         for (const auto & comp : index_range(v_comp_and_qp))
           {
-            // If scale_components_in_enrichment() returns true then we
-            // apply a scaling to give an approximately uniform scaling
-            // for all components.
             Real comp_scaling = 1.;
-            if (get_rb_eim_evaluation().scale_components_in_enrichment())
+            if (get_rb_eim_evaluation().scale_components_in_enrichment().count(comp))
               {
                 // Make sure that _component_scaling_in_training_set is initialized
                 libmesh_error_msg_if(comp >= _component_scaling_in_training_set.size(),

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -344,18 +344,21 @@ private:
    * quadrature points. The inner product includes the JxW contributions
    * stored in _local_quad_point_JxW, so that this is equivalent to
    * computing w^t M v, where M is the mass matrix.
+   *
+   * If \p apply_comp_scaling then we will incorporate the scaling from
+   * _component_scaling_in_training_set in the inner product.
    */
-  Number inner_product(const QpDataMap & v, const QpDataMap & w);
+  Number inner_product(const QpDataMap & v, const QpDataMap & w, bool apply_comp_scaling);
 
   /**
    * Same as inner_product() except for side data.
    */
-  Number side_inner_product(const SideQpDataMap & v, const SideQpDataMap & w);
+  Number side_inner_product(const SideQpDataMap & v, const SideQpDataMap & w, bool apply_comp_scaling);
 
   /**
    * Same as inner_product() except for node data.
    */
-  Number node_inner_product(const NodeDataMap & v, const NodeDataMap & w);
+  Number node_inner_product(const NodeDataMap & v, const NodeDataMap & w, bool apply_comp_scaling);
 
   /**
    * Get the maximum absolute value from a vector stored in the format that we use

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -579,15 +579,6 @@ private:
    */
   std::map<std::pair<dof_id_type,unsigned int>, unsigned int > _local_side_quad_point_side_types;
 
-  /**
-   * We also optionally store the values at the "observation points" for all parametrized functions
-   * in the training set. These values are used to obtain the observation values that are stored in
-   * RBEIMEvaluation.
-   *
-   * Indexing is: training_index --> observation point index --> component --> value.
-   */
-  std::vector<std::vector<std::vector<Number>>> _parametrized_functions_for_training_obs_values;
-
 };
 
 } // namespace libMesh

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -520,12 +520,9 @@ public:
                                        unsigned int var);
 
   /**
-   * Return a set that specifies which EIM variables will be projected
-   * and written out in write_out_projected_basis_functions().
-   * By default this returns an empty vector, but can be overridden in
-   * subclasses to specify the EIM variables that are relevant for visualization.
+   * Get _eim_vars_to_project_and_write.
    */
-  virtual std::set<unsigned int> get_eim_vars_to_project_and_write() const;
+  const std::set<unsigned int> & get_eim_vars_to_project_and_write() const;
 
   /**
    * Project all basis functions using project_qp_data_map_onto_system() and
@@ -535,12 +532,9 @@ public:
                                            const std::string & directory_name = "offline_data");
 
   /**
-   * Indicate whether we should apply scaling to the components of the parametrized
-   * function during basis function enrichment in order give an approximately uniform
-   * magnitude for all components. This is helpful in cases where the components vary
-   * widely in magnitude.
+   * Get _scale_components_in_enrichment.
    */
-  virtual bool scale_components_in_enrichment() const;
+  const std::set<unsigned int> & scale_components_in_enrichment() const;
 
   /**
    * Virtual function to indicate if we use the EIM error indicator in this case.
@@ -581,6 +575,27 @@ public:
    * Get the VectorizedEvalInput data.
    */
   const VectorizedEvalInput & get_vec_eval_input() const;
+
+protected:
+
+  /**
+   * This set specifies which EIM variables will be projected and written
+   * out in write_out_projected_basis_functions(). By default this is an empty
+   * set, but can be updated in subclasses to specify the EIM variables that
+   * are relevant for visualization.
+   */
+  std::set<unsigned int> _eim_vars_to_project_and_write;
+
+  /**
+   * This set that specifies which EIM variables will be scaled during EIM
+   * enrichment so that their maximum value matches the maximum value across
+   * all variables. This is helpful in cases where some components are much
+   * smaller in magnitude than others, since in those cases if we do not apply
+   * component scaling to the small components then the accuracy of the EIM
+   * approximation for those components will not be controlled well by the
+   * EIM enrichment process.
+   */
+  std::set<unsigned int> _scale_components_in_enrichment;
 
 private:
 

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -563,13 +563,11 @@ public:
 
   /**
    * Evaluates the EIM error indicator based on \p error_indicator_rhs, \p eim_solution,
-   * and _error_indicator_interpolation_row. We also pass in \p eim_rhs, since that is
-   * used in order to normalize the error indicator.
+   * and _error_indicator_interpolation_row.
    */
   Real get_eim_error_indicator(
     Number error_indicator_rhs,
-    const DenseVector<Number> & eim_solution,
-    const DenseVector<Number> & eim_rhs);
+    const DenseVector<Number> & eim_solution);
 
   /**
    * Get the VectorizedEvalInput data.

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -690,6 +690,12 @@ Real RBEIMConstruction::train_eim_approximation_with_POD()
   // The POD basis we use is then given by U, which
   // we can compute via U = Y V S^{-1}, which is what
   // we compute below.
+  //
+  // Note that the formulation remains the same in the
+  // case that we use a weighted inner product (as
+  // in the case that we used apply_comp_scaling=true
+  // when computing the correlation matrix), see the
+  // lecture notes from Volkwein on POD for more details.
   DenseVector<Real> sigma( n_snapshots );
   DenseMatrix<Number> U( n_snapshots, n_snapshots );
   DenseMatrix<Number> VT( n_snapshots, n_snapshots );

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -2548,6 +2548,12 @@ void RBEIMConstruction::enrich_eim_approximation_on_interiors(const QpDataMap & 
               Number value = qp_values[qp];
               Real abs_value = std::abs(value);
 
+              // If we are using component scaling in enrichment, then we
+              // also need to scale abs_value here so that we take the
+              // scaling into account when we determine largest_abs_value.
+              if (get_rb_eim_evaluation().scale_components_in_enrichment())
+                abs_value *= _component_scaling_in_training_set[comp];
+
               bool update_optimal_point = false;
               if (!eim_point_data)
                 update_optimal_point = (abs_value > largest_abs_value);

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -694,8 +694,9 @@ Real RBEIMConstruction::train_eim_approximation_with_POD()
   // Note that the formulation remains the same in the
   // case that we use a weighted inner product (as
   // in the case that we used apply_comp_scaling=true
-  // when computing the correlation matrix), see the
-  // lecture notes from Volkwein on POD for more details.
+  // when computing the correlation matrix), see (1.28)
+  // from the lecture notes from Volkwein on POD for more
+  // details.
   DenseVector<Real> sigma( n_snapshots );
   DenseMatrix<Number> U( n_snapshots, n_snapshots );
   DenseMatrix<Number> VT( n_snapshots, n_snapshots );

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -1442,7 +1442,8 @@ void RBEIMConstruction::initialize_parametrized_functions_in_training_set()
       _component_scaling_in_training_set.resize(n_comps);
       for(unsigned int i : make_range(n_comps))
         {
-          if (max_abs_value_per_component_in_training_set[i] == 0.)
+          if ((eim_eval.scale_components_in_enrichment().count(i) == 0) ||
+               max_abs_value_per_component_in_training_set[i] == 0.)
             _component_scaling_in_training_set[i] = 1.;
           else
             _component_scaling_in_training_set[i] = _max_abs_value_in_training_set / max_abs_value_per_component_in_training_set[i];
@@ -1508,7 +1509,8 @@ void RBEIMConstruction::initialize_parametrized_functions_in_training_set()
       _component_scaling_in_training_set.resize(n_comps);
       for(unsigned int i : make_range(n_comps))
         {
-          if (max_abs_value_per_component_in_training_set[i] == 0.)
+          if ((eim_eval.scale_components_in_enrichment().count(i) == 0) ||
+               max_abs_value_per_component_in_training_set[i] == 0.)
             _component_scaling_in_training_set[i] = 1.;
           else
             _component_scaling_in_training_set[i] = _max_abs_value_in_training_set / max_abs_value_per_component_in_training_set[i];
@@ -1576,7 +1578,8 @@ void RBEIMConstruction::initialize_parametrized_functions_in_training_set()
       _component_scaling_in_training_set.resize(n_comps);
       for(unsigned int i : make_range(n_comps))
         {
-          if (max_abs_value_per_component_in_training_set[i] == 0.)
+          if ((eim_eval.scale_components_in_enrichment().count(i) == 0) ||
+               max_abs_value_per_component_in_training_set[i] == 0.)
             _component_scaling_in_training_set[i] = 1.;
           else
             _component_scaling_in_training_set[i] = _max_abs_value_in_training_set / max_abs_value_per_component_in_training_set[i];

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -1556,8 +1556,6 @@ void RBEIMConstruction::initialize_parametrized_functions_in_training_set()
           else
             _component_scaling_in_training_set[i] = _max_abs_value_in_training_set / max_abs_value_per_component_in_training_set[i];
         }
-
-      _parametrized_functions_for_training_obs_values.resize( get_n_training_samples() );
     }
 }
 

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -642,7 +642,7 @@ Real RBEIMConstruction::train_eim_approximation_with_POD()
 
   std::cout << "Start computing correlation matrix" << std::endl;
 
-  bool apply_comp_scaling = get_rb_eim_evaluation().scale_components_in_enrichment();
+  bool apply_comp_scaling = !get_rb_eim_evaluation().scale_components_in_enrichment().empty();
   for (unsigned int i=0; i<n_snapshots; i++)
     {
       for (unsigned int j=0; j<=i; j++)
@@ -2105,11 +2105,8 @@ Real RBEIMConstruction::get_node_max_abs_value(const NodeDataMap & v) const
         {
           const auto & value = values[comp];
 
-          // If scale_components_in_enrichment() returns true then we
-          // apply a scaling to give an approximately uniform scaling
-          // for all components.
           Real comp_scaling = 1.;
-          if (get_rb_eim_evaluation().scale_components_in_enrichment())
+          if (get_rb_eim_evaluation().scale_components_in_enrichment().count(comp))
             {
               // Make sure that _component_scaling_in_training_set is initialized
               libmesh_error_msg_if(comp >= _component_scaling_in_training_set.size(),
@@ -2548,10 +2545,7 @@ void RBEIMConstruction::enrich_eim_approximation_on_interiors(const QpDataMap & 
               Number value = qp_values[qp];
               Real abs_value = std::abs(value);
 
-              // If we are using component scaling in enrichment, then we
-              // also need to scale abs_value here so that we take the
-              // scaling into account when we determine largest_abs_value.
-              if (get_rb_eim_evaluation().scale_components_in_enrichment())
+              if (get_rb_eim_evaluation().scale_components_in_enrichment().count(comp))
                 abs_value *= _component_scaling_in_training_set[comp];
 
               bool update_optimal_point = false;

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -634,7 +634,9 @@ Real RBEIMConstruction::train_eim_approximation_with_POD()
 
   libMesh::out << std::endl << "---- Performing POD EIM basis enrichment ----" << std::endl;
 
-  // Set up the POD "correlation matrix"
+  // Set up the POD "correlation matrix". This enables us to compute the POD via the
+  // "method of snapshots", in which we compute a low rank representation of the
+  // n_snapshots x n_snapshots matrix.
   unsigned int n_snapshots = get_n_training_samples();
   DenseMatrix<Number> correlation_matrix(n_snapshots,n_snapshots);
 
@@ -682,7 +684,12 @@ Real RBEIMConstruction::train_eim_approximation_with_POD()
     }
   std::cout << "Finished computing correlation matrix" << std::endl;
 
-  // compute SVD of correlation matrix
+  // Compute SVD of correlation matrix.
+  // Let Y = U S V^T, then the SVD below corresponds
+  // to Y^T Y = V S U^T U S V^T = V S^2 V^T.
+  // The POD basis we use is then given by U, which
+  // we can compute via U = Y V S^{-1}, which is what
+  // we compute below.
   DenseVector<Real> sigma( n_snapshots );
   DenseMatrix<Number> U( n_snapshots, n_snapshots );
   DenseMatrix<Number> VT( n_snapshots, n_snapshots );

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -2920,9 +2920,9 @@ void RBEIMEvaluation::project_qp_data_map_onto_system(System & sys,
   (*sys.solution) = current_local_soln;
 }
 
-std::set<unsigned int> RBEIMEvaluation::get_eim_vars_to_project_and_write() const
+const std::set<unsigned int> & RBEIMEvaluation::get_eim_vars_to_project_and_write() const
 {
-  return std::set<unsigned int>();
+  return _eim_vars_to_project_and_write;
 }
 
 void RBEIMEvaluation::write_out_projected_basis_functions(System & sys,
@@ -2958,12 +2958,9 @@ void RBEIMEvaluation::write_out_projected_basis_functions(System & sys,
     }
 }
 
-bool RBEIMEvaluation::scale_components_in_enrichment() const
+const std::set<unsigned int> & RBEIMEvaluation::scale_components_in_enrichment() const
 {
-  // Return false by default, but we override this in subclasses
-  // where the parametrized function components differ widely in
-  // magnitude.
-  return false;
+  return _scale_components_in_enrichment;
 }
 
 bool RBEIMEvaluation::use_eim_error_indicator() const

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -284,7 +284,7 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
             Number error_indicator_rhs = evaluated_values_at_err_indicator_point[counter];
             _rb_eim_error_indicators[counter] =
               get_eim_error_indicator(
-                error_indicator_rhs, _rb_eim_solutions[counter], EIM_rhs);
+                error_indicator_rhs, _rb_eim_solutions[counter]);
           }
 
         counter++;
@@ -2983,8 +2983,7 @@ void RBEIMEvaluation::set_eim_error_indicator_active(bool is_active)
 
 Real RBEIMEvaluation::get_eim_error_indicator(
   Number error_indicator_rhs,
-  const DenseVector<Number> & eim_solution,
-  const DenseVector<Number> & eim_rhs)
+  const DenseVector<Number> & eim_solution)
 {
   DenseVector<Number> coeffs;
   _error_indicator_interpolation_row.get_principal_subvector(eim_solution.size(), coeffs);

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -2992,12 +2992,25 @@ Real RBEIMEvaluation::get_eim_error_indicator(
   Real error_indicator_val =
     std::real(error_indicator_rhs - (coeffs.dot(eim_solution)));
 
-  // Normalize the error indicator based on the norm of the EIM RHS vector,
-  // but also check for the case that the EIM RHS vector is zero in order
-  // to handle that separately.
-  Real eim_coeff_norm = eim_rhs.linfty_norm();
+  // We normalize the EIM error indicator based on adding the abs. value
+  // of the two terms that we subtract in order to compute error_indicator_val.
+  // This approach is appealing since (by the triangle inequality) it will
+  // normalize the error indicator so that it is always be bounded above by 1,
+  // which makes the indicator easier to interpret by comparing it to 1.
+  // An alternative normalization would be to use abs(error_indicator_rhs),
+  // and we note that in cases where abs(error_indicator_val) <<
+  // abs(error_indicator_rhs), then the two error indicator normalization options
+  //  will differ by approximately a factor of 2. This means that these two
+  // options behave similarly for practical error indicator purposes in the
+  // limit that the error indicator is small (since a factor of 2 difference is small
+  // for error indicator purposes), and in the limit that the indicator is large
+  // we prefer choice we use here since (as discussed above) ensuring that the
+  // indicator is bounded by 1 is convenient.
+  Real normalization = std::abs(error_indicator_rhs) + std::abs(coeffs.dot(eim_solution));
 
-  Real normalization = (eim_coeff_norm > 0.) ? eim_coeff_norm : 1.;
+  // We avoid NaNs by setting normalization to 1 in the case that it is exactly 0.
+  if (normalization == 0.)
+    normalization = 1.;
 
   return std::abs(error_indicator_val) / normalization;
 }


### PR DESCRIPTION
We already incorporate a scaling via `_component_scaling_in_training_set` in the EIM greedy training, so here we also activate this option in the EIM POD training.