### PR TITLE
Matrix format converter utility

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -386,6 +386,26 @@ amr_dbg_CPPFLAGS = $(CPPFLAGS_DBG) $(AM_CPPFLAGS)
 amr_dbg_CXXFLAGS = $(CXXFLAGS_DBG)
 amr_dbg_LDADD    = libmesh_dbg.la
 
+# matrixconvert
+opt_programs           += matrixconvert-opt
+matrixconvert_opt_SOURCES    = src/apps/matrixconvert.C
+matrixconvert_opt_CPPFLAGS   = $(CPPFLAGS_OPT) $(AM_CPPFLAGS)
+matrixconvert_opt_CXXFLAGS   = $(CXXFLAGS_OPT)
+matrixconvert_opt_LDADD      = libmesh_opt.la
+
+devel_programs         += matrixconvert-devel
+matrixconvert_devel_SOURCES  = src/apps/matrixconvert.C
+matrixconvert_devel_CPPFLAGS = $(CPPFLAGS_DEVEL) $(AM_CPPFLAGS)
+matrixconvert_devel_CXXFLAGS = $(CXXFLAGS_DEVEL)
+matrixconvert_devel_LDADD    = libmesh_devel.la
+
+dbg_programs           += matrixconvert-dbg
+matrixconvert_dbg_SOURCES    = src/apps/matrixconvert.C
+matrixconvert_dbg_CPPFLAGS   = $(CPPFLAGS_DBG) $(AM_CPPFLAGS)
+matrixconvert_dbg_CXXFLAGS   = $(CXXFLAGS_DBG)
+matrixconvert_dbg_LDADD      = libmesh_dbg.la
+
+
 # meshtool
 opt_programs           += meshtool-opt
 meshtool_opt_SOURCES    = src/apps/meshtool.C

--- a/src/apps/matrixconvert.C
+++ b/src/apps/matrixconvert.C
@@ -1,0 +1,49 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2024 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+// libmesh includes
+#include "libmesh/libmesh.h"
+#include "libmesh/libmesh_logging.h"
+#include "libmesh/sparse_matrix.h"
+
+using namespace libMesh;
+
+// Open the matrix named in a command line argument,
+// and rewrite it out in matlab format (our most portable currently)
+// to the given output filename.
+int main(int argc, char ** argv)
+{
+  LibMeshInit init(argc, argv);
+
+  if (argc != 3)
+    libmesh_error_msg
+      ("Usage: " << argv[0] <<
+       " inputmatrix outputmatrix");
+
+  auto mat = SparseMatrix<Number>::build(init.comm());
+
+  LOG_CALL("mat.read()", "main", mat->read(argv[1]));
+
+  libMesh::out << "Loaded " << mat->m() << " by " << mat->n() <<
+    " matrix " << argv[1] << std::endl;
+
+  LOG_CALL("mat.print_matlab()", "main", mat->print_matlab(argv[2]));
+
+  libMesh::out << "Wrote output " << argv[2] << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
We can read PETSc-32-bit and PETSc-64-bit formats only when we're linked against that specific PETSc configuration, so anything going into a repository generally needs to be converted to something more portable; this makes that easier.