### PR TITLE
More testing and support for IsoGeometric Analysis on distributed meshes

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1716,6 +1716,22 @@ public:
   void copy_constraint_rows(const SparseMatrix<T> & constraint_operator);
 
   /**
+   * Prints (from processor 0) all mesh constraint rows.  If \p
+   * print_nonlocal is true, then each constraint is printed once for
+   * each processor that knows about it, which may be useful for \p
+   * DistributedMesh debugging.
+   */
+  void print_constraint_rows(std::ostream & os=libMesh::out,
+                             bool print_nonlocal=false) const;
+
+  /**
+   * Gets a string reporting all mesh constraint rows local to
+   * this processor.  If \p print_nonlocal is true, then nonlocal
+   * constraints which are locally known are included.
+   */
+  std::string get_local_constraints(bool print_nonlocal=false) const;
+
+  /**
    * \deprecated This method has ben replaced by \p cache_elem_data which
    * caches data in addition to elem dimensions (e.g. elem subdomain ids)
    * Search the mesh and cache the different dimensions of the elements

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1674,17 +1674,21 @@ public:
   typedef std::vector<std::pair<std::pair<const Elem *, unsigned int>, Real>> constraint_rows_mapped_type;
   typedef std::map<const Node *, constraint_rows_mapped_type> constraint_rows_type;
 
-
   /**
-   * Copy the constraints from the other mesh to this mesh
+   * Constraint rows accessors
    */
-  void copy_constraint_rows(const MeshBase & other_mesh);
-
   constraint_rows_type & get_constraint_rows()
   { return _constraint_rows; }
 
   const constraint_rows_type & get_constraint_rows() const
   { return _constraint_rows; }
+
+  dof_id_type n_constraint_rows() const;
+
+  /**
+   * Copy the constraints from the other mesh to this mesh
+   */
+  void copy_constraint_rows(const MeshBase & other_mesh);
 
   /**
    * Copy the constraints from the given matrix to this mesh.  The

--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -23,10 +23,13 @@
 // Local Includes
 #include "libmesh/compare_elems_by_level.h"
 #include "libmesh/libmesh_common.h"
-#include "libmesh/mesh_tools.h"
+#include "libmesh/mesh_base.h"
 
 // C++ Includes
+#include <set>
+#include <utility>
 #include <unordered_map>
+#include <vector>
 
 namespace libMesh
 {

--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -281,6 +281,10 @@ void connect_children(const MeshBase & mesh,
 // subactive descendants as well.  If a mesh is provided and has any
 // constraint rows, insert elements with the constraining nodes for
 // any constrained nodes in our set.
+//
+// This method is now deprecated, because it does not handle recursive
+// dependencies.  Use the new connect_element_dependencies method
+// instead.
 void connect_families(connected_elem_set_type & connected_elements,
                       const MeshBase * mesh = nullptr);
 

--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -256,6 +256,10 @@ public:
 
 // Related utilities
 
+// What to use to fill sets of connected nodes and elements
+typedef std::set<const Node *> connected_node_set_type;
+typedef std::set<const Elem *, CompareElemIdsByLevel> connected_elem_set_type;
+
 // Ask a mesh's ghosting functors to insert into a set all elements
 // that are either on or connected to processor id \p pid.  Ask only
 // for elements in the range from \p elem_it before \p elem_end;
@@ -264,30 +268,46 @@ void query_ghosting_functors(const MeshBase & mesh,
                              processor_id_type pid,
                              MeshBase::const_element_iterator elem_it,
                              MeshBase::const_element_iterator elem_end,
-                             std::set<const Elem *, CompareElemIdsByLevel> & connected_elements);
+                             connected_elem_set_type & connected_elements);
 
 // Take a set of elements and insert all immediate
 // children of elements in the given range
 void connect_children(const MeshBase & mesh,
                       MeshBase::const_element_iterator elem_it,
                       MeshBase::const_element_iterator elem_end,
-                      std::set<const Elem *, CompareElemIdsByLevel> & connected_elements);
+                      connected_elem_set_type & connected_elements);
 
 // Take a set of elements and insert all elements' ancestors and
 // subactive descendants as well.  If a mesh is provided and has any
 // constraint rows, insert elements with the constraining nodes for
 // any constrained nodes in our set.
-void connect_families(std::set<const Elem *, CompareElemIdsByLevel> & connected_elements,
+void connect_families(connected_elem_set_type & connected_elements,
                       const MeshBase * mesh = nullptr);
 
-// What to use to fill sets of connected nodes
-typedef std::set<const Node *> connected_node_set_type;
-
 // Take a set of elements and create a set of connected nodes.
-void reconnect_nodes (const std::set<const Elem *, CompareElemIdsByLevel> & connected_elements,
+void reconnect_nodes (connected_elem_set_type & connected_elements,
                       connected_node_set_type & connected_nodes);
 
+// Take a set of elements and of nodes, and insert all
+// libMesh-mandated element of them: ancestor elements,
+// immediate children, subactive descendents of active elements,
+// interior_parents, nodes of any of those elements, and elements used
+// to constrain any of those nodes.  This must be done recursively
+// (well, repeatedly; we unroll) in the general case, since a node
+// constraint can require a new element that can require other new
+// elements with new nodes with new constraints.
+void connect_element_dependencies(const MeshBase & mesh,
+                                  connected_elem_set_type & connected_elements,
+                                  connected_node_set_type & connected_nodes);
 
+// Takes already-examined sets and not-yet-examined sets, returns more sets
+// in need of examination (or empty sets if done).
+std::pair<connected_elem_set_type, connected_node_set_type>
+connect_element_dependencies(const MeshBase & mesh,
+                             const connected_elem_set_type & connected_elements,
+                             const connected_node_set_type & connected_nodes,
+                             const connected_elem_set_type & new_connected_elements,
+                             const connected_node_set_type & new_connected_nodes);
 
 //--------------------------------------------------------------
 // MeshCommunication inline members

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -425,13 +425,6 @@ void libmesh_assert_valid_amr_elem_ids (const MeshBase & mesh);
 void libmesh_assert_valid_amr_interior_parents (const MeshBase & mesh);
 
 /**
- * A function for verifying that all mesh constraint rows express
- * relations between nodes and elements that are semilocal (local or
- * ghosted) to the current processor's portion of the mesh.
- */
-void libmesh_assert_valid_constraint_rows (const MeshBase & mesh);
-
-/**
  * A function for verifying that degree of freedom indexes are
  * contiguous on each processor, as is required by libMesh numeric
  * classes.
@@ -505,6 +498,13 @@ void libmesh_assert_equal_connectivity (const MeshBase & mesh);
  * nodes.
  */
 void libmesh_assert_connected_nodes (const MeshBase & mesh);
