### PR TITLE
A couple small changes for subvectors

### DIFF
--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -749,7 +749,8 @@ public:
    * rows.  This  is currently only implemented for
    * PetscVectors.
    */
-  virtual void restore_subvector(NumericVector<T> &&, const std::vector<numeric_index_type> &)
+  virtual void restore_subvector(std::unique_ptr<NumericVector<T>> &&,
+                                 const std::vector<numeric_index_type> &)
   {
     libmesh_not_implemented();
   }

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -749,7 +749,7 @@ public:
    * rows.  This  is currently only implemented for
    * PetscVectors.
    */
-  virtual void restore_subvector(std::unique_ptr<NumericVector<T>> &&,
+  virtual void restore_subvector(std::unique_ptr<NumericVector<T>>,
                                  const std::vector<numeric_index_type> &)
   {
     libmesh_not_implemented();

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -349,7 +349,7 @@ public:
   virtual std::unique_ptr<NumericVector<T>>
   get_subvector(const std::vector<numeric_index_type> & rows) override;
 
-  virtual void restore_subvector(NumericVector<T> && subvector,
+  virtual void restore_subvector(std::unique_ptr<NumericVector<T>> && subvector,
                                  const std::vector<numeric_index_type> & rows) override;
 
 private:

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -349,7 +349,7 @@ public:
   virtual std::unique_ptr<NumericVector<T>>
   get_subvector(const std::vector<numeric_index_type> & rows) override;
 
-  virtual void restore_subvector(std::unique_ptr<NumericVector<T>> && subvector,
+  virtual void restore_subvector(std::unique_ptr<NumericVector<T>> subvector,
                                  const std::vector<numeric_index_type> & rows) override;
 
 private:

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -1431,10 +1431,10 @@ PetscVector<T>::get_subvector(const std::vector<numeric_index_type> & rows)
 
 template <typename T>
 void
-PetscVector<T>::restore_subvector(NumericVector<T> && subvector,
+PetscVector<T>::restore_subvector(std::unique_ptr<NumericVector<T>> && subvector,
                                   const std::vector<numeric_index_type> & rows)
 {
-  auto * const petsc_subvector = cast_ptr<PetscVector<T> *>(&subvector);
+  auto * const petsc_subvector = cast_ptr<PetscVector<T> *>(subvector.get());
 
   // Construct index set
   WrappedPetsc<IS> parent_is;

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -1426,6 +1426,8 @@ PetscVector<T>::get_subvector(const std::vector<numeric_index_type> & rows)
   ierr = VecGetSubVector(_vec, parent_is, &subvec);
   LIBMESH_CHKERR(ierr);
 
+  this->_is_closed = false;
+
   return std::make_unique<PetscVector<T>>(subvec, this->comm());
 }
 
@@ -1448,6 +1450,11 @@ PetscVector<T>::restore_subvector(std::unique_ptr<NumericVector<T>> && subvector
   Vec subvec = petsc_subvector->vec();
   ierr = VecRestoreSubVector(_vec, parent_is, &subvec);
   LIBMESH_CHKERR(ierr);
+
+  if (this->type() == GHOSTED)
+    VecGhostUpdateBeginEnd(this->comm(), _vec, INSERT_VALUES, SCATTER_FORWARD);
+
+  this->_is_closed = true;
 }
 
 //------------------------------------------------------------------

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -1433,7 +1433,7 @@ PetscVector<T>::get_subvector(const std::vector<numeric_index_type> & rows)
 
 template <typename T>
 void
-PetscVector<T>::restore_subvector(std::unique_ptr<NumericVector<T>> && subvector,
+PetscVector<T>::restore_subvector(std::unique_ptr<NumericVector<T>> subvector,
                                   const std::vector<numeric_index_type> & rows)
 {
   auto * const petsc_subvector = cast_ptr<PetscVector<T> *>(subvector.get());

--- a/src/systems/condensed_eigen_system.C
+++ b/src/systems/condensed_eigen_system.C
@@ -267,7 +267,7 @@ CondensedEigenSystem::copy_sub_to_super(const NumericVector<Number> & sub,
                           super.local_size());
   auto super_sub_view = super.get_subvector(local_non_condensed_dofs_vector);
   *super_sub_view = sub;
-  super.restore_subvector(std::move(*super_sub_view), local_non_condensed_dofs_vector);
+  super.restore_subvector(std::move(super_sub_view), local_non_condensed_dofs_vector);
 }
 
 void
@@ -279,7 +279,7 @@ CondensedEigenSystem::copy_super_to_sub(NumericVector<Number> & super,
                           super.local_size());
   auto super_sub_view = super.get_subvector(local_non_condensed_dofs_vector);
   sub = *super_sub_view;
-  super.restore_subvector(std::move(*super_sub_view), local_non_condensed_dofs_vector);
+  super.restore_subvector(std::move(super_sub_view), local_non_condensed_dofs_vector);
 }
 
 void


### PR DESCRIPTION
- Take a `unique_ptr` by value when restoring instead of an rvalue of the object. I think this makes the `get` and `restore` APIs pair better. I know that this is changing a publicly available API but as @roystgnr pointed out in #3883 it's only been around for a couple months so I'm 🤞 that he and @jwpeterson will allow it. If not, nbd, I'll go through the deprecation process
- Make sure when restoring the subvector to communicate ghost data. I ran into the bad effects of not doing this when working on #3883 