### PR TITLE
Adding Auto Area Function for Poly2Tri

### DIFF
--- a/include/mesh/triangulator_interface.h
+++ b/include/mesh/triangulator_interface.h
@@ -254,11 +254,26 @@ public:
 
   /**
   *  Generate an auto area function based on spacing of boundary points.
+  *  The external boundary as well as the hole boundaries are taken into consideration
+  *  to generate the auto area function based on inverse distance interpolation.
+  *  For each EDGE element on these boundaries, its centroid (midpoint) is used as the point
+  *  position and the desired area is calculated as 1.5 times of the area of the equilateral
+  *  triangle with the edge length as the length of the EDGE element.
+  *  For a given position, the inverse distance interpolation only considers a number of nearest
+  *  points (set by num_nearest_pts) to calculate the desired area. The weight of the value at
+  *  each point is calculated as 1/distance^power.
+  * 
+  *  In addition to these conventional inverse distance interpolation features, a concept of
+  *  "background value" and "background effective distance" is introduced. The background value
+  *  belongs to a virtual point located at a constant distance (background effective distance)
+  *  from the given position. The weight of the value at this virtual point is calculated as
+  *  1/background_effective_distance^power. Effectively, the background value is the value when
+  *  the given position is far away from the boundary points.
   */
   void generate_auto_area_function(const Parallel::Communicator &comm,
                                    const unsigned int num_nearest_pts,
                                    const unsigned int power,
-                                   const Number background_value,
+                                   const Real background_value,
                                    const Real  background_eff_dist);
 
   /**

--- a/include/mesh/triangulator_interface.h
+++ b/include/mesh/triangulator_interface.h
@@ -260,12 +260,12 @@ public:
                                    const unsigned int power,
                                    const Number background_value,
                                    const Real  background_eff_dist);
-  
+
   /**
   *  Whether or not an auto area function has been generated.
   */
   bool has_auto_area_function() {return _auto_area_function != nullptr;}
-  
+
   /**
   *  Caluclate the local desired area based on the auto area function.
   */

--- a/include/mesh/triangulator_interface.h
+++ b/include/mesh/triangulator_interface.h
@@ -98,11 +98,7 @@ public:
 
     _auto_area_mfi->interpolate_field_data(_auto_area_mfi->field_variables(), target_pts, target_vals);
 
-#ifdef LIBMESH_USE_COMPLEX_NUMBERS
-    return target_vals.front().real();
-#else
-    return target_vals.front();
-#endif
+    return libmesh_real(target_vals.front());
   }
 
   virtual void operator() (const Point & p,

--- a/include/mesh/triangulator_interface.h
+++ b/include/mesh/triangulator_interface.h
@@ -73,25 +73,36 @@ public:
     std::vector<std::string> field_vars{"f"};
     _auto_area_mfi->set_field_variables(field_vars);
     _auto_area_mfi->get_source_points() = input_pts;
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+    std::vector<Number> input_complex_vals;
+    for (const auto & input_val : input_vals)
+      input_complex_vals.push_back(Complex (input_val, 0.0));
+    _auto_area_mfi->get_source_vals() = input_complex_vals;
+#else
     _auto_area_mfi->get_source_vals() = input_vals;
+#endif
     _auto_area_mfi->prepare_for_use();
     this->_initialized = true;
   }
 
   virtual Real operator() (const Point & p,
-                             const Real /*time*/) override
+                           const Real /*time*/) override
   {
     libmesh_assert(this->_initialized);
 
     std::vector<Point> target_pts;
-    std::vector<Real> target_vals;
+    std::vector<Number> target_vals;
 
     target_pts.push_back(p);
     target_vals.resize(1);
 
     _auto_area_mfi->interpolate_field_data(_auto_area_mfi->field_variables(), target_pts, target_vals);
 
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+    return target_vals.front().real();
+#else
     return target_vals.front();
+#endif
   }
 
   virtual void operator() (const Point & p,

--- a/include/mesh/triangulator_interface.h
+++ b/include/mesh/triangulator_interface.h
@@ -267,7 +267,7 @@ public:
   bool has_auto_area_function() {return _auto_area_function != nullptr;}
 
   /**
-  *  Caluclate the local desired area based on the auto area function.
+  *  Calculate the local desired area based on the auto area function.
   */
   Real get_auto_desired_area(const Point &p);
 

--- a/include/mesh/triangulator_interface.h
+++ b/include/mesh/triangulator_interface.h
@@ -26,6 +26,8 @@
 #include "libmesh/libmesh.h"
 #include "libmesh/point.h"
 
+#include "libmesh/meshfree_interpolation.h"
+
 // C++ includes
 #include <set>
 #include <vector>
@@ -251,6 +253,25 @@ public:
   void attach_region_list(const std::vector<Region*> * regions) { _regions = regions; }
 
   /**
+  *  Generate an auto area function based on spacing of boundary points.
+  */
+  void generate_auto_area_function(const Parallel::Communicator &comm,
+                                   const unsigned int num_nearest_pts,
+                                   const unsigned int power,
+                                   const Number background_value,
+                                   const Real  background_eff_dist);
+  
+  /**
+  *  Whether or not an auto area function has been generated.
+  */
+  bool has_auto_area_function() {return _auto_area_function != nullptr;}
+  
+  /**
+  *  Caluclate the local desired area based on the auto area function.
+  */
+  Real get_auto_desired_area(const Point &p);
+
+  /**
    * A set of ids to allow on the outer boundary loop: interpreted as
    * boundary ids of 2D elements and/or subdomain ids of 1D edges.  If
    * this is empty, then the outer boundary may be constructed from
@@ -377,6 +398,11 @@ protected:
    * Flag which tells if we want to check hole geometry
    */
   bool _verify_hole_boundaries;
+
+  /**
+  * The auto area function based on the spacing of boundary points
+  */
+  std::unique_ptr<InverseDistanceInterpolation<3>> _auto_area_function;
 };
 
 } // namespace libMesh

