### PR TITLE
RBParameter vector-valued parameter support - Part1 - Foundation

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex4/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex4/assembly.h
@@ -69,15 +69,15 @@ struct ShiftedGaussian : public RBParametrizedFunction
     // Real center_y = mu.get_value("center_y");
     // return std::vector<Number> { std::exp(-2. * (pow<2>(center_x - p(0)) + pow<2>(center_y - p(1)))) };
 
-    // New way, there are get_n_components() * mu.n_steps() entries in
+    // New way, there are get_n_components() * mu.n_samples() entries in
     // the return vector.  In debug mode, we verify that the same
-    // number of steps are provided for all parameters when
-    // RBParameters::n_steps() is called.
-    std::vector<Number> ret(this->get_n_components() * mu.n_steps());
-    for (auto i : make_range(mu.n_steps()))
+    // number of samples are provided for all parameters when
+    // RBParameters::n_samples() is called.
+    std::vector<Number> ret(this->get_n_components() * mu.n_samples());
+    for (auto i : make_range(mu.n_samples()))
       {
-        Real center_x = mu.get_step_value("center_x", i);
-        Real center_y = mu.get_step_value("center_y", i);
+        Real center_x = mu.get_sample_value("center_x", i);
+        Real center_y = mu.get_sample_value("center_y", i);
         ret[i] = std::exp(-2. * (pow<2>(center_x - p(0)) + pow<2>(center_y - p(1))));
       }
     return ret;
@@ -97,36 +97,36 @@ struct ThetaConstant : RBTheta
   /**
    * Evaluate theta for a single scalar-valued RBParameters object.
    * In this case, Theta(mu) does not depend on mu explicitly, except
-   * to throw an error in case a multi-step RBParameters object has
+   * to throw an error in case a multi-sample RBParameters object has
    * been provided, since the evaluate() interface does not support
-   * multi-step RBParameters objects.
+   * multi-sample RBParameters objects.
    */
   virtual Number evaluate(const RBParameters & mu) override
   {
-    libmesh_error_msg_if(mu.n_steps() > 1,
-                         "You should only call the evaluate_vec() API when using multi-step RBParameters objects.");
+    libmesh_error_msg_if(mu.n_samples() > 1,
+                         "You should only call the evaluate_vec() API when using multi-sample RBParameters objects.");
 
     return _val;
   }
 
   /**
    * Evaluate theta for multiple mu values, each of which may have
-   * multiple "steps".  In this case, Theta(mu) does not depend on mu
-   * explicitly, except to determine the number of "steps" (aka
-   * n_steps()) which mu has, so that the output vector is sized
+   * multiple "samples".  In this case, Theta(mu) does not depend on mu
+   * explicitly, except to determine the number of "samples" (aka
+   * n_samples()) which mu has, so that the output vector is sized
    * appropriately.
    */
   virtual std::vector<Number> evaluate_vec(const std::vector<RBParameters> & mus) override
   {
     // Compute the number of values to be returned in the vector. For
-    // single-step RBParameters objects, there would be mus.size()
-    // values returned in the vector. For multi-step RBParameters
+    // single-sample RBParameters objects, there would be mus.size()
+    // values returned in the vector. For multi-sample RBParameters
     // objects, there are:
-    // sum_i mus[i].n_steps()
-    // total Thetas, i.e. one Theta per step.
+    // sum_i mus[i].n_samples()
+    // total Thetas, i.e. one Theta per sample.
     unsigned int count = 0;
     for (const auto & mu : mus)
-      count += mu.n_steps();
+      count += mu.n_samples();
 
     return std::vector<Number>(count, _val);
   }

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -255,7 +255,7 @@ int main (int argc, char ** argv)
       online_mu.push_back_value("center_y", 0.5);
 
       // Add 3rd (center_x, center_y) values. For debugging purposes,
-      // we want the number of "steps" (3) to be different from the
+      // we want the number of "samples" (3) to be different from the
       // number of parameters (2).
       online_mu.push_back_value("center_x", -0.25);
       online_mu.push_back_value("center_y", -0.25);
@@ -270,7 +270,7 @@ int main (int argc, char ** argv)
 
       // When performing an rb_solve() with "mu" values, we only
       // support single-valued RBParameters objects.  In this case,
-      // since the RBParameters object stores multiple "steps", we
+      // since the RBParameters object stores multiple "samples", we
       // take the approach of pre-evaluating the thetas for each
       // parameter while calling the rb_solve() in a loop.
       const RBThetaExpansion & rb_theta_expansion = rb_eval.get_rb_theta_expansion();
@@ -279,41 +279,41 @@ int main (int argc, char ** argv)
       // of eval_A_theta(), eval_F_theta(), etc. easier.
       std::vector<RBParameters> mu_vec = {online_mu};
 
-      // 1.) Evaluate and store "A" thetas at all steps:
+      // 1.) Evaluate and store "A" thetas at all samples:
       std::vector<std::vector<Number>> all_A(rb_theta_expansion.get_n_A_terms());
       for (unsigned int q_a=0; q_a<rb_theta_expansion.get_n_A_terms(); q_a++)
         {
           // Here we call the version of eval_A_theta() taking a
-          // vector, so we evaluate theta(mu) at all steps
+          // vector, so we evaluate theta(mu) at all samples
           // simultaneously.
           all_A[q_a] = rb_theta_expansion.eval_A_theta(q_a, mu_vec);
 
           // This size of each A_q vector here is:
-          // sum_i mu_vec[i].n_steps()
+          // sum_i mu_vec[i].n_samples()
           //
           // Each A_q vector contains the logically 2D ragged array of
-          // values (theta[i], step[j(i)]), arranged in "row-major"
-          // format, where the number of steps defined by each mu
+          // values (theta[i], sample[j(i)]), arranged in "row-major"
+          // format, where the number of samples defined by each mu
           // object can vary, and they are all concatenated together
-          // to produce one long list of steps.
+          // to produce one long list of samples.
           //
           // Example: suppose that there are 2 mu values containing
-          // the same sets of parameters, with 5 steps defined in the
-          // first and 10 steps defined in the second. Then, the A_q
+          // the same sets of parameters, with 5 samples defined in the
+          // first and 10 samples defined in the second. Then, the A_q
           // vector will look like:
           //
-          // {Theta(mu_vec[0], step_0), Theta(mu_vec[0], step_1), ... Theta(mu_vec[0], step_4),
-          //  Theta(mu_vec[1], step_0), Theta(mu_vec[1], step_1), ... Theta(mu_vec[1], step_4), ..., Theta(mu_vec[1], step_9)}
+          // {Theta(mu_vec[0], sample_0), Theta(mu_vec[0], sample_1), ... Theta(mu_vec[0], sample_4),
+          //  Theta(mu_vec[1], sample_0), Theta(mu_vec[1], sample_1), ... Theta(mu_vec[1], sample_4), ..., Theta(mu_vec[1], sample_9)}
           //
           // Note: this example is unusual in that it would be
           // conceptually much simpler to have either:
-          // (i) A vector of 15 single-step RBParameters objects, or
-          // (ii) A single RBParameters object with 15 steps defined in it.
+          // (i) A vector of 15 single-sample RBParameters objects, or
+          // (ii) A single RBParameters object with 15 samples defined in it.
           // but we can also support a combination of approaches (i)
           // and (ii) by concatenation, if necessary.
         }
 
-      // 2.) Evaluate "F" thetas at all steps:
+      // 2.) Evaluate "F" thetas at all samples:
       std::vector<std::vector<Number>> all_F(rb_theta_expansion.get_n_F_terms());
       for (unsigned int q_f=0; q_f<rb_theta_expansion.get_n_F_terms(); q_f++)
         all_F[q_f] = rb_theta_expansion.eval_F_theta(q_f, mu_vec);
@@ -327,7 +327,7 @@ int main (int argc, char ** argv)
                      << std::scientific << eim_error_indicators[idx] << std::endl;
       libMesh::out << std::endl;
 
-      // 3.) Evaluate "output" thetas at all steps: in this case, the
+      // 3.) Evaluate "output" thetas at all samples: in this case, the
       // output is particularly simple (does not depend on mu) so this
       // should just be a vector of all 1s.
       std::vector<std::vector<Number>> all_outputs(rb_theta_expansion.get_total_n_output_terms());
