### PR TITLE
GMG doesn't require these restrictions

### DIFF
--- a/examples/fem_system/fem_system_ex1/fem_system_ex1.C
+++ b/examples/fem_system/fem_system_ex1/fem_system_ex1.C
@@ -162,13 +162,6 @@ int main (int argc, char ** argv)
                                        0., 1.,
                                        HEX27);
 
-  if  (slvr_type == "petscdiff")
-    {
-      mesh->allow_renumbering(false);
-      mesh->allow_remote_element_removal(false);
-      mesh->partitioner() = nullptr;
-    }
-
   mesh_refinement.uniformly_refine(coarserefinements);
 
   // Print information about the mesh to the screen.


### PR DESCRIPTION
Or at least, I can't find any reason why it should require them (even when we coarsen to create projection operators we're guaranteed our parent elements won't be remote), it's been working without some of them accidentally (ExodusII output has been forcing renumbering), and it's passing test sweeps I run manually.

I've pulled this commit out of #3790; hopefully it'll fare better than that PR as a whole did.