--- a/include/solution_transfer/meshfree_interpolation.h
+++ b/include/solution_transfer/meshfree_interpolation.h
@@ -316,6 +316,8 @@ protected:
 
   const Real         _half_power;
   const unsigned int _n_interp_pts;
+  const Number       _background_value;
+  const Real         _background_eff_dist;
 
   /**
    * Temporary work array.  Object level scope to avoid cache thrashing.
@@ -330,13 +332,17 @@ public:
    */
   InverseDistanceInterpolation (const libMesh::Parallel::Communicator & comm_in,
                                 const unsigned int n_interp_pts = 8,
-                                const Real  power               = 2) :
+                                const Real  power               = 2,
+                                const Number background_value   = 0.,
+                                const Real  background_eff_dist = -1.0) :
     MeshfreeInterpolation(comm_in),
 #if LIBMESH_HAVE_NANOFLANN
     _point_list_adaptor(_src_pts),
 #endif
     _half_power(power/2.0),
-    _n_interp_pts(n_interp_pts)
+    _n_interp_pts(n_interp_pts),
+    _background_value(background_value),
+    _background_eff_dist(background_eff_dist)
   {}
 
   /**

--- a/include/solution_transfer/meshfree_interpolation.h
+++ b/include/solution_transfer/meshfree_interpolation.h
@@ -329,10 +329,10 @@ public:
   /**
    * Constructor. Takes the inverse distance power,
    * which defaults to 2.
-   * 
+   *
    * In addition to the conventional inverse distance interpolation,
    * the user can specify a background value and an effective distance
-   * for the background value. A background value is corresponding to a 
+   * for the background value. A background value is corresponding to a
    * virtual point that is always at a constant distance (which is set
    * by background_eff_dist) from the target point. This is useful when
    * the target point is far away from any source points and user wants

--- a/include/solution_transfer/meshfree_interpolation.h
+++ b/include/solution_transfer/meshfree_interpolation.h
@@ -329,6 +329,14 @@ public:
   /**
    * Constructor. Takes the inverse distance power,
    * which defaults to 2.
+   * 
+   * In addition to the conventional inverse distance interpolation,
+   * the user can specify a background value and an effective distance
+   * for the background value. A background value is corresponding to a 
+   * virtual point that is always at a constant distance (which is set
+   * by background_eff_dist) from the target point. This is useful when
+   * the target point is far away from any source points and user wants
+   * an independent value for this kind of scenarios.
    */
   InverseDistanceInterpolation (const libMesh::Parallel::Communicator & comm_in,
                                 const unsigned int n_interp_pts = 8,

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -792,7 +792,8 @@ bool Poly2TriTriangulator::insert_refinement_points()
   mesh.find_neighbors();
 
   if (this->desired_area() == 0 &&
-      this->get_desired_area_function() == nullptr)
+      this->get_desired_area_function() == nullptr &&
+      !this->has_auto_area_function())
     return false;
 
   BoundaryInfo & boundary_info = _mesh.get_boundary_info();
