### PR TITLE
Fix SparseMatrix::read_matlab uninitialized vars

### DIFF
--- a/src/numerics/sparse_matrix.C
+++ b/src/numerics/sparse_matrix.C
@@ -488,7 +488,8 @@ void SparseMatrix<T>::read_matlab(const std::string & filename)
   parallel_object_only();
 
   // The sizes we get from the file
-  std::size_t m, n;
+  std::size_t m = 0,
+              n = 0;
 
   // We'll read through the file three times: once to get a reliable
   // value for the matrix size (so we can divvy it up among


### PR DESCRIPTION
UB is the worst B.

In all my tests this would have turned out fine because PETSc-written matrices have the size header that sets m and n, but we were *supposed* to be able to work without that header too, at least for full-rank matrices.

Hopefully this is enough to pass devel->master CI tests; we're currently failing a couple --enable-werror builds there.