### PR TITLE
Overrule deterministic_training option in some cases

### DIFF
--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -320,11 +320,24 @@ void RBConstruction::set_rb_construction_parameters(
   // Initialize the parameter ranges and the parameters themselves
   initialize_parameters(mu_min_in, mu_max_in, discrete_parameter_values_in);
 
+  bool updated_deterministic_training = deterministic_training_in;
+  if (training_sample_list && (this->get_parameters_min().n_parameters() > 3))
+    {
+      // In this case we force deterministic_training to be false because
+      // a) deterministic training samples are not currrently supported with
+      //    more than 3 parameters, and
+      // b) we will overwrite the training samples anyway in the call to
+      //    load_training_set() below, so we do not want to generate an
+      //    error due to deterministic training sample generation when we
+      //    will the samples will be overwritten anyway.
+      updated_deterministic_training = false;
+    }
+
   initialize_training_parameters(this->get_parameters_min(),
                                  this->get_parameters_max(),
                                  n_training_samples_in,
                                  log_scaling_in,
-                                 deterministic_training_in);   // use deterministic parameters
+                                 updated_deterministic_training); // use deterministic parameters
 
   if (training_sample_list)
     {

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -328,8 +328,8 @@ void RBConstruction::set_rb_construction_parameters(
       //    more than 3 parameters, and
       // b) we will overwrite the training samples anyway in the call to
       //    load_training_set() below, so we do not want to generate an
-      //    error due to deterministic training sample generation when we
-      //    will the samples will be overwritten anyway.
+      //    error due to deterministic training sample generation when
+      //    the samples will be overwritten anyway.
       updated_deterministic_training = false;
     }
 

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -392,8 +392,8 @@ void RBEIMConstruction::set_rb_construction_parameters(unsigned int n_training_s
       //    more than 3 parameters, and
       // b) we will overwrite the training samples anyway in the call to
       //    load_training_set() below, so we do not want to generate an
-      //    error due to deterministic training sample generation when we
-      //    will the samples will be overwritten anyway.
+      //    error due to deterministic training sample generation when
+      //    the samples will be overwritten anyway.
       updated_deterministic_training = false;
     }
 

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -384,12 +384,24 @@ void RBEIMConstruction::set_rb_construction_parameters(unsigned int n_training_s
       initialize_parameters(mu_min_in, mu_max_in, discrete_parameter_values_in);
     }
 
+  bool updated_deterministic_training = deterministic_training_in;
+  if (training_sample_list && (this->get_parameters_min().n_parameters() > 3))
+    {
+      // In this case we force deterministic_training to be false because
+      // a) deterministic training samples are not currrently supported with
+      //    more than 3 parameters, and
+      // b) we will overwrite the training samples anyway in the call to
+      //    load_training_set() below, so we do not want to generate an
+      //    error due to deterministic training sample generation when we
+      //    will the samples will be overwritten anyway.
+      updated_deterministic_training = false;
+    }
 
   initialize_training_parameters(this->get_parameters_min(),
                                  this->get_parameters_max(),
                                  n_training_samples_in,
                                  log_scaling_in,
-                                 deterministic_training_in);
+                                 updated_deterministic_training);
 
   if (training_sample_list)
     {


### PR DESCRIPTION
Overrule this option in cases when it would cause an error and it's not relevant anyway since the deterministic training samples would be overwritten.