### PR TITLE
Shorten, simplify and generalise code for Nédélec finite elements

### DIFF
--- a/include/geom/cell_tet14.h
+++ b/include/geom/cell_tet14.h
@@ -91,7 +91,7 @@ public:
   virtual ElemType type () const override { return TET14; }
 
   /**
-   * \returns 10.
+   * \returns 14.
    */
   virtual unsigned int n_nodes() const override { return num_nodes; }
 

--- a/src/fe/fe_hierarchic.C
+++ b/src/fe/fe_hierarchic.C
@@ -117,8 +117,6 @@ unsigned int hierarchic_n_dofs(const ElemType t, const Order o)
     case QUAD9:
       return ((o+1)*(o+1));
     case HEX8:
-      libmesh_assert_less (o, 2);
-      libmesh_fallthrough();
     case HEX20:
       libmesh_assert_less (o, 2);
       libmesh_fallthrough();

--- a/src/fe/fe_nedelec_one.C
+++ b/src/fe/fe_nedelec_one.C
@@ -39,6 +39,10 @@ LIBMESH_DEFAULT_VECTORIZED_FE(3,NEDELEC_ONE)
 
 // Anonymous namespace for local helper functions
 namespace {
+// Forward-declare nedelec_one_n_dofs for immediate use
+unsigned int nedelec_one_n_dofs(const ElemType, const Order);
+
+
 void nedelec_one_nodal_soln(const Elem * elem,
                             const Order order,
                             const std::vector<Number> & elem_soln,
@@ -53,109 +57,43 @@ void nedelec_one_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes*dim);
 
-  FEType fe_type(order, NEDELEC_ONE);
   FEType p_refined_fe_type(totalorder, NEDELEC_ONE);
 
-  switch (totalorder)
+  if (elem_type != TRI6  && elem_type != TRI7  &&
+      elem_type != QUAD8 && elem_type != QUAD9 &&
+      elem_type != TET10 && elem_type != TET14 &&
+      elem_type != HEX20 && elem_type != HEX27)
+    libmesh_error_msg("ERROR: Invalid ElemType " << Utility::enum_to_string(elem_type) << " selected for NEDELEC_ONE FE family!");
+
+  libmesh_assert_equal_to (elem_soln.size(), nedelec_one_n_dofs(elem_type, totalorder));
+
+  const unsigned int n_sf = FEInterface::n_shape_functions(p_refined_fe_type, elem);
+
+  std::vector<Point> refspace_nodes;
+  FEVectorBase::get_refspace_nodes(elem_type,refspace_nodes);
+  libmesh_assert_equal_to (refspace_nodes.size(), n_nodes);
+
+  // Need to create new fe object so the shape function has the FETransformation
+  // applied to it.
+  std::unique_ptr<FEVectorBase> vis_fe = FEVectorBase::build(dim, p_refined_fe_type);
+
+  const std::vector<std::vector<RealGradient>> & vis_phi = vis_fe->get_phi();
+
+  vis_fe->reinit(elem,&refspace_nodes);
+
+  for (unsigned int n = 0; n < n_nodes; n++)
     {
-    case FIRST:
-      {
-        switch (elem_type)
-          {
-          case TRI6:
-          case TRI7:
-            {
-              libmesh_assert_equal_to (elem_soln.size(), 3);
+      libmesh_assert_equal_to (elem_soln.size(), n_sf);
 
-              if (elem_type == TRI6)
-                libmesh_assert_equal_to (nodal_soln.size(), 6*2);
-              else
-                libmesh_assert_equal_to (nodal_soln.size(), 7*2);
-              break;
-            }
-          case QUAD8:
-          case QUAD9:
-            {
-              libmesh_assert_equal_to (elem_soln.size(), 4);
+      // Zero before summation
+      for (int d = 0; d < dim; d++)
+        nodal_soln[dim*n+d] = 0;
 
-              if (elem_type == QUAD8)
-                libmesh_assert_equal_to (nodal_soln.size(), 8*2);
-              else
-                libmesh_assert_equal_to (nodal_soln.size(), 9*2);
-              break;
-            }
-          case TET10:
-          case TET14:
-            {
-              libmesh_assert_equal_to (elem_soln.size(), 6);
-              if (elem_type == TET10)
-                libmesh_assert_equal_to (nodal_soln.size(), 10*3);
-              else
-                libmesh_assert_equal_to (nodal_soln.size(), 14*3);
-
-              break;
-            }
-          case HEX20:
-          case HEX27:
-            {
-              libmesh_assert_equal_to (elem_soln.size(), 12);
-
-              if (elem_type == HEX20)
-                libmesh_assert_equal_to (nodal_soln.size(), 20*3);
-              else
-                libmesh_assert_equal_to (nodal_soln.size(), 27*3);
-
-              break;
-            }
-
-          default:
-            libmesh_error_msg("ERROR: Invalid ElemType " << Utility::enum_to_string(elem_type) << " selected for NEDELEC_ONE FE family!");
-
-          } // switch(elem_type)
-
-        const unsigned int n_sf =
-          FEInterface::n_shape_functions(fe_type, elem);
-
-        std::vector<Point> refspace_nodes;
-        FEVectorBase::get_refspace_nodes(elem_type,refspace_nodes);
-        libmesh_assert_equal_to (refspace_nodes.size(), n_nodes);
-
-
-        // Need to create new fe object so the shape function has the FETransformation
-        // applied to it.
-        std::unique_ptr<FEVectorBase> vis_fe = FEVectorBase::build(dim, p_refined_fe_type);
-
-        const std::vector<std::vector<RealGradient>> & vis_phi = vis_fe->get_phi();
-
-        vis_fe->reinit(elem,&refspace_nodes);
-
-        for (unsigned int n = 0; n < n_nodes; n++)
-          {
-            libmesh_assert_equal_to (elem_soln.size(), n_sf);
-
-            // Zero before summation
-            for (int d = 0; d < dim; d++)
-              {
-                nodal_soln[dim*n+d] = 0;
-              }
-
-            // u = Sum (u_i phi_i)
-            for (unsigned int i=0; i<n_sf; i++)
-              {
-                for (int d = 0; d < dim; d++)
-                  {
-                    nodal_soln[dim*n+d]   += elem_soln[i]*(vis_phi[i][n](d));
-                  }
-              }
-          }
-
-        return;
-      } // case FIRST
-
-    default:
-      libmesh_error_msg("ERROR: Invalid total order " << Utility::enum_to_string(totalorder) << " selected for NEDELEC_ONE FE family!");
-
-    }//switch (totalorder)
+      // u = Sum (u_i phi_i)
+      for (unsigned int i=0; i<n_sf; i++)
+        for (int d = 0; d < dim; d++)
+          nodal_soln[dim*n+d] += elem_soln[i]*(vis_phi[i][n](d));
+    }
 
   return;
 } // nedelec_one_nodal_soln
