### PR TITLE
Don't ruin Petsc error stack

### DIFF
--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -46,6 +46,8 @@ extern "C"
                                        PetscReal fnorm,
                                        void * ctx)
   {
+    PetscFunctionBegin;
+
     PetscDiffSolver & solver =
       *(static_cast<PetscDiffSolver *> (ctx));
 
@@ -87,6 +89,8 @@ extern "C"
   PetscErrorCode
   __libmesh_petsc_diff_solver_residual (SNES, Vec x, Vec r, void * ctx)
   {
+    PetscFunctionBegin;
+
     libmesh_assert(x);
     libmesh_assert(r);
     libmesh_assert(ctx);
@@ -138,6 +142,8 @@ extern "C"
                                         Mat pc,
                                         void * ctx)
   {
+    PetscFunctionBegin;
+
     libmesh_assert(x);
     libmesh_assert(j);
     //  libmesh_assert_equal_to (pc, j);  // We don't use separate preconditioners yet

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -79,7 +79,7 @@ extern "C"
                                         u, u.l2_norm(),
                                         res, res.l2_norm(), its);
     }
-    return static_cast<PetscErrorCode>(0);
+    PetscFunctionReturn(static_cast<PetscErrorCode>(0));
   }
 
   // Functions to hand to PETSc's SNES,
@@ -127,7 +127,7 @@ extern "C"
     R_input.swap(R_system);
 
     // No errors, we hope
-    return static_cast<PetscErrorCode>(0);
+    PetscFunctionReturn(static_cast<PetscErrorCode>(0));
   }
 
 
@@ -181,7 +181,7 @@ extern "C"
     J_input.swap(J_system);
 
     // No errors, we hope
-    return static_cast<PetscErrorCode>(0);
+    PetscFunctionReturn(static_cast<PetscErrorCode>(0));
   }
 
 } // extern "C"

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -61,6 +61,8 @@ namespace libMesh
     PetscErrorCode libmesh_petsc_DMCreateSubDM(DM dm, PetscInt numFields, const PetscInt fields[], IS *is, DM *subdm)
 #endif
     {
+      PetscFunctionBegin;
+
       PetscErrorCode ierr;
       // Basically, we copy the PETSc ShellCreateSubDM implementation,
       // but also need to set the embedding dim and also propagate
@@ -200,6 +202,8 @@ namespace libMesh
     //! Help PETSc identify the finer DM given a dmc
     PetscErrorCode libmesh_petsc_DMRefine(DM dmc, MPI_Comm /*comm*/, DM * dmf)
     {
+      PetscFunctionBegin;
+
       libmesh_assert(dmc);
       libmesh_assert(dmf);
 
@@ -222,6 +226,8 @@ namespace libMesh
     //! Help PETSc identify the coarser DM dmc given the fine DM dmf
     PetscErrorCode libmesh_petsc_DMCoarsen(DM dmf, MPI_Comm /*comm*/, DM * dmc)
     {
+      PetscFunctionBegin;
+
       libmesh_assert(dmc);
       libmesh_assert(dmf);
 
@@ -312,6 +318,8 @@ namespace libMesh
     libmesh_petsc_DMCreateInterpolation (DM dmc /*coarse*/, DM dmf /*fine*/,
                                          Mat * mat ,Vec * vec)
     {
+      PetscFunctionBegin;
+
       libmesh_assert(dmc);
       libmesh_assert(dmf);
       libmesh_assert(mat);
@@ -402,6 +410,8 @@ namespace libMesh
     PetscErrorCode
     libmesh_petsc_DMCreateRestriction (DM dmc /*coarse*/, DM dmf/*fine*/, Mat * mat)
     {
+      PetscFunctionBegin;
+
       libmesh_assert(dmc);
       libmesh_assert(dmf);
       libmesh_assert(mat);

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -194,7 +194,7 @@ namespace libMesh
           CHKERRQ(ierr);
         }
 
-      return static_cast<PetscErrorCode>(0);
+      PetscFunctionReturn(static_cast<PetscErrorCode>(0));
     }
 
     //! Help PETSc identify the finer DM given a dmc
@@ -216,7 +216,7 @@ namespace libMesh
       libmesh_assert(*(p_ctx->finer_dm));
       *(dmf) = *(p_ctx->finer_dm);
 
-      return static_cast<PetscErrorCode>(0);
+      PetscFunctionReturn(static_cast<PetscErrorCode>(0));
     }
 
     //! Help PETSc identify the coarser DM dmc given the fine DM dmf
@@ -304,7 +304,7 @@ namespace libMesh
         *(dmc) = *(p_ctx_f->coarser_dm);
       }
 
-      return static_cast<PetscErrorCode>(0);
+      PetscFunctionReturn(static_cast<PetscErrorCode>(0));
     }
 
     //! Function to give PETSc that sets the Interpolation Matrix between two DMs
