### PR TITLE
Store error indicator normalization in _rb_eim_error_indicators

### DIFF
--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -401,8 +401,10 @@ public:
 
   /**
    * Return the EIM error indicator values from the most recent call to rb_eim_solves().
+   * The first entry of each pair is the normalized error indicator, and the second
+   * entry is the normalization factor.
    */
-  const std::vector<Real> & get_rb_eim_error_indicators() const;
+  const std::vector<std::pair<Real,Real>> & get_rb_eim_error_indicators() const;
 
   /**
    * Set the data associated with EIM interpolation points.
@@ -717,7 +719,7 @@ private:
    * If we're using the EIM error indicator, then we store the error indicator
    * values corresponding to _rb_eim_solutions here.
    */
-  std::vector<Real> _rb_eim_error_indicators;
+  std::vector<std::pair<Real,Real>> _rb_eim_error_indicators;
 
   /**
    * Storage for EIM solutions from the training set. This is typically used in

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -279,7 +279,7 @@ void RBEIMEvaluation::rb_eim_solves(const std::vector<RBParameters> & mus,
             Number error_indicator_rhs = evaluated_values_at_err_indicator_point[counter];
             _rb_eim_error_indicators[counter] =
               get_eim_error_indicator(
-                error_indicator_rhs, _rb_eim_solutions[counter], EIM_rhs).first;
+                error_indicator_rhs, _rb_eim_solutions[counter], EIM_rhs);
           }
 
         counter++;
@@ -689,7 +689,7 @@ std::vector<DenseVector<Number>> & RBEIMEvaluation::get_eim_solutions_for_traini
   return _eim_solutions_for_training_set;
 }
 
-const std::vector<Real> & RBEIMEvaluation::get_rb_eim_error_indicators() const
+const std::vector<std::pair<Real,Real>> & RBEIMEvaluation::get_rb_eim_error_indicators() const
 {
   return _rb_eim_error_indicators;
 }


### PR DESCRIPTION
This is helpful since the normalization can be used to recover the absolute error indicator from the relative error indicator that is currently stored.