### PR TITLE
Keep mesh prepared when an extraction matrix has us create new NodeElems

### DIFF
--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -2082,6 +2082,8 @@ MeshBase::copy_constraint_rows(const SparseMatrix<T> & constraint_operator)
       elem->subdomain_id() = new_sbd_id;
 
       Elem * added_elem = this->add_elem(std::move(elem));
+      this->_elem_dims.insert(0);
+      this->_mesh_subdomains.insert(new_sbd_id);
       node_to_elem_ptrs.emplace(n, std::make_pair(added_elem->id(), 0));
       existing_unconstrained_columns.emplace(j,n->id());
 

--- a/tests/systems/constraint_operator_test.C
+++ b/tests/systems/constraint_operator_test.C
@@ -8,6 +8,7 @@
 #include <libmesh/mesh.h>
 #include <libmesh/mesh_generation.h>
 #include <libmesh/mesh_function.h>
+#include <libmesh/mesh_tools.h>
 #include <libmesh/numeric_vector.h>
 #include <libmesh/parallel.h>
 #include <libmesh/quadrature.h>
@@ -178,6 +179,13 @@ public:
 
     mesh.copy_constraint_rows(*matrix);
 
+    // We should be prepared at this point
+    CPPUNIT_ASSERT(mesh.is_prepared());
+    CPPUNIT_ASSERT(MeshTools::valid_is_prepared(mesh));
+
+    // Do a redundant prepare-for-use to catch any issues there
+    mesh.prepare_for_use();
+
     es.init ();
     sys.solve();
 
@@ -244,6 +252,8 @@ public:
 
     mesh.read(meshfile);
 
+    CPPUNIT_ASSERT(mesh.is_prepared());
+
     // For these matrices Coreform has been experimenting with PETSc
     // solvers which take the transpose of what we expect, so we'll
     // un-transpose here.
@@ -252,6 +262,13 @@ public:
     matrix->get_transpose(*matrix);
 
     mesh.copy_constraint_rows(*matrix);
+
+    // We should be prepared at this point
+    CPPUNIT_ASSERT(mesh.is_prepared());
+    CPPUNIT_ASSERT(MeshTools::valid_is_prepared(mesh));
+
+    // Do a redundant prepare-for-use to catch any issues there
+    mesh.prepare_for_use();
 
     es.init ();
     sys.solve();
@@ -315,6 +332,13 @@ public:
     matrix->read_matlab("meshes/constrain10to4.m");
 
     mesh.copy_constraint_rows(*matrix);
+
+    // We should be prepared at this point
+    CPPUNIT_ASSERT(mesh.is_prepared());
+    CPPUNIT_ASSERT(MeshTools::valid_is_prepared(mesh));
+
+    // Do a redundant prepare-for-use to catch any issues there
+    mesh.prepare_for_use();
 
     es.init ();
     sys.solve();


### PR DESCRIPTION
I can work around this at the application level, but we shouldn't have to.