### PR TITLE
QuadShell9 support (which also fixes QuadShell8 refinement...) and shell unit tests

### DIFF
--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -747,6 +747,7 @@ include_HEADERS = \
         geom/face_quad8.h \
         geom/face_quad8_shell.h \
         geom/face_quad9.h \
+        geom/face_quad9_shell.h \
         geom/face_tri.h \
         geom/face_tri3.h \
         geom/face_tri3_shell.h \

--- a/include/enums/enum_elem_type.h
+++ b/include/enums/enum_elem_type.h
@@ -77,6 +77,8 @@ enum ElemType : int {
                PRISM20 = 35,
                PRISM21 = 36,
                PYRAMID18 = 37,
+               // Another shell elem
+               QUADSHELL9 = 38,
                // Invalid
                INVALID_ELEM};   // should always be last
 

--- a/include/geom/face_quad9_shell.h
+++ b/include/geom/face_quad9_shell.h
@@ -1,0 +1,60 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2024 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#ifndef LIBMESH_FACE_QUAD9_SHELL_H
+#define LIBMESH_FACE_QUAD9_SHELL_H
+
+#include "face_quad9.h"
+
+namespace libMesh
+{
+
+/**
+ * QuadShell9 is almost identical to Quad9. The only difference is
+ * with the type of boundary data we store for this case. We need this
+ * "stub" class in order to differentiate between this class and other
+ * classes when reading/writing Mesh files.
+ *
+ * \author Roy Stogner
+ * \date 2024
+ * \brief A 2D quadrilateral shell element with 9 nodes.
+ */
+class QuadShell9 : public Quad9
+{
+public:
+  /**
+   * Constructor.  By default this element has no parent.
+   */
+  explicit
+  QuadShell9 (Elem * p=nullptr) :
+    Quad9(p) {}
+
+  QuadShell9 (QuadShell9 &&) = delete;
+  QuadShell9 (const QuadShell9 &) = delete;
+  QuadShell9 & operator= (const QuadShell9 &) = delete;
+  QuadShell9 & operator= (QuadShell9 &&) = delete;
+  virtual ~QuadShell9() = default;
+
+  /**
+   * \returns \p QUADSHELL9.
+   */
+  virtual ElemType type () const override { return QUADSHELL9; }
+};
+
+} // namespace libMesh
+
+#endif

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -152,6 +152,7 @@ include_HEADERS =  \
         geom/face_quad8.h \
         geom/face_quad8_shell.h \
         geom/face_quad9.h \
+        geom/face_quad9_shell.h \
         geom/face_tri.h \
         geom/face_tri3.h \
         geom/face_tri3_shell.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -142,6 +142,7 @@ BUILT_SOURCES = \
         face_quad8.h \
         face_quad8_shell.h \
         face_quad9.h \
+        face_quad9_shell.h \
         face_tri.h \
         face_tri3.h \
         face_tri3_shell.h \
@@ -999,6 +1000,9 @@ face_quad8_shell.h: $(top_srcdir)/include/geom/face_quad8_shell.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 face_quad9.h: $(top_srcdir)/include/geom/face_quad9.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+face_quad9_shell.h: $(top_srcdir)/include/geom/face_quad9_shell.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 face_tri.h: $(top_srcdir)/include/geom/face_tri.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -559,17 +559,18 @@ BUILT_SOURCES = auto_ptr.h dirichlet_boundaries.h dof_map.h \
 	elem_quality.h elem_range.h elem_side_builder.h face.h \
 	face_inf_quad.h face_inf_quad4.h face_inf_quad6.h face_quad.h \
 	face_quad4.h face_quad4_shell.h face_quad8.h \