@@ -395,7 +395,7 @@ namespace libMesh
       // Vec scaling isnt needed so were done.
       *(vec) = LIBMESH_PETSC_NULLPTR;
 
-      return static_cast<PetscErrorCode>(0);
+      PetscFunctionReturn(static_cast<PetscErrorCode>(0));
     } // end libmesh_petsc_DMCreateInterpolation
 
     //! Function to give PETSc that sets the Restriction Matrix between two DMs
@@ -423,7 +423,7 @@ namespace libMesh
       libmesh_assert(p_ctx_f->K_restrict_ptr);
       *(mat) = p_ctx_f->K_restrict_ptr->mat();
 
-      return static_cast<PetscErrorCode>(0);
+      PetscFunctionReturn(static_cast<PetscErrorCode>(0));
     }
 
   } // end extern C functions

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -47,6 +47,8 @@ extern "C"
 {
   PetscErrorCode libmesh_petsc_preconditioner_setup (PC pc)
   {
+    PetscFunctionBegin;
+
     void * ctx;
     PetscErrorCode ierr = PCShellGetContext(pc,&ctx);CHKERRQ(ierr);
     Preconditioner<Number> * preconditioner = static_cast<Preconditioner<Number> *>(ctx);
@@ -61,6 +63,8 @@ extern "C"
 
   PetscErrorCode libmesh_petsc_preconditioner_apply(PC pc, Vec x, Vec y)
   {
+    PetscFunctionBegin;
+
     void * ctx;
     PetscErrorCode ierr = PCShellGetContext(pc,&ctx);CHKERRQ(ierr);
     Preconditioner<Number> * preconditioner = static_cast<Preconditioner<Number> *>(ctx);
@@ -76,14 +80,16 @@ extern "C"
 #ifdef LIBMESH_ENABLE_DEPRECATED
   PetscErrorCode __libmesh_petsc_preconditioner_setup (PC pc)
   {
+    PetscFunctionBegin;
     libmesh_deprecated();
-    return libmesh_petsc_preconditioner_setup(pc);
+    PetscFunctionReturn(libmesh_petsc_preconditioner_setup(pc));
   }
 
   PetscErrorCode __libmesh_petsc_preconditioner_apply(PC pc, Vec x, Vec y)
   {
+    PetscFunctionBegin;
     libmesh_deprecated();
-    return libmesh_petsc_preconditioner_apply(pc, x, y);
+    PetscFunctionReturn(libmesh_petsc_preconditioner_apply(pc, x, y));
   }
 #endif
 } // end extern "C"
@@ -978,6 +984,8 @@ LinearConvergenceReason PetscLinearSolver<T>::get_converged_reason() const
 template <typename T>
 PetscErrorCode PetscLinearSolver<T>::_petsc_shell_matrix_mult(Mat mat, Vec arg, Vec dest)
 {
+  PetscFunctionBegin;
+
   // Get the matrix context.
   PetscErrorCode ierr = static_cast<PetscErrorCode>(0);
   void * ctx;
@@ -1002,6 +1010,8 @@ PetscErrorCode PetscLinearSolver<T>::_petsc_shell_matrix_mult(Mat mat, Vec arg, 
 template <typename T>
 PetscErrorCode PetscLinearSolver<T>::_petsc_shell_matrix_mult_add(Mat mat, Vec arg, Vec add, Vec dest)
 {
+  PetscFunctionBegin;
+
   // Get the matrix context.
   PetscErrorCode ierr = static_cast<PetscErrorCode>(0);
   void * ctx;
@@ -1032,6 +1042,8 @@ PetscErrorCode PetscLinearSolver<T>::_petsc_shell_matrix_mult_add(Mat mat, Vec a
 template <typename T>
 PetscErrorCode PetscLinearSolver<T>::_petsc_shell_matrix_get_diagonal(Mat mat, Vec dest)
 {
+  PetscFunctionBegin;
+
   // Get the matrix context.
   PetscErrorCode ierr = static_cast<PetscErrorCode>(0);
   void * ctx;

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -56,7 +56,7 @@ extern "C"
 
     preconditioner->setup();
 
-    return static_cast<PetscErrorCode>(0);
+    PetscFunctionReturn(static_cast<PetscErrorCode>(0));
   }
 
   PetscErrorCode libmesh_petsc_preconditioner_apply(PC pc, Vec x, Vec y)
@@ -70,7 +70,7 @@ extern "C"
 
     preconditioner->apply(x_vec,y_vec);
 
-    return static_cast<PetscErrorCode>(0);
+    PetscFunctionReturn(static_cast<PetscErrorCode>(0));
   }
 
 #ifdef LIBMESH_ENABLE_DEPRECATED

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -994,7 +994,7 @@ PetscErrorCode PetscLinearSolver<T>::_petsc_shell_matrix_mult(Mat mat, Vec arg, 
   // Call the user function.
   shell_matrix.vector_mult(dest_global,arg_global);
 
-  return ierr;
+  PetscFunctionReturn(ierr);
 }
 
 
@@ -1024,7 +1024,7 @@ PetscErrorCode PetscLinearSolver<T>::_petsc_shell_matrix_mult_add(Mat mat, Vec a
   // Call the user function.
   shell_matrix.vector_mult_add(dest_global,arg_global);
 
-  return ierr;
+  PetscFunctionReturn(ierr);
 }
 
 
@@ -1047,7 +1047,7 @@ PetscErrorCode PetscLinearSolver<T>::_petsc_shell_matrix_get_diagonal(Mat mat, V
   // Call the user function.
   shell_matrix.get_diagonal(dest_global);
 
-  return ierr;
+  PetscFunctionReturn(ierr);
 }
 
 

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -115,6 +115,8 @@ extern "C"
   PetscErrorCode
   libmesh_petsc_recalculate_monitor(SNES snes, PetscInt, PetscReal, void* ctx)
   {
+    PetscFunctionBegin;
+
     // No way to safety-check this cast, since we got a void *...
     PetscNonlinearSolver<Number> * solver =
       static_cast<PetscNonlinearSolver<Number> *> (ctx);
@@ -144,16 +146,12 @@ extern "C"
   PetscErrorCode
   libmesh_petsc_snes_monitor (SNES, PetscInt its, PetscReal fnorm, void *)
   {
-    //PetscErrorCode ierr=0;
-
-    //if (its > 0)
+    PetscFunctionBegin;
     libMesh::out << "  NL step "
                  << std::setw(2) << its
                  << std::scientific
                  << ", |residual|_2 = " << fnorm
                  << std::endl;
-
-    //PetscFunctionReturn(ierr);
     PetscFunctionReturn(static_cast<PetscErrorCode>(0));
   }
 
@@ -161,8 +159,9 @@ extern "C"
   PetscErrorCode
   __libmesh_petsc_snes_monitor (SNES, PetscInt its, PetscReal fnorm, void *)
   {
+    PetscFunctionBegin;
     libmesh_deprecated();
-    return libmesh_petsc_snes_monitor(nullptr, its, fnorm, nullptr);
+    PetscFunctionReturn(libmesh_petsc_snes_monitor(nullptr, its, fnorm, nullptr));
   }
 #endif
 
@@ -172,6 +171,8 @@ extern "C"
   PetscErrorCode
   libmesh_petsc_snes_residual (SNES snes, Vec x, Vec r, void * ctx)
   {
+    PetscFunctionBegin;
+
     ResidualContext rc = libmesh_petsc_snes_residual_helper(snes, x, ctx);
 
     libmesh_parallel_only(rc.sys.comm());
@@ -238,15 +239,16 @@ extern "C"
         R.close();
       }
 
-    return rc.ierr;
+    PetscFunctionReturn(rc.ierr);
   }
 
 #ifdef LIBMESH_ENABLE_DEPRECATED
   PetscErrorCode
   __libmesh_petsc_snes_residual (SNES snes, Vec x, Vec r, void * ctx)
   {
+    PetscFunctionBegin;
     libmesh_deprecated();
-    return libmesh_petsc_snes_residual(snes, x, r, ctx);
+    PetscFunctionReturn(libmesh_petsc_snes_residual(snes, x, r, ctx));
   }
 #endif
 
@@ -255,6 +257,8 @@ extern "C"
   PetscErrorCode
   libmesh_petsc_snes_fd_residual (SNES snes, Vec x, Vec r, void * ctx)
   {
+    PetscFunctionBegin;
+
     ResidualContext rc = libmesh_petsc_snes_residual_helper(snes, x, ctx);
 
     libmesh_parallel_only(rc.sys.comm());
@@ -290,15 +294,16 @@ extern "C"
         R.close();
       }
 
-    return rc.ierr;
+    PetscFunctionReturn(rc.ierr);
   }
 
 #ifdef LIBMESH_ENABLE_DEPRECATED
   PetscErrorCode
   __libmesh_petsc_snes_fd_residual (SNES snes, Vec x, Vec r, void * ctx)
   {
+    PetscFunctionBegin;
     libmesh_deprecated();
-    return libmesh_petsc_snes_fd_residual(snes, x, r, ctx);
+    PetscFunctionReturn(libmesh_petsc_snes_fd_residual(snes, x, r, ctx));
   }
 #endif
 
@@ -308,6 +313,8 @@ extern "C"
   PetscErrorCode
   libmesh_petsc_snes_mffd_residual (SNES snes, Vec x, Vec r, void * ctx)
   {
+    PetscFunctionBegin;
+
     ResidualContext rc = libmesh_petsc_snes_residual_helper(snes, x, ctx);
 
     libmesh_parallel_only(rc.sys.comm());
@@ -344,7 +351,7 @@ extern "C"
         R.close();
       }
 
-    return rc.ierr;
+    PetscFunctionReturn(rc.ierr);
   }
 
   //----------------------------------------------------------
@@ -436,8 +443,9 @@ extern "C"
   PetscErrorCode
   __libmesh_petsc_snes_mffd_interface (void * ctx, Vec x, Vec r)
   {
+    PetscFunctionBegin;
     libmesh_deprecated();
-    return libmesh_petsc_snes_mffd_interface(ctx, x, r);
+    PetscFunctionReturn(libmesh_petsc_snes_mffd_interface(ctx, x, r));
   }
 #endif
 
@@ -446,6 +454,8 @@ extern "C"
   PetscErrorCode
   libmesh_petsc_snes_jacobian(SNES snes, Vec x, Mat jac, Mat pc, void * ctx)
   {
+    PetscFunctionBegin;
+
     LOG_SCOPE("jacobian()", "PetscNonlinearSolver");
 
     PetscErrorCode ierr = static_cast<PetscErrorCode>(0);
@@ -550,6 +560,8 @@ extern "C"
   // * "ctx" is the PetscNonlinearSolver context
   PetscErrorCode libmesh_petsc_linesearch_shellfunc (SNESLineSearch linesearch, void * ctx)
   {
+    PetscFunctionBegin;
+
     // No way to safety-check this cast, since we got a void *...
     PetscNonlinearSolver<Number> * solver =
       static_cast<PetscNonlinearSolver<Number> *> (ctx);
@@ -564,8 +576,9 @@ extern "C"
   PetscErrorCode
   __libmesh_petsc_snes_jacobian(SNES snes, Vec x, Mat jac, Mat pc, void * ctx)
   {
+    PetscFunctionBegin;
     libmesh_deprecated();
-    return libmesh_petsc_snes_jacobian(snes, x, jac, pc, ctx);
+    PetscFunctionReturn(libmesh_petsc_snes_jacobian(snes, x, jac, pc, ctx));
   }
 #endif
 
@@ -581,6 +594,8 @@ extern "C"
   // direction or solution vector was changed, respectively.
   PetscErrorCode libmesh_petsc_snes_postcheck(SNESLineSearch, Vec x, Vec y, Vec w, PetscBool * changed_y, PetscBool * changed_w, void * context)
   {
+    PetscFunctionBegin;
+
     LOG_SCOPE("postcheck()", "PetscNonlinearSolver");
 
     PetscErrorCode ierr = static_cast<PetscErrorCode>(0);
@@ -654,13 +669,16 @@ extern "C"
 #ifdef LIBMESH_ENABLE_DEPRECATED
   PetscErrorCode __libmesh_petsc_snes_postcheck(SNESLineSearch, Vec x, Vec y, Vec w, PetscBool * changed_y, PetscBool * changed_w, void * context)
   {
+    PetscFunctionBegin;
     libmesh_deprecated();
-    return libmesh_petsc_snes_postcheck(nullptr, x, y, w, changed_y, changed_w, context);
+    PetscFunctionReturn(libmesh_petsc_snes_postcheck(nullptr, x, y, w, changed_y, changed_w, context));
   }
 #endif
 
   PetscErrorCode libmesh_petsc_snes_precheck(SNESLineSearch, Vec X, Vec Y, PetscBool * changed, void * context)
   {
+    PetscFunctionBegin;
+
     LOG_SCOPE("precheck()", "PetscNonlinearSolver");
 
     PetscErrorCode ierr = static_cast<PetscErrorCode>(0);

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -154,7 +154,7 @@ extern "C"
                  << std::endl;
 
     //return ierr;
-    return static_cast<PetscErrorCode>(0);
+    PetscFunctionReturn(static_cast<PetscErrorCode>(0));
   }
 
 #ifdef LIBMESH_ENABLE_DEPRECATED
@@ -429,7 +429,7 @@ extern "C"
 #endif
 #endif
 
-    return static_cast<PetscErrorCode>(0);
+    PetscFunctionReturn(static_cast<PetscErrorCode>(0));
   }
 
 #ifdef LIBMESH_ENABLE_DEPRECATED
@@ -557,7 +557,7 @@ extern "C"
     libmesh_parallel_only(solver->comm());
 
     solver->linesearch_object->linesearch(linesearch);
-    return static_cast<PetscErrorCode>(0);
+    PetscFunctionReturn(static_cast<PetscErrorCode>(0));
   }
 
 #ifdef LIBMESH_ENABLE_DEPRECATED

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -136,7 +136,7 @@ extern "C"
       ierr = SNESSetLagPreconditioner(snes, -2);
       LIBMESH_CHKERR2(solver->comm(),ierr);
     }
-    return ierr;
+    PetscFunctionReturn(ierr);
   }
 
   //-------------------------------------------------------------------
@@ -153,7 +153,7 @@ extern "C"
                  << ", |residual|_2 = " << fnorm
                  << std::endl;
 
-    //return ierr;
+    //PetscFunctionReturn(ierr);
     PetscFunctionReturn(static_cast<PetscErrorCode>(0));
   }
 
@@ -495,7 +495,7 @@ extern "C"
       if (pc && pc != sys_mat.mat())
         PC.close();
 
-      return ierr;
+      PetscFunctionReturn(ierr);
     }
 
     // Set the dof maps