+
+/**
+ * A function for verifying that all mesh constraint rows express
+ * relations between nodes and elements that are semilocal (local or
+ * ghosted) to the current processor's portion of the mesh.
+ */
+void libmesh_assert_valid_constraint_rows (const MeshBase & mesh);
 
 /**
  * A function for verifying that boundary condition ids match

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1914,9 +1914,6 @@ void DofMap::process_mesh_constraint_rows(const MeshBase & mesh)
   libmesh_assert(!constraint_rows_empty);
 #endif
 
-  // This is fairly new code, still a bit experimental.
-  libmesh_experimental();
-
   // We can't handle periodic boundary conditions on spline meshes
   // yet.
 #ifdef LIBMESH_ENABLE_PERIODIC

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -471,15 +471,12 @@ void CheckpointIO::write (const std::string & name)
                   query_ghosting_functors
                     (mesh, p, active_pid_elements_begin,
                      active_pid_elements_end, elements);
-                  connect_children(mesh, pid_elements_begin,
-                                   pid_elements_end, elements);
                 }
-              connect_families(elements);
             }
         }
 
       connected_node_set_type connected_nodes;
-      reconnect_nodes(elements, connected_nodes);
+      connect_element_dependencies(mesh, elements, connected_nodes);
 
       // write the nodal locations
       this->write_nodes (io, connected_nodes);

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -471,6 +471,8 @@ void CheckpointIO::write (const std::string & name)
                   query_ghosting_functors
                     (mesh, p, active_pid_elements_begin,
                      active_pid_elements_end, elements);
+                  connect_children(mesh, pid_elements_begin,
+                                   pid_elements_end, elements);
                 }
             }
         }

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -1764,6 +1764,11 @@ void DistributedMesh::delete_remote_elements()
   // elements; let's update our caches.
   this->update_parallel_id_counts();
 
+  // We may have deleted nodes or elements that were the only local
+  // representatives of some particular boundary id(s); let's update
+  // those caches.
+  this->get_boundary_info().regenerate_id_sets();
+
 #ifdef DEBUG
   // We might not have well-packed objects if the user didn't allow us
   // to renumber

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -25,6 +25,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_communication.h"
+#include "libmesh/mesh_tools.h"
 #include "libmesh/partitioner.h"
 #include "libmesh/string_to_enum.h"
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -2243,11 +2243,13 @@ std::string MeshBase::get_local_constraints(bool print_nonlocal) const
 
   for (const auto & [node, row] : _constraint_rows)
     {
+      const bool local = (node->processor_id() == this->processor_id());
+
       // Skip non-local dofs if requested
-      if (!print_nonlocal && node->processor_id() != this->processor_id())
+      if (!print_nonlocal && !local)
         continue;
 
-      os << "Constraints for Node " << node->id()
+      os << "Constraints for " << (local ? "Local" : "Ghost") << " Node " << node->id()
          << ": \t";
 
       for (const auto & [elem_and_node, coef] : row)

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -1951,6 +1951,23 @@ bool MeshBase::nodes_and_elements_equal(const MeshBase & other_mesh) const
 }
 
 
+dof_id_type MeshBase::n_constraint_rows() const
+{
+  dof_id_type n_local_rows=0, n_unpartitioned_rows=0;
+  for (const auto & [node, node_constraints] : _constraint_rows)
+    {
+      // Unpartitioned nodes
+      if (node->processor_id() == DofObject::invalid_processor_id)
+        n_unpartitioned_rows++;
+      else if (node->processor_id() == this->processor_id())
+        n_local_rows++;
+    }
+
+  this->comm().sum(n_local_rows);
+
+  return n_unpartitioned_rows + n_local_rows;
+}
+
 
 void
 MeshBase::copy_constraint_rows(const MeshBase & other_mesh)

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -221,38 +221,62 @@ bool MeshBase::operator== (const MeshBase & other_mesh) const
 
 bool MeshBase::locally_equals (const MeshBase & other_mesh) const
 {
-  // Check whether everything in the base is equal
-  if (_n_parts != other_mesh._n_parts ||
-      _default_mapping_type != other_mesh._default_mapping_type ||
-      _default_mapping_data != other_mesh._default_mapping_data ||
-      _is_prepared != other_mesh._is_prepared ||
-      _count_lower_dim_elems_in_point_locator !=
-        other_mesh._count_lower_dim_elems_in_point_locator ||
-      // We expect this to change in a DistributeMesh prepare_for_use();
-      // it's conceptually "mutable"...
-/*
-#ifdef LIBMESH_ENABLE_UNIQUE_ID
-      _next_unique_id != other_mesh._next_unique_id ||
-#endif
-*/
-      _skip_noncritical_partitioning != other_mesh._skip_noncritical_partitioning ||
-      _skip_all_partitioning != other_mesh._skip_all_partitioning ||
-      _skip_renumber_nodes_and_elements != other_mesh._skip_renumber_nodes_and_elements ||
-      _skip_find_neighbors != other_mesh._skip_find_neighbors ||
-      _allow_remote_element_removal != other_mesh._allow_remote_element_removal ||
-      _spatial_dimension != other_mesh._spatial_dimension ||
-      _point_locator_close_to_point_tol != other_mesh._point_locator_close_to_point_tol ||
-      _block_id_to_name != other_mesh._block_id_to_name ||
-      _elem_dims != other_mesh._elem_dims ||
-      _mesh_subdomains != other_mesh._mesh_subdomains ||
-      _all_elemset_ids != other_mesh._all_elemset_ids ||
-      _elem_integer_names != other_mesh._elem_integer_names ||
-      _elem_integer_default_values != other_mesh._elem_integer_default_values ||
-      _node_integer_names != other_mesh._node_integer_names ||
-      _node_integer_default_values != other_mesh._node_integer_default_values ||
-      bool(_default_ghosting) != bool(other_mesh._default_ghosting) ||
-      bool(_partitioner) != bool(other_mesh._partitioner) ||
-      *boundary_info != *other_mesh.boundary_info)
+  // Check whether (almost) everything in the base is equal
+  //
+  // We don't check _next_unique_id here, because it's expected to
+  // change in a DistributedMesh prepare_for_use(); it's conceptually
+  // "mutable".
+  //
+  // We use separate if statements instead of logical operators here,
+  // to make it easy to see the failing condition when using a
+  // debugger to figure out why a MeshTools::valid_is_prepared(mesh)
+  // is failing.
+  if (_n_parts != other_mesh._n_parts)
+    return false;
+  if (_default_mapping_type != other_mesh._default_mapping_type)
+    return false;
+  if (_default_mapping_data != other_mesh._default_mapping_data)
+    return false;
+  if (_is_prepared != other_mesh._is_prepared)
+    return false;
+  if (_count_lower_dim_elems_in_point_locator !=
+        other_mesh._count_lower_dim_elems_in_point_locator)
+    return false;
+  if (_skip_noncritical_partitioning != other_mesh._skip_noncritical_partitioning)
+    return false;
+  if (_skip_all_partitioning != other_mesh._skip_all_partitioning)
+    return false;
+  if (_skip_renumber_nodes_and_elements != other_mesh._skip_renumber_nodes_and_elements)
+    return false;
+  if (_skip_find_neighbors != other_mesh._skip_find_neighbors)
+    return false;
+  if (_allow_remote_element_removal != other_mesh._allow_remote_element_removal)
+    return false;
+  if (_spatial_dimension != other_mesh._spatial_dimension)
+    return false;
+  if (_point_locator_close_to_point_tol != other_mesh._point_locator_close_to_point_tol)
+    return false;
+  if (_block_id_to_name != other_mesh._block_id_to_name)
+    return false;
+  if (_elem_dims != other_mesh._elem_dims)
+    return false;
+  if (_mesh_subdomains != other_mesh._mesh_subdomains)
+    return false;
+  if (_all_elemset_ids != other_mesh._all_elemset_ids)
+    return false;
+  if (_elem_integer_names != other_mesh._elem_integer_names)
+    return false;
+  if (_elem_integer_default_values != other_mesh._elem_integer_default_values)
+    return false;
+  if (_node_integer_names != other_mesh._node_integer_names)
+    return false;
+  if (_node_integer_default_values != other_mesh._node_integer_default_values)
+    return false;
+  if (bool(_default_ghosting) != bool(other_mesh._default_ghosting))
+    return false;
+  if (bool(_partitioner) != bool(other_mesh._partitioner))
+    return false;
+  if (*boundary_info != *other_mesh.boundary_info)
     return false;
 
   const constraint_rows_type & other_rows =

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -768,6 +768,12 @@ void MeshBase::prepare_for_use ()
 
   libmesh_assert(this->comm().verify(this->is_serial()));
 
