### PR TITLE
Matrix read/write to matlab format, unit test coverage improvements

### DIFF
--- a/include/base/sparsity_pattern.h
+++ b/include/base/sparsity_pattern.h
@@ -159,6 +159,11 @@ public:
   { return nonlocal_pattern; }
 
   /**
+   * The total number of nonzeros in the global matrix.
+   */
+  std::size_t n_nonzeros() const;
+
+  /**
    * The number of on-processor nonzeros in my portion of the
    * global matrix.
    */

--- a/include/numerics/diagonal_matrix.h
+++ b/include/numerics/diagonal_matrix.h
@@ -124,6 +124,10 @@ public:
 
   virtual numeric_index_type row_stop() const override;
 
+  virtual numeric_index_type col_start() const override;
+
+  virtual numeric_index_type col_stop() const override;
+
   virtual void set(const numeric_index_type i, const numeric_index_type j, const T value) override;
 
   virtual void add(const numeric_index_type i, const numeric_index_type j, const T value) override;

--- a/include/numerics/diagonal_matrix.h
+++ b/include/numerics/diagonal_matrix.h
@@ -157,6 +157,10 @@ public:
 
   virtual void get_transpose(SparseMatrix<T> & dest) const override;
 
+  virtual void get_row(numeric_index_type i,
+                       std::vector<numeric_index_type> & indices,
+                       std::vector<T> & values) const override;
+
   virtual void zero_rows(std::vector<numeric_index_type> & rows, T val = 0) override;
 
   const NumericVector<T> & diagonal() const;

--- a/include/numerics/eigen_sparse_matrix.h
+++ b/include/numerics/eigen_sparse_matrix.h
@@ -111,6 +111,10 @@ public:
 
   virtual numeric_index_type row_stop () const override;
 
+  virtual numeric_index_type col_start () const override;
+
+  virtual numeric_index_type col_stop () const override;
+
   virtual void set (const numeric_index_type i,
                     const numeric_index_type j,
                     const T value) override;

--- a/include/numerics/eigen_sparse_matrix.h
+++ b/include/numerics/eigen_sparse_matrix.h
@@ -147,6 +147,9 @@ public:
 
   virtual void get_transpose (SparseMatrix<T> & dest) const override;
 
+  virtual void get_row(numeric_index_type i,
+                       std::vector<numeric_index_type> & indices,
+                       std::vector<T> & values) const override;
 private:
 
   /**

--- a/include/numerics/laspack_matrix.h
+++ b/include/numerics/laspack_matrix.h
@@ -164,6 +164,10 @@ public:
 
   virtual void get_transpose (SparseMatrix<T> & dest) const override;
 
+  virtual void get_row(numeric_index_type i,
+                       std::vector<numeric_index_type> & indices,
+                       std::vector<T> & values) const override;
+
 private:
 
   /**

--- a/include/numerics/laspack_matrix.h
+++ b/include/numerics/laspack_matrix.h
@@ -152,7 +152,7 @@ public:
   virtual T operator () (const numeric_index_type i,
                          const numeric_index_type j) const override;
 
-  virtual Real l1_norm () const override { libmesh_not_implemented(); return 0.; }
+  virtual Real l1_norm () const override;
 
   virtual Real linfty_norm () const override { libmesh_not_implemented(); return 0.; }
 

--- a/include/numerics/laspack_matrix.h
+++ b/include/numerics/laspack_matrix.h
@@ -121,6 +121,10 @@ public:
 
   virtual numeric_index_type row_stop () const override;
 
+  virtual numeric_index_type col_start () const override;
+
+  virtual numeric_index_type col_stop () const override;
+
   virtual void set (const numeric_index_type i,
                     const numeric_index_type j,
                     const T value) override;

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -210,6 +210,10 @@ public:
 
   virtual numeric_index_type row_stop () const override;
 
+  virtual numeric_index_type col_start () const override;
+
+  virtual numeric_index_type col_stop () const override;
+
   virtual void set (const numeric_index_type i,
                     const numeric_index_type j,
                     const T value) override;

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -197,7 +197,7 @@ public:
   /**
    * Get the number of columns owned by this process
    */
-  numeric_index_type local_n () const;
+  virtual numeric_index_type local_n () const final;
 
   /**
    * Get the number of rows and columns owned by this process

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -225,6 +225,11 @@ public:
   virtual numeric_index_type local_m () const { return row_stop() - row_start(); }
 
   /**
+   * Get the number of columns owned by this process
+   */
+  virtual numeric_index_type local_n () const { return col_stop() - col_start(); }
+
+  /**
    * \returns The column-dimension of the matrix.
    */
   virtual numeric_index_type n () const = 0;
@@ -240,6 +245,18 @@ public:
    * processor.
    */
   virtual numeric_index_type row_stop () const = 0;
+
+  /**
+   * \returns The index of the first matrix column owned by this
+   * processor.
+   */
+  virtual numeric_index_type col_start () const = 0;
+
+  /**
+   * \returns The index of the last matrix column (+1) owned by this
+   * processor.
+   */
+  virtual numeric_index_type col_stop () const = 0;
 
   /**
    * Set the element \p (i,j) to \p value.  Throws an error if the

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -421,6 +421,19 @@ public:
   virtual void print_matlab(const std::string & /*name*/ = "") const;
 
   /**
+   * Read the contents of the matrix from Matlab's sparse matrix
+   * format.
+   *
+   * If the size and sparsity of the matrix in \p filename appears
+   * consistent with the existing sparsity of \p this then the
+   * existing parallel decomposition and sparsity will be retained.
+   * If not, then \p this will be initialized with the sparsity from
+   * the file, linearly partitioned onto the number of processors
+   * available.
+   */
+  virtual void read_matlab(const std::string & filename);
+
+  /**
    * This function creates a matrix called "submatrix" which is defined
    * by the row and column indices given in the "rows" and "cols" entries.
    * Currently this operation is only defined for the PetscMatrix type.

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -350,6 +350,12 @@ public:
   virtual bool closed() const = 0;
 
   /**
+   * \returns the global number of non-zero entries in the matrix
+   * sparsity pattern
+   */
+  virtual std::size_t n_nonzeros() const;
+
+  /**
    * Print the contents of the matrix to the screen in a uniform
    * style, regardless of matrix/solver package being used.
    */
@@ -395,10 +401,7 @@ public:
    * format. Optionally prints the matrix to the file named \p name.
    * If \p name is not specified it is dumped to the screen.
    */
-  virtual void print_matlab(const std::string & /*name*/ = "") const
-  {
-    libmesh_not_implemented();
-  }
+  virtual void print_matlab(const std::string & /*name*/ = "") const;
 
   /**
    * This function creates a matrix called "submatrix" which is defined

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -514,12 +514,9 @@ public:
    *                corresponding to (possibly) non-zero values
    * @param values A container holding the column values
    */
-  virtual void get_row(numeric_index_type /*i*/,
-                       std::vector<numeric_index_type> & /*indices*/,
-                       std::vector<T> & /*values*/) const
-  {
-    libmesh_not_implemented();
-  }
+  virtual void get_row(numeric_index_type i,
+                       std::vector<numeric_index_type> & indices,
+                       std::vector<T> & values) const = 0;
 
 protected:
 

--- a/include/numerics/trilinos_epetra_matrix.h
+++ b/include/numerics/trilinos_epetra_matrix.h
@@ -141,6 +141,10 @@ public:
 
   virtual numeric_index_type row_stop () const override;
 
+  virtual numeric_index_type col_start () const override;
+
+  virtual numeric_index_type col_stop () const override;
+
   virtual void set (const numeric_index_type i,
                     const numeric_index_type j,
                     const T value) override;

--- a/include/numerics/trilinos_epetra_matrix.h
+++ b/include/numerics/trilinos_epetra_matrix.h
@@ -187,6 +187,10 @@ public:
 
   virtual void get_transpose (SparseMatrix<T> & dest) const override;
 
+  virtual void get_row(numeric_index_type i,
+                       std::vector<numeric_index_type> & indices,
+                       std::vector<T> & values) const override;
+
   /**
    * Swaps the internal data pointers, no actual values are swapped.
    */