@@ -539,7 +539,7 @@ extern "C"
 
     Jac.close();
 
-    return ierr;
+    PetscFunctionReturn(ierr);
   }
 
   // This function gets called by PETSc in place of the standard Petsc line searches
@@ -608,7 +608,7 @@ extern "C"
     NonlinearImplicitSystem & sys = solver->system();
 
     if (!solver->postcheck && !solver->postcheck_object)
-      return ierr;
+      PetscFunctionReturn(ierr);
 
     // We definitely need to wrap at least "w"
     PetscVector<Number> petsc_w(w, sys.comm());
@@ -648,7 +648,7 @@ extern "C"
     if (changed_new_soln)
       *changed_w = PETSC_TRUE;
 
-    return ierr;
+    PetscFunctionReturn(ierr);
   }
 
 #ifdef LIBMESH_ENABLE_DEPRECATED
@@ -680,7 +680,7 @@ extern "C"
     // It's possible that we don't need to do anything at all, in
     // that case return early...
     if (!solver->precheck_object)
-      return ierr;
+      PetscFunctionReturn(ierr);
 
     // The user sets these flags in his/her postcheck function to
     // indicate whether they changed something.
@@ -715,7 +715,7 @@ extern "C"
     if (petsc_changed)
       *changed = PETSC_TRUE;
 
