### PR TITLE
Support and use simple -pc_type on non-PETSc solvers

### DIFF
--- a/examples/transient/transient_ex2/run.sh
+++ b/examples/transient/transient_ex2/run.sh
@@ -7,7 +7,7 @@ source $LIBMESH_DIR/examples/run_common.sh
 example_name=transient_ex2
 example_dir=examples/transient/$example_name
 
-options="pipe-mesh.unv"
+options="pipe-mesh.unv -pc_type jacobi"
 run_example "$example_name" "$options"
 
 # No benchmark here; "result_node = 274" makes mesh modification iffy

--- a/examples/transient/transient_ex2/transient_ex2.C
+++ b/examples/transient/transient_ex2/transient_ex2.C
@@ -260,6 +260,8 @@ int main (int argc, char** argv)
         fill_dirichlet_bc(equation_systems, "Wave");
 
       // Solve the system "Wave".
+      // Tell the user what we are doing.
+      libMesh::out << "Solving time step " << time_step << '/' << n_time_steps << std::endl;
       t_system.solve();
 
       // After solving the system, write the solution

--- a/include/solvers/linear_solver.h
+++ b/include/solvers/linear_solver.h
@@ -85,9 +85,9 @@ public:
   bool initialized () const { return _is_initialized; }
 
   /**
-   * Release all memory and clear data structures.
+   * Reset data
    */
-  virtual void clear () {}
+  virtual void clear ();
 
   /**
    * Initialize data structures if not done so already.
@@ -125,6 +125,12 @@ public:
    * Sets the type of preconditioner to use.
    */
   void set_preconditioner_type (const PreconditionerType pct);
+
+  /**
+   * Sets the preconditioner to use a default type or to use a type
+   * specified via a PETSc-style command line argument..
+   */
+  void set_default_preconditioner_type ();
 
   /**
    * Attaches a Preconditioner object to be used

--- a/src/solvers/eigen_sparse_linear_solver.C
+++ b/src/solvers/eigen_sparse_linear_solver.C
@@ -55,13 +55,8 @@ EigenSparseLinearSolver(const Parallel::Communicator & comm_in) :
 template <typename T>
 void EigenSparseLinearSolver<T>::clear ()
 {
-  if (this->initialized())
-    {
-      this->_is_initialized = false;
-
-      this->_solver_type         = BICGSTAB;
-      this->_preconditioner_type = ILU_PRECOND;
-    }
+  this->LinearSolver<T>::clear ();
+  this->_solver_type = BICGSTAB;
 }
 
 

--- a/src/utils/string_to_enum.C
+++ b/src/utils/string_to_enum.C
@@ -338,6 +338,9 @@ std::map<std::string, PreconditionerType> preconditioner_type_to_enum {
    {"AMG"         , AMG_PRECOND},
    {"SVD"         , SVD_PRECOND},
    {"INVALID"     , INVALID_PRECONDITIONER},
+
+      // PETSc compatible
+   {"NONE"    , IDENTITY_PRECOND},
   };
 
 std::map<PreconditionerType, std::string> enum_to_preconditioner_type =


### PR DESCRIPTION
I'm on some flaky internet today, on a new laptop where I'd not yet gotten around to building PETSc, and while working on fixing that I stumbled across some too-slow-in-dbg Eigen sparse solver behavior that had an IMHO natural fix.

Assuming I haven't broken anything else in the process, of course.  I still can't test this with PETSc...