@@ -362,29 +362,29 @@ int main (int argc, char ** argv)
       rb_construction.set_rb_evaluation(rb_eval);
       rb_eval.read_in_basis_functions(rb_construction, "rb_data");
 
-      // Loop over each step, fill the evaluated_thetas array, call rb_solve()
-      for (unsigned step=0; step<online_mu.n_steps(); ++step)
+      // Loop over each sample, fill the evaluated_thetas array, call rb_solve()
+      for (unsigned sample_idx=0; sample_idx<online_mu.n_samples(); ++sample_idx)
         {
           unsigned int counter = 0;
 
-          // Set A Theta values for current step
+          // Set A Theta values for current sample
           for (unsigned int q_a=0; q_a<rb_theta_expansion.get_n_A_terms(); q_a++)
-            evaluated_thetas[counter++] = all_A[q_a][step];
+            evaluated_thetas[counter++] = all_A[q_a][sample_idx];
 
-          // Set F Theta values for current step
+          // Set F Theta values for current sample
           for (unsigned int q_f=0; q_f<rb_theta_expansion.get_n_F_terms(); q_f++)
-            evaluated_thetas[counter++] = all_F[q_f][step];
+            evaluated_thetas[counter++] = all_F[q_f][sample_idx];
 
-          // Set output Theta values for current step
+          // Set output Theta values for current sample
           {
             unsigned int output_counter = 0;
             for (unsigned int n=0; n<rb_theta_expansion.get_n_outputs(); n++)
               for (unsigned int q_l=0; q_l<rb_theta_expansion.get_n_output_terms(n); q_l++)
-                evaluated_thetas[counter++] = all_outputs[output_counter++][step];
+                evaluated_thetas[counter++] = all_outputs[output_counter++][sample_idx];
           }
 
           // Call rb_solve() for the current thetas
-          libMesh::out << "Performing solve for step " << step << std::endl;
+          libMesh::out << "Performing solve for step " << sample_idx << std::endl;
           rb_eval.rb_solve(rb_eval.get_n_basis_functions(), &evaluated_thetas);
 
           // Print the output as well as the corresponding output error bound
@@ -396,9 +396,9 @@ int main (int argc, char ** argv)
           // Write an exo file to visualize this solution
           rb_construction.load_rb_solution();
 #ifdef LIBMESH_HAVE_EXODUS_API
-          ExodusII_IO(mesh).write_equation_systems("RB_sol_" + std::to_string(step) + ".e", equation_systems);
+          ExodusII_IO(mesh).write_equation_systems("RB_sol_" + std::to_string(sample_idx) + ".e", equation_systems);
 #endif
-        } // end for (step)
+        } // end for (sample)
     }
 
 #endif // LIBMESH_ENABLE_DIRICHLET

--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -438,7 +438,7 @@ public:
                                       const RBParameters & mu_max_in,
                                       const std::map<std::string, std::vector<Real>> & discrete_parameter_values_in,
                                       const std::map<std::string,bool> & log_scaling,
-                                      std::map<std::string, std::vector<Number>> * training_sample_list=nullptr);
+                                      std::map<std::string, std::vector<Real>> * training_sample_list=nullptr);
 
   /**
    * Print out info that describes the current setup of this RBConstruction.

--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -434,10 +434,10 @@ public:
                                       Real abs_training_tolerance_in,
                                       bool normalize_rb_error_bound_in_greedy_in,
                                       const std::string & RB_training_type_in,
-                                      RBParameters mu_min_in,
-                                      RBParameters mu_max_in,
-                                      std::map<std::string, std::vector<Real>> discrete_parameter_values_in,
-                                      std::map<std::string,bool> log_scaling,
+                                      const RBParameters & mu_min_in,
+                                      const RBParameters & mu_max_in,
+                                      const std::map<std::string, std::vector<Real>> & discrete_parameter_values_in,
+                                      const std::map<std::string,bool> & log_scaling,
                                       std::map<std::string, std::vector<Number>> * training_sample_list=nullptr);
 
   /**

--- a/include/reduced_basis/rb_construction_base.h
+++ b/include/reduced_basis/rb_construction_base.h
@@ -133,7 +133,7 @@ public:
   virtual void initialize_training_parameters(const RBParameters & mu_min,
                                               const RBParameters & mu_max,
                                               unsigned int n_training_parameters,
-                                              std::map<std::string, bool> log_param_scale,
+                                              const std::map<std::string, bool> & log_param_scale,
                                               bool deterministic=true);
 
   /**
@@ -181,7 +181,7 @@ public:
    * Static helper function for generating a randomized set of parameters.
    */
   static void generate_training_parameters_random(const Parallel::Communicator & communicator,
-                                                  std::map<std::string, bool> log_param_scale,
+                                                  const std::map<std::string, bool> & log_param_scale,
                                                   std::map<std::string, std::unique_ptr<NumericVector<Number>>> & training_parameters_in,
                                                   unsigned int n_training_samples_in,
                                                   const RBParameters & min_parameters,
@@ -194,7 +194,7 @@ public:
    * parameters (as defined by the lengths of min/max parameters vectors), otherwise throws an error.
    */
   static void generate_training_parameters_deterministic(const Parallel::Communicator & communicator,
-                                                         std::map<std::string, bool> log_param_scale,
+                                                         const std::map<std::string, bool> & log_param_scale,
                                                          std::map<std::string, std::unique_ptr<NumericVector<Number>>> & training_parameters_in,
                                                          unsigned int n_training_samples_in,
                                                          const RBParameters & min_parameters,

--- a/include/reduced_basis/rb_construction_base.h
+++ b/include/reduced_basis/rb_construction_base.h
@@ -143,13 +143,13 @@ public:
    * Overwrite the training parameters with new_training_set.
    * This training set is assumed to contain only the samples local to this processor.
    */
-  virtual void load_training_set(std::map<std::string, std::vector<Number>> & new_training_set);
+  virtual void load_training_set(const std::map<std::string, std::vector<Real>> & new_training_set);
 
   /**
    * Overwrite the local training samples for \p param_name using \p values.
    * This assumes that values.size() matches get_local_n_training_samples().
    */
-  void set_training_parameter_values(const std::string & param_name, const std::vector<Number> & values);
+  void set_training_parameter_values(const std::string & param_name, const std::vector<Real> & values);
 
   /**
    * Broadcasts parameters from processor proc_id to all processors.
@@ -192,7 +192,7 @@ public:
   static std::pair<std::size_t, std::size_t>
   generate_training_parameters_random(const Parallel::Communicator & communicator,
                                       const std::map<std::string, bool> & log_param_scale,
-                                      std::map<std::string, std::vector<Number>> & local_training_parameters_in,
+                                      std::map<std::string, std::vector<Real>> & local_training_parameters_in,
                                       const unsigned int n_global_training_samples_in,
                                       const RBParameters & min_parameters,
                                       const RBParameters & max_parameters,
@@ -210,7 +210,7 @@ public:
   static std::pair<std::size_t, std::size_t>
   generate_training_parameters_deterministic(const Parallel::Communicator & communicator,
                                              const std::map<std::string, bool> & log_param_scale,
-                                             std::map<std::string, std::vector<Number>> & local_training_parameters_in,
+                                             std::map<std::string, std::vector<Real>> & local_training_parameters_in,
                                              const unsigned int n_global_training_samples_in,
                                              const RBParameters & min_parameters,
                                              const RBParameters & max_parameters,
@@ -288,7 +288,7 @@ private:
    * Otherwise, the sample vectors will only contain the values for the local samples
    * as defined by _first_local_index and _n_local_training_samples.
    */
-  std::map<std::string, std::vector<Number>> _training_parameters;
+  std::map<std::string, std::vector<Real>> _training_parameters;
 
   /**
    * The first sample-vector index from the global vector which is stored in

--- a/include/reduced_basis/rb_construction_base.h
+++ b/include/reduced_basis/rb_construction_base.h
@@ -263,12 +263,12 @@ private:
    * Boolean flag to indicate whether or not the
    * parameter ranges have been initialized.
    */
-  bool training_parameters_initialized;
+  bool _training_parameters_initialized;
 
   /**
    * The training samples.
    */
-  std::map<std::string, std::unique_ptr<NumericVector<Number>>> training_parameters;
+  std::map<std::string, std::unique_ptr<NumericVector<Number>>> _training_parameters;
 
   /**
    * If < 0, use std::time() * processor_id() to seed the random
@@ -276,7 +276,7 @@ private:
    * >= 0, use the provided value * processor_id() as the random
    * number generator seed.
    */
-  int training_parameters_random_seed;
+  int _training_parameters_random_seed;
 };
 
 } // namespace libMesh

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -151,7 +151,7 @@ public:
                                       const RBParameters & mu_max_in,
                                       const std::map<std::string, std::vector<Real>> & discrete_parameter_values_in,
                                       const std::map<std::string,bool> & log_scaling,