@@ -1482,13 +1483,14 @@ bool Poly2TriTriangulator::should_refine_elem(Elem & elem)
 
   // If this isn't a question, why are we here?
   libmesh_assert(min_area_target > 0 ||
-                 area_func != nullptr);
+                 area_func != nullptr ||
+                 this->has_auto_area_function());
 
   const Real area = elem.volume();
 
   // If we don't have position-dependent area targets we can make a
   // decision quickly
-  if (!area_func)
+  if (!area_func && !this->has_auto_area_function())
     return (area > min_area_target);
 
   // If we do?
@@ -1497,7 +1499,8 @@ bool Poly2TriTriangulator::should_refine_elem(Elem & elem)
   // vertices first
   for (auto v : make_range(elem.n_vertices()))
     {
-      const Real local_area_target = (*area_func)(elem.point(v));
+      // If we have an auto area function, we'll use it and override other area options
+      const Real local_area_target = this->has_auto_area_function() ? this->get_auto_desired_area(elem.point(v)) : (*area_func)(elem.point(v));
       libmesh_error_msg_if
         (local_area_target <= 0,
          "Non-positive desired element areas are unachievable");

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -1491,6 +1491,8 @@ bool Poly2TriTriangulator::should_refine_elem(Elem & elem)
   // decision quickly
   if (!area_func && !this->has_auto_area_function())
     return (area > min_area_target);
+  else if(area_func && this->has_auto_area_function())
+    libmesh_warning("WARNING:  both desired are function and automatic area function are set.  Using automatic area function.");
 
   // If we do?
   //

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -346,7 +346,6 @@ unsigned int segment_intersection(const Elem & elem,
 
 namespace libMesh
 {
-
 //
 // Function definitions for the Poly2TriTriangulator class
 //
@@ -1479,7 +1478,7 @@ bool Poly2TriTriangulator::insert_refinement_points()
 bool Poly2TriTriangulator::should_refine_elem(Elem & elem)
 {
   const Real min_area_target = this->desired_area();
-  FunctionBase<Real> * area_func = this->get_desired_area_function();
+  FunctionBase<Real> *area_func = this->has_auto_area_function() ? this->get_auto_area_function() : this->get_desired_area_function();
 
   // If this isn't a question, why are we here?
   libmesh_assert(min_area_target > 0 ||
@@ -1500,7 +1499,7 @@ bool Poly2TriTriangulator::should_refine_elem(Elem & elem)
   for (auto v : make_range(elem.n_vertices()))
     {
       // If we have an auto area function, we'll use it and override other area options
-      const Real local_area_target = this->has_auto_area_function() ? this->get_auto_desired_area(elem.point(v)) : (*area_func)(elem.point(v));
+      const Real local_area_target = (*area_func)(elem.point(v));
       libmesh_error_msg_if
         (local_area_target <= 0,
          "Non-positive desired element areas are unachievable");

--- a/src/mesh/triangulator_interface.C
+++ b/src/mesh/triangulator_interface.C
@@ -418,7 +418,7 @@ unsigned int TriangulatorInterface::total_hole_points()
 void TriangulatorInterface::generate_auto_area_function(const Parallel::Communicator &comm,
                                                         const unsigned int num_nearest_pts,
                                                         const unsigned int power,
-                                                        const Number background_value,
+                                                        const Real background_value,
                                                         const Real  background_eff_dist)
 {
   // Get the hole mesh of the outer boundary

--- a/src/mesh/triangulator_interface.C
+++ b/src/mesh/triangulator_interface.C
@@ -33,12 +33,72 @@
 #include "libmesh/enum_to_string.h"
 #include "libmesh/utility.h"
 
+#include "libmesh/meshfree_interpolation.h"
+
 // C/C++ includes
 #include <sstream>
 
 
 namespace libMesh
 {
+//
+// Function definitions for the AutoAreaFunction class
+//
+
+// Constructor
+AutoAreaFunction::AutoAreaFunction (const Parallel::Communicator &comm,
+                                    const unsigned int num_nearest_pts,
+                                    const unsigned int power,
+                                    const Real background_value,
+                                    const Real  background_eff_dist):
+  _comm(comm),
+  _num_nearest_pts(num_nearest_pts),
+  _power(power),
+  _background_value(background_value),
+  _background_eff_dist(background_eff_dist),
+  _auto_area_mfi(std::make_unique<InverseDistanceInterpolation<3>>(_comm, _num_nearest_pts, _power, _background_value, _background_eff_dist))
+{
+  this->_initialized = false;
+  this->_is_time_dependent = false;
+}
+
+// Destructor
+AutoAreaFunction::~AutoAreaFunction () = default;
+
+void AutoAreaFunction::init_mfi (const std::vector<Point> & input_pts,
+                                 const std::vector<Real> & input_vals)
+{
+  std::vector<std::string> field_vars{"f"};
+  _auto_area_mfi->set_field_variables(field_vars);
+  _auto_area_mfi->get_source_points() = input_pts;
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+  std::vector<Number> input_complex_vals;
+  for (const auto & input_val : input_vals)
+    input_complex_vals.push_back(Complex (input_val, 0.0));
+  _auto_area_mfi->get_source_vals() = input_complex_vals;
+#else
+  _auto_area_mfi->get_source_vals() = input_vals;
+#endif
+  _auto_area_mfi->prepare_for_use();
+  this->_initialized = true;
+}
+
+Real AutoAreaFunction::operator() (const Point & p,
+                                   const Real /*time*/)
+{
+  libmesh_assert(this->_initialized);
+
+  std::vector<Point> target_pts;
+  std::vector<Number> target_vals;
+
+  target_pts.push_back(p);
+  target_vals.resize(1);
+
+  _auto_area_mfi->interpolate_field_data(_auto_area_mfi->field_variables(), target_pts, target_vals);
+
+  return libmesh_real(target_vals.front());
+}
+
 //
 // Function definitions for the TriangulatorInterface class
 //

--- a/src/mesh/triangulator_interface.C
+++ b/src/mesh/triangulator_interface.C
@@ -448,7 +448,7 @@ void TriangulatorInterface::generate_auto_area_function(const Parallel::Communic
             (hole->point(i) - hole->point((i + 1) % hole->n_points())).norm());
       }
     }
-  
+
   // We use the 150% area of the equilateral triangle with the same side length as the segment as the target size
   // This might be adjusted in future versions
   std::for_each(
@@ -460,7 +460,7 @@ void TriangulatorInterface::generate_auto_area_function(const Parallel::Communic
   _auto_area_function->set_field_variables(field_vars);
   _auto_area_function->get_source_points() = function_points;
   _auto_area_function->get_source_vals() = function_sizes;
-  _auto_area_function->prepare_for_use();    
+  _auto_area_function->prepare_for_use();
 }
 
 Real TriangulatorInterface::get_auto_desired_area(const Point &p)

--- a/src/mesh/triangulator_interface.C
+++ b/src/mesh/triangulator_interface.C
@@ -55,7 +55,8 @@ TriangulatorInterface::TriangulatorInterface(UnstructuredMesh & mesh)
     _triangulation_type(GENERATE_CONVEX_HULL),
     _insert_extra_points(false),
     _smooth_after_generating(true),
-    _quiet(true)
+    _quiet(true),
+    _auto_area_function(nullptr)
 {}
 
 
@@ -412,6 +413,68 @@ unsigned int TriangulatorInterface::total_hole_points()
     }
 
   return n_hole_points;
+}
+
+void TriangulatorInterface::generate_auto_area_function(const Parallel::Communicator &comm,
+                                                        const unsigned int num_nearest_pts,
+                                                        const unsigned int power,
+                                                        const Number background_value,
+                                                        const Real  background_eff_dist)
+{
+  // Get the hole mesh of the outer boundary
+  // Holes should already be attached if applicable when this function is called
+  const TriangulatorInterface::MeshedHole bdry_mh { _mesh, this->_bdy_ids };
+  // Points and target element sizes for the interpolation
+  std::vector<Point> function_points;
+  std::vector<Real> function_sizes;
+  // Collect all the centroid points of the outer boundary segments
+  // and the corresponding element sizes
+  for (unsigned int i = 0; i < bdry_mh.n_points(); i++)
+  {
+    function_points.push_back((bdry_mh.point(i) + bdry_mh.point((i + 1) % bdry_mh.n_points())) /
+                              2.0);
+    function_sizes.push_back(
+        (bdry_mh.point(i) - bdry_mh.point((i + 1) % bdry_mh.n_points())).norm());
+  }
+  // If holes are present, do the same for the hole boundaries
+  if(_holes)
+    for (const Hole * hole : *_holes)
+    {
+      for (unsigned int i = 0; i < hole->n_points(); i++)
+      {
+        function_points.push_back(
+            (hole->point(i) + hole->point((i + 1) % hole->n_points())) / 2.0);
+        function_sizes.push_back(
+            (hole->point(i) - hole->point((i + 1) % hole->n_points())).norm());
+      }
+    }
+  
+  // We use the 150% area of the equilateral triangle with the same side length as the segment as the target size
+  // This might be adjusted in future versions
+  std::for_each(
+      function_sizes.begin(), function_sizes.end(), [](Real & a) { a = a * a * 1.5 * std::sqrt(3.0) / 4.0; });
+  // Use the inverse distance interpolation to interpolate the target element size
+  _auto_area_function = std::make_unique<InverseDistanceInterpolation<3>>(
+    comm, std::min(function_points.size(), (unsigned long)num_nearest_pts), power, background_value, background_eff_dist);
+  std::vector<std::string> field_vars{"f"};
+  _auto_area_function->set_field_variables(field_vars);
+  _auto_area_function->get_source_points() = function_points;
+  _auto_area_function->get_source_vals() = function_sizes;
+  _auto_area_function->prepare_for_use();    
+}
+
+Real TriangulatorInterface::get_auto_desired_area(const Point &p)
+{
+  libmesh_assert(_auto_area_function);
+  std::vector<Point> target_pts;
+  std::vector<Real> target_vals;
+
+  target_pts.push_back(p);
+  target_vals.resize(1);
+
+  _auto_area_function->interpolate_field_data(_auto_area_function->field_variables(), target_pts, target_vals);
+
+  return target_vals.front();
 }
 
 } // namespace libMesh

--- a/src/solution_transfer/meshfree_interpolation.C
+++ b/src/solution_transfer/meshfree_interpolation.C
@@ -281,10 +281,22 @@ void InverseDistanceInterpolation<KDDim>::interpolate (const Point              
 
   // Compute the interpolation weights & interpolated value
   const unsigned int n_fv = this->n_field_variables();
-  _vals.resize(n_fv); /**/ std::fill (_vals.begin(), _vals.end(), Number(0.));
+  _vals.resize(n_fv);
 
-  Real tot_weight = 0.;
-
+  std::fill (_vals.begin(), _vals.end(), Number(0.));
+  Real tot_weight(0.);
+  // The background value is optional
+  // If background value option is enabled, add it to the total weight
+  // If not, a "zero" weight is added
+  if (_background_eff_dist > 0.0)
+  {
+    const Number background_wt = _background_eff_dist * _background_eff_dist > std::numeric_limits<Real>::epsilon()
+                             ? 1.0 / std::pow(_background_eff_dist * _background_eff_dist, _half_power)
+                             : 0.0;
+    tot_weight += background_wt;
+    std::fill (_vals.begin(), _vals.end(), Number(_background_value * background_wt));
+  }
+  
   std::vector<Real>::const_iterator src_dist_sqr_it=src_dist_sqr.begin();
   std::vector<size_t>::const_iterator src_idx_it=src_indices.begin();
 

--- a/src/solution_transfer/meshfree_interpolation.C
+++ b/src/solution_transfer/meshfree_interpolation.C
@@ -296,7 +296,7 @@ void InverseDistanceInterpolation<KDDim>::interpolate (const Point              
     tot_weight += background_wt;
     std::fill (_vals.begin(), _vals.end(), Number(_background_value * background_wt));
   }
-  
+
   std::vector<Real>::const_iterator src_dist_sqr_it=src_dist_sqr.begin();
   std::vector<size_t>::const_iterator src_idx_it=src_indices.begin();
 

--- a/src/solution_transfer/meshfree_interpolation.C
+++ b/src/solution_transfer/meshfree_interpolation.C
@@ -290,9 +290,9 @@ void InverseDistanceInterpolation<KDDim>::interpolate (const Point              
   // If not, a "zero" weight is added
   if (_background_eff_dist > 0.0)
   {
-    const Number background_wt = _background_eff_dist * _background_eff_dist > std::numeric_limits<Real>::epsilon()
-                             ? 1.0 / std::pow(_background_eff_dist * _background_eff_dist, _half_power)
-                             : 0.0;
+    const Real background_wt = _background_eff_dist * _background_eff_dist > std::numeric_limits<Real>::epsilon()
+                           ? 1.0 / std::pow(_background_eff_dist * _background_eff_dist, _half_power)
+                           : 0.0;
     tot_weight += background_wt;
     std::fill (_vals.begin(), _vals.end(), Number(_background_value * background_wt));
   }


### PR DESCRIPTION
Thinking about adding an automatically generated element area function for poly2tri that can be called by `XYDelaunay` in MOOSE. The auto function is based on inverse Distance Interpolation of the EDGE elements sizes of the outer boundary as well as the holes boundaries.

I also modified the interpolation a little bit to add a "background" value and the corresponding effective distance so that a default area value can be used in those areas away from boundaries.