### PR TITLE
RBParameter vector-valued parameter support - Part2 (final) - Implementation

### DIFF
--- a/contrib/capnproto/rb_data.capnp
+++ b/contrib/capnproto/rb_data.capnp
@@ -17,7 +17,10 @@ struct Complex @0xda65bfa81ea2ce0b {
 
 struct RBParameter @0xb73e071e0a405648 {
   name  @0 :Text;
-  value @1 :Real;
+  value    :union {
+    singleValued @1 :Real;              # single-value support.
+    vectorValued @2 :List(List(Real));  # support for sample-vector and value-vector.
+  }
 }
 
 struct ParameterRanges @0xeccae95c5c74616e {

--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -438,7 +438,7 @@ public:
                                       const RBParameters & mu_max_in,
                                       const std::map<std::string, std::vector<Real>> & discrete_parameter_values_in,
                                       const std::map<std::string,bool> & log_scaling,
-                                      std::map<std::string, std::vector<Real>> * training_sample_list=nullptr);
+                                      std::map<std::string, std::vector<RBParameter>> * training_sample_list=nullptr);
 
   /**
    * Print out info that describes the current setup of this RBConstruction.

--- a/include/reduced_basis/rb_construction_base.h
+++ b/include/reduced_basis/rb_construction_base.h
@@ -287,6 +287,7 @@ private:
    * When serial_training_set is true, the map contains all samples of all parameters.
    * Otherwise, the sample vectors will only contain the values for the local samples
    * as defined by _first_local_index and _n_local_training_samples.
+   * Mapped from parameter_name -> sample_vector -> value_vector.
    */
   std::map<std::string, std::vector<RBParameter>> _training_parameters;
 

--- a/include/reduced_basis/rb_construction_base.h
+++ b/include/reduced_basis/rb_construction_base.h
@@ -143,13 +143,13 @@ public:
    * Overwrite the training parameters with new_training_set.
    * This training set is assumed to contain only the samples local to this processor.
    */
-  virtual void load_training_set(const std::map<std::string, std::vector<Real>> & new_training_set);
+  virtual void load_training_set(const std::map<std::string, std::vector<RBParameter>> & new_training_set);
 
   /**
    * Overwrite the local training samples for \p param_name using \p values.
    * This assumes that values.size() matches get_local_n_training_samples().
    */
-  void set_training_parameter_values(const std::string & param_name, const std::vector<Real> & values);
+  void set_training_parameter_values(const std::string & param_name, const std::vector<RBParameter> & values);
 
   /**
    * Broadcasts parameters from processor proc_id to all processors.
@@ -192,7 +192,7 @@ public:
   static std::pair<std::size_t, std::size_t>
   generate_training_parameters_random(const Parallel::Communicator & communicator,
                                       const std::map<std::string, bool> & log_param_scale,
-                                      std::map<std::string, std::vector<Real>> & local_training_parameters_in,
+                                      std::map<std::string, std::vector<RBParameter>> & local_training_parameters_in,
                                       const unsigned int n_global_training_samples_in,
                                       const RBParameters & min_parameters,
                                       const RBParameters & max_parameters,
@@ -210,7 +210,7 @@ public:
   static std::pair<std::size_t, std::size_t>
   generate_training_parameters_deterministic(const Parallel::Communicator & communicator,
                                              const std::map<std::string, bool> & log_param_scale,
-                                             std::map<std::string, std::vector<Real>> & local_training_parameters_in,
+                                             std::map<std::string, std::vector<RBParameter>> & local_training_parameters_in,
                                              const unsigned int n_global_training_samples_in,
                                              const RBParameters & min_parameters,
                                              const RBParameters & max_parameters,
@@ -288,7 +288,7 @@ private:
    * Otherwise, the sample vectors will only contain the values for the local samples
    * as defined by _first_local_index and _n_local_training_samples.
    */
-  std::map<std::string, std::vector<Real>> _training_parameters;
+  std::map<std::string, std::vector<RBParameter>> _training_parameters;
 
   /**
    * The first sample-vector index from the global vector which is stored in

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -151,7 +151,7 @@ public:
                                       const RBParameters & mu_max_in,
                                       const std::map<std::string, std::vector<Real>> & discrete_parameter_values_in,
                                       const std::map<std::string,bool> & log_scaling,
-                                      std::map<std::string, std::vector<Real>> * training_sample_list=nullptr);
+                                      std::map<std::string, std::vector<RBParameter>> * training_sample_list=nullptr);
 
   /**
    * Specify which type of "best fit" we use to guide the EIM

--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -33,6 +33,11 @@ namespace libMesh
 {
 
 /**
+ * Typedef for an individual RB parameter.
+ */
+using RBParameter = Real;
+
+/**
  * This class is part of the rbOOmit framework.
  *
  * This class defines a set of parameters index by strings.
@@ -64,9 +69,8 @@ public:
   /**
    * Constructor. Set parameters based on the std::map \p parameter_map.
    *
-   * This constructor will still be supported once we switch over to
-   * the vector-based storage for RBParameters objects. It will just set
-   * the 0th entry of the vector corresponding to each parameter name.
+   * It sets the values as the 0th entry of the sample-vector
+   * corresponding to each parameter name.
    */
   RBParameters(const std::map<std::string, Real> & parameter_map);
 
