### PR TITLE
Use if-statements with initializers to limit variable scope

### DIFF
--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1486,10 +1486,8 @@ merge_ghost_functor_outputs(GhostingFunctor::map_type & elements_to_ghost,
           // if we had to fix up gf output to get here.
           libmesh_assert(elem->active());
 
-          GhostingFunctor::map_type::iterator existing_it =
-            elements_to_ghost.find (elem);
-
-          if (existing_it == elements_to_ghost.end())
+          if (auto existing_it = elements_to_ghost.find(elem);
+              existing_it == elements_to_ghost.end())
             elements_to_ghost.emplace(elem, elem_cm);
           else
             {
@@ -1524,8 +1522,8 @@ merge_ghost_functor_outputs(GhostingFunctor::map_type & elements_to_ghost,
                       // we don't need it anymore; we might as well
                       // remove it to keep the set of temporaries
                       // small.
-                      auto temp_it = temporary_coupling_matrices.find(existing_it->second);
-                      if (temp_it != temporary_coupling_matrices.end())
+                      if (auto temp_it = temporary_coupling_matrices.find(existing_it->second);
+                          temp_it != temporary_coupling_matrices.end())
                         temporary_coupling_matrices.erase(temp_it);
 
                       existing_it->second = nullptr;
@@ -1875,8 +1873,8 @@ DofMap::remove_coupling_functor(GhostingFunctor & coupling_functor)
   _coupling_functors.erase(&coupling_functor);
   _mesh.remove_ghosting_functor(coupling_functor);
 
-  auto it = _shared_functors.find(&coupling_functor);
-  if (it != _shared_functors.end())
+  if (auto it = _shared_functors.find(&coupling_functor);
+      it != _shared_functors.end())
     _shared_functors.erase(it);
 }
 
@@ -1900,8 +1898,8 @@ DofMap::remove_algebraic_ghosting_functor(GhostingFunctor & evaluable_functor)
   _algebraic_ghosting_functors.erase(&evaluable_functor);
   _mesh.remove_ghosting_functor(evaluable_functor);
 
-  auto it = _shared_functors.find(&evaluable_functor);
-  if (it != _shared_functors.end())
+  if (auto it = _shared_functors.find(&evaluable_functor);
+      it != _shared_functors.end())
     _shared_functors.erase(it);
 }
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1486,7 +1486,7 @@ merge_ghost_functor_outputs(GhostingFunctor::map_type & elements_to_ghost,
           // if we had to fix up gf output to get here.
           libmesh_assert(elem->active());
 
-          if (auto existing_it = elements_to_ghost.find(elem);
+          if (const auto existing_it = elements_to_ghost.find(elem);
               existing_it == elements_to_ghost.end())
             elements_to_ghost.emplace(elem, elem_cm);
           else
@@ -1522,7 +1522,7 @@ merge_ghost_functor_outputs(GhostingFunctor::map_type & elements_to_ghost,
                       // we don't need it anymore; we might as well
                       // remove it to keep the set of temporaries
                       // small.
-                      if (auto temp_it = temporary_coupling_matrices.find(existing_it->second);
+                      if (const auto temp_it = temporary_coupling_matrices.find(existing_it->second);
                           temp_it != temporary_coupling_matrices.end())
                         temporary_coupling_matrices.erase(temp_it);
 
@@ -1873,7 +1873,7 @@ DofMap::remove_coupling_functor(GhostingFunctor & coupling_functor)
   _coupling_functors.erase(&coupling_functor);
   _mesh.remove_ghosting_functor(coupling_functor);
 
-  if (auto it = _shared_functors.find(&coupling_functor);
+  if (const auto it = _shared_functors.find(&coupling_functor);
       it != _shared_functors.end())
     _shared_functors.erase(it);
 }
@@ -1898,7 +1898,7 @@ DofMap::remove_algebraic_ghosting_functor(GhostingFunctor & evaluable_functor)
   _algebraic_ghosting_functors.erase(&evaluable_functor);
   _mesh.remove_ghosting_functor(evaluable_functor);
 
-  if (auto it = _shared_functors.find(&evaluable_functor);
+  if (const auto it = _shared_functors.find(&evaluable_functor);
       it != _shared_functors.end())
     _shared_functors.erase(it);
 }

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1089,7 +1089,7 @@ private:
         // current DirichletBoundary object.  In case the map does not
         // contain an entry for this DirichletBoundary object, it
         // means there are no boundary edges active.
-        if (auto is_boundary_edge_it = sebi.is_boundary_edge_map.find(&dirichlet);
+        if (const auto is_boundary_edge_it = sebi.is_boundary_edge_map.find(&dirichlet);
             is_boundary_edge_it != sebi.is_boundary_edge_map.end())
         {
         for (unsigned int e=0; e != sebi.n_edges; ++e)
@@ -1247,7 +1247,7 @@ private:
         // current DirichletBoundary object.  In case the map does not
         // contain an entry for this DirichletBoundary object, it
         // means there are no boundary sides active.
-        if (auto is_boundary_side_it = sebi.is_boundary_side_map.find(&dirichlet);
+        if (const auto is_boundary_side_it = sebi.is_boundary_side_map.find(&dirichlet);
             is_boundary_side_it != sebi.is_boundary_side_map.end())
         {
         for (unsigned int s=0; s != sebi.n_sides; ++s)
@@ -1404,7 +1404,7 @@ private:
         // current DirichletBoundary object.  In case the map does not
         // contain an entry for this DirichletBoundary object, it
         // means there are no boundary shellfaces active.
-        if (auto is_boundary_shellface_it = sebi.is_boundary_shellface_map.find(&dirichlet);
+        if (const auto is_boundary_shellface_it = sebi.is_boundary_shellface_map.find(&dirichlet);
             is_boundary_shellface_it != sebi.is_boundary_shellface_map.end())
         {
         for (unsigned int shellface=0; shellface != 2; ++shellface)
@@ -3325,7 +3325,7 @@ void DofMap::enforce_adjoint_constraints_exactly (NumericVector<Number> & v,
       Number exact_value = 0;
       if (constraint_map)
         {
-          if (auto adjoint_constraint_it = constraint_map->find(constrained_dof);
+          if (const auto adjoint_constraint_it = constraint_map->find(constrained_dof);
               adjoint_constraint_it != constraint_map->end())
             exact_value = adjoint_constraint_it->second;
         }
@@ -3639,7 +3639,7 @@ void DofMap::build_constraint_matrix_and_vector (DenseMatrix<Number> & C,
 
             if (rhs_values)
               {
-                if (auto rhsit = rhs_values->find(elem_dofs[i]);
+                if (const auto rhsit = rhs_values->find(elem_dofs[i]);
                     rhsit != rhs_values->end())
                   H(i) = rhsit->second;
               }

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1247,12 +1247,12 @@ private:
         // current DirichletBoundary object.  In case the map does not
         // contain an entry for this DirichletBoundary object, it
         // means there are no boundary sides active.
-        auto is_boundary_side_it = sebi.is_boundary_side_map.find(&dirichlet);
-
+        if (auto is_boundary_side_it = sebi.is_boundary_side_map.find(&dirichlet);
+            is_boundary_side_it != sebi.is_boundary_side_map.end())
+        {
         for (unsigned int s=0; s != sebi.n_sides; ++s)
           {
-            if (is_boundary_side_it == sebi.is_boundary_side_map.end() ||
-                !is_boundary_side_it->second[s])
+            if (!is_boundary_side_it->second[s])
               continue;
 
             FEInterface::dofs_on_side(elem, dim, fe_type, s,
@@ -1371,6 +1371,7 @@ private:
                 dof_is_fixed[side_dofs[free_dof[i]]] = true;
               }
           } // end for (s = 0..n_sides)
+        } // end if (is_boundary_side_it != sebi.is_boundary_side_map.end())
       } // end if (dim > 1 && cont != DISCONTINUOUS)
 
         // Project any shellface values

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1089,12 +1089,12 @@ private:
         // current DirichletBoundary object.  In case the map does not
         // contain an entry for this DirichletBoundary object, it
         // means there are no boundary edges active.
-        auto is_boundary_edge_it = sebi.is_boundary_edge_map.find(&dirichlet);
-
+        if (auto is_boundary_edge_it = sebi.is_boundary_edge_map.find(&dirichlet);
+            is_boundary_edge_it != sebi.is_boundary_edge_map.end())
+        {
         for (unsigned int e=0; e != sebi.n_edges; ++e)
           {
-            if (is_boundary_edge_it == sebi.is_boundary_edge_map.end() ||
-                !is_boundary_edge_it->second[e])
+            if (!is_boundary_edge_it->second[e])
               continue;
 
             FEInterface::dofs_on_edge(elem, dim, fe_type, e,
@@ -1211,6 +1211,7 @@ private:
                 dof_is_fixed[edge_dofs[free_dof[i]]] = true;
               }
           } // end for (e = 0..n_edges)
+        } // end if (is_boundary_edge_it != sebi.is_boundary_edge_map.end())
       } // end if (dim > 2 && cont != DISCONTINUOUS)
 
         // Project any side values (edges in 2D, faces in 3D)

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -3322,10 +3322,8 @@ void DofMap::enforce_adjoint_constraints_exactly (NumericVector<Number> & v,
       Number exact_value = 0;
       if (constraint_map)
         {
-          const DofConstraintValueMap::const_iterator
-            adjoint_constraint_it =
-            constraint_map->find(constrained_dof);
-          if (adjoint_constraint_it != constraint_map->end())
+          if (auto adjoint_constraint_it = constraint_map->find(constrained_dof);
+              adjoint_constraint_it != constraint_map->end())
             exact_value = adjoint_constraint_it->second;
         }
 
@@ -3638,9 +3636,8 @@ void DofMap::build_constraint_matrix_and_vector (DenseMatrix<Number> & C,
 
             if (rhs_values)
               {
-                DofConstraintValueMap::const_iterator rhsit =
-                  rhs_values->find(elem_dofs[i]);
-                if (rhsit != rhs_values->end())
+                if (auto rhsit = rhs_values->find(elem_dofs[i]);
+                    rhsit != rhs_values->end())
                   H(i) = rhsit->second;
               }
           }

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1404,12 +1404,12 @@ private:
         // current DirichletBoundary object.  In case the map does not
         // contain an entry for this DirichletBoundary object, it
         // means there are no boundary shellfaces active.
-        auto is_boundary_shellface_it = sebi.is_boundary_shellface_map.find(&dirichlet);
-
+        if (auto is_boundary_shellface_it = sebi.is_boundary_shellface_map.find(&dirichlet);
+            is_boundary_shellface_it != sebi.is_boundary_shellface_map.end())
+        {
         for (unsigned int shellface=0; shellface != 2; ++shellface)
           {
-            if (is_boundary_shellface_it == sebi.is_boundary_shellface_map.end() ||
-                !is_boundary_shellface_it->second[shellface])
+            if (!is_boundary_shellface_it->second[shellface])
               continue;
 
             // A shellface has the same dof indices as the element itself
@@ -1526,6 +1526,7 @@ private:
                 dof_is_fixed[shellface_dofs[free_dof[i]]] = true;
               }
           } // end for (shellface = 0..2)
+        } // end if (is_boundary_shellface_it != sebi.is_boundary_shellface_map.end())
       } // end if (dim == 2 && cont != DISCONTINUOUS)
 
     // Lock the DofConstraints since it is shared among threads.

--- a/src/base/sparsity_pattern.C
+++ b/src/base/sparsity_pattern.C
@@ -436,8 +436,8 @@ void Build::join (const SparsityPattern::Build & other)
       // We should have no empty values in a map
       libmesh_assert (!their_row.empty());
 
-      NonlocalGraph::iterator my_it = nonlocal_pattern.find(p.first);
-      if (my_it == nonlocal_pattern.end())
+      if (auto my_it = nonlocal_pattern.find(p.first);
+          my_it == nonlocal_pattern.end())
         {
           //          nonlocal_pattern[it->first].swap(their_row);
           nonlocal_pattern[p.first] = their_row;

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -664,8 +664,8 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
 
       // If it's a vector we already had (and not a newly created
       // vector like an adjoint rhs), we need to restore it.
-      auto it = coarse_vectors.find(var_name);
-      if (it != coarse_vectors.end())
+      if (auto it = coarse_vectors.find(var_name);
+          it != coarse_vectors.end())
         {
           NumericVector<Number> * coarsevec = it->second.get();
           system.get_vector(var_name) = *coarsevec;

--- a/src/error_estimation/error_estimator.C
+++ b/src/error_estimation/error_estimator.C
@@ -57,7 +57,7 @@ void ErrorEstimator::estimate_errors(const EquationSystems & equation_systems,
     {
       ErrorVector system_error_per_cell;
       const System & sys = equation_systems.get_system(s);
-      if (auto it = error_norms.find(&sys);
+      if (const auto it = error_norms.find(&sys);
           it == error_norms.end())
         this->error_norm = old_error_norm;
       else

--- a/src/error_estimation/error_estimator.C
+++ b/src/error_estimation/error_estimator.C
@@ -57,10 +57,11 @@ void ErrorEstimator::estimate_errors(const EquationSystems & equation_systems,
     {
       ErrorVector system_error_per_cell;
       const System & sys = equation_systems.get_system(s);
-      if (error_norms.find(&sys) == error_norms.end())
+      if (auto it = error_norms.find(&sys);
+          it == error_norms.end())
         this->error_norm = old_error_norm;
       else
-        this->error_norm = error_norms.find(&sys)->second;
+        this->error_norm = it->second;
 
       const NumericVector<Number> * solution_vector = nullptr;
       if (solution_vectors &&

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -942,14 +942,10 @@ void AbaqusIO::read_sideset(const std::string & sideset_name,
         {
           // Create a sideset from a nodeset. This is not currently
           // supported, so print a warning and keep going.
-          auto it = _nodeset_ids.find(elem_id_or_set);
-
-          if (it != _nodeset_ids.end())
-            {
-              libMesh::out << "Warning: skipped creating a sideset from a "
-                           << "nodeset, this is not yet supported."
-                           << std::endl;
-            }
+          if (_nodeset_ids.count(elem_id_or_set))
+            libMesh::out << "Warning: skipped creating a sideset from a "
+                         << "nodeset, this is not yet supported."
+                         << std::endl;
         }
 
       // Otherwise, we assume it's a sideset of the form: "391, S2" or "Elset_1, S3".

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -76,7 +76,7 @@ void erase_if(std::multimap<Key,T> & map, Pred pred)
 template <typename Map, typename T>
 void renumber_name(Map & m, T old_id, T new_id)
 {
-  if (auto it = m.find(old_id);
+  if (const auto it = m.find(old_id);
       it != m.end())
     {
       m[new_id] = it->second;
@@ -379,7 +379,7 @@ void BoundaryInfo::regenerate_id_sets()
       const boundary_id_type id = pr.second;
       _boundary_ids.insert(id);
       _node_boundary_ids.insert(id);
-      if (auto it = old_ns_id_to_name.find(id);
+      if (const auto it = old_ns_id_to_name.find(id);
           it != old_ns_id_to_name.end())
         _ns_id_to_name.emplace(id, it->second);
     }
@@ -389,7 +389,7 @@ void BoundaryInfo::regenerate_id_sets()
       const boundary_id_type id = pr.second.second;
       _boundary_ids.insert(id);
       _edge_boundary_ids.insert(id);
-      if (auto it = old_es_id_to_name.find(id);
+      if (const auto it = old_es_id_to_name.find(id);
           it != old_es_id_to_name.end())
         _es_id_to_name.emplace(id, it->second);
     }
@@ -399,7 +399,7 @@ void BoundaryInfo::regenerate_id_sets()
       const boundary_id_type id = pr.second.second;
       _boundary_ids.insert(id);
       _side_boundary_ids.insert(id);
-      if (auto it = old_ss_id_to_name.find(id);
+      if (const auto it = old_ss_id_to_name.find(id);
           it != old_ss_id_to_name.end())
         _ss_id_to_name.emplace(id, it->second);
     }
@@ -2972,7 +2972,7 @@ void BoundaryInfo::print_summary(std::ostream & out_stream) const
 const std::string & BoundaryInfo::get_sideset_name(boundary_id_type id) const
 {
   static const std::string empty_string;
-  if (auto it = _ss_id_to_name.find(id);
+  if (const auto it = _ss_id_to_name.find(id);
       it == _ss_id_to_name.end())
     return empty_string;
   else
@@ -2988,7 +2988,7 @@ std::string & BoundaryInfo::sideset_name(boundary_id_type id)
 const std::string & BoundaryInfo::get_nodeset_name(boundary_id_type id) const
 {
   static const std::string empty_string;
-  if (auto it = _ns_id_to_name.find(id);
+  if (const auto it = _ns_id_to_name.find(id);
       it == _ns_id_to_name.end())
     return empty_string;
   else
@@ -3003,7 +3003,7 @@ std::string & BoundaryInfo::nodeset_name(boundary_id_type id)
 const std::string & BoundaryInfo::get_edgeset_name(boundary_id_type id) const
 {
   static const std::string empty_string;
-  if (auto it = _es_id_to_name.find(id);
+  if (const auto it = _es_id_to_name.find(id);
       it == _es_id_to_name.end())
     return empty_string;
   else

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -76,7 +76,7 @@ void erase_if(std::multimap<Key,T> & map, Pred pred)
 template <typename Map, typename T>
 void renumber_name(Map & m, T old_id, T new_id)
 {
-  if (const auto it = m.find(old_id);
+  if (const auto it = std::as_const(m).find(old_id);
       it != m.end())
     {
       m[new_id] = it->second;

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -76,8 +76,8 @@ void erase_if(std::multimap<Key,T> & map, Pred pred)
 template <typename Map, typename T>
 void renumber_name(Map & m, T old_id, T new_id)
 {
-  const typename Map::const_iterator it = m.find(old_id);
-  if (it != m.end())
+  if (auto it = m.find(old_id);
+      it != m.end())
     {
       m[new_id] = it->second;
       m.erase(it);
@@ -379,8 +379,8 @@ void BoundaryInfo::regenerate_id_sets()
       const boundary_id_type id = pr.second;
       _boundary_ids.insert(id);
       _node_boundary_ids.insert(id);
-      auto it = old_ns_id_to_name.find(id);
-      if (it != old_ns_id_to_name.end())
+      if (auto it = old_ns_id_to_name.find(id);
+          it != old_ns_id_to_name.end())
         _ns_id_to_name.emplace(id, it->second);
     }
 
@@ -389,8 +389,8 @@ void BoundaryInfo::regenerate_id_sets()
       const boundary_id_type id = pr.second.second;
       _boundary_ids.insert(id);
       _edge_boundary_ids.insert(id);
-      auto it = old_es_id_to_name.find(id);
-      if (it != old_es_id_to_name.end())
+      if (auto it = old_es_id_to_name.find(id);
+          it != old_es_id_to_name.end())
         _es_id_to_name.emplace(id, it->second);
     }
 
@@ -399,8 +399,8 @@ void BoundaryInfo::regenerate_id_sets()
       const boundary_id_type id = pr.second.second;
       _boundary_ids.insert(id);
       _side_boundary_ids.insert(id);
-      auto it = old_ss_id_to_name.find(id);
-      if (it != old_ss_id_to_name.end())
+      if (auto it = old_ss_id_to_name.find(id);
+          it != old_ss_id_to_name.end())
         _ss_id_to_name.emplace(id, it->second);
     }
 
@@ -2972,9 +2972,8 @@ void BoundaryInfo::print_summary(std::ostream & out_stream) const
 const std::string & BoundaryInfo::get_sideset_name(boundary_id_type id) const
 {
   static const std::string empty_string;
-  std::map<boundary_id_type, std::string>::const_iterator it =
-    _ss_id_to_name.find(id);
-  if (it == _ss_id_to_name.end())
+  if (auto it = _ss_id_to_name.find(id);
+      it == _ss_id_to_name.end())
     return empty_string;
   else
     return it->second;
@@ -2989,9 +2988,8 @@ std::string & BoundaryInfo::sideset_name(boundary_id_type id)
 const std::string & BoundaryInfo::get_nodeset_name(boundary_id_type id) const
 {
   static const std::string empty_string;
-  std::map<boundary_id_type, std::string>::const_iterator it =
-    _ns_id_to_name.find(id);
-  if (it == _ns_id_to_name.end())
+  if (auto it = _ns_id_to_name.find(id);
+      it == _ns_id_to_name.end())
     return empty_string;
   else
     return it->second;
@@ -3005,9 +3003,8 @@ std::string & BoundaryInfo::nodeset_name(boundary_id_type id)
 const std::string & BoundaryInfo::get_edgeset_name(boundary_id_type id) const
 {
   static const std::string empty_string;
-  std::map<boundary_id_type, std::string>::const_iterator it =
-    _es_id_to_name.find(id);
-  if (it == _es_id_to_name.end())
+  if (auto it = _es_id_to_name.find(id);
+      it == _es_id_to_name.end())
     return empty_string;
   else
     return it->second;

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -392,8 +392,8 @@ void CheckpointIO::write (const std::string & name)
       for (auto & elem : mesh.element_ptr_range())
         {
           const processor_id_type p = elem->processor_id();
-          auto eop_it = elements_on_pid.find(p);
-          if (eop_it != eop_end)
+          if (auto eop_it = elements_on_pid.find(p);
+              eop_it != eop_end)
             eop_it->second.push_back(elem);
         }
     }
@@ -446,8 +446,8 @@ void CheckpointIO::write (const std::string & name)
         {
           for (processor_id_type p : {my_pid, DofObject::invalid_processor_id})
             {
-              const auto elements_vec_it = elements_on_pid.find(p);
-              if (elements_vec_it != elements_on_pid.end())
+              if (auto elements_vec_it = elements_on_pid.find(p);
+                  elements_vec_it != elements_on_pid.end())
                 {
                   auto & p_elements = elements_vec_it->second;
 

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -446,7 +446,7 @@ void CheckpointIO::write (const std::string & name)
         {
           for (processor_id_type p : {my_pid, DofObject::invalid_processor_id})
             {
-              if (auto elements_vec_it = elements_on_pid.find(p);
+              if (const auto elements_vec_it = elements_on_pid.find(p);
                   elements_vec_it != elements_on_pid.end())
                 {
                   auto & p_elements = elements_vec_it->second;

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -1274,7 +1274,7 @@ DistributedMesh::renumber_dof_objects(dofobject_container<T> & objects)
   for (auto p : make_range(this->n_processors()))
     if (p != this->processor_id())
       {
-        if (auto p_it = ghost_objects_from_proc.find(p);
+        if (const auto p_it = ghost_objects_from_proc.find(p);
             p_it != ghost_end)
           requested_ids[p].reserve(p_it->second);
       }

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -445,8 +445,9 @@ Node * DistributedMesh::node_ptr (const dof_id_type i)
 
 const Node * DistributedMesh::query_node_ptr (const dof_id_type i) const
 {
-  auto it = _nodes.find(i);
-  if (it != _nodes.end())
+
+  if (auto it = _nodes.find(i);
+      it != _nodes.end())
     {
       const Node * n = *it;
       libmesh_assert (!n || n->id() == i);
@@ -461,8 +462,8 @@ const Node * DistributedMesh::query_node_ptr (const dof_id_type i) const
 
 Node * DistributedMesh::query_node_ptr (const dof_id_type i)
 {
-  auto it = _nodes.find(i);
-  if (it != _nodes.end())
+  if (auto it = _nodes.find(i);
+      it != _nodes.end())
     {
       Node * n = *it;
       libmesh_assert (!n || n->id() == i);
@@ -499,8 +500,8 @@ Elem * DistributedMesh::elem_ptr (const dof_id_type i)
 
 const Elem * DistributedMesh::query_elem_ptr (const dof_id_type i) const
 {
-  auto it = _elements.find(i);
-  if (it != _elements.end())
+  if (auto it = _elements.find(i);
+      it != _elements.end())
     {
       const Elem * e = *it;
       libmesh_assert (!e || e->id() == i);
@@ -515,8 +516,8 @@ const Elem * DistributedMesh::query_elem_ptr (const dof_id_type i) const
 
 Elem * DistributedMesh::query_elem_ptr (const dof_id_type i)
 {
-  auto it = _elements.find(i);
-  if (it != _elements.end())
+  if (auto it = _elements.find(i);
+      it != _elements.end())
     {
       Elem * e = _elements[i];
       libmesh_assert (!e || e->id() == i);
@@ -762,8 +763,8 @@ Node * DistributedMesh::add_point (const Point & p,
                                    const dof_id_type id,
                                    const processor_id_type proc_id)
 {
-  auto n_it = _nodes.find(id);
-  if (n_it != _nodes.end())
+  if (auto n_it = _nodes.find(id);
+      n_it != _nodes.end())
     {
       Node * n = *n_it;
       libmesh_assert (n);
@@ -1273,8 +1274,8 @@ DistributedMesh::renumber_dof_objects(dofobject_container<T> & objects)
   for (auto p : make_range(this->n_processors()))
     if (p != this->processor_id())
       {
-        const auto p_it = ghost_objects_from_proc.find(p);
-        if (p_it != ghost_end)
+        if (auto p_it = ghost_objects_from_proc.find(p);
+            p_it != ghost_end)
           requested_ids[p].reserve(p_it->second);
       }
 
@@ -1526,8 +1527,8 @@ void DistributedMesh::renumber_nodes_and_elements ()
               // else does, better figure out who should own it next.
               if (!used_nodes.count(n))
                 {
-                  auto it = repartitioned_node_pids.find(n);
-                  if (sender_could_become_owner)
+                  if (auto it = repartitioned_node_pids.find(n);
+                      sender_could_become_owner)
                     {
                       if (it != repartitioned_node_pids.end() &&
                           pid < it->second)

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -445,8 +445,7 @@ Node * DistributedMesh::node_ptr (const dof_id_type i)
 
 const Node * DistributedMesh::query_node_ptr (const dof_id_type i) const
 {
-
-  if (auto it = _nodes.find(i);
+  if (const auto it = _nodes.find(i);
       it != _nodes.end())
     {
       const Node * n = *it;
@@ -500,7 +499,7 @@ Elem * DistributedMesh::elem_ptr (const dof_id_type i)
 
 const Elem * DistributedMesh::query_elem_ptr (const dof_id_type i) const
 {
-  if (auto it = _elements.find(i);
+  if (const auto it = _elements.find(i);
       it != _elements.end())
     {
       const Elem * e = *it;
@@ -519,7 +518,7 @@ Elem * DistributedMesh::query_elem_ptr (const dof_id_type i)
   if (auto it = _elements.find(i);
       it != _elements.end())
     {
-      Elem * e = _elements[i];
+      Elem * e = *it;
       libmesh_assert (!e || e->id() == i);
       return e;
     }

--- a/src/mesh/dyna_io.C
+++ b/src/mesh/dyna_io.C
@@ -674,9 +674,8 @@ void DynaIO::read_mesh(std::istream & in)
                     key.emplace_back(global_node_idx, coef);
                 }
 
-              auto local_node_it = local_nodes.find(key);
-
-              if (local_node_it != local_nodes.end())
+              if (auto local_node_it = local_nodes.find(key);
+                  local_node_it != local_nodes.end())
                 elem->set_node(elem_defn.nodes[elem_node_index]) =
                   local_node_it->second;
               else

--- a/src/mesh/dyna_io.C
+++ b/src/mesh/dyna_io.C
@@ -674,7 +674,7 @@ void DynaIO::read_mesh(std::istream & in)
                     key.emplace_back(global_node_idx, coef);
                 }
 
-              if (auto local_node_it = local_nodes.find(key);
+              if (const auto local_node_it = local_nodes.find(key);
                   local_node_it != local_nodes.end())
                 elem->set_node(elem_defn.nodes[elem_node_index]) =
                   local_node_it->second;

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1066,7 +1066,7 @@ void ExodusII_IO::copy_nodal_solution(System & system,
           values.resize(query_size);
           for (std::size_t i=0; i != query_size; ++i)
             {
-              if (auto it = node_var_value_map.find(ids[i]);
+              if (const auto it = node_var_value_map.find(ids[i]);
                   it != node_var_value_map.end())
                 {
                   values[i] = it->second;
@@ -1184,7 +1184,7 @@ void ExodusII_IO::copy_elemental_solution(System & system,
           values.resize(query_size);
           for (std::size_t i=0; i != query_size; ++i)
             {
-              if (auto it = elem_var_value_map.find(ids[i]);
+              if (const auto it = elem_var_value_map.find(ids[i]);
                   it != elem_var_value_map.end())
                 {
                   values[i] = it->second;

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -580,7 +580,7 @@ void ExodusII_IO::read (const std::string & fname)
                         key.emplace_back(libmesh_node_id, coef);
                     }
 
-                  if (auto local_node_it = local_nodes.find(key);
+                  if (const auto local_node_it = local_nodes.find(key);
                       local_node_it != local_nodes.end())
                     elem->set_node(dyna_elem_defn.nodes[elem_node_index]) = local_node_it->second;
                   else

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -580,11 +580,9 @@ void ExodusII_IO::read (const std::string & fname)
                         key.emplace_back(libmesh_node_id, coef);
                     }
 
-                  auto local_node_it = local_nodes.find(key);
-
-                  if (local_node_it != local_nodes.end())
-                    elem->set_node(dyna_elem_defn.nodes[elem_node_index]) =
-                      local_node_it->second;
+                  if (auto local_node_it = local_nodes.find(key);
+                      local_node_it != local_nodes.end())
+                    elem->set_node(dyna_elem_defn.nodes[elem_node_index]) = local_node_it->second;
                   else
                     {
                       Point p(0);
@@ -1068,8 +1066,8 @@ void ExodusII_IO::copy_nodal_solution(System & system,
           values.resize(query_size);
           for (std::size_t i=0; i != query_size; ++i)
             {
-              const auto it = node_var_value_map.find(ids[i]);
-              if (it != node_var_value_map.end())
+              if (auto it = node_var_value_map.find(ids[i]);
+                  it != node_var_value_map.end())
                 {
                   values[i] = it->second;
                   node_var_value_map.erase(it);
@@ -1186,8 +1184,8 @@ void ExodusII_IO::copy_elemental_solution(System & system,
           values.resize(query_size);
           for (std::size_t i=0; i != query_size; ++i)
             {
-              const auto it = elem_var_value_map.find(ids[i]);
-              if (it != elem_var_value_map.end())
+              if (auto it = elem_var_value_map.find(ids[i]);
+                  it != elem_var_value_map.end())
                 {
                   values[i] = it->second;
                   elem_var_value_map.erase(it);

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -2665,9 +2665,8 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
 
       // Error checking: make sure that all edges in this block are
       // the same geometric type.
-      auto check_it = edge_id_to_elem_type.find(b_id);
-
-      if (check_it == edge_id_to_elem_type.end())
+      if (auto check_it = edge_id_to_elem_type.find(b_id);
+          check_it == edge_id_to_elem_type.end())
         {
           // Keep track of the ElemType and number of nodes in this boundary id.
           edge_id_to_elem_type[b_id] = std::make_pair(edge->type(), edge->n_nodes());
@@ -3074,8 +3073,8 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
           sets[i].num_distribution_factor = 0;
           sets[i].distribution_factor_list = nullptr;
 
-          auto elem_it = elem_lists.find(ss_id);
-          if (elem_it == elem_lists.end())
+          if (auto elem_it = elem_lists.find(ss_id);
+              elem_it == elem_lists.end())
             {
               sets[i].num_entry = 0;
               sets[i].entry_list = nullptr;

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -2665,7 +2665,7 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
 
       // Error checking: make sure that all edges in this block are
       // the same geometric type.
-      if (auto check_it = edge_id_to_elem_type.find(b_id);
+      if (const auto check_it = edge_id_to_elem_type.find(b_id);
           check_it == edge_id_to_elem_type.end())
         {
           // Keep track of the ElemType and number of nodes in this boundary id.
@@ -2674,7 +2674,7 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
       else
         {
           // Make sure the existing data is consistent
-          auto & val_pair = check_it->second;
+          const auto & val_pair = check_it->second;
           libmesh_error_msg_if(val_pair.first != edge->type() || val_pair.second != edge->n_nodes(),
                                "All edges in a block must have same geometric type.");
         }
@@ -3073,7 +3073,7 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
           sets[i].num_distribution_factor = 0;
           sets[i].distribution_factor_list = nullptr;
 
-          if (auto elem_it = elem_lists.find(ss_id);
+          if (const auto elem_it = elem_lists.find(ss_id);
               elem_it == elem_lists.end())
             {
               sets[i].num_entry = 0;

--- a/src/mesh/fro_io.C
+++ b/src/mesh/fro_io.C
@@ -166,7 +166,7 @@ void FroIO::write (const std::string & fname)
                   back_node  = node_list.back();
 
                 // look for front_pair in the backward_edges list
-                if (auto pos = backward_edges.find(front_node);
+                if (const auto pos = backward_edges.find(front_node);
                     pos != backward_edges.end())
                   {
                     node_list.push_front(pos->second);
@@ -174,7 +174,7 @@ void FroIO::write (const std::string & fname)
                   }
 
                 // look for back_pair in the forward_edges list
-                if (auto pos = forward_edges.find(back_node);
+                if (const auto pos = forward_edges.find(back_node);
                     pos != forward_edges.end())
                   {
                     node_list.push_back(pos->second);

--- a/src/mesh/fro_io.C
+++ b/src/mesh/fro_io.C
@@ -166,28 +166,20 @@ void FroIO::write (const std::string & fname)
                   back_node  = node_list.back();
 
                 // look for front_pair in the backward_edges list
-                {
-                  auto pos = backward_edges.find(front_node);
-
-                  if (pos != backward_edges.end())
-                    {
-                      node_list.push_front(pos->second);
-
-                      backward_edges.erase(pos);
-                    }
-                }
+                if (auto pos = backward_edges.find(front_node);
+                    pos != backward_edges.end())
+                  {
+                    node_list.push_front(pos->second);
+                    backward_edges.erase(pos);
+                  }
 
                 // look for back_pair in the forward_edges list
-                {
-                  auto pos = forward_edges.find(back_node);
-
-                  if (pos != forward_edges.end())
-                    {
-                      node_list.push_back(pos->second);
-
-                      forward_edges.erase(pos);
-                    }
-                }
+                if (auto pos = forward_edges.find(back_node);
+                    pos != forward_edges.end())
+                  {
+                    node_list.push_back(pos->second);
+                    forward_edges.erase(pos);
+                  }
               }
 
             out_stream << ++bc_id << " " << node_list.size() << '\n';

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -288,7 +288,7 @@ bool MeshBase::locally_equals (const MeshBase & other_mesh) const
     }
 
   for (const auto & [elemset_code, elemset_ptr] : this->_elemset_codes)
-    if (auto it = other_mesh._elemset_codes.find(elemset_code);
+    if (const auto it = other_mesh._elemset_codes.find(elemset_code);
         it == other_mesh._elemset_codes.end() || *elemset_ptr != *it->second)
       return false;
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -380,7 +380,7 @@ void MeshBase::get_elemsets(dof_id_type elemset_code, MeshBase::elemset_type & i
   // If we don't recognize this elemset_code, hand back an empty set
   id_set_to_fill.clear();
 
-  if (auto it = _elemset_codes.find(elemset_code);
+  if (const auto it = _elemset_codes.find(elemset_code);
       it != _elemset_codes.end())
     id_set_to_fill.insert(it->second->begin(), it->second->end());
 }
@@ -546,7 +546,7 @@ std::vector<unsigned int> MeshBase::add_elem_integers(const std::vector<std::str
   for (auto i : index_range(names))
     {
       const std::string & name = names[i];
-      if (auto it = name_indices.find(name);
+      if (const auto it = name_indices.find(name);
           it != name_indices.end())
         {
           returnval[i] = it->second;
@@ -635,7 +635,7 @@ std::vector<unsigned int> MeshBase::add_node_integers(const std::vector<std::str
   for (auto i : index_range(names))
     {
       const std::string & name = names[i];
-      if (auto it = name_indices.find(name);
+      if (const auto it = name_indices.find(name);
           it != name_indices.end())
         {
           returnval[i] = it->second;
@@ -886,7 +886,7 @@ void MeshBase::remove_ghosting_functor(GhostingFunctor & ghosting_functor)
 {
   _ghosting_functors.erase(&ghosting_functor);
 
-  if (auto it = _shared_functors.find(&ghosting_functor);
+  if (const auto it = _shared_functors.find(&ghosting_functor);
       it != _shared_functors.end())
     _shared_functors.erase(it);
 }
@@ -1623,7 +1623,7 @@ const std::string & MeshBase::subdomain_name(subdomain_id_type id) const
   // An empty string to return when no matching subdomain name is found
   static const std::string empty;
 
-  if (auto iter = _block_id_to_name.find(id);
+  if (const auto iter = _block_id_to_name.find(id);
       iter == _block_id_to_name.end())
     return empty;
   else

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -208,9 +208,9 @@ void connect_families(std::set<const Elem *, CompareElemIdsByLevel> & connected_
         {
           for (const Node & node : elem->node_ref_range())
             {
-              auto it = constraint_rows.find(&node);
               // Retain all elements containing constraining nodes
-              if (it != constraint_rows.end())
+              if (auto it = constraint_rows.find(&node);
+                  it != constraint_rows.end())
                 for (auto & p : it->second)
                   {
                     const Elem * constraining_elem = p.first.first;
@@ -949,9 +949,8 @@ void MeshCommunication::send_coarse_ghosts(MeshBase & mesh) const
       std::set<const Elem *, CompareElemIdsByLevel> elements_to_send;
       std::set<const Node *> nodes_to_send;
 
-      const ghost_map::const_iterator it =
-        coarsening_elements_to_ghost.find(p);
-      if (it != coarsening_elements_to_ghost.end())
+      if (auto it = coarsening_elements_to_ghost.find(p);
+          it != coarsening_elements_to_ghost.end())
         {
           const std::vector<Elem *> & elems = it->second;
           libmesh_assert(elems.size());

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -209,7 +209,7 @@ void connect_families(std::set<const Elem *, CompareElemIdsByLevel> & connected_
           for (const Node & node : elem->node_ref_range())
             {
               // Retain all elements containing constraining nodes
-              if (auto it = constraint_rows.find(&node);
+              if (const auto it = constraint_rows.find(&node);
                   it != constraint_rows.end())
                 for (auto & p : it->second)
                   {

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -949,7 +949,7 @@ void MeshCommunication::send_coarse_ghosts(MeshBase & mesh) const
       std::set<const Elem *, CompareElemIdsByLevel> elements_to_send;
       std::set<const Node *> nodes_to_send;
 
-      if (auto it = coarsening_elements_to_ghost.find(p);
+      if (const auto it = std::as_const(coarsening_elements_to_ghost).find(p);
           it != coarsening_elements_to_ghost.end())
         {
           const std::vector<Elem *> & elems = it->second;

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -161,7 +161,7 @@ Node * MeshRefinement::add_node(Elem & parent,
   // We'll leave the processor_id untouched in this case - if we're
   // repartitioning later or if this is a new unpartitioned node,
   // we'll update it then, and if not then we don't want to update it.
-  if (auto new_node_id = _new_nodes_map.find(bracketing_nodes);
+  if (const auto new_node_id = _new_nodes_map.find(bracketing_nodes);
       new_node_id != DofObject::invalid_id)
     return _mesh.node_ptr(new_node_id);
 

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -156,15 +156,13 @@ Node * MeshRefinement::add_node(Elem & parent,
   // one pair of parent nodes
   libmesh_assert(bracketing_nodes.size());
 
-  const dof_id_type new_node_id =
-    _new_nodes_map.find(bracketing_nodes);
-
   // Return the node if it already exists.
   //
   // We'll leave the processor_id untouched in this case - if we're
   // repartitioning later or if this is a new unpartitioned node,
   // we'll update it then, and if not then we don't want to update it.
-  if (new_node_id != DofObject::invalid_id)
+  if (auto new_node_id = _new_nodes_map.find(bracketing_nodes);
+      new_node_id != DofObject::invalid_id)
     return _mesh.node_ptr(new_node_id);
 
   // Otherwise we need to add a new node.

--- a/src/mesh/mesh_refinement_smoothing.C
+++ b/src/mesh/mesh_refinement_smoothing.C
@@ -181,19 +181,17 @@ bool MeshRefinement::limit_level_mismatch_at_edge (const unsigned int max_mismat
               std::pair<unsigned int, unsigned int> edge_key =
                 std::make_pair(node0, node1);
 
-              if (max_level_at_edge.find(edge_key) ==
-                  max_level_at_edge.end())
-                {
-                  max_level_at_edge[edge_key] = elem_level;
-                  max_p_level_at_edge[edge_key] = elem_p_level;
-                }
-              else
-                {
-                  max_level_at_edge[edge_key] =
-                    std::max (max_level_at_edge[edge_key], elem_level);
-                  max_p_level_at_edge[edge_key] =
-                    std::max (max_p_level_at_edge[edge_key], elem_p_level);
-                }
+              // Try emplacing (edge_key, elem_level) into max_level_at_edge map.
+              // If emplacing fails, it means the edge_key already existed, so
+              // we need to take the max of the previous and current values.
+              if (auto [it, emplaced] = max_level_at_edge.emplace(edge_key, elem_level);
+                  !emplaced)
+                it->second = std::max(it->second, elem_level);
+
+              // Same thing for p_level
+              if (auto [it, emplaced] = max_p_level_at_edge.emplace(edge_key, elem_p_level);
+                  !emplaced)
+                it->second = std::max(it->second, elem_p_level);
             }
         }
     }

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -2305,7 +2305,7 @@ void correct_node_proc_ids (MeshBase & mesh)
     {
       for (const auto & [id, pid] : data)
         {
-          if (auto it = new_proc_ids.find(id);
+          if (const auto it = new_proc_ids.find(id);
               it == new_proc_ids.end())
             new_proc_ids.emplace(id, pid);
           else
@@ -2325,7 +2325,7 @@ void correct_node_proc_ids (MeshBase & mesh)
   // lest we get them confused with nodes we newly own.
   std::unordered_set<Node *> ex_local_nodes;
   for (auto & node : mesh.local_node_ptr_range())
-    if (auto it = new_proc_ids.find(node->id());
+    if (const auto it = new_proc_ids.find(node->id());
         it != new_proc_ids.end() && it->second != mesh.processor_id())
       ex_local_nodes.insert(node);
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -2294,7 +2294,7 @@ void correct_node_proc_ids (MeshBase & mesh)
     ids_to_push;
 
   for (const auto & node : mesh.node_ptr_range())
-    if (const auto it = new_proc_ids.find(node->id());
+    if (const auto it = std::as_const(new_proc_ids).find(node->id());
         it != new_proc_ids.end() && node->processor_id() != DofObject::invalid_processor_id)
       ids_to_push[node->processor_id()].emplace_back(node->id(), /*pid=*/it->second);
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -2188,7 +2188,7 @@ struct SyncProcIdsFromMap
 
         // Return the node's new processor id if it has one, or its
         // old processor id if not.
-        if (auto it = new_proc_ids.find(id);
+        if (const auto it = new_proc_ids.find(id);
             it != new_proc_ids.end())
           data[i] = it->second;
         else
@@ -2294,7 +2294,7 @@ void correct_node_proc_ids (MeshBase & mesh)
     ids_to_push;
 
   for (const auto & node : mesh.node_ptr_range())
-    if (auto it = new_proc_ids.find(node->id());
+    if (const auto it = new_proc_ids.find(node->id());
         it != new_proc_ids.end() && node->processor_id() != DofObject::invalid_processor_id)
       ids_to_push[node->processor_id()].emplace_back(node->id(), /*pid=*/it->second);
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -2118,7 +2118,7 @@ struct SyncNodeSet
         Node * node = mesh.node_ptr(id);
 
         // Return if the node is in the set.
-        data[i] = (node_set.find(node) != node_set.end());
+        data[i] = node_set.count(node);
       }
   }
 
@@ -2185,11 +2185,11 @@ struct SyncProcIdsFromMap
     for (auto i : index_range(ids))
       {
         const dof_id_type id = ids[i];
-        const proc_id_map_type::const_iterator it = new_proc_ids.find(id);
 
         // Return the node's new processor id if it has one, or its
         // old processor id if not.
-        if (it != new_proc_ids.end())
+        if (auto it = new_proc_ids.find(id);
+            it != new_proc_ids.end())
           data[i] = it->second;
         else
           {
@@ -2281,8 +2281,8 @@ void correct_node_proc_ids (MeshBase & mesh)
       for (auto & node : elem->node_ref_range())
         {
           const dof_id_type id = node.id();
-          const proc_id_map_type::iterator it = new_proc_ids.find(id);
-          if (it == new_proc_ids.end())
+          if (auto it = new_proc_ids.find(id);
+              it == new_proc_ids.end())
             new_proc_ids.emplace(id, pid);
           else
             it->second = node.choose_processor_id(it->second, pid);
@@ -2294,15 +2294,9 @@ void correct_node_proc_ids (MeshBase & mesh)
     ids_to_push;
 
   for (const auto & node : mesh.node_ptr_range())
-    {
-      const dof_id_type id = node->id();
-      const proc_id_map_type::iterator it = new_proc_ids.find(id);
-      if (it == new_proc_ids.end())
-        continue;
-      const processor_id_type pid = it->second;
-      if (node->processor_id() != DofObject::invalid_processor_id)
-        ids_to_push[node->processor_id()].emplace_back(id, pid);
-    }
+    if (auto it = new_proc_ids.find(node->id());
+        it != new_proc_ids.end() && node->processor_id() != DofObject::invalid_processor_id)
+      ids_to_push[node->processor_id()].emplace_back(node->id(), /*pid=*/it->second);
 
   auto action_functor =
     [& mesh, & new_proc_ids]
@@ -2311,8 +2305,8 @@ void correct_node_proc_ids (MeshBase & mesh)
     {
       for (const auto & [id, pid] : data)
         {
-          const proc_id_map_type::iterator it = new_proc_ids.find(id);
-          if (it == new_proc_ids.end())
+          if (auto it = new_proc_ids.find(id);
+              it == new_proc_ids.end())
             new_proc_ids.emplace(id, pid);
           else
             {
@@ -2331,11 +2325,9 @@ void correct_node_proc_ids (MeshBase & mesh)
   // lest we get them confused with nodes we newly own.
   std::unordered_set<Node *> ex_local_nodes;
   for (auto & node : mesh.local_node_ptr_range())
-    {
-      const proc_id_map_type::iterator it = new_proc_ids.find(node->id());
-      if (it != new_proc_ids.end() && it->second != mesh.processor_id())
-        ex_local_nodes.insert(node);
-    }
+    if (auto it = new_proc_ids.find(node->id());
+        it != new_proc_ids.end() && it->second != mesh.processor_id())
+      ex_local_nodes.insert(node);
 
   SyncProcIdsFromMap sync(new_proc_ids, mesh);
   if (repartition_all_nodes)

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -2009,7 +2009,7 @@ void Nemesis_IO_Helper::write_nodesets(const MeshBase & mesh)
           */
 
           // Try to find this boundary ID in the local list we created
-          if (auto it = local_node_boundary_id_lists.find (cast_int<boundary_id_type>(nodeset_id));
+          if (const auto it = local_node_boundary_id_lists.find (cast_int<boundary_id_type>(nodeset_id));
               it == local_node_boundary_id_lists.end())
             {
               // No nodes found for this boundary ID on this processor
@@ -2029,7 +2029,7 @@ void Nemesis_IO_Helper::write_nodesets(const MeshBase & mesh)
           else // Boundary ID *was* found in list
             {
               // Get reference to the vector of node IDs
-              std::vector<int> & current_nodeset_ids = it->second;
+              const std::vector<int> & current_nodeset_ids = it->second;
 
               // Call the Exodus interface to write the parameters of this node set
               this->ex_err = exII::ex_put_node_set_param(this->ex_id,
@@ -2144,7 +2144,7 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
             }
 
           // Try to find this boundary ID in the local list we created
-          if (auto it = local_elem_boundary_id_lists.find (cast_int<boundary_id_type>(exodus_id));
+          if (const auto it = local_elem_boundary_id_lists.find (cast_int<boundary_id_type>(exodus_id));
               it == local_elem_boundary_id_lists.end())
             {
               // No sides found for this boundary ID on this processor
@@ -2164,7 +2164,7 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
           else // Boundary ID *was* found in list
             {
               // Get reference to the vector of elem IDs
-              std::vector<int> & current_sideset_elem_ids = it->second;
+              const std::vector<int> & current_sideset_elem_ids = it->second;
 
               // Get reference to the vector of side IDs
               std::vector<int> & current_sideset_side_ids =
@@ -2283,7 +2283,7 @@ void Nemesis_IO_Helper::write_elements(const MeshBase & mesh, bool /*use_discont
             (mesh.subdomain_name(cast_int<subdomain_id_type>(this->global_elem_blk_ids[i])));
 
           // Search for the current global block ID in the map
-          if (auto it = this->block_id_to_elem_connectivity.find( this->global_elem_blk_ids[i] );
+          if (const auto it = this->block_id_to_elem_connectivity.find( this->global_elem_blk_ids[i] );
               it == this->block_id_to_elem_connectivity.end())
             {
               // If not found, write a zero to file....
@@ -2302,7 +2302,7 @@ void Nemesis_IO_Helper::write_elements(const MeshBase & mesh, bool /*use_discont
             {
               subdomain_id_type block =
                 cast_int<subdomain_id_type>(it->first);
-              std::vector<int> & this_block_connectivity = it->second;
+              const std::vector<int> & this_block_connectivity = it->second;
               std::vector<dof_id_type> & elements_in_this_block = subdomain_map[block];
 
               // Use the first element in this block to get representative information.

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -1947,7 +1947,7 @@ void Nemesis_IO_Helper::write_nodesets(const MeshBase & mesh)
     {
       // Don't try to grab a reference to the vector unless the current node is attached
       // to a local element.  Otherwise, another processor will be responsible for writing it in its nodeset.
-      if (auto it = this->libmesh_node_num_to_exodus.find(std::get<0>(t));
+      if (const auto it = this->libmesh_node_num_to_exodus.find(std::get<0>(t));
           it != this->libmesh_node_num_to_exodus.end())
         {
           // Get reference to the vector where this node ID will be inserted.  If it

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -1947,9 +1947,8 @@ void Nemesis_IO_Helper::write_nodesets(const MeshBase & mesh)
     {
       // Don't try to grab a reference to the vector unless the current node is attached
       // to a local element.  Otherwise, another processor will be responsible for writing it in its nodeset.
-      const auto it = this->libmesh_node_num_to_exodus.find(std::get<0>(t));
-
-      if (it != this->libmesh_node_num_to_exodus.end())
+      if (auto it = this->libmesh_node_num_to_exodus.find(std::get<0>(t));
+          it != this->libmesh_node_num_to_exodus.end())
         {
           // Get reference to the vector where this node ID will be inserted.  If it
           // doesn't yet exist, this will create it.
@@ -2010,12 +2009,10 @@ void Nemesis_IO_Helper::write_nodesets(const MeshBase & mesh)
           */
 
           // Try to find this boundary ID in the local list we created
-          auto it =
-            local_node_boundary_id_lists.find (cast_int<boundary_id_type>(nodeset_id));
-
-          // No nodes found for this boundary ID on this processor
-          if (it == local_node_boundary_id_lists.end())
+          if (auto it = local_node_boundary_id_lists.find (cast_int<boundary_id_type>(nodeset_id));
+              it == local_node_boundary_id_lists.end())
             {
+              // No nodes found for this boundary ID on this processor
               if (verbose)
                 libMesh::out << "[" << this->processor_id()
                              << "] No nodeset data for ID: " << nodeset_id
@@ -2147,12 +2144,10 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
             }
 
           // Try to find this boundary ID in the local list we created
-          auto it =
-            local_elem_boundary_id_lists.find (cast_int<boundary_id_type>(exodus_id));
-
-          // No sides found for this boundary ID on this processor
-          if (it == local_elem_boundary_id_lists.end())
+          if (auto it = local_elem_boundary_id_lists.find (cast_int<boundary_id_type>(exodus_id));
+              it == local_elem_boundary_id_lists.end())
             {
+              // No sides found for this boundary ID on this processor
               if (verbose)
                 libMesh::out << "[" << this->processor_id()
                              << "] No sideset data for ID: " << exodus_id
@@ -2288,12 +2283,10 @@ void Nemesis_IO_Helper::write_elements(const MeshBase & mesh, bool /*use_discont
             (mesh.subdomain_name(cast_int<subdomain_id_type>(this->global_elem_blk_ids[i])));
 
           // Search for the current global block ID in the map
-          std::map<int, std::vector<int>>::iterator it =
-            this->block_id_to_elem_connectivity.find( this->global_elem_blk_ids[i] );
-
-          // If not found, write a zero to file....
-          if (it == this->block_id_to_elem_connectivity.end())
+          if (auto it = this->block_id_to_elem_connectivity.find( this->global_elem_blk_ids[i] );
+              it == this->block_id_to_elem_connectivity.end())
             {
+              // If not found, write a zero to file....
               this->ex_err = exII::ex_put_elem_block(this->ex_id,
                                                      this->global_elem_blk_ids[i],
                                                      "Empty",

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -602,7 +602,7 @@ void Poly2TriTriangulator::triangulate_current_points()
       for (auto & node : _mesh.node_ptr_range())
         {
           const p2t::Point pt = to_p2t(*node);
-          if (auto it = point_node_map.find(pt);
+          if (const auto it = point_node_map.find(pt);
               it == point_node_map.end())
             {
               steiner_points.insert(pt);
@@ -1112,7 +1112,7 @@ bool Poly2TriTriangulator::insert_refinement_points()
                     (Elem * new_neigh, boundary_id_type bcid)
                   {
                     // Set clockwise neighbor and vice-versa if possible
-                    if (auto CW_it = neighbors_CW.find(node_CW);
+                    if (const auto CW_it = neighbors_CW.find(node_CW);
                         CW_it == neighbors_CW.end())
                       {
                         libmesh_assert(!neighbors_CCW.count(node_CW));
@@ -1139,7 +1139,7 @@ bool Poly2TriTriangulator::insert_refinement_points()
                       }
 
                     // Set counter-CW neighbor and vice-versa if possible
-                    if (auto CCW_it = neighbors_CCW.find(node_CCW);
+                    if (const auto CCW_it = neighbors_CCW.find(node_CCW);
                         CCW_it == neighbors_CCW.end())
                       {
                         libmesh_assert(!neighbors_CW.count(node_CCW));
@@ -1219,7 +1219,7 @@ bool Poly2TriTriangulator::insert_refinement_points()
       // elements!) it's safe to delete them.
       for (Elem * old_elem : cavity)
         {
-          if (auto it = new_elems.find(old_elem);
+          if (const auto it = new_elems.find(old_elem);
               it == new_elems.end())
             mesh.delete_elem(old_elem);
           else
@@ -1329,13 +1329,13 @@ bool Poly2TriTriangulator::insert_refinement_points()
 
           auto old_it  = old_segments.begin();
 
-          Node * node = _mesh.node_ptr(old_it->first);
-          Node * const first_node = node;
+          const Node * node = _mesh.node_ptr(old_it->first);
+          const Node * const first_node = node;
 
           do
             {
               const dof_id_type node_id = node->id();
-              if (auto it = next_boundary_node.find(*node);
+              if (const auto it = next_boundary_node.find(*node);
                   it == next_boundary_node.end())
                 {
                   while (node_id != old_it->first)

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -602,10 +602,8 @@ void Poly2TriTriangulator::triangulate_current_points()
       for (auto & node : _mesh.node_ptr_range())
         {
           const p2t::Point pt = to_p2t(*node);
-
-          auto it = point_node_map.find(pt);
-
-          if (it == point_node_map.end())
+          if (auto it = point_node_map.find(pt);
+              it == point_node_map.end())
             {
               steiner_points.insert(pt);
               point_node_map.emplace(pt, node);
@@ -921,8 +919,8 @@ bool Poly2TriTriangulator::insert_refinement_points()
         libmesh_assert(old_segment_end);
         libmesh_assert(old_segment_end->valid_id());
 
-        auto it = next_boundary_node.find(*old_segment_start);
-        if (it != next_boundary_node.end())
+        if (auto it = next_boundary_node.find(*old_segment_start);
+            it != next_boundary_node.end())
           {
             libmesh_assert(it->second == old_segment_end);
             it->second = new_node;
@@ -1075,13 +1073,7 @@ bool Poly2TriTriangulator::insert_refinement_points()
               for (auto s : make_range(3u))
                 {
                   Elem * neigh = checking_elem->neighbor_ptr(s);
-                  if (!neigh)
-                    continue;
-                  if (checking_cavity.find(neigh) !=
-                      checking_cavity.end())
-                    continue;
-                  if (cavity.find(neigh) !=
-                      cavity.end())
+                  if (!neigh || checking_cavity.count(neigh) || cavity.count(neigh))
                     continue;
 
                   if (in_circumcircle(*neigh, new_pt, TOLERANCE*TOLERANCE))
@@ -1120,8 +1112,8 @@ bool Poly2TriTriangulator::insert_refinement_points()
                     (Elem * new_neigh, boundary_id_type bcid)
                   {
                     // Set clockwise neighbor and vice-versa if possible
-                    auto CW_it = neighbors_CW.find(node_CW);
-                    if (CW_it == neighbors_CW.end())
+                    if (auto CW_it = neighbors_CW.find(node_CW);
+                        CW_it == neighbors_CW.end())
                       {
                         libmesh_assert(!neighbors_CCW.count(node_CW));
                         neighbors_CCW[node_CW] = std::make_pair(new_neigh, bcid);
@@ -1147,8 +1139,8 @@ bool Poly2TriTriangulator::insert_refinement_points()
                       }
 
                     // Set counter-CW neighbor and vice-versa if possible
-                    auto CCW_it = neighbors_CCW.find(node_CCW);
-                    if (CCW_it == neighbors_CCW.end())
+                    if (auto CCW_it = neighbors_CCW.find(node_CCW);
+                        CCW_it == neighbors_CCW.end())
                       {
                         libmesh_assert(!neighbors_CW.count(node_CCW));
                         neighbors_CW[node_CCW] = std::make_pair(new_neigh, bcid);
@@ -1224,11 +1216,11 @@ bool Poly2TriTriangulator::insert_refinement_points()
 
       // Now that we're done using our cavity elems (including with a
       // cavity.find() that used a comparator that dereferences the
-      // elmeents!) it's safe to delete them.
+      // elements!) it's safe to delete them.
       for (Elem * old_elem : cavity)
         {
-          auto it = new_elems.find(old_elem);
-          if (it == new_elems.end())
+          if (auto it = new_elems.find(old_elem);
+              it == new_elems.end())
             mesh.delete_elem(old_elem);
           else
             new_elems.erase(it);
@@ -1343,8 +1335,8 @@ bool Poly2TriTriangulator::insert_refinement_points()
           do
             {
               const dof_id_type node_id = node->id();
-              auto it = next_boundary_node.find(*node);
-              if (it == next_boundary_node.end())
+              if (auto it = next_boundary_node.find(*node);
+                  it == next_boundary_node.end())
                 {
                   while (node_id != old_it->first)
                     {

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -805,7 +805,7 @@ void ReplicatedMesh::renumber_nodes_and_elements ()
             Node * & nd = *in;
 
             // If this node is still connected to an elem, put it in the list
-            if (connected_nodes.find(nd) != connected_nodes.end())
+            if (connected_nodes.count(nd))
               {
                 *out_iter = nd;
                 ++out_iter;
@@ -1011,7 +1011,7 @@ ReplicatedMesh::get_boundary_points() const
     while (true)
     {
       std::pair<const Elem *, unsigned int> side(elem, s);
-      libmesh_assert(boundary_elements.find(side) != boundary_elements.end());
+      libmesh_assert(boundary_elements.count(side));
       boundary_elements.erase(side);
 
       // push all nodes on the side except the node on the other end of the side (index 1)

--- a/src/mesh/triangulator_interface.C
+++ b/src/mesh/triangulator_interface.C
@@ -357,7 +357,7 @@ void TriangulatorInterface::increase_triangle_order()
 
           const Point & p = elem->point(n);
 
-          if (auto it = all_midpoints.find({p,0});
+          if (const auto it = all_midpoints.find({p,0});
               it != all_midpoints.end())
             elem->point(n+3) = it->second;
         }

--- a/src/mesh/triangulator_interface.C
+++ b/src/mesh/triangulator_interface.C
@@ -356,8 +356,9 @@ void TriangulatorInterface::increase_triangle_order()
             continue;
 
           const Point & p = elem->point(n);
-          auto it = all_midpoints.find({p,0});
-          if (it != all_midpoints.end())
+
+          if (auto it = all_midpoints.find({p,0});
+              it != all_midpoints.end())
             elem->point(n+3) = it->second;
         }
     }

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -2115,7 +2115,7 @@ UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
           // For that we will use the reverse mapping we created at
           // the same time as the forward mapping.
           for (auto & n : el->node_ref_range())
-            if (auto it = other_to_this_node_map.find(/*other_node_id=*/n.id());
+            if (const auto it = other_to_this_node_map.find(/*other_node_id=*/n.id());
                 it != other_to_this_node_map.end())
               node_to_elems_map[/*this_node_id=*/it->second].push_back( el->id() );
         }
@@ -2240,7 +2240,7 @@ UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
               // The same name with the same id means we're fine.  The
               // same name with another id means we remap their id to
               // ours
-              if (auto other_reverse_it = other_map_reversed.find(sname);
+              if (const auto other_reverse_it = other_map_reversed.find(sname);
                   other_reverse_it != other_map_reversed.end() && other_reverse_it->second != sid)
                 id_remapping[other_reverse_it->second] = sid;
 
@@ -2267,8 +2267,7 @@ UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
               // At this point we've figured out any remapping
               // necessary for an sname that we share.  And we don't
               // need to remap any sid we don't share.
-              if (auto reverse_it = this_map_reversed.find(sname);
-                  reverse_it == this_map_reversed.end())
+              if (!this_map_reversed.count(sname))
                 {
                   // But if we don't have this sname and we do have this
                   // sid then we can't just merge into that.

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -248,8 +248,8 @@ void transfer_elem(Elem & lo_elem,
   if (interior_p)
     hi_elem->set_interior_parent(interior_p);
 
-  auto parent_exterior_it = exterior_children_of.find(interior_p);
-  if (parent_exterior_it != exterior_children_of.end())
+  if (auto parent_exterior_it = exterior_children_of.find(interior_p);
+      parent_exterior_it != exterior_children_of.end())
     {
       auto & exteriors = parent_exterior_it->second;
       for (std::size_t i : index_range(exteriors))
@@ -264,8 +264,8 @@ void transfer_elem(Elem & lo_elem,
    * If we had interior_parent() links to the old element, transfer
    * them to the new element.
    */
-  auto exterior_it = exterior_children_of.find(&lo_elem);
-  if (exterior_it != exterior_children_of.end())
+  if (auto exterior_it = exterior_children_of.find(&lo_elem);
+      exterior_it != exterior_children_of.end())
     {
       for (Elem * exterior_elem : exterior_it->second)
         {
@@ -481,12 +481,9 @@ all_increased_order_range (UnstructuredMesh & mesh,
    * need to upgrade later.
    */
   for (auto & elem : mesh.element_ptr_range())
-    {
-      Elem * interior_parent = elem->interior_parent();
-      auto exterior_map_it = exterior_children_of.find(interior_parent);
-      if (exterior_map_it != exterior_children_of.end())
-        exterior_map_it->second.push_back(elem);
-    }
+    if (auto exterior_map_it = exterior_children_of.find(elem->interior_parent());
+        exterior_map_it != exterior_children_of.end())
+      exterior_map_it->second.push_back(elem);
 
   /**
    * Loop over the low-ordered elements in the _elements vector.
@@ -2118,17 +2115,9 @@ UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
           // For that we will use the reverse mapping we created at
           // the same time as the forward mapping.
           for (auto & n : el->node_ref_range())
-            {
-              dof_id_type other_node_id = n.id();
-              std::map<dof_id_type, dof_id_type>::iterator it =
-                other_to_this_node_map.find(other_node_id);
-
-              if (it != other_to_this_node_map.end())
-                {
-                  dof_id_type this_node_id = it->second;
-                  node_to_elems_map[this_node_id].push_back( el->id() );
-                }
-            }
+            if (auto it = other_to_this_node_map.find(/*other_node_id=*/n.id());
+                it != other_to_this_node_map.end())
+              node_to_elems_map[/*this_node_id=*/it->second].push_back( el->id() );
         }
 
       if (verbose)
@@ -2248,16 +2237,12 @@ UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
 
           for (auto & [sid, sname] : this_map)
             {
-              auto other_reverse_it = other_map_reversed.find(sname);
-
               // The same name with the same id means we're fine.  The
               // same name with another id means we remap their id to
               // ours
-              if (other_reverse_it != other_map_reversed.end())
-                {
-                  if (other_reverse_it->second != sid)
-                    id_remapping[other_reverse_it->second] = sid;
-                }
+              if (auto other_reverse_it = other_map_reversed.find(sname);
+                  other_reverse_it != other_map_reversed.end() && other_reverse_it->second != sid)
+                id_remapping[other_reverse_it->second] = sid;
 
               // The same id with a different name, we'll get to
               // later.  The same id without any name means we don't
@@ -2279,12 +2264,11 @@ UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
 
           for (auto & [sid, sname] : other_map)
             {
-              auto reverse_it = this_map_reversed.find(sname);
-
               // At this point we've figured out any remapping
               // necessary for an sname that we share.  And we don't
               // need to remap any sid we don't share.
-              if (reverse_it == this_map_reversed.end())
+              if (auto reverse_it = this_map_reversed.find(sname);
+                  reverse_it == this_map_reversed.end())
                 {
                   // But if we don't have this sname and we do have this
                   // sid then we can't just merge into that.
@@ -2472,7 +2456,7 @@ UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
           for (std::size_t i=0; i<n_elems; i++)
             {
               dof_id_type elem_id = pr.second[i];
-              if (fixed_elems.find(elem_id) == fixed_elems.end())
+              if (!fixed_elems.count(elem_id))
                 {
                   Elem * el = this->elem_ptr(elem_id);
                   fixed_elems.insert(elem_id);

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -497,8 +497,8 @@ void UNVIO::groups_in (std::istream & in_file)
                            << std::endl;
 
             // Try to find this ID in the map from UNV element ids to libmesh ids.
-            auto it = _unv_elem_id_to_libmesh_elem_id.find(entity_tag);
-            if (it != _unv_elem_id_to_libmesh_elem_id.end())
+            if (auto it = _unv_elem_id_to_libmesh_elem_id.find(entity_tag);
+                it != _unv_elem_id_to_libmesh_elem_id.end())
               {
                 unsigned libmesh_elem_id = it->second;
 
@@ -1318,9 +1318,8 @@ void UNVIO::read_dataset(std::string file_name)
 const std::vector<Number> *
 UNVIO::get_data (Node * node) const
 {
-  auto it = _node_data.find(node);
-
-  if (it == _node_data.end())
+  if (auto it = _node_data.find(node);
+      it == _node_data.end())
     return nullptr;
   else
     return &(it->second);

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -497,7 +497,7 @@ void UNVIO::groups_in (std::istream & in_file)
                            << std::endl;
 
             // Try to find this ID in the map from UNV element ids to libmesh ids.
-            if (auto it = _unv_elem_id_to_libmesh_elem_id.find(entity_tag);
+            if (const auto it = _unv_elem_id_to_libmesh_elem_id.find(entity_tag);
                 it != _unv_elem_id_to_libmesh_elem_id.end())
               {
                 unsigned libmesh_elem_id = it->second;
@@ -1318,7 +1318,7 @@ void UNVIO::read_dataset(std::string file_name)
 const std::vector<Number> *
 UNVIO::get_data (Node * node) const
 {
-  if (auto it = _node_data.find(node);
+  if (const auto it = _node_data.find(node);
       it == _node_data.end())
     return nullptr;
   else

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -610,7 +610,7 @@ void VTKIO::cells_to_vtk()
           // If the node ID is not found in the _local_node_map, we'll
           // add it to the _vtk_grid.  NOTE[JWP]: none of the examples
           // I have actually enters this section of code...
-          if (_local_node_map.find(conn[i]) == _local_node_map.end())
+          if (!_local_node_map.count(conn[i]))
             {
               dof_id_type global_node_id = elem->node_id(i);
 
@@ -685,13 +685,9 @@ void VTKIO::get_local_node_values(std::vector<Number> & local_values,
   // loop over all nodes and get the solution for the current
   // variable, if the node is in the current partition
   for (dof_id_type k=0; k<num_nodes; ++k)
-    {
-      std::map<dof_id_type, dof_id_type>::iterator local_node_it = _local_node_map.find(k);
-      if (local_node_it == _local_node_map.end())
-        continue; // not a local node
-
+    if (auto local_node_it = _local_node_map.find(k);
+        local_node_it != _local_node_map.end())
       local_values[local_node_it->second] = soln[k*num_vars + variable];
-    }
 }
 
 

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -685,7 +685,7 @@ void VTKIO::get_local_node_values(std::vector<Number> & local_values,
   // loop over all nodes and get the solution for the current
   // variable, if the node is in the current partition
   for (dof_id_type k=0; k<num_nodes; ++k)
-    if (auto local_node_it = _local_node_map.find(k);
+    if (const auto local_node_it = _local_node_map.find(k);
         local_node_it != _local_node_map.end())
       local_values[local_node_it->second] = soln[k*num_vars + variable];
 }

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -107,7 +107,7 @@ struct CorrectProcIds
         processor_id_type & proc_id = node.processor_id();
         const processor_id_type new_proc_id = proc_ids[i];
 
-        if (auto it = bad_pids.find(ids[i]);
+        if (const auto it = bad_pids.find(ids[i]);
             (new_proc_id != proc_id || it != bad_pids.end()) &&
             new_proc_id != DofObject::invalid_processor_id)
           {
@@ -985,7 +985,7 @@ void Partitioner::set_node_processor_ids(MeshBase & mesh)
               {
                 Node & node = mesh.node_ref(pair.first);
                 processor_id_type & pid = node.processor_id();
-                if (auto it = bad_pids.find(pair.first);
+                if (const auto it = bad_pids.find(pair.first);
                     it != bad_pids.end())
                   {
                     pid = pair.second;
@@ -1137,9 +1137,9 @@ void Partitioner::build_graph (const MeshBase & mesh)
           std::set<const Elem *> constraining_elems;
           for (const Node & node : elem->node_ref_range())
             {
-              if (auto row_it = mesh_constrained_nodes.find(&node);
+              if (const auto row_it = mesh_constrained_nodes.find(&node);
                   row_it != end_it)
-                for (auto [pr, coef] : row_it->second)
+                for (const auto & [pr, coef] : row_it->second)
                   {
                     libmesh_ignore(coef); // avoid gcc 7 warning
                     constraining_elems.insert(pr.first);
@@ -1300,9 +1300,9 @@ void Partitioner::build_graph (const MeshBase & mesh)
           std::set<const Elem *> constraining_elems;
           for (const Node & node : elem->node_ref_range())
             {
-              if (auto row_it = mesh_constrained_nodes.find(&node);
+              if (const auto row_it = mesh_constrained_nodes.find(&node);
                   row_it != end_it)
-                for (auto [pr, coef] : row_it->second)
+                for (const auto & [pr, coef] : row_it->second)
                   {
                     libmesh_ignore(coef); // avoid gcc 7 warning
                     constraining_elems.insert(pr.first);

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -107,10 +107,8 @@ struct CorrectProcIds
         processor_id_type & proc_id = node.processor_id();
         const processor_id_type new_proc_id = proc_ids[i];
 
-        auto it = bad_pids.find(ids[i]);
-
-        if ((new_proc_id != proc_id ||
-             it != bad_pids.end()) &&
+        if (auto it = bad_pids.find(ids[i]);
+            (new_proc_id != proc_id || it != bad_pids.end()) &&
             new_proc_id != DofObject::invalid_processor_id)
           {
             if (it != bad_pids.end())
@@ -689,7 +687,7 @@ void Partitioner::set_interface_node_processor_ids_BFS(MeshBase & mesh)
         {
           mesh.node_ref(id).processor_id() = pmap.first.second;
 
-          if (visted_nodes.find(id) != visted_nodes.end())
+          if (visted_nodes.count(id))
             continue;
           else
             {
@@ -716,7 +714,7 @@ void Partitioner::set_interface_node_processor_ids_BFS(MeshBase & mesh)
                                     std::back_inserter(common_nodes));
 
               for (auto c_node : common_nodes)
-                if (visted_nodes.find(c_node) == visted_nodes.end())
+                if (!visted_nodes.count(c_node))
                   {
                     nodes_queue.push(c_node);
                     visted_nodes.insert(c_node);
@@ -987,8 +985,8 @@ void Partitioner::set_node_processor_ids(MeshBase & mesh)
               {
                 Node & node = mesh.node_ref(pair.first);
                 processor_id_type & pid = node.processor_id();
-                auto it = bad_pids.find(pair.first);
-                if (it != bad_pids.end())
+                if (auto it = bad_pids.find(pair.first);
+                    it != bad_pids.end())
                   {
                     pid = pair.second;
                     bad_pids.erase(it);
@@ -1139,8 +1137,8 @@ void Partitioner::build_graph (const MeshBase & mesh)
           std::set<const Elem *> constraining_elems;
           for (const Node & node : elem->node_ref_range())
             {
-              auto row_it = mesh_constrained_nodes.find(&node);
-              if (row_it != end_it)
+              if (auto row_it = mesh_constrained_nodes.find(&node);
+                  row_it != end_it)
                 for (auto [pr, coef] : row_it->second)
                   {
                     libmesh_ignore(coef); // avoid gcc 7 warning
@@ -1302,8 +1300,8 @@ void Partitioner::build_graph (const MeshBase & mesh)
           std::set<const Elem *> constraining_elems;
           for (const Node & node : elem->node_ref_range())
             {
-              auto row_it = mesh_constrained_nodes.find(&node);
-              if (row_it != end_it)
+              if (auto row_it = mesh_constrained_nodes.find(&node);
+                  row_it != end_it)
                 for (auto [pr, coef] : row_it->second)
                   {
                     libmesh_ignore(coef); // avoid gcc 7 warning

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -346,8 +346,9 @@ void RBConstructionBase<Base>::initialize_training_parameters(const RBParameters
         {
           if (is_discrete_parameter(param_name))
             {
-              std::vector<Real> discrete_values =
-                get_discrete_parameter_values().find(param_name)->second;
+              const std::vector<Real> & discrete_values =
+                libmesh_map_find(get_discrete_parameter_values(), param_name);
+
               for (const auto sample_idx : index_range(sample_vector))
                 {
                   // Round all values to the closest discrete value.

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -470,7 +470,7 @@ Number RBEIMEvaluation::get_parametrized_function_node_local_value(
 {
   LOG_SCOPE("get_parametrized_function_node_local_value()", "RBEIMConstruction");
 
-  if (auto it = pf.find(node_id);
+  if (const auto it = pf.find(node_id);
       it != pf.end())
     {
       const std::vector<Number> & vec = it->second;

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -430,7 +430,7 @@ void RBEIMEvaluation::get_parametrized_function_values_at_qps(
 
   values.clear();
 
-  if (auto it = pf.find(elem_id);
+  if (const auto it = pf.find(elem_id);
       it != pf.end())
   {
     const auto & comps_and_qps_on_elem = it->second;
@@ -452,7 +452,7 @@ void RBEIMEvaluation::get_parametrized_function_side_values_at_qps(
 
   values.clear();
 
-  if (auto it = pf.find(std::make_pair(elem_id, side_index));
+  if (const auto it = pf.find(std::make_pair(elem_id, side_index));
       it != pf.end())
   {
     const auto & comps_and_qps_on_elem = it->second;

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -430,8 +430,8 @@ void RBEIMEvaluation::get_parametrized_function_values_at_qps(
 
   values.clear();
 
-  const auto it = pf.find(elem_id);
-  if (it != pf.end())
+  if (auto it = pf.find(elem_id);
+      it != pf.end())
   {
     const auto & comps_and_qps_on_elem = it->second;
     libmesh_error_msg_if(comp >= comps_and_qps_on_elem.size(),
@@ -452,8 +452,8 @@ void RBEIMEvaluation::get_parametrized_function_side_values_at_qps(
 
   values.clear();
 
-  const auto it = pf.find(std::make_pair(elem_id,side_index));
-  if (it != pf.end())
+  if (auto it = pf.find(std::make_pair(elem_id, side_index));
+      it != pf.end())
   {
     const auto & comps_and_qps_on_elem = it->second;
     libmesh_error_msg_if(comp >= comps_and_qps_on_elem.size(),
@@ -470,8 +470,8 @@ Number RBEIMEvaluation::get_parametrized_function_node_local_value(
 {
   LOG_SCOPE("get_parametrized_function_node_local_value()", "RBEIMConstruction");
 
-  auto it = pf.find(node_id);
-  if (it != pf.end())
+  if (auto it = pf.find(node_id);
+      it != pf.end())
     {
       const std::vector<Number> & vec = it->second;
       libmesh_error_msg_if (comp >= vec.size(), "Error: Invalid comp index");

--- a/src/reduced_basis/rb_parametrized.C
+++ b/src/reduced_basis/rb_parametrized.C
@@ -362,9 +362,10 @@ void RBParametrized::read_discrete_parameter_values_from_file(const std::string 
 
 bool RBParametrized::is_discrete_parameter(const std::string & mu_name) const
 {
-  libmesh_error_msg_if(!parameters_initialized, "Error: parameters not initialized in RBParametrized::is_discrete_parameter");
+  libmesh_error_msg_if(!parameters_initialized,
+                       "Error: parameters not initialized in RBParametrized::is_discrete_parameter");
 
-  return (_discrete_parameter_values.find(mu_name) != _discrete_parameter_values.end());
+  return _discrete_parameter_values.count(mu_name);
 }
 
 const std::map<std::string, std::vector<Real>> & RBParametrized::get_discrete_parameter_values() const

--- a/src/solution_transfer/boundary_volume_solution_transfer.C
+++ b/src/solution_transfer/boundary_volume_solution_transfer.C
@@ -92,13 +92,9 @@ transfer_volume_boundary(const Variable & from_var, const Variable & to_var)
                                                                 from_var_number,
                                                                 from_n_comp - 1);
 
-              // See if we've already encountered this DOF in the loop
-              // over boundary elements.
-              DofMapping::iterator it = dof_mapping.find(from_dof);
-
               // If we've already mapped this dof, we don't need to map
               // it again or do floating point comparisons.
-              if (it == dof_mapping.end() &&
+              if (!dof_mapping.count(from_dof) &&
                   from_node.absolute_fuzzy_equals(to_node, TOLERANCE))
                 {
                   // Global dof_index for node in BoundaryMesh.

--- a/src/solution_transfer/dtk_adapter.C
+++ b/src/solution_transfer/dtk_adapter.C
@@ -175,28 +175,36 @@ DTKAdapter::DTKAdapter(Teuchos::RCP<const Teuchos::Comm<int>> in_comm, EquationS
 DTKAdapter::RCP_Evaluator
 DTKAdapter::get_variable_evaluator(std::string var_name)
 {
-  if (evaluators.find(var_name) == evaluators.end()) // We haven't created an evaluator for the variable yet
+  // We try emplacing a nullptr into the "evaluators" map.
+  auto [it, emplaced] = evaluators.emplace(var_name, nullptr);
+
+  // If the emplace succeeded, that means it was a new entry in the
+  // map, so we need to actually construct the object.
+  if (emplaced)
     {
       System * sys = find_sys(var_name);
-
-      // Create the FieldEvaluator
-      evaluators[var_name] = Teuchos::rcp(new DTKEvaluator(*sys, var_name));
+      it->second = Teuchos::rcp(new DTKEvaluator(*sys, var_name));
     }
 
-  return evaluators[var_name];
+  return it->second;
 }
 
 Teuchos::RCP<DataTransferKit::FieldManager<DTKAdapter::FieldContainerType>>
 DTKAdapter::get_values_to_fill(std::string var_name)
 {
-  if (values_to_fill.find(var_name) == values_to_fill.end())
+  // We try emplacing a nullptr into the "values_to_fill" map.
+  auto [it, emplaced] = values_to_fill.emplace(var_name, nullptr);
+
+  // If the emplace succeeded, that means it was a new entry in the
+  // map, so we need to actually construct the object.
+  if (emplaced)
     {
       Teuchos::ArrayRCP<double> data_space(num_local_nodes);
       Teuchos::RCP<FieldContainerType> field_container = Teuchos::rcp(new FieldContainerType(data_space, 1));
-      values_to_fill[var_name] = Teuchos::rcp(new DataTransferKit::FieldManager<FieldContainerType>(field_container, comm));
+      it->second = Teuchos::rcp(new DataTransferKit::FieldManager<FieldContainerType>(field_container, comm));
     }
 
-  return values_to_fill[var_name];
+  return it->second;
 }
 
 void

--- a/src/solvers/eigen_sparse_linear_solver.C
+++ b/src/solvers/eigen_sparse_linear_solver.C
@@ -215,7 +215,7 @@ EigenSparseLinearSolver<T>::solve (SparseMatrix<T> & matrix_in,
           // SolverConfiguration object, pass it to the Eigen GMRES
           // solver.
           if (this->_solver_configuration)
-            if (auto it = this->_solver_configuration->int_valued_data.find("gmres_restart");
+            if (const auto it = this->_solver_configuration->int_valued_data.find("gmres_restart");
                 it != this->_solver_configuration->int_valued_data.end())
               gm_solver.set_restart(it->second);
 

--- a/src/solvers/eigen_sparse_linear_solver.C
+++ b/src/solvers/eigen_sparse_linear_solver.C
@@ -209,14 +209,15 @@ EigenSparseLinearSolver<T>::solve (SparseMatrix<T> & matrix_in,
     case GMRES:
       {
         auto set_restart_and_solve = [this, &do_solve]
-          (auto & gm_solver, std::string_view msg) {
-        // If there is an int parameter called "gmres_restart" in the
-        // SolverConfiguration object, pass it to the Eigen GMRES
-        // solver.
-        if (this->_solver_configuration)
-          if (auto it = this->_solver_configuration->int_valued_data.find("gmres_restart");
-              it != this->_solver_configuration->int_valued_data.end())
-            gm_solver.set_restart(it->second);
+          (auto & gm_solver, std::string_view msg)
+        {
+          // If there is an int parameter called "gmres_restart" in the
+          // SolverConfiguration object, pass it to the Eigen GMRES
+          // solver.
+          if (this->_solver_configuration)
+            if (auto it = this->_solver_configuration->int_valued_data.find("gmres_restart");
+                it != this->_solver_configuration->int_valued_data.end())
+              gm_solver.set_restart(it->second);
 
           std::ostringstream full_msg;
           full_msg << msg << ", restart = " << gm_solver.get_restart();

--- a/src/solvers/eigen_sparse_linear_solver.C
+++ b/src/solvers/eigen_sparse_linear_solver.C
@@ -214,12 +214,9 @@ EigenSparseLinearSolver<T>::solve (SparseMatrix<T> & matrix_in,
         // SolverConfiguration object, pass it to the Eigen GMRES
         // solver.
         if (this->_solver_configuration)
-          {
-            auto it = this->_solver_configuration->int_valued_data.find("gmres_restart");
-
-            if (it != this->_solver_configuration->int_valued_data.end())
-              gm_solver.set_restart(it->second);
-          }
+          if (auto it = this->_solver_configuration->int_valued_data.find("gmres_restart");
+              it != this->_solver_configuration->int_valued_data.end())
+            gm_solver.set_restart(it->second);
 
           std::ostringstream full_msg;
           full_msg << msg << ", restart = " << gm_solver.get_restart();
@@ -417,11 +414,10 @@ void EigenSparseLinearSolver<T>::set_eigen_preconditioner_type ()
 template <typename T>
 LinearConvergenceReason EigenSparseLinearSolver<T>::get_converged_reason() const
 {
-  auto it = _convergence_reasons.find(_comp_info);
-
   // If later versions of Eigen start returning new enumerations,
   // we'll need to add them to the map...
-  if (it == _convergence_reasons.end())
+  if (auto it = _convergence_reasons.find(_comp_info);
+      it == _convergence_reasons.end())
     {
       libmesh_warning("Warning: unknown Eigen::ComputationInfo: " \
                       << _comp_info \

--- a/src/solvers/linear_solver.C
+++ b/src/solvers/linear_solver.C
@@ -190,7 +190,7 @@ double LinearSolver<T>::get_real_solver_setting (const std::string & setting_nam
     return setting.value();
   else if (_solver_configuration)
   {
-    if (auto it = this->_solver_configuration->real_valued_data.find(setting_name);
+    if (const auto it = this->_solver_configuration->real_valued_data.find(setting_name);
         it != this->_solver_configuration->real_valued_data.end())
       return it->second;
   }
@@ -211,7 +211,7 @@ int LinearSolver<T>::get_int_solver_setting (const std::string & setting_name,
     return setting.value();
   else if (_solver_configuration)
   {
-    if (auto it = this->_solver_configuration->int_valued_data.find(setting_name);
+    if (const auto it = this->_solver_configuration->int_valued_data.find(setting_name);
         it != this->_solver_configuration->int_valued_data.end())
       return it->second;
   }

--- a/src/solvers/linear_solver.C
+++ b/src/solvers/linear_solver.C
@@ -190,9 +190,8 @@ double LinearSolver<T>::get_real_solver_setting (const std::string & setting_nam
     return setting.value();
   else if (_solver_configuration)
   {
-    auto it = this->_solver_configuration->real_valued_data.find(setting_name);
-
-    if (it != this->_solver_configuration->real_valued_data.end())
+    if (auto it = this->_solver_configuration->real_valued_data.find(setting_name);
+        it != this->_solver_configuration->real_valued_data.end())
       return it->second;
   }
   else if (default_value.has_value())
@@ -212,9 +211,8 @@ int LinearSolver<T>::get_int_solver_setting (const std::string & setting_name,
     return setting.value();
   else if (_solver_configuration)
   {
-    auto it = this->_solver_configuration->int_valued_data.find(setting_name);
-
-    if (it != this->_solver_configuration->int_valued_data.end())
+    if (auto it = this->_solver_configuration->int_valued_data.find(setting_name);
+        it != this->_solver_configuration->int_valued_data.end())
       return it->second;
   }
   else if (default_value.has_value())

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -847,7 +847,7 @@ void System::remove_vector (std::string_view vec_name)
 {
   parallel_object_only();  // Not strictly needed, but the only safe way to keep in sync
 
-  if (auto pos = _vectors.find(vec_name);
+  if (const auto pos = _vectors.find(vec_name);
       pos != _vectors.end())
     {
       _vectors.erase(pos);
@@ -863,7 +863,7 @@ void System::remove_vector (std::string_view vec_name)
 
 const NumericVector<Number> * System::request_vector (std::string_view vec_name) const
 {
-  if (auto pos = _vectors.find(vec_name);
+  if (const auto pos = _vectors.find(vec_name);
       pos != _vectors.end())
     return pos->second.get();
 
@@ -1031,7 +1031,7 @@ void System::remove_matrix (std::string_view mat_name)
 {
   parallel_object_only();  // Not strictly needed, but the only safe way to keep in sync
 
-  if (auto pos = _matrices.find(mat_name);
+  if (const auto pos = _matrices.find(mat_name);
       pos != _matrices.end())
     _matrices.erase(pos); // erase()'d entries are destroyed
 }
@@ -1040,7 +1040,7 @@ void System::remove_matrix (std::string_view mat_name)
 
 const SparseMatrix<Number> * System::request_matrix (std::string_view mat_name) const
 {
-  if (auto pos = _matrices.find(mat_name);
+  if (const auto pos = _matrices.find(mat_name);
       pos != _matrices.end())
     return pos->second.get();
 
@@ -1113,7 +1113,7 @@ void System::set_vector_as_adjoint (const std::string & vec_name,
 
 int System::vector_is_adjoint (std::string_view vec_name) const
 {
-  auto it = _vector_is_adjoint.find(vec_name);
+  const auto it = _vector_is_adjoint.find(vec_name);
   libmesh_assert(it != _vector_is_adjoint.end());
   return it->second;
 }

--- a/src/systems/system_subset_by_subdomain.C
+++ b/src/systems/system_subset_by_subdomain.C
@@ -44,7 +44,7 @@ bool
 SystemSubsetBySubdomain::SubdomainSelectionByList::
 operator()(const subdomain_id_type & subdomain_id)const
 {
-  return _list.find(subdomain_id)!=_list.end();
+  return _list.count(subdomain_id); // _list is actually a std::set
 }
 
 // ------------------------------------------------------------

--- a/src/utils/perf_log.C
+++ b/src/utils/perf_log.C
@@ -105,7 +105,7 @@ void PerfLog::push (const std::string & label,
   const char * label_c_str;
   const char * header_c_str;
 
-  if (auto label_it = non_temporary_strings.find(label);
+  if (const auto label_it = non_temporary_strings.find(label);
       label_it != non_temporary_strings.end())
     label_c_str = label_it->second.get();
   else
@@ -117,7 +117,7 @@ void PerfLog::push (const std::string & label,
       non_temporary_strings[label] = std::move(newcopy);
     }
 
-  if (auto header_it = non_temporary_strings.find(header);
+  if (const auto header_it = non_temporary_strings.find(header);
       header_it != non_temporary_strings.end())
     header_c_str = header_it->second.get();
   else

--- a/src/utils/perf_log.C
+++ b/src/utils/perf_log.C
@@ -105,8 +105,8 @@ void PerfLog::push (const std::string & label,
   const char * label_c_str;
   const char * header_c_str;
 
-  auto label_it = non_temporary_strings.find(label);
-  if (label_it != non_temporary_strings.end())
+  if (auto label_it = non_temporary_strings.find(label);
+      label_it != non_temporary_strings.end())
     label_c_str = label_it->second.get();
   else
     {
@@ -117,8 +117,8 @@ void PerfLog::push (const std::string & label,
       non_temporary_strings[label] = std::move(newcopy);
     }
 
-  auto header_it = non_temporary_strings.find(header);
-  if (header_it != non_temporary_strings.end())
+  if (auto header_it = non_temporary_strings.find(header);
+      header_it != non_temporary_strings.end())
     header_c_str = header_it->second.get();
   else
     {
@@ -776,9 +776,8 @@ void PerfLog::split_on_whitespace(const std::string & input, std::vector<std::st
   while (true)
     {
       // Find next end location
-      size_t end_pos = input.find(split_on, current_pos);
-
-      if (end_pos != std::string::npos)
+      if (size_t end_pos = input.find(split_on, current_pos);
+          end_pos != std::string::npos)
         {
           // Create substring.  Note: the second argument to substr is
           // the *length* of string to create, not the ending position!

--- a/src/utils/string_to_enum.C
+++ b/src/utils/string_to_enum.C
@@ -68,8 +68,8 @@ build_reverse_map (const MapType & forward)
       // preimage according to operator<; for std::string this will
       // give us the longest, hopefully most specific name
       // corresponding to an enum.
-      auto preimage = reverse.find(val);
-      if (preimage == reverse.end())
+      if (auto preimage = reverse.find(val);
+          preimage == reverse.end())
         reverse.emplace (val, key);
       else if (preimage->second < key)
         preimage->second = key;

--- a/src/utils/topology_map.C
+++ b/src/utils/topology_map.C
@@ -66,7 +66,7 @@ void TopologyMap::add_node(const Node & mid_node,
 
       // We should never be inserting inconsistent data
 #ifndef NDEBUG
-      if (auto it = _map.find(std::make_pair(lower_id, upper_id));
+      if (const auto it = _map.find(std::make_pair(lower_id, upper_id));
           it != _map.end())
         libmesh_assert_equal_to (it->second, mid_node_id);
 #endif

--- a/src/utils/topology_map.C
+++ b/src/utils/topology_map.C
@@ -66,10 +66,8 @@ void TopologyMap::add_node(const Node & mid_node,
 
       // We should never be inserting inconsistent data
 #ifndef NDEBUG
-      map_type::iterator it =
-        _map.find(std::make_pair(lower_id, upper_id));
-
-      if (it != _map.end())
+      if (auto it = _map.find(std::make_pair(lower_id, upper_id));
+          it != _map.end())
         libmesh_assert_equal_to (it->second, mid_node_id);
 #endif
 
@@ -120,15 +118,15 @@ dof_id_type TopologyMap::find(dof_id_type bracket_node1,
   const dof_id_type lower_id = std::min(bracket_node1, bracket_node2);
   const dof_id_type upper_id = std::max(bracket_node1, bracket_node2);
 
-  map_type::const_iterator it =
-    _map.find(std::make_pair(lower_id, upper_id));
+  if (auto it = _map.find(std::make_pair(lower_id, upper_id));
+      it != _map.end())
+    {
+      libmesh_assert_not_equal_to (it->second, DofObject::invalid_id);
+      return it->second;
+    }
 
-  if (it == _map.end())
-    return DofObject::invalid_id;
-
-  libmesh_assert_not_equal_to (it->second, DofObject::invalid_id);
-
-  return it->second;
+  // If not found, return invalid_id
+  return DofObject::invalid_id;
 }
 
 

--- a/src/utils/topology_map.C
+++ b/src/utils/topology_map.C
@@ -118,7 +118,7 @@ dof_id_type TopologyMap::find(dof_id_type bracket_node1,
   const dof_id_type lower_id = std::min(bracket_node1, bracket_node2);
   const dof_id_type upper_id = std::max(bracket_node1, bracket_node2);
 
-  if (auto it = _map.find(std::make_pair(lower_id, upper_id));
+  if (const auto it = _map.find(std::make_pair(lower_id, upper_id));
       it != _map.end())
     {
       libmesh_assert_not_equal_to (it->second, DofObject::invalid_id);


### PR DESCRIPTION
This is a [C++17 feature](https://en.cppreference.com/w/cpp/language/if) which all of our "min" compilers correctly support.