--- a/src/base/sparsity_pattern.C
+++ b/src/base/sparsity_pattern.C
@@ -607,8 +607,17 @@ void Build::apply_extra_sparsity_object(SparsityPattern::AugmentSparsityPattern 
 
 std::size_t Build::n_nonzeros() const
 {
-  std::size_t total_nonzeros = std::reduce(n_nz.begin(), n_nz.end(), std::size_t(0));
-  total_nonzeros += std::reduce(n_oz.begin(), n_oz.end(), std::size_t(0));
+  // At some point I'll remember that "C++17" compilers don't always
+  // come with complete C++17 standard libraries.
+  // std::size_t total_nonzeros = std::reduce(n_nz.begin(), n_nz.end(), std::size_t(0));
+  // total_nonzeros += std::reduce(n_oz.begin(), n_oz.end(), std::size_t(0));
+
+  std::size_t total_nonzeros = 0;
+  for (auto nnzi : n_nz)
+    total_nonzeros += nnzi;
+  for (auto nozi : n_oz)
+    total_nonzeros += nozi;
+
   this->comm().sum(total_nonzeros);
   return total_nonzeros;
 }

--- a/src/base/sparsity_pattern.C
+++ b/src/base/sparsity_pattern.C
@@ -605,5 +605,14 @@ void Build::apply_extra_sparsity_object(SparsityPattern::AugmentSparsityPattern 
 }
 
 
+std::size_t Build::n_nonzeros() const
+{
+  std::size_t total_nonzeros = std::reduce(n_nz.begin(), n_nz.end(), std::size_t(0));
+  total_nonzeros += std::reduce(n_oz.begin(), n_oz.end(), std::size_t(0));
+  this->comm().sum(total_nonzeros);
+  return total_nonzeros;
+}
+
+
 } // namespace SparsityPattern
 } // namespace libMesh

--- a/src/numerics/diagonal_matrix.C
+++ b/src/numerics/diagonal_matrix.C
@@ -178,6 +178,20 @@ DiagonalMatrix<T>::row_stop() const
 }
 
 template <typename T>
+numeric_index_type
+DiagonalMatrix<T>::col_start() const
+{
+  return _diagonal->first_local_index();
+}
+
+template <typename T>
+numeric_index_type
+DiagonalMatrix<T>::col_stop() const
+{
+  return _diagonal->last_local_index();
+}
+
+template <typename T>
 void
 DiagonalMatrix<T>::set(const numeric_index_type i, const numeric_index_type j, const T value)
 {

--- a/src/numerics/diagonal_matrix.C
+++ b/src/numerics/diagonal_matrix.C
@@ -281,12 +281,16 @@ DiagonalMatrix<T>::print_personal(std::ostream & os) const
   _diagonal->print(os);
 }
 
+
+
 template <typename T>
 void
 DiagonalMatrix<T>::get_diagonal(NumericVector<T> & dest) const
 {
   dest = *_diagonal;
 }
+
+
 
 template <typename T>
 void
@@ -299,6 +303,22 @@ DiagonalMatrix<T>::get_transpose(SparseMatrix<T> & dest) const
     libmesh_error_msg("DenseMatrix<T>::get_transpose currently only accepts another DenseMatrix<T> "
                       "as its argument");
 }
+
+
+
+template <typename T>
+void
+DiagonalMatrix<T>::get_row(numeric_index_type i,
+                           std::vector<numeric_index_type> & indices,
+                           std::vector<T> & values) const
+{
+  indices.clear();
+  indices.push_back(i);
+  values.clear();
+  values.push_back((*_diagonal)(i));
+}
+
+
 
 template <typename T>
 void

--- a/src/numerics/eigen_sparse_matrix.C
+++ b/src/numerics/eigen_sparse_matrix.C
@@ -380,6 +380,27 @@ Real EigenSparseMatrix<T>::linfty_norm () const
 }
 
 
+
+template <typename T>
+void EigenSparseMatrix<T>::get_row(numeric_index_type i,
+                                   std::vector<numeric_index_type> & indices,
+                                   std::vector<T> & values) const
+{
+  indices.clear();
+  values.clear();
+
+  // InnerIterator is over rows in RowMajor ordering
+  static_assert(EigenSM::IsRowMajor);
+
+  for (EigenSM::InnerIterator it(_mat, i); it; ++it)
+    {
+      indices.push_back(it.col());
+      values.push_back(it.value());
+    }
+}
+
+
+
 //------------------------------------------------------------------
 // Explicit instantiations
 template class LIBMESH_EXPORT EigenSparseMatrix<Number>;

--- a/src/numerics/eigen_sparse_matrix.C
+++ b/src/numerics/eigen_sparse_matrix.C
@@ -255,6 +255,22 @@ numeric_index_type EigenSparseMatrix<T>::row_stop () const
 
 
 template <typename T>
+numeric_index_type EigenSparseMatrix<T>::col_start () const
+{
+  return 0;
+}
+
+
+
+template <typename T>
+numeric_index_type EigenSparseMatrix<T>::col_stop () const
+{
+  return this->n();
+}
+
+
+
+template <typename T>
 void EigenSparseMatrix<T>::set (const numeric_index_type i,
                                 const numeric_index_type j,
                                 const T value)

--- a/src/numerics/laspack_matrix.C
+++ b/src/numerics/laspack_matrix.C
@@ -234,6 +234,36 @@ void LaspackMatrix<T>::get_transpose (SparseMatrix<T> & /*dest*/) const
 
 
 template <typename T>
+void LaspackMatrix<T>::get_row(numeric_index_type i,
+                               std::vector<numeric_index_type> & indices,
+                               std::vector<T> & values) const
+{
+  indices.clear();
+  values.clear();
+
+  const numeric_index_type len = (_row_start[i+1] - _row_start[i]);
+
+  // Make sure we agree on the row length
+  libmesh_assert_equal_to (len, Q_GetLen(&_QMat, i+1));
+
+  auto r_start = _row_start[i];
+
+  for (numeric_index_type l=0; l<len; l++)
+    {
+      const numeric_index_type j = *(r_start + l);
+
+      // Make sure the data structures are working
+      libmesh_assert_equal_to ((j+1), Q_GetPos (&_QMat, i+1, l));
+
+      indices.push_back(j);
+
+      values.push_back(Q_GetVal (&_QMat, i+1, l));
+    }
+}
+
+
+
+template <typename T>
 LaspackMatrix<T>::LaspackMatrix (const Parallel::Communicator & comm) :
   SparseMatrix<T>(comm),
   _closed (false)

--- a/src/numerics/laspack_matrix.C
+++ b/src/numerics/laspack_matrix.C
@@ -365,6 +365,22 @@ numeric_index_type LaspackMatrix<T>::row_stop () const
 
 
 template <typename T>
+numeric_index_type LaspackMatrix<T>::col_start () const
+{
+  return 0;
+}
+
+
+
+template <typename T>
+numeric_index_type LaspackMatrix<T>::col_stop () const
+{
+  return this->n();
+}
+
+
+
+template <typename T>
 void LaspackMatrix<T>::set (const numeric_index_type i,
                             const numeric_index_type j,
                             const T value)

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -1073,6 +1073,8 @@ void PetscMatrix<T>::get_local_size (numeric_index_type & m,
   n = static_cast<numeric_index_type>(petsc_n);
 }
 
