### PR TITLE
Include <memory> in getpot.h

### DIFF
--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -36,6 +36,7 @@
 #include <cstddef>
 #include <fstream>
 #include <iostream> // not every compiler distribution includes <iostream> with <fstream>
+#include <memory>
 #include <set>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
Required due to use of `std::unique_ptr`.