@@ -85,7 +89,7 @@ public:
     typedef value_type& reference;
 
     // Underlying iterator type, must match the container type of _parameters.
-    typedef std::map<std::string, std::vector<Real>>::const_iterator MapIter;
+    typedef std::map<std::string, std::vector<RBParameter>>::const_iterator MapIter;
 
     // Constructor
     const_iterator(const MapIter & it,
@@ -377,10 +381,10 @@ private:
    * Helper function for the 3-parameter versions of set_value() and
    * set_extra_value().
    */
-  void set_value_helper(std::map<std::string, std::vector<Real>> & map,
+  void set_value_helper(std::map<std::string, std::vector<RBParameter>> & map,
                         const std::string & param_name,
-                        std::size_t index,
-                        Real value);
+                        const std::size_t index,
+                        const RBParameter &value);
 
   /**
    * The number of samples represented by this RBParameters object, in
@@ -391,16 +395,16 @@ private:
   unsigned int _n_samples;
 
   /**
-   * The map that stores the actual parameter vectors. Each vector is
-   * indexed by a name.
+   * Actual parameter values (in std::vector<RBParameter> form) across a vector of samples.
+   * Each vector is indexed by a name.
    */
-  std::map<std::string, std::vector<Real>> _parameters;
+  std::map<std::string, std::vector<RBParameter>> _parameters;
 
   /**
    * Extra parameter vectors not used for RB training.
    * Each vector is indexed by a name.
    */
-  std::map<std::string, std::vector<Real>> _extra_parameters;
+  std::map<std::string, std::vector<RBParameter>> _extra_parameters;
 };
 
 } // namespace libMesh