-    return ierr;
+    PetscFunctionReturn(ierr);
   }
 } // end extern "C"
 

--- a/src/solvers/petscdmlibmeshimpl.C
+++ b/src/solvers/petscdmlibmeshimpl.C
@@ -81,7 +81,7 @@ PetscErrorCode DMlibMeshGetVec_Private(DM /*dm*/, const char * /*name*/, Vec *)
 {
   PetscFunctionBegin;
 
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 
@@ -147,7 +147,7 @@ PetscErrorCode DMlibMeshSetSystem_libMesh(DM dm, NonlinearImplicitSystem & sys)
     dlm->blocknames->insert(std::pair<unsigned int,std::string>(bid,bname));
   }
   ierr = DMlibMeshSetUpName_Private(dm); CHKERRQ(ierr);
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 #undef  __FUNCT__
@@ -163,7 +163,7 @@ PetscErrorCode DMlibMeshGetSystem_libMesh(DM dm, NonlinearImplicitSystem *& sys)
   if (!islibmesh) LIBMESH_SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
   sys = dlm->sys;
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 
@@ -186,7 +186,7 @@ PetscErrorCode DMlibMeshGetBlocks(DM dm, PetscInt * n, char *** blocknames)
   PetscValidPointer(n,2);
 #endif
   *n = cast_int<unsigned int>(dlm->blockids->size());