+
+
 template <typename T>
 numeric_index_type PetscMatrix<T>::row_start () const
 {
@@ -1098,6 +1100,38 @@ numeric_index_type PetscMatrix<T>::row_stop () const
   PetscErrorCode ierr=0;
 
   ierr = MatGetOwnershipRange(_mat, &start, &stop);
+  LIBMESH_CHKERR(ierr);
+
+  return static_cast<numeric_index_type>(stop);
+}
+
+
+
+template <typename T>
+numeric_index_type PetscMatrix<T>::col_start () const
+{
+  libmesh_assert (this->initialized());
+
+  PetscInt start=0, stop=0;
+  PetscErrorCode ierr=0;
+
+  ierr = MatGetOwnershipRangeColumn(_mat, &start, &stop);
+  LIBMESH_CHKERR(ierr);
+
+  return static_cast<numeric_index_type>(start);
+}
+
+
+
+template <typename T>
+numeric_index_type PetscMatrix<T>::col_stop () const
+{
+  libmesh_assert (this->initialized());
+
+  PetscInt start=0, stop=0;
+  PetscErrorCode ierr=0;
+
+  ierr = MatGetOwnershipRangeColumn(_mat, &start, &stop);
   LIBMESH_CHKERR(ierr);
 
   return static_cast<numeric_index_type>(stop);

--- a/src/numerics/sparse_matrix.C
+++ b/src/numerics/sparse_matrix.C
@@ -237,15 +237,15 @@ void SparseMatrix<T>::print(std::ostream & os, const bool sparse) const
 
   libmesh_assert (this->initialized());
 
-  libmesh_error_msg_if(!this->_dof_map, "Error!  Trying to print a matrix with no dof_map set!");
+  const numeric_index_type first_dof = this->row_start(),
+                           end_dof   = this->row_stop();
 
   // We'll print the matrix from processor 0 to make sure
   // it's serialized properly
   if (this->processor_id() == 0)
     {
-      libmesh_assert_equal_to (this->_dof_map->first_dof(), 0);
-      for (numeric_index_type i=this->_dof_map->first_dof();
-           i!=this->_dof_map->end_dof(); ++i)
+      libmesh_assert_equal_to (first_dof, 0);
+      for (numeric_index_type i : make_range(end_dof))
         {
           if (sparse)
             {
@@ -268,7 +268,7 @@ void SparseMatrix<T>::print(std::ostream & os, const bool sparse) const
 
       std::vector<numeric_index_type> ibuf, jbuf;
       std::vector<T> cbuf;
-      numeric_index_type currenti = this->_dof_map->end_dof();
+      numeric_index_type currenti = end_dof;
       for (auto p : IntRange<processor_id_type>(1, this->n_processors()))
         {
           this->comm().receive(p, ibuf);
@@ -333,8 +333,7 @@ void SparseMatrix<T>::print(std::ostream & os, const bool sparse) const
 
       // We'll assume each processor has access to entire
       // matrix rows, so (*this)(i,j) is valid if i is a local index.
-      for (numeric_index_type i=this->_dof_map->first_dof();
-           i!=this->_dof_map->end_dof(); ++i)
+      for (numeric_index_type i : make_range(first_dof, end_dof))
         {
           for (auto j : make_range(this->n()))
             {
@@ -361,8 +360,8 @@ void SparseMatrix<T>::print_matlab(const std::string & name) const
 
   libmesh_assert (this->initialized());
 
-  libmesh_error_msg_if(!this->_dof_map, "Error!  Trying to print a matrix with no dof_map set!");
-
+  const numeric_index_type first_dof = this->row_start(),
+                           end_dof   = this->row_stop();
 
   // We'll print the matrix from processor 0 to make sure
   // it's serialized properly
@@ -379,8 +378,8 @@ void SparseMatrix<T>::print_matlab(const std::string & name) const
 
       std::size_t real_nonzeros = 0;
 
-      for (numeric_index_type i=this->_dof_map->first_dof();
-           i!=this->_dof_map->end_dof(); ++i)
+      libmesh_assert_equal_to(first_dof, 0);
+      for (numeric_index_type i : make_range(end_dof))
         {
           for (auto j : make_range(this->n()))
             {
@@ -415,9 +414,7 @@ void SparseMatrix<T>::print_matlab(const std::string & name) const
          << "zzz = zeros(" << real_nonzeros << ",3);\n"
          << "zzz = [\n";
 
-      libmesh_assert_equal_to (this->_dof_map->first_dof(), 0);
-      for (numeric_index_type i=this->_dof_map->first_dof();
-           i!=this->_dof_map->end_dof(); ++i)
+      for (numeric_index_type i : make_range(end_dof))
         {
           // FIXME - we need a base class way to iterate over a
           // SparseMatrix row.
@@ -456,8 +453,7 @@ void SparseMatrix<T>::print_matlab(const std::string & name) const
 
       // We'll assume each processor has access to entire
       // matrix rows, so (*this)(i,j) is valid if i is a local index.
-      for (numeric_index_type i=this->_dof_map->first_dof();
-           i!=this->_dof_map->end_dof(); ++i)
+      for (numeric_index_type i : make_range(first_dof, end_dof))
         {
           for (auto j : make_range(this->n()))
             {

--- a/src/numerics/trilinos_epetra_matrix.C
+++ b/src/numerics/trilinos_epetra_matrix.C
@@ -413,6 +413,28 @@ numeric_index_type EpetraMatrix<T>::row_stop () const
 
 
 template <typename T>
+numeric_index_type EpetraMatrix<T>::col_start () const
+{
+  libmesh_assert (this->initialized());
+  libmesh_assert(_map);
+
+  return static_cast<numeric_index_type>(_map->MinMyGID());
+}
+
+
+
+template <typename T>
+numeric_index_type EpetraMatrix<T>::col_stop () const
+{
+  libmesh_assert (this->initialized());
+  libmesh_assert(_map);
+
+  return static_cast<numeric_index_type>(_map->MaxMyGID())+1;
+}
+
+
+
+template <typename T>
 void EpetraMatrix<T>::set (const numeric_index_type i,
                            const numeric_index_type j,
                            const T value)

--- a/src/numerics/trilinos_epetra_matrix.C
+++ b/src/numerics/trilinos_epetra_matrix.C
@@ -329,6 +329,38 @@ void EpetraMatrix<T>::get_transpose (SparseMatrix<T> & dest) const
 
 
 template <typename T>
+void EpetraMatrix<T>::get_row(numeric_index_type i,
+                              std::vector<numeric_index_type> & indices,
+                              std::vector<T> & values) const
+{
+  libmesh_assert (this->initialized());
+  libmesh_assert(this->_mat);
+  libmesh_assert (this->_mat->MyGlobalRow(static_cast<int>(i)));
+  libmesh_assert_greater_equal (i, this->row_start());
+  libmesh_assert_less (i, this->row_stop());
+
+  int row_length;
+  int * row_indices;
+  double * row_values;
+
+  _mat->ExtractMyRowView (i-this->row_start(),
+                          row_length,
+                          row_values,
+                          row_indices);
+
+  indices.resize(row_length);
+  values.resize(row_length);
+
+  for (auto i : make_range(row_length))
+    {
+      indices[i] = row_indices[i];
+      values[i] = row_values[i];
+    }
+}
+
+
+
+template <typename T>
 EpetraMatrix<T>::EpetraMatrix(const Parallel::Communicator & comm) :
   SparseMatrix<T>(comm),
   _destroy_mat_on_exit(true),

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -100,6 +100,7 @@ unit_tests_sources = \
   numerics/type_vector_test.h \
   numerics/vector_value_test.C \
   numerics/type_tensor_test.C \
+  numerics/sparse_matrix_test.h \
   numerics/dense_matrix_test.C \
   numerics/petsc_matrix_test.C \
   numerics/diagonal_matrix_test.C \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -92,6 +92,7 @@ unit_tests_sources = \
   numerics/distributed_vector_test.C \
   numerics/eigen_sparse_vector_test.C \
   numerics/laspack_vector_test.C \
+  numerics/laspack_matrix_test.C \
   numerics/numeric_vector_test.h \
   numerics/parsed_fem_function_test.C \
   numerics/parsed_function_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -230,13 +230,15 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
-	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
+	numerics/laspack_vector_test.C numerics/laspack_matrix_test.C \
+	numerics/numeric_vector_test.h \
 	numerics/parsed_fem_function_test.C \
 	numerics/parsed_function_test.C numerics/petsc_vector_test.C \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
-	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	numerics/petsc_matrix_test.C numerics/diagonal_matrix_test.C \
+	numerics/type_tensor_test.C numerics/sparse_matrix_test.h \
+	numerics/dense_matrix_test.C numerics/petsc_matrix_test.C \
+	numerics/diagonal_matrix_test.C \
 	numerics/lumped_mass_matrix_test.C \
 	numerics/eigen_sparse_matrix_test.C \
 	numerics/tensor_traits_test.C parallel/message_tag.C \
@@ -343,6 +345,7 @@ am__objects_3 = unit_tests_dbg-driver.$(OBJEXT) \
 	numerics/unit_tests_dbg-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-eigen_sparse_vector_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-laspack_vector_test.$(OBJEXT) \
+	numerics/unit_tests_dbg-laspack_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-parsed_fem_function_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-parsed_function_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-petsc_vector_test.$(OBJEXT) \
@@ -430,13 +433,15 @@ am__unit_tests_devel_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
-	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
+	numerics/laspack_vector_test.C numerics/laspack_matrix_test.C \
+	numerics/numeric_vector_test.h \
 	numerics/parsed_fem_function_test.C \
 	numerics/parsed_function_test.C numerics/petsc_vector_test.C \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
-	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	numerics/petsc_matrix_test.C numerics/diagonal_matrix_test.C \
+	numerics/type_tensor_test.C numerics/sparse_matrix_test.h \
+	numerics/dense_matrix_test.C numerics/petsc_matrix_test.C \
+	numerics/diagonal_matrix_test.C \
 	numerics/lumped_mass_matrix_test.C \
 	numerics/eigen_sparse_matrix_test.C \
 	numerics/tensor_traits_test.C parallel/message_tag.C \
@@ -541,6 +546,7 @@ am__objects_5 = unit_tests_devel-driver.$(OBJEXT) \
 	numerics/unit_tests_devel-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_devel-eigen_sparse_vector_test.$(OBJEXT) \
 	numerics/unit_tests_devel-laspack_vector_test.$(OBJEXT) \
+	numerics/unit_tests_devel-laspack_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_devel-parsed_fem_function_test.$(OBJEXT) \
 	numerics/unit_tests_devel-parsed_function_test.$(OBJEXT) \
 	numerics/unit_tests_devel-petsc_vector_test.$(OBJEXT) \
@@ -624,13 +630,15 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
-	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
+	numerics/laspack_vector_test.C numerics/laspack_matrix_test.C \
+	numerics/numeric_vector_test.h \
 	numerics/parsed_fem_function_test.C \
 	numerics/parsed_function_test.C numerics/petsc_vector_test.C \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
-	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	numerics/petsc_matrix_test.C numerics/diagonal_matrix_test.C \
+	numerics/type_tensor_test.C numerics/sparse_matrix_test.h \
+	numerics/dense_matrix_test.C numerics/petsc_matrix_test.C \
+	numerics/diagonal_matrix_test.C \
 	numerics/lumped_mass_matrix_test.C \
 	numerics/eigen_sparse_matrix_test.C \
 	numerics/tensor_traits_test.C parallel/message_tag.C \
@@ -735,6 +743,7 @@ am__objects_7 = unit_tests_oprof-driver.$(OBJEXT) \
 	numerics/unit_tests_oprof-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-eigen_sparse_vector_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-laspack_vector_test.$(OBJEXT) \
+	numerics/unit_tests_oprof-laspack_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-parsed_fem_function_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-parsed_function_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-petsc_vector_test.$(OBJEXT) \
@@ -818,13 +827,15 @@ am__unit_tests_opt_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
-	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
+	numerics/laspack_vector_test.C numerics/laspack_matrix_test.C \
+	numerics/numeric_vector_test.h \
 	numerics/parsed_fem_function_test.C \
 	numerics/parsed_function_test.C numerics/petsc_vector_test.C \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
-	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	numerics/petsc_matrix_test.C numerics/diagonal_matrix_test.C \
+	numerics/type_tensor_test.C numerics/sparse_matrix_test.h \
+	numerics/dense_matrix_test.C numerics/petsc_matrix_test.C \
+	numerics/diagonal_matrix_test.C \
 	numerics/lumped_mass_matrix_test.C \
 	numerics/eigen_sparse_matrix_test.C \
 	numerics/tensor_traits_test.C parallel/message_tag.C \
@@ -929,6 +940,7 @@ am__objects_9 = unit_tests_opt-driver.$(OBJEXT) \
 	numerics/unit_tests_opt-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_opt-eigen_sparse_vector_test.$(OBJEXT) \
 	numerics/unit_tests_opt-laspack_vector_test.$(OBJEXT) \
+	numerics/unit_tests_opt-laspack_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_opt-parsed_fem_function_test.$(OBJEXT) \
 	numerics/unit_tests_opt-parsed_function_test.$(OBJEXT) \
 	numerics/unit_tests_opt-petsc_vector_test.$(OBJEXT) \
@@ -1012,13 +1024,15 @@ am__unit_tests_prof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
-	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
+	numerics/laspack_vector_test.C numerics/laspack_matrix_test.C \
+	numerics/numeric_vector_test.h \
 	numerics/parsed_fem_function_test.C \
 	numerics/parsed_function_test.C numerics/petsc_vector_test.C \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
-	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	numerics/petsc_matrix_test.C numerics/diagonal_matrix_test.C \
+	numerics/type_tensor_test.C numerics/sparse_matrix_test.h \
+	numerics/dense_matrix_test.C numerics/petsc_matrix_test.C \
+	numerics/diagonal_matrix_test.C \
 	numerics/lumped_mass_matrix_test.C \
 	numerics/eigen_sparse_matrix_test.C \
 	numerics/tensor_traits_test.C parallel/message_tag.C \
@@ -1123,6 +1137,7 @@ am__objects_11 = unit_tests_prof-driver.$(OBJEXT) \
 	numerics/unit_tests_prof-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_prof-eigen_sparse_vector_test.$(OBJEXT) \
 	numerics/unit_tests_prof-laspack_vector_test.$(OBJEXT) \
+	numerics/unit_tests_prof-laspack_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_prof-parsed_fem_function_test.$(OBJEXT) \
 	numerics/unit_tests_prof-parsed_function_test.$(OBJEXT) \
 	numerics/unit_tests_prof-petsc_vector_test.$(OBJEXT) \
@@ -1517,6 +1532,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-distributed_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_vector_test.Po \
+	numerics/$(DEPDIR)/unit_tests_dbg-laspack_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-laspack_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-lumped_mass_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-parsed_fem_function_test.Po \
@@ -1534,6 +1550,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-distributed_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_vector_test.Po \
+	numerics/$(DEPDIR)/unit_tests_devel-laspack_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-laspack_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-lumped_mass_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Po \
@@ -1551,6 +1568,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-distributed_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_vector_test.Po \
+	numerics/$(DEPDIR)/unit_tests_oprof-laspack_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-laspack_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-lumped_mass_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-parsed_fem_function_test.Po \
@@ -1568,6 +1586,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-distributed_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_vector_test.Po \
+	numerics/$(DEPDIR)/unit_tests_opt-laspack_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-laspack_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-lumped_mass_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Po \
@@ -1585,6 +1604,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-distributed_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_vector_test.Po \
+	numerics/$(DEPDIR)/unit_tests_prof-laspack_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-laspack_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-lumped_mass_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Po \
@@ -2224,13 +2244,15 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
-	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
+	numerics/laspack_vector_test.C numerics/laspack_matrix_test.C \
+	numerics/numeric_vector_test.h \
 	numerics/parsed_fem_function_test.C \
 	numerics/parsed_function_test.C numerics/petsc_vector_test.C \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
-	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	numerics/petsc_matrix_test.C numerics/diagonal_matrix_test.C \
+	numerics/type_tensor_test.C numerics/sparse_matrix_test.h \
+	numerics/dense_matrix_test.C numerics/petsc_matrix_test.C \
+	numerics/diagonal_matrix_test.C \
 	numerics/lumped_mass_matrix_test.C \
 	numerics/eigen_sparse_matrix_test.C \
 	numerics/tensor_traits_test.C parallel/message_tag.C \
@@ -2540,6 +2562,8 @@ numerics/unit_tests_dbg-eigen_sparse_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_dbg-laspack_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_dbg-laspack_matrix_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_dbg-parsed_fem_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_dbg-parsed_function_test.$(OBJEXT):  \
@@ -2810,6 +2834,8 @@ numerics/unit_tests_devel-eigen_sparse_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-laspack_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_devel-laspack_matrix_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-parsed_fem_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-parsed_function_test.$(OBJEXT):  \
@@ -3037,6 +3063,8 @@ numerics/unit_tests_oprof-distributed_vector_test.$(OBJEXT):  \
 numerics/unit_tests_oprof-eigen_sparse_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_oprof-laspack_vector_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_oprof-laspack_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_oprof-parsed_fem_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
@@ -3266,6 +3294,8 @@ numerics/unit_tests_opt-eigen_sparse_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-laspack_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_opt-laspack_matrix_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-parsed_fem_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-parsed_function_test.$(OBJEXT):  \
@@ -3493,6 +3523,8 @@ numerics/unit_tests_prof-distributed_vector_test.$(OBJEXT):  \
 numerics/unit_tests_prof-eigen_sparse_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_prof-laspack_vector_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_prof-laspack_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_prof-parsed_fem_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
@@ -3937,6 +3969,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-distributed_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_vector_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-laspack_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-laspack_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-lumped_mass_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-parsed_fem_function_test.Po@am__quote@ # am--include-marker
@@ -3954,6 +3987,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-distributed_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_vector_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-laspack_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-laspack_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-lumped_mass_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Po@am__quote@ # am--include-marker
@@ -3971,6 +4005,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-distributed_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_vector_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-laspack_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-laspack_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-lumped_mass_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-parsed_fem_function_test.Po@am__quote@ # am--include-marker
@@ -3988,6 +4023,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-distributed_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_vector_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-laspack_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-laspack_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-lumped_mass_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Po@am__quote@ # am--include-marker
@@ -4005,6 +4041,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-distributed_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_vector_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-laspack_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-laspack_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-lumped_mass_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Po@am__quote@ # am--include-marker
@@ -5146,6 +5183,20 @@ numerics/unit_tests_dbg-laspack_vector_test.obj: numerics/laspack_vector_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/laspack_vector_test.C' object='numerics/unit_tests_dbg-laspack_vector_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-laspack_vector_test.obj `if test -f 'numerics/laspack_vector_test.C'; then $(CYGPATH_W) 'numerics/laspack_vector_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_vector_test.C'; fi`
+
+numerics/unit_tests_dbg-laspack_matrix_test.o: numerics/laspack_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-laspack_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-laspack_matrix_test.Tpo -c -o numerics/unit_tests_dbg-laspack_matrix_test.o `test -f 'numerics/laspack_matrix_test.C' || echo '$(srcdir)/'`numerics/laspack_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_dbg-laspack_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_dbg-laspack_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/laspack_matrix_test.C' object='numerics/unit_tests_dbg-laspack_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-laspack_matrix_test.o `test -f 'numerics/laspack_matrix_test.C' || echo '$(srcdir)/'`numerics/laspack_matrix_test.C
+
+numerics/unit_tests_dbg-laspack_matrix_test.obj: numerics/laspack_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-laspack_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-laspack_matrix_test.Tpo -c -o numerics/unit_tests_dbg-laspack_matrix_test.obj `if test -f 'numerics/laspack_matrix_test.C'; then $(CYGPATH_W) 'numerics/laspack_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_dbg-laspack_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_dbg-laspack_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/laspack_matrix_test.C' object='numerics/unit_tests_dbg-laspack_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-laspack_matrix_test.obj `if test -f 'numerics/laspack_matrix_test.C'; then $(CYGPATH_W) 'numerics/laspack_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_matrix_test.C'; fi`
 
 numerics/unit_tests_dbg-parsed_fem_function_test.o: numerics/parsed_fem_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-parsed_fem_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-parsed_fem_function_test.Tpo -c -o numerics/unit_tests_dbg-parsed_fem_function_test.o `test -f 'numerics/parsed_fem_function_test.C' || echo '$(srcdir)/'`numerics/parsed_fem_function_test.C
@@ -6673,6 +6724,20 @@ numerics/unit_tests_devel-laspack_vector_test.obj: numerics/laspack_vector_test.
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-laspack_vector_test.obj `if test -f 'numerics/laspack_vector_test.C'; then $(CYGPATH_W) 'numerics/laspack_vector_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_vector_test.C'; fi`
 
+numerics/unit_tests_devel-laspack_matrix_test.o: numerics/laspack_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-laspack_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-laspack_matrix_test.Tpo -c -o numerics/unit_tests_devel-laspack_matrix_test.o `test -f 'numerics/laspack_matrix_test.C' || echo '$(srcdir)/'`numerics/laspack_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-laspack_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-laspack_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/laspack_matrix_test.C' object='numerics/unit_tests_devel-laspack_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-laspack_matrix_test.o `test -f 'numerics/laspack_matrix_test.C' || echo '$(srcdir)/'`numerics/laspack_matrix_test.C
+
+numerics/unit_tests_devel-laspack_matrix_test.obj: numerics/laspack_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-laspack_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-laspack_matrix_test.Tpo -c -o numerics/unit_tests_devel-laspack_matrix_test.obj `if test -f 'numerics/laspack_matrix_test.C'; then $(CYGPATH_W) 'numerics/laspack_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-laspack_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-laspack_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/laspack_matrix_test.C' object='numerics/unit_tests_devel-laspack_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-laspack_matrix_test.obj `if test -f 'numerics/laspack_matrix_test.C'; then $(CYGPATH_W) 'numerics/laspack_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_matrix_test.C'; fi`
+
 numerics/unit_tests_devel-parsed_fem_function_test.o: numerics/parsed_fem_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-parsed_fem_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Tpo -c -o numerics/unit_tests_devel-parsed_fem_function_test.o `test -f 'numerics/parsed_fem_function_test.C' || echo '$(srcdir)/'`numerics/parsed_fem_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Po
@@ -8198,6 +8263,20 @@ numerics/unit_tests_oprof-laspack_vector_test.obj: numerics/laspack_vector_test.
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/laspack_vector_test.C' object='numerics/unit_tests_oprof-laspack_vector_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-laspack_vector_test.obj `if test -f 'numerics/laspack_vector_test.C'; then $(CYGPATH_W) 'numerics/laspack_vector_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_vector_test.C'; fi`
+
+numerics/unit_tests_oprof-laspack_matrix_test.o: numerics/laspack_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-laspack_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-laspack_matrix_test.Tpo -c -o numerics/unit_tests_oprof-laspack_matrix_test.o `test -f 'numerics/laspack_matrix_test.C' || echo '$(srcdir)/'`numerics/laspack_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_oprof-laspack_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_oprof-laspack_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/laspack_matrix_test.C' object='numerics/unit_tests_oprof-laspack_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-laspack_matrix_test.o `test -f 'numerics/laspack_matrix_test.C' || echo '$(srcdir)/'`numerics/laspack_matrix_test.C
+
+numerics/unit_tests_oprof-laspack_matrix_test.obj: numerics/laspack_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-laspack_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-laspack_matrix_test.Tpo -c -o numerics/unit_tests_oprof-laspack_matrix_test.obj `if test -f 'numerics/laspack_matrix_test.C'; then $(CYGPATH_W) 'numerics/laspack_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_oprof-laspack_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_oprof-laspack_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/laspack_matrix_test.C' object='numerics/unit_tests_oprof-laspack_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-laspack_matrix_test.obj `if test -f 'numerics/laspack_matrix_test.C'; then $(CYGPATH_W) 'numerics/laspack_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_matrix_test.C'; fi`
 
 numerics/unit_tests_oprof-parsed_fem_function_test.o: numerics/parsed_fem_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-parsed_fem_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-parsed_fem_function_test.Tpo -c -o numerics/unit_tests_oprof-parsed_fem_function_test.o `test -f 'numerics/parsed_fem_function_test.C' || echo '$(srcdir)/'`numerics/parsed_fem_function_test.C
@@ -9725,6 +9804,20 @@ numerics/unit_tests_opt-laspack_vector_test.obj: numerics/laspack_vector_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-laspack_vector_test.obj `if test -f 'numerics/laspack_vector_test.C'; then $(CYGPATH_W) 'numerics/laspack_vector_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_vector_test.C'; fi`
 
+numerics/unit_tests_opt-laspack_matrix_test.o: numerics/laspack_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-laspack_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-laspack_matrix_test.Tpo -c -o numerics/unit_tests_opt-laspack_matrix_test.o `test -f 'numerics/laspack_matrix_test.C' || echo '$(srcdir)/'`numerics/laspack_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-laspack_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-laspack_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/laspack_matrix_test.C' object='numerics/unit_tests_opt-laspack_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-laspack_matrix_test.o `test -f 'numerics/laspack_matrix_test.C' || echo '$(srcdir)/'`numerics/laspack_matrix_test.C
+
+numerics/unit_tests_opt-laspack_matrix_test.obj: numerics/laspack_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-laspack_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-laspack_matrix_test.Tpo -c -o numerics/unit_tests_opt-laspack_matrix_test.obj `if test -f 'numerics/laspack_matrix_test.C'; then $(CYGPATH_W) 'numerics/laspack_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-laspack_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-laspack_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/laspack_matrix_test.C' object='numerics/unit_tests_opt-laspack_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-laspack_matrix_test.obj `if test -f 'numerics/laspack_matrix_test.C'; then $(CYGPATH_W) 'numerics/laspack_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_matrix_test.C'; fi`
+
 numerics/unit_tests_opt-parsed_fem_function_test.o: numerics/parsed_fem_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-parsed_fem_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Tpo -c -o numerics/unit_tests_opt-parsed_fem_function_test.o `test -f 'numerics/parsed_fem_function_test.C' || echo '$(srcdir)/'`numerics/parsed_fem_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Po
@@ -11251,6 +11344,20 @@ numerics/unit_tests_prof-laspack_vector_test.obj: numerics/laspack_vector_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-laspack_vector_test.obj `if test -f 'numerics/laspack_vector_test.C'; then $(CYGPATH_W) 'numerics/laspack_vector_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_vector_test.C'; fi`
 
+numerics/unit_tests_prof-laspack_matrix_test.o: numerics/laspack_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-laspack_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-laspack_matrix_test.Tpo -c -o numerics/unit_tests_prof-laspack_matrix_test.o `test -f 'numerics/laspack_matrix_test.C' || echo '$(srcdir)/'`numerics/laspack_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_prof-laspack_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_prof-laspack_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/laspack_matrix_test.C' object='numerics/unit_tests_prof-laspack_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-laspack_matrix_test.o `test -f 'numerics/laspack_matrix_test.C' || echo '$(srcdir)/'`numerics/laspack_matrix_test.C
+
+numerics/unit_tests_prof-laspack_matrix_test.obj: numerics/laspack_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-laspack_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-laspack_matrix_test.Tpo -c -o numerics/unit_tests_prof-laspack_matrix_test.obj `if test -f 'numerics/laspack_matrix_test.C'; then $(CYGPATH_W) 'numerics/laspack_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_prof-laspack_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_prof-laspack_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/laspack_matrix_test.C' object='numerics/unit_tests_prof-laspack_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-laspack_matrix_test.obj `if test -f 'numerics/laspack_matrix_test.C'; then $(CYGPATH_W) 'numerics/laspack_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_matrix_test.C'; fi`
+
 numerics/unit_tests_prof-parsed_fem_function_test.o: numerics/parsed_fem_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-parsed_fem_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Tpo -c -o numerics/unit_tests_prof-parsed_fem_function_test.o `test -f 'numerics/parsed_fem_function_test.C' || echo '$(srcdir)/'`numerics/parsed_fem_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Tpo numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Po
@@ -12505,6 +12612,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-laspack_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-lumped_mass_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-parsed_fem_function_test.Po
@@ -12522,6 +12630,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_devel-laspack_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-lumped_mass_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Po
@@ -12539,6 +12648,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-laspack_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-lumped_mass_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-parsed_fem_function_test.Po
@@ -12556,6 +12666,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_opt-laspack_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-lumped_mass_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Po
@@ -12573,6 +12684,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_prof-laspack_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-lumped_mass_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Po
@@ -13097,6 +13209,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-laspack_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-lumped_mass_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-parsed_fem_function_test.Po
@@ -13114,6 +13227,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_devel-laspack_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-lumped_mass_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Po
@@ -13131,6 +13245,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-laspack_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-lumped_mass_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-parsed_fem_function_test.Po
@@ -13148,6 +13263,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_opt-laspack_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-lumped_mass_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Po
@@ -13165,6 +13281,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_vector_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_prof-laspack_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-laspack_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-lumped_mass_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Po

--- a/tests/numerics/eigen_sparse_matrix_test.C
+++ b/tests/numerics/eigen_sparse_matrix_test.C
@@ -2,109 +2,44 @@
 
 #ifdef LIBMESH_HAVE_EIGEN
 
-// Unit test includes
-#include "libmesh_cppunit.h"
-#include "test_comm.h"
-
-// libMesh includes
 #include <libmesh/eigen_sparse_matrix.h>
-#include <libmesh/dense_matrix.h>
 
-// C++ includes
-#include <memory>
-#include <vector>
+#include "sparse_matrix_test.h"
 
 using namespace libMesh;
 
-class EigenSparseMatrixTest : public CppUnit::TestCase
+class EigenSparseMatrixTest : public SparseMatrixTest<EigenSparseMatrix<Number>>
 {
 public:
-  LIBMESH_CPPUNIT_TEST_SUITE(EigenSparseMatrixTest);
+  EigenSparseMatrixTest() :
+    SparseMatrixTest<EigenSparseMatrix<Number>>() {
+    if (unitlog->summarized_logs_enabled())
+      this->libmesh_suite_name = "SparseMatrixTest";
+    else
+      this->libmesh_suite_name = "EigenSparseMatrixTest";
+  }
 
-  CPPUNIT_TEST(testGetAndSet);
-  CPPUNIT_TEST(testClone);
+  void setUp()
+  {
+    // EigenSparseMatrix is serial; we'll tell it to use MPI_COMM_SELF
+    // so we just do these tests embarrassingly parallel
+    my_comm = &comm_self;
+
+    // EigenSparseMatrix doesn't support non-square matrices?
+    nonsquare = 0;
+
+    SparseMatrixTest<EigenSparseMatrix<Number>>::setUp();
+  }
+
+  CPPUNIT_TEST_SUITE(EigenSparseMatrixTest);
+
+  SPARSEMATRIXTEST
 
   CPPUNIT_TEST_SUITE_END();
 
-public:
-  void setUp()
-  {
-    // EigenSparseMatrix is serial, but its constructor takes a comm
-    // for consistency with other SparseMatrix types.
-    _comm = TestCommWorld;
-    _matrix = std::make_unique<EigenSparseMatrix<Number>>(*_comm);
-
-    // All parameters are ignored except the number of global rows and columns and nnz.
-    _matrix->init(/*m*/10,
-                  /*n*/10,
-                  /*m_l==m*/10,
-                  /*n_l==n*/10,
-                  /*nnz*/3);
-  }
-
-  void tearDown() {}
-
-  void testGetAndSet()
-  {
-    LOG_UNIT_TEST;
-
-    // EigenSparseMatrix is serial, so we simply test inserting the
-    // same values on all procs.
-    std::vector<numeric_index_type> rows = {0, 1, 2};
-    std::vector<numeric_index_type> cols = {0, 1, 2};
-    DenseMatrix<Number> local(3, 3);
-    local.get_values() =
-      {
-        2., -1,  0,
-        -1, 2., -1,
-         0, -1,  2
-      };
-
-    _matrix->add_matrix(local, rows, cols);
-    _matrix->close();
-  }
-
-  void testClone()
-  {
-    LOG_UNIT_TEST;
-
-    {
-      // Create copy, test that it can go out of scope
-      auto copy = _matrix->clone();
-
-      // Check that matrices have the same local/global sizes
-      CPPUNIT_ASSERT_EQUAL(copy->m(), _matrix->m());
-      CPPUNIT_ASSERT_EQUAL(copy->n(), _matrix->n());
-      CPPUNIT_ASSERT_EQUAL(copy->local_m(), _matrix->local_m());
-      CPPUNIT_ASSERT_EQUAL(copy->row_start(), _matrix->row_start());
-      CPPUNIT_ASSERT_EQUAL(copy->row_stop(), _matrix->row_stop());
-
-      // Check that copy has same values as original
-      LIBMESH_ASSERT_FP_EQUAL(copy->l1_norm(), _matrix->l1_norm(), _tolerance);
-    }
-
-    {
-      // Create zero copy
-      auto zero_copy = _matrix->zero_clone();
-
-      // Check that matrices have the same local/global sizes
-      CPPUNIT_ASSERT_EQUAL(zero_copy->m(), _matrix->m());
-      CPPUNIT_ASSERT_EQUAL(zero_copy->n(), _matrix->n());
-      CPPUNIT_ASSERT_EQUAL(zero_copy->local_m(), _matrix->local_m());
-      CPPUNIT_ASSERT_EQUAL(zero_copy->row_start(), _matrix->row_start());
-      CPPUNIT_ASSERT_EQUAL(zero_copy->row_stop(), _matrix->row_stop());
-
-      // Check that zero_copy has same values as original
-      LIBMESH_ASSERT_FP_EQUAL(0.0, zero_copy->l1_norm(), _tolerance);
-    }
-  }
-
 private:
 
-  Parallel::Communicator * _comm;
-  std::unique_ptr<EigenSparseMatrix<Number>> _matrix;
-  const Real _tolerance = TOLERANCE * TOLERANCE;
-
+  Parallel::Communicator comm_self;
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(EigenSparseMatrixTest);

--- a/tests/numerics/laspack_matrix_test.C
+++ b/tests/numerics/laspack_matrix_test.C
@@ -1,0 +1,47 @@
+#include <libmesh/libmesh_config.h>
+
+#ifdef LIBMESH_HAVE_LASPACK
+
+#include <libmesh/laspack_matrix.h>
+
+#include "sparse_matrix_test.h"
+
+using namespace libMesh;
+
+class LaspackMatrixTest : public SparseMatrixTest<LaspackMatrix<Number>>
+{
+public:
+  LaspackMatrixTest() :
+    SparseMatrixTest<LaspackMatrix<Number>>() {
+    if (unitlog->summarized_logs_enabled())
+      this->libmesh_suite_name = "SparseMatrixTest";
+    else
+      this->libmesh_suite_name = "LaspackMatrixTest";
+  }
+
+  void setUp()
+  {
+    // LaspackMatrix is serial; we'll tell it to use MPI_COMM_SELF
+    // so we just do these tests embarrassingly parallel
+    my_comm = &comm_self;
+
+    // LaspackMatrix doesn't support non-square matrices?
+    nonsquare = 0;
+
+    SparseMatrixTest<LaspackMatrix<Number>>::setUp();
+  }
+
+  CPPUNIT_TEST_SUITE(LaspackMatrixTest);
+
+  SPARSEMATRIXTEST
+
+  CPPUNIT_TEST_SUITE_END();
+
+private:
+
+  Parallel::Communicator comm_self;
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(LaspackMatrixTest);
+
+#endif

--- a/tests/numerics/petsc_matrix_test.C
+++ b/tests/numerics/petsc_matrix_test.C
@@ -1,6 +1,8 @@
-#include <libmesh/petsc_matrix.h>
+#include <libmesh/libmesh_config.h>
 
 #ifdef LIBMESH_HAVE_PETSC
+
+#include <libmesh/petsc_matrix.h>
 
 #include "sparse_matrix_test.h"
 

--- a/tests/numerics/petsc_matrix_test.C
+++ b/tests/numerics/petsc_matrix_test.C
@@ -2,159 +2,26 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 
-#include <libmesh/parallel.h>
-#include <libmesh/dense_matrix.h>
-
-#include "libmesh_cppunit.h"
-#include "test_comm.h"
-
-#include <vector>
-#ifdef LIBMESH_HAVE_CXX11_THREAD
-#include <thread>
-#include <algorithm>
-#endif
+#include "sparse_matrix_test.h"
 
 using namespace libMesh;
 
-class PetscMatrixTest : public CppUnit::TestCase
+class PetscMatrixTest : public SparseMatrixTest<PetscMatrix<Number>>
 {
 public:
-  LIBMESH_CPPUNIT_TEST_SUITE(PetscMatrixTest);
+  PetscMatrixTest() :
+    SparseMatrixTest<PetscMatrix<Number>>() {
+    if (unitlog->summarized_logs_enabled())
+      this->libmesh_suite_name = "SparseMatrixTest";
+    else
+      this->libmesh_suite_name = "PetscMatrixTest";
+  }
 
-  CPPUNIT_TEST(testGetAndSet);
-  CPPUNIT_TEST(testClone);
+  CPPUNIT_TEST_SUITE(PetscMatrixTest);
+
+  SPARSEMATRIXTEST
 
   CPPUNIT_TEST_SUITE_END();
-
-public:
-  void setUp()
-  {
-    _comm = TestCommWorld;
-    _matrix = std::make_unique<PetscMatrix<Number>>(*_comm);
-
-    numeric_index_type root_block_size = 2;
-    _local_size = root_block_size + static_cast<numeric_index_type>(_comm->rank());
-    _global_size = 0;
-    _i.push_back(0);
-
-    for (processor_id_type p = 0; p < _comm->size(); ++p)
-    {
-      numeric_index_type block_size = root_block_size + static_cast<numeric_index_type>(p);
-      _global_size += block_size;
-      _i.push_back(_global_size);
-    }
-
-    _matrix->init(_global_size,
-                  _global_size,
-                  _local_size,
-                  _local_size,
-                  /*nnz=*/_local_size,
-                  /*noz=*/0);
-  }
-
-  void tearDown() {}
-
-  void testGetAndSet()
-  {
-    LOG_UNIT_TEST;
-
-    std::vector<numeric_index_type> rows(_local_size);
-    std::vector<numeric_index_type> cols(_local_size);
-    DenseMatrix<Number> local(_local_size, _local_size);
-
-    numeric_index_type index = _i[_comm->rank()], count = 0;
-    for (; count < _local_size; ++count, ++index)
-    {
-      rows[count] = index;
-      cols[count] = index;
-      for (numeric_index_type j = 0; j < _local_size; ++j)
-        local(count, j) = (count + 1) * (j + 1) * (_comm->rank() + 1);
-    }
-
-    _matrix->add_matrix(local, rows, cols);
-    _matrix->close();
-
-    index = _i[_comm->rank()], count = 0;
-
-    auto functor = [this]()
-    {
-      std::vector<numeric_index_type> cols_to_get;
-      std::vector<Number> values;
-      numeric_index_type local_index = _i[_comm->rank()], local_count = 0;
-      for (; local_count < _local_size; ++local_count, ++local_index)
-      {
-        _matrix->get_row(local_index, cols_to_get, values);
-        for (numeric_index_type j = 0; j < _local_size; ++j)
-        {
-          LIBMESH_ASSERT_FP_EQUAL((local_count + 1) * (j + 1) * (_comm->rank() + 1),
-                                  libMesh::libmesh_real(values[j]),
-                                  _tolerance);
-          CPPUNIT_ASSERT_EQUAL(cols_to_get[local_count], local_index);
-        }
-      }
-    };
-
-#ifdef LIBMESH_HAVE_CXX11_THREAD
-    auto num_threads = std::min(unsigned(2),
-                                std::max(
-                                  std::thread::hardware_concurrency(),
-                                  unsigned(1)));
-    std::vector<std::thread> threads(num_threads);
-    for (unsigned int thread = 0; thread < num_threads; ++thread)
-      threads[thread] = std::thread(functor);
-    std::for_each(threads.begin(), threads.end(),
-                  [](std::thread & x){x.join();});
-#else
-    functor();
-#endif
-  }
-
-  void testClone()
-  {
-    LOG_UNIT_TEST;
-
-    // Matrix must be closed before it can be cloned.
-    _matrix->close();
-
-    {
-      // Create copy, test that it can go out of scope
-      auto copy = _matrix->clone();
-
-      // Check that matrices have the same local/global sizes
-      CPPUNIT_ASSERT_EQUAL(copy->m(), _matrix->m());
-      CPPUNIT_ASSERT_EQUAL(copy->n(), _matrix->n());
-      CPPUNIT_ASSERT_EQUAL(copy->local_m(), _matrix->local_m());
-      CPPUNIT_ASSERT_EQUAL(copy->row_start(), _matrix->row_start());
-      CPPUNIT_ASSERT_EQUAL(copy->row_stop(), _matrix->row_stop());
-
-      // Check that copy has same values as original
-      LIBMESH_ASSERT_FP_EQUAL(copy->l1_norm(), _matrix->l1_norm(), _tolerance);
-    }
-
-    {
-      // Create zero copy
-      auto zero_copy = _matrix->zero_clone();
-
-      // Check that matrices have the same local/global sizes
-      CPPUNIT_ASSERT_EQUAL(zero_copy->m(), _matrix->m());
-      CPPUNIT_ASSERT_EQUAL(zero_copy->n(), _matrix->n());
-      CPPUNIT_ASSERT_EQUAL(zero_copy->local_m(), _matrix->local_m());
-      CPPUNIT_ASSERT_EQUAL(zero_copy->row_start(), _matrix->row_start());
-      CPPUNIT_ASSERT_EQUAL(zero_copy->row_stop(), _matrix->row_stop());
-
-      // Check that zero_copy has same values as original
-      LIBMESH_ASSERT_FP_EQUAL(0.0, zero_copy->l1_norm(), _tolerance);
-    }
-  }
-
-private:
-
-  Parallel::Communicator * _comm;
-  std::unique_ptr<PetscMatrix<Number>> _matrix;
-  numeric_index_type _local_size, _global_size;
-  std::vector<numeric_index_type> _i;
-  const Real _tolerance = TOLERANCE * TOLERANCE;
-
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(PetscMatrixTest);

--- a/tests/numerics/sparse_matrix_test.h
+++ b/tests/numerics/sparse_matrix_test.h
@@ -1,0 +1,194 @@
+#ifndef SPARSE_MATRIX_TEST_H
+#define SPARSE_MATRIX_TEST_H
+
+// test includes
+#include "test_comm.h"
+
+// libMesh includes
+#include <libmesh/dense_matrix.h>
+#include <libmesh/sparse_matrix.h>
+
+#include "libmesh_cppunit.h"
+
+// C++ includes
+#include <vector>
+#ifdef LIBMESH_HAVE_CXX11_THREAD
+#include <thread>
+#include <algorithm>
+#endif
+
+
+#define SPARSEMATRIXTEST                     \
+  CPPUNIT_TEST(testGetAndSet);               \
+  CPPUNIT_TEST(testClone);
+
+
+
+template <class DerivedClass>
+class SparseMatrixTest : public CppUnit::TestCase
+{
+public:
+
+  void setUp()
+  {
+    // By default we'll use the whole communicator in parallel;
+    // Serial-only NumericVector subclasses will need to override
+    // this and set something else first.
+    if (!my_comm)
+      my_comm = TestCommWorld;
+
+    matrix = std::make_unique<DerivedClass>(*my_comm);
+
+    // Use the same even partitioning that we'll auto-deduce in matrix
+    // read, to make it easier to test parallel reads
+
+    global_m = global_n = my_comm->size() * 5.75 - 1;
+    if (nonsquare)
+      global_n *= 1.3;
+
+    libMesh::dof_id_type
+      row_start =     my_comm->rank() * global_m / my_comm->size(),
+      row_stop  = (my_comm->rank()+1) * global_m / my_comm->size();
+    libMesh::dof_id_type
+      col_start =     my_comm->rank() * global_n / my_comm->size(),
+      col_stop  = (my_comm->rank()+1) * global_n / my_comm->size();
+
+    local_m = row_stop - row_start;
+    local_n = col_stop - col_start;
+
+    // Let's just play around with locally dense blocks for now
+    matrix->init(global_m,
+                 global_n,
+                 local_m,
+                 local_n,
+                 /*nnz=*/local_n,
+                 /*noz=*/5);
+  }
+
+
+  void tearDown() {}
+
+
+  void setValues()
+  {
+    std::vector<libMesh::numeric_index_type> rows(local_m);
+    std::iota(rows.begin(), rows.end(), matrix->row_start());
+    std::vector<libMesh::numeric_index_type> cols(local_n);
+    std::iota(cols.begin(), cols.end(), matrix->col_start());
+
+    libMesh::DenseMatrix<libMesh::Number> local(local_m, local_n);
+
+    for (auto i : libMesh::make_range(local_m))
+      for (auto j : libMesh::make_range(local_n))
+        local(i, j) = (i + 1) * (j + 1) * (my_comm->rank() + 1);
+
+    matrix->zero();
+
+    matrix->add_matrix(local, rows, cols);
+    matrix->close();
+  }
+
+
+  void testValues()
+  {
+    auto functor = [this]()
+    {
+      std::vector<libMesh::numeric_index_type> cols_to_get;
+      std::vector<libMesh::Number> values;
+      const libMesh::numeric_index_type col_start =
+        matrix->col_start();
+      for (libMesh::numeric_index_type i :
+           libMesh::make_range(matrix->row_start(),
+                               matrix->row_stop()))
+        {
+          matrix->get_row(i, cols_to_get, values);
+          for (libMesh::numeric_index_type col_j :
+               libMesh::index_range(cols_to_get))
+            {
+              CPPUNIT_ASSERT_EQUAL(cols_to_get[col_j], col_start + col_j);
+              LIBMESH_ASSERT_FP_EQUAL
+                ((i - matrix->row_start() + 1) * (col_j + 1) * (my_comm->rank() + 1),
+                 libMesh::libmesh_real(values[col_j]), _tolerance);
+            }
+        }
+    };
+
+#ifdef LIBMESH_HAVE_CXX11_THREAD
+    auto num_threads = std::min(unsigned(2),
+                                std::max(
+                                  std::thread::hardware_concurrency(),
+                                  unsigned(1)));
+    std::vector<std::thread> threads(num_threads);
+    for (unsigned int thread = 0; thread < num_threads; ++thread)
+      threads[thread] = std::thread(functor);
+    std::for_each(threads.begin(), threads.end(),
+                  [](std::thread & x){x.join();});
+#else
+    functor();
+#endif
+  }
+
+
+  void testGetAndSet()
+  {
+    LOG_UNIT_TEST;
+
+    setValues();
+
+    testValues();
+  }
+
+  void testClone()
+  {
+    LOG_UNIT_TEST;
+
+    // Matrix must be closed before it can be cloned.
+    matrix->close();
+
+    {
+      // Create copy, test that it can go out of scope
+      auto copy = matrix->clone();
+
+      // Check that matrices have the same local/global sizes
+      CPPUNIT_ASSERT_EQUAL(copy->m(), matrix->m());
+      CPPUNIT_ASSERT_EQUAL(copy->n(), matrix->n());
+      CPPUNIT_ASSERT_EQUAL(copy->local_m(), matrix->local_m());
+      CPPUNIT_ASSERT_EQUAL(copy->row_start(), matrix->row_start());
+      CPPUNIT_ASSERT_EQUAL(copy->row_stop(), matrix->row_stop());
+
+      // Check that copy has same values as original
+      LIBMESH_ASSERT_FP_EQUAL(copy->l1_norm(), matrix->l1_norm(), _tolerance);
+    }
+
+    {
+      // Create zero copy
+      auto zero_copy = matrix->zero_clone();
+
+      // Check that matrices have the same local/global sizes
+      CPPUNIT_ASSERT_EQUAL(zero_copy->m(), matrix->m());
+      CPPUNIT_ASSERT_EQUAL(zero_copy->n(), matrix->n());
+      CPPUNIT_ASSERT_EQUAL(zero_copy->local_m(), matrix->local_m());
+      CPPUNIT_ASSERT_EQUAL(zero_copy->row_start(), matrix->row_start());
+      CPPUNIT_ASSERT_EQUAL(zero_copy->row_stop(), matrix->row_stop());
+
+      // Check that zero_copy has same values as original
+      LIBMESH_ASSERT_FP_EQUAL(0.0, zero_copy->l1_norm(), _tolerance);
+    }
+  }
+
+protected:
+
+  std::string libmesh_suite_name;
+
+  libMesh::Parallel::Communicator * my_comm = nullptr;
+
+  std::unique_ptr<DerivedClass> matrix;
+
+  libMesh::numeric_index_type nonsquare = 1,
+      local_m, local_n,
+      global_m, global_n;
+
+  const libMesh::Real _tolerance = libMesh::TOLERANCE * libMesh::TOLERANCE;
+};
+
+#endif // SPARSE_MATRIX_TEST_H

--- a/tests/numerics/sparse_matrix_test.h
+++ b/tests/numerics/sparse_matrix_test.h
@@ -20,6 +20,7 @@
 
 #define SPARSEMATRIXTEST                     \
   CPPUNIT_TEST(testGetAndSet);               \
+  CPPUNIT_TEST(testWriteAndRead);            \
   CPPUNIT_TEST(testClone);
 
 
@@ -134,6 +135,33 @@ public:
     LOG_UNIT_TEST;
 
     setValues();
+
+    testValues();
+  }
+
+  void testWriteAndRead()
+  {
+    LOG_UNIT_TEST;
+
+    setValues();
+
+    // If we're working with serial matrices then just print one of
+    // them so they don't step on the others' toes.
+    if (matrix->n_processors() > 1 ||
+        TestCommWorld->rank() == 0)
+      matrix->print_matlab(libmesh_suite_name+"_matrix.m");
+
+    matrix->clear();
+
+    // Let's make sure we don't have any race conditions; we have
+    // multiple SparseMatrix subclasses that might be trying to read
+    // and write the same file.
+
+    TestCommWorld->barrier();
+
+    matrix->read_matlab(libmesh_suite_name+"_matrix.m");
+
+    TestCommWorld->barrier();
 
     testValues();
   }

--- a/tests/numerics/sparse_matrix_test.h
+++ b/tests/numerics/sparse_matrix_test.h
@@ -159,6 +159,11 @@ public:
 
     TestCommWorld->barrier();
 
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+    // We're not supporting complex reads quite yet
+    return;
+#endif
+
     matrix->read_matlab(libmesh_suite_name+"_matrix.m");
 
     TestCommWorld->barrier();


### PR DESCRIPTION
My original impetus here was just to get a `PetscMatrix::read_matlab()` working for some prototyping of other features, but then I decided to get some proper test coverage of it, and that entailed adding a handful of other `SparseMatrix` methods plus adding non-PETSc implementations of some of the existing methods.

The git history here is the result of a ton of interactive rebasing to clean up a very trashy original history; I think it's now at the point where it should pass tests at all intermediate stages, but I wouldn't guarantee that.