### PR TITLE
FEMContext::hardest_fe_type() fix

### DIFF
--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -68,6 +68,7 @@ FEMContext::FEMContext (const System & sys,
 {
   if (active_vars)
     {
+      libmesh_assert(!active_vars->empty());
       auto vars_copy =
         std::make_unique<std::vector<unsigned int>>(*active_vars);
 

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -86,7 +86,9 @@ FEMContext::FEMContext (const System & sys,
 FEType FEMContext::find_hardest_fe_type()
 {
   const System & sys = this->get_system();
-  FEType hardest_fe_type = sys.variable_type(0);
+  FEType hardest_fe_type =
+    sys.variable_type(_active_vars ?
+                      (*_active_vars)[0] : 0);
 
   auto check_var = [&hardest_fe_type, &sys](unsigned int v)
     {


### PR DESCRIPTION
Starting with var 0 even when we have an `active_vars` that doesn't include it can cause us to use too many quadrature points, which can be wasteful in some cases and a disaster in others.  See https://github.com/idaholab/moose/issues/26605