### PR TITLE
Don't try to solve() when we lack solvers

### DIFF
--- a/tests/systems/constraint_operator_test.C
+++ b/tests/systems/constraint_operator_test.C
@@ -95,8 +95,10 @@ class ConstraintOperatorTest : public CppUnit::TestCase {
 public:
   LIBMESH_CPPUNIT_TEST_SUITE( ConstraintOperatorTest );
 
+#ifdef LIBMESH_HAVE_SOLVER
   CPPUNIT_TEST( test1DCoarseningOperator );
   CPPUNIT_TEST( test1DCoarseningNewNodes );
+#endif
 
   CPPUNIT_TEST_SUITE_END();
 


### PR DESCRIPTION
This should remove failures in a couple new unit tests in the No-Optional test recipe.