### PR TITLE
Fixes for compilations using single/triple/quadruple precision

### DIFF
--- a/configure
+++ b/configure
@@ -50525,14 +50525,16 @@ fi
 fi
 
 
-          if test "x$enableboost" = "xyes"
+              if test "x$enableboost" = "xyes"
 then :
 
           if test "x$install_internal_boost" = "xyes"
 then :
   libmesh_contrib_INCLUDES="$BOOST_INCLUDE $libmesh_contrib_INCLUDES"
+                 export timpi_CPPFLAGS="-I$(realpath $top_srcdir)/contrib/boost/include"
 else $as_nop
   libmesh_optional_INCLUDES="$BOOST_CPPFLAGS $libmesh_optional_INCLUDES"
+                 export timpi_CPPFLAGS="$BOOST_CPPFLAGS"
 fi
 
 fi

--- a/configure
+++ b/configure
@@ -50531,10 +50531,10 @@ then :
           if test "x$install_internal_boost" = "xyes"
 then :
   libmesh_contrib_INCLUDES="$BOOST_INCLUDE $libmesh_contrib_INCLUDES"
-                 export timpi_CPPFLAGS="-I$(realpath $top_srcdir)/contrib/boost/include"
+                 export timpi_CPPFLAGS="$timpi_CPPFLAGS -I$(realpath $top_srcdir)/contrib/boost/include"
 else $as_nop
   libmesh_optional_INCLUDES="$BOOST_CPPFLAGS $libmesh_optional_INCLUDES"
-                 export timpi_CPPFLAGS="$BOOST_CPPFLAGS"
+                 export timpi_CPPFLAGS="$timpi_CPPFLAGS $BOOST_CPPFLAGS"
 fi
 
 fi

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -1093,6 +1093,8 @@ l1_norm_diff(const NumericVector<T> & vec1, const NumericVector<T> & vec2)
 
 // Workaround for weird boost/NumericVector interaction bug
 #ifdef LIBMESH_DEFAULT_QUADRUPLE_PRECISION
+#include <boost/mpl/bool.hpp>
+
 namespace boost { namespace multiprecision { namespace detail {
 template <typename T, typename To>
 struct is_lossy_conversion<libMesh::NumericVector<T>, To> {

--- a/m4/boost.m4
+++ b/m4/boost.m4
@@ -71,9 +71,9 @@ AC_DEFUN([CONFIGURE_BOOST],
         [
           AS_IF([test "x$install_internal_boost" = "xyes"],
                 [libmesh_contrib_INCLUDES="$BOOST_INCLUDE $libmesh_contrib_INCLUDES"
-                 export timpi_CPPFLAGS="-I$(realpath $top_srcdir)/contrib/boost/include"],
+                 export timpi_CPPFLAGS="$timpi_CPPFLAGS -I$(realpath $top_srcdir)/contrib/boost/include"],
                 [libmesh_optional_INCLUDES="$BOOST_CPPFLAGS $libmesh_optional_INCLUDES"
-                 export timpi_CPPFLAGS="$BOOST_CPPFLAGS"])
+                 export timpi_CPPFLAGS="$timpi_CPPFLAGS $BOOST_CPPFLAGS"])
         ])
 
   AM_CONDITIONAL(LIBMESH_INSTALL_INTERNAL_BOOST, test x$install_internal_boost = xyes)

--- a/m4/boost.m4
+++ b/m4/boost.m4
@@ -65,11 +65,15 @@ AC_DEFUN([CONFIGURE_BOOST],
   dnl which is not exported during install.  If we are using an external boost,
   dnl add its (absolute) path, as determined by AX_BOOST_BASE to the
   dnl libmesh_optional_INCLUDES variable.
+  dnl In either case, we also add Boost's absolute path to timpi_CPPFLAGS so
+  dnl that, if we are using quadruple precision, TIMPI can use Boost's headers.
   AS_IF([test "x$enableboost" = "xyes"],
         [
           AS_IF([test "x$install_internal_boost" = "xyes"],
-                [libmesh_contrib_INCLUDES="$BOOST_INCLUDE $libmesh_contrib_INCLUDES"],
-                [libmesh_optional_INCLUDES="$BOOST_CPPFLAGS $libmesh_optional_INCLUDES"])
+                [libmesh_contrib_INCLUDES="$BOOST_INCLUDE $libmesh_contrib_INCLUDES"
+                 export timpi_CPPFLAGS="-I$(realpath $top_srcdir)/contrib/boost/include"],
+                [libmesh_optional_INCLUDES="$BOOST_CPPFLAGS $libmesh_optional_INCLUDES"
+                 export timpi_CPPFLAGS="$BOOST_CPPFLAGS"])
         ])
 
   AM_CONDITIONAL(LIBMESH_INSTALL_INTERNAL_BOOST, test x$install_internal_boost = xyes)

--- a/src/apps/embedding.C
+++ b/src/apps/embedding.C
@@ -179,7 +179,7 @@ int main(int argc, char ** argv)
             }
           else
             {
-              int oldnumerator = std::round(shape*denominator);
+              int oldnumerator = int(std::round(shape*denominator));
               int newnumerator = oldnumerator;
               int newdenominator = denominator;
 

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -1434,5 +1434,5 @@ INSTANTIATE_FE(3);
 
 INSTANTIATE_SUBDIVISION_FE;
 
-template LIBMESH_EXPORT void rational_all_shape_derivs<double> (const Elem & elem, const FEType underlying_fe_type, const std::vector<Point> & p, std::vector<std::vector<Real>> * comps[3], const bool add_p_level);
+template LIBMESH_EXPORT void rational_all_shape_derivs<Real> (const Elem & elem, const FEType underlying_fe_type, const std::vector<Point> & p, std::vector<std::vector<Real>> * comps[3], const bool add_p_level);
 } // namespace libMesh

