### PR TITLE
Allow 1D elements to break symmetry of the "is neighbor of" relationship

### DIFF
--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -963,7 +963,6 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                               {
                                 neighbor->set_neighbor(ns,element);
                               }
-                            side_to_elem_map.erase (bounds.first);
 
                             // get out of this nested crap
                             goto next_side;

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -882,7 +882,9 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
   // with identical side keys and then check to see if they
   // are neighbors
   {
-    // data structures -- Use the hash_multimap if available
+    // map from side_key -> (Elem, side_index)
+    // We use a multimap since side keys are not guaranteed to be
+    // unique, then we verify sides actually match using Elem::operator==()
     typedef dof_id_type                     key_type;
     typedef std::pair<Elem *, unsigned char> val_type;
     typedef std::unordered_multimap<key_type, val_type> map_type;


### PR DESCRIPTION
Previously if we had an odd number of 1D elements which met at the same Node, one of them would end up not being paired off as neighbors with any other elements, and therefore, from its perspective, would appear to be on a boundary. This PR changes that behavior by allowing multiple 1D elements to have the same neighbor in that situation. I had to weaken some of the checks in `Elem::libmesh_assert_valid_neighbors()` to make this work, and I'm curious what else will break due to this change.