### PR TITLE
fix read VTK_IO bug

### DIFF
--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -344,11 +344,11 @@ void Prism6::connectivity(const unsigned int libmesh_dbg_var(sc),
       {
         conn.resize(6);
         conn[0] = this->node_id(0);
-        conn[1] = this->node_id(2);
-        conn[2] = this->node_id(1);
+        conn[1] = this->node_id(1);
+        conn[2] = this->node_id(2);
         conn[3] = this->node_id(3);
-        conn[4] = this->node_id(5);
-        conn[5] = this->node_id(4);
+        conn[4] = this->node_id(4);
+        conn[5] = this->node_id(5);
         return;
       }
 

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -257,10 +257,10 @@ void Pyramid5::connectivity(const unsigned int libmesh_dbg_var(sc),
     case VTK:
       {
         conn.resize(5);
-        conn[0] = this->node_id(3);
-        conn[1] = this->node_id(2);
-        conn[2] = this->node_id(1);
-        conn[3] = this->node_id(0);
+        conn[0] = this->node_id(0);
+        conn[1] = this->node_id(1);
+        conn[2] = this->node_id(2);
+        conn[3] = this->node_id(3);
         conn[4] = this->node_id(4);
         return;
       }

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -194,7 +194,7 @@ void VTKIO::read (const std::string & name)
   elems_of_dimension.resize(4, false);
 
   // Use a typedef, because these names are just crazy
-  typedef vtkSmartPointer<vtkXMLPUnstructuredGridReader> MyReader;
+  typedef vtkSmartPointer<vtkXMLUnstructuredGridReader> MyReader;
   MyReader reader = MyReader::New();
 
   // Pass the filename along to the reader


### PR DESCRIPTION
When I read in a mesh file using VTK, I encounter that the volume of the triangular prisms is negative.

I compared the node connection order distribution of the VTK `VTK_WEDGE` and the libmesh `PRISM6`,their connection order is the same.
![image](https://github.com/libMesh/libmesh/assets/32708792/02bac471-56df-442e-978f-7508db7bdc06)
![image](https://github.com/libMesh/libmesh/assets/32708792/d55a3af9-489a-4e7c-944b-93a92073ca11)
