### PR TITLE
Drop workaround that was only required on 'older' compilers

### DIFF
--- a/src/numerics/diagonal_matrix.C
+++ b/src/numerics/diagonal_matrix.C
@@ -118,9 +118,7 @@ std::unique_ptr<SparseMatrix<T>> DiagonalMatrix<T>::zero_clone () const
   // zero values using fast == false.
   mat_copy->init(*this, /*fast=*/false);
 
-  // Work around an issue on older compilers.  We are able to simply
-  // "return mat_copy;" on newer compilers
-  return std::unique_ptr<SparseMatrix<T>>(mat_copy.release());
+  return mat_copy;
 }
 
 
@@ -137,9 +135,7 @@ std::unique_ptr<SparseMatrix<T>> DiagonalMatrix<T>::clone () const
   // Swap diag_copy with diagonal in mat_copy
   *mat_copy = std::move(*diag_copy);
 
-  // Work around an issue on older compilers.  We are able to simply
-  // "return mat_copy;" on newer compilers
-  return std::unique_ptr<SparseMatrix<T>>(mat_copy.release());
+  return mat_copy;
 }
 
 template <typename T>

--- a/src/numerics/eigen_sparse_matrix.C
+++ b/src/numerics/eigen_sparse_matrix.C
@@ -203,9 +203,7 @@ std::unique_ptr<SparseMatrix<T>> EigenSparseMatrix<T>::zero_clone () const
   auto ret = std::make_unique<EigenSparseMatrix<T>>(*this);
   ret->zero();
 
-  // Work around an issue on older compilers.  We are able to simply
-  // "return ret;" on newer compilers
-  return std::unique_ptr<SparseMatrix<T>>(ret.release());
+  return ret;
 }
 
 

--- a/src/numerics/laspack_matrix.C
+++ b/src/numerics/laspack_matrix.C
@@ -445,9 +445,7 @@ std::unique_ptr<SparseMatrix<T>> LaspackMatrix<T>::clone () const
   auto mat_copy = this->zero_clone();
   mat_copy->add(1., *this);
 
-  // Work around an issue on older compilers.  We are able to simply
-  // "return mat_copy;" on newer compilers
-  return std::unique_ptr<SparseMatrix<T>>(mat_copy.release());
+  return mat_copy;
 }
 
 template <typename T>

--- a/src/numerics/lumped_mass_matrix.C
+++ b/src/numerics/lumped_mass_matrix.C
@@ -42,9 +42,7 @@ LumpedMassMatrix<T>::zero_clone() const
   // zero values using fast == false.
   mat_copy->init(*this, /*fast=*/false);
 
-  // Work around an issue on older compilers.  We are able to simply
-  // "return mat_copy;" on newer compilers
-  return std::unique_ptr<SparseMatrix<T>>(mat_copy.release());
+  return mat_copy;
 }
 
 template <typename T>
@@ -60,9 +58,7 @@ LumpedMassMatrix<T>::clone() const
   // Swap diag_copy with diagonal in mat_copy
   *mat_copy = std::move(*diag_copy);
 
-  // Work around an issue on older compilers.  We are able to simply
-  // "return mat_copy;" on newer compilers
-  return std::unique_ptr<SparseMatrix<T>>(mat_copy.release());
+  return mat_copy;
 }
 
 template <typename T>

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -472,9 +472,7 @@ std::unique_ptr<SparseMatrix<T>> PetscMatrix<T>::zero_clone () const
   auto ret = std::make_unique<PetscMatrix<T>>(copy, this->comm());
   ret->set_destroy_mat_on_exit(true);
 
-  // Work around an issue on older compilers.  We are able to simply
-  // "return ret;" on newer compilers
-  return std::unique_ptr<SparseMatrix<T>>(ret.release());
+  return ret;
 }
 
 
@@ -494,9 +492,7 @@ std::unique_ptr<SparseMatrix<T>> PetscMatrix<T>::clone () const
   auto ret = std::make_unique<PetscMatrix<T>>(copy, this->comm());
   ret->set_destroy_mat_on_exit(true);
 
-  // Work around an issue on older compilers.  We are able to simply
-  // "return ret;" on newer compilers
-  return std::unique_ptr<SparseMatrix<T>>(ret.release());
+  return ret;
 }
 
 template <typename T>

--- a/src/numerics/trilinos_epetra_matrix.C
+++ b/src/numerics/trilinos_epetra_matrix.C
@@ -214,9 +214,7 @@ std::unique_ptr<SparseMatrix<T>> EpetraMatrix<T>::zero_clone () const
   mat_copy->init();
   mat_copy->zero();
 
-  // Work around an issue on older compilers.  We are able to simply
-  // "return mat_copy;" on newer compilers
-  return std::unique_ptr<SparseMatrix<T>>(mat_copy.release());
+  return mat_copy;
 }
 
 
@@ -229,9 +227,7 @@ std::unique_ptr<SparseMatrix<T>> EpetraMatrix<T>::clone () const
   auto mat_copy = this->zero_clone();
   mat_copy->add(1., *this);
 
-  // Work around an issue on older compilers.  We are able to simply
-  // "return mat_copy;" on newer compilers
-  return std::unique_ptr<SparseMatrix<T>>(mat_copy.release());
+  return mat_copy;
 }
 
 


### PR DESCRIPTION
Our minimum compilers may now be new enough to handle this type of converting constructor: https://stackoverflow.com/questions/58181090/why-does-unique-ptrderived-implicitly-cast-to-unique-ptrbase