### PR TITLE
Strict petsc error code compatibility

### DIFF
--- a/configure
+++ b/configure
@@ -51471,8 +51471,10 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
           int main(int argc, char **argv)
           {
-            PetscInitialize(&argc, &argv, (char*)0,help);
-            PetscFinalize();
+            auto ierr = PetscInitialize(&argc, &argv, (char*)0,help);
+            CHKERRQ(ierr);
+            ierr = PetscFinalize();
+            CHKERRQ(ierr);
             return 0;
           }
 

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -27,6 +27,7 @@
 // Local includes
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/petsc_macro.h"
+#include "libmesh/petsc_solver_exception.h"
 
 // C++ includes
 #include <algorithm>
@@ -45,11 +46,13 @@
 #include <cstring>
 
 #define semiparallel_only() do { if (this->initialized()) { const char * mytype; \
-      MatGetType(_mat,&mytype);                                         \
+      auto semiparallel_only_ierr = MatGetType(_mat,&mytype);           \
+      LIBMESH_CHKERR(semiparallel_only_ierr);                           \
       if (!strcmp(mytype, MATSEQAIJ))                                   \
         parallel_object_only(); } } while (0)
 #define exceptionless_semiparallel_only() do { if (this->initialized()) { const char * mytype; \
-      MatGetType(_mat,&mytype);                                         \
+      auto semiparallel_only_ierr = MatGetType(_mat,&mytype);           \
+      libmesh_ignore(semiparallel_only_ierr);                           \
       if (!strcmp(mytype, MATSEQAIJ))                                   \
         exceptionless_parallel_object_only(); } } while (0)
 #else

