### PR TITLE
Update to plotting EIM variables

### DIFF
--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -43,6 +43,7 @@ class RBParametrizedFunction;
 class RBTheta;
 class System;
 class Elem;
+class FEType;
 
 /**
  * This class enables evaluation of an Empirical Interpolation Method (EIM)
@@ -513,16 +514,18 @@ public:
                                bool read_binary_basis_functions = true);
 
   /**
-   * Project variable \p var of \p bf_data into the solution vector of System.
+   * Project variable the specified variable of \p bf_data into the solution
+   * vector of System. This method is virtual so that it can be overridden in
+   * sub-classes, e.g. to perform a specialized type of projection.
    */
-  void project_qp_data_map_onto_system(System & sys,
-                                       const QpDataMap & bf_data,
-                                       unsigned int var);
+  virtual void project_qp_data_map_onto_system(System & sys,
+                                               const QpDataMap & bf_data,
+                                               const std::tuple<unsigned int,FEType,std::string> & eim_var_tuple);
 
   /**
    * Get _eim_vars_to_project_and_write.
    */
-  const std::set<unsigned int> & get_eim_vars_to_project_and_write() const;
+  const std::set<std::tuple<unsigned int,FEType,std::string>> & get_eim_vars_to_project_and_write() const;
 
   /**
    * Project all basis functions using project_qp_data_map_onto_system() and
@@ -602,8 +605,13 @@ protected:
    * out in write_out_projected_basis_functions(). By default this is an empty
    * set, but can be updated in subclasses to specify the EIM variables that
    * are relevant for visualization.
+   *
+   * For each variable we specify a tuple with the following data:
+   *  - variable number
+   *  - FEType used in the projection of the data
+   *  - a property name that can be used to identify the type of data
    */
-  std::set<unsigned int> _eim_vars_to_project_and_write;
+  std::set<std::tuple<unsigned int,FEType,std::string>> _eim_vars_to_project_and_write;
 
   /**
    * This set that specifies which EIM variables will be scaled during EIM

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -520,12 +520,12 @@ public:
    */
   virtual void project_qp_data_map_onto_system(System & sys,
                                                const QpDataMap & bf_data,
-                                               const std::tuple<unsigned int,FEType,std::string> & eim_var_tuple);
+                                               const std::tuple<unsigned int,unsigned int,FEType,std::string> & eim_var_tuple);
 
   /**
    * Get _eim_vars_to_project_and_write.
    */
-  const std::set<std::tuple<unsigned int,FEType,std::string>> & get_eim_vars_to_project_and_write() const;
+  const std::vector<std::tuple<unsigned int,unsigned int,FEType,std::string>> & get_eim_vars_to_project_and_write() const;
 
   /**
    * Project all basis functions using project_qp_data_map_onto_system() and
@@ -601,17 +601,22 @@ public:
 protected:
 
   /**
-   * This set specifies which EIM variables will be projected and written
+   * This vector specifies which EIM variables will be projected and written
    * out in write_out_projected_basis_functions(). By default this is an empty
    * set, but can be updated in subclasses to specify the EIM variables that
    * are relevant for visualization.
    *
-   * For each variable we specify a tuple with the following data:
-   *  - variable number
+   * We identify groups of variables with one or more variables in a group.
+   * The purpose of using a group is often we plot multiple components of
+   * a tensor-valued or vector-valued quantity, so it makes sense to refer
+   * to the entire group of variables together in those cases. For each
+   * variable group we specify a tuple with the following data:
+   *  - First variable number in variable group
+   *  - Number of variables in group (indices are assumed to be contiguous)
    *  - FEType used in the projection of the data
-   *  - a property name that can be used to identify the type of data
+   *  - A property name that can be used to identify the type of data
    */
-  std::set<std::tuple<unsigned int,FEType,std::string>> _eim_vars_to_project_and_write;
+  std::vector<std::tuple<unsigned int,unsigned int,FEType,std::string>> _eim_vars_to_project_and_write;
 
   /**
    * This set that specifies which EIM variables will be scaled during EIM

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -75,7 +75,7 @@ struct EIMVarGroupPlottingInfo
 
   /**
    * A string that specifies how we plot this variable. This string
-   * will be interpreted as needing in subclasses that perform the
+   * will be interpreted as needed in subclasses that perform the
    * plotting. Some plotting options are whether we extrapolate data
    * or copy data from qps to nodes.
    */
@@ -551,7 +551,7 @@ public:
                                bool read_binary_basis_functions = true);
 
   /**
-   * Project variable the specified variable of \p bf_data into the solution
+   * Project the specified variable of \p bf_data into the solution
    * vector of System. This method is virtual so that it can be overridden in
    * sub-classes, e.g. to perform a specialized type of projection.
    */

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -50,7 +50,7 @@ class Elem;
  * This struct encapsulates data that specifies how we will
  * perform plotting for EIM variable groups.
  */