-                                      std::map<std::string, std::vector<Number>> * training_sample_list=nullptr);
+                                      std::map<std::string, std::vector<Real>> * training_sample_list=nullptr);
 
   /**
    * Specify which type of "best fit" we use to guide the EIM

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -147,10 +147,10 @@ public:
                                       unsigned int Nmax_in,
                                       Real rel_training_tolerance_in,
                                       Real abs_training_tolerance_in,
-                                      RBParameters mu_min_in,
-                                      RBParameters mu_max_in,
-                                      std::map<std::string, std::vector<Real>> discrete_parameter_values_in,
-                                      std::map<std::string,bool> log_scaling,
+                                      const RBParameters & mu_min_in,
+                                      const RBParameters & mu_max_in,
+                                      const std::map<std::string, std::vector<Real>> & discrete_parameter_values_in,
+                                      const std::map<std::string,bool> & log_scaling,
                                       std::map<std::string, std::vector<Number>> * training_sample_list=nullptr);
 
   /**

--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -45,8 +45,8 @@ class RBParameters
 public:
 
   /**
-   * Constructor. Initializes the _n_steps parameter to 1 for
-   * backwards compatibility, but the set_n_steps() function can
+   * Constructor. Initializes the _n_samples parameter to 1 for
+   * backwards compatibility, but the set_n_samples() function can
    * always be called later to update this value.
    */
   RBParameters();
@@ -184,30 +184,30 @@ public:
 
   /**
    * Get the value of the specified parameter, throw an error if it does not exist.
-   * Here we assume that there is only one "step", throw an error otherwise.
+   * Here we assume that there is only one sample, throw an error otherwise.
    */
   Real get_value(const std::string & param_name) const;
 
   /**
    * Get the value of the specified parameter, returning the provided
    * default value if it does not exist.
-   * If the value does exist, we assume that there is only one "step",
+   * If the value does exist, we assume that there is only one sample,
    * and throw an error otherwise.
    */
   Real get_value(const std::string & param_name, const Real & default_val) const;
 
   /**
-   * Get the value of the specified parameter at the specified step,
+   * Get the value of the specified parameter at the specified sample,
    * throwing an error if it does not exist.
    */
-  Real get_step_value(const std::string & param_name, std::size_t step) const;
+  Real get_sample_value(const std::string & param_name, std::size_t sample_idx) const;
 
   /**
-   * Get the value of the specified parameter at the specified step,
+   * Get the value of the specified parameter at the specified sample,
    * returning the provided default value if either the parameter is
-   * not defined or the step is invalid.
+   * not defined or the sample is invalid.
    */
-  Real get_step_value(const std::string & param_name, std::size_t step, const Real & default_val) const;
+  Real get_sample_value(const std::string & param_name, std::size_t sample_idx, const Real & default_val) const;
 
   /**
    * Set the value of the specified parameter. If param_name
@@ -219,10 +219,8 @@ public:
   void set_value(const std::string & param_name, Real value);
 
   /**
-   * Set the value of the specified parameter at the specified vector
-   * index.  Note: each parameter is now allowed to be vector-valued,
-   * it is up to the user to organize what the vector indices refer to
-   * (e.g. load or time steps).
+   * Set the value of the specified parameter at the specified sample
+   * index. The sample index can refer to, e.g., load or time steps.
    */
   void set_value(const std::string & param_name, std::size_t index, Real value);
 
@@ -252,17 +250,17 @@ public:
   Real get_extra_value(const std::string & param_name, const Real & default_val) const;
 
   /**
-   * Get the value of the specified "extra" parameter at the specified step,
+   * Get the value of the specified "extra" parameter at the specified sample index,
    * throwing an error if it does not exist.
    */
-  Real get_extra_step_value(const std::string & param_name, std::size_t step) const;
+  Real get_extra_sample_value(const std::string & param_name, std::size_t sample_idx) const;
 
   /**
-   * Get the value of the specified extra parameter at the specified step,
+   * Get the value of the specified extra parameter at the specified sample index,
    * returning the provided default value if either the parameter is
-   * not defined or the step is invalid.
+   * not defined or the sample index is invalid.
    */
-  Real get_extra_step_value(const std::string & param_name, std::size_t step, const Real & default_val) const;
+  Real get_extra_sample_value(const std::string & param_name, std::size_t sample_idx, const Real & default_val) const;
 
   /**
    * Set the value of the specified extra parameter. If param_name
@@ -271,10 +269,8 @@ public:
   void set_extra_value(const std::string & param_name, Real value);
 
   /**
-   * Set the value of the specified extra parameter at the specified vector
-   * index.  Note: each parameter is now allowed to be vector-valued,
-   * it is up to the user to organize what the vector indices refer to
-   * (e.g. load or time steps).
+   * Set the value of the specified extra parameter at the specified sample
+   * index. The sample index can refer to, e.g., load or time steps.
    */
   void set_extra_value(const std::string & param_name, std::size_t index, Real value);
 
@@ -284,22 +280,22 @@ public:
   unsigned int n_parameters() const;
 
   /**
-   * Set the number of steps this RBParameters object is intended to
+   * Set the number of samples this RBParameters object is intended to
    * represent, in the case that there are no actual parameters stored
    * on it. Note: this value will only be used in the no-parameters
    * case; if there are actual parameters specified in this class, the
    * number set via this API is ignored. All parameters stored within
-   * the RBParameters object must have n_steps() steps.
+   * the RBParameters object must have n_samples() samples.
    */
-  void set_n_steps(unsigned int n_steps);
+  void set_n_samples(unsigned int n_samples);
 
   /**
-   * Returns the number of steps stored for all parameters. For
+   * Returns the number of samples stored for all parameters. For
    * simplicity, we require all parameters to store the same number of
-   * steps ("step" here may refer to time step or load step) and in
+   * "samples" ("sample" here may refer to, e.g., time step or load step) and in
    * debug mode we actually verify that is the case.
    */
-  unsigned int n_steps() const;
+  unsigned int n_samples() const;
 
   /**
    * Fill \p param_names with the names of the parameters.
@@ -357,7 +353,7 @@ public:
 
   /**
    * Append "rhs" to "*this".  Both RBParameters objects must have the
-   * same n_steps(), otherwise an error is thrown. If some of the
+   * same n_samples(), otherwise an error is thrown. If some of the
    * parameter names overlap, then the values from rhs overwrite
    * *this. Both parameters and "extra" parameters are appended.
    */
@@ -387,12 +383,12 @@ private:
                         Real value);
 
   /**
-   * The number of steps represented by this RBParameters object, in
+   * The number of samples represented by this RBParameters object, in
    * the case where there are no parameters actually stored on it. If
    * there are parameters stored on this RBParameters object, then the
-   * n_steps() API returns that number of steps instead.
+   * n_samples() API returns that number of samples instead.
    */
-  unsigned int _n_steps;
+  unsigned int _n_samples;
 
   /**
    * The map that stores the actual parameter vectors. Each vector is

--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -183,14 +183,16 @@ public:
   bool has_extra_value(const std::string & param_name) const;
 
   /**
-   * Get the value of the specified parameter, throwing an error if it
-   * does not exist.
+   * Get the value of the specified parameter, throw an error if it does not exist.
+   * Here we assume that there is only one "step", throw an error otherwise.
    */
   Real get_value(const std::string & param_name) const;
 
   /**
    * Get the value of the specified parameter, returning the provided
    * default value if it does not exist.
+   * If the value does exist, we assume that there is only one "step",
+   * and throw an error otherwise.
    */
   Real get_value(const std::string & param_name, const Real & default_val) const;
 
@@ -399,8 +401,8 @@ private:
   std::map<std::string, std::vector<Real>> _parameters;
 
   /**
-   * The map that stores extra parameter vectors not used for RB
-   * training. Each vector is indexed by a name.
+   * Extra parameter vectors not used for RB training.
+   * Each vector is indexed by a name.
    */
   std::map<std::string, std::vector<Real>> _extra_parameters;
 };

