### PR TITLE
Another change to EIM error indicator normalization

### DIFF
--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -563,11 +563,13 @@ public:
 
   /**
    * Evaluates the EIM error indicator based on \p error_indicator_rhs, \p eim_solution,
-   * and _error_indicator_interpolation_row.
+   * and _error_indicator_interpolation_row. We also pass in \p eim_rhs since this is
+   * used to normalize the error indicator.
    */
   Real get_eim_error_indicator(
     Number error_indicator_rhs,
-    const DenseVector<Number> & eim_solution);
+    const DenseVector<Number> & eim_solution,
+    const DenseVector<Number> & eim_rhs);
 
   /**
    * Get the VectorizedEvalInput data.

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -565,8 +565,12 @@ public:
    * Evaluates the EIM error indicator based on \p error_indicator_rhs, \p eim_solution,
    * and _error_indicator_interpolation_row. We also pass in \p eim_rhs since this is
    * used to normalize the error indicator.
+   *
+   * We return a pair that specifies the relative error indicator, and the normalization
+   * that was used to compute the relative error indicator. We can then recover the
+   * absolute error indicator via rel. indicator x normalization.
    */
-  Real get_eim_error_indicator(
+  std::pair<Real,Real> get_eim_error_indicator(
     Number error_indicator_rhs,
     const DenseVector<Number> & eim_solution,
     const DenseVector<Number> & eim_rhs);


### PR DESCRIPTION
Go back to using the EIM rhs since that handles cases with different component magnitudes better