### PR TITLE
Bump coverage of petscdmlibmeshimpl

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex7/run.sh
+++ b/examples/miscellaneous/miscellaneous_ex7/run.sh
@@ -10,6 +10,8 @@ options="--verbose dim=1 N=1024 initial_state=strip initial_center=0.5 initial_w
 
 run_example "$example_name" "$options"
 run_example "$example_name" "$options" -snes_mf_operator
+run_example "$example_name" "$options" -snes_type vinewtonrsls
+run_example "$example_name" "$options" -snes_type vinewtonssls
 
 # No benchmark here - I can't seem to pick parameters that aren't
 # either way too easy or prone to solver convergence failure


### PR DESCRIPTION
I wanted to check whether the hooks to this code still exist and they seem like they do. In that case, let's ensure that we have *some* coverage so that the likelihood of those hooks continuing to function over time is a bit higher