--- a/include/reduced_basis/rb_parametrized.h
+++ b/include/reduced_basis/rb_parametrized.h
@@ -211,9 +211,13 @@ private:
                                                 std::map<std::string, std::vector<Real>> & discrete_parameter_values_in);
 
   /**
-   * Helper function to check that \p params is valid.
+   * Helper function to check that \p params is valid:
+   *  - same number of parameters (error)
+   *  - parameter values are within the min/max range (warning)
+   *  - discrete values are correctly discrete within tolerance (warning)
+   * Warnings are only printed if "verbose_mode" is true.
    */
-  bool valid_params(const RBParameters & params);
+  bool check_if_valid_params(const RBParameters & params) const;
 
   /**
    * Helper function to check if the specified value

--- a/include/reduced_basis/rb_parametrized.h
+++ b/include/reduced_basis/rb_parametrized.h
@@ -27,6 +27,7 @@
 #include "libmesh/reference_counted_object.h"
 
 // C++ includes
+#include <cstddef>
 #include <vector>
 
 namespace libMesh
@@ -69,6 +70,7 @@ public:
 
   /**
    * Initialize the parameter ranges and set current_parameters.
+   * The input min/max parameters should have exactly 1 sample each.
    */
   void initialize_parameters(const RBParameters & mu_min_in,
                              const RBParameters & mu_max_in,
@@ -111,8 +113,13 @@ public:
 
   /**
    * Set the current parameters to \p params
+   * The parameters are checked for validity; an error is thrown if
+   * the number of parameters or samples is different than expected.
+   * We \return a boolean true if the new parameters are within the min/max
+   * range, and false otherwise (but the parameters are set regardless).
+   * Enabling the "verbose_mode" flag will also print more details.
    */
-  void set_parameters(const RBParameters & params);
+  bool set_parameters(const RBParameters & params);
 
   /**
    * Get an RBParameters object that specifies the minimum allowable value

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -2730,7 +2730,7 @@ void RBConstruction::preevaluate_thetas()
 
   // Collect all training parameters
   // TODO: Here instead of using a vector of RBParameters objects,
-  // we could use a single RBParameters object with multiple "steps".
+  // we could use a single RBParameters object with multiple samples.
   // This would save memory over the current approach, but that may
   // not be a big deal in practice unless the number of training samples
   // is very large for some reason.
@@ -2771,10 +2771,10 @@ void RBConstruction::preevaluate_thetas()
 
           // TODO: the size of _evaluated_thetas is currently assumed to be
           // the same as get_local_n_training_samples(), but this won't be
-          // the case if we use RBParameters objects that have multiple steps.
+          // the case if we use RBParameters objects that have multiple samples.
           // So just make sure that's the case for now.
           libmesh_error_msg_if(output_vals.size() != get_local_n_training_samples(),
-                               "We currently only support single-step RBParameters "
+                               "We currently only support single-sample RBParameters "
                                "objects during the training stage.");
 
           for (auto i : index_range(output_vals))

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -292,10 +292,10 @@ void RBConstruction::set_rb_construction_parameters(
                                                     Real abs_training_tolerance_in,
                                                     bool normalize_rb_bound_in_greedy_in,
                                                     const std::string & RB_training_type_in,
-                                                    RBParameters mu_min_in,
-                                                    RBParameters mu_max_in,
-                                                    std::map<std::string, std::vector<Real>> discrete_parameter_values_in,
-                                                    std::map<std::string,bool> log_scaling_in,
+                                                    const RBParameters & mu_min_in,
+                                                    const RBParameters & mu_max_in,
+                                                    const std::map<std::string, std::vector<Real>> & discrete_parameter_values_in,
+                                                    const std::map<std::string,bool> & log_scaling_in,
                                                     std::map<std::string, std::vector<Number>> * training_sample_list)
 {
   // Read in training_parameters_random_seed value.  This is used to

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -296,7 +296,7 @@ void RBConstruction::set_rb_construction_parameters(
                                                     const RBParameters & mu_max_in,
                                                     const std::map<std::string, std::vector<Real>> & discrete_parameter_values_in,
                                                     const std::map<std::string,bool> & log_scaling_in,
-                                                    std::map<std::string, std::vector<Number>> * training_sample_list)
+                                                    std::map<std::string, std::vector<Real>> * training_sample_list)
 {
   // Read in training_parameters_random_seed value.  This is used to
   // seed the RNG when picking the training parameters.  By default the

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -398,9 +398,9 @@ void RBConstructionBase<Base>::load_training_set(const std::map<std::string, std
         }
 
       // Ensure that the parameters are the same.
-      for (auto & [param_name, _] : _training_parameters)
+      for (auto & it : _training_parameters)
         {
-          libmesh_error_msg_if(new_training_set.find(param_name)==new_training_set.end(),
+          libmesh_error_msg_if(new_training_set.find(it.first)==new_training_set.end(),
             "Parameters must be identical in order to overwrite dataset.");
         }
 
@@ -508,8 +508,8 @@ RBConstructionBase<Base>::generate_training_parameters_random(const Parallel::Co
   const auto &[n_local_training_samples, first_local_index] =
       calculate_n_local_samples_and_index(communicator, n_global_training_samples_in,
                                           serial_training_set);
-  for (const auto &[param_name, _] : min_parameters)
-    local_training_parameters_in[param_name] = std::vector<Real>(n_local_training_samples);
+  for (const auto & it : min_parameters)
+    local_training_parameters_in[it.first] = std::vector<Real>(n_local_training_samples);
 
   // finally, set the values
   for (auto & [param_name, sample_vector]: local_training_parameters_in)
@@ -564,8 +564,8 @@ RBConstructionBase<Base>::generate_training_parameters_deterministic(const Paral
       calculate_n_local_samples_and_index(communicator, n_global_training_samples_in,
                                          serial_training_set);
   const auto last_local_index = first_local_index + n_local_training_samples;
-  for (const auto & [param_name, _] : min_parameters)
-    local_training_parameters_in[param_name] = std::vector<Real>(n_local_training_samples);
+  for (const auto & it : min_parameters)
+    local_training_parameters_in[it.first] = std::vector<Real>(n_local_training_samples);
 
   // n_training_samples_per_param has 3 entries, but entries after "num_params"
   // are unused so we just set their value to 1. We need to set it to 1 (rather
@@ -608,8 +608,9 @@ RBConstructionBase<Base>::generate_training_parameters_deterministic(const Paral
   std::vector<std::vector<Real>> training_samples_per_param(num_params);
   {
     unsigned int i = 0;
-    for (const auto & [param_name, _] : min_parameters)
+    for (const auto & it : min_parameters)
       {
+        const std::string &param_name = it.first;
         const bool use_log_scaling = log_param_scale.at(param_name);
         Real min_param = min_parameters.get_value(param_name);
         Real max_param = max_parameters.get_value(param_name);
@@ -664,6 +665,7 @@ RBConstructionBase<Base>::generate_training_parameters_deterministic(const Paral
                 unsigned int param_count = 0;
                 for (const auto & [param_name, _] : min_parameters)
                   {
+                    libmesh_ignore(_);
                     const auto & it = local_training_parameters_in.find(param_name);
                     libmesh_error_msg_if(it == local_training_parameters_in.end(),
                                          "Invalid parameter name: " + param_name);
@@ -707,9 +709,9 @@ void RBConstructionBase<Base>::broadcast_parameters(const unsigned int proc_id)
   // update the copy of the RBParameters object.
   // TODO - this only works with single-sample parameter objects.
   unsigned int count = 0;
-  for (const auto & [param_name, _]: current_parameters)
+  for (const auto & it : current_parameters)
     {
-      current_parameters.set_value(param_name, current_parameters_vector[count]);
+      current_parameters.set_value(it.first, current_parameters_vector[count]);
       count++;
     }
 

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -99,7 +99,8 @@ void RBConstructionBase<Base>::get_global_max_error_pair(const Parallel::Communi
 template <class Base>
 numeric_index_type RBConstructionBase<Base>::get_n_training_samples() const
 {
-  libmesh_assert(_training_parameters_initialized);
+  libmesh_error_msg_if(!_training_parameters_initialized,
+                       "Error: training parameters must first be initialized.");
 
   // First we check if there are no parameters here, and in that case we
   // return 1 since a single training sample is sufficient to generate an
@@ -120,7 +121,8 @@ numeric_index_type RBConstructionBase<Base>::get_n_training_samples() const
 template <class Base>
 numeric_index_type RBConstructionBase<Base>::get_local_n_training_samples() const
 {
-  libmesh_assert(_training_parameters_initialized);
+  libmesh_error_msg_if(!_training_parameters_initialized,
+                       "Error: training parameters must first be initialized.");
 
   // First we check if there are no parameters here, and in that case we
   // return 1 for both serial and parallel training sets. This is consistent
@@ -135,7 +137,8 @@ numeric_index_type RBConstructionBase<Base>::get_local_n_training_samples() cons
 template <class Base>
 numeric_index_type RBConstructionBase<Base>::get_first_local_training_index() const
 {
-  libmesh_assert(_training_parameters_initialized);
+  libmesh_error_msg_if(!_training_parameters_initialized,
+                       "Error: training parameters must first be initialized.");
 
   // First we check if there are no parameters here, and in that case we
   // return 0 for a serial training set and comm().rank() for a parallel
@@ -156,7 +159,8 @@ numeric_index_type RBConstructionBase<Base>::get_first_local_training_index() co
 template <class Base>
 numeric_index_type RBConstructionBase<Base>::get_last_local_training_index() const
 {
-  libmesh_assert(_training_parameters_initialized);
+  libmesh_error_msg_if(!_training_parameters_initialized,
+                       "Error: training parameters must first be initialized.");
 
   if (_training_parameters.empty())
     return 0;
@@ -173,7 +177,8 @@ void RBConstructionBase<Base>::set_params_from_training_set(unsigned int index)
 template <class Base>
 RBParameters RBConstructionBase<Base>::get_params_from_training_set(unsigned int index)
 {
-  libmesh_assert(_training_parameters_initialized);
+  libmesh_error_msg_if(!_training_parameters_initialized,
+                       "Error: training parameters must first be initialized.");
 
   libmesh_assert( (this->get_first_local_training_index() <= index) &&
                   (index < this->get_last_local_training_index()) );
@@ -196,7 +201,8 @@ RBParameters RBConstructionBase<Base>::get_params_from_training_set(unsigned int
 template <class Base>
 void RBConstructionBase<Base>::set_params_from_training_set_and_broadcast(unsigned int index)
 {
-  libmesh_assert(_training_parameters_initialized);
+  libmesh_error_msg_if(!_training_parameters_initialized,
+                       "Error: training parameters must first be initialized.");
 
   processor_id_type root_id = 0;
   if ((this->get_first_local_training_index() <= index) &&
@@ -419,8 +425,9 @@ void RBConstructionBase<Base>::generate_training_parameters_random(const Paralle
                                                                    int training_parameters_random_seed,
                                                                    bool serial_training_set)
 {
-  libmesh_assert_equal_to ( min_parameters.n_parameters(), max_parameters.n_parameters() );
   const unsigned int num_params = min_parameters.n_parameters();
+  libmesh_error_msg_if(num_params!=max_parameters.n_parameters(),
+    "Number of parameters must be identical for min/max.");
 
   // Clear training_parameters_in
   training_parameters_in.clear();
@@ -537,11 +544,8 @@ void RBConstructionBase<Base>::generate_training_parameters_deterministic(const 
     return;
 
   if (num_params > 3)
-    {
-      libMesh::out << "ERROR: Deterministic training sample generation "
-                   << "not implemented for more than three parameters." << std::endl;
-      libmesh_not_implemented();
-    }
+    libmesh_not_implemented_msg("ERROR: Deterministic training sample generation "
+                                "not implemented for more than three parameters.");
 
   // Clear training_parameters_in (but don't remove existing keys!)
   for (auto & pr : training_parameters_in)

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -230,7 +230,7 @@ template <class Base>
 void RBConstructionBase<Base>::initialize_training_parameters(const RBParameters & mu_min,
                                                               const RBParameters & mu_max,
                                                               unsigned int n_training_samples,
-                                                              std::map<std::string,bool> log_param_scale,
+                                                              const std::map<std::string,bool> & log_param_scale,
                                                               bool deterministic)
 {
   if (!is_quiet())
@@ -423,7 +423,7 @@ void RBConstructionBase<Base>::set_training_parameter_values(
 
 template <class Base>
 void RBConstructionBase<Base>::generate_training_parameters_random(const Parallel::Communicator & communicator,
-                                                                   std::map<std::string, bool> log_param_scale,
+                                                                   const std::map<std::string, bool> & log_param_scale,
                                                                    std::map<std::string, std::unique_ptr<NumericVector<Number>>> & training_parameters_in,
                                                                    unsigned int n_training_samples_in,
                                                                    const RBParameters & min_parameters,
@@ -517,7 +517,7 @@ void RBConstructionBase<Base>::generate_training_parameters_random(const Paralle
           Real random_number = static_cast<Real>(std::rand()) / RAND_MAX; // in range [0,1]
 
           // Generate log10 scaled training parameters
-          if (log_param_scale[param_name])
+          if (log_param_scale.at(param_name))
             {
               Real log_min   = log10(min_parameters.get_value(param_name));
               Real log_range = log10(max_parameters.get_value(param_name) / min_parameters.get_value(param_name));
@@ -536,7 +536,7 @@ void RBConstructionBase<Base>::generate_training_parameters_random(const Paralle
 
 template <class Base>
 void RBConstructionBase<Base>::generate_training_parameters_deterministic(const Parallel::Communicator & communicator,
-                                                                          std::map<std::string, bool> log_param_scale,
+                                                                          const std::map<std::string, bool> & log_param_scale,
                                                                           std::map<std::string, std::unique_ptr<NumericVector<Number>>> & training_parameters_in,
                                                                           unsigned int n_training_samples_in,
                                                                           const RBParameters & min_parameters,
@@ -630,7 +630,7 @@ void RBConstructionBase<Base>::generate_training_parameters_deterministic(const 
     unsigned int i = 0;
     for (const std::string & param_name : param_names)
       {
-        bool use_log_scaling = log_param_scale[param_name];
+        const bool use_log_scaling = log_param_scale.at(param_name);
         Real min_param = min_parameters.get_value(param_name);
         Real max_param = max_parameters.get_value(param_name);
 

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -619,7 +619,8 @@ void RBConstructionBase<Base>::generate_training_parameters_deterministic(const 
                          "Error: Number of training samples = "
                          << n_training_samples_in
                          << " does not enable a uniform grid of samples with "
-                         << num_params << " parameters.");
+                         << num_params << " parameters. Try "
+                         << total_samples_check << " samples instead?");
   }
 
   // First we make a list of training samples associated with each parameter,

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -333,7 +333,7 @@ void RBEIMConstruction::set_rb_construction_parameters(unsigned int n_training_s
                                                        const RBParameters & mu_max_in,
                                                        const std::map<std::string, std::vector<Real>> & discrete_parameter_values_in,
                                                        const std::map<std::string,bool> & log_scaling_in,
-                                                       std::map<std::string, std::vector<Number>> * training_sample_list)
+                                                       std::map<std::string, std::vector<Real>> * training_sample_list)
 {
   // Read in training_parameters_random_seed value.  This is used to
   // seed the RNG when picking the training parameters.  By default the
@@ -404,7 +404,7 @@ void RBEIMConstruction::set_rb_construction_parameters(unsigned int n_training_s
       const std::string & lookup_table_param_name =
         get_rb_eim_evaluation().get_parametrized_function().lookup_table_param_name;
 
-      std::vector<Number> lookup_table_training_samples(n_training_samples_in);
+      std::vector<Real> lookup_table_training_samples(n_training_samples_in);
       std::iota(lookup_table_training_samples.begin(), lookup_table_training_samples.end(), 0);
 
       set_training_parameter_values(lookup_table_param_name, lookup_table_training_samples);

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -329,10 +329,10 @@ void RBEIMConstruction::set_rb_construction_parameters(unsigned int n_training_s
                                                        unsigned int Nmax_in,
                                                        Real rel_training_tolerance_in,
                                                        Real abs_training_tolerance_in,
-                                                       RBParameters mu_min_in,
-                                                       RBParameters mu_max_in,
-                                                       std::map<std::string, std::vector<Real>> discrete_parameter_values_in,
-                                                       std::map<std::string,bool> log_scaling_in,
+                                                       const RBParameters & mu_min_in,
+                                                       const RBParameters & mu_max_in,
+                                                       const std::map<std::string, std::vector<Real>> & discrete_parameter_values_in,
+                                                       const std::map<std::string,bool> & log_scaling_in,
                                                        std::map<std::string, std::vector<Number>> * training_sample_list)
 {
   // Read in training_parameters_random_seed value.  This is used to
@@ -357,8 +357,12 @@ void RBEIMConstruction::set_rb_construction_parameters(unsigned int n_training_s
       libmesh_error_msg_if(!discrete_parameter_values_in.count(lookup_table_param_name),
         "Lookup table parameter should be discrete");
 
+      // Make an editable copy of discrete_parameters_values_in.
+      std::map<std::string, std::vector<Real>> discrete_parameter_values_final(
+          discrete_parameter_values_in);
+
       std::vector<Real> & lookup_table_param_values =
-        libmesh_map_find(discrete_parameter_values_in, lookup_table_param_name);
+        libmesh_map_find(discrete_parameter_values_final, lookup_table_param_name);
 
       // Overwrite the discrete values for lookup_table_param to make sure that
       // it is: 0, 1, 2, ..., size-1.
@@ -368,10 +372,16 @@ void RBEIMConstruction::set_rb_construction_parameters(unsigned int n_training_s
       // lookup_table_size so that we will get full coverage of the
       // lookup table in our training set.
       n_training_samples_in = lookup_table_param_values.size();
+
+      // Initialize the parameter ranges and the parameters themselves
+      initialize_parameters(mu_min_in, mu_max_in, discrete_parameter_values_final);
+    }
+  else
+    {
+      // Initialize the parameter ranges and the parameters themselves
+      initialize_parameters(mu_min_in, mu_max_in, discrete_parameter_values_in);
     }
 
-  // Initialize the parameter ranges and the parameters themselves
-  initialize_parameters(mu_min_in, mu_max_in, discrete_parameter_values_in);
 
   initialize_training_parameters(this->get_parameters_min(),
                                  this->get_parameters_max(),

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -177,17 +177,17 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
     get_parametrized_function().vectorized_evaluate(mus, _vec_eval_input, output_all_comps);
 
   // Previously we did one RB-EIM solve per input mu, but now we do
-  // one RB-EIM solve per input mu, per step. In order for this to
+  // one RB-EIM solve per input mu, per sample. In order for this to
   // work, we require that all the input mu objects have the same
-  // number of steps.
-  auto n_steps_0 = mus[0].n_steps();
+  // number of samples.
+  auto n_samples_0 = mus[0].n_samples();
   for (const auto & mu : mus)
-    libmesh_error_msg_if(mu.n_steps() != n_steps_0, "All RBParameters objects must have same n_steps()");
+    libmesh_error_msg_if(mu.n_samples() != n_samples_0, "All RBParameters objects must have same n_samples()");
 
-  // After we verified that all mus have the same number of steps,
+  // After we verified that all mus have the same number of samples,
   // the total number of RB-EIM solves is simply the number of mus
-  // times the number of steps.
-  unsigned int num_rb_eim_solves = mus.size() * n_steps_0;
+  // times the number of samples.
+  unsigned int num_rb_eim_solves = mus.size() * n_samples_0;
 
   // A special case is when we are passed a single RBParameters object
   // with no parameters stored on it. In this case, we effectively
@@ -212,10 +212,10 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
   {
     unsigned int counter = 0;
     for (auto mu_index : index_range(mus))
-      for (auto step_index : make_range(mus[mu_index].n_steps()))
+      for (auto sample_index : make_range(mus[mu_index].n_samples()))
       {
         // Ignore compiler warnings about unused loop index
-        libmesh_ignore(step_index);
+        libmesh_ignore(sample_index);
 
         evaluated_values_at_interp_points[counter].resize(N);
 
@@ -224,7 +224,7 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
             unsigned int comp = _interpolation_points_comp[interp_pt_index];
 
             // This line of code previously used "mu_index", now we use
-            // "counter" handle the multi-step RBParameters case.
+            // "counter" handle the multi-sample RBParameters case.
             evaluated_values_at_interp_points[counter][interp_pt_index] =
               output_all_comps[counter][interp_pt_index][comp];
           }
@@ -260,10 +260,10 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
   {
     unsigned int counter = 0;
     for (auto mu_index : index_range(mus))
-      for (auto step_index : make_range(mus[mu_index].n_steps()))
+      for (auto sample_index : make_range(mus[mu_index].n_samples()))
       {
         // Ignore compiler warnings about unused loop index
-        libmesh_ignore(step_index);
+        libmesh_ignore(sample_index);
 
         DenseVector<Number> EIM_rhs = evaluated_values_at_interp_points[counter];
         interpolation_matrix_N.lu_solve(EIM_rhs, _rb_eim_solutions[counter]);

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -61,17 +61,17 @@ bool RBParameters::has_extra_value(const std::string & param_name) const
 
 Real RBParameters::get_value(const std::string & param_name) const
 {
-  // get_value() is maintained for backwards compatibility. It simply
-  // returns the [0]th entry of the vector if it can, throwing an
-  // error otherwise.
+  // Simply return the [0]th entry of the vector if possible, otherwise error.
+  libmesh_error_msg_if(this->n_steps() != 1,
+    "Requesting value for parameter " << param_name << ", but parameter contains multiple steps.");
   return this->get_step_value(param_name, /*step=*/0);
 }
 
 Real RBParameters::get_value(const std::string & param_name, const Real & default_val) const
 {
-  // get_value() is maintained for backwards compatibility. It simply
-  // returns the [0]th entry of the vector if it can, or the default
-  // value otherwise.
+  // Simply return the [0]th entry of the vector if possible, otherwise error.
+  libmesh_error_msg_if(this->n_steps() != 1,
+    "Requesting value for parameter " << param_name << ", but parameter contains multiple steps.");
   return this->get_step_value(param_name, /*step=*/0, default_val);
 }
 
