### PR TITLE
Always number IGA nodes consecutively

### DIFF
--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -381,6 +381,13 @@ void ExodusII_IO::read (const std::string & fname)
   // maximum of subdomain_id() values set via Exodus block ids.
   int max_subdomain_id = std::numeric_limits<int>::min();
 
+  // We've already added all the nodes explicitly specified in the
+  // file, but if we have spline nodes we may need to add assembly
+  // element nodes based on them.  Add them contiguously so we're
+  // compatible with any subsequent code paths (including our
+  // ExodusII_IO::write()!) that don't support sparse ids.
+  dof_id_type n_nodes = mesh.n_nodes();
+
   // Loop over all the element blocks
   for (int i=0; i<exio_helper->num_elem_blk; i++)
     {
@@ -618,7 +625,7 @@ void ExodusII_IO::read (const std::string & fname)
                             }
                         }
 
-                      Node *n = mesh.add_point(p);
+                      Node *n = mesh.add_point(p, n_nodes++);
                       if (weights_exist)
                         n->set_extra_datum<Real>(weight_index, w);
 


### PR DESCRIPTION
If we don't do so, then we can easily trigger renumbering that other code paths are not prepared for.

On a DistributedMesh, this means numbering new nodes manually, to override the default "stay prepared to mix replicated with distributed node addition" sparse numbering.

This is approximately one-third of the *right* fix for this problem, but it's a *sufficient* fix; I have a set of tests in a MOOSE branch which (when run with --distributed-mesh) fail on master and pass on this branch.