@@ -163,257 +101,191 @@ void nedelec_one_nodal_soln(const Elem * elem,
 
 unsigned int nedelec_one_n_dofs(const ElemType t, const Order o)
 {
-  switch (o)
+  libmesh_assert_greater (o, 0);
+  switch (t)
     {
-    case FIRST:
-      {
-        switch (t)
-          {
-          case TRI6:
-          case TRI7:
-            return 3;
-
-          case QUAD8:
-          case QUAD9:
-            return 4;
-
-          case TET10:
-          case TET14:
-            return 6;
-
-          case HEX20:
-          case HEX27:
-            return 12;
-
-          case INVALID_ELEM:
-            return 0;
-
-          default:
-            libmesh_error_msg("ERROR: Bad ElemType = " << Utility::enum_to_string(t) << " for " << Utility::enum_to_string(o) << " order approximation!");
-          }
-      }
-
+    case TRI6:
+    case TRI7:
+      return o*(o+2);
+    case QUAD8:
+    case QUAD9:
+      return 2*o*(o+1);
+    case TET10:
+      libmesh_assert_less (o, 2);
+      libmesh_fallthrough();
+    case TET14:
+      return o*(o+2)*(o+3)/2;
+    case HEX20:
+      libmesh_assert_less (o, 2);
+      libmesh_fallthrough();
+    case HEX27:
+      return 3*o*(o+1)*(o+1);
+    case INVALID_ELEM:
+      return 0;
     default:
-      libmesh_error_msg("ERROR: Invalid Order " << Utility::enum_to_string(o) << " selected for NEDELEC_ONE FE family!");
+      libmesh_error_msg("ERROR: Invalid ElemType " << Utility::enum_to_string(t) << " selected for NEDELEC_ONE FE family!");
     }
 }
-
-
 
 
 unsigned int nedelec_one_n_dofs_at_node(const ElemType t,
                                         const Order o,
                                         const unsigned int n)
 {
-  switch (o)
+  libmesh_assert_greater (o, 0);
+  switch (t)
     {
-    case FIRST:
+    case TRI6:
+    case TRI7:
       {
-        switch (t)
+        switch (n)
           {
-          case TRI6:
-            {
-              switch (n)
-                {
-                case 0:
-                case 1:
-                case 2:
-                  return 0;
-                case 3:
-                case 4:
-                case 5:
-                  return 1;
-
-                default:
-                  libmesh_error_msg("ERROR: Invalid node ID " << n);
-                }
-            }
-          case TRI7:
-            {
-              switch (n)
-                {
-                case 0:
-                case 1:
-                case 2:
-                case 6:
-                  return 0;
-                case 3:
-                case 4:
-                case 5:
-                  return 1;
-
-                default:
-                  libmesh_error_msg("ERROR: Invalid node ID " << n);
-                }
-            }
-          case QUAD8:
-            {
-              switch (n)
-                {
-                case 0:
-                case 1:
-                case 2:
-                case 3:
-                  return 0;
-                case 4:
-                case 5:
-                case 6:
-                case 7:
-                  return 1;
-
-                default:
-                  libmesh_error_msg("ERROR: Invalid node ID " << n);
-                }
-            }
-          case QUAD9:
-            {
-              switch (n)
-                {
-                case 0:
-                case 1:
-                case 2:
-                case 3:
-                case 8:
-                  return 0;
-                case 4:
-                case 5:
-                case 6:
-                case 7:
-                  return 1;
-
-                default:
-                  libmesh_error_msg("ERROR: Invalid node ID " << n);
-                }
-            }
-          case TET10:
-            {
-              switch (n)
-                {
-                case 0:
-                case 1:
-                case 2:
-                case 3:
-                  return 0;
-                case 4:
-                case 5:
-                case 6:
-                case 7:
-                case 8:
-                case 9:
-                  return 1;
-
-                default:
-                  libmesh_error_msg("ERROR: Invalid node ID " << n);
-                }
-            }
-          case TET14:
-            {
-              switch (n)
-                {
-                case 0:
-                case 1:
-                case 2:
-                case 3:
-                case 10:
-                case 11:
-                case 12:
-                case 13:
-                  return 0;
-                case 4:
-                case 5:
-                case 6:
-                case 7:
-                case 8:
-                case 9:
-                  return 1;
-
-                default:
-                  libmesh_error_msg("ERROR: Invalid node ID " << n);
-                }
-            }
-          case HEX20:
-            {
-              switch (n)
-                {
-                case 0:
-                case 1:
-                case 2:
-                case 3:
-                case 4:
-                case 5:
-                case 6:
-                case 7:
-                  return 0;
-                case 8:
-                case 9:
-                case 10:
-                case 11:
-                case 12:
-                case 13:
-                case 14:
-                case 15:
-                case 16:
-                case 17:
-                case 18:
-                case 19:
-                  return 1;
-
-                default:
-                  libmesh_error_msg("ERROR: Invalid node ID " << n);
-                }
-            }
-          case HEX27:
-            {
-              switch (n)
-                {
-                case 0:
-                case 1:
-                case 2:
-                case 3:
-                case 4:
-                case 5:
-                case 6:
-                case 7:
-                case 20:
-                case 21:
-                case 22:
-                case 23:
-                case 24:
-                case 25:
-                case 26:
-                  return 0;
-                case 8:
-                case 9:
-                case 10:
-                case 11:
-                case 12:
-                case 13:
-                case 14:
-                case 15:
-                case 16:
-                case 17:
-                case 18:
-                case 19:
-                  return 1;
-
-                default:
-                  libmesh_error_msg("ERROR: Invalid node ID " << n);
-                }
-            }
-
-          case INVALID_ELEM:
+          case 0:
+          case 1:
+          case 2:
             return 0;
-
+          case 3:
+          case 4:
+          case 5:
+            return o;
+          case 6:
+            libmesh_assert_equal_to(t, TRI7);
+            return 0;
           default:
-            libmesh_error_msg("ERROR: Bad ElemType = " << Utility::enum_to_string(t) << " for " << Utility::enum_to_string(o) << " order approximation!");
+            libmesh_error_msg("ERROR: Invalid node ID " << n);
           }
       }
-
+    case QUAD8:
+    case QUAD9:
+      {
+        switch (n)
+          {
+          case 0:
+          case 1:
+          case 2:
+          case 3:
+            return 0;
+          case 4:
+          case 5:
+          case 6:
+          case 7:
+            return o;
+          case 8:
+            libmesh_assert_equal_to(t, QUAD9);
+            return 0;
+          default:
+            libmesh_error_msg("ERROR: Invalid node ID " << n);
+          }
+      }
+    case TET10:
+      libmesh_assert_less (o, 2);
+      libmesh_fallthrough();
+    case TET14:
+      {
+        switch (n)
+          {
+          case 0:
+          case 1:
+          case 2:
+          case 3:
+            return 0;
+          case 4:
+          case 5:
+          case 6:
+          case 7:
+          case 8:
+          case 9:
+            return o;
+          case 10:
+          case 11:
+          case 12:
+          case 13:
+            libmesh_assert_equal_to(t, TET14);
+            return o*(o-1);
+          default:
+            libmesh_error_msg("ERROR: Invalid node ID " << n);
+          }
+      }
+    case HEX20:
+      libmesh_assert_less (o, 2);
+      libmesh_fallthrough();
+    case HEX27:
+      {
+        switch (n)
+          {
+          case 0:
+          case 1:
+          case 2:
+          case 3:
+          case 4:
+          case 5:
+          case 6:
+          case 7:
+            return 0;
+          case 8:
+          case 9:
+          case 10:
+          case 11:
+          case 12:
+          case 13:
+          case 14:
+          case 15:
+          case 16:
+          case 17:
+          case 18:
+          case 19:
+            return o;
+          case 20:
+          case 21:
+          case 22:
+          case 23:
+          case 24:
+          case 25:
+            libmesh_assert_equal_to(t, HEX27);
+            return 2*o*(o-1);
+          case 26:
+            libmesh_assert_equal_to(t, HEX27);
+            return 0;
+          default:
+            libmesh_error_msg("ERROR: Invalid node ID " << n);
+          }
+      }
+    case INVALID_ELEM:
+      return 0;
     default:
-      libmesh_error_msg("ERROR: Invalid Order " << Utility::enum_to_string(o) << " selected for NEDELEC_ONE FE family!");
+      libmesh_error_msg("ERROR: Invalid ElemType " << Utility::enum_to_string(t) << " selected for NEDELEC_ONE FE family!");
     }
 }
 
+
+unsigned int nedelec_one_n_dofs_per_elem(const ElemType t,
+                                         const Order o)
+{
+  libmesh_assert_greater (o, 0);
+  switch (t)
+    {
+    case TRI6:
+    case TRI7:
+      return o*(o-1);
+    case QUAD8:
+    case QUAD9:
+      return 2*o*(o-1);
+    case TET10:
+      libmesh_assert_less (o, 2);
+      libmesh_fallthrough();
+    case TET14:
+      return o*(o-1)*(o-2)/2;
+    case HEX20:
+      libmesh_assert_less (o, 2);
+      libmesh_fallthrough();
+    case HEX27:
+      return 3*o*(o-1)*(o-1);
+    case INVALID_ELEM:
+      return 0;
+    default:
+      libmesh_error_msg("ERROR: Invalid ElemType " << Utility::enum_to_string(t) << " selected for NEDELEC_ONE FE family!");
+    }
+}
 
 
 #ifdef LIBMESH_ENABLE_AMR
@@ -484,21 +356,15 @@ template <> unsigned int FE<1,NEDELEC_ONE>::n_dofs(const ElemType, const Order) 
 template <> unsigned int FE<2,NEDELEC_ONE>::n_dofs(const ElemType t, const Order o) { return nedelec_one_n_dofs(t, o); }
 template <> unsigned int FE<3,NEDELEC_ONE>::n_dofs(const ElemType t, const Order o) { return nedelec_one_n_dofs(t, o); }
 
-
-// Do full-specialization for every dimension, instead
-// of explicit instantiation at the end of this function.
 template <> unsigned int FE<0,NEDELEC_ONE>::n_dofs_at_node(const ElemType, const Order, const unsigned int) { NEDELEC_LOW_D_ERROR_MESSAGE }
 template <> unsigned int FE<1,NEDELEC_ONE>::n_dofs_at_node(const ElemType, const Order, const unsigned int) { NEDELEC_LOW_D_ERROR_MESSAGE }
 template <> unsigned int FE<2,NEDELEC_ONE>::n_dofs_at_node(const ElemType t, const Order o, const unsigned int n) { return nedelec_one_n_dofs_at_node(t, o, n); }
 template <> unsigned int FE<3,NEDELEC_ONE>::n_dofs_at_node(const ElemType t, const Order o, const unsigned int n) { return nedelec_one_n_dofs_at_node(t, o, n); }
 
-
-// Nedelec first type elements have no dofs per element
-// FIXME: Only for first order!
 template <> unsigned int FE<0,NEDELEC_ONE>::n_dofs_per_elem(const ElemType, const Order) { NEDELEC_LOW_D_ERROR_MESSAGE }
 template <> unsigned int FE<1,NEDELEC_ONE>::n_dofs_per_elem(const ElemType, const Order) { NEDELEC_LOW_D_ERROR_MESSAGE }
-template <> unsigned int FE<2,NEDELEC_ONE>::n_dofs_per_elem(const ElemType, const Order) { return 0; }
-template <> unsigned int FE<3,NEDELEC_ONE>::n_dofs_per_elem(const ElemType, const Order) { return 0; }
+template <> unsigned int FE<2,NEDELEC_ONE>::n_dofs_per_elem(const ElemType t, const Order o) { return nedelec_one_n_dofs_per_elem(t, o); }
+template <> unsigned int FE<3,NEDELEC_ONE>::n_dofs_per_elem(const ElemType t, const Order o) { return nedelec_one_n_dofs_per_elem(t, o); }
 
 // Nedelec first type FEMs are always tangentially continuous
 template <> FEContinuity FE<0,NEDELEC_ONE>::get_continuity() const { NEDELEC_LOW_D_ERROR_MESSAGE }

--- a/src/fe/fe_nedelec_one_shape_2D.C
+++ b/src/fe/fe_nedelec_one_shape_2D.C
@@ -37,6 +37,10 @@ RealGradient FE<2,NEDELEC_ONE>::shape(const Elem * elem,
   libmesh_assert(elem);
 
   const Order total_order = static_cast<Order>(order + add_p_level * elem->p_level());
+  const short sign = elem->point(i) > elem->point((i+1) % elem->n_vertices()) ? 1 : -1;
+
+  const Real xi  = p(0);
+  const Real eta = p(1);
 
   switch (total_order)
     {
@@ -50,9 +54,6 @@ RealGradient FE<2,NEDELEC_ONE>::shape(const Elem * elem,
             {
               libmesh_assert_less (i, 4);
 
-              const Real xi  = p(0);
-              const Real eta = p(1);
-
               // Even with a loose inverse_map tolerance we ought to
               // be nearly on the element interior in master
               // coordinates
@@ -62,34 +63,13 @@ RealGradient FE<2,NEDELEC_ONE>::shape(const Elem * elem,
               switch(i)
                 {
                 case 0:
-                  {
-                    if (elem->point(0) > elem->point(1))
-                      return RealGradient( -0.25*(1.0-eta), 0.0 );
-                    else
-                      return RealGradient( 0.25*(1.0-eta), 0.0 );
-                  }
+                  return sign * RealGradient( -0.25*(1.0-eta), 0.0 );
                 case 1:
-                  {
-                    if (elem->point(1) > elem->point(2))
-                      return RealGradient( 0.0, -0.25*(1.0+xi) );
-                    else
-                      return RealGradient( 0.0, 0.25*(1.0+xi) );
-                  }
-
+                  return sign * RealGradient( 0.0, -0.25*(1.0+xi) );
                 case 2:
-                  {
-                    if (elem->point(2) > elem->point(3))
-                      return RealGradient( 0.25*(1.0+eta), 0.0 );
-                    else
-                      return RealGradient( -0.25*(1.0+eta), 0.0 );
-                  }
+                  return sign * RealGradient( 0.25*(1.0+eta), 0.0 );
                 case 3:
-                  {
-                    if (elem->point(3) > elem->point(0))
-                      return RealGradient( 0.0, -0.25*(xi-1.0) );
-                    else
-                      return RealGradient( 0.0, 0.25*(xi-1.0) );
-                  }
+                  return sign * RealGradient( 0.0, -0.25*(xi-1.0) );
 
                 default:
                   libmesh_error_msg("Invalid i = " << i);
@@ -101,35 +81,16 @@ RealGradient FE<2,NEDELEC_ONE>::shape(const Elem * elem,
           case TRI6:
           case TRI7:
             {
-              const Real xi  = p(0);
-              const Real eta = p(1);
-
               libmesh_assert_less (i, 3);
 
               switch(i)
                 {
                 case 0:
-                  {
-                    if (elem->point(0) > elem->point(1))
-                      return RealGradient( -1.0+eta, -xi );
-                    else
-                      return RealGradient( 1.0-eta, xi );
-                  }
+                  return sign * RealGradient( -1.0+eta, -xi );
                 case 1:
-                  {
-                    if (elem->point(1) > elem->point(2))
-                      return RealGradient( eta, -xi );
-                    else
-                      return RealGradient( -eta, xi );
-                  }
-
+                  return sign * RealGradient( eta, -xi );
                 case 2:
-                  {
-                    if (elem->point(2) > elem->point(0))
-                      return RealGradient( eta, -xi+1.0 );
-                    else
-                      return RealGradient( -eta, xi-1.0 );
-                  }
+                  return sign * RealGradient( eta, -xi+1.0 );
 
                 default:
                   libmesh_error_msg("Invalid i = " << i);
@@ -188,6 +149,7 @@ RealGradient FE<2,NEDELEC_ONE>::shape_deriv(const Elem * elem,
   libmesh_assert_less (j, 2);
 
   const Order total_order = static_cast<Order>(order + add_p_level * elem->p_level());
+  const short sign = elem->point(i) > elem->point((i+1) % elem->n_vertices()) ? 1 : -1;
 
   switch (total_order)
     {
@@ -212,19 +174,9 @@ RealGradient FE<2,NEDELEC_ONE>::shape_deriv(const Elem * elem,
                       case 2:
                         return RealGradient();
                       case 1:
-                        {
-                          if (elem->point(1) > elem->point(2))
-                            return RealGradient( 0.0, -0.25 );
-                          else
-                            return RealGradient( 0.0, 0.25 );
-                        }
                       case 3:
-                        {
-                          if (elem->point(3) > elem->point(0))
-                            return RealGradient( 0.0, -0.25 );
-                          else
-                            return RealGradient( 0.0, 0.25 );
-                        }
+                        return sign * RealGradient( 0.0, -0.25 );
+
                       default:
                         libmesh_error_msg("Invalid i = " << i);
                       }
@@ -239,19 +191,9 @@ RealGradient FE<2,NEDELEC_ONE>::shape_deriv(const Elem * elem,
                       case 3:
                         return RealGradient();
                       case 0:
-                        {
-                          if (elem->point(0) > elem->point(1))
-                            return RealGradient( 0.25 );
-                          else
-                            return RealGradient( -0.25 );
-                        }
                       case 2:
-                        {
-                          if (elem->point(2) > elem->point(3))
-                            return RealGradient( 0.25 );
-                          else
-                            return RealGradient( -0.25 );
-                        }
+                        return sign * RealGradient( 0.25 );
+
                       default:
                         libmesh_error_msg("Invalid i = " << i);
                       }
@@ -260,8 +202,6 @@ RealGradient FE<2,NEDELEC_ONE>::shape_deriv(const Elem * elem,
                 default:
                   libmesh_error_msg("Invalid j = " << j);
                 }
-
-              return RealGradient();
             }
 
           case TRI6:
@@ -269,45 +209,16 @@ RealGradient FE<2,NEDELEC_ONE>::shape_deriv(const Elem * elem,
             {
               libmesh_assert_less (i, 3);
 
-              // Account for edge flipping
-              Real f = 1.0;
-
-              switch(i)
-                {
-                case 0:
-                  {
-                    if (elem->point(0) > elem->point(1))
-                      f = -1.0;
-                    break;
-                  }
-                case 1:
-                  {
-                    if (elem->point(1) > elem->point(2))
-                      f = -1.0;
-                    break;
-                  }
-                case 2:
-                  {
-                    if (elem->point(2) > elem->point(0))
-                      f = -1.0;
-                    break;
-                  }
-                default:
-                  libmesh_error_msg("Invalid i = " << i);
-                }
-
               switch (j)
                 {
                   // d()/dxi
                 case 0:
-                  {
-                    return RealGradient( 0.0, f*1.0);
-                  }
+                  return sign * RealGradient( 0.0, -1.0 );
+
                   // d()/deta
                 case 1:
-                  {
-                    return RealGradient( f*(-1.0) );
-                  }
+                  return sign * RealGradient( 1.0 );
+
                 default:
                   libmesh_error_msg("Invalid j = " << j);
                 }


### PR DESCRIPTION
Hi Roy (@roystgnr), Alex (@lindsayad),

The overarching idea here is to generalise (some of) the code for arbitrary order finite elements.
I'm aware this would be a mammoth task, but I thought we could start with some small steps to better grasp the range of changes that'd be needed.

Since we are working on adding support for 2nd order Nédélec elements of the first kind, I thought instead of just hard-coding the various properties (e.g. the no. of dofs) we could try to generalise them. In the same spirit, for the shape functions, since they are orientation-dependent, I tried to avoid writing them twice as we had done thus far because even though that's not a lot for 1st order, trust me, it is for 2nd order. Here, it'd also be interesting to experiment with obtaining the shape functions from the dof definitions, although this would (a bit more fundamentally) change the way we think about assembly (we'd need to store the shape functions a-priori for a given element type and order perhaps the first time we see such an element).

Lastly, I'd like to understand what `n_dofs_per_elem` is supposed to return, and in particular its relationship with the middle node on TRI7, QUAD9 or HEX27 elements. For 2nd order Nédélec, we do have some dofs that are associated with the element, so where should they go? The middle node, or the element?

Cheers,
-Nuno