### PR TITLE
Respect allow_renumbering(false)

### DIFF
--- a/examples/fem_system/fem_system_ex1/fem_system_ex1.C
+++ b/examples/fem_system/fem_system_ex1/fem_system_ex1.C
@@ -162,13 +162,6 @@ int main (int argc, char ** argv)
                                        0., 1.,
                                        HEX27);
 
-  if  (slvr_type == "petscdiff")
-    {
-      mesh->allow_renumbering(false);
-      mesh->allow_remote_element_removal(false);
-      mesh->partitioner() = nullptr;
-    }
-
   mesh_refinement.uniformly_refine(coarserefinements);
 
   // Print information about the mesh to the screen.

--- a/src/mesh/mesh_output.C
+++ b/src/mesh/mesh_output.C
@@ -52,17 +52,7 @@ void MeshOutput<MT>::write_equation_systems (const std::string & fname,
       // been properly renumbered...
       libmesh_assert(!my_mesh.allow_renumbering());
 
-      libmesh_do_once(libMesh::out <<
-                      "Warning:  This MeshOutput subclass only supports meshes which are contiguously renumbered!"
-                      << std::endl;);
-
-      my_mesh.allow_renumbering(true);
-
-      my_mesh.renumber_nodes_and_elements();
-
-      // Not sure what good going back to false will do here, the
-      // renumbering horses have already left the barn...
-      my_mesh.allow_renumbering(false);
+      libmesh_error_msg("This MeshOutput subclass only supports meshes which are contiguously numbered!");
     }
 
   if (!_is_parallel_format)


### PR DESCRIPTION
With an error message, we can find a fix or a workaround for the incompatibility with ExodusII.

With the current mere warning message and forced renumbering, we're liable to break whatever code wasn't compatible with renumbering.