+  // If we don't go into this method with valid constraint rows, we're
+  // only going to be able to make that worse.
+#ifdef DEBUG
+  MeshTools::libmesh_assert_valid_constraint_rows(*this);
+#endif
+
   // A distributed mesh may have processors with no elements (or
   // processors with no elements of higher dimension, if we ever
   // support mixed-dimension meshes), but we want consistent

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -2082,6 +2082,8 @@ MeshBase::copy_constraint_rows(const SparseMatrix<T> & constraint_operator)
       elem->subdomain_id() = new_sbd_id;
 
       Elem * added_elem = this->add_elem(std::move(elem));
+      this->_elem_dims.insert(0);
+      this->_mesh_subdomains.insert(new_sbd_id);
       node_to_elem_ptrs.emplace(n, std::make_pair(added_elem->id(), 0));
       existing_unconstrained_columns.emplace(j,n->id());
 

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -2173,6 +2173,7 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
   const dof_id_type par_max_elem_id = mesh.parallel_max_elem_id();
   libmesh_assert_equal_to (par_max_node_id, mesh.max_node_id());
   libmesh_assert_equal_to (par_max_elem_id, mesh.max_elem_id());
+  const dof_id_type n_constraint_rows = mesh.n_constraint_rows();
 #endif
 
   connected_elem_set_type elements_to_keep;
@@ -2264,6 +2265,9 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
     gf->delete_remote_elements();
 
 #ifdef DEBUG
+  const dof_id_type n_new_constraint_rows = mesh.n_constraint_rows();
+  libmesh_assert_equal_to(n_constraint_rows, n_new_constraint_rows);
+
   MeshTools::libmesh_assert_valid_refinement_tree(mesh);
   MeshTools::libmesh_assert_valid_constraint_rows(mesh);
 #endif

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -544,6 +544,11 @@ void MeshCommunication::redistribute (DistributedMesh & mesh,
   bool have_constraint_rows = !constraint_rows.empty();
   mesh.comm().broadcast(have_constraint_rows);
 
+#ifdef DEBUG
+  const dof_id_type n_constraint_rows =
+    have_constraint_rows ? mesh.n_constraint_rows() : 0;
+#endif
+
   typedef std::vector<std::pair<std::pair<dof_id_type, unsigned int>, Real>>
     serialized_row_type;
   std::unordered_map<processor_id_type,
@@ -659,6 +664,13 @@ void MeshCommunication::redistribute (DistributedMesh & mesh,
   MeshTools::libmesh_assert_equal_n_systems(mesh);
 
   MeshTools::libmesh_assert_valid_refinement_tree(mesh);
+
+  const dof_id_type new_n_constraint_rows =
+    have_constraint_rows ? mesh.n_constraint_rows() : 0;
+
+  libmesh_assert_equal_to(n_constraint_rows, new_n_constraint_rows);
+
+  MeshTools::libmesh_assert_valid_constraint_rows(mesh);
 #endif
 
   // If we had a point locator, it's invalid now that there are new

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -128,6 +128,194 @@ struct SyncNeighbors
   }
 };
 