--- a/include/reduced_basis/rb_parametrized.h
+++ b/include/reduced_basis/rb_parametrized.h
@@ -70,7 +70,10 @@ public:
 
   /**
    * Initialize the parameter ranges and set current_parameters.
-   * The input min/max parameters should have exactly 1 sample each.
+   * Parameter ranges are inclusive.
+   * The input min/max RBParameters should have exactly 1 sample each.
+   * Vector-valued samples are not currently supported for the min/max
+   * parameters or for discrete parameters.
    */
   void initialize_parameters(const RBParameters & mu_min_in,
                              const RBParameters & mu_max_in,

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -18,6 +18,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 // rbOOmit includes
+#include "libmesh/rb_construction_base.h"
 #include "libmesh/rb_construction.h"
 #include "libmesh/rb_assembly_expansion.h"
 #include "libmesh/rb_evaluation.h"
@@ -296,7 +297,7 @@ void RBConstruction::set_rb_construction_parameters(
                                                     const RBParameters & mu_max_in,
                                                     const std::map<std::string, std::vector<Real>> & discrete_parameter_values_in,
                                                     const std::map<std::string,bool> & log_scaling_in,
-                                                    std::map<std::string, std::vector<Real>> * training_sample_list)
+                                                    std::map<std::string, std::vector<RBParameter>> * training_sample_list)
 {
   // Read in training_parameters_random_seed value.  This is used to
   // seed the RNG when picking the training parameters.  By default the

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -29,6 +29,7 @@
 
 // rbOOmit includes
 #include "libmesh/rb_construction_base.h"
+#include "libmesh/rb_parameters.h"
 
 // libMesh includes
 #include "libmesh/id_types.h"
@@ -357,7 +358,7 @@ void RBConstructionBase<Base>::initialize_training_parameters(const RBParameters
 }
 
 template <class Base>
-void RBConstructionBase<Base>::load_training_set(const std::map<std::string, std::vector<Real>> & new_training_set)
+void RBConstructionBase<Base>::load_training_set(const std::map<std::string, std::vector<RBParameter>> & new_training_set)
 {
   // Make sure we're running this on all processors at the same time
   libmesh_parallel_only(this->comm());
@@ -435,7 +436,7 @@ void RBConstructionBase<Base>::load_training_set(const std::map<std::string, std
 
 template <class Base>
 void RBConstructionBase<Base>::set_training_parameter_values(
-  const std::string & param_name, const std::vector<Real> & values)
+  const std::string & param_name, const std::vector<RBParameter> & values)
 {
   libmesh_error_msg_if(!_training_parameters_initialized,
     "Training parameters must be initialized before calling set_training_parameter_values");
@@ -452,7 +453,7 @@ template <class Base>
 std::pair<std::size_t, std::size_t>
 RBConstructionBase<Base>::generate_training_parameters_random(const Parallel::Communicator & communicator,
                                                               const std::map<std::string, bool> & log_param_scale,
-                                                              std::map<std::string, std::vector<Real>> & local_training_parameters_in,
+                                                              std::map<std::string, std::vector<RBParameter>> & local_training_parameters_in,
                                                               const unsigned int n_global_training_samples_in,
                                                               const RBParameters & min_parameters,
                                                               const RBParameters & max_parameters,
@@ -512,7 +513,7 @@ RBConstructionBase<Base>::generate_training_parameters_random(const Parallel::Co
       calculate_n_local_samples_and_index(communicator, n_global_training_samples_in,
                                           serial_training_set);
   for (const auto & pr : min_parameters)
-    local_training_parameters_in[pr.first] = std::vector<Real>(n_local_training_samples);
+    local_training_parameters_in[pr.first] = std::vector<RBParameter>(n_local_training_samples);
 
   // finally, set the values
   for (auto & [param_name, sample_vector] : local_training_parameters_in)
@@ -546,7 +547,7 @@ template <class Base>
 std::pair<std::size_t, std::size_t>
 RBConstructionBase<Base>::generate_training_parameters_deterministic(const Parallel::Communicator & communicator,
                                                                      const std::map<std::string, bool> & log_param_scale,
-                                                                     std::map<std::string, std::vector<Real>> & local_training_parameters_in,
+                                                                     std::map<std::string, std::vector<RBParameter>> & local_training_parameters_in,
                                                                      const unsigned int n_global_training_samples_in,
                                                                      const RBParameters & min_parameters,
                                                                      const RBParameters & max_parameters,
@@ -568,7 +569,7 @@ RBConstructionBase<Base>::generate_training_parameters_deterministic(const Paral
                                          serial_training_set);
   const auto last_local_index = first_local_index + n_local_training_samples;
   for (const auto & pr : min_parameters)
-    local_training_parameters_in[pr.first] = std::vector<Real>(n_local_training_samples);
+    local_training_parameters_in[pr.first] = std::vector<RBParameter>(n_local_training_samples);
 
   // n_training_samples_per_param has 3 entries, but entries after "num_params"
   // are unused so we just set their value to 1. We need to set it to 1 (rather
@@ -668,7 +669,7 @@ RBConstructionBase<Base>::generate_training_parameters_deterministic(const Paral
                 unsigned int param_count = 0;
                 for (const auto & pr : min_parameters)
                   {
-                    std::vector<Real> & training_vector =
+                    std::vector<RBParameter> & training_vector =
                       libmesh_map_find(local_training_parameters_in, pr.first);
                     if (first_local_index <= index_count && index_count < last_local_index)
                       training_vector[index_count - first_local_index] =

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -263,7 +263,7 @@ void add_parameter_ranges_to_builder(const RBParametrized & rb_evaluation,
       if (!rb_evaluation.is_discrete_parameter(key))
         {
           names.set(count, key);
-          mins.set(count, val);
+          mins.set(count, parameters_min.get_value(key));
           maxs.set(count, parameters_max.get_value(key));
           ++count;
         }

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -406,10 +406,15 @@ void RBEIMConstruction::set_rb_construction_parameters(unsigned int n_training_s
       const std::string & lookup_table_param_name =
         get_rb_eim_evaluation().get_parametrized_function().lookup_table_param_name;
 
+      // Fill the lookup_table_training_samples with sequential single-entry vectors,
+      // i.e. {{0.0}, {1.0}, {2.0}, ...}
       Real val = 0.0;
       std::vector<RBParameter> lookup_table_training_samples(n_training_samples_in, {val});
-      for(auto it = lookup_table_training_samples.begin(); it != lookup_table_training_samples.end(); ++it, ++val)
-        (*it)[0] = val;
+      for(auto & vec : lookup_table_training_samples)
+        {
+          vec[0] = val;
+          val += 1.0;   // Could use val++, but better to be explicit for doubles.
+        }
 
       set_training_parameter_values(lookup_table_param_name, lookup_table_training_samples);
     }

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -43,8 +43,10 @@
 #include "libmesh/int_range.h"
 
 // rbOOmit includes
+#include "libmesh/rb_construction_base.h"
 #include "libmesh/rb_eim_construction.h"
 #include "libmesh/rb_eim_evaluation.h"
+#include "libmesh/rb_parameters.h"
 #include "libmesh/rb_parametrized_function.h"
 
 // C++ include
@@ -333,7 +335,7 @@ void RBEIMConstruction::set_rb_construction_parameters(unsigned int n_training_s
                                                        const RBParameters & mu_max_in,
                                                        const std::map<std::string, std::vector<Real>> & discrete_parameter_values_in,
                                                        const std::map<std::string,bool> & log_scaling_in,
-                                                       std::map<std::string, std::vector<Real>> * training_sample_list)
+                                                       std::map<std::string, std::vector<RBParameter>> * training_sample_list)
 {
   // Read in training_parameters_random_seed value.  This is used to
   // seed the RNG when picking the training parameters.  By default the

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -406,8 +406,10 @@ void RBEIMConstruction::set_rb_construction_parameters(unsigned int n_training_s
       const std::string & lookup_table_param_name =
         get_rb_eim_evaluation().get_parametrized_function().lookup_table_param_name;
 
-      std::vector<Real> lookup_table_training_samples(n_training_samples_in);
-      std::iota(lookup_table_training_samples.begin(), lookup_table_training_samples.end(), 0);
+      Real val = 0.0;
+      std::vector<RBParameter> lookup_table_training_samples(n_training_samples_in, {val});
+      for(auto it = lookup_table_training_samples.begin(); it != lookup_table_training_samples.end(); ++it, ++val)
+        (*it)[0] = val;
 
       set_training_parameter_values(lookup_table_param_name, lookup_table_training_samples);
     }

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -22,6 +22,7 @@
 #include "libmesh/rb_theta_expansion.h"
 
 // libMesh includes
+#include "libmesh/libmesh_common.h"
 #include "libmesh/libmesh_version.h"
 #include "libmesh/system.h"
 #include "libmesh/numeric_vector.h"
@@ -733,12 +734,15 @@ void RBEvaluation::legacy_write_offline_data_to_files(const std::string & direct
 
         for (const auto & param : greedy_param_list)
           for (const auto & pr : param)
-            {
-              // Need to make a copy of the value so that it's not const
-              // Xdr is not templated on const's
-              Real param_value = pr.second;
-              greedy_params_out << param_value;
-            }
+            for(const auto & value_vector : pr.second)
+              {
+                // Need to make a copy of the value so that it's not const
+                // Xdr is not templated on const's
+                libmesh_error_msg_if(value_vector.size() != 1,
+                                     "Error: multi-value RB parameters are not yet supported here.");
+                Real param_value = value_vector[0];
+                greedy_params_out << param_value;
+              }
         greedy_params_out.close();
       }
 

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -160,7 +160,7 @@ Real RBParameters::get_extra_value(const std::string & param_name, const Real & 
 {
   // same as get_value(param_name, default_val) but for the map of extra parameters
   auto it = _extra_parameters.find(param_name);
-  if (it == _parameters.end())
+  if (it == _extra_parameters.end())
     return default_val;
 
   libmesh_error_msg_if(it->second.size() != 1,

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -18,10 +18,12 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 // libmesh includes
+#include "libmesh/libmesh_common.h"
 #include "libmesh/rb_parameters.h"
 #include "libmesh/utility.h"
 
 // C++ includes
+#include <algorithm>
 #include <sstream>
 
 namespace libMesh
@@ -39,7 +41,7 @@ RBParameters::RBParameters(const std::map<std::string, Real> & parameter_map) :
   // object from a map<string, Real>. We store a single entry in each
   // vector in the map.
   for (const auto & [key, val] : parameter_map)
-    _parameters[key] = {val};
+    _parameters[key] = {{val}};
 }
 
 void RBParameters::clear()
@@ -67,6 +69,14 @@ Real RBParameters::get_value(const std::string & param_name) const
   return this->get_sample_value(param_name, /*sample_idx=*/0);
 }
 
+const RBParameter& RBParameters::get_vector_value(const std::string & param_name) const
+{
+  // Simply return the [0]th entry of the vector if possible, otherwise error.
+  libmesh_error_msg_if(this->n_samples() != 1,
+    "Requesting value for parameter " << param_name << ", but parameter contains multiple sample.");
+  return this->get_sample_vector_value(param_name, /*sample_idx=*/0);
+}
+
 Real RBParameters::get_value(const std::string & param_name, const Real & default_val) const
 {
   // Simply return the [0]th entry of the vector if possible, otherwise error.
@@ -75,20 +85,57 @@ Real RBParameters::get_value(const std::string & param_name, const Real & defaul
   return this->get_sample_value(param_name, /*sample_idx=*/0, default_val);
 }
 
+const RBParameter & RBParameters::get_vector_value(const std::string & param_name, const RBParameter & default_val) const
+{
+  // Simply return the [0]th entry of the vector if possible, otherwise error.
+  libmesh_error_msg_if(this->n_samples() != 1,
+    "Requesting value for parameter " << param_name << ", but parameter contains multiple samples.");
+  return this->get_sample_vector_value(param_name, /*sample_idx=*/0, default_val);
+}
+
 Real RBParameters::get_sample_value(const std::string & param_name, std::size_t sample_idx) const
 {
-  const auto & vec = libmesh_map_find(_parameters, param_name);
-  libmesh_error_msg_if(sample_idx >= vec.size(), "Error getting value for parameter " << param_name);
-  return vec[sample_idx];
+  const auto & sample_vec = libmesh_map_find(_parameters, param_name);
+  libmesh_error_msg_if(sample_idx >= sample_vec.size(), "Error getting value for parameter " << param_name);
+  libmesh_error_msg_if(sample_vec[sample_idx].size() != 1,
+    "Requesting Real value for parameter " << param_name << ", but parameter contains multiple values.");
+  return sample_vec[sample_idx][0];
+}
+
+const RBParameter & RBParameters::get_sample_vector_value(const std::string & param_name, std::size_t sample_idx) const
+{
+  const auto & sample_vec = libmesh_map_find(_parameters, param_name);
+  libmesh_error_msg_if(sample_idx >= sample_vec.size(), "Error getting value for parameter " << param_name);
+  return sample_vec[sample_idx];
 }
 
 Real RBParameters::get_sample_value(const std::string & param_name, std::size_t sample_idx, const Real & default_val) const
 {
   auto it = _parameters.find(param_name);
-  return ((it != _parameters.end() && sample_idx < it->second.size()) ? it->second[sample_idx] : default_val);
+  if (it == _parameters.end() || sample_idx >= it->second.size())
+    return default_val;
+  libmesh_error_msg_if(it->second[sample_idx].size() != 1,
+    "Requesting Real value for parameter " << param_name << ", but parameter contains multiple values.");
+  return it->second[sample_idx][0];
+}
+
+const RBParameter & RBParameters::get_sample_vector_value(const std::string & param_name, std::size_t sample_idx, const RBParameter & default_val) const
+{
+  auto it = _parameters.find(param_name);
+  if (it == _parameters.end() || sample_idx >= it->second.size())
+    return default_val;
+  return it->second[sample_idx];
 }
 
 void RBParameters::set_value(const std::string & param_name, Real value)
+{
+  // This version of set_value() does not take an index and is provided
+  // for backwards compatibility. It creates a vector entry for the specified
+  // param_name, overwriting any value(s) that were present.
+  _parameters[param_name] = {{value}};
+}
+
+void RBParameters::set_value(const std::string & param_name, const RBParameter & value)
 {
   // This version of set_value() does not take an index and is provided
   // for backwards compatibility. It creates a vector entry for the specified
@@ -97,38 +144,49 @@ void RBParameters::set_value(const std::string & param_name, Real value)
 }
 
 void
-RBParameters::set_value_helper(std::map<std::string, std::vector<Real>> & map,
+RBParameters::set_value_helper(std::map<std::string, std::vector<RBParameter>> & map,
                                const std::string & param_name,
-                               std::size_t index,
-                               Real value)
+                               const std::size_t index,
+                               RBParameter value)
 {
   // Get reference to vector of values for this parameter, creating it
   // if it does not already exist.
-  auto & vec = map[param_name];
+  auto & sample_vec = map[param_name];
 
   // If vec is already big enough, just set the value
-  if (vec.size() > index)
-    vec[index] = value;
+  if (sample_vec.size() > index)
+    sample_vec[index] = std::move(value);
 
   // Otherwise push_back() if the vec is just barely not big enough
-  else if (vec.size() == index)
-    vec.push_back(value);
+  else if (sample_vec.size() == index)
+    sample_vec.emplace_back(std::move(value));
 
   // Otherwise, allocate more space (padding with 0s) if vector is not
   // big enough to fit the user's requested index.
   else
     {
-      vec.resize(index+1);
-      vec[index] = value;
+      RBParameter zero_parameter(value.size(), 0.0);
+      sample_vec.resize(index+1, zero_parameter);
+      sample_vec[index] = std::move(value);
     }
 }
 
 void RBParameters::set_value(const std::string & param_name, std::size_t index, Real value)
 {
+  this->set_value_helper(_parameters, param_name, index, {value});
+}
+
+void RBParameters::set_value(const std::string & param_name, std::size_t index, const RBParameter & value)
+{
   this->set_value_helper(_parameters, param_name, index, value);
 }
 
 void RBParameters::set_extra_value(const std::string & param_name, std::size_t index, Real value)
+{
+  this->set_value_helper(_extra_parameters, param_name, index, {value});
+}
+
+void RBParameters::set_extra_value(const std::string & param_name, std::size_t index, const RBParameter & value)
 {
   this->set_value_helper(_extra_parameters, param_name, index, value);
 }
@@ -137,10 +195,24 @@ void RBParameters::push_back_value(const std::string & param_name, Real value)
 {
   // Get reference to vector of values for this parameter, creating it
   // if it does not already exist, and push back the specified value.
+  _parameters[param_name].push_back({value});
+}
+
+void RBParameters::push_back_value(const std::string & param_name, const RBParameter & value)
+{
+  // Get reference to vector of values for this parameter, creating it
+  // if it does not already exist, and push back the specified value.
   _parameters[param_name].push_back(value);
 }
 
 void RBParameters::push_back_extra_value(const std::string & param_name, Real value)
+{
+  // Get reference to vector of values for this extra parameter, creating it
+  // if it does not already exist, and push back the specified value.
+  _extra_parameters[param_name].push_back({value});
+}
+
+void RBParameters::push_back_extra_value(const std::string & param_name, const RBParameter & value)
 {
   // Get reference to vector of values for this extra parameter, creating it
   // if it does not already exist, and push back the specified value.
@@ -153,6 +225,16 @@ Real RBParameters::get_extra_value(const std::string & param_name) const
   const auto & sample_vec = libmesh_map_find(_extra_parameters, param_name);
   libmesh_error_msg_if(sample_vec.size() != 1,
     "Requesting value for extra parameter " << param_name << ", but parameter contains multiple samples.");
+  libmesh_error_msg_if(sample_vec[0].size() != 1,
+    "Requesting Real value for extra parameter " << param_name << ", but parameter contains multiple values.");
+  return sample_vec[0][0];
+}
+
+const RBParameter & RBParameters::get_extra_vector_value(const std::string & param_name) const
+{
+  // Same as get_value(param_name) but for the map of extra parameters
+  const auto & sample_vec = libmesh_map_find(_extra_parameters, param_name);
+  libmesh_error_msg_if(sample_vec.size() == 0, "Error getting value for extra parameter " << param_name);
   return sample_vec[0];
 }
 
@@ -165,26 +247,62 @@ Real RBParameters::get_extra_value(const std::string & param_name, const Real & 
 
   libmesh_error_msg_if(it->second.size() != 1,
                        "Requesting value for extra parameter " << param_name << ", but parameter contains multiple samples.");
-  return it->second[0];
+  libmesh_error_msg_if(it->second[0].size() != 1,
+    "Requesting Real value for extra parameter " << param_name << ", but parameter contains multiple values.");
+  return it->second[0][0];
 }
 
 Real RBParameters::get_extra_sample_value(const std::string & param_name, std::size_t sample_idx) const
 {
-  const auto & vec = libmesh_map_find(_extra_parameters, param_name);
-  libmesh_error_msg_if(sample_idx >= vec.size(), "Error getting value for parameter " << param_name);
-  return vec[sample_idx];
+  const auto & sample_vec = libmesh_map_find(_extra_parameters, param_name);
+  libmesh_error_msg_if(sample_idx >= sample_vec.size(), "Error getting value for extra parameter " << param_name);
+  libmesh_error_msg_if(sample_vec[sample_idx].size() != 1,
+    "Requesting Real value for extra parameter " << param_name << ", but parameter contains multiple values.");
+  return sample_vec[sample_idx][0];
+}
+
+const RBParameter & RBParameters::get_extra_sample_vector_value(const std::string & param_name, std::size_t sample_idx) const
+{
+  const auto & sample_vec = libmesh_map_find(_extra_parameters, param_name);
+  libmesh_error_msg_if(sample_idx >= sample_vec.size(), "Error getting value for extra parameter " << param_name);
+  return sample_vec[sample_idx];
 }
 
 Real RBParameters::get_extra_sample_value(const std::string & param_name, std::size_t sample_idx, const Real & default_val) const
 {
   // same as get_sample_value(param_name, index, default_val) but for the map of extra parameters
   auto it = _extra_parameters.find(param_name);
-  return ((it != _extra_parameters.end() && sample_idx < it->second.size()) ? it->second[sample_idx] : default_val);
+  if (it==_extra_parameters.end() || sample_idx >= it->second.size())
+    return default_val;
+  libmesh_error_msg_if(it->second[sample_idx].size() != 1,
+    "Requesting Real value for extra parameter " << param_name << ", but parameter contains multiple values.");
+  return it->second[sample_idx][0];
+}
+
+const RBParameter & RBParameters::get_extra_sample_vector_value(
+    const std::string &param_name,
+    std::size_t sample_idx,
+    const RBParameter &default_val) const
+{
+  auto it = _extra_parameters.find(param_name);
+  if (it == _extra_parameters.end() || sample_idx >= it->second.size())
+    return default_val;
+  return it->second[sample_idx];
 }
 
 void RBParameters::set_extra_value(const std::string & param_name, Real value)
 {
-  // Same as set_value(param_name, value) but for the map of extra parameters
+  // This version of set_extra_value() does not take an index and is provided
+  // for backwards compatibility. It creates a vector entry for the specified
+  // param_name, overwriting any value(s) that were present.
+  _extra_parameters[param_name] = {{value}};
+}
+
+void RBParameters::set_extra_value(const std::string & param_name, const RBParameter & value)
+{
+  // This version of set_extra_value() does not take an index and is provided
+  // for backwards compatibility. It creates a vector entry for the specified
+  // param_name, overwriting any value(s) that were present.
   _extra_parameters[param_name] = {value};
 }
 
@@ -218,18 +336,20 @@ unsigned int RBParameters::n_samples() const
   return size_first;
 }
 
-void RBParameters::get_parameter_names(std::set<std::string> & param_names) const
+std::set<std::string> RBParameters::get_parameter_names() const
 {
-  param_names.clear();
+  std::set<std::string> param_names;
   for (const auto & pr : _parameters)
     param_names.insert(pr.first);
+  return param_names;
 }
 
-void RBParameters::get_extra_parameter_names(std::set<std::string> & param_names) const
+std::set<std::string> RBParameters::get_extra_parameter_names() const
 {
-  param_names.clear();
+  std::set<std::string> param_names;
   for (const auto & pr : _extra_parameters)
     param_names.insert(pr.first);
+  return param_names;
 }
 
 void RBParameters::erase_parameter(const std::string & param_name)
@@ -242,28 +362,48 @@ void RBParameters::erase_extra_parameter(const std::string & param_name)
   _extra_parameters.erase(param_name);
 }
 
-RBParameters::const_iterator RBParameters::begin() const
+std::map<std::string,std::vector<RBParameter>>::const_iterator RBParameters::begin() const
 {
-  return const_iterator(_parameters.begin(), 0);
+  return _parameters.cbegin();
 }
 
-RBParameters::const_iterator RBParameters::end() const
+std::map<std::string,std::vector<RBParameter>>::const_iterator RBParameters::end() const
+{
+  return _parameters.cend();
+}
+
+std::map<std::string,std::vector<RBParameter>>::const_iterator RBParameters::extra_begin() const
+{
+  return _extra_parameters.cbegin();
+}
+
+std::map<std::string,std::vector<RBParameter>>::const_iterator RBParameters::extra_end() const
+{
+  return _extra_parameters.cend();
+}
+
+RBParameters::const_iterator RBParameters::begin_serialized() const
+{
+  return {_parameters.cbegin(), 0, 0};
+}
+
+RBParameters::const_iterator RBParameters::end_serialized() const
 {
   // Note: the index 0 is irrelevant here since _parameters.end() does
   // not refer to a valid vector entry in the map.
-  return const_iterator(_parameters.end(), 0);
+  return {_parameters.cend(), 0, 0};
 }
 
-RBParameters::const_iterator RBParameters::extra_begin() const
+RBParameters::const_iterator RBParameters::begin_serialized_extra() const
 {
-  return const_iterator(_extra_parameters.begin(), 0);
+  return {_extra_parameters.cbegin(), 0, 0};
 }
 
-RBParameters::const_iterator RBParameters::extra_end() const
+RBParameters::const_iterator RBParameters::end_serialized_extra() const
 {
   // Note: the index 0 is irrelevant here since _parameters.end() does
   // not refer to a valid vector entry in the map.
-  return const_iterator(_extra_parameters.end(), 0);
+  return {_extra_parameters.cend(), 0, 0};
 }
 
 bool RBParameters::operator==(const RBParameters & rhs) const
@@ -304,7 +444,9 @@ std::string RBParameters::get_string(unsigned int precision) const
     std::string separator = "";
     for (const auto & val : vec)
     {
-      param_stringstream << separator << val;
+      param_stringstream << separator;
+      for (const auto & v : val)
+        param_stringstream << v << " ";
       separator = ", ";
     }
     param_stringstream << std::endl;

--- a/src/reduced_basis/rb_parametrized.C
+++ b/src/reduced_basis/rb_parametrized.C
@@ -220,7 +220,7 @@ void RBParametrized::write_parameter_ranges_to_file(const std::string & file_nam
       std::string param_name = pr.first;
       if (!is_discrete_parameter(param_name))
         {
-          Real param_value = pr.second;
+          Real param_value = get_parameters_min().get_value(param_name);
           parameter_ranges_out << param_name << param_value;
         }
     }
@@ -229,7 +229,7 @@ void RBParametrized::write_parameter_ranges_to_file(const std::string & file_nam
       std::string param_name = pr.first;
       if (!is_discrete_parameter(param_name))
         {
-          Real param_value = pr.second;
+          Real param_value = get_parameters_max().get_value(param_name);
           parameter_ranges_out << param_name << param_value;
         }
     }

--- a/src/reduced_basis/rb_parametrized.C
+++ b/src/reduced_basis/rb_parametrized.C
@@ -18,6 +18,8 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 // libMesh includes
+#include "libmesh/int_range.h"
+#include "libmesh/simple_range.h"
 #include "libmesh/xdr_cxx.h"
 
 // rbOOmit includes
@@ -60,9 +62,9 @@ void RBParametrized::initialize_parameters(const RBParameters & mu_min_in,
                        "Error: Invalid mu_min/mu_max in initialize_parameters(), only 1 sample supported.");
 
   // Ensure all the values are valid for min and max.
-  auto pr_min = mu_min_in.begin();
-  auto pr_max = mu_max_in.begin();
-  for(; pr_min!=mu_min_in.end(); ++pr_min, ++pr_max)
+  auto pr_min = mu_min_in.begin_serialized();
+  auto pr_max = mu_max_in.begin_serialized();
+  for(; pr_min!=mu_min_in.end_serialized(); ++pr_min, ++pr_max)
     libmesh_error_msg_if((*pr_min).second > (*pr_max).second,
                          "Error: Invalid mu_min/mu_max in RBParameters constructor.");
 
@@ -393,35 +395,45 @@ bool RBParametrized::check_if_valid_params(const RBParameters &params) const
                        << get_n_params());
 
   bool is_valid = true;
-  for(const auto & [param_name, param_val] : params)
+  std::string prev_param_name = "";
+  for (const auto & [param_name, sample_vec] : params)
     {
-      // Check every parameter value (including across samples) to ensure
-      // it's within the min/max range.
-      const bool outside_range =
-        ((param_val < get_parameter_min(param_name)) ||
-         (param_val > get_parameter_max(param_name)));
-      is_valid = is_valid && !outside_range;
-      if(outside_range && verbose_mode)
+      std::size_t sample_idx = 0;
+      const Real & min_value = get_parameter_min(param_name);
+      const Real & max_value = get_parameter_max(param_name);
+      for (const auto & value_vec : sample_vec)
         {
-          libMesh::out << "Warning: parameter " << param_name << " value="
-                       << param_val << " outside acceptable range: ("
-                       << get_parameter_min(param_name) << ", "
-                       << get_parameter_max(param_name)
-                       << ")";
-        }
+          for (const auto & value : value_vec)
+            {
+              // Check every parameter value (including across samples and vector-values)
+              // to ensure it's within the min/max range.
+              const bool outside_range = ((value < min_value) || (value > max_value));
+              is_valid = is_valid && !outside_range;
+              if(outside_range && verbose_mode)
+                {
+                  libMesh::out << "Warning: parameter " << param_name << " value="
+                               << value << " outside acceptable range: ("
+                               << min_value << ", " << max_value << ")";
+                }
 
-      // For discrete params, make sure params.get_value(param_name) is sufficiently
-      // close to one of the discrete parameter values.
-      if (is_discrete_parameter(param_name))
-        {
-          const bool is_value_discrete =
-            is_value_in_list(param_val,
-                             get_discrete_parameter_values().find(param_name)->second,
-                             TOLERANCE);
-          is_valid = is_valid && is_value_discrete;
-          if(!is_value_discrete && verbose_mode)
-            libMesh::out << "Warning: parameter " << param_name << " value="
-                         << param_val << " is not in discrete value list.";
+              // For discrete params, make sure params.get_value(param_name) is sufficiently
+              // close to one of the discrete parameter values.
+              // Note that vector-values not yet supported in discrete parameters,
+              // and the .get_sample_value() call will throw an error if the user
+              // tries to do it.
+              if (is_discrete_parameter(param_name))
+                {
+                  const bool is_value_discrete =
+                    is_value_in_list(params.get_sample_value(param_name, sample_idx),
+                                     get_discrete_parameter_values().find(param_name)->second,
+                                     TOLERANCE);
+                  is_valid = is_valid && is_value_discrete;
+                  if (!is_value_discrete && verbose_mode)
+                    libMesh::out << "Warning: parameter " << param_name << " value="
+                                 << value << " is not in discrete value list.";
+                }
+            }
+          ++sample_idx;
         }
     }
   return is_valid;

--- a/src/reduced_basis/rb_parametrized.C
+++ b/src/reduced_basis/rb_parametrized.C
@@ -421,11 +421,12 @@ bool RBParametrized::check_if_valid_params(const RBParameters &params) const
               // Note that vector-values not yet supported in discrete parameters,
               // and the .get_sample_value() call will throw an error if the user
               // tries to do it.
-              if (is_discrete_parameter(param_name))
+              if (const auto it = get_discrete_parameter_values().find(param_name);
+                  it != get_discrete_parameter_values().end())
                 {
                   const bool is_value_discrete =
                     is_value_in_list(params.get_sample_value(param_name, sample_idx),
-                                     get_discrete_parameter_values().find(param_name)->second,
+                                     it->second,
                                      TOLERANCE);
                   is_valid = is_valid && is_value_discrete;
                   if (!is_value_discrete && verbose_mode)

--- a/src/reduced_basis/rb_scm_evaluation.C
+++ b/src/reduced_basis/rb_scm_evaluation.C
@@ -400,14 +400,17 @@ void RBSCMEvaluation::legacy_write_offline_data_to_files(const std::string & dir
       file_name << directory_name << "/C_J" << suffix;
       Xdr C_J_out(file_name.str(), mode);
 
-      for (auto & param : C_J)
-        for (const auto & item : param)
-          {
-            // Need to make a copy of the value so that it's not const
-            // Xdr is not templated on const's
-            Real param_value = item.second;
-            C_J_out << param_value;
-          }
+      for (const auto & param : C_J)
+        for (const auto & pr : param)
+          for(const auto & value_vector : pr.second)
+            {
+              // Need to make a copy of the value so that it's not const
+              // Xdr is not templated on const's
+              libmesh_error_msg_if(value_vector.size() != 1,
+                                   "Error: multi-value RB parameters are not yet supported here.");
+              Real param_value = value_vector[0];
+              C_J_out << param_value;
+            }
       C_J_out.close();
 
       // Write out SCM_UB_vectors get_SCM_UB_vector


### PR DESCRIPTION
This is part 2 (final part), part 1 was here: https://github.com/libMesh/libmesh/pull/3778 .

This adds support in RBParameters for vector-valued parameters. I've changed the underlying datastructure for parameters from `std::map<std::string, std::vector<Real>>` to `std::map<std::string, std::vector<std::vector<Real>>` .

I've tried to maintain compatibility as much as possible by maintaining the old setter/getter functions, which work with the new vectors behind-the-scenes, and generally throw errors if you're trying to use functions expecting single-values on multi-valued data.

There are a few notable breakages of backwards compatibility:
- Cap'n Proto Interfaces
  Because now we need to serialize additional data, the interfaces have changed. However, I've implemented it as a union, so that existing data should be possible to read. Unfortunately, any code which reads/writes a Cap'nProto `RBParameter` needs to be updated.

- Iterators
  Previously we provided custom `.begin()` and `.end()` iterators (and similarly for the "extra parameters") for the RBParameters class. Those iterators iterated over the whole parameter vector, including the steps. Now they've been renamed to `.begin_serialized()` and `.end_serialized()`, and new iterators take the place of the old ones in `.begin()/.end()` which provide a more "standard" map iteration.

  The new iterators are handy for getting parameter names, and also for iterating over the parameters with a better understanding of steps/values. The old "serialized" iterators are occasionally useful when you just want to check all the values without caring where you are in the step/value vector.