### PR TITLE
Don't try to interpolate Dirichlet values on non-Lagrange non-vertices

### DIFF
--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -871,10 +871,13 @@ private:
     // hold those fixed and project boundary edges, then hold
     // those fixed and project boundary faces,
 
-    // Interpolate node values first. Note that we have a special
-    // case for nodes that have a boundary nodeset, since we do
-    // need to interpolate them directly, even if they're non-vertex
-    // nodes.
+    // Interpolate node values first.
+    //
+    // If we have non-vertex nodes that have a boundary nodeset, we
+    // need to interpolate them directly, but that had better be
+    // happening in the apply_lagrange_dirichlet_impl code path,
+    // because you *can't* interpolate to evaluate non-nodal FE
+    // coefficients.
     unsigned int current_dof = 0;
     for (unsigned int n=0; n!= sebi.n_nodes; ++n)
       {
@@ -900,14 +903,7 @@ private:
           (is_boundary_node_it == sebi.is_boundary_node_map.end() ||
            !is_boundary_node_it->second[n]);
 
-        // Same thing for nodesets
-        auto is_boundary_nodeset_it = sebi.is_boundary_nodeset_map.find(&dirichlet);
-        const bool not_boundary_nodeset =
-          (is_boundary_nodeset_it == sebi.is_boundary_nodeset_map.end() ||
-           !is_boundary_nodeset_it->second[n]);
-
-        if ((!elem->is_vertex(n) || not_boundary_node) &&
-            not_boundary_nodeset)
+        if (!elem->is_vertex(n) || not_boundary_node)
           {
             current_dof += nc;
             continue;


### PR DESCRIPTION
In the best case we notice that the non-vertex hosts multiple DoFs and we fail an assertion; in the worst case just setting a coefficient value to a function value would give garbage here.

I've never tripped this with libMesh/GRINS/etc codes, but MOOSE hits it as soon as I try adding a DirichletBoundary there, since MOOSE generates nodesets from sidesets.

Pinging @dknez, since this basically reverts some of his #672 changes.  Fortunately, in the time since that PR we tried to do some optimization by splitting apart Lagrange from non-Lagrange code paths, and we only have to revert the broken non-Lagrange case, which shouldn't change the behavior Akselos is depending on in the Lagrange case.

It wouldn't be crazy to support the non-Lagrange case (we'd end up pinning one linear combination of the DoFs at a node in a Dirichlet nodeset that wasn't part of a side in a Dirichlet sideset) but I don't have time or a use case for that right now.