+
+void connect_new_children(const MeshBase & mesh,
+                          const connected_elem_set_type & connected_elements,
+                          const connected_elem_set_type & new_connected_elements,
+                          connected_elem_set_type & newer_connected_elements)
+{
+  // None of these parameters are used when !LIBMESH_ENABLE_AMR.
+  libmesh_ignore(mesh, connected_elements, new_connected_elements,
+                 newer_connected_elements);
+
+#ifdef LIBMESH_ENABLE_AMR
+  // Our XdrIO output needs inactive local elements to not have any
+  // remote_elem children.  Let's make sure that doesn't happen.
+  //
+  for (const auto & elem : new_connected_elements)
+    {
+      if (elem->has_children())
+        for (auto & child : elem->child_ref_range())
+          if (&child != remote_elem &&
+              !connected_elements.count(&child) &&
+              !new_connected_elements.count(&child))
+            newer_connected_elements.insert(&child);
+    }
+#endif // LIBMESH_ENABLE_AMR
+}
+
+
+void
+connect_element_families(const connected_elem_set_type & connected_elements,
+                         const connected_elem_set_type & new_connected_elements,
+                         connected_elem_set_type & newer_connected_elements,
+                         const MeshBase * mesh)
+{
+  // mesh was an optional parameter for API backwards compatibility
+  if (mesh && !mesh->get_constraint_rows().empty())
+    {
+      // We start with the constraint connections, not ancestors,
+      // because we don't need constraining nodes of elements'
+      // ancestors' constrained nodes.
+      const auto & constraint_rows = mesh->get_constraint_rows();
+
+      std::unordered_set<const Elem *> constraining_nodes_elems;
+      for (const Elem * elem : connected_elements)
+        {
+          for (const Node & node : elem->node_ref_range())
+            {
+              // Retain all elements containing constraining nodes
+              if (const auto it = constraint_rows.find(&node);
+                  it != constraint_rows.end())
+                for (auto & p : it->second)
+                  {
+                    const Elem * constraining_elem = p.first.first;
+                    libmesh_assert(constraining_elem ==
+                                   mesh->elem_ptr(constraining_elem->id()));
+                    if (!connected_elements.count(constraining_elem) &&
+                        !new_connected_elements.count(constraining_elem))
+                      constraining_nodes_elems.insert(constraining_elem);
+                  }
+            }
+        }
+
+      newer_connected_elements.insert(constraining_nodes_elems.begin(),
+                                      constraining_nodes_elems.end());
+    }
+
+#ifdef LIBMESH_ENABLE_AMR
+
+  // Because our set is sorted by ascending level, we can traverse it
+  // in reverse order, adding parents as we go, and end up with all
+  // ancestors added.  This is safe for std::set where insert doesn't
+  // invalidate iterators.
+  //
+  // This only works because we do *not* cache
+  // connected_elements.rend(), whose value can change when we insert
+  // elements which are sorted before the original rend.
+  //
+  // We're also going to get subactive descendents here, when any
+  // exist.  We're iterating in the wrong direction to do that
+  // non-recursively, so we'll cop out and rely on total_family_tree.
+  // Iterating backwards does mean that we won't be querying the newly
+  // inserted subactive elements redundantly.
+
+  connected_elem_set_type::reverse_iterator
+    elem_rit  = new_connected_elements.rbegin();
+
+  for (; elem_rit != new_connected_elements.rend(); ++elem_rit)
+    {
+      const Elem * elem = *elem_rit;
+      libmesh_assert(elem);
+
+      // We let ghosting functors worry about only active elements,
+      // but the remote processor needs all its semilocal elements'
+      // ancestors and active semilocal elements' descendants too.
+      for (const Elem * parent = elem->parent(); parent;
+           parent = parent->parent())
+        if (!connected_elements.count(parent) &&
+            !new_connected_elements.count(parent))
+          newer_connected_elements.insert (parent);
+
+      auto total_family_insert =
+        [&connected_elements, &new_connected_elements,
+         &newer_connected_elements]
+        (const Elem * e)
+        {
+          if (e->active() && e->has_children())
+            {
+              std::vector<const Elem *> subactive_family;
+              e->total_family_tree(subactive_family);
+              for (const auto & f : subactive_family)
+                {
+                  libmesh_assert(f != remote_elem);
+                  if (!connected_elements.count(f) &&
+                      !new_connected_elements.count(f))
+                    newer_connected_elements.insert(f);
+                }
+            }
+        };
+
+      total_family_insert(elem);
+
+      // We also need any interior parents on this mesh, which will
+      // then need their own ancestors and descendants.
+      const Elem * interior_parent = elem->interior_parent();
+
+      // Don't try to grab interior parents from other meshes, e.g. if
+      // this was a BoundaryMesh associated with a separate Mesh.
+
+      // We can't test this if someone's using the pre-mesh-ptr API
+      libmesh_assert(!interior_parent || mesh);
+
+      if (interior_parent &&
+          interior_parent == mesh->query_elem_ptr(interior_parent->id()) &&
+          !connected_elements.count(interior_parent) &&
+          !new_connected_elements.count(interior_parent))
+        {
+          newer_connected_elements.insert (interior_parent);
+          total_family_insert(interior_parent);
+        }
+    }
+
+#  ifdef DEBUG
+  // Let's be paranoid and make sure that all our ancestors
+  // really did get inserted.  I screwed this up the first time
+  // by caching rend, and I can easily imagine screwing it up in
+  // the future by changing containers.
+  auto check_elem =
+    [&connected_elements,
+     &new_connected_elements,
+     &newer_connected_elements]
+    (const Elem * elem)
+    {
+      libmesh_assert(elem);
+      const Elem * parent = elem->parent();
+      if (parent)
+        libmesh_assert(connected_elements.count(parent) ||
+                       new_connected_elements.count(parent) ||
+                       newer_connected_elements.count(parent));
+    };
+
+  for (const auto & elem : connected_elements)
+    check_elem(elem);
+  for (const auto & elem : new_connected_elements)
+    check_elem(elem);
+  for (const auto & elem : newer_connected_elements)
+    check_elem(elem);
+#  endif // DEBUG
+
+#endif // LIBMESH_ENABLE_AMR
+}
+
+
+
+void connect_nodes (const connected_elem_set_type & new_connected_elements,
+                    const connected_node_set_type & connected_nodes,
+                    const connected_node_set_type & new_connected_nodes,
+                    connected_node_set_type & newer_connected_nodes)
+{
+  for (const auto & elem : new_connected_elements)
+    for (auto & n : elem->node_ref_range())
+      if (!connected_nodes.count(&n) &&
+          !new_connected_nodes.count(&n))
+        newer_connected_nodes.insert(&n);
+}
+
+
+
+
+
 } // anonymous namespace
 #endif // LIBMESH_HAVE_MPI
 
