### PR TITLE
Quadratic Elem support in TriangulatorInterface

### DIFF
--- a/include/mesh/mesh_triangle_holes.h
+++ b/include/mesh/mesh_triangle_holes.h
@@ -64,9 +64,22 @@ public:
   virtual unsigned int n_points() const = 0;
 
   /**
+   * The number of geometric midpoints along *each* of the sides
+   * defining the hole.
+   */
+  virtual unsigned int n_midpoints() const { return 0; }
+
+  /**
    * Return the nth point defining the hole.
    */
   virtual Point point(const unsigned int n) const = 0;
+
+  /**
+   * Return the midpoint \p m along the side \p n defining the hole.
+   */
+  virtual Point midpoint(const unsigned int /* m */,
+                         const unsigned int /* n */) const
+  { libmesh_error(); /* by default holes are polygonal */ }
 
   /**
    * Return an (arbitrary) point which lies inside the hole.
@@ -75,11 +88,17 @@ public:
 
   /**
    * Return true iff \p p lies inside the hole.
+   *
+   * This method currently does not take any higher-order hole
+   * geometry into account, but treats the hole as a polygon.
    */
   bool contains(Point p) const;
 
   /**
    * Return the area of the hole
+   *
+   * This method currently does not take any higher-order hole
+   * geometry into account, but treats the hole as a polygon.
    */
   Real area() const;
 
@@ -87,6 +106,9 @@ public:
    * Return a vector with right-hand-rule orientation and length of
    * twice area() squared.  This is useful for determining
    * orientation of non-planar or non-counter-clockwise holes.
+   *
+   * This method currently does not take any higher-order hole
+   * geometry into account, but treats the hole as a polygon.
    */
   RealGradient areavec() const;
 
@@ -330,7 +352,12 @@ public:
 
   virtual unsigned int n_points() const override;
 
+  virtual unsigned int n_midpoints() const override;
+
   virtual Point point(const unsigned int n) const override;
+
+  virtual Point midpoint(const unsigned int m,
+                         const unsigned int n) const override;
 
   virtual Point inside() const override;
 
@@ -346,6 +373,14 @@ private:
    * The sorted vector of points which makes up the hole.
    */
   std::vector<Point> _points;
+
+  /**
+   * The sorted vector of midpoints in between points along the edges
+   * of the hole.  For a hole with m midpoints per edge, between
+   * _points[n] and _points[n+1] lies _midpoints[n*m] through
+   * _midpoints[n*m+m-1]
+   */
+  std::vector<Point> _midpoints;
 };
 
 

--- a/include/mesh/triangulator_interface.h
+++ b/include/mesh/triangulator_interface.h
@@ -24,6 +24,7 @@
 
 // Local Includes
 #include "libmesh/libmesh.h"
+#include "libmesh/point.h"
 
 // C++ includes
 #include <set>
@@ -229,6 +230,14 @@ public:
   std::vector<std::pair<unsigned int, unsigned int>> segments;
 
   /**
+   * When constructing a second-order triangulation from a
+   * second-order boundary, we may do the triangulation using
+   * first-order elements, in which case we need to save midpoint
+   * location data in order to reconstruct curvature along boundaries.
+   */
+  std::vector<Point> segment_midpoints;
+
+  /**
    * Attaches boundary markers.
    * If segments is set, the number of markers must be equal to the size of segments,
    * otherwise, it is equal to the number of points.
@@ -269,6 +278,13 @@ protected:
    * segments) to a PSLG triangulation
    */
   void insert_any_extra_boundary_points();