-struct EimVargroupPlottingInfo
+struct EIMVarGroupPlottingInfo
 {
   /**
    * The index for the first EIM variable in this variable group.
@@ -557,12 +557,12 @@ public:
    */
   virtual void project_qp_data_map_onto_system(System & sys,
                                                const QpDataMap & bf_data,
-                                               const EimVargroupPlottingInfo & eim_vargroup);
+                                               const EIMVarGroupPlottingInfo & eim_vargroup);
 
   /**
    * Get _eim_vars_to_project_and_write.
    */
-  const std::vector<EimVargroupPlottingInfo> & get_eim_vars_to_project_and_write() const;
+  const std::vector<EIMVarGroupPlottingInfo> & get_eim_vars_to_project_and_write() const;
 
   /**
    * Project all basis functions using project_qp_data_map_onto_system() and
@@ -648,7 +648,7 @@ protected:
    * a tensor-valued or vector-valued quantity, so it makes sense to refer
    * to the entire group of variables together in those cases.
    */
-  std::vector<EimVargroupPlottingInfo> _eim_vars_to_project_and_write;
+  std::vector<EIMVarGroupPlottingInfo> _eim_vars_to_project_and_write;
 
   /**
    * This set that specifies which EIM variables will be scaled during EIM

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -42,6 +42,7 @@ class RBParameters;
 class RBParametrizedFunction;
 class RBTheta;
 class System;
+class EquationSystems;
 class Elem;
 class FEType;
 
@@ -531,7 +532,7 @@ public:
    * Project all basis functions using project_qp_data_map_onto_system() and
    * then write out the resulting vectors.
    */
-  void write_out_projected_basis_functions(System & sys,
+  void write_out_projected_basis_functions(EquationSystems & es,
                                            const std::string & directory_name = "offline_data");
 
   /**

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -28,6 +28,7 @@
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
 #include "libmesh/rb_parametrized_function.h"
+#include "libmesh/fe_type.h"
 
 // C++ includes
 #include <memory>
@@ -44,7 +45,42 @@ class RBTheta;
 class System;
 class EquationSystems;
 class Elem;
-class FEType;
+
+/**
+ * This struct encapsulates data that specifies how we will
+ * perform plotting for EIM variable groups.
+ */
+struct EimVargroupPlottingInfo
+{
+  /**
+   * The index for the first EIM variable in this variable group.
+   */
+  unsigned int first_eim_var_index;
+
+  /**
+   * The number of EIM variables in the group. The variables
+   * are assumed to be numbered contiguously.
+   */
+  unsigned int n_eim_vars;
+
+  /**
+   * The FEType for the variables in this group.
+   */
+  FEType eim_var_fe_type;
+
+  /**
+   * The name of the System we use for plotting this EIM variable group.
+   */
+  std::string eim_sys_name;
+
+  /**
+   * A string that specifies how we plot this variable. This string
+   * will be interpreted as needing in subclasses that perform the
+   * plotting. Some plotting options are whether we extrapolate data
+   * or copy data from qps to nodes.
+   */
+  std::string plotting_type;
+};
 
 /**
  * This class enables evaluation of an Empirical Interpolation Method (EIM)
@@ -521,12 +557,12 @@ public:
    */
   virtual void project_qp_data_map_onto_system(System & sys,
                                                const QpDataMap & bf_data,
-                                               const std::tuple<unsigned int,unsigned int,FEType,std::string> & eim_var_tuple);
+                                               const EimVargroupPlottingInfo & eim_vargroup);
 
   /**
    * Get _eim_vars_to_project_and_write.
    */
-  const std::vector<std::tuple<unsigned int,unsigned int,FEType,std::string>> & get_eim_vars_to_project_and_write() const;
+  const std::vector<EimVargroupPlottingInfo> & get_eim_vars_to_project_and_write() const;
 
   /**
    * Project all basis functions using project_qp_data_map_onto_system() and
@@ -610,14 +646,9 @@ protected:
    * We identify groups of variables with one or more variables in a group.
    * The purpose of using a group is often we plot multiple components of
    * a tensor-valued or vector-valued quantity, so it makes sense to refer
-   * to the entire group of variables together in those cases. For each
-   * variable group we specify a tuple with the following data:
-   *  - First variable number in variable group
-   *  - Number of variables in group (indices are assumed to be contiguous)
-   *  - FEType used in the projection of the data
-   *  - A property name that can be used to identify the type of data
+   * to the entire group of variables together in those cases.
    */