@@ -141,7 +329,7 @@ void query_ghosting_functors(const MeshBase & mesh,
                              processor_id_type pid,
                              MeshBase::const_element_iterator elem_it,
                              MeshBase::const_element_iterator elem_end,
-                             std::set<const Elem *, CompareElemIdsByLevel> & connected_elements)
+                             connected_elem_set_type & connected_elements)
 {
   for (auto & gf :
          as_range(mesh.ghosting_functors_begin(),
@@ -172,154 +360,100 @@ void query_ghosting_functors(const MeshBase & mesh,
 void connect_children(const MeshBase & mesh,
                       MeshBase::const_element_iterator elem_it,
                       MeshBase::const_element_iterator elem_end,
-                      std::set<const Elem *, CompareElemIdsByLevel> & connected_elements)
+                      connected_elem_set_type & newer_connected_elements)
 {
-  // None of these parameters are used when !LIBMESH_ENABLE_AMR.
-  libmesh_ignore(mesh, elem_it, elem_end, connected_elements);
+  connected_elem_set_type new_connected_elements(elem_it, elem_end);
 
-#ifdef LIBMESH_ENABLE_AMR
-  // Our XdrIO output needs inactive local elements to not have any
-  // remote_elem children.  Let's make sure that doesn't happen.
-  //
-  for (const auto & elem : as_range(elem_it, elem_end))
-    {
-      if (elem->has_children())
-        for (auto & child : elem->child_ref_range())
-          if (&child != remote_elem)
-            connected_elements.insert(&child);
-    }
-#endif // LIBMESH_ENABLE_AMR
+  connect_new_children(mesh, new_connected_elements,
+                       new_connected_elements,
+                       newer_connected_elements);
 }
 
 
-void connect_families(std::set<const Elem *, CompareElemIdsByLevel> & connected_elements,
+void connect_families(connected_elem_set_type & connected_elements,
                       const MeshBase * mesh)
 {
-  // mesh was an optional parameter for API backwards compatibility
-  if (mesh && !mesh->get_constraint_rows().empty())
-    {
-      // We start with the constraint connections, not ancestors,
-      // because we don't need constraining nodes of elements'
-      // ancestors' constrained nodes.
-      const auto & constraint_rows = mesh->get_constraint_rows();
+  // This old API won't be sufficient in cases (IGA meshes with
+  // non-NodeElem nodes acting as the unconstrained DoFs) that require
+  // recursion.
+  libmesh_deprecated();
 
-      std::unordered_set<const Elem *> constraining_nodes_elems;
-      for (const Elem * elem : connected_elements)
-        {
-          for (const Node & node : elem->node_ref_range())
-            {
-              // Retain all elements containing constraining nodes
-              if (const auto it = constraint_rows.find(&node);
-                  it != constraint_rows.end())
-                for (auto & p : it->second)
-                  {
-                    const Elem * constraining_elem = p.first.first;
-                    libmesh_assert(constraining_elem ==
-                                   mesh->elem_ptr(constraining_elem->id()));
-                    constraining_nodes_elems.insert(constraining_elem);
-                  }
-            }
-        }
-
-      connected_elements.insert(constraining_nodes_elems.begin(),
-                                constraining_nodes_elems.end());
-    }
-
-#ifdef LIBMESH_ENABLE_AMR
-
-  // Because our set is sorted by ascending level, we can traverse it
-  // in reverse order, adding parents as we go, and end up with all
-  // ancestors added.  This is safe for std::set where insert doesn't
-  // invalidate iterators.
-  //
-  // This only works because we do *not* cache
-  // connected_elements.rend(), whose value can change when we insert
-  // elements which are sorted before the original rend.
-  //
-  // We're also going to get subactive descendents here, when any
-  // exist.  We're iterating in the wrong direction to do that
-  // non-recursively, so we'll cop out and rely on total_family_tree.
-  // Iterating backwards does mean that we won't be querying the newly
-  // inserted subactive elements redundantly.
-
-  std::set<const Elem *, CompareElemIdsByLevel>::reverse_iterator
-    elem_rit  = connected_elements.rbegin();
-
-  for (; elem_rit != connected_elements.rend(); ++elem_rit)
-    {
-      const Elem * elem = *elem_rit;
-      libmesh_assert(elem);
-
-      // We let ghosting functors worry about only active elements,
-      // but the remote processor needs all its semilocal elements'
-      // ancestors and active semilocal elements' descendants too.
-      const Elem * parent = elem->parent();
-      if (parent)
-        connected_elements.insert (parent);
-
-      auto total_family_insert = [& connected_elements](const Elem * e)
-        {
-          if (e->active() && e->has_children())
-            {
-              std::vector<const Elem *> subactive_family;
-              e->total_family_tree(subactive_family);
-              for (const auto & f : subactive_family)
-                {
-                  libmesh_assert(f != remote_elem);
-                  connected_elements.insert(f);
-                }
-            }
-        };
-
-      total_family_insert(elem);
-
-      // We also need any interior parents on this mesh, which will
-      // then need their own ancestors and descendants.
-      const Elem * interior_parent = elem->interior_parent();
-
-      // Don't try to grab interior parents from other meshes, e.g. if
-      // this was a BoundaryMesh associated with a separate Mesh.
-
-      // We can't test this if someone's using the pre-mesh-ptr API
-      libmesh_assert(!interior_parent || mesh);
-
-      if (interior_parent &&
-          interior_parent == mesh->query_elem_ptr(interior_parent->id()) &&
-          !connected_elements.count(interior_parent))
-        {
-          connected_elements.insert (interior_parent);
-          total_family_insert(interior_parent);
-        }
-    }
-
-#  ifdef DEBUG
-  // Let's be paranoid and make sure that all our ancestors
-  // really did get inserted.  I screwed this up the first time
-  // by caching rend, and I can easily imagine screwing it up in
-  // the future by changing containers.
-  for (const auto & elem : connected_elements)
-    {
-      libmesh_assert(elem);
-      const Elem * parent = elem->parent();
-      if (parent)
-        libmesh_assert(connected_elements.count(parent));
-    }
-#  endif // DEBUG
-
-#endif // LIBMESH_ENABLE_AMR
+  // Just do everything in one fell swoop; this is adequate for most
+  // meshes.
+  connect_element_families(connected_elements, connected_elements,
+                           connected_elements, mesh);
 }
 
 
-void reconnect_nodes (const std::set<const Elem *, CompareElemIdsByLevel> & connected_elements,
+
+void reconnect_nodes (connected_elem_set_type & connected_elements,
                       connected_node_set_type & connected_nodes)
 {
   // We're done using the nodes list for element decisions; now
   // let's reuse it for nodes of the elements we've decided on.
   connected_nodes.clear();
 
-  for (const auto & elem : connected_elements)
-    for (auto & n : elem->node_ref_range())
-      connected_nodes.insert(&n);
+  // Use the newer API
+  connect_nodes(connected_elements, connected_nodes, connected_nodes,
+                connected_nodes);
+}
+
+
+void connect_element_dependencies(const MeshBase & mesh,
+                                  connected_node_set_type & connected_nodes,
+                                  connected_elem_set_type & connected_elements)
+{
+  // We haven't examined any of these inputs for dependencies yet, so
+  // let's mark them all as to be examined now.
+  connected_elem_set_type new_connected_elements;
+  connected_node_set_type new_connected_nodes;
+  new_connected_elements.swap(connected_elements);
+  new_connected_nodes.swap(connected_nodes);
+
+  while (!new_connected_elements.empty() ||
+         !new_connected_nodes.empty())
+    {
+      auto [newer_connected_elements,
+            newer_connected_nodes] =
+        connect_element_dependencies
+          (mesh, connected_elements, connected_nodes,
+           new_connected_elements, new_connected_nodes);
+
+      // These have now been examined
+      connected_elements.merge(new_connected_elements);
+      connected_nodes.merge(new_connected_nodes);
+
+      // merge() doesn't guarantee empty() unless there are no
+      // duplicates, which there shouldn't be
+      libmesh_assert(new_connected_elements.empty());
+      libmesh_assert(new_connected_nodes.empty());
+
+      // These now need to be examined
+      new_connected_elements.swap(newer_connected_elements);
+      new_connected_nodes.swap(newer_connected_nodes);
+    }
+}
+
+
+std::pair<connected_elem_set_type, connected_node_set_type>
+connect_element_dependencies(const MeshBase & mesh,
+                             const connected_elem_set_type & connected_elements,
+                             const connected_node_set_type & connected_nodes,
+                             const connected_elem_set_type & new_connected_elements,
+                             const connected_node_set_type & new_connected_nodes)
+{
+  std::pair<connected_elem_set_type, connected_node_set_type> returnval;
+  auto & [newer_connected_elements, newer_connected_nodes] = returnval;
+  connect_new_children(mesh, connected_elements,
+                       new_connected_elements,
+                       newer_connected_elements);
+  connect_element_families(connected_elements, new_connected_elements,
+                           newer_connected_elements, &mesh);
+
+  connect_nodes(new_connected_elements, connected_nodes,
+                new_connected_nodes, newer_connected_nodes);
+
+  return returnval;
 }
 
 
@@ -450,26 +584,15 @@ void MeshCommunication::redistribute (DistributedMesh & mesh,
         MeshBase::const_element_iterator
           (elemend, elemend, Predicates::NotNull<v_t *>());
 
-      std::set<const Elem *, CompareElemIdsByLevel> elements_to_send;
+      connected_elem_set_type elements_to_send;
 
       // See which to-be-ghosted elements we need to send
       query_ghosting_functors (mesh, pid, elem_it, elem_end,
                                elements_to_send);
 
-      // The inactive elements we need to send should have their
-      // immediate children present.
-      connect_children(mesh, mesh.pid_elements_begin(pid),
-                       mesh.pid_elements_end(pid),
-                       elements_to_send);
-
-      // The elements we need should have their ancestors and their
-      // subactive children present too.  If the mesh has any
-      // constraint rows, then elements with constrained nodes need
-      // elements with constraining nodes to remain present.
-      connect_families(elements_to_send, &mesh);
-
+      // And see which elements and nodes they depend on
       connected_node_set_type connected_nodes;
-      reconnect_nodes(elements_to_send, connected_nodes);
+      connect_element_dependencies(mesh, connected_nodes, elements_to_send);
 
       all_nodes_to_send[pid].assign(connected_nodes.begin(),
                                     connected_nodes.end());
@@ -768,7 +891,7 @@ void MeshCommunication::gather_neighboring_elements (DistributedMesh & mesh) con
           // We also ship any nodes connected to these elements.  Note
           // some of these nodes and elements may be replicated from
           // other processors, but that is OK.
-          std::set<const Elem *, CompareElemIdsByLevel> elements_to_send;
+          connected_elem_set_type elements_to_send;
 
           // Technically we're not doing reconnect_nodes on this, but
           // we might as well use the same data structure since the
@@ -989,7 +1112,7 @@ void MeshCommunication::send_coarse_ghosts(MeshBase & mesh) const
       if (p == proc_id)
         continue;
 
-      std::set<const Elem *, CompareElemIdsByLevel> elements_to_send;
+      connected_elem_set_type elements_to_send;
       std::set<const Node *> nodes_to_send;
 
       if (const auto it = std::as_const(coarsening_elements_to_ghost).find(p);
@@ -2037,7 +2160,7 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
   libmesh_assert_equal_to (par_max_elem_id, mesh.max_elem_id());
 #endif
 
-  std::set<const Elem *, CompareElemIdsByLevel> elements_to_keep;
+  connected_elem_set_type elements_to_keep;
 
   // Don't delete elements that we were explicitly told not to
   for (const auto & elem : extra_ghost_elem_ids)
@@ -2077,16 +2200,9 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
                    mesh.pid_elements_end(DofObject::invalid_processor_id),
                    elements_to_keep);
 
-  // The elements we need should have their ancestors, their
-  // interior_parent links, and their subactive children present too.
-  // If the mesh has any constraint rows, then elements with
-  // constrained nodes need elements with constraining nodes to remain
-  // present.
-  connect_families(elements_to_keep, &mesh);
-
-  // Don't delete nodes that our semilocal elements need
+  // And see which elements and nodes they depend on
   connected_node_set_type connected_nodes;
-  reconnect_nodes(elements_to_keep, connected_nodes);
+  connect_element_dependencies(mesh, connected_nodes, elements_to_keep);
 
   // Delete all the elements we have no reason to save,
   // starting with the most refined so that the mesh

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1442,6 +1442,9 @@ void MeshCommunication::gather (const processor_id_type root_id, MeshBase & mesh
               constraint_rows.emplace(node, deserialized_row);
             }
         }
+#ifdef DEBUG
+      MeshTools::libmesh_assert_valid_constraint_rows(mesh);
+#endif
     }
 
 

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1395,7 +1395,7 @@ void MeshCommunication::gather (const processor_id_type root_id, MeshBase & mesh
   // elements may not exist at that point.
   auto & constraint_rows = mesh.get_constraint_rows();
   bool have_constraint_rows = !constraint_rows.empty();
-  mesh.comm().broadcast(have_constraint_rows);
+  mesh.comm().max(have_constraint_rows);
   if (have_constraint_rows)
     {
       std::map<dof_id_type,

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -400,8 +400,8 @@ void reconnect_nodes (connected_elem_set_type & connected_elements,
 
 
 void connect_element_dependencies(const MeshBase & mesh,
-                                  connected_node_set_type & connected_nodes,
-                                  connected_elem_set_type & connected_elements)
+                                  connected_elem_set_type & connected_elements,
+                                  connected_node_set_type & connected_nodes)
 {
   // We haven't examined any of these inputs for dependencies yet, so
   // let's mark them all as to be examined now.
@@ -597,7 +597,7 @@ void MeshCommunication::redistribute (DistributedMesh & mesh,
 
       // And see which elements and nodes they depend on
       connected_node_set_type connected_nodes;
-      connect_element_dependencies(mesh, connected_nodes, elements_to_send);
+      connect_element_dependencies(mesh, elements_to_send, connected_nodes);
 
       all_nodes_to_send[pid].assign(connected_nodes.begin(),
                                     connected_nodes.end());
@@ -2218,7 +2218,7 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
 
   // And see which elements and nodes they depend on
   connected_node_set_type connected_nodes;
-  connect_element_dependencies(mesh, connected_nodes, elements_to_keep);
+  connect_element_dependencies(mesh, elements_to_keep, connected_nodes);
 
   // Delete all the elements we have no reason to save,
   // starting with the most refined so that the mesh

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -410,6 +410,13 @@ void connect_element_dependencies(const MeshBase & mesh,
   new_connected_elements.swap(connected_elements);
   new_connected_nodes.swap(connected_nodes);
 
+  // We require that inactive local elements not have any remote_elem
+  // children, so we connect them here, but we do not require this of
+  // ghosted elements so we will not call it recursively.
+  connect_new_children(mesh, connected_elements,
+                       new_connected_elements,
+                       new_connected_elements);
+
   while (!new_connected_elements.empty() ||
          !new_connected_nodes.empty())
     {
@@ -444,9 +451,6 @@ connect_element_dependencies(const MeshBase & mesh,
 {
   std::pair<connected_elem_set_type, connected_node_set_type> returnval;
   auto & [newer_connected_elements, newer_connected_nodes] = returnval;
-  connect_new_children(mesh, connected_elements,
-                       new_connected_elements,
-                       newer_connected_elements);
   connect_element_families(connected_elements, new_connected_elements,
                            newer_connected_elements, &mesh);
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1518,7 +1518,14 @@ void libmesh_assert_valid_constraint_rows (const MeshBase & mesh)
 {
   libmesh_parallel_only(mesh.comm());
 
-  for (auto & row : mesh.get_constraint_rows())
+  const auto & constraint_rows = mesh.get_constraint_rows();
+
+  bool have_constraint_rows = !constraint_rows.empty();
+  mesh.comm().max(have_constraint_rows);
+  if (!have_constraint_rows)
+    return;
+
+  for (auto & row : constraint_rows)
     {
       const Node * node = row.first;
       libmesh_assert(node == mesh.node_ptr(node->id()));
@@ -1532,8 +1539,6 @@ void libmesh_assert_valid_constraint_rows (const MeshBase & mesh)
 
   dof_id_type pmax_node_id = mesh.max_node_id();
   mesh.comm().max(pmax_node_id);
-
-  const auto & constraint_rows = mesh.get_constraint_rows();
 
   for (dof_id_type i=0; i != pmax_node_id; ++i)
     {

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -27,6 +27,7 @@
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/mesh_communication.h"
+#include "libmesh/mesh_tools.h"
 #include "libmesh/metis_csr_graph.h"
 #include "libmesh/parallel.h"
 #include "libmesh/utility.h"

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -17,8 +17,10 @@
 
 
 
-// libMesh includes
 #include "libmesh/partitioner.h"
+
+// libMesh includes
+#include "libmesh/compare_elems_by_level.h"
 #include "libmesh/elem.h"
 #include "libmesh/enum_to_string.h"
 #include "libmesh/int_range.h"
@@ -1133,8 +1135,9 @@ void Partitioner::build_graph (const MeshBase & mesh)
         {
           const auto end_it = mesh_constrained_nodes.end();
 
-          // Use a set to avoid duplicates
-          std::set<const Elem *> constraining_elems;
+          // Use a set to avoid duplicates.  Use a well-defined method
+          // of ordering that set to make debugging easier.
+          std::set<const Elem *, CompareElemIdsByLevel> constraining_elems;
           for (const Node & node : elem->node_ref_range())
             {
               if (const auto row_it = mesh_constrained_nodes.find(&node);
@@ -1301,8 +1304,9 @@ void Partitioner::build_graph (const MeshBase & mesh)
         {
           const auto end_it = mesh_constrained_nodes.end();
 
-          // Use a set to avoid duplicates
-          std::set<const Elem *> constraining_elems;
+          // Use a set to avoid duplicates.  Use a well-defined method
+          // of ordering that set to make debugging easier.
+          std::set<const Elem *, CompareElemIdsByLevel> constraining_elems;
           for (const Node & node : elem->node_ref_range())
             {
               if (const auto row_it = mesh_constrained_nodes.find(&node);

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -214,7 +214,7 @@ public:
     // Come up with some crazy numbering.  Make all the new ids higher
     // than the existing ids so we don't have to worry about conflicts
     // while renumbering.
-    const dof_id_type start_id = 10;
+    dof_id_type start_id;
 
     // first scope: write file
     {
@@ -222,8 +222,12 @@ public:
       mesh.allow_renumbering(false);
       MeshTools::Generation::build_square (mesh, 3, 3, 0., 1., 0., 1.);
 
-      CPPUNIT_ASSERT_LESS(start_id, mesh.max_elem_id());
-      for (const auto & elem : mesh.element_ptr_range())
+      start_id = mesh.max_elem_id();
+
+      // Use a separate container that won't invalidate iterators when
+      // we renumber
+      std::set<Elem *> elements {mesh.elements_begin(), mesh.elements_end()};
+      for (Elem * elem : elements)
       {
         const Point center = elem->vertex_average();
         const int xn = center(0)*3;

--- a/tests/mesh/mesh_stitch.C
+++ b/tests/mesh/mesh_stitch.C
@@ -5,6 +5,7 @@
 #include <libmesh/mesh.h>
 #include <libmesh/mesh_generation.h>
 #include <libmesh/mesh_modification.h>
+#include <libmesh/parallel_implementation.h>
 #include <libmesh/node.h>
 #include <libmesh/replicated_mesh.h>
 #include <libmesh/utility.h>
@@ -86,11 +87,14 @@ public:
     CPPUNIT_ASSERT_EQUAL(mesh0.n_nodes(), static_cast<dof_id_type>(45));
 
     const BoundaryInfo & bi = mesh0.get_boundary_info();
-    const auto & sbi = bi.get_side_boundary_ids();
+    std::set<boundary_id_type> sbi = bi.get_side_boundary_ids();
+    TestCommWorld->set_union(sbi);
+
     typename std::decay<decltype(sbi.size())>::type expected_size = 10;
     CPPUNIT_ASSERT_EQUAL(expected_size, sbi.size());
 
-    const auto & nbi = bi.get_node_boundary_ids();
+    std::set<boundary_id_type> nbi = bi.get_node_boundary_ids();
+    TestCommWorld->set_union(nbi);
     CPPUNIT_ASSERT_EQUAL(expected_size, nbi.size());
 
     // We expect that the "zero_right" and "one_left" boundaries have

--- a/tests/systems/constraint_operator_test.C
+++ b/tests/systems/constraint_operator_test.C
@@ -8,6 +8,7 @@
 #include <libmesh/mesh.h>
 #include <libmesh/mesh_generation.h>
 #include <libmesh/mesh_function.h>
+#include <libmesh/mesh_tools.h>
 #include <libmesh/numeric_vector.h>
 #include <libmesh/parallel.h>
 #include <libmesh/quadrature.h>
@@ -178,6 +179,13 @@ public:
 
     mesh.copy_constraint_rows(*matrix);
 
+    // We should be prepared at this point
+    CPPUNIT_ASSERT(mesh.is_prepared());
+    CPPUNIT_ASSERT(MeshTools::valid_is_prepared(mesh));
+
+    // Do a redundant prepare-for-use to catch any issues there
+    mesh.prepare_for_use();
+
     es.init ();
     sys.solve();
 
@@ -244,6 +252,8 @@ public:
 
     mesh.read(meshfile);
 
+    CPPUNIT_ASSERT(mesh.is_prepared());
+
     // For these matrices Coreform has been experimenting with PETSc
     // solvers which take the transpose of what we expect, so we'll
     // un-transpose here.
@@ -252,6 +262,13 @@ public:
     matrix->get_transpose(*matrix);
 
     mesh.copy_constraint_rows(*matrix);
+
+    // We should be prepared at this point
+    CPPUNIT_ASSERT(mesh.is_prepared());
+    CPPUNIT_ASSERT(MeshTools::valid_is_prepared(mesh));
+
+    // Do a redundant prepare-for-use to catch any issues there
+    mesh.prepare_for_use();
 
     es.init ();
     sys.solve();
@@ -315,6 +332,13 @@ public:
     matrix->read_matlab("meshes/constrain10to4.m");
 
     mesh.copy_constraint_rows(*matrix);
+
+    // We should be prepared at this point
+    CPPUNIT_ASSERT(mesh.is_prepared());
+    CPPUNIT_ASSERT(MeshTools::valid_is_prepared(mesh));
+
+    // Do a redundant prepare-for-use to catch any issues there
+    mesh.prepare_for_use();
 
     es.init ();
     sys.solve();

--- a/tests/systems/constraint_operator_test.C
+++ b/tests/systems/constraint_operator_test.C
@@ -154,6 +154,10 @@ public:
                                        0., 1.,
                                        EDGE2);
 
+    // We should be prepared at this point
+    CPPUNIT_ASSERT(mesh.is_prepared());
+    CPPUNIT_ASSERT(MeshTools::valid_is_prepared(mesh));
+
     auto matrix = SparseMatrix<Number>::build (mesh.comm());
 
     // Create a projection matrix from 10 elements to 5.  We might as
@@ -179,7 +183,7 @@ public:
 
     mesh.copy_constraint_rows(*matrix);
 
-    // We should be prepared at this point
+    // We should still be prepared at this point
     CPPUNIT_ASSERT(mesh.is_prepared());
     CPPUNIT_ASSERT(MeshTools::valid_is_prepared(mesh));
 
@@ -324,6 +328,10 @@ public:
                                        0., 1.,
                                        EDGE2);
 
+    // We should be prepared at this point
+    CPPUNIT_ASSERT(mesh.is_prepared());
+    CPPUNIT_ASSERT(MeshTools::valid_is_prepared(mesh));
+
     auto matrix = SparseMatrix<Number>::build (mesh.comm());
 
     // Create a projection matrix from 10 elements to 4.  We'll only
@@ -333,7 +341,7 @@ public:
 
     mesh.copy_constraint_rows(*matrix);
 
-    // We should be prepared at this point
+    // We should still be prepared at this point
     CPPUNIT_ASSERT(mesh.is_prepared());
     CPPUNIT_ASSERT(MeshTools::valid_is_prepared(mesh));
 


### PR DESCRIPTION
We've been running IGA on distributed meshes for a while, but it turned out that there were a number of corner cases that could trigger bugs, including simple *re*-distribution.  This adds test coverage (when run in a --enable-distmesh sweep, as we do on master merges and as I'll do here) as well as fixes for those cases, plus a lot of additional diagnostic tools and internal assertions that were helpful along the way.

This also includes the improvements from #3844, which were the first things to trigger a couple of these bugs and send me down this rabbit hole.