### PR TITLE
Create `Elem::is_internal` API for local node indices

### DIFF
--- a/include/geom/cell_inf_hex.h
+++ b/include/geom/cell_inf_hex.h
@@ -127,7 +127,7 @@ public:
   /**
    * We number faces last.
    */
-  virtual bool is_face(const unsigned int i) const override final { return (i >= 12 && i < 16); }
+  virtual bool is_face(const unsigned int i) const override final { return (i >= 12 && i < 17); }
 
   /**
    * \returns \p true if the specified child is on the

--- a/include/geom/cell_inf_prism.h
+++ b/include/geom/cell_inf_prism.h
@@ -110,12 +110,12 @@ public:
   /**
    * We number edges next.
    */
-  virtual bool is_edge(const unsigned int i) const override final { return (i > 6 && i < 9); }
+  virtual bool is_edge(const unsigned int i) const override final { return (i >= 6 && i < 9); }
 
   /**
    * We number faces last.
    */
-  virtual bool is_face(const unsigned int i) const override final { return (i > 9 && i < 12); }
+  virtual bool is_face(const unsigned int i) const override final { return (i >= 9 && i < 12); }
 
   /**
    * \returns \p true if the specified (local) node number is a

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -739,6 +739,11 @@ public:
   virtual bool is_face(const unsigned int i) const = 0;
 
   /**
+   * \returns \p true if the specified (local) node number is an interior node.
+   */
+  bool is_internal(const unsigned int i) const;
+
+  /**
    * \returns \p true if the specified (local) node number is on the
    * specified side.
    */

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -739,7 +739,7 @@ public:
   virtual bool is_face(const unsigned int i) const = 0;
 
   /**
-   * \returns \p true if the specified (local) node number is an interior node.
+   * \returns \p true if the specified (local) node number is an internal node.
    */
   bool is_internal(const unsigned int i) const;
 

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -3206,13 +3206,13 @@ Elem::is_internal(const unsigned int i) const
       return false;
 
     case 1:
-      return !is_vertex(i);
+      return !this->is_vertex(i);
 
     case 2:
-      return !is_vertex(i) && !is_edge(i);
+      return !this->is_vertex(i) && !this->is_edge(i);
 
     case 3:
-      return !is_vertex(i) && !is_edge(i) && !is_face(i);
+      return !this->is_vertex(i) && !this->is_edge(i) && !this->is_face(i);
 
     default:
       libmesh_error_msg("impossible element dimension " << std::to_string(this->dim()));

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -3197,4 +3197,27 @@ void Elem::swap2boundaryedges(unsigned short e1,
     boundary_info->add_edge(this, e1, ids2);
 }
 
+bool
+Elem::is_internal(const unsigned int i) const
+{
+  switch (this->dim())
+  {
+    case 0:
+      return false;
+
+    case 1:
+      return !is_vertex(i);
+
+    case 2:
+      return !is_vertex(i) && !is_edge(i);
+
+    case 3:
+      return !is_vertex(i) && !is_edge(i) && !is_face(i);
+
+    default:
+      libmesh_error_msg("impossible element dimension " << std::to_string(this->dim()));
+      return 0;
+  }
+}
+
 } // namespace libMesh

--- a/src/geom/face_tri7.C
+++ b/src/geom/face_tri7.C
@@ -128,7 +128,7 @@ bool Tri7::is_vertex(const unsigned int i) const
 
 bool Tri7::is_edge(const unsigned int i) const
 {
-  if (i < 3)
+  if (i < 3 || i == 6)
     return false;
   return true;
 }

--- a/tests/geom/elem_test.C
+++ b/tests/geom/elem_test.C
@@ -636,6 +636,30 @@ public:
     test_n_refinements(2);
   }
 
+  void test_is_internal()
+  {
+    LOG_UNIT_TEST;
+
+    for (const auto & elem :
+         this->_mesh->active_local_element_ptr_range())
+      for (const auto nd : elem->node_index_range())
+        {
+          if ((elem->type() == EDGE3 || elem->type() == EDGE4) && nd >= 2)
+            CPPUNIT_ASSERT(elem->is_internal(nd));
+          else if (elem->type() == HEX27 && nd == 26)
+            CPPUNIT_ASSERT(elem->is_internal(nd));
+          else if (elem->type() == PRISM21 && nd == 20)
+            CPPUNIT_ASSERT(elem->is_internal(nd));
+          else if (elem->type() == QUAD9 && nd == 8)
+            CPPUNIT_ASSERT(elem->is_internal(nd));
+          else if (elem->type() == TRI7 && nd == 6)
+            CPPUNIT_ASSERT(elem->is_internal(nd));
+          else
+            CPPUNIT_ASSERT(!elem->is_internal(nd));
+        }
+  }
+
+
 };
 
 #define ELEMTEST                                \
@@ -651,8 +675,9 @@ public:
   CPPUNIT_TEST( test_center_node_on_side );     \
   CPPUNIT_TEST( test_side_type );               \
   CPPUNIT_TEST( test_elem_side_builder );       \
-  CPPUNIT_TEST( test_refinement);               \
-  CPPUNIT_TEST( test_double_refinement);
+  CPPUNIT_TEST( test_refinement );              \
+  CPPUNIT_TEST( test_double_refinement );       \
+  CPPUNIT_TEST( test_is_internal )
 
 #define INSTANTIATE_ELEMTEST(elemtype)                          \
   class ElemTest_##elemtype : public ElemTest<elemtype> {       \

--- a/tests/geom/elem_test.C
+++ b/tests/geom/elem_test.C
@@ -650,7 +650,7 @@ public:
             CPPUNIT_ASSERT(elem->is_internal(nd));
           else if (elem->type() == PRISM21 && nd == 20)
             CPPUNIT_ASSERT(elem->is_internal(nd));
-          else if (elem->type() == QUAD9 && nd == 8)
+          else if ((elem->type() == QUAD9 || elem->type() == QUADSHELL9) && nd == 8)
             CPPUNIT_ASSERT(elem->is_internal(nd));
           else if (elem->type() == TRI7 && nd == 6)
             CPPUNIT_ASSERT(elem->is_internal(nd));

--- a/tests/geom/elem_test.C
+++ b/tests/geom/elem_test.C
@@ -654,6 +654,10 @@ public:
             CPPUNIT_ASSERT(elem->is_internal(nd));
           else if (elem->type() == TRI7 && nd == 6)
             CPPUNIT_ASSERT(elem->is_internal(nd));
+          else if (elem->type() == INFHEX18 && nd == 17)
+            CPPUNIT_ASSERT(elem->is_internal(nd));
+          else if (elem->type() == INFQUAD6 && nd == 5)
+            CPPUNIT_ASSERT(elem->is_internal(nd));
           else
             CPPUNIT_ASSERT(!elem->is_internal(nd));
         }


### PR DESCRIPTION
This is useful for determining condensed/uncondensed dofs for uses cases such as static condensation in #3883

- [x] Add unit tests