### PR TITLE
Avoid warning in case compiler does not have regex support

### DIFF
--- a/src/numerics/sparse_matrix.C
+++ b/src/numerics/sparse_matrix.C
@@ -484,6 +484,7 @@ void SparseMatrix<T>::read_matlab(const std::string & filename)
 {
 #ifndef LIBMESH_HAVE_CXX11_REGEX
   libmesh_not_implemented();  // What is your compiler?!?  Email us!
+  libmesh_ignore(filename);
 #else
   parallel_object_only();
 


### PR DESCRIPTION
We currently have a compiler that fails to configure C++11 regexes for some reason, [see here, for example](https://civet.inl.gov/job/2055463/) so this avoids a `-Werror` in that case, but the real fix would be to figure out what is going on with that compiler.