### PR TITLE
Relax some find_neighbors() assertions that can be overzealous for 1D Elems

### DIFF
--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -1068,11 +1068,13 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                       libmesh_assert(neigh_has_remote_children ||
                                      neigh->dim() == 1);
 
-                      // And let's double-check that we don't have
-                      // a remote_elem neighboring an active local element
+                      // And let's double-check that we don't have a
+                      // remote_elem neighboring an active local element
+                      // unless this is a 1D Elem, for the reasons
+                      // discussed above.
                       if (current_elem->active())
-                        libmesh_assert_not_equal_to (current_elem->processor_id(),
-                                                     this->processor_id());
+                        libmesh_assert (current_elem->dim() == 1 ||
+                                        current_elem->processor_id() != this->processor_id());
 #endif // DEBUG
                       neigh = const_cast<RemoteElem *>(remote_elem);
                     }


### PR DESCRIPTION
I don't think it will be easy to make #3851 work correctly in the short term, so this PR takes a different approach which is basically to just allow incomplete/incorrect neighbor information on meshes with multiple 1D Elems meeting in a single Node. To be clear, we were already doing this so the PR doesn't make it any worse, but we did have some overzealous asserts in `find_neighbors()` which are currently being tripped when refining such meshes.