-  if (!blocknames) return static_cast<PetscErrorCode>(0);
+  if (!blocknames) PetscFunctionReturn(static_cast<PetscErrorCode>(0));
   ierr = PetscMalloc(*n*sizeof(char *), blocknames); CHKERRQ(ierr);
   i = 0;
   for (const auto & pr : *(dlm->blockids))
@@ -194,7 +194,7 @@ PetscErrorCode DMlibMeshGetBlocks(DM dm, PetscInt * n, char *** blocknames)
       ierr = PetscStrallocpy(pr.first.c_str(), *blocknames+i); CHKERRQ(ierr);
       ++i;
     }
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 #undef  __FUNCT__
@@ -216,7 +216,7 @@ PetscErrorCode DMlibMeshGetVariables(DM dm, PetscInt * n, char *** varnames)
   PetscValidPointer(n,2);
 #endif
   *n = cast_int<unsigned int>(dlm->varids->size());
-  if (!varnames) return static_cast<PetscErrorCode>(0);
+  if (!varnames) PetscFunctionReturn(static_cast<PetscErrorCode>(0));
   ierr = PetscMalloc(*n*sizeof(char *), varnames); CHKERRQ(ierr);
   i = 0;
   for (const auto & pr : *(dlm->varids))
@@ -224,7 +224,7 @@ PetscErrorCode DMlibMeshGetVariables(DM dm, PetscInt * n, char *** varnames)
       ierr = PetscStrallocpy(pr.first.c_str(), *varnames+i); CHKERRQ(ierr);
       ++i;
     }
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 #undef  __FUNCT__
@@ -278,7 +278,7 @@ PetscErrorCode DMlibMeshSetUpName_Private(DM dm)
     name += ";";
   }
   ierr = PetscObjectSetName((PetscObject)dm, name.c_str()); CHKERRQ(ierr);
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 
@@ -291,7 +291,7 @@ static PetscErrorCode  DMCreateFieldDecomposition_libMesh(DM dm, PetscInt * len,
   DM_libMesh     * dlm = (DM_libMesh *)(dm->data);
   NonlinearImplicitSystem * sys = dlm->sys;
   IS emb;
-  if (dlm->decomposition_type != DMLIBMESH_FIELD_DECOMPOSITION) return static_cast<PetscErrorCode>(0);
+  if (dlm->decomposition_type != DMLIBMESH_FIELD_DECOMPOSITION) PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 
   *len = cast_int<unsigned int>(dlm->decomposition->size());
   if (namelist) {ierr = PetscMalloc(*len*sizeof(char *), namelist);  CHKERRQ(ierr);}
@@ -381,7 +381,7 @@ static PetscErrorCode  DMCreateFieldDecomposition_libMesh(DM dm, PetscInt * len,
       (*dmlist)[d] = ddm;
     }
   }
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 #undef __FUNCT__
@@ -393,7 +393,7 @@ static PetscErrorCode  DMCreateDomainDecomposition_libMesh(DM dm, PetscInt * len
   DM_libMesh     * dlm = (DM_libMesh *)(dm->data);
   NonlinearImplicitSystem * sys = dlm->sys;
   IS emb;
-  if (dlm->decomposition_type != DMLIBMESH_DOMAIN_DECOMPOSITION) return static_cast<PetscErrorCode>(0);
+  if (dlm->decomposition_type != DMLIBMESH_DOMAIN_DECOMPOSITION) PetscFunctionReturn(static_cast<PetscErrorCode>(0));
   *len = cast_int<unsigned int>(dlm->decomposition->size());
   if (namelist)      {ierr = PetscMalloc(*len*sizeof(char *), namelist);  CHKERRQ(ierr);}
   if (innerislist)   {ierr = PetscMalloc(*len*sizeof(IS),    innerislist);    CHKERRQ(ierr);}
@@ -486,7 +486,7 @@ static PetscErrorCode  DMCreateDomainDecomposition_libMesh(DM dm, PetscInt * len
       (*dmlist)[d] = ddm;
     }
   }
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 
@@ -544,7 +544,7 @@ PetscErrorCode DMlibMeshCreateFieldDecompositionDM(DM dm, PetscInt dnumber, Pets
   ierr = DMlibMeshSetUpName_Private(*ddm); CHKERRQ(ierr);
   ierr = DMSetFromOptions(*ddm);           CHKERRQ(ierr);
   ierr = DMSetUp(*ddm);                    CHKERRQ(ierr);
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 #undef  __FUNCT__
@@ -601,7 +601,7 @@ PetscErrorCode DMlibMeshCreateDomainDecompositionDM(DM dm, PetscInt dnumber, Pet
   ierr = DMlibMeshSetUpName_Private(*ddm); CHKERRQ(ierr);
   ierr = DMSetFromOptions(*ddm);           CHKERRQ(ierr);
   ierr = DMSetUp(*ddm);                    CHKERRQ(ierr);
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 struct token {
@@ -664,7 +664,7 @@ static PetscErrorCode DMlibMeshFunction(DM dm, Vec x, Vec r)
 
   R.close();
   X_global.close();
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 #undef __FUNCT__
@@ -675,7 +675,7 @@ static PetscErrorCode SNESFunction_DMlibMesh(SNES, Vec x, Vec r, void * ctx)
   PetscErrorCode ierr;
   PetscFunctionBegin;
   ierr = DMlibMeshFunction(dm,x,r);CHKERRQ(ierr);
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 
@@ -737,7 +737,7 @@ static PetscErrorCode DMlibMeshJacobian(DM dm, Vec x, Mat jac, Mat pc)
   the_pc.close();
   Jac.close();
   X_global.close();
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 #undef  __FUNCT__
@@ -748,7 +748,7 @@ static PetscErrorCode SNESJacobian_DMlibMesh(SNES, Vec x, Mat jac, Mat pc, void 
   PetscErrorCode ierr;
   PetscFunctionBegin;
   ierr = DMlibMeshJacobian(dm,x,jac,pc); CHKERRQ(ierr);
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 #undef __FUNCT__
@@ -773,7 +773,7 @@ static PetscErrorCode DMVariableBounds_libMesh(DM dm, Vec xl, Vec xu)
   else
     SETERRQ(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "No bounds calculation in this libMesh object");
 
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 
@@ -818,7 +818,7 @@ static PetscErrorCode DMCreateGlobalVector_libMesh(DM dm, Vec *x)
   ierr = VecSetDM(*x, dm);CHKERRQ(ierr);
 #endif
 
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 
@@ -843,7 +843,7 @@ static PetscErrorCode DMCreateMatrix_libMesh(DM dm, Mat * A)
 
   *A = (dynamic_cast<PetscMatrix<Number> *>(dlm->sys->matrix))->mat();
   ierr = PetscObjectReference((PetscObject)(*A)); CHKERRQ(ierr);
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 
@@ -903,7 +903,7 @@ static PetscErrorCode  DMView_libMesh(DM dm, PetscViewer viewer)
     }
   }
 
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 #undef __FUNCT__
@@ -941,7 +941,7 @@ static PetscErrorCode  DMSetUp_libMesh(DM dm)
     dm->ops->createglobalvector = 0;
     dm->ops->creatematrix = 0;
   }
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 
@@ -962,7 +962,7 @@ static PetscErrorCode  DMDestroy_libMesh(DM dm)
   ierr = ISDestroy(&dlm->embedding); CHKERRQ(ierr);
   ierr = PetscFree(dm->data); CHKERRQ(ierr);
 
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 
 EXTERN_C_BEGIN
@@ -1019,7 +1019,7 @@ PetscErrorCode  DMCreate_libMesh(DM dm)
   ierr = PetscObjectComposeFunction((PetscObject)dm,"DMlibMeshSetSystem_C",DMlibMeshSetSystem_libMesh);CHKERRQ(ierr);
   ierr = PetscObjectComposeFunction((PetscObject)dm,"DMlibMeshGetSystem_C",DMlibMeshGetSystem_libMesh);CHKERRQ(ierr);
 
-  return static_cast<PetscErrorCode>(0);
+  PetscFunctionReturn(static_cast<PetscErrorCode>(0));
 }
 EXTERN_C_END
 