@@ -150,16 +150,21 @@ void RBParameters::push_back_extra_value(const std::string & param_name, Real va
 Real RBParameters::get_extra_value(const std::string & param_name) const
 {
   // Same as get_value(param_name) but for the map of extra parameters
-  const auto & vec = libmesh_map_find(_extra_parameters, param_name);
-  libmesh_error_msg_if(vec.size() == 0, "Error getting value for extra parameter " << param_name);
-  return vec[0];
+  const auto & step_vec = libmesh_map_find(_extra_parameters, param_name);
+  libmesh_error_msg_if(step_vec.size() != 1,
+    "Requesting value for extra parameter " << param_name << ", but parameter contains multiple steps.");
+  return step_vec[0];
 }
 
 Real RBParameters::get_extra_value(const std::string & param_name, const Real & default_val) const
 {
   // same as get_value(param_name, default_val) but for the map of extra parameters
   auto it = _extra_parameters.find(param_name);
-  return ((it != _extra_parameters.end() && it->second.size() != 0) ? it->second[0] : default_val);
+  if(it==_parameters.end())
+    return default_val;
+  libmesh_error_msg_if(it->second.size()!=1,
+    "Requesting value for extra parameter " << param_name << ", but parameter contains multiple steps.");
+  return it->second[0];
 }
 
 Real RBParameters::get_extra_step_value(const std::string & param_name, std::size_t step) const

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -28,12 +28,12 @@ namespace libMesh
 {
 
 RBParameters::RBParameters() :
-  _n_steps(1)
+  _n_samples(1)
 {
 }
 
 RBParameters::RBParameters(const std::map<std::string, Real> & parameter_map) :
-  _n_steps(1)
+  _n_samples(1)
 {
   // Backwards compatible support for constructing an RBParameters
   // object from a map<string, Real>. We store a single entry in each
@@ -44,7 +44,7 @@ RBParameters::RBParameters(const std::map<std::string, Real> & parameter_map) :
 
 void RBParameters::clear()
 {
-  _n_steps = 1;
+  _n_samples = 1;
   _parameters.clear();
   _extra_parameters.clear();
 }
@@ -62,30 +62,30 @@ bool RBParameters::has_extra_value(const std::string & param_name) const
 Real RBParameters::get_value(const std::string & param_name) const
 {
   // Simply return the [0]th entry of the vector if possible, otherwise error.
-  libmesh_error_msg_if(this->n_steps() != 1,
-    "Requesting value for parameter " << param_name << ", but parameter contains multiple steps.");
-  return this->get_step_value(param_name, /*step=*/0);
+  libmesh_error_msg_if(this->n_samples() != 1,
+    "Requesting value for parameter " << param_name << ", but parameter contains multiple samples.");
+  return this->get_sample_value(param_name, /*sample_idx=*/0);
 }
 
 Real RBParameters::get_value(const std::string & param_name, const Real & default_val) const
 {
   // Simply return the [0]th entry of the vector if possible, otherwise error.
-  libmesh_error_msg_if(this->n_steps() != 1,
-    "Requesting value for parameter " << param_name << ", but parameter contains multiple steps.");
-  return this->get_step_value(param_name, /*step=*/0, default_val);
+  libmesh_error_msg_if(this->n_samples() != 1,
+    "Requesting value for parameter " << param_name << ", but parameter contains multiple samples.");
+  return this->get_sample_value(param_name, /*sample_idx=*/0, default_val);
 }
 
-Real RBParameters::get_step_value(const std::string & param_name, std::size_t step) const
+Real RBParameters::get_sample_value(const std::string & param_name, std::size_t sample_idx) const
 {
   const auto & vec = libmesh_map_find(_parameters, param_name);
-  libmesh_error_msg_if(step >= vec.size(), "Error getting value for parameter " << param_name);
-  return vec[step];
+  libmesh_error_msg_if(sample_idx >= vec.size(), "Error getting value for parameter " << param_name);
+  return vec[sample_idx];
 }
 
-Real RBParameters::get_step_value(const std::string & param_name, std::size_t step, const Real & default_val) const
+Real RBParameters::get_sample_value(const std::string & param_name, std::size_t sample_idx, const Real & default_val) const
 {
   auto it = _parameters.find(param_name);
-  return ((it != _parameters.end() && step < it->second.size()) ? it->second[step] : default_val);
+  return ((it != _parameters.end() && sample_idx < it->second.size()) ? it->second[sample_idx] : default_val);
 }
 
 void RBParameters::set_value(const std::string & param_name, Real value)
@@ -150,10 +150,10 @@ void RBParameters::push_back_extra_value(const std::string & param_name, Real va
 Real RBParameters::get_extra_value(const std::string & param_name) const
 {
   // Same as get_value(param_name) but for the map of extra parameters
-  const auto & step_vec = libmesh_map_find(_extra_parameters, param_name);
-  libmesh_error_msg_if(step_vec.size() != 1,
-    "Requesting value for extra parameter " << param_name << ", but parameter contains multiple steps.");
-  return step_vec[0];
+  const auto & sample_vec = libmesh_map_find(_extra_parameters, param_name);
+  libmesh_error_msg_if(sample_vec.size() != 1,
+    "Requesting value for extra parameter " << param_name << ", but parameter contains multiple samples.");
+  return sample_vec[0];
 }
 
 Real RBParameters::get_extra_value(const std::string & param_name, const Real & default_val) const
@@ -163,22 +163,22 @@ Real RBParameters::get_extra_value(const std::string & param_name, const Real & 
   if(it==_parameters.end())
     return default_val;
   libmesh_error_msg_if(it->second.size()!=1,
-    "Requesting value for extra parameter " << param_name << ", but parameter contains multiple steps.");
+    "Requesting value for extra parameter " << param_name << ", but parameter contains multiple samples.");
   return it->second[0];
 }
 
-Real RBParameters::get_extra_step_value(const std::string & param_name, std::size_t step) const
+Real RBParameters::get_extra_sample_value(const std::string & param_name, std::size_t sample_idx) const
 {
   const auto & vec = libmesh_map_find(_extra_parameters, param_name);
-  libmesh_error_msg_if(step >= vec.size(), "Error getting value for parameter " << param_name);
-  return vec[step];
+  libmesh_error_msg_if(sample_idx >= vec.size(), "Error getting value for parameter " << param_name);
+  return vec[sample_idx];
 }
 
-Real RBParameters::get_extra_step_value(const std::string & param_name, std::size_t step, const Real & default_val) const
+Real RBParameters::get_extra_sample_value(const std::string & param_name, std::size_t sample_idx, const Real & default_val) const
 {
-  // same as get_step_value(param_name, index, default_val) but for the map of extra parameters
+  // same as get_sample_value(param_name, index, default_val) but for the map of extra parameters
   auto it = _extra_parameters.find(param_name);
-  return ((it != _extra_parameters.end() && step < it->second.size()) ? it->second[step] : default_val);
+  return ((it != _extra_parameters.end() && sample_idx < it->second.size()) ? it->second[sample_idx] : default_val);
 }
 
 void RBParameters::set_extra_value(const std::string & param_name, Real value)
@@ -192,28 +192,28 @@ unsigned int RBParameters::n_parameters() const
   return cast_int<unsigned int>(_parameters.size());
 }
 
-void RBParameters::set_n_steps(unsigned int n_steps)
+void RBParameters::set_n_samples(unsigned int n_samples)
 {
-  _n_steps = n_steps;
+  _n_samples = n_samples;
 }
 
-unsigned int RBParameters::n_steps() const
+unsigned int RBParameters::n_samples() const
 {
   // Quick return if there are no parameters
   if (_parameters.empty())
-    return _n_steps;
+    return _n_samples;
 
-  // If _parameters is not empty, we can check the number of steps in the first param
+  // If _parameters is not empty, we can check the number of samples in the first param
   auto size_first = _parameters.begin()->second.size();
 
 #ifdef DEBUG
-  // In debug mode, verify that all parameters have the same number of steps
+  // In debug mode, verify that all parameters have the same number of samples
   for (const auto & pr : _parameters)
-    libmesh_assert_msg(pr.second.size() == size_first, "All parameters must have the same number of steps.");
+    libmesh_assert_msg(pr.second.size() == size_first, "All parameters must have the same number of samples.");
 #endif
 
   // If we made it here in DEBUG mode, then all parameters were
-  // verified to have the same number of steps.
+  // verified to have the same number of samples.
   return size_first;
 }
 
@@ -278,8 +278,8 @@ bool RBParameters::operator!=(const RBParameters & rhs) const
 
 RBParameters & RBParameters::operator+= (const RBParameters & rhs)
 {
-  libmesh_error_msg_if(this->n_steps() != rhs.n_steps(),
-                       "Can only append RBParameters objects with matching numbers of steps");
+  libmesh_error_msg_if(this->n_samples() != rhs.n_samples(),
+                       "Can only append RBParameters objects with matching numbers of samples.");
 
   // Overwrite or add each (key, vec) pair in rhs to *this.
   for (const auto & [key, vec] : rhs._parameters)

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -160,10 +160,11 @@ Real RBParameters::get_extra_value(const std::string & param_name, const Real & 
 {
   // same as get_value(param_name, default_val) but for the map of extra parameters
   auto it = _extra_parameters.find(param_name);
-  if(it==_parameters.end())
+  if (it == _parameters.end())
     return default_val;
-  libmesh_error_msg_if(it->second.size()!=1,
-    "Requesting value for extra parameter " << param_name << ", but parameter contains multiple samples.");
+
+  libmesh_error_msg_if(it->second.size() != 1,
+                       "Requesting value for extra parameter " << param_name << ", but parameter contains multiple samples.");
   return it->second[0];
 }
 

--- a/src/reduced_basis/rb_parametrized.C
+++ b/src/reduced_basis/rb_parametrized.C
@@ -132,7 +132,7 @@ std::set<std::string> RBParametrized::get_parameter_names() const
 
 void RBParametrized::set_parameters(const RBParameters & params)
 {
-  libmesh_error_msg_if(!parameters_initialized, "Error: parameters not initialized in RBParametrized::set_current_parameters");
+  libmesh_error_msg_if(!parameters_initialized, "Error: parameters not initialized in RBParametrized::set_parameters");
 
   valid_params(params); // Terminates if params has the wrong number of parameters
 
@@ -142,7 +142,7 @@ void RBParametrized::set_parameters(const RBParameters & params)
 
 const RBParameters & RBParametrized::get_parameters() const
 {
-  libmesh_error_msg_if(!parameters_initialized, "Error: parameters not initialized in RBParametrized::get_current_parameters");
+  libmesh_error_msg_if(!parameters_initialized, "Error: parameters not initialized in RBParametrized::get_parameters");
 
   return parameters;
 }
@@ -376,7 +376,11 @@ void RBParametrized::print_discrete_parameter_values() const
 
 bool RBParametrized::valid_params(const RBParameters & params)
 {
-  libmesh_error_msg_if(params.n_parameters() != get_n_params(), "Error: Number of parameters don't match");
+  libmesh_error_msg_if(params.n_parameters() != get_n_params(),
+                       "Error: Number of parameters don't match; found "
+                       << params.n_parameters() << ", expected "
+                       << get_n_params());
+
 
   bool valid = true;
   for (const auto & pr : params)

--- a/src/reduced_basis/rb_theta.C
+++ b/src/reduced_basis/rb_theta.C
@@ -28,10 +28,10 @@ namespace libMesh
 Number RBTheta::evaluate(const RBParameters & mu)
 {
   // The RBTheta::evaluate() API is not general enough to handle the
-  // multi-step RBParameters case, and you must therefore call
+  // multi-sample RBParameters case, and you must therefore call
   // RBTheta::evaluate_vec() instead.
-  libmesh_error_msg_if(mu.n_steps() > 1,
-                       "You should only call the evaluate_vec() API when using multi-step RBParameters objects.");
+  libmesh_error_msg_if(mu.n_samples() > 1,
+                       "You should only call the evaluate_vec() API when using multi-sample RBParameters objects.");
 
   return 1.;
 }
@@ -44,16 +44,16 @@ RBTheta::evaluate_vec(const std::vector<RBParameters> & mus)
 
   for (const auto & mu : mus)
     {
-      // Backwards-compatible behavior: for single-step RBParameters objects, we fall back on
+      // Backwards-compatible behavior: for single-sample RBParameters objects, we fall back on
       // calling the scalar evaluate() function for this RBTheta object, which may have been
       // overridden by the user.
-      if (mu.n_steps() == 1)
+      if (mu.n_samples() == 1)
         result.push_back( this->evaluate(mu) );
       else
         {
-          // For multistep RBParameters objects, all we can do is return
-          // mu.n_steps() copies of 1 here at the base class level.
-          result.insert(result.end(), /*count=*/mu.n_steps(), /*val=*/1.);
+          // For multi-sample RBParameters objects, all we can do is return
+          // mu.n_samples() copies of 1 here at the base class level.
+          result.insert(result.end(), /*count=*/mu.n_samples(), /*val=*/1.);
         }
     }
 

--- a/tests/utils/rb_parameters_test.C
+++ b/tests/utils/rb_parameters_test.C
@@ -221,10 +221,10 @@ public:
     RBParametrized rb_parametrized;
     // rb_parametrized.verbose_mode = true; // Enable for more printed details.
     // Throw an error due to invalid min/max.
-    CPPUNIT_ASSERT_THROW(rb_parametrized.initialize_parameters(mu_min,mu_max, {}), libMesh::LogicError);
+    CPPUNIT_ASSERT_THROW(rb_parametrized.initialize_parameters(mu_min, mu_max, {}), libMesh::LogicError);
 
     mu_max.set_value("a",  10.);
-    rb_parametrized.initialize_parameters(mu_min,mu_max, {});
+    rb_parametrized.initialize_parameters(mu_min, mu_max, {});
 
     RBParameters params;
 
@@ -243,7 +243,7 @@ public:
 
     // Throw an error due to different number of parameters.
     mu_max.set_value("b", 3,  40.);
-    CPPUNIT_ASSERT_THROW(rb_parametrized.initialize_parameters(mu_min,mu_max, {}), libMesh::LogicError);
+    CPPUNIT_ASSERT_THROW(rb_parametrized.initialize_parameters(mu_min, mu_max, {}), libMesh::LogicError);
   }
 
 };

--- a/tests/utils/rb_parameters_test.C
+++ b/tests/utils/rb_parameters_test.C
@@ -67,8 +67,8 @@ public:
     CPPUNIT_ASSERT_EQUAL(params.get_value("c"), 3.);
 
     // Test that RBParameters objects constructed with the old
-    // constructor have the correct number of steps.
-    CPPUNIT_ASSERT_EQUAL(params.n_steps(), 1u);
+    // constructor have the correct number of samples.
+    CPPUNIT_ASSERT_EQUAL(params.n_samples(), 1u);
   }
 
   void testIterators()
@@ -100,13 +100,13 @@ public:
   {
     LOG_UNIT_TEST;
 
-    // Create first multi-step RBParameters object
+    // Create first multi-sample RBParameters object
     RBParameters params1;
     for (int i=0; i<3; ++i)
       params1.push_back_value("a", Real(i));
 
-    // Create second multi-step RBParameters object
-    // (must have same number of steps)
+    // Create second multi-sample RBParameters object
+    // (must have same number of samples)
     RBParameters params2;
     for (int i=0; i<3; ++i)
       {
@@ -125,8 +125,8 @@ public:
     CPPUNIT_ASSERT(params1.has_extra_value("c"));
     for (int i=0; i<3; ++i)
       {
-        CPPUNIT_ASSERT_EQUAL(params1.get_step_value("b", i), static_cast<Real>(i+3));
-        CPPUNIT_ASSERT_EQUAL(params1.get_extra_step_value("c", i), static_cast<Real>(i*i));
+        CPPUNIT_ASSERT_EQUAL(params1.get_sample_value("b", i), static_cast<Real>(i+3));
+        CPPUNIT_ASSERT_EQUAL(params1.get_extra_sample_value("c", i), static_cast<Real>(i*i));
       }
   }
 
@@ -134,19 +134,19 @@ public:
   {
     LOG_UNIT_TEST;
 
-    // A default-constructed RBparameters object has 1 step by definition
+    // A default-constructed RBparameters object has 1 sample by definition
     RBParameters params;
-    CPPUNIT_ASSERT_EQUAL(params.n_steps(), static_cast<unsigned int>(1));
+    CPPUNIT_ASSERT_EQUAL(params.n_samples(), static_cast<unsigned int>(1));
 
-    // Set the number of steps to use in the no-parameters case
-    params.set_n_steps(10);
-    CPPUNIT_ASSERT_EQUAL(params.n_steps(), static_cast<unsigned int>(10));
+    // Set the number of samples to use in the no-parameters case
+    params.set_n_samples(10);
+    CPPUNIT_ASSERT_EQUAL(params.n_samples(), static_cast<unsigned int>(10));
 
-    // Define multiple steps for a single parameter. Now we no longer
-    // use the set_n_steps() value, since we have actual steps.
+    // Define multiple samples for a single parameter. Now we no longer
+    // use the set_n_samples() value, since we have actual samples.
     params.push_back_value("a", 1.);
     params.push_back_value("a", 2.);
-    CPPUNIT_ASSERT_EQUAL(params.n_steps(), static_cast<unsigned int>(2));
+    CPPUNIT_ASSERT_EQUAL(params.n_samples(), static_cast<unsigned int>(2));
   }
 };
 


### PR DESCRIPTION
This is some foundational work to add support in RBParameters for vector-valued parameters, e.g. `_parameters` defined as a `  std::map<std::string, std::vector<std::vector<Real>>>`. That change will happen in a future PR, here I'm just putting some work in place.

In this PR, I've:
- clarified some docs
- added new and improved existing error checking (in opt)
- changed some arguments to be const references, in order to avoid needless copies
- Removed NumericVector from rb_construcion_base, because it will not be able to function in the future as `NumericVector<std::vector<Real>>`. It's use was quite limited here, so this was relatively simple.
- changed the user API in two ways (described below)

The changes to the API are:

- renaming "steps" to "samples", e.g. `RBParameters::n_samples()`
This better reflects the way these values are typically used; during RB training we typically have a vector of "samples" that does not correspond to the definitions we commonly use for "loadsteps" or "timesteps".

- taking input vectors of Reals instead of Numbers
Previously, we took some inputs as Numbers and converted them to Real internally (without making it clear to the user that any imaginary parts would be lost). Now we explicitly take Reals as inputs, which should make that limitation more clear and avoids some unnecessary copies. Support for Number is not inherently difficult if someone wants it at some point in the future, the primary limitation to address would be the capnproto serialization/deserialization.

Normally, other than the changes to the API, existing tests should continue to function. Backwards-compatibility will be maintained after the transition to vector-valued parameters as much as possible (the biggest upcoming breaking changes will be related to the iterators).