+
+  /**
+   * Helper function to upconvert Tri3 to any higher order triangle
+   * type if requested via \p _elem_type.  Should be called at the end
+   * of triangulate()
+   */
+  void increase_triangle_order();
 
   /**
    * Helper function to check holes for intersections if requested.

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -1753,17 +1753,31 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
   // with the ElemType.
   if (mesh.mesh_dimension() == 1)
     {
-      if (type==HEX8 || type==HEX27)
+      switch (type)
+      {
+      case HEX8:
+      case HEX27:
         mesh.set_mesh_dimension(3);
-
-      else if (type==TRI3 || type==QUAD4)
+        break;
+      case TRI3:
+      case TRI6:
+      case TRI7:
+      case QUAD4:
+      case QUAD8:
+      case QUAD9:
         mesh.set_mesh_dimension(2);
-
-      else if (type==EDGE2 || type==EDGE3 || type==EDGE4 || type==INVALID_ELEM)
+        break;
+      case EDGE2:
+      case EDGE3:
+      case EDGE4:
         mesh.set_mesh_dimension(1);
-
-      else
-        libmesh_error_msg("build_sphere(): Please specify a mesh dimension or a valid ElemType (EDGE{2,3,4}, TRI3, QUAD4, HEX{8,27})");
+        break;
+      case INVALID_ELEM:
+        // Just keep the existing dimension
+        break;
+      default:
+        libmesh_error_msg("build_sphere(): Please specify a mesh dimension or a valid ElemType (EDGE{2,3,4}, TRI{3,6,7}, QUAD{4,8,9}, HEX{8,27})");
+      }
     }
 
   BoundaryInfo & boundary_info = mesh.get_boundary_info();

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -2192,7 +2192,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
   // In 2D, convert all the quads to triangles if requested
   if (mesh.mesh_dimension()==2)
     {
-      if ((type == TRI6) || (type == TRI3))
+      if ((type == TRI7) || (type == TRI6) || (type == TRI3))
         {
           // A DistributedMesh needs a little prep before all_tri()
           if (is_replicated)

--- a/src/mesh/mesh_triangle_holes.C
+++ b/src/mesh/mesh_triangle_holes.C
@@ -478,6 +478,7 @@ TriangulatorInterface::MeshedHole::MeshedHole(const MeshBase & mesh,
 
       // Receive the points proc 0 will send later
       mesh.comm().broadcast(_points);
+      mesh.comm().broadcast(_midpoints);
       return;
     }
 

--- a/src/mesh/mesh_triangle_holes.C
+++ b/src/mesh/mesh_triangle_holes.C
@@ -487,7 +487,14 @@ TriangulatorInterface::MeshedHole::MeshedHole(const MeshBase & mesh,
   // around the element or "2" for CCW, to make it easier to detect
   // and scream about cases where we have a disconnected outer
   // boundary.
-  std::multimap<const Node *, std::pair<const Node *, int>> hole_edge_map;
+  std::multimap<const Node *,
+                std::pair<const Node *, int>> hole_edge_map;
+
+  // If we're looking at higher-order elements, we have mid-edge edge
+  // nodes to worry about.  hole_midpoint_map[{m,n}][i] should give us
+  // the ith mid-edge node traveling from vertex m to vertex n
+  std::map<std::pair<const Node *, const Node *>,
+           std::vector<const Node *>> hole_midpoint_map;
 
   std::vector<boundary_id_type> bcids;
 
@@ -505,6 +512,28 @@ TriangulatorInterface::MeshedHole::MeshedHole(const MeshBase & mesh,
               hole_edge_map.emplace(elem->node_ptr(1),
                                     std::make_pair(elem->node_ptr(0),
                                                    /*edge*/ 0));
+              if (elem->type() == EDGE3)
+                {
+                  hole_midpoint_map.emplace(std::make_pair(elem->node_ptr(0),
+                                                           elem->node_ptr(1)),
+                                            std::vector<const Node *>{elem->node_ptr(2)});
+                  hole_midpoint_map.emplace(std::make_pair(elem->node_ptr(1),
+                                                           elem->node_ptr(0)),
+                                            std::vector<const Node *>{elem->node_ptr(2)});
+                }
+              else if (elem->type() == EDGE4)
+                {
+                  hole_midpoint_map.emplace(std::make_pair(elem->node_ptr(0),
+                                                           elem->node_ptr(1)),
+                                            std::vector<const Node *>{elem->node_ptr(2),
+                                                                      elem->node_ptr(3)});
+                  hole_midpoint_map.emplace(std::make_pair(elem->node_ptr(1),
+                                                           elem->node_ptr(0)),
+                                            std::vector<const Node *>{elem->node_ptr(3),
+                                                                      elem->node_ptr(2)});
+                }
+              else
+                libmesh_assert_equal_to(elem->default_side_order(), 1);
             }
           continue;
         }