--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -895,6 +895,8 @@ void SlepcEigenSolver<T>::set_initial_space(NumericVector<T> & initial_space_in)
 template <typename T>
 PetscErrorCode SlepcEigenSolver<T>::_petsc_shell_matrix_mult(Mat mat, Vec arg, Vec dest)
 {
+  PetscFunctionBegin;
+
   // Get the matrix context.
   PetscErrorCode ierr = static_cast<PetscErrorCode>(0);
   void * ctx;
@@ -917,6 +919,8 @@ PetscErrorCode SlepcEigenSolver<T>::_petsc_shell_matrix_mult(Mat mat, Vec arg, V
 template <typename T>
 PetscErrorCode SlepcEigenSolver<T>::_petsc_shell_matrix_get_diagonal(Mat mat, Vec dest)
 {
+  PetscFunctionBegin;
+
   // Get the matrix context.
   PetscErrorCode ierr = static_cast<PetscErrorCode>(0);
   void * ctx;

--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -911,7 +911,7 @@ PetscErrorCode SlepcEigenSolver<T>::_petsc_shell_matrix_mult(Mat mat, Vec arg, V
   // Call the user function.
   shell_matrix.vector_mult(dest_global,arg_global);
 
-  return ierr;
+  PetscFunctionReturn(ierr);
 }
 
 template <typename T>
@@ -932,7 +932,7 @@ PetscErrorCode SlepcEigenSolver<T>::_petsc_shell_matrix_get_diagonal(Mat mat, Ve
   // Call the user function.
   shell_matrix.get_diagonal(dest_global);
 
-  return ierr;
+  PetscFunctionReturn(ierr);
 }
 
 //------------------------------------------------------------------

--- a/src/solvers/tao_optimization_solver.C
+++ b/src/solvers/tao_optimization_solver.C
@@ -87,7 +87,7 @@ extern "C"
     else
       libmesh_error_msg("Objective function not defined in __libmesh_tao_objective");
 
-    return ierr;
+    PetscFunctionReturn(ierr);
   }
 
 
@@ -140,7 +140,7 @@ extern "C"
 
     gradient.close();
 
-    return ierr;
+    PetscFunctionReturn(ierr);
   }
 
   //---------------------------------------------------------------
@@ -196,7 +196,7 @@ extern "C"
     PC.close();
     hessian.close();
 
-    return ierr;
+    PetscFunctionReturn(ierr);
   }
 
 