--- a/include/numerics/petsc_solver_exception.h
+++ b/include/numerics/petsc_solver_exception.h
@@ -59,9 +59,10 @@ public:
   {
     const char * text;
     char * specific;
-    // This is one scenario where we don't catch the error code
+    auto ierr = PetscErrorMessage(cast_int<PetscErrorCode>(error_code), &text, &specific);
+    // This is one scenario where we ignore the error code
     // returned by a PETSc function :)
-    PetscErrorMessage(error_code, &text, &specific);
+    libmesh_ignore(ierr);
 
     // Usually the "specific" error message string is more useful than
     // the generic text corresponding to the error_code, since many
@@ -112,7 +113,7 @@ public:
   inline                                                                \
   void Function ## BeginEnd(const Parallel::Communicator & comm, const Args&... args) \
   {                                                                     \
-    PetscErrorCode ierr = 0;                                            \
+    PetscErrorCode ierr = (PetscErrorCode)0;                            \
     ierr = Function ## Begin(args...);                                  \
     LIBMESH_CHKERR2(comm, ierr);                                        \
     ierr = Function ## End(args...);                                    \

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -571,7 +571,7 @@ PetscVector<T>::PetscVector (Vec v,
 
   /* We need to ask PETSc about the (local to global) ghost value
      mapping and create the inverse mapping out of it.  */
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt petsc_local_size=0;
   ierr = VecGetLocalSize(_vec, &petsc_local_size);
   LIBMESH_CHKERR(ierr);
@@ -678,7 +678,7 @@ void PetscVector<T>::init (const numeric_index_type n,
 {
   parallel_object_only();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt petsc_n=static_cast<PetscInt>(n);
 
   // Clear initialized vectors
@@ -757,7 +757,7 @@ void PetscVector<T>::init (const numeric_index_type n,
 {
   parallel_object_only();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt petsc_n=static_cast<PetscInt>(n);
   PetscInt petsc_n_local=static_cast<PetscInt>(n_local);
   PetscInt petsc_n_ghost=static_cast<PetscInt>(ghost.size());
@@ -908,7 +908,7 @@ void PetscVector<T>::zero ()
 
   this->_restore_array();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   PetscScalar z=0.;
 
@@ -966,7 +966,7 @@ numeric_index_type PetscVector<T>::size () const
 {
   libmesh_assert (this->initialized());
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt petsc_size=0;
 
   if (!this->initialized())
@@ -986,7 +986,7 @@ numeric_index_type PetscVector<T>::local_size () const
 {
   libmesh_assert (this->initialized());
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt petsc_size=0;
 
   ierr = VecGetLocalSize(_vec, &petsc_size);
@@ -1009,7 +1009,7 @@ numeric_index_type PetscVector<T>::first_local_index () const
     first = _first;
   else
     {
-      PetscErrorCode ierr=0;
+      PetscErrorCode ierr = (PetscErrorCode)0;
       PetscInt petsc_first=0, petsc_last=0;
       ierr = VecGetOwnershipRange (_vec, &petsc_first, &petsc_last);
       LIBMESH_CHKERR(ierr);
@@ -1033,7 +1033,7 @@ numeric_index_type PetscVector<T>::last_local_index () const
     last = _last;
   else
     {
-      PetscErrorCode ierr=0;
+      PetscErrorCode ierr = (PetscErrorCode)0;
       PetscInt petsc_first=0, petsc_last=0;
       ierr = VecGetOwnershipRange (_vec, &petsc_first, &petsc_last);
       LIBMESH_CHKERR(ierr);
@@ -1061,7 +1061,7 @@ numeric_index_type PetscVector<T>::map_global_to_local_index (const numeric_inde
     }
   else
     {
-      PetscErrorCode ierr=0;
+      PetscErrorCode ierr = (PetscErrorCode)0;
       PetscInt petsc_first=0, petsc_last=0;
       ierr = VecGetOwnershipRange (_vec, &petsc_first, &petsc_last);
       LIBMESH_CHKERR(ierr);
@@ -1187,7 +1187,7 @@ Real PetscVector<T>::min () const
 
   this->_restore_array();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt index=0;
   PetscReal returnval=0.;
 
@@ -1208,7 +1208,7 @@ Real PetscVector<T>::max() const
 
   this->_restore_array();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt index=0;
   PetscReal returnval=0.;
 

--- a/m4/petsc.m4
+++ b/m4/petsc.m4
@@ -83,8 +83,10 @@ AC_DEFUN([CONFIGURE_PETSC],
 
           int main(int argc, char **argv)
           {
-            PetscInitialize(&argc, &argv, (char*)0,help);
-            PetscFinalize();
+            auto ierr = PetscInitialize(&argc, &argv, (char*)0,help);
+            CHKERRQ(ierr);
+            ierr = PetscFinalize();
+            CHKERRQ(ierr);
             return 0;
           }
           ]])],[

--- a/m4/slepc.m4
+++ b/m4/slepc.m4
@@ -149,8 +149,10 @@ AC_DEFUN([CONFIGURE_SLEPC],
 
                             int main(int argc, char **argv)
                             {
-                              SlepcInitialize(&argc, &argv, (char*)0, help);
-                              SlepcFinalize();
+                              auto ierr = SlepcInitialize(&argc, &argv, (char*)0, help);
+                              CHKERRQ(ierr);
+                              ierr = SlepcFinalize();
+                              CHKERRQ(ierr);
                               return 0;
                             }
                             ]])],[

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -481,7 +481,7 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
 #endif
       )
     {
-      int ierr=0;
+      PetscErrorCode ierr = (PetscErrorCode)0;
 
 #ifdef LIBMESH_HAVE_MPI
       PETSC_COMM_WORLD = libMesh::GLOBAL_COMM_WORLD;
@@ -773,9 +773,13 @@ LibMeshInit::~LibMeshInit()
         // replicating; let's protect against trying to clear
         // already-used values
         PetscBool used = PETSC_FALSE;
-        PetscOptionsUsed(NULL, name.c_str(), &used);
+        auto ierr = PetscOptionsUsed(NULL, name.c_str(), &used);
+        CHKERRABORT(libMesh::GLOBAL_COMM_WORLD, ierr);
         if (used == PETSC_FALSE)
-          PetscOptionsClearValue(NULL, name.c_str());
+          {
+            ierr = PetscOptionsClearValue(NULL, name.c_str());
+            CHKERRABORT(libMesh::GLOBAL_COMM_WORLD, ierr);
+          }
       }
 
   // Allow the user to bypass PETSc finalization
@@ -785,13 +789,15 @@ LibMeshInit::~LibMeshInit()
 #endif
       )
     {
+      PetscErrorCode ierr = (PetscErrorCode)0;
 # if defined(LIBMESH_HAVE_SLEPC)
       if (libmesh_initialized_slepc)
-        SlepcFinalize();
+        ierr = SlepcFinalize();
 # else
       if (libmesh_initialized_petsc)
-        PetscFinalize();
+        ierr = PetscFinalize();
 # endif
+      CHKERRABORT(libMesh::GLOBAL_COMM_WORLD, ierr);
     }
 #endif
 

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -136,7 +136,7 @@ void PetscMatrix<T>::init (const numeric_index_type m_in,
   this->_is_initialized = true;
 
 
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt m_global   = static_cast<PetscInt>(m_in);
   PetscInt n_global   = static_cast<PetscInt>(n_in);
   PetscInt m_local    = static_cast<PetscInt>(m_l);
@@ -257,7 +257,7 @@ void PetscMatrix<T>::init (const numeric_index_type m_in,
   libmesh_assert_equal_to (n_nz.size(), m_l);
   libmesh_assert_equal_to (n_oz.size(), m_l);
 
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt m_global   = static_cast<PetscInt>(m_in);
   PetscInt n_global   = static_cast<PetscInt>(n_in);
   PetscInt m_local    = static_cast<PetscInt>(m_l);
@@ -420,7 +420,7 @@ void PetscMatrix<T>::zero ()
 
   semiparallel_only();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   PetscInt m_l, n_l;
 
@@ -441,7 +441,7 @@ void PetscMatrix<T>::zero_rows (std::vector<numeric_index_type> & rows, T diag_v
 
   semiparallel_only();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // As of petsc-dev at the time of 3.1.0, MatZeroRows now takes two additional
   // optional arguments.  The optional arguments (x,b) can be used to specify the
@@ -521,7 +521,7 @@ Real PetscMatrix<T>::l1_norm () const
 
   semiparallel_only();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscReal petsc_value;
   Real value;
 
@@ -544,7 +544,7 @@ Real PetscMatrix<T>::linfty_norm () const
 
   semiparallel_only();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscReal petsc_value;
   Real value;
 
@@ -575,7 +575,7 @@ void PetscMatrix<T>::print_matlab (const std::string & name) const
       const_cast<PetscMatrix<T> *>(this)->close();
     }
 
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   WrappedPetsc<PetscViewer> petsc_viewer;
   ierr = PetscViewerCreate (this->comm().get(),
@@ -650,7 +650,7 @@ void PetscMatrix<T>::print_personal(std::ostream & os) const
       const_cast<PetscMatrix<T> *>(this)->close();
     }
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // Print to screen if ostream is stdout
   if (os.rdbuf() == std::cout.rdbuf())
@@ -737,7 +737,7 @@ void PetscMatrix<T>::_petsc_viewer(const std::string & filename,
 {
   parallel_object_only();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // We'll get matrix sizes from the file, but we need to at least
   // have a Mat object
@@ -819,7 +819,7 @@ void PetscMatrix<T>::add_matrix(const DenseMatrix<T> & dm,
   libmesh_assert_equal_to (rows.size(), n_rows);
   libmesh_assert_equal_to (cols.size(), n_cols);
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   ierr = MatSetValues(_mat,
                       n_rows, numeric_petsc_cast(rows.data()),
                       n_cols, numeric_petsc_cast(cols.data()),
@@ -845,7 +845,7 @@ void PetscMatrix<T>::add_block_matrix(const DenseMatrix<T> & dm,
   const numeric_index_type n_bcols =
     cast_int<numeric_index_type>(bcols.size());
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
 #ifndef NDEBUG
   const numeric_index_type n_rows  =
@@ -900,7 +900,7 @@ void PetscMatrix<T>::_get_submatrix(SparseMatrix<T> & submatrix,
     submatrix.clear();
 
   // Construct row and column index sets.
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   WrappedPetsc<IS> isrow;
   ierr = ISCreateGeneral(this->comm().get(),
@@ -944,7 +944,7 @@ void PetscMatrix<T>::create_submatrix_nosort(SparseMatrix<T> & submatrix,
   // Make sure the SparseMatrix passed in is really a PetscMatrix
   PetscMatrix<T> * petsc_submatrix = cast_ptr<PetscMatrix<T> *>(&submatrix);
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   ierr=MatZeroEntries(petsc_submatrix->_mat);
   LIBMESH_CHKERR(ierr);
@@ -1079,7 +1079,7 @@ numeric_index_type PetscMatrix<T>::m () const
   libmesh_assert (this->initialized());
 
   PetscInt petsc_m=0, petsc_n=0;
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   ierr = MatGetSize (_mat, &petsc_m, &petsc_n);
   LIBMESH_CHKERR(ierr);
@@ -1106,7 +1106,7 @@ numeric_index_type PetscMatrix<T>::n () const
   libmesh_assert (this->initialized());
 
   PetscInt petsc_m=0, petsc_n=0;
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   ierr = MatGetSize (_mat, &petsc_m, &petsc_n);
   LIBMESH_CHKERR(ierr);
@@ -1150,7 +1150,7 @@ numeric_index_type PetscMatrix<T>::row_start () const
   libmesh_assert (this->initialized());
 
   PetscInt start=0, stop=0;
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   ierr = MatGetOwnershipRange(_mat, &start, &stop);
   LIBMESH_CHKERR(ierr);
@@ -1166,7 +1166,7 @@ numeric_index_type PetscMatrix<T>::row_stop () const
   libmesh_assert (this->initialized());
 
   PetscInt start=0, stop=0;
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   ierr = MatGetOwnershipRange(_mat, &start, &stop);
   LIBMESH_CHKERR(ierr);
@@ -1182,7 +1182,7 @@ numeric_index_type PetscMatrix<T>::col_start () const
   libmesh_assert (this->initialized());
 
   PetscInt start=0, stop=0;
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   ierr = MatGetOwnershipRangeColumn(_mat, &start, &stop);
   LIBMESH_CHKERR(ierr);
@@ -1198,7 +1198,7 @@ numeric_index_type PetscMatrix<T>::col_stop () const
   libmesh_assert (this->initialized());
 
   PetscInt start=0, stop=0;
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   ierr = MatGetOwnershipRangeColumn(_mat, &start, &stop);
   LIBMESH_CHKERR(ierr);
@@ -1215,7 +1215,7 @@ void PetscMatrix<T>::set (const numeric_index_type i,
 {
   libmesh_assert (this->initialized());
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt i_val=i, j_val=j;
 
   PetscScalar petsc_value = static_cast<PetscScalar>(value);
@@ -1233,7 +1233,7 @@ void PetscMatrix<T>::add (const numeric_index_type i,
 {
   libmesh_assert (this->initialized());
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt i_val=i, j_val=j;
 
   PetscScalar petsc_value = static_cast<PetscScalar>(value);
@@ -1272,7 +1272,7 @@ void PetscMatrix<T>::add (const T a_in, const SparseMatrix<T> & X_in)
 
   libmesh_assert (X);
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // the matrix from which we copy the values has to be assembled/closed
   libmesh_assert(X->closed());
@@ -1296,7 +1296,7 @@ void PetscMatrix<T>::matrix_matrix_mult (SparseMatrix<T> & X_in, SparseMatrix<T>
   const PetscMatrix<T> * X = cast_ptr<const PetscMatrix<T> *> (&X_in);
   PetscMatrix<T> * Y = cast_ptr<PetscMatrix<T> *> (&Y_out);
 
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // the matrix from which we copy the values has to be assembled/closed
   libmesh_assert(X->closed());
@@ -1338,7 +1338,7 @@ PetscMatrix<T>::add_sparse_matrix (const SparseMatrix<T> & spm,
   if (!this->closed())
     this->close();
 
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   auto pscm = cast_ptr<const PetscMatrix<T> *>(&spm);
 
@@ -1389,7 +1389,7 @@ T PetscMatrix<T>::operator () (const numeric_index_type i_in,
   T value=0.;
 
   PetscErrorCode
-    ierr=0;
+    ierr = (PetscErrorCode)0;
   PetscInt
     ncols=0,
     i_val=static_cast<PetscInt>(i_in),
@@ -1442,7 +1442,7 @@ void PetscMatrix<T>::get_row (numeric_index_type i_in,
   const PetscScalar * petsc_row;
   const PetscInt    * petsc_cols;
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt
     ncols=0,
     i_val = static_cast<PetscInt>(i_in);
@@ -1494,7 +1494,7 @@ bool PetscMatrix<T>::closed() const
 {
   libmesh_assert (this->initialized());
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscBool assembled;
 
   ierr = MatAssembled(_mat, &assembled);

--- a/src/numerics/petsc_preconditioner.C
+++ b/src/numerics/petsc_preconditioner.C
@@ -109,11 +109,12 @@ PC PetscPreconditioner<T>::pc()
 template <typename T>
 void PetscPreconditioner<T>::set_petsc_preconditioner_type (const PreconditionerType & preconditioner_type, PC & pc)
 {
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // get the communicator from the PETSc object
   Parallel::communicator comm;
-  PetscObjectGetComm((PetscObject)pc, & comm);
+  ierr = PetscObjectGetComm((PetscObject)pc, & comm);
+  LIBMESH_CHKERR(ierr);
   Parallel::Communicator communicator(comm);
 
   switch (preconditioner_type)
@@ -253,11 +254,12 @@ template <typename T>
 void PetscPreconditioner<T>::set_petsc_subpreconditioner_type(const PCType type, PC & pc)
 {
   // For catching PETSc error return codes
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // get the communicator from the PETSc object
   Parallel::communicator comm;
-  PetscObjectGetComm((PetscObject)pc, & comm);
+  ierr = PetscObjectGetComm((PetscObject)pc, & comm);
+  LIBMESH_CHKERR(ierr);
   Parallel::Communicator communicator(comm);
 
   // All docs say must call KSPSetUp or PCSetUp before calling PCBJacobiGetSubKSP.

--- a/src/numerics/petsc_shell_matrix.C
+++ b/src/numerics/petsc_shell_matrix.C
@@ -84,7 +84,7 @@ void PetscShellMatrix<T>::init ()
   const numeric_index_type n_l  = m_l;
 
 
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt m_global   = static_cast<PetscInt>(my_m);
   PetscInt n_global   = static_cast<PetscInt>(my_n);
   PetscInt m_local    = static_cast<PetscInt>(m_l);

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -46,7 +46,7 @@ T PetscVector<T>::sum () const
   this->_restore_array();
   libmesh_assert(this->closed());
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscScalar value=0.;
 
   ierr = VecSum (_vec, &value);
@@ -62,7 +62,7 @@ Real PetscVector<T>::l1_norm () const
   this->_restore_array();
   libmesh_assert(this->closed());
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscReal value=0.;
 
   ierr = VecNorm (_vec, NORM_1, &value);
@@ -81,7 +81,7 @@ Real PetscVector<T>::l2_norm () const
   this->_restore_array();
   libmesh_assert(this->closed());
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscReal value=0.;
 
   ierr = VecNorm (_vec, NORM_2, &value);
@@ -101,7 +101,7 @@ Real PetscVector<T>::linfty_norm () const
   this->_restore_array();
   libmesh_assert(this->closed());
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscReal value=0.;
 
   ierr = VecNorm (_vec, NORM_INFINITY, &value);
@@ -151,7 +151,7 @@ void PetscVector<T>::set (const numeric_index_type i, const T value)
   this->_restore_array();
   libmesh_assert_less (i, size());
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt i_val = static_cast<PetscInt>(i);
   PetscScalar petsc_value = PS(value);
 
@@ -169,7 +169,7 @@ void PetscVector<T>::reciprocal()
 {
   parallel_object_only();
 
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // VecReciprocal has been in PETSc since at least 2.3.3 days
   ierr = VecReciprocal(_vec);
@@ -183,7 +183,7 @@ void PetscVector<T>::conjugate()
 {
   parallel_object_only();
 
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // We just call the PETSc VecConjugate
   ierr = VecConjugate(_vec);
@@ -198,7 +198,7 @@ void PetscVector<T>::add (const numeric_index_type i, const T value)
   this->_restore_array();
   libmesh_assert_less (i, size());
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt i_val = static_cast<PetscInt>(i);
   PetscScalar petsc_value = PS(value);
 
@@ -221,7 +221,7 @@ void PetscVector<T>::add_vector (const T * v,
 
   this->_restore_array();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   const PetscInt * i_val = reinterpret_cast<const PetscInt *>(dof_indices.data());
   const PetscScalar * petsc_value = pPS(v);
 
@@ -246,7 +246,7 @@ void PetscVector<T>::add_vector (const NumericVector<T> & v_in,
   const PetscVector<T> * v = cast_ptr<const PetscVector<T> *>(&v_in);
   const PetscMatrix<T> * A = cast_ptr<const PetscMatrix<T> *>(&A_in);
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // We shouldn't close() the matrix for you, as that would potentially modify the state of a const object.
   if (!A->closed())
@@ -276,7 +276,7 @@ void PetscVector<T>::add_vector_transpose (const NumericVector<T> & v_in,
   const PetscVector<T> * v = cast_ptr<const PetscVector<T> *>(&v_in);
   const PetscMatrix<T> * A = cast_ptr<const PetscMatrix<T> *>(&A_in);
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // We shouldn't close() the matrix for you, as that would potentially modify the state of a const object.
   if (!A->closed())
@@ -395,7 +395,7 @@ void PetscVector<T>::insert (const T * v,
 
   this->_restore_array();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt * idx_values = numeric_petsc_cast(dof_indices.data());
   std::scoped_lock lock(this->_numeric_vector_mutex);
   ierr = VecSetValues (_vec, cast_int<PetscInt>(dof_indices.size()),
@@ -430,7 +430,7 @@ NumericVector<T> & PetscVector<T>::operator *= (const NumericVector<T> & v)
 {
   parallel_object_only();
 
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   const PetscVector<T> * v_vec = cast_ptr<const PetscVector<T> *>(&v);
 
@@ -445,7 +445,7 @@ NumericVector<T> & PetscVector<T>::operator /= (const NumericVector<T> & v)
 {
   parallel_object_only();
 
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   const PetscVector<T> * v_vec = cast_ptr<const PetscVector<T> *>(&v);
 
@@ -479,7 +479,7 @@ T PetscVector<T>::dot (const NumericVector<T> & v_in) const
   this->_restore_array();
 
   // Error flag
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // Return value
   PetscScalar value=0.;
@@ -502,7 +502,7 @@ T PetscVector<T>::indefinite_dot (const NumericVector<T> & v_in) const
   this->_restore_array();
 
   // Error flag
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // Return value
   PetscScalar value=0.;
@@ -574,7 +574,7 @@ PetscVector<T>::operator = (const PetscVector<T> & v)
   libmesh_assert_equal_to (this->local_size(), v.local_size());
   libmesh_assert (v.closed());
 
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   ierr = VecCopy (v._vec, this->_vec);
   LIBMESH_CHKERR(ierr);
@@ -650,7 +650,7 @@ void PetscVector<T>::localize (NumericVector<T> & v_local_in) const
   // Cases 2) and 3) should be scalable
   libmesh_assert(this->size()==v_local->local_size() || this->local_size()==v_local->local_size());
 
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   if (v_local->type() == SERIAL && this->size() == v_local->local_size())
   {
@@ -709,7 +709,7 @@ void PetscVector<T>::localize (NumericVector<T> & v_local_in,
   libmesh_assert_equal_to (v_local->size(), this->size());
   libmesh_assert_less_equal (send_list.size(), v_local->size());
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   const numeric_index_type n_sl =
     cast_int<numeric_index_type>(send_list.size());
 
@@ -750,7 +750,7 @@ void PetscVector<T>::localize (std::vector<T> & v_local,
   parallel_object_only();
 
   // Error code used to check the status of all PETSc function calls.
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // Create a sequential destination Vec with the right number of entries on each proc.
   WrappedPetsc<Vec> dest;
@@ -812,7 +812,7 @@ void PetscVector<T>::localize (const numeric_index_type first_local_idx,
 
   const numeric_index_type my_size       = this->size();
   const numeric_index_type my_local_size = (last_local_idx + 1 - first_local_idx);
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // Don't bother for serial cases
   //  if ((first_local_idx == 0) &&
@@ -869,7 +869,7 @@ void PetscVector<T>::localize (std::vector<T> & v_local) const
   // This function must be run on all processors at once
   parallel_object_only();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   const PetscInt n = this->size();
   const PetscInt nl = this->local_size();
   PetscScalar * values;
@@ -905,7 +905,7 @@ void PetscVector<Real>::localize_to_one (std::vector<Real> & v_local,
 
   this->_restore_array();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   const PetscInt n  = size();
   PetscScalar * values;
 
@@ -995,7 +995,7 @@ void PetscVector<Complex>::localize_to_one (std::vector<Complex> & v_local,
 
   this->_restore_array();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   const PetscInt n  = size();
   const PetscInt nl = local_size();
   PetscScalar * values;
@@ -1133,7 +1133,7 @@ void PetscVector<T>::print_matlab (const std::string & name) const
   this->_restore_array();
   libmesh_assert (this->closed());
 
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   WrappedPetsc<PetscViewer> petsc_viewer;
   ierr = PetscViewerCreate (this->comm().get(), petsc_viewer.get());
@@ -1194,7 +1194,7 @@ void PetscVector<T>::create_subvector(NumericVector<T> & subvector,
   this->_restore_array();
 
   // PETSc data structures
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // Make sure the passed in subvector is really a PetscVector
   PetscVector<T> * petsc_subvector = cast_ptr<PetscVector<T> *>(&subvector);
@@ -1289,7 +1289,7 @@ void PetscVector<T>::_get_array(bool read_only) const
       std::scoped_lock lock(_petsc_get_restore_array_mutex);
       if (!_array_is_present.load(std::memory_order_relaxed))
         {
-          PetscErrorCode ierr=0;
+          PetscErrorCode ierr = (PetscErrorCode)0;
           if (this->type() != GHOSTED)
             {
               if (read_only)
@@ -1354,7 +1354,7 @@ void PetscVector<T>::_restore_array() const
       std::scoped_lock lock(_petsc_get_restore_array_mutex);
       if (_array_is_present.load(std::memory_order_relaxed))
         {
-          PetscErrorCode ierr=0;
+          PetscErrorCode ierr = (PetscErrorCode)0;
           if (this->type() != GHOSTED)
             {
               if (_values_read_only)

--- a/src/numerics/wrapped_petsc.C
+++ b/src/numerics/wrapped_petsc.C
@@ -22,6 +22,7 @@
 // libMesh includes
 #include "libmesh/wrapped_petsc.h"
 #include "libmesh/petsc_macro.h"
+#include "libmesh/petsc_solver_exception.h"
 
 // PETSc includes
 #ifdef I
@@ -52,18 +53,18 @@ namespace libMesh
 
 // Specializations of the destroy() method for different PETSc classes
 // This could also be macro-ized, but maybe it's not necessary?
-template <> void WrappedPetsc<Vec>::destroy() { VecDestroy(&obj); }
-template <> void WrappedPetsc<KSP>::destroy() { KSPDestroy(&obj); }
-template <> void WrappedPetsc<IS>::destroy() { ISDestroy(&obj); }
-template <> void WrappedPetsc<Mat>::destroy() { MatDestroy(&obj); }
-template <> void WrappedPetsc<VecScatter>::destroy() { VecScatterDestroy(&obj); }
-template <> void WrappedPetsc<PetscViewer>::destroy() { PetscViewerDestroy(&obj); }
-template <> void WrappedPetsc<MatNullSpace>::destroy() { MatNullSpaceDestroy(&obj); }
-template <> void WrappedPetsc<DM>::destroy() { DMDestroy(&obj); }
-template <> void WrappedPetsc<MatPartitioning>::destroy() { MatPartitioningDestroy(&obj); }
-template <> void WrappedPetsc<SNES>::destroy() { SNESDestroy(&obj); }
-template <> void WrappedPetsc<PC>::destroy() { PCDestroy(&obj); }
-template <> void WrappedPetsc<PetscSection>::destroy() { PetscSectionDestroy(&obj); }
+template <> void WrappedPetsc<Vec>::destroy() { auto ierr = VecDestroy(&obj); LIBMESH_CHKERR(ierr); }
+template <> void WrappedPetsc<KSP>::destroy() { auto ierr = KSPDestroy(&obj); LIBMESH_CHKERR(ierr); }
+template <> void WrappedPetsc<IS>::destroy() { auto ierr = ISDestroy(&obj); LIBMESH_CHKERR(ierr); }
+template <> void WrappedPetsc<Mat>::destroy() { auto ierr = MatDestroy(&obj); LIBMESH_CHKERR(ierr); }
+template <> void WrappedPetsc<VecScatter>::destroy() { auto ierr = VecScatterDestroy(&obj); LIBMESH_CHKERR(ierr); }
+template <> void WrappedPetsc<PetscViewer>::destroy() { auto ierr = PetscViewerDestroy(&obj); LIBMESH_CHKERR(ierr); }
+template <> void WrappedPetsc<MatNullSpace>::destroy() { auto ierr = MatNullSpaceDestroy(&obj); LIBMESH_CHKERR(ierr); }
+template <> void WrappedPetsc<DM>::destroy() { auto ierr = DMDestroy(&obj); LIBMESH_CHKERR(ierr); }
+template <> void WrappedPetsc<MatPartitioning>::destroy() { auto ierr = MatPartitioningDestroy(&obj); LIBMESH_CHKERR(ierr); }
+template <> void WrappedPetsc<SNES>::destroy() { auto ierr = SNESDestroy(&obj); LIBMESH_CHKERR(ierr); }
+template <> void WrappedPetsc<PC>::destroy() { auto ierr = PCDestroy(&obj); LIBMESH_CHKERR(ierr); }
+template <> void WrappedPetsc<PetscSection>::destroy() { auto ierr = PetscSectionDestroy(&obj); LIBMESH_CHKERR(ierr); }
 
 }
 

--- a/src/solvers/petsc_auto_fieldsplit.C
+++ b/src/solvers/petsc_auto_fieldsplit.C
@@ -38,8 +38,8 @@ void indices_to_fieldsplit (const Parallel::Communicator & comm,
     idx = reinterpret_cast<const PetscInt *>(indices.data());
 
   IS is;
-  int ierr = ISCreateGeneral(comm.get(), cast_int<PetscInt>(indices.size()),
-                             idx, PETSC_COPY_VALUES, &is);
+  auto ierr = ISCreateGeneral(comm.get(), cast_int<PetscInt>(indices.size()),
+                              idx, PETSC_COPY_VALUES, &is);
   CHKERRABORT(comm.get(), ierr);
 
   ierr = PCFieldSplitSetIS(my_pc, field_name.c_str(), is);

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -54,7 +54,7 @@ extern "C"
                    << ", |residual|_2 = " << fnorm << std::endl;
     if (solver.linear_solution_monitor.get())
     {
-      PetscErrorCode ierr = 0;
+      PetscErrorCode ierr = (PetscErrorCode)0;
 
       Vec petsc_delta_u;
       ierr = SNESGetSolutionUpdate(snes, &petsc_delta_u);
@@ -79,7 +79,7 @@ extern "C"
                                         u, u.l2_norm(),
                                         res, res.l2_norm(), its);
     }
-    return 0;
+    return PetscErrorCode(0);
   }
 
   // Functions to hand to PETSc's SNES,
@@ -127,7 +127,7 @@ extern "C"
     R_input.swap(R_system);
 
     // No errors, we hope
-    return 0;
+    return PetscErrorCode(0);
   }
 
 
@@ -181,7 +181,7 @@ extern "C"
     J_input.swap(J_system);
 
     // No errors, we hope
-    return 0;
+    return PetscErrorCode(0);
   }
 
 } // extern "C"
@@ -303,7 +303,7 @@ unsigned int PetscDiffSolver::solve()
   PetscVector<Number> & r =
     *(cast_ptr<PetscVector<Number> *>(_system.rhs));
 
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   ierr = SNESSetFunction (_snes, r.vec(),
                           __libmesh_petsc_diff_solver_residual, this);
@@ -325,7 +325,8 @@ unsigned int PetscDiffSolver::solve()
 #endif
 
   SNESConvergedReason reason;
-  SNESGetConvergedReason(_snes, &reason);
+  ierr = SNESGetConvergedReason(_snes, &reason);
+  LIBMESH_CHKERR(ierr);
 
   PetscInt l_its, nl_its;
   ierr = SNESGetLinearSolveIterations(_snes, &l_its);
@@ -341,7 +342,7 @@ unsigned int PetscDiffSolver::solve()
 
 void PetscDiffSolver::setup_petsc_data()
 {
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   ierr = SNESCreate(this->comm().get(), _snes.get());
   LIBMESH_CHKERR(ierr);

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -194,7 +194,7 @@ namespace libMesh
           CHKERRQ(ierr);
         }
 
-      return 0;
+      return PetscErrorCode(0);
     }
 
     //! Help PETSc identify the finer DM given a dmc
@@ -216,7 +216,7 @@ namespace libMesh
       libmesh_assert(*(p_ctx->finer_dm));
       *(dmf) = *(p_ctx->finer_dm);
 
-      return 0;
+      return PetscErrorCode(0);
     }
 
     //! Help PETSc identify the coarser DM dmc given the fine DM dmf
@@ -280,8 +280,9 @@ namespace libMesh
 
           // Next, for the found fields we create a subDM
           DM subdm;
-          libmesh_petsc_DMCreateSubDM(*(p_ctx_f->coarser_dm), nfieldsf,
-                                      p_ctx_f->subfields.data(), nullptr, &subdm);
+          ierr = libmesh_petsc_DMCreateSubDM(*(p_ctx_f->coarser_dm), nfieldsf,
+                                             p_ctx_f->subfields.data(), nullptr, &subdm);
+          CHKERRQ(ierr);
 
           // Extract our coarse context from the created subDM so we
           // can set its subfields for use in createInterp.
@@ -303,7 +304,7 @@ namespace libMesh
         *(dmc) = *(p_ctx_f->coarser_dm);
       }
 
-      return 0;
+      return PetscErrorCode(0);
     }
 
     //! Function to give PETSc that sets the Interpolation Matrix between two DMs
@@ -319,7 +320,8 @@ namespace libMesh
       // Get a communicator from incoming DM
       PetscErrorCode ierr;
       MPI_Comm comm;
-      PetscObjectGetComm((PetscObject)dmc, &comm);
+      ierr = PetscObjectGetComm((PetscObject)dmc, &comm);
+      CHKERRQ(ierr);
 
       // Extract our coarse context from the incoming DM
       void * ctx_c = nullptr;
@@ -393,7 +395,7 @@ namespace libMesh
       // Vec scaling isnt needed so were done.
       *(vec) = LIBMESH_PETSC_NULLPTR;
 
-      return 0;
+      return PetscErrorCode(0);
     } // end libmesh_petsc_DMCreateInterpolation
 
     //! Function to give PETSc that sets the Restriction Matrix between two DMs
@@ -408,7 +410,8 @@ namespace libMesh
 
       // get a communicator from incoming DM
       MPI_Comm comm;
-      PetscObjectGetComm((PetscObject)dmc, &comm);
+      ierr = PetscObjectGetComm((PetscObject)dmc, &comm);
+      CHKERRQ(ierr);
 
       // extract our fine context from the incoming DM
       void * ctx_f = nullptr;
@@ -420,7 +423,7 @@ namespace libMesh
       libmesh_assert(p_ctx_f->K_restrict_ptr);
       *(mat) = p_ctx_f->K_restrict_ptr->mat();
 
-      return 0;
+      return PetscErrorCode(0);
     }
 
   } // end extern C functions

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -56,7 +56,7 @@ extern "C"
 
     preconditioner->setup();
 
-    return 0;
+    return PetscErrorCode(0);
   }
 
   PetscErrorCode libmesh_petsc_preconditioner_apply(PC pc, Vec x, Vec y)
@@ -70,7 +70,7 @@ extern "C"
 
     preconditioner->apply(x_vec,y_vec);
 
-    return 0;
+    return PetscErrorCode(0);
   }
 
 #ifdef LIBMESH_ENABLE_DEPRECATED
@@ -145,7 +145,7 @@ void PetscLinearSolver<T>::init (const char * name)
     {
       this->_is_initialized = true;
 
-      PetscErrorCode ierr=0;
+      PetscErrorCode ierr = (PetscErrorCode)0;
 
       ierr = KSPCreate (this->comm().get(), _ksp.get());
       LIBMESH_CHKERR(ierr);
@@ -210,9 +210,12 @@ void PetscLinearSolver<T>::init (const char * name)
       if (this->_preconditioner)
         {
           this->_preconditioner->init();
-          PCShellSetContext(_pc,(void *)this->_preconditioner);
-          PCShellSetSetUp(_pc,libmesh_petsc_preconditioner_setup);
-          PCShellSetApply(_pc,libmesh_petsc_preconditioner_apply);
+          ierr = PCShellSetContext(_pc,(void *)this->_preconditioner);
+          LIBMESH_CHKERR(ierr);
+          ierr = PCShellSetSetUp(_pc,libmesh_petsc_preconditioner_setup);
+          LIBMESH_CHKERR(ierr);
+          ierr = PCShellSetApply(_pc,libmesh_petsc_preconditioner_apply);
+          LIBMESH_CHKERR(ierr);
         }
     }
 }
@@ -227,7 +230,7 @@ void PetscLinearSolver<T>::init (PetscMatrix<T> * matrix,
     {
       this->_is_initialized = true;
 
-      PetscErrorCode ierr=0;
+      PetscErrorCode ierr = (PetscErrorCode)0;
 
       ierr = KSPCreate (this->comm().get(), _ksp.get());
       LIBMESH_CHKERR(ierr);
@@ -295,9 +298,12 @@ void PetscLinearSolver<T>::init (PetscMatrix<T> * matrix,
         {
           this->_preconditioner->set_matrix(*matrix);
           this->_preconditioner->init();
-          PCShellSetContext(_pc,(void *)this->_preconditioner);
-          PCShellSetSetUp(_pc,libmesh_petsc_preconditioner_setup);
-          PCShellSetApply(_pc,libmesh_petsc_preconditioner_apply);
+          ierr = PCShellSetContext(_pc,(void *)this->_preconditioner);
+          LIBMESH_CHKERR(ierr);
+          ierr = PCShellSetSetUp(_pc,libmesh_petsc_preconditioner_setup);
+          LIBMESH_CHKERR(ierr);
+          ierr = PCShellSetApply(_pc,libmesh_petsc_preconditioner_apply);
+          LIBMESH_CHKERR(ierr);
         }
     }
 }
@@ -318,7 +324,7 @@ void
 PetscLinearSolver<T>::restrict_solve_to (const std::vector<unsigned int> * const dofs,
                                          const SubsetSolveMode subset_solve_mode)
 {
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // The preconditioner (in particular if a default preconditioner)
   // will have to be reset.  We call this->clear() to do that.  This
@@ -486,7 +492,7 @@ PetscLinearSolver<T>::shell_solve_common (const ShellMatrix<T> & shell_matrix,
 
   this->init ();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // Prepare the matrix.
   WrappedPetsc<Mat> mat;
@@ -536,7 +542,7 @@ PetscLinearSolver<T>::solve_base (SparseMatrix<T> * matrix,
   solution->close ();
   rhs->close ();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt its=0, max_its = static_cast<PetscInt>(m_its);
   PetscReal final_resid=0.;
 
@@ -766,7 +772,7 @@ KSP PetscLinearSolver<T>::ksp()
 template <typename T>
 void PetscLinearSolver<T>::get_residual_history(std::vector<double> & hist)
 {
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt its  = 0;
 
   // Fill the residual history vector with the residual norms
@@ -807,7 +813,7 @@ void PetscLinearSolver<T>::get_residual_history(std::vector<double> & hist)
 template <typename T>
 Real PetscLinearSolver<T>::get_initial_residual()
 {
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscInt its  = 0;
 
   // Fill the residual history vector with the residual norms
@@ -846,7 +852,7 @@ Real PetscLinearSolver<T>::get_initial_residual()
 template <typename T>
 void PetscLinearSolver<T>::set_petsc_solver_type()
 {
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   switch (this->_solver_type)
     {
@@ -924,7 +930,8 @@ template <typename T>
 LinearConvergenceReason PetscLinearSolver<T>::get_converged_reason() const
 {
   KSPConvergedReason reason;
-  KSPGetConvergedReason(_ksp, &reason);
+  auto ierr = KSPGetConvergedReason(_ksp, &reason);
+  LIBMESH_CHKERR(ierr);
 
   switch(reason)
     {
@@ -972,7 +979,7 @@ template <typename T>
 PetscErrorCode PetscLinearSolver<T>::_petsc_shell_matrix_mult(Mat mat, Vec arg, Vec dest)
 {
   // Get the matrix context.
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   void * ctx;
   ierr = MatShellGetContext(mat,&ctx);
 
@@ -996,7 +1003,7 @@ template <typename T>
 PetscErrorCode PetscLinearSolver<T>::_petsc_shell_matrix_mult_add(Mat mat, Vec arg, Vec add, Vec dest)
 {
   // Get the matrix context.
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   void * ctx;
   ierr = MatShellGetContext(mat,&ctx);
 
@@ -1026,7 +1033,7 @@ template <typename T>
 PetscErrorCode PetscLinearSolver<T>::_petsc_shell_matrix_get_diagonal(Mat mat, Vec dest)
 {
   // Get the matrix context.
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   void * ctx;
   ierr = MatShellGetContext(mat,&ctx);
 

--- a/src/solvers/petscdmlibmesh.C
+++ b/src/solvers/petscdmlibmesh.C
@@ -41,7 +41,7 @@ PetscErrorCode DMlibMeshSetSystem(DM dm, libMesh::NonlinearImplicitSystem & sys)
   ierr = PetscObjectQueryFunction((PetscObject)dm,"DMlibMeshSetSystem_C",&f);CHKERRQ(ierr);
   if (!f) SETERRQ(PETSC_COMM_SELF,PETSC_ERR_SUP, "DM has no implementation for DMlibMeshSetSystem");
   ierr = (*f)(dm,sys);CHKERRQ(ierr);
-  PetscFunctionReturn(0);
+  PetscFunctionReturn((PetscErrorCode)0);
 }
 
 #undef  __FUNCT__
@@ -56,7 +56,7 @@ PetscErrorCode DMlibMeshGetSystem(DM dm, libMesh::NonlinearImplicitSystem *& sys
   ierr = PetscObjectQueryFunction((PetscObject)dm,"DMlibMeshGetSystem_C",&f);CHKERRQ(ierr);
   if (!f) SETERRQ(PETSC_COMM_SELF,PETSC_ERR_SUP, "DM has no implementation for DMlibMeshGetSystem");
   ierr = (*f)(dm,sys);CHKERRQ(ierr);
-  PetscFunctionReturn(0);
+  PetscFunctionReturn((PetscErrorCode)0);
 }
 
 #endif // LIBMESH_HAVE_PETSC

--- a/src/solvers/petscdmlibmeshimpl.C
+++ b/src/solvers/petscdmlibmeshimpl.C
@@ -81,7 +81,7 @@ PetscErrorCode DMlibMeshGetVec_Private(DM /*dm*/, const char * /*name*/, Vec *)
 {
   PetscFunctionBegin;
 
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 
@@ -147,7 +147,7 @@ PetscErrorCode DMlibMeshSetSystem_libMesh(DM dm, NonlinearImplicitSystem & sys)
     dlm->blocknames->insert(std::pair<unsigned int,std::string>(bid,bname));
   }
   ierr = DMlibMeshSetUpName_Private(dm); CHKERRQ(ierr);
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 #undef  __FUNCT__
@@ -163,7 +163,7 @@ PetscErrorCode DMlibMeshGetSystem_libMesh(DM dm, NonlinearImplicitSystem *& sys)
   if (!islibmesh) LIBMESH_SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
   sys = dlm->sys;
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 
@@ -186,7 +186,7 @@ PetscErrorCode DMlibMeshGetBlocks(DM dm, PetscInt * n, char *** blocknames)
   PetscValidPointer(n,2);
 #endif
   *n = cast_int<unsigned int>(dlm->blockids->size());
-  if (!blocknames) PetscFunctionReturn(0);
+  if (!blocknames) return PetscErrorCode(0);
   ierr = PetscMalloc(*n*sizeof(char *), blocknames); CHKERRQ(ierr);
   i = 0;
   for (const auto & pr : *(dlm->blockids))
@@ -194,7 +194,7 @@ PetscErrorCode DMlibMeshGetBlocks(DM dm, PetscInt * n, char *** blocknames)
       ierr = PetscStrallocpy(pr.first.c_str(), *blocknames+i); CHKERRQ(ierr);
       ++i;
     }
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 #undef  __FUNCT__
@@ -216,7 +216,7 @@ PetscErrorCode DMlibMeshGetVariables(DM dm, PetscInt * n, char *** varnames)
   PetscValidPointer(n,2);
 #endif
   *n = cast_int<unsigned int>(dlm->varids->size());
-  if (!varnames) PetscFunctionReturn(0);
+  if (!varnames) return PetscErrorCode(0);
   ierr = PetscMalloc(*n*sizeof(char *), varnames); CHKERRQ(ierr);
   i = 0;
   for (const auto & pr : *(dlm->varids))
@@ -224,7 +224,7 @@ PetscErrorCode DMlibMeshGetVariables(DM dm, PetscInt * n, char *** varnames)
       ierr = PetscStrallocpy(pr.first.c_str(), *varnames+i); CHKERRQ(ierr);
       ++i;
     }
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 #undef  __FUNCT__
@@ -278,7 +278,7 @@ PetscErrorCode DMlibMeshSetUpName_Private(DM dm)
     name += ";";
   }
   ierr = PetscObjectSetName((PetscObject)dm, name.c_str()); CHKERRQ(ierr);
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 
@@ -291,7 +291,7 @@ static PetscErrorCode  DMCreateFieldDecomposition_libMesh(DM dm, PetscInt * len,
   DM_libMesh     * dlm = (DM_libMesh *)(dm->data);
   NonlinearImplicitSystem * sys = dlm->sys;
   IS emb;
-  if (dlm->decomposition_type != DMLIBMESH_FIELD_DECOMPOSITION) PetscFunctionReturn(0);
+  if (dlm->decomposition_type != DMLIBMESH_FIELD_DECOMPOSITION) return PetscErrorCode(0);
 
   *len = cast_int<unsigned int>(dlm->decomposition->size());
   if (namelist) {ierr = PetscMalloc(*len*sizeof(char *), namelist);  CHKERRQ(ierr);}
@@ -381,7 +381,7 @@ static PetscErrorCode  DMCreateFieldDecomposition_libMesh(DM dm, PetscInt * len,
       (*dmlist)[d] = ddm;
     }
   }
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 #undef __FUNCT__
@@ -393,7 +393,7 @@ static PetscErrorCode  DMCreateDomainDecomposition_libMesh(DM dm, PetscInt * len
   DM_libMesh     * dlm = (DM_libMesh *)(dm->data);
   NonlinearImplicitSystem * sys = dlm->sys;
   IS emb;
-  if (dlm->decomposition_type != DMLIBMESH_DOMAIN_DECOMPOSITION) PetscFunctionReturn(0);
+  if (dlm->decomposition_type != DMLIBMESH_DOMAIN_DECOMPOSITION) return PetscErrorCode(0);
   *len = cast_int<unsigned int>(dlm->decomposition->size());
   if (namelist)      {ierr = PetscMalloc(*len*sizeof(char *), namelist);  CHKERRQ(ierr);}
   if (innerislist)   {ierr = PetscMalloc(*len*sizeof(IS),    innerislist);    CHKERRQ(ierr);}
@@ -486,7 +486,7 @@ static PetscErrorCode  DMCreateDomainDecomposition_libMesh(DM dm, PetscInt * len
       (*dmlist)[d] = ddm;
     }
   }
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 
@@ -544,7 +544,7 @@ PetscErrorCode DMlibMeshCreateFieldDecompositionDM(DM dm, PetscInt dnumber, Pets
   ierr = DMlibMeshSetUpName_Private(*ddm); CHKERRQ(ierr);
   ierr = DMSetFromOptions(*ddm);           CHKERRQ(ierr);
   ierr = DMSetUp(*ddm);                    CHKERRQ(ierr);
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 #undef  __FUNCT__
@@ -601,7 +601,7 @@ PetscErrorCode DMlibMeshCreateDomainDecompositionDM(DM dm, PetscInt dnumber, Pet
   ierr = DMlibMeshSetUpName_Private(*ddm); CHKERRQ(ierr);
   ierr = DMSetFromOptions(*ddm);           CHKERRQ(ierr);
   ierr = DMSetUp(*ddm);                    CHKERRQ(ierr);
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 struct token {
@@ -664,7 +664,7 @@ static PetscErrorCode DMlibMeshFunction(DM dm, Vec x, Vec r)
 
   R.close();
   X_global.close();
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 #undef __FUNCT__
@@ -675,7 +675,7 @@ static PetscErrorCode SNESFunction_DMlibMesh(SNES, Vec x, Vec r, void * ctx)
   PetscErrorCode ierr;
   PetscFunctionBegin;
   ierr = DMlibMeshFunction(dm,x,r);CHKERRQ(ierr);
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 
@@ -737,7 +737,7 @@ static PetscErrorCode DMlibMeshJacobian(DM dm, Vec x, Mat jac, Mat pc)
   the_pc.close();
   Jac.close();
   X_global.close();
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 #undef  __FUNCT__
@@ -748,7 +748,7 @@ static PetscErrorCode SNESJacobian_DMlibMesh(SNES, Vec x, Mat jac, Mat pc, void 
   PetscErrorCode ierr;
   PetscFunctionBegin;
   ierr = DMlibMeshJacobian(dm,x,jac,pc); CHKERRQ(ierr);
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 #undef __FUNCT__
@@ -773,7 +773,7 @@ static PetscErrorCode DMVariableBounds_libMesh(DM dm, Vec xl, Vec xu)
   else
     SETERRQ(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "No bounds calculation in this libMesh object");
 
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 
@@ -818,7 +818,7 @@ static PetscErrorCode DMCreateGlobalVector_libMesh(DM dm, Vec *x)
   ierr = VecSetDM(*x, dm);CHKERRQ(ierr);
 #endif
 
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 
@@ -843,7 +843,7 @@ static PetscErrorCode DMCreateMatrix_libMesh(DM dm, Mat * A)
 
   *A = (dynamic_cast<PetscMatrix<Number> *>(dlm->sys->matrix))->mat();
   ierr = PetscObjectReference((PetscObject)(*A)); CHKERRQ(ierr);
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 
@@ -903,7 +903,7 @@ static PetscErrorCode  DMView_libMesh(DM dm, PetscViewer viewer)
     }
   }
 
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 #undef __FUNCT__
@@ -941,7 +941,7 @@ static PetscErrorCode  DMSetUp_libMesh(DM dm)
     dm->ops->createglobalvector = 0;
     dm->ops->creatematrix = 0;
   }
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 
@@ -962,7 +962,7 @@ static PetscErrorCode  DMDestroy_libMesh(DM dm)
   ierr = ISDestroy(&dlm->embedding); CHKERRQ(ierr);
   ierr = PetscFree(dm->data); CHKERRQ(ierr);
 
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 
 EXTERN_C_BEGIN
@@ -1019,7 +1019,7 @@ PetscErrorCode  DMCreate_libMesh(DM dm)
   ierr = PetscObjectComposeFunction((PetscObject)dm,"DMlibMeshSetSystem_C",DMlibMeshSetSystem_libMesh);CHKERRQ(ierr);
   ierr = PetscObjectComposeFunction((PetscObject)dm,"DMlibMeshGetSystem_C",DMlibMeshGetSystem_libMesh);CHKERRQ(ierr);
 
-  PetscFunctionReturn(0);
+  return PetscErrorCode(0);
 }
 EXTERN_C_END
 

--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -86,7 +86,7 @@ template <typename T>
 void SlepcEigenSolver<T>::init ()
 {
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // Initialize the data structures if not done so already.
   if (!this->initialized())
@@ -143,7 +143,7 @@ SlepcEigenSolver<T>::solve_standard (ShellMatrix<T> & shell_matrix,
 
   this->init ();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // Prepare the matrix.  Note that the const_cast is only necessary
   // because PETSc does not accept a const void *.  Inside the member
@@ -282,7 +282,7 @@ SlepcEigenSolver<T>::solve_generalized (ShellMatrix<T> & shell_matrix_A,
 
   this->init ();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // Prepare the matrix. Note that the const_cast is only necessary
   // because PETSc does not accept a const void *.  Inside the member
@@ -327,7 +327,7 @@ SlepcEigenSolver<T>::solve_generalized (SparseMatrix<T> & matrix_A_in,
 
   this->init ();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   PetscMatrix<T> * matrix_A = dynamic_cast<PetscMatrix<T> *>(&matrix_A_in);
 
@@ -373,7 +373,7 @@ SlepcEigenSolver<T>::solve_generalized (ShellMatrix<T> & shell_matrix_A,
 
   this->init ();
 
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // Prepare the matrices.  Note that the const_casts are only
   // necessary because PETSc does not accept a const void *.  Inside
@@ -501,7 +501,7 @@ SlepcEigenSolver<T>::_solve_helper(Mat precond,
                                    const double tol,         // solver tolerance
                                    const unsigned int m_its) // maximum number of iterations
 {
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // converged eigen pairs and number of iterations
   PetscInt nconv=0;
@@ -639,7 +639,7 @@ void SlepcEigenSolver<T>::print_eigenvalues() const
 template <typename T>
 void SlepcEigenSolver<T>::set_slepc_solver_type()
 {
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   switch (this->_eigen_solver_type)
     {
@@ -671,7 +671,7 @@ void SlepcEigenSolver<T>::set_slepc_solver_type()
 template <typename T>
 void SlepcEigenSolver<T>:: set_slepc_problem_type()
 {
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   switch (this->_eigen_problem_type)
     {
@@ -701,7 +701,7 @@ void SlepcEigenSolver<T>:: set_slepc_problem_type()
 template <typename T>
 void SlepcEigenSolver<T>:: set_slepc_position_of_spectrum()
 {
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   switch (this->_position_of_spectrum)
     {
@@ -784,7 +784,7 @@ template <typename T>
 std::pair<Real, Real> SlepcEigenSolver<T>::get_eigenpair(dof_id_type i,
                                                          NumericVector<T> & solution_in)
 {
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   PetscReal re, im;
 
@@ -817,7 +817,7 @@ std::pair<Real, Real> SlepcEigenSolver<T>::get_eigenpair(dof_id_type i,
 template <typename T>
 std::pair<Real, Real> SlepcEigenSolver<T>::get_eigenvalue(dof_id_type i)
 {
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   PetscReal re, im;
 
@@ -842,7 +842,7 @@ std::pair<Real, Real> SlepcEigenSolver<T>::get_eigenvalue(dof_id_type i)
 template <typename T>
 Real SlepcEigenSolver<T>::get_relative_error(unsigned int i)
 {
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   PetscReal error;
 
 #if SLEPC_VERSION_LESS_THAN(3,6,0)
@@ -861,7 +861,7 @@ void SlepcEigenSolver<T>::attach_deflation_space(NumericVector<T> & deflation_ve
 {
   this->init();
 
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // Make sure the input vector is actually a PetscVector
   PetscVector<T> * deflation_vector_petsc_vec =
@@ -896,13 +896,10 @@ template <typename T>
 PetscErrorCode SlepcEigenSolver<T>::_petsc_shell_matrix_mult(Mat mat, Vec arg, Vec dest)
 {
   // Get the matrix context.
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   void * ctx;
   ierr = MatShellGetContext(mat,&ctx);
-
-  Parallel::communicator comm;
-  PetscObjectGetComm((PetscObject)mat,&comm);
-  CHKERRABORT(comm,ierr);
+  LIBMESH_CHKERR(ierr);
 
   // Get user shell matrix object.
   const ShellMatrix<T> & shell_matrix = *static_cast<const ShellMatrix<T> *>(ctx);
@@ -921,13 +918,10 @@ template <typename T>
 PetscErrorCode SlepcEigenSolver<T>::_petsc_shell_matrix_get_diagonal(Mat mat, Vec dest)
 {
   // Get the matrix context.
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   void * ctx;
   ierr = MatShellGetContext(mat,&ctx);
-
-  Parallel::communicator comm;
-  PetscObjectGetComm((PetscObject)mat,&comm);
-  CHKERRABORT(comm,ierr);
+  LIBMESH_CHKERR(ierr);
 
   // Get user shell matrix object.
   const ShellMatrix<T> & shell_matrix = *static_cast<const ShellMatrix<T> *>(ctx);

--- a/src/solvers/tao_optimization_solver.C
+++ b/src/solvers/tao_optimization_solver.C
@@ -51,7 +51,7 @@ extern "C"
   {
     LOG_SCOPE("objective()", "TaoOptimizationSolver");
 
-    PetscErrorCode ierr = 0;
+    PetscErrorCode ierr = (PetscErrorCode)0;
 
     libmesh_assert(x);
     libmesh_assert(objective);
@@ -99,7 +99,7 @@ extern "C"
   {
     LOG_SCOPE("gradient()", "TaoOptimizationSolver");
 
-    PetscErrorCode ierr = 0;
+    PetscErrorCode ierr = (PetscErrorCode)0;
 
     libmesh_assert(x);
     libmesh_assert(g);
@@ -150,7 +150,7 @@ extern "C"
   {
     LOG_SCOPE("hessian()", "TaoOptimizationSolver");
 
-    PetscErrorCode ierr = 0;
+    PetscErrorCode ierr = (PetscErrorCode)0;
 
     libmesh_assert(x);
     libmesh_assert(h);
@@ -207,7 +207,7 @@ extern "C"
   {
     LOG_SCOPE("equality_constraints()", "TaoOptimizationSolver");
 
-    PetscErrorCode ierr = 0;
+    PetscErrorCode ierr = (PetscErrorCode)0;
 
     libmesh_assert(x);
     libmesh_assert(ce);
@@ -259,7 +259,7 @@ extern "C"
   {
     LOG_SCOPE("equality_constraints_jacobian()", "TaoOptimizationSolver");
 
-    PetscErrorCode ierr = 0;
+    PetscErrorCode ierr = (PetscErrorCode)0;
 
     libmesh_assert(x);
     libmesh_assert(J);
@@ -308,7 +308,7 @@ extern "C"
   {
     LOG_SCOPE("inequality_constraints()", "TaoOptimizationSolver");
 
-    PetscErrorCode ierr = 0;
+    PetscErrorCode ierr = (PetscErrorCode)0;
 
     libmesh_assert(x);
     libmesh_assert(cineq);
@@ -360,7 +360,7 @@ extern "C"
   {
     LOG_SCOPE("inequality_constraints_jacobian()", "TaoOptimizationSolver");
 
-    PetscErrorCode ierr = 0;
+    PetscErrorCode ierr = (PetscErrorCode)0;
 
     libmesh_assert(x);
     libmesh_assert(J);
@@ -449,7 +449,7 @@ void TaoOptimizationSolver<T>::init ()
     {
       this->_is_initialized = true;
 
-      PetscErrorCode ierr=0;
+      PetscErrorCode ierr = (PetscErrorCode)0;
 
       ierr = TaoCreate(this->comm().get(),&_tao);
       LIBMESH_CHKERR(ierr);
@@ -478,7 +478,7 @@ void TaoOptimizationSolver<T>::solve ()
   // Set the starting guess to zero.
   x->zero();
 
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   // Workaround for bug where TaoSetFromOptions *reset*
   // programmatically set tolerance and max. function evaluation
@@ -635,7 +635,7 @@ void TaoOptimizationSolver<T>::get_dual_variables()
   Vec lambda_eq_petsc_vec = lambda_eq_petsc->vec();
   Vec lambda_ineq_petsc_vec = lambda_ineq_petsc->vec();
 
-  PetscErrorCode ierr = 0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
   ierr = TaoGetDualVariables(_tao,
                              &lambda_eq_petsc_vec,
                              &lambda_ineq_petsc_vec);
@@ -655,7 +655,7 @@ void TaoOptimizationSolver<T>::print_converged_reason()
 template <typename T>
 int TaoOptimizationSolver<T>::get_converged_reason()
 {
-  PetscErrorCode ierr=0;
+  PetscErrorCode ierr = (PetscErrorCode)0;
 
   if (this->initialized())
     {


### PR DESCRIPTION
Some PETSc devs only configure with `--with-strict-petscerrorcode` and if I'd ever like them to look at something, it's a lot easier if our stack builds out of the box for them