### PR TITLE
Fix p=2 Lagrange nodal_soln on Tri7-sided elems

### DIFF
--- a/examples/adaptivity/adaptivity_ex3/run.sh
+++ b/examples/adaptivity/adaptivity_ex3/run.sh
@@ -33,6 +33,7 @@ run_example "$example_name" dimension=2 element_type=simplex approx_type=HIERARC
 run_example "$example_name" dimension=2 element_type=simplex approx_type=CLOUGH singularity=false approx_order=3 refinement_type=h max_r_steps=3
 run_example "$example_name" dimension=3 element_type=simplex extrusion=true approx_type=LAGRANGE approx_order=1 refinement_type=h max_r_steps=3
 run_example "$example_name" dimension=3 element_type=simplex extrusion=true approx_type=LAGRANGE approx_order=2 refinement_type=h max_r_steps=3
+run_example "$example_name" dimension=3 element_type=simplex extrusion=true complete=true approx_type=LAGRANGE approx_order=2 refinement_type=h max_r_steps=3
 run_example "$example_name" dimension=3 element_type=simplex extrusion=true complete=true approx_type=LAGRANGE approx_order=3 refinement_type=h max_r_steps=3
 
 # Examples to use for benchmarking

--- a/src/fe/fe_lagrange.C
+++ b/src/fe/fe_lagrange.C
@@ -361,6 +361,39 @@ void lagrange_nodal_soln(const Elem * elem,
               return;
             }
 
+          case PRISM21:
+            {
+              nodal_soln[20]  = (elem_soln[9] + elem_soln[10] + elem_soln[11])/Real(3);
+              libmesh_fallthrough();
+            }
+          case PRISM20:
+            {
+              if (type == PRISM20)
+                libmesh_assert_equal_to (nodal_soln.size(), 20);
+
+              for (int i=0; i != 18; ++i)
+                nodal_soln[i] = elem_soln[i];
+
+              nodal_soln[18]  = (elem_soln[0] + elem_soln[1] + elem_soln[2])/Real(3);
+              nodal_soln[19]  = (elem_soln[3] + elem_soln[4] + elem_soln[5])/Real(3);
+              return;
+            }
+
+          case PYRAMID18:
+            {
+              libmesh_assert_equal_to (nodal_soln.size(), 18);
+
+              for (int i=0; i != 14; ++i)
+                nodal_soln[i] = elem_soln[i];
+
+              nodal_soln[14] = (elem_soln[0] + elem_soln[1] + elem_soln[4])/Real(3);
+              nodal_soln[15] = (elem_soln[1] + elem_soln[2] + elem_soln[4])/Real(3);
+              nodal_soln[16] = (elem_soln[2] + elem_soln[3] + elem_soln[4])/Real(3);
+              nodal_soln[17] = (elem_soln[0] + elem_soln[3] + elem_soln[4])/Real(3);
+
+              libmesh_fallthrough();
+            }
+
           default:
             {
               // By default the element solution _is_ nodal, so just


### PR DESCRIPTION
I must have missed this because I still think of those elements as just
ways to host Hierarchic bases, and although they need Lagrange support
for mappings, we only hit nodal_soln when decimating solution variables
for visualization.

This fixes (and tests the fix for) the bug in https://github.com/libMesh/libmesh/discussions/3794#discussioncomment-8843171