-	face_quad8_shell.h face_quad9.h face_tri.h face_tri3.h \
-	face_tri3_shell.h face_tri3_subdivision.h face_tri6.h \
-	face_tri7.h node.h node_elem.h node_range.h plane.h point.h \
-	reference_elem.h remote_elem.h side.h sphere.h stored_range.h \
-	surface.h default_coupling.h ghost_point_neighbors.h \
-	ghosting_functor.h point_neighbor_coupling.h \
-	sibling_coupling.h abaqus_io.h boundary_info.h boundary_mesh.h \
-	checkpoint_io.h distributed_mesh.h dyna_io.h ensight_io.h \
-	exodusII_io.h exodusII_io_helper.h exodus_header_info.h \
-	fro_io.h gmsh_io.h gmv_io.h gnuplot_io.h inf_elem_builder.h \
-	matlab_io.h medit_io.h mesh.h mesh_base.h mesh_communication.h \
+	face_quad8_shell.h face_quad9.h face_quad9_shell.h face_tri.h \
+	face_tri3.h face_tri3_shell.h face_tri3_subdivision.h \
+	face_tri6.h face_tri7.h node.h node_elem.h node_range.h \
+	plane.h point.h reference_elem.h remote_elem.h side.h sphere.h \
+	stored_range.h surface.h default_coupling.h \
+	ghost_point_neighbors.h ghosting_functor.h \
+	point_neighbor_coupling.h sibling_coupling.h abaqus_io.h \
+	boundary_info.h boundary_mesh.h checkpoint_io.h \
+	distributed_mesh.h dyna_io.h ensight_io.h exodusII_io.h \
+	exodusII_io_helper.h exodus_header_info.h fro_io.h gmsh_io.h \
+	gmv_io.h gnuplot_io.h inf_elem_builder.h matlab_io.h \
+	medit_io.h mesh.h mesh_base.h mesh_communication.h \
 	mesh_function.h mesh_generation.h mesh_input.h \
 	mesh_inserter_iterator.h mesh_modification.h mesh_output.h \
 	mesh_refinement.h mesh_serializer.h mesh_smoother.h \
@@ -1335,6 +1336,9 @@ face_quad8_shell.h: $(top_srcdir)/include/geom/face_quad8_shell.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 face_quad9.h: $(top_srcdir)/include/geom/face_quad9.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+face_quad9_shell.h: $(top_srcdir)/include/geom/face_quad9_shell.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 face_tri.h: $(top_srcdir)/include/geom/face_tri.h

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -420,6 +420,7 @@ void FEAbstract::get_refspace_nodes(const ElemType itemType, std::vector<Point> 
         return;
       }
     case QUAD9:
+    case QUADSHELL9:
       {
         nodes[8] = Point (0.,0.,0.);
         libmesh_fallthrough();
@@ -654,6 +655,7 @@ bool FEAbstract::on_reference_element(const Point & p, const ElemType t, const R
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       {
         // The reference quadrilateral element is [-1,1]^2.
         if ((xi  >= -1.-eps) &&

--- a/src/fe/fe_bernstein.C
+++ b/src/fe/fe_bernstein.C
@@ -133,6 +133,7 @@ unsigned int bernstein_n_dofs(const ElemType t, const Order o)
           libmesh_error_msg("ERROR: Invalid Order " << Utility::enum_to_string(o) << " selected for BERNSTEIN FE family!");
       }
     case QUAD9:
+    case QUADSHELL9:
       return ((o+1)*(o+1));
     case HEX8:
       libmesh_assert_less (o, 2);
@@ -367,6 +368,7 @@ unsigned int bernstein_n_dofs_per_elem(const ElemType t, const Order o)
         return 0;
       libmesh_fallthrough();
     case QUAD9:
+    case QUADSHELL9:
       return 0;
     case HEX8:
       libmesh_assert_less (o, 2);

--- a/src/fe/fe_bernstein_shape_2D.C
+++ b/src/fe/fe_bernstein_shape_2D.C
@@ -117,6 +117,7 @@ Real FE<2,BERNSTEIN>::shape(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
     case QUAD9:
+    case QUADSHELL9:
       {
         // Compute quad shape functions as a tensor-product
         auto [i0, i1] = quad_i0_i1(i, totalorder, *elem);
@@ -431,6 +432,7 @@ Real FE<2,BERNSTEIN>::shape_deriv(const Elem * elem,
       // Hierarchic shape functions on the quadrilateral.
     case QUAD4:
     case QUAD9:
+    case QUADSHELL9:
       {
         // Compute quad shape functions as a tensor-product
         auto [i0, i1] = quad_i0_i1(i, totalorder, *elem);
@@ -558,6 +560,7 @@ Real FE<2,BERNSTEIN>::shape_second_deriv(const Elem * elem,
       // Hierarchic shape functions on the quadrilateral.
     case QUAD4:
     case QUAD9:
+    case QUADSHELL9:
       {
         // Compute quad shape functions as a tensor-product
         auto [i0, i1] = quad_i0_i1(i, totalorder, *elem);

--- a/src/fe/fe_hermite.C
+++ b/src/fe/fe_hermite.C
@@ -95,6 +95,7 @@ unsigned int hermite_n_dofs(const ElemType t, const Order o)
       libmesh_assert_less (o, 4);
       libmesh_fallthrough();
     case QUAD9:
+    case QUADSHELL9:
       return ((o+1)*(o+1));
 
     case HEX8:
@@ -150,6 +151,7 @@ unsigned int hermite_n_dofs_at_node(const ElemType t,
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       {
         switch (n)
           {
@@ -254,6 +256,7 @@ unsigned int hermite_n_dofs_per_elem(const ElemType t,
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       return ((o-3)*(o-3));
     case HEX8:
       libmesh_assert_less (o, 4);

--- a/src/fe/fe_hermite_shape_2D.C
+++ b/src/fe/fe_hermite_shape_2D.C
@@ -226,6 +226,7 @@ Real FE<2,HERMITE>::shape(const Elem * elem,
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       {
         libmesh_assert_less (i, (totalorder+1u)*(totalorder+1u));
 
@@ -302,6 +303,7 @@ Real FE<2,HERMITE>::shape_deriv(const Elem * elem,
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       {
         libmesh_assert_less (i, (totalorder+1u)*(totalorder+1u));
 
@@ -395,6 +397,7 @@ Real FE<2,HERMITE>::shape_second_deriv(const Elem * elem,
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       {
         libmesh_assert_less (i, (totalorder+1u)*(totalorder+1u));
 

--- a/src/fe/fe_hierarchic.C
+++ b/src/fe/fe_hierarchic.C
@@ -115,6 +115,7 @@ unsigned int hierarchic_n_dofs(const ElemType t, const Order o)
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       return ((o+1)*(o+1));
     case HEX8:
     case HEX20:
@@ -213,6 +214,7 @@ unsigned int hierarchic_n_dofs_at_node(const ElemType t,
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       switch (n)
         {
         case 0:
@@ -408,6 +410,7 @@ unsigned int hierarchic_n_dofs_per_elem(const ElemType t,
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       return ((o-1)*(o-1));
     case HEX8:
     case HEX20:

--- a/src/fe/fe_hierarchic_shape_2D.C
+++ b/src/fe/fe_hierarchic_shape_2D.C
@@ -299,6 +299,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape(const Elem * elem,
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       {
         libmesh_assert_less(i, 4*dofs_per_side);
 
@@ -594,6 +595,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape_deriv(const Elem * elem,
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       {
         libmesh_assert_less(i, 4*dofs_per_side);
 
@@ -808,6 +810,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape_second_deriv(const Elem * elem,
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       {
         libmesh_assert_less(i, 4*dofs_per_side);
 
@@ -1039,6 +1042,7 @@ Real fe_hierarchic_2D_shape(const Elem * elem,
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       {
         // Compute quad shape functions as a tensor-product
         auto [i0, i1, f] = quad_indices(elem, totalorder, i);
@@ -1090,6 +1094,7 @@ Real fe_hierarchic_2D_shape_deriv(const Elem * elem,
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       {
         // Compute quad shape functions as a tensor-product
         auto [i0, i1, f] = quad_indices(elem, totalorder, i);

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -2467,6 +2467,7 @@ unsigned int FEInterface::max_order(const FEType & fe_t,
         case QUAD8:
         case QUADSHELL8:
         case QUAD9:
+        case QUADSHELL9:
           return 2;
         case TET4:
           return 1;
@@ -2518,6 +2519,7 @@ unsigned int FEInterface::max_order(const FEType & fe_t,
         case QUAD8:
         case QUADSHELL8:
         case QUAD9:
+        case QUADSHELL9:
         case TET4:
         case TET10:
         case TET14:
@@ -2559,6 +2561,7 @@ unsigned int FEInterface::max_order(const FEType & fe_t,
         case QUAD8:
         case QUADSHELL8:
         case QUAD9:
+        case QUADSHELL9:
           return unlimited;
         case TET4:
           return 1;
@@ -2605,6 +2608,7 @@ unsigned int FEInterface::max_order(const FEType & fe_t,
         case QUAD8:
         case QUADSHELL8:
         case QUAD9:
+        case QUADSHELL9:
           return 7;
         case TET4:
         case TET10:
@@ -2642,6 +2646,7 @@ unsigned int FEInterface::max_order(const FEType & fe_t,
         case QUAD8:
         case QUADSHELL8:
         case QUAD9:
+        case QUADSHELL9:
         case TET4:
         case TET10:
         case TET14:
@@ -2680,6 +2685,7 @@ unsigned int FEInterface::max_order(const FEType & fe_t,
         case QUAD8:
         case QUADSHELL8:
         case QUAD9:
+        case QUADSHELL9:
         case TET4:
         case TET10:
         case TET14:
@@ -2718,6 +2724,7 @@ unsigned int FEInterface::max_order(const FEType & fe_t,
         case QUAD8:
         case QUADSHELL8:
         case QUAD9:
+        case QUADSHELL9:
           return unlimited;
         case TET4:
         case TET10:
@@ -2762,6 +2769,7 @@ unsigned int FEInterface::max_order(const FEType & fe_t,
         case QUAD8:
         case QUADSHELL8:
         case QUAD9:
+        case QUADSHELL9:
           return unlimited;
         case TET4:
           return 1;
@@ -2808,6 +2816,7 @@ unsigned int FEInterface::max_order(const FEType & fe_t,
         case QUAD8:
         case QUADSHELL8:
         case QUAD9:
+        case QUADSHELL9:
           return unlimited;
         case TET4:
         case TET10:

--- a/src/fe/fe_l2_hierarchic.C
+++ b/src/fe/fe_l2_hierarchic.C
@@ -113,6 +113,7 @@ unsigned int l2_hierarchic_n_dofs(const ElemType t, const Order o)
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       return ((o+1)*(o+1));
     case HEX8:
     case HEX20:

--- a/src/fe/fe_l2_lagrange.C
+++ b/src/fe/fe_l2_lagrange.C
@@ -63,6 +63,7 @@ unsigned int l2_lagrange_n_dofs(const ElemType t, const Order o)
           case QUAD8:
           case QUADSHELL8:
           case QUAD9:
+          case QUADSHELL9:
             return 4;
 
           case TET4:
@@ -120,6 +121,7 @@ unsigned int l2_lagrange_n_dofs(const ElemType t, const Order o)
 
           case QUAD4:
           case QUAD9:
+          case QUADSHELL9:
             return 9;
 
           case TET4:

--- a/src/fe/fe_lagrange.C
+++ b/src/fe/fe_lagrange.C
@@ -460,6 +460,7 @@ unsigned int lagrange_n_dofs(const ElemType t, const Order o)
           case QUAD8:
           case QUADSHELL8:
           case QUAD9:
+          case QUADSHELL9:
             return 4;
 
           case TET4:
@@ -514,6 +515,7 @@ unsigned int lagrange_n_dofs(const ElemType t, const Order o)
             return 8;
 
           case QUAD9:
+          case QUADSHELL9:
             return 9;
 
           case TET10:
@@ -643,6 +645,7 @@ unsigned int lagrange_n_dofs_at_node(const ElemType t,
           case QUAD8:
           case QUADSHELL8:
           case QUAD9:
+          case QUADSHELL9:
             {
               switch (n)
                 {
@@ -756,6 +759,7 @@ unsigned int lagrange_n_dofs_at_node(const ElemType t,
           case QUAD8:
           case QUADSHELL8:
           case QUAD9:
+          case QUADSHELL9:
           case TET10:
           case HEX20:
           case HEX27:

--- a/src/fe/fe_lagrange_shape_2D.C
+++ b/src/fe/fe_lagrange_shape_2D.C
@@ -339,6 +339,7 @@ Real fe_lagrange_2D_shape(const ElemType type,
           case QUAD8:
           case QUADSHELL8:
           case QUAD9:
+          case QUADSHELL9:
             {
               // Compute quad shape functions as a tensor-product
               const Real xi  = p(0);
@@ -436,6 +437,7 @@ Real fe_lagrange_2D_shape(const ElemType type,
                                "High order on first order elements only supported for L2 families");
             libmesh_fallthrough();
           case QUAD9:
+          case QUADSHELL9:
             {
 
               // Compute quad shape functions as a tensor-product
@@ -581,6 +583,7 @@ Real fe_lagrange_2D_shape_deriv(const ElemType type,
           case QUAD8:
           case QUADSHELL8:
           case QUAD9:
+          case QUADSHELL9:
             {
               // Compute quad shape functions as a tensor-product
               const Real xi  = p(0);
@@ -770,6 +773,7 @@ Real fe_lagrange_2D_shape_deriv(const ElemType type,
                                "High order on first order elements only supported for L2 families");
             libmesh_fallthrough();
           case QUAD9:
+          case QUADSHELL9:
             {
               // Compute quad shape functions as a tensor-product
               const Real xi  = p(0);
@@ -1023,6 +1027,7 @@ Real fe_lagrange_2D_shape_second_deriv(const ElemType type,
           case QUAD8:
           case QUADSHELL8:
           case QUAD9:
+          case QUADSHELL9:
             {
               // Compute quad shape functions as a tensor-product
               const Real xi  = p(0);
@@ -1185,6 +1190,7 @@ Real fe_lagrange_2D_shape_second_deriv(const ElemType type,
                                "High order on first order elements only supported for L2 families");
             libmesh_fallthrough();
           case QUAD9:
+          case QUADSHELL9:
             {
               // Compute QUAD9 second derivatives as tensor product
               const Real xi  = p(0);

--- a/src/fe/fe_monomial.C
+++ b/src/fe/fe_monomial.C
@@ -61,6 +61,7 @@ unsigned int monomial_n_dofs(const ElemType t, const Order o)
           case QUAD8:
           case QUADSHELL8:
           case QUAD9:
+          case QUADSHELL9:
             return 3;
 
           case TET4:
@@ -112,6 +113,7 @@ unsigned int monomial_n_dofs(const ElemType t, const Order o)
           case QUAD8:
           case QUADSHELL8:
           case QUAD9:
+          case QUADSHELL9:
             return 6;
 
           case TET4:
@@ -163,6 +165,7 @@ unsigned int monomial_n_dofs(const ElemType t, const Order o)
           case QUAD8:
           case QUADSHELL8:
           case QUAD9:
+          case QUADSHELL9:
             return 10;
 
           case TET4:
@@ -213,6 +216,7 @@ unsigned int monomial_n_dofs(const ElemType t, const Order o)
           case QUAD8:
           case QUADSHELL8:
           case QUAD9:
+          case QUADSHELL9:
             return 15;
 
           case TET4:
@@ -261,6 +265,7 @@ unsigned int monomial_n_dofs(const ElemType t, const Order o)
           case QUAD8:
           case QUADSHELL8:
           case QUAD9:
+          case QUADSHELL9:
             return (order+1)*(order+2)/2;
 
           case TET4:

--- a/src/fe/fe_side_hierarchic.C
+++ b/src/fe/fe_side_hierarchic.C
@@ -105,6 +105,7 @@ unsigned int side_hierarchic_n_dofs_at_node(const ElemType t,
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       if (n > 3 && n < 8)
         return o+1;
       else
@@ -155,6 +156,7 @@ unsigned int side_hierarchic_n_dofs(const ElemType t, const Order o)
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       return ((o+1)*4); // o+1 per side
     case HEX27:
       return ((o+1)*(o+1)*6); // (o+1)^2 per side

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -37,6 +37,7 @@
 #include "libmesh/face_quad8.h"
 #include "libmesh/face_quad8_shell.h"
 #include "libmesh/face_quad9.h"
+#include "libmesh/face_quad9_shell.h"
 #include "libmesh/face_inf_quad4.h"
 #include "libmesh/face_inf_quad6.h"
 #include "libmesh/cell_tet4.h"
@@ -154,6 +155,8 @@ const unsigned int Elem::type_to_n_nodes_map [] =
     20, // PRISM20
     21, // PRISM21
     18, // PYRAMID18
+
+    9,  // QUADSHELL9
   };
 
 const unsigned int Elem::type_to_n_sides_map [] =
@@ -210,6 +213,8 @@ const unsigned int Elem::type_to_n_sides_map [] =
     5,  // PRISM20
     5,  // PRISM21
     5,  // PYRAMID18
+
+    4,  // QUADSHELL9
   };
 
 const unsigned int Elem::type_to_n_edges_map [] =
@@ -266,6 +271,8 @@ const unsigned int Elem::type_to_n_edges_map [] =
     9,  // PRISM20
     9,  // PRISM21
     8,  // PYRAMID18
+
+    4,  // QUADSHELL9
   };
 
 // ------------------------------------------------------------
@@ -308,6 +315,8 @@ std::unique_ptr<Elem> Elem::build(const ElemType type,
       return std::make_unique<QuadShell8>(p);
     case QUAD9:
       return std::make_unique<Quad9>(p);
+    case QUADSHELL9:
+      return std::make_unique<QuadShell9>(p);
 
       // 3D elements
     case TET4:
@@ -2711,6 +2720,7 @@ ElemType Elem::first_order_equivalent_type (const ElemType et)
       return QUAD4;
     case QUADSHELL4:
     case QUADSHELL8:
+    case QUADSHELL9:
       return QUADSHELL4;
     case TET4:
     case TET10:
@@ -2804,15 +2814,22 @@ ElemType Elem::second_order_equivalent_type (const ElemType et,
     case QUADSHELL4:
     case QUADSHELL8:
       {
-        // There is no QUADSHELL9, so in that sense QUADSHELL8 is the
-        // "full ordered" element.
-        return QUADSHELL8;
+        if (full_ordered)
+          return QUADSHELL9;
+        else
+          return QUADSHELL8;
       }
 
     case QUAD9:
       {
         // full_ordered not relevant
         return QUAD9;
+      }
+
+    case QUADSHELL9:
+      {
+        // full_ordered not relevant
+        return QUADSHELL9;
       }
 
     case TET4:
@@ -2964,11 +2981,8 @@ ElemType Elem::complete_order_equivalent_type (const ElemType et)
 
     case QUADSHELL4:
     case QUADSHELL8:
-      {
-        // There is no QUADSHELL9, so in that sense QUADSHELL8 is the
-        // "full ordered" element.
-        return QUADSHELL8;
-      }
+    case QUADSHELL9:
+      return QUADSHELL9;
 
     case TET4:
     case TET10:

--- a/src/geom/elem_quality.C
+++ b/src/geom/elem_quality.C
@@ -356,6 +356,7 @@ std::vector<ElemQuality> Quality::valid(const ElemType t)
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       {
         v.resize(13);
         v[0]  = ASPECT_RATIO;

--- a/src/geom/face_quad9_shell.C
+++ b/src/geom/face_quad9_shell.C
@@ -1,0 +1,18 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2024 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+// The QuadShell9 functions are all declared inline.

--- a/src/geom/reference_elem.C
+++ b/src/geom/reference_elem.C
@@ -258,6 +258,9 @@ const Elem & get (const ElemType type_in)
   if (type_in == QUADSHELL8)
     base_type = QUAD8;
 
+  if (type_in == QUADSHELL9)
+    base_type = QUAD9;
+
   init_ref_elem_table();
 
   // Throw an error if the user asked for an ElemType that we don't

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -168,6 +168,7 @@ libmesh_SOURCES =  \
         src/geom/face_quad8.C \
         src/geom/face_quad8_shell.C \
         src/geom/face_quad9.C \
+        src/geom/face_quad9_shell.C \
         src/geom/face_tri.C \
         src/geom/face_tri3.C \
         src/geom/face_tri3_shell.C \

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -359,6 +359,9 @@ void ExodusII_IO_Helper::init_conversion_map()
   convert_type(QUADSHELL8, "SHELL8", nullptr, nullptr, nullptr,
                /* inverse_side_map = */ &quadshell4_inverse_edge_map,
                nullptr, nullptr, /* shellface_index_offset = */ 2);
+  convert_type(QUADSHELL9, "SHELL9", nullptr, nullptr, nullptr,
+               /* inverse_side_map = */ &quadshell4_inverse_edge_map,
+               nullptr, nullptr, /* shellface_index_offset = */ 2);
 
   convert_type(TRI3, "TRI3");
   convert_type(TRI6, "TRI6");
@@ -460,9 +463,11 @@ void ExodusII_IO_Helper::init_element_equivalence_map()
 
   // QUAD9 equivalences
   element_equivalence_map["QUAD9"]  = QUAD9;
-  // element_equivalence_map["SHELL9"] = QUAD9;
   // This only supports p==2 IGA:
   element_equivalence_map["BEX_QUAD"]  = QUAD9;
+
+  // QUADSHELL9 equivalences
+  element_equivalence_map["SHELL9"] = QUADSHELL9;
 
   // TRI3 equivalences
   element_equivalence_map["TRI"]       = TRI3;

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -94,6 +94,7 @@ unsigned int idx(const ElemType type,
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
     case TRI6:
     case TRI7:
       {
@@ -598,6 +599,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
           case QUAD8:
           case QUADSHELL8:
           case QUAD9:
+          case QUADSHELL9:
             {
               mesh.reserve_elem (nx*ny);
               break;
@@ -635,6 +637,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
           case QUAD8:
           case QUADSHELL8:
           case QUAD9:
+          case QUADSHELL9:
           case TRI6:
             {
               mesh.reserve_nodes( (2*nx+1)*(2*ny+1) );
@@ -689,6 +692,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
           case QUAD8:
           case QUADSHELL8:
           case QUAD9:
+          case QUADSHELL9:
           case TRI6:
           case TRI7:
             {
@@ -813,6 +817,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
           case QUAD8:
           case QUADSHELL8:
           case QUAD9:
+          case QUADSHELL9:
             {
               for (unsigned int j=0; j<(2*ny); j += 2)
                 for (unsigned int i=0; i<(2*nx); i += 2)
@@ -827,7 +832,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                     elem->set_node(6) = mesh.node_ptr(idx(type,nx,i+1,j+2));
                     elem->set_node(7) = mesh.node_ptr(idx(type,nx,i,j+1)  );
 
-                    if (type == QUAD9)
+                    if (type == QUAD9 || type == QUADSHELL9)
                       elem->set_node(8) = mesh.node_ptr(idx(type,nx,i+1,j+1));
 
                     if (j == 0)
@@ -1768,8 +1773,11 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
       case TRI6:
       case TRI7:
       case QUAD4:
+      case QUADSHELL4:
       case QUAD8:
+      case QUADSHELL8:
       case QUAD9:
+      case QUADSHELL9:
         mesh.set_mesh_dimension(2);
         break;
       case EDGE2:

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -86,6 +86,7 @@ unsigned int idx(const ElemType type,
     case QUAD4:
     case QUADSHELL4:
     case TRI3:
+    case TRISHELL3:
       {
         return i + j*(nx+1);
       }
@@ -603,6 +604,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
             }
 
           case TRI3:
+          case TRISHELL3:
           case TRI6:
           case TRI7:
             {
@@ -624,6 +626,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
           case QUAD4:
           case QUADSHELL4:
           case TRI3:
+          case TRISHELL3:
             {
               mesh.reserve_nodes( (nx+1)*(ny+1) );
               break;
@@ -660,6 +663,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
           case QUAD4:
           case QUADSHELL4:
           case TRI3:
+          case TRISHELL3:
             {
               for (unsigned int j=0; j<=ny; j++)
                 for (unsigned int i=0; i<=nx; i++)
@@ -772,12 +776,13 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
 
 
           case TRI3:
+          case TRISHELL3:
             {
               for (unsigned int j=0; j<ny; j++)
                 for (unsigned int i=0; i<nx; i++)
                   {
                     // Add first Tri3
-                    Elem * elem = mesh.add_elem(Elem::build_with_id(TRI3, elem_id++));
+                    Elem * elem = mesh.add_elem(Elem::build_with_id(type, elem_id++));
                     elem->set_node(0) = mesh.node_ptr(idx(type,nx,i,j)    );
                     elem->set_node(1) = mesh.node_ptr(idx(type,nx,i+1,j)  );
                     elem->set_node(2) = mesh.node_ptr(idx(type,nx,i+1,j+1));
@@ -789,7 +794,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                       boundary_info.add_side(elem, 1, 1);
 
                     // Add second Tri3
-                    elem = mesh.add_elem(Elem::build_with_id(TRI3, elem_id++));
+                    elem = mesh.add_elem(Elem::build_with_id(type, elem_id++));
                     elem->set_node(0) = mesh.node_ptr(idx(type,nx,i,j)    );
                     elem->set_node(1) = mesh.node_ptr(idx(type,nx,i+1,j+1));
                     elem->set_node(2) = mesh.node_ptr(idx(type,nx,i,j+1)  );

--- a/src/quadrature/quadrature_gauss_2D.C
+++ b/src/quadrature/quadrature_gauss_2D.C
@@ -43,6 +43,7 @@ void QGauss::init_2D(const ElemType, unsigned int)
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       {
         // We compute the 2D quadrature rule as a tensor
         // product of the 1D quadrature rule.

--- a/src/quadrature/quadrature_gauss_lobatto_2D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_2D.C
@@ -34,6 +34,7 @@ void QGaussLobatto::init_2D(const ElemType, unsigned int)
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       {
         // We compute the 2D quadrature rule as a tensor
         // product of the 1D quadrature rule.

--- a/src/quadrature/quadrature_grid_2D.C
+++ b/src/quadrature/quadrature_grid_2D.C
@@ -39,6 +39,7 @@ void QGrid::init_2D(const ElemType, unsigned int)
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       {
         // We compute the 2D quadrature rule as a tensor
         // product of the 1D quadrature rule.

--- a/src/quadrature/quadrature_monomial_2D.C
+++ b/src/quadrature/quadrature_monomial_2D.C
@@ -37,6 +37,7 @@ void QMonomial::init_2D(const ElemType, unsigned int)
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       {
         switch(get_order())
           {

--- a/src/quadrature/quadrature_nodal_2D.C
+++ b/src/quadrature/quadrature_nodal_2D.C
@@ -136,6 +136,7 @@ void QNodal::init_2D(const ElemType, unsigned int)
       }
 
     case QUAD9:
+    case QUADSHELL9:
     case TRI6:
       {
         QSimpson rule(/*dim=*/2, /*ignored*/_order);

--- a/src/quadrature/quadrature_simpson_2D.C
+++ b/src/quadrature/quadrature_simpson_2D.C
@@ -41,6 +41,7 @@ void QSimpson::init_2D(const ElemType, unsigned int)
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       {
         // We compute the 2D quadrature rule as a tensor
         // product of the 1D quadrature rule.

--- a/src/quadrature/quadrature_trap_2D.C
+++ b/src/quadrature/quadrature_trap_2D.C
@@ -41,6 +41,7 @@ void QTrap::init_2D(const ElemType, unsigned int)
     case QUAD8:
     case QUADSHELL8:
     case QUAD9:
+    case QUADSHELL9:
       {
 
         // We compute the 2D quadrature rule as a tensor

--- a/src/utils/string_to_enum.C
+++ b/src/utils/string_to_enum.C
@@ -98,6 +98,7 @@ std::map<std::string, ElemType> elem_type_to_enum {
    {"QUAD8"          , QUAD8},
    {"QUADSHELL8"     , QUADSHELL8},
    {"QUAD9"          , QUAD9},
+   {"QUADSHELL9"     , QUADSHELL9},
 
    {"TET"            , TET4},
    {"TET4"           , TET4},

--- a/tests/geom/elem_test.C
+++ b/tests/geom/elem_test.C
@@ -382,7 +382,8 @@ public:
             CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(s), elem->center_node_on_side(s));
           else if (elem->type() == TRI6 || elem->type() == TRI7)
             CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(s + 3), elem->center_node_on_side(s));
-          else if (elem->type() == QUAD8 || elem->type() == QUAD9 || elem->type() == QUADSHELL8)
+          else if (elem->type() == QUAD8 || elem->type() == QUAD9 ||
+                   elem->type() == QUADSHELL8 || elem->type() == QUADSHELL9)
             CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(s + 4), elem->center_node_on_side(s));
           else if (elem->type() == HEX27)
             CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(s + 20), elem->center_node_on_side(s));
@@ -676,12 +677,16 @@ INSTANTIATE_ELEMTEST(EDGE4);
 
 #if LIBMESH_DIM > 1
 INSTANTIATE_ELEMTEST(TRI3);
+INSTANTIATE_ELEMTEST(TRISHELL3);
 INSTANTIATE_ELEMTEST(TRI6);
 INSTANTIATE_ELEMTEST(TRI7);
 
 INSTANTIATE_ELEMTEST(QUAD4);
+INSTANTIATE_ELEMTEST(QUADSHELL4);
 INSTANTIATE_ELEMTEST(QUAD8);
+INSTANTIATE_ELEMTEST(QUADSHELL8);
 INSTANTIATE_ELEMTEST(QUAD9);
+INSTANTIATE_ELEMTEST(QUADSHELL9);
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 INSTANTIATE_ELEMTEST(INFQUAD4);


### PR DESCRIPTION
Hopefully this will fix https://github.com/idaholab/moose/issues/27974 as well; it at least passes our standard Elem unit tests now.  Previously QuadShell8 would fail on the refinement tests, because in the bracketing-nodes calculation where a Quad8 would use a Quad9 to "steal" its middle node, a QuadShell8 would just fail.