--- a/src/fe/fe_hierarchic_shape_3D.C
+++ b/src/fe/fe_hierarchic_shape_3D.C
@@ -1298,7 +1298,7 @@ Real FE<3,SIDE_HIERARCHIC>::shape(const Elem * elem,
         const unsigned int dofs_per_side = (totalorder+1u)*(totalorder+2u)/2u;
         libmesh_assert_less(i, 4*dofs_per_side);
 
-        const Real zeta[4] = { 1. - p(0) - p(1) - p(2), p(0), p(1), p(2) };
+        const Real zeta[4] = { Real(1.) - p(0) - p(1) - p(2), p(0), p(1), p(2) };
 
         unsigned int face_num = 0;
         if (zeta[0] > zeta[3] &&
@@ -1385,7 +1385,7 @@ Real FE<3,SIDE_HIERARCHIC>::shape(const Elem * elem,
         unsigned int i_offset = 0;
 
         // Triangular coordinates
-        const Real zeta[3] = { 1. - p(0) - p(1), p(0), p(1) };
+        const Real zeta[3] = { Real(1.) - p(0) - p(1), p(0), p(1) };
 
         // Closeness to midplane
         const Real zmid = 1 - std::abs(p(2));

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -81,7 +81,7 @@ void get_hilbert_coords (const Point & p,
 {
   static const Hilbert::inttype max_inttype = static_cast<Hilbert::inttype>(-1);
 
-  const double // put (x,y,z) in [0,1]^3 (don't divide by 0)
+  const Real // put (x,y,z) in [0,1]^3 (don't divide by 0)
     x = (p(0)-bbox.first(0)) * bboxinv(0),
 
 #if LIBMESH_DIM > 1

--- a/src/mesh/mesh_netgen_interface.C
+++ b/src/mesh/mesh_netgen_interface.C
@@ -109,7 +109,7 @@ void NetGenMeshInterface::triangulate ()
       params.optsteps_3d = 0;
     }
   else
-    params.maxh = std::pow(_desired_volume, 1./3.);
+    params.maxh = double(std::pow(_desired_volume, 1./3.));
 
   // Keep track of how NetGen copies of nodes map back to our original
   // nodes, so we can connect new elements to nodes correctly.
@@ -220,7 +220,7 @@ void NetGenMeshInterface::triangulate ()
               else
                 {
                   for (auto i : make_range(3))
-                    point_val[i] = n(i);
+                    point_val[i] = double(n(i));
 
                   Ng_AddPoint(ngmesh, point_val.data());
 

--- a/src/mesh/mesh_triangle_holes.C
+++ b/src/mesh/mesh_triangle_holes.C
@@ -51,8 +51,8 @@ namespace
                   const Point & p1,
                   const Point & p2)
   {
-    const double detleft  = (p0(0)-p2(0))*(p1(1)-p2(1));
-    const double detright = (p0(1)-p2(1))*(p1(0)-p2(0));
+    const Real detleft  = (p0(0)-p2(0))*(p1(1)-p2(1));
+    const Real detright = (p0(1)-p2(1))*(p1(0)-p2(0));
 
     return signof(detleft - detright);
   }
@@ -65,7 +65,7 @@ namespace
   {
     const Point rayvec = ray_target - source;
     const Point edgevec = p1 - p0;
-    const double det = edgevec(0)*rayvec(1)-edgevec(1)*rayvec(0);
+    const Real det = edgevec(0)*rayvec(1)-edgevec(1)*rayvec(0);
 
     return signof(det);
   }

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -582,7 +582,7 @@ void Poly2TriTriangulator::triangulate_current_points()
                                "Triangulator segments reference nonexistent node id " <<
                                segment_start);
 
-          outer_boundary_points.emplace_back((*node)(0), (*node)(1));
+          outer_boundary_points.emplace_back(double((*node)(0)), double((*node)(1)));
           p2t::Point * pt = &outer_boundary_points.back();
 
           // We're not going to support overlapping nodes on the boundary

--- a/src/mesh/poly2tri_triangulator.C
+++ b/src/mesh/poly2tri_triangulator.C
@@ -61,7 +61,7 @@ p2t::Point to_p2t(const libMesh::Point & p)
      "Poly2TriTriangulator only supports point sets in the XY plane");
 #endif
 
-  return {p(0), p(1)};
+  return {double(p(0)), double(p(1))};
 }
 
 Real distance_from_circumcircle(const Elem & elem,

--- a/src/mesh/triangulator_interface.C
+++ b/src/mesh/triangulator_interface.C
@@ -509,7 +509,7 @@ void TriangulatorInterface::calculate_auto_desired_area_samples(std::vector<Poin
   for (unsigned int i = 0; i < bdry_mh.n_points(); i++)
   {
     function_points.push_back((bdry_mh.point(i) + bdry_mh.point((i + 1) % bdry_mh.n_points())) /
-                              2.0);
+                              Real(2.0));
     function_sizes.push_back(
         (bdry_mh.point(i) - bdry_mh.point((i + 1) % bdry_mh.n_points())).norm());
   }
@@ -520,7 +520,7 @@ void TriangulatorInterface::calculate_auto_desired_area_samples(std::vector<Poin
       for (unsigned int i = 0; i < hole->n_points(); i++)
       {
         function_points.push_back(
-            (hole->point(i) + hole->point((i + 1) % hole->n_points())) / 2.0);
+            (hole->point(i) + hole->point((i + 1) % hole->n_points())) / Real(2.0));
         function_sizes.push_back(
             (hole->point(i) - hole->point((i + 1) % hole->n_points())).norm());
       }

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -545,7 +545,7 @@ RBConstructionBase<Base>::generate_training_parameters_random(const Parallel::Co
               Real log_min   = std::log10(min_parameters.get_value(param_name));
               Real log_range = std::log10(max_parameters.get_value(param_name) / min_parameters.get_value(param_name));
 
-              sample_vector[i] = {std::pow(10., log_min + random_number*log_range )};
+              sample_vector[i] = {std::pow(Real(10.), log_min + random_number*log_range )};
             }
           // Generate linearly scaled training parameters
           else

--- a/src/solvers/linear_solver.C
+++ b/src/solvers/linear_solver.C
@@ -192,7 +192,7 @@ double LinearSolver<T>::get_real_solver_setting (const std::string & setting_nam
   {
     if (const auto it = this->_solver_configuration->real_valued_data.find(setting_name);
         it != this->_solver_configuration->real_valued_data.end())
-      return it->second;
+      return double(it->second);
   }
   else if (default_value.has_value())
     return default_value.value();


### PR DESCRIPTION
Hey,

This completely fixes single/triple precision compilations for me.

Compilations using quadruple precision, however, will still fail:
1) The boost installation we ship with libMesh is missing some necessary definitions:
`./include/libmesh/point.h:104:73: error: use of deleted function ‘std::hash<boost::multiprecision::number<boost::multiprecision::backends::float128_backend, boost::multiprecision::et_off> >::hash()’`
2) Even with the latest version of boost, we have an incompatible assertion (`__float128` is trivially copyable but boost's wrapper unfortunately isn't? After writing that, I checked, and the docs claim it should be...?! boostorg/multiprecision#635):
`../src/geom/point.C:28:80: error: static assertion failed: Someone made Point non-TriviallyCopyable`

Cheers,
-Nuno