@@ -534,6 +563,19 @@ TriangulatorInterface::MeshedHole::MeshedHole(const MeshBase & mesh,
                   hole_edge_map.emplace(elem->node_ptr((s+1)%ns),
                                         std::make_pair(elem->node_ptr(s),
                                                        /*clockwise*/ 1));
+
+                  if (elem->default_side_order() == 2)
+                    {
+                      hole_midpoint_map.emplace(std::make_pair(elem->node_ptr(s),
+                                                               elem->node_ptr((s+1)%ns)),
+                                                std::vector<const Node *>{elem->node_ptr(s+ns)});
+                      hole_midpoint_map.emplace(std::make_pair(elem->node_ptr((s+1)%ns),
+                                                               elem->node_ptr(s)),
+                                                std::vector<const Node *>{elem->node_ptr(s+ns)});
+                    }
+                  else
+                    libmesh_assert_equal_to(elem->default_side_order(), 1);
+
                   continue;
                 }
             }
@@ -549,14 +591,16 @@ TriangulatorInterface::MeshedHole::MeshedHole(const MeshBase & mesh,
   // then a random vector will be extracted; this function will be
   // called multiple times so that the various options can be
   // compared.  We choose the largest option.
-  auto extract_edge_vector = [&report_error, &hole_edge_map]() {
-    // Start with any edge
-    std::pair<std::vector<const Node *>, int> hole_points_and_edge_type
-    {{hole_edge_map.begin()->first, hole_edge_map.begin()->second.first},
-     hole_edge_map.begin()->second.second};
+  auto extract_edge_vector =
+    [&report_error, &hole_edge_map, &hole_midpoint_map]() {
+    std::tuple<std::vector<const Node *>, std::vector<const Node *>, int>
+    hole_points_and_edge_type
+      {{hole_edge_map.begin()->first, hole_edge_map.begin()->second.first},
+       {}, hole_edge_map.begin()->second.second};
 
-    int & edge_type = hole_points_and_edge_type.second;
-    auto & hole_points = hole_points_and_edge_type.first;
+    auto & hole_points = std::get<0>(hole_points_and_edge_type);
+    auto & midpoint_points = std::get<1>(hole_points_and_edge_type);
+    int & edge_type = std::get<2>(hole_points_and_edge_type);
 
     // We won't be needing to search for this edge
     hole_edge_map.erase(hole_points.front());
@@ -603,6 +647,13 @@ TriangulatorInterface::MeshedHole::MeshedHole(const MeshBase & mesh,
         hole_points.push_back(next);
       }
 
+    for (auto i : make_range(hole_points.size()-1))
+      {
+        const auto & midpoints = hole_midpoint_map[{hole_points[i],hole_points[i+1]}];
+        midpoint_points.insert(midpoint_points.end(),
+                               midpoints.begin(), midpoints.end());
+      }
+
     hole_points.pop_back();
 
     return hole_points_and_edge_type;
@@ -616,7 +667,7 @@ TriangulatorInterface::MeshedHole::MeshedHole(const MeshBase & mesh,
       n_positive_areas = 0,
       n_edgeelem_loops = 0;
 
-  std::vector<const Node *> outer_hole_points;
+  std::vector<const Node *> outer_hole_points, outer_mid_points;
   int outer_edge_type = -1;
   Real twice_outer_area = 0,
        abs_twice_outer_area = 0;
@@ -627,7 +678,7 @@ TriangulatorInterface::MeshedHole::MeshedHole(const MeshBase & mesh,
 #endif
 
   while (!hole_edge_map.empty()) {
-    auto [hole_points, edge_type] = extract_edge_vector();
+    auto [hole_points, mid_points, edge_type] = extract_edge_vector();
 
     if (edge_type == 0)
     {
@@ -670,6 +721,7 @@ TriangulatorInterface::MeshedHole::MeshedHole(const MeshBase & mesh,
         twice_outer_area = twice_this_area;
         abs_twice_outer_area = abs_twice_this_area;
         outer_hole_points = std::move(hole_points);
+        outer_mid_points = std::move(mid_points);
         outer_edge_type = edge_type;
       }
   }
@@ -679,6 +731,11 @@ TriangulatorInterface::MeshedHole::MeshedHole(const MeshBase & mesh,
                  outer_hole_points.end(),
                  _points.begin(),
                  [](const Node * n){ return Point(*n); });
+  _midpoints.resize(outer_mid_points.size());
+  std::transform(outer_mid_points.begin(),
+                 outer_mid_points.end(),
+                 _midpoints.begin(),
+                 [](const Node * n){ return Point(*n); });
 
   if (!twice_outer_area)
     report_error("Zero-area MeshedHoles are not currently supported");
@@ -686,7 +743,18 @@ TriangulatorInterface::MeshedHole::MeshedHole(const MeshBase & mesh,
   // We ordered ourselves counter-clockwise?  But a hole is expected
   // to be clockwise, so use the reverse order.
   if (twice_outer_area > 0)
-    std::reverse(_points.begin(), _points.end());
+    {
+      std::reverse(_points.begin(), _points.end());
+
+      // Our midpoints are numbered e.g.
+      // (01a)(01b)(12a)(12b)(23a)(23b)(30a)(30b) for points 0123, but
+      // if we reverse to get 3210 then we want our midpoints to be
+      // (23b)(23a)(12b)(12a)(01b)(01a)(30b)(30a)
+      const unsigned int n_midpoints = _midpoints.size() / _points.size();
+      auto split_it = _midpoints.end() - n_midpoints;
+      std::reverse(_midpoints.begin(), split_it);
+      std::reverse(split_it, _midpoints.end());
+    }
 
 #ifdef DEBUG
   auto print_areas = [areas](){
@@ -728,6 +796,7 @@ TriangulatorInterface::MeshedHole::MeshedHole(const MeshBase & mesh,
   // Hey, no errors!  Broadcast that empty string.
   mesh.comm().broadcast(error_reported);
   mesh.comm().broadcast(_points);
+  mesh.comm().broadcast(_midpoints);
 }
 
 
@@ -737,10 +806,27 @@ unsigned int TriangulatorInterface::MeshedHole::n_points() const
 }
 
 
+unsigned int TriangulatorInterface::MeshedHole::n_midpoints() const
+{
+  libmesh_assert (!(_midpoints.size() % _points.size()));
+  return _midpoints.size() / _points.size();
+}
+
+
 Point TriangulatorInterface::MeshedHole::point(const unsigned int n) const
 {
   libmesh_assert_less (n, _points.size());
   return _points[n];
+}
+
+
+Point TriangulatorInterface::MeshedHole::midpoint(const unsigned int m,
+                                                  const unsigned int n) const
+{
+  const unsigned int n_mid = this->n_midpoints();
+  libmesh_assert_less (m, n_mid);
+  libmesh_assert_less (n, _points.size());
+  return _midpoints[n*n_mid+m];
 }
 
 

--- a/src/mesh/mesh_triangle_interface.C
+++ b/src/mesh/mesh_triangle_interface.C
@@ -353,6 +353,14 @@ void TriangleInterface::triangulate()
 
   _mesh.set_mesh_dimension(2);
 
+  // The user might have requested TRI6 or higher instead of TRI3.  If
+  // so then we'll need to get our neighbor pointers in order ahead of
+  // time for increase_triangle_order() to use.
+  if (_elem_type != TRI3)
+    {
+      _mesh.find_neighbors();
+      this->increase_triangle_order();
+    }
 
   // To the naked eye, a few smoothing iterations usually looks better,
   // so we do this by default unless the user says not to.

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -432,6 +432,11 @@ void Poly2TriTriangulator::triangulate()
   if (this->_smooth_after_generating)
     LaplaceMeshSmoother(_mesh).smooth(2);
 
+  // The user might have requested TRI6 or higher instead of TRI3.  We
+  // can do this before prepare_for_use() because all we need for it
+  // is find_neighbors(), which we did in insert_refinement_points()
+  this->increase_triangle_order();
+
   // Prepare the mesh for use before returning.  This ensures (among
   // other things) that it is partitioned and therefore users can
   // iterate over local elements, etc.


### PR DESCRIPTION
This is enough to let us mix and match lower- and higher-order elements in boundary and hole definitions for the same triangulation, and get a triangulation output that matches the higher-order midpoint nodes where they're available.

This should be everything we need on the libMesh end to support what I called "level 1" in https://github.com/libMesh/libmesh/pull/3811