@@ -248,7 +248,7 @@ extern "C"
 
     eq_constraints.close();
 
-    return ierr;
+    PetscFunctionReturn(ierr);
   }
 
   //---------------------------------------------------------------
@@ -298,7 +298,7 @@ extern "C"
     J_petsc.close();
     Jpre_petsc.close();
 
-    return ierr;
+    PetscFunctionReturn(ierr);
   }
 
   //---------------------------------------------------------------
@@ -349,7 +349,7 @@ extern "C"
 
     ineq_constraints.close();
 
-    return ierr;
+    PetscFunctionReturn(ierr);
   }
 
   //---------------------------------------------------------------
@@ -399,7 +399,7 @@ extern "C"
     J_petsc.close();
     Jpre_petsc.close();
 
-    return ierr;
+    PetscFunctionReturn(ierr);
   }
 
 } // end extern "C"

--- a/src/solvers/tao_optimization_solver.C
+++ b/src/solvers/tao_optimization_solver.C
@@ -49,6 +49,8 @@ extern "C"
   PetscErrorCode
   __libmesh_tao_objective (Tao /*tao*/, Vec x, PetscReal * objective, void * ctx)
   {
+    PetscFunctionBegin;
+
     LOG_SCOPE("objective()", "TaoOptimizationSolver");
 
     PetscErrorCode ierr = static_cast<PetscErrorCode>(0);
@@ -97,6 +99,8 @@ extern "C"
   PetscErrorCode
   __libmesh_tao_gradient(Tao /*tao*/, Vec x, Vec g, void * ctx)
   {
+    PetscFunctionBegin;
+
     LOG_SCOPE("gradient()", "TaoOptimizationSolver");
 
     PetscErrorCode ierr = static_cast<PetscErrorCode>(0);
@@ -148,6 +152,8 @@ extern "C"
   PetscErrorCode
   __libmesh_tao_hessian(Tao /*tao*/, Vec x, Mat h, Mat pc, void * ctx)
   {
+    PetscFunctionBegin;
+
     LOG_SCOPE("hessian()", "TaoOptimizationSolver");
 
     PetscErrorCode ierr = static_cast<PetscErrorCode>(0);
@@ -205,6 +211,8 @@ extern "C"
   PetscErrorCode
   __libmesh_tao_equality_constraints(Tao /*tao*/, Vec x, Vec ce, void * ctx)
   {
+    PetscFunctionBegin;
+
     LOG_SCOPE("equality_constraints()", "TaoOptimizationSolver");
 
     PetscErrorCode ierr = static_cast<PetscErrorCode>(0);
@@ -257,6 +265,8 @@ extern "C"
   PetscErrorCode
   __libmesh_tao_equality_constraints_jacobian(Tao /*tao*/, Vec x, Mat J, Mat Jpre, void * ctx)
   {
+    PetscFunctionBegin;
+
     LOG_SCOPE("equality_constraints_jacobian()", "TaoOptimizationSolver");
 
     PetscErrorCode ierr = static_cast<PetscErrorCode>(0);
@@ -306,6 +316,8 @@ extern "C"
   PetscErrorCode
   __libmesh_tao_inequality_constraints(Tao /*tao*/, Vec x, Vec cineq, void * ctx)
   {
+    PetscFunctionBegin;
+
     LOG_SCOPE("inequality_constraints()", "TaoOptimizationSolver");
 
     PetscErrorCode ierr = static_cast<PetscErrorCode>(0);
@@ -358,6 +370,8 @@ extern "C"
   PetscErrorCode
   __libmesh_tao_inequality_constraints_jacobian(Tao /*tao*/, Vec x, Mat J, Mat Jpre, void * ctx)
   {
+    PetscFunctionBegin;
+
     LOG_SCOPE("inequality_constraints_jacobian()", "TaoOptimizationSolver");
 
     PetscErrorCode ierr = static_cast<PetscErrorCode>(0);


### PR DESCRIPTION
I believe `PetscFunctionBegin` pushes and `PetscFunctionReturn` pops. So I messed that up with my recent changes