### PR TITLE
Wrap `_local_size` into atomic to avoid unwanted modifications while `operator()` is used with `set()` in petsc vector.

### DIFF
--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -370,19 +370,31 @@ private:
    *
    * Only valid when _array_is_present
    */
+#ifdef LIBMESH_HAVE_CXX11_THREAD
+  mutable std::atomic<numeric_index_type> _first;
+#else
   mutable numeric_index_type _first;
+#endif
 
   /**
    * Last local index.
    *
    * Only valid when _array_is_present
    */
+#ifdef LIBMESH_HAVE_CXX11_THREAD
+  mutable std::atomic<numeric_index_type> _last;
+#else
   mutable numeric_index_type _last;
+#endif
 
   /**
    * Size of the local values from _get_array()
    */
+#ifdef LIBMESH_HAVE_CXX11_THREAD
+  mutable std::atomic<numeric_index_type> _local_size;
+#else
   mutable numeric_index_type _local_size;
+#endif
 
   /**
    * PETSc vector datatype to hold the local form of a ghosted vector.

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -335,7 +335,7 @@ void PetscVector<T>::add (const T v_in)
 {
   this->_get_array(false);
 
-  for (numeric_index_type i=0; i<_local_size; i++)
+  for (const auto i : make_range(_local_size.load()))
     _values[i] += PetscScalar(v_in);
 }
 
@@ -617,7 +617,7 @@ PetscVector<T>::operator = (const std::vector<T> & v)
    */
   else
     {
-      for (numeric_index_type i=0; i<_local_size; i++)
+      for (const auto i : make_range(_local_size.load()))
         _values[i] = PS(v[i]);
     }
 


### PR DESCRIPTION
Closes #3808 