-  std::vector<std::tuple<unsigned int,unsigned int,FEType,std::string>> _eim_vars_to_project_and_write;
+  std::vector<EimVargroupPlottingInfo> _eim_vars_to_project_and_write;
 
   /**
    * This set that specifies which EIM variables will be scaled during EIM

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -2821,12 +2821,13 @@ void RBEIMEvaluation::node_distribute_bfs(const System & sys)
 
 void RBEIMEvaluation::project_qp_data_map_onto_system(System & sys,
                                                       const QpDataMap & qp_data_map,
-                                                      const std::tuple<unsigned int,FEType,std::string> & eim_var_tuple)
+                                                      const std::tuple<unsigned int,unsigned int,FEType,std::string> & eim_var_tuple)
 {
   LOG_SCOPE("project_basis_function_onto_system()", "RBEIMEvaluation");
 
   libmesh_error_msg_if(sys.n_vars() == 0, "System must have at least one variable");
 
+  // TODO: Currently only implemented for the case of one variable in a variable group
   unsigned int var = std::get<0>(eim_var_tuple);
 
   FEMContext context(sys);
@@ -2916,7 +2917,7 @@ void RBEIMEvaluation::project_qp_data_map_onto_system(System & sys,
   (*sys.solution) = current_local_soln;
 }
 
-const std::set<std::tuple<unsigned int,FEType,std::string>> & RBEIMEvaluation::get_eim_vars_to_project_and_write() const
+const std::vector<std::tuple<unsigned int,unsigned int,FEType,std::string>> & RBEIMEvaluation::get_eim_vars_to_project_and_write() const
 {
   return _eim_vars_to_project_and_write;
 }
@@ -2927,6 +2928,7 @@ void RBEIMEvaluation::write_out_projected_basis_functions(System & sys,
   if (get_eim_vars_to_project_and_write().empty())
     return;
 
+  unsigned int var_group_idx = 0;
   for (const auto & eim_var_tuple : get_eim_vars_to_project_and_write())
     {
       std::vector<std::unique_ptr<NumericVector<Number>>> projected_bfs;
@@ -2947,11 +2949,11 @@ void RBEIMEvaluation::write_out_projected_basis_functions(System & sys,
           projected_bfs_ptrs[i] = projected_bfs[i].get();
         }
 
-      auto eim_var = std::get<0>(eim_var_tuple);
       RBEvaluation::write_out_vectors(sys,
                                       projected_bfs_ptrs,
                                       directory_name,
-                                      "projected_bf_var_" + std::to_string(eim_var));
+                                      "projected_bf_vargroup_" + var_group_idx);
+      var_group_idx++;
     }
 }
 

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -30,6 +30,7 @@
 #include "libmesh/replicated_mesh.h"
 #include "libmesh/elem.h"
 #include "libmesh/system.h"
+#include "libmesh/equation_systems.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/quadrature.h"
 #include "libmesh/boundary_info.h"
@@ -2922,7 +2923,7 @@ const std::vector<std::tuple<unsigned int,unsigned int,FEType,std::string>> & RB
   return _eim_vars_to_project_and_write;
 }
 
-void RBEIMEvaluation::write_out_projected_basis_functions(System & sys,
+void RBEIMEvaluation::write_out_projected_basis_functions(EquationSystems & es,
                                                           const std::string & directory_name)
 {
   if (get_eim_vars_to_project_and_write().empty())
@@ -2932,6 +2933,10 @@ void RBEIMEvaluation::write_out_projected_basis_functions(System & sys,
   for (const auto & eim_var_tuple : get_eim_vars_to_project_and_write())
     {
       std::vector<std::unique_ptr<NumericVector<Number>>> projected_bfs;
+
+      const auto & sys_name = std::get<3>(eim_var_tuple);
+      System & sys = es.get_system(sys_name);
+
       for (unsigned int bf_index : make_range(get_n_basis_functions()))
         {
           project_qp_data_map_onto_system(
@@ -2952,7 +2957,7 @@ void RBEIMEvaluation::write_out_projected_basis_functions(System & sys,
       RBEvaluation::write_out_vectors(sys,
                                       projected_bfs_ptrs,
                                       directory_name,
-                                      "projected_bf_vargroup_" + var_group_idx);
+                                      "projected_bf_vargroup_" + std::to_string(var_group_idx));
       var_group_idx++;
     }
 }

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -2822,7 +2822,7 @@ void RBEIMEvaluation::node_distribute_bfs(const System & sys)
 
 void RBEIMEvaluation::project_qp_data_map_onto_system(System & sys,
                                                       const QpDataMap & qp_data_map,
-                                                      const EimVargroupPlottingInfo & eim_vargroup)
+                                                      const EIMVarGroupPlottingInfo & eim_vargroup)
 {
   LOG_SCOPE("project_basis_function_onto_system()", "RBEIMEvaluation");
 
@@ -2918,7 +2918,7 @@ void RBEIMEvaluation::project_qp_data_map_onto_system(System & sys,
   (*sys.solution) = current_local_soln;
 }
 
-const std::vector<EimVargroupPlottingInfo> & RBEIMEvaluation::get_eim_vars_to_project_and_write() const
+const std::vector<EIMVarGroupPlottingInfo> & RBEIMEvaluation::get_eim_vars_to_project_and_write() const
 {
   return _eim_vars_to_project_and_write;
 }


### PR DESCRIPTION
Updates to enable more than one EIM variable to be plotted. We specify variables to be plotted via the new `EimVargroupPlottingInfo` struct.