### PR TITLE
Allow all Petsc matrix types to proceed from a common base class

### DIFF
--- a/examples/subdomains/subdomains_ex2/subdomains_ex2.C
+++ b/examples/subdomains/subdomains_ex2/subdomains_ex2.C
@@ -577,7 +577,7 @@ void assemble_poisson(EquationSystems & es,
 
       // The element matrix and right-hand-side are now built
       // for this element.  Add them to the global matrix and
-      // right-hand-side vector.  The PetscMatrix::add_matrix()
+      // right-hand-side vector.  The PetscMatrixBase::add_matrix()
       // and PetscVector::add_vector() members do this for us.
       // Start logging the insertion of the local (element)
       // matrix and vector into the global matrix and vector

--- a/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.C
@@ -21,7 +21,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/fe_compute_data.h"
-#include "libmesh/petsc_matrix.h"
+#include "libmesh/petsc_matrix_base.h"
 #include "libmesh/edge_edge2.h"
 #include "libmesh/boundary_info.h"
 #include "libmesh/tensor_value.h"

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -863,6 +863,9 @@ include_HEADERS = \
         numerics/parsed_function_parameter.h \
         numerics/petsc_macro.h \
         numerics/petsc_matrix.h \
+        numerics/petsc_matrix_base.h \
+        numerics/petsc_matrix_shell_matrix.h \
+        numerics/petsc_mffd_matrix.h \
         numerics/petsc_preconditioner.h \
         numerics/petsc_shell_matrix.h \
         numerics/petsc_solver_exception.h \

--- a/include/base/sparsity_pattern.h
+++ b/include/base/sparsity_pattern.h
@@ -93,7 +93,7 @@ static void sort_row (const BidirectionalIterator begin,
  * the sparsity pattern (or graph) of the sparse matrix resulting
  * from the discretization.  This pattern may be used directly by
  * a particular sparse matrix format (e.g. \p LaspackMatrix)
- * or indirectly (e.g. \p PetscMatrix).  In the latter case the
+ * or indirectly (e.g. \p PetscMatrixBase).  In the latter case the
  * number of nonzeros per row of the matrix is needed for efficient
  * preallocation.  In this case it suffices to provide estimate
  * (but bounding) values, and in this case the threaded method can

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -263,6 +263,9 @@ include_HEADERS =  \
         numerics/parsed_function_parameter.h \
         numerics/petsc_macro.h \
         numerics/petsc_matrix.h \
+        numerics/petsc_matrix_base.h \
+        numerics/petsc_matrix_shell_matrix.h \
+        numerics/petsc_mffd_matrix.h \
         numerics/petsc_preconditioner.h \
         numerics/petsc_shell_matrix.h \
         numerics/petsc_solver_exception.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -256,6 +256,9 @@ BUILT_SOURCES = \
         parsed_function_parameter.h \
         petsc_macro.h \
         petsc_matrix.h \
+        petsc_matrix_base.h \
+        petsc_matrix_shell_matrix.h \
+        petsc_mffd_matrix.h \
         petsc_preconditioner.h \
         petsc_shell_matrix.h \
         petsc_solver_exception.h \
@@ -1345,6 +1348,15 @@ petsc_macro.h: $(top_srcdir)/include/numerics/petsc_macro.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 petsc_matrix.h: $(top_srcdir)/include/numerics/petsc_matrix.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+petsc_matrix_base.h: $(top_srcdir)/include/numerics/petsc_matrix_base.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+petsc_matrix_shell_matrix.h: $(top_srcdir)/include/numerics/petsc_matrix_shell_matrix.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+petsc_mffd_matrix.h: $(top_srcdir)/include/numerics/petsc_mffd_matrix.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 petsc_preconditioner.h: $(top_srcdir)/include/numerics/petsc_preconditioner.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -183,11 +183,11 @@ am__v_P_1 = :
 AM_V_GEN = $(am__v_GEN_@AM_V@)
 am__v_GEN_ = $(am__v_GEN_@AM_DEFAULT_V@)
 am__v_GEN_0 = @echo "  GEN     " $@;
-am__v_GEN_1 = 
+am__v_GEN_1 =
 AM_V_at = $(am__v_at_@AM_V@)
 am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
 am__v_at_0 = @
-am__v_at_1 = 
+am__v_at_1 =
 SOURCES =
 DIST_SOURCES =
 am__can_run_installinfo = \
@@ -601,28 +601,29 @@ BUILT_SOURCES = auto_ptr.h dirichlet_boundaries.h dof_map.h \
 	numeric_vector.h parsed_fem_function.h \
 	parsed_fem_function_parameter.h parsed_function.h \
 	parsed_function_parameter.h petsc_macro.h petsc_matrix.h \
-	petsc_preconditioner.h petsc_shell_matrix.h \
-	petsc_solver_exception.h petsc_vector.h preconditioner.h \
-	raw_accessor.h refinement_selector.h shell_matrix.h \
-	sparse_matrix.h sparse_shell_matrix.h sum_shell_matrix.h \
-	tensor_shell_matrix.h tensor_tools.h tensor_value.h \
-	trilinos_epetra_matrix.h trilinos_epetra_vector.h \
-	trilinos_preconditioner.h tuple_of.h type_n_tensor.h \
-	type_tensor.h type_vector.h vector_value.h wrapped_function.h \
-	wrapped_functor.h wrapped_petsc.h zero_function.h \
-	libmesh_call_mpi.h parallel.h parallel_algebra.h \
-	parallel_bin_sorter.h parallel_conversion_utils.h \
-	parallel_eigen.h parallel_elem.h parallel_fe_type.h \
-	parallel_ghost_sync.h parallel_hilbert.h parallel_histogram.h \
-	parallel_node.h parallel_object.h parallel_only.h \
-	parallel_sort.h threads.h threads_allocators.h threads_none.h \
-	threads_pthread.h threads_tbb.h centroid_partitioner.h \
-	hilbert_sfc_partitioner.h linear_partitioner.h \
-	mapped_subdomain_partitioner.h metis_csr_graph.h \
-	metis_partitioner.h morton_sfc_partitioner.h parmetis_helper.h \
-	parmetis_partitioner.h partitioner.h sfc_partitioner.h \
-	subdomain_partitioner.h diff_physics.h diff_qoi.h \
-	fem_physics.h quadrature.h quadrature_clough.h \
+	petsc_matrix_base.h petsc_matrix_shell_matrix.h \
+	petsc_mffd_matrix.h petsc_preconditioner.h \
+	petsc_shell_matrix.h petsc_solver_exception.h petsc_vector.h \
+	preconditioner.h raw_accessor.h refinement_selector.h \
+	shell_matrix.h sparse_matrix.h sparse_shell_matrix.h \
+	sum_shell_matrix.h tensor_shell_matrix.h tensor_tools.h \
+	tensor_value.h trilinos_epetra_matrix.h \
+	trilinos_epetra_vector.h trilinos_preconditioner.h tuple_of.h \
+	type_n_tensor.h type_tensor.h type_vector.h vector_value.h \
+	wrapped_function.h wrapped_functor.h wrapped_petsc.h \
+	zero_function.h libmesh_call_mpi.h parallel.h \
+	parallel_algebra.h parallel_bin_sorter.h \
+	parallel_conversion_utils.h parallel_eigen.h parallel_elem.h \
+	parallel_fe_type.h parallel_ghost_sync.h parallel_hilbert.h \
+	parallel_histogram.h parallel_node.h parallel_object.h \
+	parallel_only.h parallel_sort.h threads.h threads_allocators.h \
+	threads_none.h threads_pthread.h threads_tbb.h \
+	centroid_partitioner.h hilbert_sfc_partitioner.h \
+	linear_partitioner.h mapped_subdomain_partitioner.h \
+	metis_csr_graph.h metis_partitioner.h morton_sfc_partitioner.h \
+	parmetis_helper.h parmetis_partitioner.h partitioner.h \
+	sfc_partitioner.h subdomain_partitioner.h diff_physics.h \
+	diff_qoi.h fem_physics.h quadrature.h quadrature_clough.h \
 	quadrature_composite.h quadrature_conical.h quadrature_gauss.h \
 	quadrature_gauss_lobatto.h quadrature_gm.h quadrature_grid.h \
 	quadrature_jacobi.h quadrature_monomial.h quadrature_nodal.h \
@@ -1685,6 +1686,15 @@ petsc_macro.h: $(top_srcdir)/include/numerics/petsc_macro.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 petsc_matrix.h: $(top_srcdir)/include/numerics/petsc_matrix.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+petsc_matrix_base.h: $(top_srcdir)/include/numerics/petsc_matrix_base.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+petsc_matrix_shell_matrix.h: $(top_srcdir)/include/numerics/petsc_matrix_shell_matrix.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+petsc_mffd_matrix.h: $(top_srcdir)/include/numerics/petsc_mffd_matrix.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 petsc_preconditioner.h: $(top_srcdir)/include/numerics/petsc_preconditioner.h

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -83,7 +83,7 @@ public:
    */
   explicit
   PetscMatrix (Mat m,
-                  const Parallel::Communicator & comm_in);
+               const Parallel::Communicator & comm_in);
 
   /**
    * This class manages a C-style struct (Mat) manually, so we

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -25,7 +25,7 @@
 #ifdef LIBMESH_HAVE_PETSC
 
 // Local includes
-#include "libmesh/sparse_matrix.h"
+#include "libmesh/petsc_matrix_base.h"
 #include "libmesh/petsc_macro.h"
 #include "libmesh/petsc_solver_exception.h"
 
@@ -34,40 +34,6 @@
 #ifdef LIBMESH_HAVE_CXX11_THREAD
 #include <atomic>
 #include <mutex>
-#endif
-
-// Macro to identify and debug functions which should be called in
-// parallel on parallel matrices but which may be called in serial on
-// serial matrices.  This macro will only be valid inside non-static
-// PetscMatrix methods
-#undef semiparallel_only
-#undef exceptionless_semiparallel_only
-#ifndef NDEBUG
-#include <cstring>
-
-#define semiparallel_only() do { if (this->initialized()) { const char * mytype; \
-      auto semiparallel_only_ierr = MatGetType(_mat,&mytype);           \
-      LIBMESH_CHKERR(semiparallel_only_ierr);                           \
-      if (!strcmp(mytype, MATSEQAIJ))                                   \
-        parallel_object_only(); } } while (0)
-#define exceptionless_semiparallel_only() do { if (this->initialized()) { const char * mytype; \
-      auto semiparallel_only_ierr = MatGetType(_mat,&mytype);           \
-      libmesh_ignore(semiparallel_only_ierr);                           \
-      if (!strcmp(mytype, MATSEQAIJ))                                   \
-        exceptionless_parallel_object_only(); } } while (0)
-#else
-#define semiparallel_only()
-#define exceptionless_semiparallel_only()
-#endif
-
-
-// Petsc include files.
-#ifdef I
-# define LIBMESH_SAW_I
-#endif
-#include <petscmat.h>
-#ifndef LIBMESH_SAW_I
-# undef I // Avoid complex.h contamination
 #endif
 
 
@@ -82,9 +48,8 @@ enum PetscMatrixType : int {
                  AIJ=0,
                  HYPRE};
 
-
 /**
- * This class provides a nice interface to the PETSc C-based data
+ * This class provides a nice interface to the PETSc C-based AIJ data
  * structures for parallel, sparse matrices. All overridden virtual
  * functions are documented in sparse_matrix.h.
  *
@@ -93,7 +58,7 @@ enum PetscMatrixType : int {
  * \brief SparseMatrix interface to PETSc Mat.
  */
 template <typename T>
-class PetscMatrix final : public SparseMatrix<T>
+class PetscMatrix final : public PetscMatrixBase<T>
 {
 public:
   /**
@@ -118,7 +83,7 @@ public:
    */
   explicit
   PetscMatrix (Mat m,
-               const Parallel::Communicator & comm_in);
+                  const Parallel::Communicator & comm_in);
 
   /**
    * This class manages a C-style struct (Mat) manually, so we
@@ -132,13 +97,6 @@ public:
 
   PetscMatrix & operator= (const PetscMatrix &);
   virtual SparseMatrix<T> & operator= (const SparseMatrix<T> & v) override;
-
-  virtual SolverPackage solver_package() override
-  {
-    return PETSC_SOLVERS;
-  }
-
-  void set_matrix_type(PetscMatrixType mat_type);
 
   virtual void init (const numeric_index_type m,
                      const numeric_index_type n,
@@ -181,11 +139,6 @@ public:
    */
   void reset_preallocation();
 
-  /**
-   * clear() is called from the destructor, so it should not throw.
-   */
-  virtual void clear () noexcept override;
-
   virtual void zero () override;
 
   virtual std::unique_ptr<SparseMatrix<T>> zero_clone () const override;
@@ -194,20 +147,7 @@ public:
 
   virtual void zero_rows (std::vector<numeric_index_type> & rows, T diag_value = 0.0) override;
 
-  virtual void close () override;
-
   virtual void flush () override;
-
-  virtual numeric_index_type m () const override;
-
-  virtual numeric_index_type local_m () const final;
-
-  virtual numeric_index_type n () const override;
-
-  /**
-   * Get the number of columns owned by this process
-   */
-  virtual numeric_index_type local_n () const final;
 
   /**
    * Get the number of rows and columns owned by this process
@@ -215,14 +155,6 @@ public:
    * @param j Column size
    */
   void get_local_size (numeric_index_type & m, numeric_index_type & n) const;
-
-  virtual numeric_index_type row_start () const override;
-
-  virtual numeric_index_type row_stop () const override;
-
-  virtual numeric_index_type col_start () const override;
-
-  virtual numeric_index_type col_stop () const override;
 
   virtual void set (const numeric_index_type i,
                     const numeric_index_type j,
@@ -286,14 +218,6 @@ public:
 
   virtual Real linfty_norm () const override;
 
-  virtual bool closed() const override;
-
-  /**
-   * If set to false, we don't delete the Mat on destruction and allow
-   * instead for \p PETSc to manage it.
-   */
-  virtual void set_destroy_mat_on_exit(bool destroy = true);
-
   /**
    * Print the contents of the matrix to the screen with the PETSc
    * viewer. This function only allows printing to standard out since
@@ -315,22 +239,6 @@ public:
   virtual void get_diagonal (NumericVector<T> & dest) const override;
 
   virtual void get_transpose (SparseMatrix<T> & dest) const override;
-
-  /**
-   * Swaps the internal data pointers of two PetscMatrices, no actual
-   * values are swapped.
-   */
-  void swap (PetscMatrix<T> &);
-
-  /**
-   * \returns The raw PETSc matrix pointer.
-   *
-   * \note This is generally not required in user-level code.
-   *
-   * \note Don't do anything crazy like calling MatDestroy() on
-   * it, or very bad things will likely happen!
-   */
-  Mat mat () { libmesh_assert (_mat); return _mat; }
 
   virtual
   void get_row(numeric_index_type i,
@@ -372,21 +280,9 @@ protected:
                      PetscViewerType viewertype,
                      PetscFileMode filemode);
 
-private:
-
-  /**
-   * PETSc matrix datatype to store values.
-   */
-  Mat _mat;
-
-  /**
-   * This boolean value should only be set to \p false for the
-   * constructor which takes a PETSc Mat object.
-   */
-  bool _destroy_mat_on_exit;
-
   PetscMatrixType _mat_type;
 
+private:
 #ifdef LIBMESH_HAVE_CXX11_THREAD
   mutable std::mutex _petsc_matrix_mutex;
 #else

--- a/include/numerics/petsc_matrix_base.h
+++ b/include/numerics/petsc_matrix_base.h
@@ -1,0 +1,191 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2024 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#ifndef LIBMESH_PETSC_MATRIX_BASE_H
+#define LIBMESH_PETSC_MATRIX_BASE_H
+
+#include "libmesh/libmesh_common.h"
+
+#ifdef LIBMESH_HAVE_PETSC
+
+// Local includes
+#include "libmesh/sparse_matrix.h"
+#include "libmesh/petsc_macro.h"
+#include "libmesh/petsc_solver_exception.h"
+#include "libmesh/wrapped_petsc.h"
+
+// Petsc include files.
+#ifdef I
+# define LIBMESH_SAW_I
+#endif
+#include <petscmat.h>
+#ifndef LIBMESH_SAW_I
+# undef I // Avoid complex.h contamination
+#endif
+
+// Macro to identify and debug functions which should be called in
+// parallel on parallel matrices but which may be called in serial on
+// serial matrices.  This macro will only be valid inside non-static
+// PetscMatrix methods
+#undef semiparallel_only
+#undef exceptionless_semiparallel_only
+#ifndef NDEBUG
+#include <cstring>
+
+#define semiparallel_only() do { if (this->initialized()) { const char * mytype; \
+      auto semiparallel_only_ierr = MatGetType(this->_mat,&mytype);     \
+      LIBMESH_CHKERR(semiparallel_only_ierr);                           \
+      if (!strcmp(mytype, MATSEQAIJ))                                   \
+        parallel_object_only(); } } while (0)
+#define exceptionless_semiparallel_only() do { if (this->initialized()) { const char * mytype; \
+      auto semiparallel_only_ierr = MatGetType(this->_mat,&mytype);     \
+      libmesh_ignore(semiparallel_only_ierr);                           \
+      if (!strcmp(mytype, MATSEQAIJ))                                   \
+        exceptionless_parallel_object_only(); } } while (0)
+#else
+#define semiparallel_only()
+#define exceptionless_semiparallel_only()
+#endif
+
+
+namespace libMesh
+{
+
+/**
+ * This class provides a nice interface to the PETSc C-based data
+ * structures for parallel, sparse matrices. All overridden virtual
+ * functions are documented in sparse_matrix.h.
+ *
+ * \author Benjamin S. Kirk
+ * \date 2002
+ * \brief SparseMatrix interface to PETSc Mat.
+ */
+template <typename T>
+class PetscMatrixBase : public SparseMatrix<T>
+{
+public:
+  explicit
+  PetscMatrixBase (const Parallel::Communicator & comm_in);
+
+  /**
+   * Constructor.  Creates a PetscMatrixBase assuming you already have a
+   * valid Mat object.  In this case, m is NOT destroyed by the
+   * PetscMatrixBase destructor when this object goes out of scope.  This
+   * allows ownership of m to remain with the original creator, and to
+   * simply provide additional functionality with the PetscMatrixBase.
+   */
+  explicit
+  PetscMatrixBase (Mat m,
+               const Parallel::Communicator & comm_in);
+
+  /**
+   * This class manages a C-style struct (Mat) manually, so we
+   * don't want to allow any automatic copy/move functions to be
+   * generated, and we can't default the destructor.
+   */
+  PetscMatrixBase (PetscMatrixBase &&) = delete;
+  PetscMatrixBase (const PetscMatrixBase &) = delete;
+  PetscMatrixBase & operator= (PetscMatrixBase &&) = delete;
+  virtual ~PetscMatrixBase ();
+
+  virtual SolverPackage solver_package() override
+  {
+    return PETSC_SOLVERS;
+  }
+
+  /**
+   * \returns The raw PETSc matrix pointer.
+   *
+   * \note This is generally not required in user-level code.
+   *
+   * \note Don't do anything crazy like calling MatDestroy() on
+   * it, or very bad things will likely happen!
+   */
+  Mat mat () { libmesh_assert (_mat); return _mat; }
+
+  /**
+   * clear() is called from the destructor, so it should not throw.
+   */
+  virtual void clear() noexcept override;
+
+  /**
+   * If set to false, we don't delete the Mat on destruction and allow
+   * instead for \p PETSc to manage it.
+   */
+  void set_destroy_mat_on_exit(bool destroy = true);
+
+  /**
+   * Swaps the internal data pointers of two PetscMatrices, no actual
+   * values are swapped.
+   */
+  void swap (PetscMatrixBase<T> &);
+
+  using SparseMatrix<T>::operator=;
+
+  /**
+   * Set the context (ourself) for \p _mat
+   */
+  void set_context();
+
+  /**
+   * @returns The context for \p mat if it exists, else a \p nullptr
+   */
+  static PetscMatrixBase<T> * get_context(Mat mat);
+
+  virtual numeric_index_type m () const override;
+
+  virtual numeric_index_type local_m () const final;
+
+  virtual numeric_index_type n () const override;
+
+  /**
+   * Get the number of columns owned by this process
+   */
+  virtual numeric_index_type local_n () const final;
+
+  virtual numeric_index_type row_start () const override;
+
+  virtual numeric_index_type row_stop () const override;
+
+  virtual numeric_index_type col_start () const override;
+
+  virtual numeric_index_type col_stop () const override;
+
+  virtual void close () override;
+
+  virtual bool closed() const override;
+
+protected:
+
+  /**
+   * PETSc matrix datatype to store values.
+   */
+  Mat _mat;
+
+  /**
+   * This boolean value should only be set to \p false for the
+   * constructor which takes a PETSc Mat object.
+   */
+  bool _destroy_mat_on_exit;
+};
+
+} // namespace libMesh
+
+#endif // #ifdef LIBMESH_HAVE_PETSC
+#endif // LIBMESH_PETSC_MATRIX_BASE_H

--- a/include/numerics/petsc_matrix_base.h
+++ b/include/numerics/petsc_matrix_base.h
@@ -92,7 +92,7 @@ public:
    */
   explicit
   PetscMatrixBase (Mat m,
-               const Parallel::Communicator & comm_in);
+                   const Parallel::Communicator & comm_in);
 
   /**
    * This class manages a C-style struct (Mat) manually, so we

--- a/include/numerics/petsc_matrix_shell_matrix.h
+++ b/include/numerics/petsc_matrix_shell_matrix.h
@@ -1,0 +1,94 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2024 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#ifndef LIBMESH_PETSC_MATRIX_SHELL_MATRIX_H
+#define LIBMESH_PETSC_MATRIX_SHELL_MATRIX_H
+
+#include "libmesh/libmesh_config.h"
+
+#ifdef LIBMESH_HAVE_PETSC
+
+#include "libmesh/petsc_matrix_base.h"
+#include "libmesh/petsc_shell_matrix.h"
+
+namespace libMesh
+{
+
+/**
+ * This class allows to use a PETSc shell matrix as a PetscMatrix
+ *
+ * \author Alexander Lindsay
+ * \date 2024
+ */
+template <typename T>
+class PetscMatrixShellMatrix : public PetscMatrixBase<T>
+{
+public:
+  explicit PetscMatrixShellMatrix(const Parallel::Communicator & comm_in);
+
+  virtual void init(const numeric_index_type m,
+                    const numeric_index_type n,
+                    const numeric_index_type m_l,
+                    const numeric_index_type n_l,
+                    const numeric_index_type = 30,
+                    const numeric_index_type = 10,
+                    const numeric_index_type blocksize = 1) override;
+
+  /**
+   * Initialize this matrix using the sparsity structure computed by \p dof_map.
+   * @param type The serial/parallel/ghosted type of the matrix
+   */
+  virtual void init(ParallelType = PARALLEL) override;
+
+  virtual SparseMatrix<T> & operator=(const SparseMatrix<T> &) override;
+
+private:
+  // Make this private because we mark as initialized after we've done our initialization, and we
+  // don't want derived classes to mistakenly register their data as initialized (or not)
+  using PetscMatrixBase<T>::_is_initialized;
+
+  /// Whether to omit constrained degrees of freedom
+  const bool _omit_constrained_dofs;
+
+  friend void init_shell_mat<PetscMatrixShellMatrix<T>>(PetscMatrixShellMatrix<T> & obj);
+  friend void init_shell_mat<PetscMatrixShellMatrix<T>>(PetscMatrixShellMatrix<T> & obj,
+                                                        const numeric_index_type m,
+                                                        const numeric_index_type n,
+                                                        const numeric_index_type m_l,
+                                                        const numeric_index_type n_l,
+                                                        const numeric_index_type blocksize_in);
+};
+
+//-----------------------------------------------------------------------
+// PetscMatrixShellMatrix inline members
+template <typename T>
+PetscMatrixShellMatrix<T>::PetscMatrixShellMatrix(const Parallel::Communicator & comm_in)
+  : PetscMatrixBase<T>(comm_in), _omit_constrained_dofs(false)
+{
+}
+
+template <typename T>
+SparseMatrix<T> &
+PetscMatrixShellMatrix<T>::operator=(const SparseMatrix<T> &)
+{
+  libmesh_not_implemented();
+}
+
+} // namespace libMesh
+
+#endif // LIBMESH_HAVE_PETSC
+#endif // LIBMESH_SPARSE_SHELL_MATRIX_H

--- a/include/numerics/petsc_matrix_shell_matrix.h
+++ b/include/numerics/petsc_matrix_shell_matrix.h
@@ -85,7 +85,7 @@ template <typename T>
 SparseMatrix<T> &
 PetscMatrixShellMatrix<T>::operator=(const SparseMatrix<T> &)
 {
-  libmesh_not_implemented();
+  libmesh_error();
 }
 
 } // namespace libMesh

--- a/include/numerics/petsc_mffd_matrix.h
+++ b/include/numerics/petsc_mffd_matrix.h
@@ -1,0 +1,250 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2024 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#ifndef LIBMESH_PETSC_MFFD_MATRIX_H
+#define LIBMESH_PETSC_MFFD_MATRIX_H
+
+#include "libmesh/libmesh_config.h"
+
+#ifdef LIBMESH_HAVE_PETSC
+
+#include "libmesh/petsc_matrix_base.h"
+
+namespace libMesh
+{
+
+/**
+ * This class allows to use a PETSc shell matrix as a PetscMatrix
+ *
+ * \author Alexander Lindsay
+ * \date 2024
+ */
+template <typename T>
+class PetscMFFDMatrix : public PetscMatrixBase<T>
+{
+public:
+  /**
+   * Constructor.  Creates a PetscMFFDMatrix assuming you already have a
+   * valid Mat object.  In this case, m is NOT destroyed by the
+   * PetscMFFDMatrix destructor when this object goes out of scope.  This
+   * allows ownership of m to remain with the original creator, and to
+   * simply provide additional functionality with the PetscMFFDMatrix.
+   */
+  explicit PetscMFFDMatrix(Mat m, const Parallel::Communicator & comm_in);
+
+  explicit PetscMFFDMatrix(const Parallel::Communicator & comm_in);
+
+  PetscMFFDMatrix & operator=(Mat m);
+
+  virtual void init(const numeric_index_type,
+                    const numeric_index_type,
+                    const numeric_index_type,
+                    const numeric_index_type,
+                    const numeric_index_type = 30,
+                    const numeric_index_type = 10,
+                    const numeric_index_type = 1) override;
+
+  /**
+   * Initialize this matrix using the sparsity structure computed by \p dof_map.
+   * @param type The serial/parallel/ghosted type of the matrix
+   */
+  virtual void init(ParallelType = PARALLEL) override;
+
+  virtual SparseMatrix<T> & operator=(const SparseMatrix<T> &) override;
+
+  virtual void zero() override;
+  virtual std::unique_ptr<SparseMatrix<T>> zero_clone() const override;
+  virtual std::unique_ptr<SparseMatrix<T>> clone() const override;
+  virtual void set(const numeric_index_type i, const numeric_index_type j, const T value) override;
+  virtual void add(const numeric_index_type i, const numeric_index_type j, const T value) override;
+  virtual void add_matrix(const DenseMatrix<T> & dm,
+                          const std::vector<numeric_index_type> & rows,
+                          const std::vector<numeric_index_type> & cols) override;
+  virtual void add_matrix(const DenseMatrix<T> & dm,
+                          const std::vector<numeric_index_type> & dof_indices) override;
+  virtual void add(const T a, const SparseMatrix<T> & X) override;
+  virtual T operator()(const numeric_index_type i, const numeric_index_type j) const override;
+  virtual Real l1_norm() const override;
+  virtual Real linfty_norm() const override;
+  virtual void print_personal(std::ostream & os = libMesh::out) const override;
+  virtual void get_diagonal(NumericVector<T> & dest) const override;
+  virtual void get_transpose(SparseMatrix<T> & dest) const override;
+  virtual void get_row(numeric_index_type i,
+                       std::vector<numeric_index_type> & indices,
+                       std::vector<T> & values) const override;
+};
+
+template <typename T>
+PetscMFFDMatrix<T>::PetscMFFDMatrix(Mat m, const Parallel::Communicator & comm_in)
+  : PetscMatrixBase<T>(m, comm_in)
+{
+}
+
+template <typename T>
+PetscMFFDMatrix<T>::PetscMFFDMatrix(const Parallel::Communicator & comm_in)
+  : PetscMatrixBase<T>(comm_in)
+{
+}
+
+template <typename T>
+PetscMFFDMatrix<T> &
+PetscMFFDMatrix<T>::operator=(Mat m)
+{
+  this->_mat = m;
+  return *this;
+}
+
+template <typename T>
+void
+PetscMFFDMatrix<T>::init(const numeric_index_type,
+                         const numeric_index_type,
+                         const numeric_index_type,
+                         const numeric_index_type,
+                         const numeric_index_type,
+                         const numeric_index_type,
+                         const numeric_index_type)
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+void
+PetscMFFDMatrix<T>::init(ParallelType)
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+SparseMatrix<T> &
+PetscMFFDMatrix<T>::operator=(const SparseMatrix<T> &)
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+void
+PetscMFFDMatrix<T>::zero()
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+std::unique_ptr<SparseMatrix<T>>
+PetscMFFDMatrix<T>::zero_clone() const
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+std::unique_ptr<SparseMatrix<T>>
+PetscMFFDMatrix<T>::clone() const
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+void
+PetscMFFDMatrix<T>::set(const numeric_index_type, const numeric_index_type, const T)
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+void
+PetscMFFDMatrix<T>::add(const numeric_index_type, const numeric_index_type, const T)
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+void
+PetscMFFDMatrix<T>::add_matrix(const DenseMatrix<T> &,
+                               const std::vector<numeric_index_type> &,
+                               const std::vector<numeric_index_type> &)
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+void
+PetscMFFDMatrix<T>::add_matrix(const DenseMatrix<T> &, const std::vector<numeric_index_type> &)
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+void
+PetscMFFDMatrix<T>::add(const T, const SparseMatrix<T> &)
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+T
+PetscMFFDMatrix<T>::operator()(const numeric_index_type, const numeric_index_type) const
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+Real
+PetscMFFDMatrix<T>::l1_norm() const
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+Real
+PetscMFFDMatrix<T>::linfty_norm() const
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+void
+PetscMFFDMatrix<T>::print_personal(std::ostream &) const
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+void
+PetscMFFDMatrix<T>::get_diagonal(NumericVector<T> &) const
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+void
+PetscMFFDMatrix<T>::get_transpose(SparseMatrix<T> &) const
+{
+  libmesh_not_implemented();
+}
+
+template <typename T>
+void
+PetscMFFDMatrix<T>::get_row(numeric_index_type,
+                            std::vector<numeric_index_type> &,
+                            std::vector<T> &) const
+{
+  libmesh_not_implemented();
+}
+
+} // namespace libMesh
+
+#endif // LIBMESH_HAVE_PETSC
+#endif // LIBMESH_SPARSE_SHELL_MATRIX_H

--- a/include/numerics/petsc_mffd_matrix.h
+++ b/include/numerics/petsc_mffd_matrix.h
@@ -118,35 +118,35 @@ PetscMFFDMatrix<T>::init(const numeric_index_type,
                          const numeric_index_type,
                          const numeric_index_type)
 {
-  libmesh_not_implemented();
+  libmesh_error();
 }
 
 template <typename T>
 void
 PetscMFFDMatrix<T>::init(ParallelType)
 {
-  libmesh_not_implemented();
+  libmesh_error();
 }
 
 template <typename T>
 SparseMatrix<T> &
 PetscMFFDMatrix<T>::operator=(const SparseMatrix<T> &)
 {
-  libmesh_not_implemented();
+  libmesh_error();
 }
 
 template <typename T>
 void
 PetscMFFDMatrix<T>::zero()
 {
-  libmesh_not_implemented();
+  libmesh_error();
 }
 
 template <typename T>
 std::unique_ptr<SparseMatrix<T>>
 PetscMFFDMatrix<T>::zero_clone() const
 {
-  libmesh_not_implemented();
+  libmesh_error();
 }
 
 template <typename T>
@@ -160,14 +160,14 @@ template <typename T>
 void
 PetscMFFDMatrix<T>::set(const numeric_index_type, const numeric_index_type, const T)
 {
-  libmesh_not_implemented();
+  libmesh_error();
 }
 
 template <typename T>
 void
 PetscMFFDMatrix<T>::add(const numeric_index_type, const numeric_index_type, const T)
 {
-  libmesh_not_implemented();
+  libmesh_error();
 }
 
 template <typename T>
@@ -176,63 +176,63 @@ PetscMFFDMatrix<T>::add_matrix(const DenseMatrix<T> &,
                                const std::vector<numeric_index_type> &,
                                const std::vector<numeric_index_type> &)
 {
-  libmesh_not_implemented();
+  libmesh_error();
 }
 
 template <typename T>
 void
 PetscMFFDMatrix<T>::add_matrix(const DenseMatrix<T> &, const std::vector<numeric_index_type> &)
 {
-  libmesh_not_implemented();
+  libmesh_error();
 }
 
 template <typename T>
 void
 PetscMFFDMatrix<T>::add(const T, const SparseMatrix<T> &)
 {
-  libmesh_not_implemented();
+  libmesh_error();
 }
 
 template <typename T>
 T
 PetscMFFDMatrix<T>::operator()(const numeric_index_type, const numeric_index_type) const
 {
-  libmesh_not_implemented();
+  libmesh_error();
 }
 
 template <typename T>
 Real
 PetscMFFDMatrix<T>::l1_norm() const
 {
-  libmesh_not_implemented();
+  libmesh_error();
 }
 
 template <typename T>
 Real
 PetscMFFDMatrix<T>::linfty_norm() const
 {
-  libmesh_not_implemented();
+  libmesh_error();
 }
 
 template <typename T>
 void
 PetscMFFDMatrix<T>::print_personal(std::ostream &) const
 {
-  libmesh_not_implemented();
+  libmesh_error();
 }
 
 template <typename T>
 void
 PetscMFFDMatrix<T>::get_diagonal(NumericVector<T> &) const
 {
-  libmesh_not_implemented();
+  libmesh_error();
 }
 
 template <typename T>
 void
 PetscMFFDMatrix<T>::get_transpose(SparseMatrix<T> &) const
 {
-  libmesh_not_implemented();
+  libmesh_error();
 }
 
 template <typename T>
@@ -241,7 +241,7 @@ PetscMFFDMatrix<T>::get_row(numeric_index_type,
                             std::vector<numeric_index_type> &,
                             std::vector<T> &) const
 {
-  libmesh_not_implemented();
+  libmesh_error();
 }
 
 } // namespace libMesh

--- a/include/numerics/petsc_shell_matrix.h
+++ b/include/numerics/petsc_shell_matrix.h
@@ -47,6 +47,23 @@ namespace libMesh
 {
 
 /**
+ * Initialize a shell matrix object
+ */
+template <typename Obj>
+void init_shell_mat(Obj & obj,
+                    const numeric_index_type m,
+                    const numeric_index_type n,
+                    const numeric_index_type m_l,
+                    const numeric_index_type n_l,
+                    const numeric_index_type blocksize_in);
+
+/**
+ * Initialize a shell matrix object using information from the \p DofMap
+ */
+template <typename Obj>
+void init_shell_mat(Obj & obj);
+
+/**
  * This class allows to use a PETSc shell matrix.
  * All overridden virtual functions are documented in
  * shell_matrix.h.
@@ -100,9 +117,17 @@ protected:
   /**
    * Petsc Shell Matrix
    */
-  WrappedPetsc<Mat> _mat;
+  Mat _mat;
 
   bool _is_initialized;
+
+  friend void init_shell_mat<PetscShellMatrix<T>>(PetscShellMatrix<T> & obj);
+  friend void init_shell_mat<PetscShellMatrix<T>>(PetscShellMatrix<T> & obj,
+                                                  const numeric_index_type m,
+                                                  const numeric_index_type n,
+                                                  const numeric_index_type m_l,
+                                                  const numeric_index_type n_l,
+                                                  const numeric_index_type blocksize_in);
 };
 
 

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -154,7 +154,7 @@ public:
    * \returns \p true if this sparse matrix format needs to be fed the
    * graph of the sparse matrix.
    *
-   * This is true for \p LaspackMatrix, but not \p PetscMatrix.  In
+   * This is true for \p LaspackMatrix, but not \p PetscMatrixBase.  In
    * the case where the full graph is not required, we can efficiently
    * approximate it to provide a good estimate of the required size of
    * the sparse matrix.
@@ -496,7 +496,7 @@ public:
   /**
    * This function creates a matrix called "submatrix" which is defined
    * by the row and column indices given in the "rows" and "cols" entries.
-   * Currently this operation is only defined for the PetscMatrix type.
+   * Currently this operation is only defined for the PetscMatrixBase type.
    * Note: The \p rows and \p cols vectors need to be sorted;
    *       Use the nosort version below if \p rows and \p cols vectors are not sorted;
    *       The \p rows and \p cols only contain indices that are owned by this processor.

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -154,7 +154,7 @@ public:
    * \returns \p true if this sparse matrix format needs to be fed the
    * graph of the sparse matrix.
    *
-   * This is true for \p LaspackMatrix, but not \p PetscMatrixBase.  In
+   * This is true for \p LaspackMatrix, but not \p PetscMatrixBase subclasses.  In
    * the case where the full graph is not required, we can efficiently
    * approximate it to provide a good estimate of the required size of
    * the sparse matrix.
@@ -496,7 +496,7 @@ public:
   /**
    * This function creates a matrix called "submatrix" which is defined
    * by the row and column indices given in the "rows" and "cols" entries.
-   * Currently this operation is only defined for the PetscMatrixBase type.
+   * Currently this operation is only defined for the PetscMatrixBase subclasses.
    * Note: The \p rows and \p cols vectors need to be sorted;
    *       Use the nosort version below if \p rows and \p cols vectors are not sorted;
    *       The \p rows and \p cols only contain indices that are owned by this processor.

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -26,7 +26,7 @@
 
 // libMesh includes
 #include "libmesh/petsc_macro.h"
-#include "libmesh/petsc_matrix.h"
+#include "libmesh/petsc_matrix_base.h"
 #include "libmesh/petsc_vector.h"
 #include "libmesh/wrapped_petsc.h"
 
@@ -59,9 +59,9 @@ namespace libMesh
     DM * coarser_dm;
     DM * finer_dm;
     DM * global_dm;
-    PetscMatrix<libMesh::Number> * K_interp_ptr;
-    PetscMatrix<libMesh::Number> * K_sub_interp_ptr;
-    PetscMatrix<libMesh::Number> * K_restrict_ptr;
+    PetscMatrixBase<libMesh::Number> * K_interp_ptr;
+    PetscMatrixBase<libMesh::Number> * K_sub_interp_ptr;
+    PetscMatrixBase<libMesh::Number> * K_restrict_ptr;
     PetscVector<libMesh::Number> * current_vec;
 
     //! Stores local dofs for each var for use in subprojection matrixes
@@ -140,14 +140,14 @@ namespace libMesh
      * C++ objects, they are cleaned up automatically by their
      * destructors.
      */
-    std::vector<std::unique_ptr<PetscMatrix<Number>>> _pmtx_vec;
+    std::vector<std::unique_ptr<PetscMatrixBase<Number>>> _pmtx_vec;
 
     /**
      * Vector of sub projection matrixes for all grid levels for
      * fieldsplit.  These are C++ objects, they are cleaned up
      * automatically by their destructors.
      */
-    std::vector<std::unique_ptr<PetscMatrix<Number>>> _subpmtx_vec;
+    std::vector<std::unique_ptr<PetscMatrixBase<Number>>> _subpmtx_vec;
 
     /**
      * Vector of internal PetscDM context structs for all grid levels

--- a/include/solvers/petsc_linear_solver.h
+++ b/include/solvers/petsc_linear_solver.h
@@ -85,7 +85,7 @@ namespace libMesh
 {
 
 // forward declarations
-template <typename T> class PetscMatrix;
+template <typename T> class PetscMatrixBase;
 
 /**
  * This class provides an interface to PETSc
@@ -124,7 +124,7 @@ public:
   /**
    * Initialize data structures if not done so already plus much more
    */
-  void init (PetscMatrix<T> * matrix,
+  void init (PetscMatrixBase<T> * matrix,
              const char * name = nullptr);
 
   /**
@@ -280,7 +280,7 @@ private:
    */
   virtual std::pair<unsigned int, Real>
   shell_solve_common (const ShellMatrix<T> & shell_matrix,
-                      PetscMatrix<T> * precond_matrix,
+                      PetscMatrixBase<T> * precond_matrix,
                       NumericVector<T> & solution_in,
                       NumericVector<T> & rhs_in,
                       const double rel_tol,
@@ -292,7 +292,7 @@ private:
    */
   std::pair<unsigned int, Real>
   solve_base (SparseMatrix<T> * matrix,
-              PetscMatrix<T> * precond,
+              PetscMatrixBase<T> * precond,
               Mat mat,
               NumericVector<T> & solution_in,
               NumericVector<T> & rhs_in,

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -29,6 +29,7 @@
 #include "libmesh/nonlinear_solver.h"
 #include "libmesh/petsc_macro.h"
 #include "libmesh/wrapped_petsc.h"
+#include "libmesh/petsc_mffd_matrix.h"
 
 // PETSc includes
 #ifdef I
@@ -287,6 +288,9 @@ protected:
     * Whether we've triggered the preconditioner reuse
     */
   bool _setup_reuse;
+
+  /// Wrapper for matrix-free finite-difference Jacobians
+  PetscMFFDMatrix<Number> _mffd_jac;
 
 private:
   friend ResidualContext libmesh_petsc_snes_residual_helper (SNES snes, Vec x, void * ctx);

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -29,7 +29,6 @@
 #include "libmesh/nonlinear_solver.h"
 #include "libmesh/petsc_macro.h"
 #include "libmesh/wrapped_petsc.h"
-#include "libmesh/petsc_mffd_matrix.h"
 
 // PETSc includes
 #ifdef I
@@ -288,9 +287,6 @@ protected:
     * Whether we've triggered the preconditioner reuse
     */
   bool _setup_reuse;
-
-  /// Wrapper for matrix-free finite-difference Jacobians
-  PetscMFFDMatrix<Number> _mffd_jac;
 
 private:
   friend ResidualContext libmesh_petsc_snes_residual_helper (SNES snes, Vec x, void * ctx);

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -69,7 +69,7 @@ DofMap::build_sparsity (const MeshBase & mesh,
   LOG_SCOPE("build_sparsity()", "DofMap");
 
   // Compute the sparsity structure of the global matrix.  This can be
-  // fed into a PetscMatrix to allocate exactly the number of nonzeros
+  // fed into a PetscMatrixBase to allocate exactly the number of nonzeros
   // necessary to store the matrix.  This algorithm should be linear
   // in the (# of elements)*(# nodes per element)
 

--- a/src/base/sparsity_pattern.C
+++ b/src/base/sparsity_pattern.C
@@ -238,7 +238,7 @@ void Build::handle_vi_vj(const std::vector<dof_id_type> & element_dofs_i,
 void Build::operator()(const ConstElemRange & range)
 {
   // Compute the sparsity structure of the global matrix.  This can be
-  // fed into a PetscMatrix to allocate exactly the number of nonzeros
+  // fed into a PetscMatrixBase to allocate exactly the number of nonzeros
   // necessary to store the matrix.  This algorithm should be linear
   // in the (# of elements)*(# nodes per element)
   const processor_id_type proc_id     = dof_map.processor_id();

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -262,6 +262,8 @@ libmesh_SOURCES =  \
         src/numerics/lumped_mass_matrix.C \
         src/numerics/numeric_vector.C \
         src/numerics/petsc_matrix.C \
+        src/numerics/petsc_matrix_base.C \
+        src/numerics/petsc_matrix_shell_matrix.C \
         src/numerics/petsc_preconditioner.C \
         src/numerics/petsc_shell_matrix.C \
         src/numerics/petsc_vector.C \

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -94,7 +94,7 @@ PetscMatrix<T>::PetscMatrix(const Parallel::Communicator & comm_in) :
 // for destroying it
 template <typename T>
 PetscMatrix<T>::PetscMatrix(Mat mat_in,
-                                  const Parallel::Communicator & comm_in) :
+                            const Parallel::Communicator & comm_in) :
   PetscMatrixBase<T>(mat_in, comm_in)
 {
   MatType mat_type;
@@ -117,12 +117,12 @@ PetscMatrix<T>::~PetscMatrix() = default;
 
 template <typename T>
 void PetscMatrix<T>::init (const numeric_index_type m_in,
-                              const numeric_index_type n_in,
-                              const numeric_index_type m_l,
-                              const numeric_index_type n_l,
-                              const numeric_index_type nnz,
-                              const numeric_index_type noz,
-                              const numeric_index_type blocksize_in)
+                           const numeric_index_type n_in,
+                           const numeric_index_type m_l,
+                           const numeric_index_type n_l,
+                           const numeric_index_type nnz,
+                           const numeric_index_type noz,
+                           const numeric_index_type blocksize_in)
 {
   // So compilers don't warn when !LIBMESH_ENABLE_BLOCKED_STORAGE
   libmesh_ignore(blocksize_in);
@@ -234,12 +234,12 @@ void PetscMatrix<T>::init (const numeric_index_type m_in,
 
 template <typename T>
 void PetscMatrix<T>::init (const numeric_index_type m_in,
-                              const numeric_index_type n_in,
-                              const numeric_index_type m_l,
-                              const numeric_index_type n_l,
-                              const std::vector<numeric_index_type> & n_nz,
-                              const std::vector<numeric_index_type> & n_oz,
-                              const numeric_index_type blocksize_in)
+                           const numeric_index_type n_in,
+                           const numeric_index_type m_l,
+                           const numeric_index_type n_l,
+                           const std::vector<numeric_index_type> & n_nz,
+                           const std::vector<numeric_index_type> & n_oz,
+                           const numeric_index_type blocksize_in)
 {
   // So compilers don't warn when !LIBMESH_ENABLE_BLOCKED_STORAGE
   libmesh_ignore(blocksize_in);
@@ -715,8 +715,8 @@ void PetscMatrix<T>::print_personal(std::ostream & os) const
 
 template <typename T>
 void PetscMatrix<T>::_petsc_viewer(const std::string & filename,
-                                      PetscViewerType viewertype,
-                                      PetscFileMode filemode)
+                                   PetscViewerType viewertype,
+                                   PetscFileMode filemode)
 {
   parallel_object_only();
 
@@ -795,8 +795,8 @@ void PetscMatrix<T>::read_petsc_hdf5(const std::string & filename)
 
 template <typename T>
 void PetscMatrix<T>::add_matrix(const DenseMatrix<T> & dm,
-                                   const std::vector<numeric_index_type> & rows,
-                                   const std::vector<numeric_index_type> & cols)
+                                const std::vector<numeric_index_type> & rows,
+                                const std::vector<numeric_index_type> & cols)
 {
   libmesh_assert (this->initialized());
 
@@ -822,8 +822,8 @@ void PetscMatrix<T>::add_matrix(const DenseMatrix<T> & dm,
 
 template <typename T>
 void PetscMatrix<T>::add_block_matrix(const DenseMatrix<T> & dm,
-                                         const std::vector<numeric_index_type> & brows,
-                                         const std::vector<numeric_index_type> & bcols)
+                                      const std::vector<numeric_index_type> & brows,
+                                      const std::vector<numeric_index_type> & bcols)
 {
   libmesh_assert (this->initialized());
 
@@ -866,9 +866,9 @@ void PetscMatrix<T>::add_block_matrix(const DenseMatrix<T> & dm,
 
 template <typename T>
 void PetscMatrix<T>::_get_submatrix(SparseMatrix<T> & submatrix,
-                                       const std::vector<numeric_index_type> & rows,
-                                       const std::vector<numeric_index_type> & cols,
-                                       const bool reuse_submatrix) const
+                                    const std::vector<numeric_index_type> & rows,
+                                    const std::vector<numeric_index_type> & cols,
+                                    const bool reuse_submatrix) const
 {
   if (!this->closed())
     {
@@ -917,8 +917,8 @@ void PetscMatrix<T>::_get_submatrix(SparseMatrix<T> & submatrix,
 
 template <typename T>
 void PetscMatrix<T>::create_submatrix_nosort(SparseMatrix<T> & submatrix,
-                                                const std::vector<numeric_index_type> & rows,
-                                                const std::vector<numeric_index_type> & cols) const
+                                             const std::vector<numeric_index_type> & rows,
+                                             const std::vector<numeric_index_type> & cols) const
 {
   if (!this->closed())
     {
@@ -1045,8 +1045,8 @@ void PetscMatrix<T>::flush ()
 
 template <typename T>
 void PetscMatrix<T>::set (const numeric_index_type i,
-                             const numeric_index_type j,
-                             const T value)
+                          const numeric_index_type j,
+                          const T value)
 {
   libmesh_assert (this->initialized());
 
@@ -1063,8 +1063,8 @@ void PetscMatrix<T>::set (const numeric_index_type i,
 
 template <typename T>
 void PetscMatrix<T>::add (const numeric_index_type i,
-                             const numeric_index_type j,
-                             const T value)
+                          const numeric_index_type j,
+                          const T value)
 {
   libmesh_assert (this->initialized());
 
@@ -1081,7 +1081,7 @@ void PetscMatrix<T>::add (const numeric_index_type i,
 
 template <typename T>
 void PetscMatrix<T>::add_matrix(const DenseMatrix<T> & dm,
-                                   const std::vector<numeric_index_type> & dof_indices)
+                                const std::vector<numeric_index_type> & dof_indices)
 {
   this->add_matrix (dm, dof_indices, dof_indices);
 }
@@ -1157,9 +1157,9 @@ void PetscMatrix<T>::matrix_matrix_mult (SparseMatrix<T> & X_in, SparseMatrix<T>
 template <typename T>
 void
 PetscMatrix<T>::add_sparse_matrix (const SparseMatrix<T> & spm,
-                                      const std::map<numeric_index_type, numeric_index_type> & row_ltog,
-                                      const std::map<numeric_index_type, numeric_index_type> & col_ltog,
-                                      const T scalar)
+                                   const std::map<numeric_index_type, numeric_index_type> & row_ltog,
+                                   const std::map<numeric_index_type, numeric_index_type> & col_ltog,
+                                   const T scalar)
 {
   // size of spm is usually greater than row_ltog and col_ltog in parallel as the indices are owned by the processor
   // also, we should allow adding certain parts of spm to _mat
@@ -1212,7 +1212,7 @@ PetscMatrix<T>::add_sparse_matrix (const SparseMatrix<T> & spm,
 
 template <typename T>
 T PetscMatrix<T>::operator () (const numeric_index_type i_in,
-                                  const numeric_index_type j_in) const
+                               const numeric_index_type j_in) const
 {
   libmesh_assert (this->initialized());
 
@@ -1269,8 +1269,8 @@ T PetscMatrix<T>::operator () (const numeric_index_type i_in,
 
 template <typename T>
 void PetscMatrix<T>::get_row (numeric_index_type i_in,
-                                 std::vector<numeric_index_type> & indices,
-                                 std::vector<T> & values) const
+                              std::vector<numeric_index_type> & indices,
+                              std::vector<T> & values) const
 {
   libmesh_assert (this->initialized());
 

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -84,11 +84,9 @@ namespace libMesh
 // Constructor
 template <typename T>
 PetscMatrix<T>::PetscMatrix(const Parallel::Communicator & comm_in) :
-  SparseMatrix<T>(comm_in),
-  _mat(nullptr),
-  _destroy_mat_on_exit(true),
-  _mat_type(AIJ)
-{}
+  PetscMatrixBase<T>(comm_in), _mat_type(AIJ)
+{
+}
 
 
 
@@ -96,38 +94,35 @@ PetscMatrix<T>::PetscMatrix(const Parallel::Communicator & comm_in) :
 // for destroying it
 template <typename T>
 PetscMatrix<T>::PetscMatrix(Mat mat_in,
-                            const Parallel::Communicator & comm_in) :
-  SparseMatrix<T>(comm_in),
-  _destroy_mat_on_exit(false),
-  _mat_type(AIJ)
+                                  const Parallel::Communicator & comm_in) :
+  PetscMatrixBase<T>(mat_in, comm_in)
 {
-  this->_mat = mat_in;
-  this->_is_initialized = true;
+  MatType mat_type;
+  LibmeshPetscCall(MatGetType(mat_in, &mat_type));
+  PetscBool is_hypre;
+  LibmeshPetscCall(PetscStrcmp(mat_type, MATHYPRE, &is_hypre));
+  if (is_hypre == PETSC_TRUE)
+    _mat_type = HYPRE;
+  else
+    _mat_type = AIJ;
 }
 
 
 
 // Destructor
 template <typename T>
-PetscMatrix<T>::~PetscMatrix()
-{
-  this->clear();
-}
+PetscMatrix<T>::~PetscMatrix() = default;
 
-template <typename T>
-void PetscMatrix<T>::set_matrix_type(PetscMatrixType mat_type)
-{
-  _mat_type = mat_type;
-}
+
 
 template <typename T>
 void PetscMatrix<T>::init (const numeric_index_type m_in,
-                           const numeric_index_type n_in,
-                           const numeric_index_type m_l,
-                           const numeric_index_type n_l,
-                           const numeric_index_type nnz,
-                           const numeric_index_type noz,
-                           const numeric_index_type blocksize_in)
+                              const numeric_index_type n_in,
+                              const numeric_index_type m_l,
+                              const numeric_index_type n_l,
+                              const numeric_index_type nnz,
+                              const numeric_index_type noz,
+                              const numeric_index_type blocksize_in)
 {
   // So compilers don't warn when !LIBMESH_ENABLE_BLOCKED_STORAGE
   libmesh_ignore(blocksize_in);
@@ -147,12 +142,12 @@ void PetscMatrix<T>::init (const numeric_index_type m_in,
   PetscInt n_nz       = static_cast<PetscInt>(nnz);
   PetscInt n_oz       = static_cast<PetscInt>(noz);
 
-  ierr = MatCreate(this->comm().get(), &_mat);
+  ierr = MatCreate(this->comm().get(), &this->_mat);
   LIBMESH_CHKERR(ierr);
-  ierr = MatSetSizes(_mat, m_local, n_local, m_global, n_global);
+  ierr = MatSetSizes(this->_mat, m_local, n_local, m_global, n_global);
   LIBMESH_CHKERR(ierr);
   PetscInt blocksize  = static_cast<PetscInt>(blocksize_in);
-  ierr = MatSetBlockSize(_mat,blocksize);
+  ierr = MatSetBlockSize(this->_mat,blocksize);
   LIBMESH_CHKERR(ierr);
 
 #ifdef LIBMESH_ENABLE_BLOCKED_STORAGE
@@ -167,19 +162,19 @@ void PetscMatrix<T>::init (const numeric_index_type m_in,
       libmesh_assert_equal_to (n_nz     % blocksize, 0);
       libmesh_assert_equal_to (n_oz     % blocksize, 0);
 
-      ierr = MatSetType(_mat, MATBAIJ); // Automatically chooses seqbaij or mpibaij
+      ierr = MatSetType(this->_mat, MATBAIJ); // Automatically chooses seqbaij or mpibaij
       LIBMESH_CHKERR(ierr);
 
       // MatSetFromOptions needs to happen before Preallocation routines
       // since MatSetFromOptions can change matrix type and remove incompatible
       // preallocation
-      ierr = MatSetOptionsPrefix(_mat, "");
+      ierr = MatSetOptionsPrefix(this->_mat, "");
       LIBMESH_CHKERR(ierr);
-      ierr = MatSetFromOptions(_mat);
+      ierr = MatSetFromOptions(this->_mat);
       LIBMESH_CHKERR(ierr);
-      ierr = MatSeqBAIJSetPreallocation(_mat, blocksize, n_nz/blocksize, NULL);
+      ierr = MatSeqBAIJSetPreallocation(this->_mat, blocksize, n_nz/blocksize, NULL);
       LIBMESH_CHKERR(ierr);
-      ierr = MatMPIBAIJSetPreallocation(_mat, blocksize,
+      ierr = MatMPIBAIJSetPreallocation(this->_mat, blocksize,
                                         n_nz/blocksize, NULL,
                                         n_oz/blocksize, NULL);
       LIBMESH_CHKERR(ierr);
@@ -187,37 +182,37 @@ void PetscMatrix<T>::init (const numeric_index_type m_in,
   else
 #endif
     {
-      switch (_mat_type) {
+      switch (this->_mat_type) {
         case AIJ:
-          ierr = MatSetType(_mat, MATAIJ); // Automatically chooses seqaij or mpiaij
+          ierr = MatSetType(this->_mat, MATAIJ); // Automatically chooses seqaij or mpiaij
           LIBMESH_CHKERR(ierr);
 
           // MatSetFromOptions needs to happen before Preallocation routines
           // since MatSetFromOptions can change matrix type and remove incompatible
           // preallocation
-          ierr = MatSetOptionsPrefix(_mat, "");
+          ierr = MatSetOptionsPrefix(this->_mat, "");
           LIBMESH_CHKERR(ierr);
-          ierr = MatSetFromOptions(_mat);
+          ierr = MatSetFromOptions(this->_mat);
           LIBMESH_CHKERR(ierr);
-          ierr = MatSeqAIJSetPreallocation(_mat, n_nz, NULL);
+          ierr = MatSeqAIJSetPreallocation(this->_mat, n_nz, NULL);
           LIBMESH_CHKERR(ierr);
-          ierr = MatMPIAIJSetPreallocation(_mat, n_nz, NULL, n_oz, NULL);
+          ierr = MatMPIAIJSetPreallocation(this->_mat, n_nz, NULL, n_oz, NULL);
           LIBMESH_CHKERR(ierr);
           break;
 
         case HYPRE:
 #if !PETSC_VERSION_LESS_THAN(3,9,4) && LIBMESH_HAVE_PETSC_HYPRE
-          ierr = MatSetType(_mat, MATHYPRE);
+          ierr = MatSetType(this->_mat, MATHYPRE);
 
           // MatSetFromOptions needs to happen before Preallocation routines
           // since MatSetFromOptions can change matrix type and remove incompatible
           // preallocation
           LIBMESH_CHKERR(ierr);
-          ierr = MatSetOptionsPrefix(_mat, "");
+          ierr = MatSetOptionsPrefix(this->_mat, "");
           LIBMESH_CHKERR(ierr);
-          ierr = MatSetFromOptions(_mat);
+          ierr = MatSetFromOptions(this->_mat);
           LIBMESH_CHKERR(ierr);
-          ierr = MatHYPRESetPreallocation(_mat, n_nz, NULL, n_oz, NULL);
+          ierr = MatHYPRESetPreallocation(this->_mat, n_nz, NULL, n_oz, NULL);
           LIBMESH_CHKERR(ierr);
 #else
           libmesh_error_msg("PETSc 3.9.4 or higher with hypre is required for MatHypre");
@@ -229,21 +224,22 @@ void PetscMatrix<T>::init (const numeric_index_type m_in,
     }
 
   // Make it an error for PETSc to allocate new nonzero entries during assembly
-  ierr = MatSetOption(_mat, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
+  ierr = MatSetOption(this->_mat, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
   LIBMESH_CHKERR(ierr);
 
+  this->set_context ();
   this->zero ();
 }
 
 
 template <typename T>
 void PetscMatrix<T>::init (const numeric_index_type m_in,
-                           const numeric_index_type n_in,
-                           const numeric_index_type m_l,
-                           const numeric_index_type n_l,
-                           const std::vector<numeric_index_type> & n_nz,
-                           const std::vector<numeric_index_type> & n_oz,
-                           const numeric_index_type blocksize_in)
+                              const numeric_index_type n_in,
+                              const numeric_index_type m_l,
+                              const numeric_index_type n_l,
+                              const std::vector<numeric_index_type> & n_nz,
+                              const std::vector<numeric_index_type> & n_oz,
+                              const numeric_index_type blocksize_in)
 {
   // So compilers don't warn when !LIBMESH_ENABLE_BLOCKED_STORAGE
   libmesh_ignore(blocksize_in);
@@ -266,11 +262,11 @@ void PetscMatrix<T>::init (const numeric_index_type m_in,
   PetscInt m_local    = static_cast<PetscInt>(m_l);
   PetscInt n_local    = static_cast<PetscInt>(n_l);
 
-  ierr = MatCreate(this->comm().get(), &_mat);
+  ierr = MatCreate(this->comm().get(), &this->_mat);
   LIBMESH_CHKERR(ierr);
-  ierr = MatSetSizes(_mat, m_local, n_local, m_global, n_global);
+  ierr = MatSetSizes(this->_mat, m_local, n_local, m_global, n_global);
   LIBMESH_CHKERR(ierr);
-  ierr = MatSetBlockSize(_mat,blocksize);
+  ierr = MatSetBlockSize(this->_mat,blocksize);
   LIBMESH_CHKERR(ierr);
 
 #ifdef LIBMESH_ENABLE_BLOCKED_STORAGE
@@ -283,16 +279,16 @@ void PetscMatrix<T>::init (const numeric_index_type m_in,
       libmesh_assert_equal_to (m_global % blocksize, 0);
       libmesh_assert_equal_to (n_global % blocksize, 0);
 
-      ierr = MatSetType(_mat, MATBAIJ); // Automatically chooses seqbaij or mpibaij
+      ierr = MatSetType(this->_mat, MATBAIJ); // Automatically chooses seqbaij or mpibaij
       LIBMESH_CHKERR(ierr);
 
       // MatSetFromOptions needs to happen before Preallocation routines
       // since MatSetFromOptions can change matrix type and remove incompatible
       // preallocation
       LIBMESH_CHKERR(ierr);
-      ierr = MatSetOptionsPrefix(_mat, "");
+      ierr = MatSetOptionsPrefix(this->_mat, "");
       LIBMESH_CHKERR(ierr);
-      ierr = MatSetFromOptions(_mat);
+      ierr = MatSetFromOptions(this->_mat);
       LIBMESH_CHKERR(ierr);
       // transform the per-entry n_nz and n_oz arrays into their block counterparts.
       std::vector<numeric_index_type> b_n_nz, b_n_oz;
@@ -301,13 +297,13 @@ void PetscMatrix<T>::init (const numeric_index_type m_in,
                                       n_nz, n_oz,
                                       b_n_nz, b_n_oz);
 
-      ierr = MatSeqBAIJSetPreallocation (_mat,
+      ierr = MatSeqBAIJSetPreallocation (this->_mat,
                                          blocksize,
                                          0,
                                          numeric_petsc_cast(b_n_nz.empty() ? nullptr : b_n_nz.data()));
       LIBMESH_CHKERR(ierr);
 
-      ierr = MatMPIBAIJSetPreallocation (_mat,
+      ierr = MatMPIBAIJSetPreallocation (this->_mat,
                                          blocksize,
                                          0,
                                          numeric_petsc_cast(b_n_nz.empty() ? nullptr : b_n_nz.data()),
@@ -318,24 +314,24 @@ void PetscMatrix<T>::init (const numeric_index_type m_in,
   else
 #endif
     {
-      switch (_mat_type) {
+      switch (this->_mat_type) {
         case AIJ:
-          ierr = MatSetType(_mat, MATAIJ); // Automatically chooses seqaij or mpiaij
+          ierr = MatSetType(this->_mat, MATAIJ); // Automatically chooses seqaij or mpiaij
           LIBMESH_CHKERR(ierr);
 
           // MatSetFromOptions needs to happen before Preallocation routines
           // since MatSetFromOptions can change matrix type and remove incompatible
           // preallocation
           LIBMESH_CHKERR(ierr);
-          ierr = MatSetOptionsPrefix(_mat, "");
+          ierr = MatSetOptionsPrefix(this->_mat, "");
           LIBMESH_CHKERR(ierr);
-          ierr = MatSetFromOptions(_mat);
+          ierr = MatSetFromOptions(this->_mat);
           LIBMESH_CHKERR(ierr);
-          ierr = MatSeqAIJSetPreallocation (_mat,
+          ierr = MatSeqAIJSetPreallocation (this->_mat,
                                             0,
                                             numeric_petsc_cast(n_nz.empty() ? nullptr : n_nz.data()));
           LIBMESH_CHKERR(ierr);
-          ierr = MatMPIAIJSetPreallocation (_mat,
+          ierr = MatMPIAIJSetPreallocation (this->_mat,
                                             0,
                                             numeric_petsc_cast(n_nz.empty() ? nullptr : n_nz.data()),
                                             0,
@@ -344,18 +340,18 @@ void PetscMatrix<T>::init (const numeric_index_type m_in,
 
         case HYPRE:
 #if !PETSC_VERSION_LESS_THAN(3,9,4) && LIBMESH_HAVE_PETSC_HYPRE
-          ierr = MatSetType(_mat, MATHYPRE);
+          ierr = MatSetType(this->_mat, MATHYPRE);
           LIBMESH_CHKERR(ierr);
 
           // MatSetFromOptions needs to happen before Preallocation routines
           // since MatSetFromOptions can change matrix type and remove incompatible
           // preallocation
           LIBMESH_CHKERR(ierr);
-          ierr = MatSetOptionsPrefix(_mat, "");
+          ierr = MatSetOptionsPrefix(this->_mat, "");
           LIBMESH_CHKERR(ierr);
-          ierr = MatSetFromOptions(_mat);
+          ierr = MatSetFromOptions(this->_mat);
           LIBMESH_CHKERR(ierr);
-          ierr = MatHYPRESetPreallocation (_mat,
+          ierr = MatHYPRESetPreallocation (this->_mat,
                                            0,
                                            numeric_petsc_cast(n_nz.empty() ? nullptr : n_nz.data()),
                                            0,
@@ -372,8 +368,9 @@ void PetscMatrix<T>::init (const numeric_index_type m_in,
     }
 
   // Make it an error for PETSc to allocate new nonzero entries during assembly
-  ierr = MatSetOption(_mat, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
+  ierr = MatSetOption(this->_mat, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
   LIBMESH_CHKERR(ierr);
+  this->set_context();
   this->zero();
 }
 
@@ -407,7 +404,7 @@ void PetscMatrix<T>::reset_preallocation()
 #if !PETSC_VERSION_LESS_THAN(3,9,0)
   libmesh_assert (this->initialized());
 
-  auto ierr = MatResetPreallocation(_mat);
+  auto ierr = MatResetPreallocation(this->_mat);
   LIBMESH_CHKERR(ierr);
 #else
   libmesh_warning("Your version of PETSc doesn't support resetting of "
@@ -427,12 +424,12 @@ void PetscMatrix<T>::zero ()
 
   PetscInt m_l, n_l;
 
-  ierr = MatGetLocalSize(_mat,&m_l,&n_l);
+  ierr = MatGetLocalSize(this->_mat,&m_l,&n_l);
   LIBMESH_CHKERR(ierr);
 
   if (n_l)
     {
-      ierr = MatZeroEntries(_mat);
+      ierr = MatZeroEntries(this->_mat);
       LIBMESH_CHKERR(ierr);
     }
 }
@@ -451,11 +448,11 @@ void PetscMatrix<T>::zero_rows (std::vector<numeric_index_type> & rows, T diag_v
   // solutions for the zeroed rows (x) and right hand side (b) to update.
   // Could be useful for setting boundary conditions...
   if (!rows.empty())
-    ierr = MatZeroRows(_mat, cast_int<PetscInt>(rows.size()),
+    ierr = MatZeroRows(this->_mat, cast_int<PetscInt>(rows.size()),
                        numeric_petsc_cast(rows.data()), PS(diag_value),
                        NULL, NULL);
   else
-    ierr = MatZeroRows(_mat, 0, NULL, PS(diag_value), NULL, NULL);
+    ierr = MatZeroRows(this->_mat, 0, NULL, PS(diag_value), NULL, NULL);
 
   LIBMESH_CHKERR(ierr);
 }
@@ -467,7 +464,7 @@ std::unique_ptr<SparseMatrix<T>> PetscMatrix<T>::zero_clone () const
 
   // Copy the nonzero pattern only
   Mat copy;
-  PetscErrorCode ierr = MatDuplicate(_mat, MAT_DO_NOT_COPY_VALUES, &copy);
+  PetscErrorCode ierr = MatDuplicate(this->_mat, MAT_DO_NOT_COPY_VALUES, &copy);
   LIBMESH_CHKERR(ierr);
 
   // Call wrapping PetscMatrix constructor, have it take over
@@ -487,7 +484,7 @@ std::unique_ptr<SparseMatrix<T>> PetscMatrix<T>::clone () const
 
   // Copy the nonzero pattern and numerical values
   Mat copy;
-  PetscErrorCode ierr = MatDuplicate(_mat, MAT_COPY_VALUES, &copy);
+  PetscErrorCode ierr = MatDuplicate(this->_mat, MAT_COPY_VALUES, &copy);
   LIBMESH_CHKERR(ierr);
 
   // Call wrapping PetscMatrix constructor, have it take over
@@ -496,23 +493,6 @@ std::unique_ptr<SparseMatrix<T>> PetscMatrix<T>::clone () const
   ret->set_destroy_mat_on_exit(true);
 
   return ret;
-}
-
-template <typename T>
-void PetscMatrix<T>::clear () noexcept
-{
-  if ((this->initialized()) && (this->_destroy_mat_on_exit))
-    {
-      exceptionless_semiparallel_only();
-
-      // If we encounter an error here, print a warning but otherwise
-      // keep going since we may be recovering from an exception.
-      PetscErrorCode ierr = MatDestroy (&_mat);
-      if (ierr)
-        libmesh_warning("Warning: MatDestroy returned a non-zero error code which we ignored.");
-
-      this->_is_initialized = false;
-    }
 }
 
 
@@ -530,7 +510,7 @@ Real PetscMatrix<T>::l1_norm () const
 
   libmesh_assert (this->closed());
 
-  ierr = MatNorm(_mat, NORM_1, &petsc_value);
+  ierr = MatNorm(this->_mat, NORM_1, &petsc_value);
   LIBMESH_CHKERR(ierr);
 
   value = static_cast<Real>(petsc_value);
@@ -553,7 +533,7 @@ Real PetscMatrix<T>::linfty_norm () const
 
   libmesh_assert (this->closed());
 
-  ierr = MatNorm(_mat, NORM_INFINITY, &petsc_value);
+  ierr = MatNorm(this->_mat, NORM_INFINITY, &petsc_value);
   LIBMESH_CHKERR(ierr);
 
   value = static_cast<Real>(petsc_value);
@@ -604,7 +584,7 @@ void PetscMatrix<T>::print_matlab (const std::string & name) const
 
       LIBMESH_CHKERR(ierr);
 
-      ierr = MatView (_mat, petsc_viewer);
+      ierr = MatView (this->_mat, petsc_viewer);
       LIBMESH_CHKERR(ierr);
     }
 
@@ -621,7 +601,7 @@ void PetscMatrix<T>::print_matlab (const std::string & name) const
 
       LIBMESH_CHKERR(ierr);
 
-      ierr = MatView (_mat, PETSC_VIEWER_STDOUT_WORLD);
+      ierr = MatView (this->_mat, PETSC_VIEWER_STDOUT_WORLD);
       LIBMESH_CHKERR(ierr);
     }
 }
@@ -658,7 +638,7 @@ void PetscMatrix<T>::print_personal(std::ostream & os) const
   // Print to screen if ostream is stdout
   if (os.rdbuf() == std::cout.rdbuf())
     {
-      ierr = MatView(_mat, NULL);
+      ierr = MatView(this->_mat, NULL);
       LIBMESH_CHKERR(ierr);
     }
 
@@ -713,7 +693,7 @@ void PetscMatrix<T>::print_personal(std::ostream & os) const
       //      LIBMESH_CHKERR(ierr);
 
       // Finally print the matrix using the viewer
-      ierr = MatView (_mat, petsc_viewer);
+      ierr = MatView (this->_mat, petsc_viewer);
       LIBMESH_CHKERR(ierr);
 
       if (this->processor_id() == 0)
@@ -735,8 +715,8 @@ void PetscMatrix<T>::print_personal(std::ostream & os) const
 
 template <typename T>
 void PetscMatrix<T>::_petsc_viewer(const std::string & filename,
-                                   PetscViewerType viewertype,
-                                   PetscFileMode filemode)
+                                      PetscViewerType viewertype,
+                                      PetscFileMode filemode)
 {
   parallel_object_only();
 
@@ -746,7 +726,7 @@ void PetscMatrix<T>::_petsc_viewer(const std::string & filename,
   // have a Mat object
   if (!this->initialized())
     {
-      ierr = MatCreate(this->comm().get(), &_mat);
+      ierr = MatCreate(this->comm().get(), &this->_mat);
       LIBMESH_CHKERR(ierr);
       this->_is_initialized = true;
     }
@@ -763,9 +743,9 @@ void PetscMatrix<T>::_petsc_viewer(const std::string & filename,
   ierr = PetscViewerFileSetName(viewer, filename.c_str());
   LIBMESH_CHKERR(ierr);
   if (filemode == FILE_MODE_READ)
-    ierr = MatLoad(_mat, viewer);
+    ierr = MatLoad(this->_mat, viewer);
   else
-    ierr = MatView(_mat, viewer);
+    ierr = MatView(this->_mat, viewer);
   LIBMESH_CHKERR(ierr);
   ierr = PetscViewerDestroy(&viewer);
   LIBMESH_CHKERR(ierr);
@@ -815,8 +795,8 @@ void PetscMatrix<T>::read_petsc_hdf5(const std::string & filename)
 
 template <typename T>
 void PetscMatrix<T>::add_matrix(const DenseMatrix<T> & dm,
-                                const std::vector<numeric_index_type> & rows,
-                                const std::vector<numeric_index_type> & cols)
+                                   const std::vector<numeric_index_type> & rows,
+                                   const std::vector<numeric_index_type> & cols)
 {
   libmesh_assert (this->initialized());
 
@@ -827,7 +807,7 @@ void PetscMatrix<T>::add_matrix(const DenseMatrix<T> & dm,
   libmesh_assert_equal_to (cols.size(), n_cols);
 
   PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
-  ierr = MatSetValues(_mat,
+  ierr = MatSetValues(this->_mat,
                       n_rows, numeric_petsc_cast(rows.data()),
                       n_cols, numeric_petsc_cast(cols.data()),
                       pPS(const_cast<T*>(dm.get_values().data())),
@@ -842,8 +822,8 @@ void PetscMatrix<T>::add_matrix(const DenseMatrix<T> & dm,
 
 template <typename T>
 void PetscMatrix<T>::add_block_matrix(const DenseMatrix<T> & dm,
-                                      const std::vector<numeric_index_type> & brows,
-                                      const std::vector<numeric_index_type> & bcols)
+                                         const std::vector<numeric_index_type> & brows,
+                                         const std::vector<numeric_index_type> & bcols)
 {
   libmesh_assert (this->initialized());
 
@@ -866,13 +846,13 @@ void PetscMatrix<T>::add_block_matrix(const DenseMatrix<T> & dm,
   libmesh_assert_equal_to (blocksize*n_bcols, n_cols);
 
   PetscInt petsc_blocksize;
-  ierr = MatGetBlockSize(_mat, &petsc_blocksize);
+  ierr = MatGetBlockSize(this->_mat, &petsc_blocksize);
   LIBMESH_CHKERR(ierr);
   libmesh_assert_equal_to (blocksize, static_cast<numeric_index_type>(petsc_blocksize));
 #endif
 
   // These casts are required for PETSc <= 2.1.5
-  ierr = MatSetValuesBlocked(_mat,
+  ierr = MatSetValuesBlocked(this->_mat,
                              n_brows, numeric_petsc_cast(brows.data()),
                              n_bcols, numeric_petsc_cast(bcols.data()),
                              pPS(const_cast<T*>(dm.get_values().data())),
@@ -886,9 +866,9 @@ void PetscMatrix<T>::add_block_matrix(const DenseMatrix<T> & dm,
 
 template <typename T>
 void PetscMatrix<T>::_get_submatrix(SparseMatrix<T> & submatrix,
-                                    const std::vector<numeric_index_type> & rows,
-                                    const std::vector<numeric_index_type> & cols,
-                                    const bool reuse_submatrix) const
+                                       const std::vector<numeric_index_type> & rows,
+                                       const std::vector<numeric_index_type> & cols,
+                                       const bool reuse_submatrix) const
 {
   if (!this->closed())
     {
@@ -924,11 +904,11 @@ void PetscMatrix<T>::_get_submatrix(SparseMatrix<T> & submatrix,
                          iscol.get()); LIBMESH_CHKERR(ierr);
 
   // Extract submatrix
-  ierr = LibMeshCreateSubMatrix(_mat,
+  ierr = LibMeshCreateSubMatrix(this->_mat,
                                 isrow,
                                 iscol,
                                 (reuse_submatrix ? MAT_REUSE_MATRIX : MAT_INITIAL_MATRIX),
-                                &(petsc_submatrix->_mat));  LIBMESH_CHKERR(ierr);
+                                (&petsc_submatrix->_mat));  LIBMESH_CHKERR(ierr);
 
   // Specify that the new submatrix is initialized and close it.
   petsc_submatrix->_is_initialized = true;
@@ -937,8 +917,8 @@ void PetscMatrix<T>::_get_submatrix(SparseMatrix<T> & submatrix,
 
 template <typename T>
 void PetscMatrix<T>::create_submatrix_nosort(SparseMatrix<T> & submatrix,
-                                             const std::vector<numeric_index_type> & rows,
-                                             const std::vector<numeric_index_type> & cols) const
+                                                const std::vector<numeric_index_type> & rows,
+                                                const std::vector<numeric_index_type> & cols) const
 {
   if (!this->closed())
     {
@@ -972,7 +952,7 @@ void PetscMatrix<T>::create_submatrix_nosort(SparseMatrix<T> & submatrix,
     if (rows[i]>= this->row_start() && rows[i]< this->row_stop())
     {
       // get one row of data from the original matrix
-      ierr = MatGetRow(_mat, rid, &pc_ncols, &pc_cols, &pc_vals);
+      ierr = MatGetRow(this->_mat, rid, &pc_ncols, &pc_cols, &pc_vals);
       LIBMESH_CHKERR(ierr);
       // extract data from certain cols, save the indices and entries sub_cols and sub_vals
       for (auto j : index_range(cols))
@@ -995,7 +975,7 @@ void PetscMatrix<T>::create_submatrix_nosort(SparseMatrix<T> & submatrix,
                           sub_vals.data(),
                           INSERT_VALUES);
       LIBMESH_CHKERR(ierr);
-      ierr = MatRestoreRow(_mat, rid, &pc_ncols, &pc_cols, &pc_vals);
+      ierr = MatRestoreRow(this->_mat, rid, &pc_ncols, &pc_cols, &pc_vals);
       LIBMESH_CHKERR(ierr);
       // clear data for this row
       sub_cols.clear();
@@ -1038,12 +1018,12 @@ void PetscMatrix<T>::get_transpose (SparseMatrix<T> & dest) const
     // The MAT_REUSE_MATRIX flag was replaced by MAT_INPLACE_MATRIX
     // in PETSc 3.7.0
 #if PETSC_VERSION_LESS_THAN(3,7,0)
-    ierr = MatTranspose(_mat,MAT_REUSE_MATRIX,&petsc_dest._mat);
+    ierr = MatTranspose(this->_mat,MAT_REUSE_MATRIX, &petsc_dest._mat);
 #else
-    ierr = MatTranspose(_mat, MAT_INPLACE_MATRIX, &petsc_dest._mat);
+    ierr = MatTranspose(this->_mat, MAT_INPLACE_MATRIX, &petsc_dest._mat);
 #endif
   else
-    ierr = MatTranspose(_mat,MAT_INITIAL_MATRIX,&petsc_dest._mat);
+    ierr = MatTranspose(this->_mat,MAT_INITIAL_MATRIX, &petsc_dest._mat);
   LIBMESH_CHKERR(ierr);
 
   // Specify that the transposed matrix is initialized and close it.
@@ -1053,172 +1033,20 @@ void PetscMatrix<T>::get_transpose (SparseMatrix<T> & dest) const
 
 
 
-
-
-template <typename T>
-void PetscMatrix<T>::close ()
-{
-  semiparallel_only();
-
-  // BSK - 1/19/2004
-  // strictly this check should be OK, but it seems to
-  // fail on matrix-free matrices.  Do they falsely
-  // state they are assembled?  Check with the developers...
-  //   if (this->closed())
-  //     return;
-
-  MatAssemblyBeginEnd(this->comm(), _mat, MAT_FINAL_ASSEMBLY);
-}
-
 template <typename T>
 void PetscMatrix<T>::flush ()
 {
   semiparallel_only();
 
-  MatAssemblyBeginEnd(this->comm(), _mat, MAT_FLUSH_ASSEMBLY);
-}
-
-
-
-template <typename T>
-numeric_index_type PetscMatrix<T>::m () const
-{
-  libmesh_assert (this->initialized());
-
-  PetscInt petsc_m=0, petsc_n=0;
-  PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
-
-  ierr = MatGetSize (_mat, &petsc_m, &petsc_n);
-  LIBMESH_CHKERR(ierr);
-
-  return static_cast<numeric_index_type>(petsc_m);
-}
-
-template <typename T>
-numeric_index_type PetscMatrix<T>::local_m () const
-{
-  libmesh_assert (this->initialized());
-
-  PetscInt m = 0;
-
-  auto ierr = MatGetLocalSize (_mat, &m, NULL);
-  LIBMESH_CHKERR(ierr);
-
-  return static_cast<numeric_index_type>(m);
-}
-
-template <typename T>
-numeric_index_type PetscMatrix<T>::n () const
-{
-  libmesh_assert (this->initialized());
-
-  PetscInt petsc_m=0, petsc_n=0;
-  PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
-
-  ierr = MatGetSize (_mat, &petsc_m, &petsc_n);
-  LIBMESH_CHKERR(ierr);
-
-  return static_cast<numeric_index_type>(petsc_n);
-}
-
-template <typename T>
-numeric_index_type PetscMatrix<T>::local_n () const
-{
-  libmesh_assert (this->initialized());
-
-  PetscInt n = 0;
-
-  auto ierr = MatGetLocalSize (_mat, NULL, &n);
-  LIBMESH_CHKERR(ierr);
-
-  return static_cast<numeric_index_type>(n);
-}
-
-template <typename T>
-void PetscMatrix<T>::get_local_size (numeric_index_type & m,
-                                     numeric_index_type & n) const
-{
-  libmesh_assert (this->initialized());
-
-  PetscInt petsc_m = 0, petsc_n = 0;
-
-  auto ierr = MatGetLocalSize (_mat, &petsc_m, &petsc_n);
-  LIBMESH_CHKERR(ierr);
-
-  m = static_cast<numeric_index_type>(petsc_m);
-  n = static_cast<numeric_index_type>(petsc_n);
-}
-
-
-
-template <typename T>
-numeric_index_type PetscMatrix<T>::row_start () const
-{
-  libmesh_assert (this->initialized());
-
-  PetscInt start=0, stop=0;
-  PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
-
-  ierr = MatGetOwnershipRange(_mat, &start, &stop);
-  LIBMESH_CHKERR(ierr);
-
-  return static_cast<numeric_index_type>(start);
-}
-
-
-
-template <typename T>
-numeric_index_type PetscMatrix<T>::row_stop () const
-{
-  libmesh_assert (this->initialized());
-
-  PetscInt start=0, stop=0;
-  PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
-
-  ierr = MatGetOwnershipRange(_mat, &start, &stop);
-  LIBMESH_CHKERR(ierr);
-
-  return static_cast<numeric_index_type>(stop);
-}
-
-
-
-template <typename T>
-numeric_index_type PetscMatrix<T>::col_start () const
-{
-  libmesh_assert (this->initialized());
-
-  PetscInt start=0, stop=0;
-  PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
-
-  ierr = MatGetOwnershipRangeColumn(_mat, &start, &stop);
-  LIBMESH_CHKERR(ierr);
-
-  return static_cast<numeric_index_type>(start);
-}
-
-
-
-template <typename T>
-numeric_index_type PetscMatrix<T>::col_stop () const
-{
-  libmesh_assert (this->initialized());
-
-  PetscInt start=0, stop=0;
-  PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
-
-  ierr = MatGetOwnershipRangeColumn(_mat, &start, &stop);
-  LIBMESH_CHKERR(ierr);
-
-  return static_cast<numeric_index_type>(stop);
+  MatAssemblyBeginEnd(this->comm(), this->_mat, MAT_FLUSH_ASSEMBLY);
 }
 
 
 
 template <typename T>
 void PetscMatrix<T>::set (const numeric_index_type i,
-                          const numeric_index_type j,
-                          const T value)
+                             const numeric_index_type j,
+                             const T value)
 {
   libmesh_assert (this->initialized());
 
@@ -1226,7 +1054,7 @@ void PetscMatrix<T>::set (const numeric_index_type i,
   PetscInt i_val=i, j_val=j;
 
   PetscScalar petsc_value = static_cast<PetscScalar>(value);
-  ierr = MatSetValues(_mat, 1, &i_val, 1, &j_val,
+  ierr = MatSetValues(this->_mat, 1, &i_val, 1, &j_val,
                       &petsc_value, INSERT_VALUES);
   LIBMESH_CHKERR(ierr);
 }
@@ -1235,8 +1063,8 @@ void PetscMatrix<T>::set (const numeric_index_type i,
 
 template <typename T>
 void PetscMatrix<T>::add (const numeric_index_type i,
-                          const numeric_index_type j,
-                          const T value)
+                             const numeric_index_type j,
+                             const T value)
 {
   libmesh_assert (this->initialized());
 
@@ -1244,7 +1072,7 @@ void PetscMatrix<T>::add (const numeric_index_type i,
   PetscInt i_val=i, j_val=j;
 
   PetscScalar petsc_value = static_cast<PetscScalar>(value);
-  ierr = MatSetValues(_mat, 1, &i_val, 1, &j_val,
+  ierr = MatSetValues(this->_mat, 1, &i_val, 1, &j_val,
                       &petsc_value, ADD_VALUES);
   LIBMESH_CHKERR(ierr);
 }
@@ -1253,7 +1081,7 @@ void PetscMatrix<T>::add (const numeric_index_type i,
 
 template <typename T>
 void PetscMatrix<T>::add_matrix(const DenseMatrix<T> & dm,
-                                const std::vector<numeric_index_type> & dof_indices)
+                                   const std::vector<numeric_index_type> & dof_indices)
 {
   this->add_matrix (dm, dof_indices, dof_indices);
 }
@@ -1286,7 +1114,7 @@ void PetscMatrix<T>::add (const T a_in, const SparseMatrix<T> & X_in)
 
   semiparallel_only();
 
-  ierr = MatAXPY(_mat, a, X->_mat, DIFFERENT_NONZERO_PATTERN);
+  ierr = MatAXPY(this->_mat, a, X->_mat, DIFFERENT_NONZERO_PATTERN);
   LIBMESH_CHKERR(ierr);
 }
 
@@ -1312,13 +1140,13 @@ void PetscMatrix<T>::matrix_matrix_mult (SparseMatrix<T> & X_in, SparseMatrix<T>
 
   if (reuse)
   {
-    ierr = MatMatMult(_mat, X->_mat, MAT_REUSE_MATRIX, PETSC_DEFAULT, &Y->_mat);
+    ierr = MatMatMult(this->_mat, X->_mat, MAT_REUSE_MATRIX, PETSC_DEFAULT, &Y->_mat);
     LIBMESH_CHKERR(ierr);
   }
   else
   {
     Y->clear();
-    ierr = MatMatMult(_mat, X->_mat, MAT_INITIAL_MATRIX, PETSC_DEFAULT, &Y->_mat);
+    ierr = MatMatMult(this->_mat, X->_mat, MAT_INITIAL_MATRIX, PETSC_DEFAULT, &Y->_mat);
     LIBMESH_CHKERR(ierr);
   }
   // Specify that the new matrix is initialized
@@ -1329,9 +1157,9 @@ void PetscMatrix<T>::matrix_matrix_mult (SparseMatrix<T> & X_in, SparseMatrix<T>
 template <typename T>
 void
 PetscMatrix<T>::add_sparse_matrix (const SparseMatrix<T> & spm,
-                                   const std::map<numeric_index_type, numeric_index_type> & row_ltog,
-                                   const std::map<numeric_index_type, numeric_index_type> & col_ltog,
-                                   const T scalar)
+                                      const std::map<numeric_index_type, numeric_index_type> & row_ltog,
+                                      const std::map<numeric_index_type, numeric_index_type> & col_ltog,
+                                      const T scalar)
 {
   // size of spm is usually greater than row_ltog and col_ltog in parallel as the indices are owned by the processor
   // also, we should allow adding certain parts of spm to _mat
@@ -1373,7 +1201,7 @@ PetscMatrix<T>::add_sparse_matrix (const SparseMatrix<T> & spm,
       values[i] = PS(scalar) * vals[i];
     }
 
-    ierr = MatSetValues(_mat, 1, grow, ncols, gcols.data(), values.data(), ADD_VALUES);
+    ierr = MatSetValues(this->_mat, 1, grow, ncols, gcols.data(), values.data(), ADD_VALUES);
     LIBMESH_CHKERR(ierr);
     ierr = MatRestoreRow(pscm->_mat, static_cast<PetscInt>(ltog.first), &ncols, &lcols, &vals);
     LIBMESH_CHKERR(ierr);
@@ -1384,7 +1212,7 @@ PetscMatrix<T>::add_sparse_matrix (const SparseMatrix<T> & spm,
 
 template <typename T>
 T PetscMatrix<T>::operator () (const numeric_index_type i_in,
-                               const numeric_index_type j_in) const
+                                  const numeric_index_type j_in) const
 {
   libmesh_assert (this->initialized());
 
@@ -1409,7 +1237,7 @@ T PetscMatrix<T>::operator () (const numeric_index_type i_in,
   // to run on one processor.
   libmesh_assert(this->closed());
 
-  ierr = MatGetRow(_mat, i_val, &ncols, &petsc_cols, &petsc_row);
+  ierr = MatGetRow(this->_mat, i_val, &ncols, &petsc_cols, &petsc_row);
   LIBMESH_CHKERR(ierr);
 
   // Perform a binary search to find the contiguous index in
@@ -1432,7 +1260,7 @@ T PetscMatrix<T>::operator () (const numeric_index_type i_in,
       value = static_cast<T> (petsc_row[j]);
     }
 
-  ierr  = MatRestoreRow(_mat, i_val,
+  ierr  = MatRestoreRow(this->_mat, i_val,
                         &ncols, &petsc_cols, &petsc_row);
   LIBMESH_CHKERR(ierr);
 
@@ -1441,8 +1269,8 @@ T PetscMatrix<T>::operator () (const numeric_index_type i_in,
 
 template <typename T>
 void PetscMatrix<T>::get_row (numeric_index_type i_in,
-                              std::vector<numeric_index_type> & indices,
-                              std::vector<T> & values) const
+                                 std::vector<numeric_index_type> & indices,
+                                 std::vector<T> & values) const
 {
   libmesh_assert (this->initialized());
 
@@ -1477,7 +1305,7 @@ void PetscMatrix<T>::get_row (numeric_index_type i_in,
 #endif
     lock(_petsc_matrix_mutex);
 
-  ierr = MatGetRow(_mat, i_val, &ncols, &petsc_cols, &petsc_row);
+  ierr = MatGetRow(this->_mat, i_val, &ncols, &petsc_cols, &petsc_row);
   LIBMESH_CHKERR(ierr);
 
   // Copy the data
@@ -1490,47 +1318,20 @@ void PetscMatrix<T>::get_row (numeric_index_type i_in,
     values[i] = static_cast<T>(petsc_row[i]);
   }
 
-  ierr  = MatRestoreRow(_mat, i_val,
+  ierr  = MatRestoreRow(this->_mat, i_val,
                         &ncols, &petsc_cols, &petsc_row);
   LIBMESH_CHKERR(ierr);
 }
 
 
-template <typename T>
-bool PetscMatrix<T>::closed() const
-{
-  libmesh_assert (this->initialized());
-
-  PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
-  PetscBool assembled;
-
-  ierr = MatAssembled(_mat, &assembled);
-  LIBMESH_CHKERR(ierr);
-
-  return (assembled == PETSC_TRUE);
-}
-
-template <typename T>
-void PetscMatrix<T>::set_destroy_mat_on_exit(bool destroy)
-{
-  this->_destroy_mat_on_exit = destroy;
-}
-
-
-template <typename T>
-void PetscMatrix<T>::swap(PetscMatrix<T> & m_in)
-{
-  std::swap(_mat, m_in._mat);
-  std::swap(_destroy_mat_on_exit, m_in._destroy_mat_on_exit);
-}
 
 template <typename T>
 PetscMatrix<T> & PetscMatrix<T>::operator= (const PetscMatrix<T> & v)
 {
-  if (_mat)
+  if (this->_mat)
     {
       PetscBool assembled;
-      auto ierr = MatAssembled(_mat, &assembled);
+      auto ierr = MatAssembled(this->_mat, &assembled);
       LIBMESH_CHKERR(ierr);
       bool same_nonzero_pattern = false;
 
@@ -1538,7 +1339,7 @@ PetscMatrix<T> & PetscMatrix<T>::operator= (const PetscMatrix<T> & v)
         {
           MatInfo our_info, v_info;
 
-          ierr = MatGetInfo(_mat, MAT_GLOBAL_SUM, &our_info);
+          ierr = MatGetInfo(this->_mat, MAT_GLOBAL_SUM, &our_info);
           LIBMESH_CHKERR(ierr);
           ierr = MatGetInfo(v._mat, MAT_GLOBAL_SUM, &v_info);
           LIBMESH_CHKERR(ierr);
@@ -1552,14 +1353,14 @@ PetscMatrix<T> & PetscMatrix<T>::operator= (const PetscMatrix<T> & v)
         this->close();
 
       if (same_nonzero_pattern)
-        ierr = MatCopy(v._mat, _mat, SAME_NONZERO_PATTERN);
+        ierr = MatCopy(v._mat, this->_mat, SAME_NONZERO_PATTERN);
       else
-        ierr = MatCopy(v._mat, _mat, DIFFERENT_NONZERO_PATTERN);
+        ierr = MatCopy(v._mat, this->_mat, DIFFERENT_NONZERO_PATTERN);
       LIBMESH_CHKERR(ierr);
     }
   else
     {
-      auto ierr = MatDuplicate(v._mat, MAT_COPY_VALUES, &_mat);
+      auto ierr = MatDuplicate(v._mat, MAT_COPY_VALUES, &this->_mat);
       LIBMESH_CHKERR(ierr);
     }
 

--- a/src/numerics/petsc_matrix_base.C
+++ b/src/numerics/petsc_matrix_base.C
@@ -1,0 +1,274 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2024 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#include "libmesh/libmesh_config.h"
+
+#ifdef LIBMESH_HAVE_PETSC
+
+// Local includes
+#include "libmesh/petsc_matrix_base.h"
+#include "libmesh/petsc_matrix_shell_matrix.h"
+#include "libmesh/petsc_matrix.h"
+
+namespace libMesh
+{
+
+
+//-----------------------------------------------------------------------
+// PetscMatrixBase members
+
+
+// Constructor
+template <typename T>
+PetscMatrixBase<T>::PetscMatrixBase(const Parallel::Communicator & comm_in) :
+  SparseMatrix<T>(comm_in),
+  _mat(nullptr),
+  _destroy_mat_on_exit(true)
+{}
+
+
+
+// Constructor taking an existing Mat but not the responsibility
+// for destroying it
+template <typename T>
+PetscMatrixBase<T>::PetscMatrixBase(Mat mat_in,
+                            const Parallel::Communicator & comm_in) :
+  SparseMatrix<T>(comm_in),
+  _destroy_mat_on_exit(false)
+{
+  this->_mat = mat_in;
+  this->_is_initialized = true;
+
+  this->set_context();
+}
+
+
+
+// Destructor
+template <typename T>
+PetscMatrixBase<T>::~PetscMatrixBase()
+{
+  this->clear();
+}
+
+
+
+template <typename T>
+void PetscMatrixBase<T>::clear () noexcept
+{
+  if ((this->initialized()) && (this->_destroy_mat_on_exit))
+    {
+      exceptionless_semiparallel_only();
+
+      // If we encounter an error here, print a warning but otherwise
+      // keep going since we may be recovering from an exception.
+      PetscErrorCode ierr = MatDestroy (&_mat);
+      if (ierr)
+        libmesh_warning("Warning: MatDestroy returned a non-zero error code which we ignored.");
+
+      this->_is_initialized = false;
+    }
+}
+
+template <typename T>
+void PetscMatrixBase<T>::set_destroy_mat_on_exit(bool destroy)
+{
+  this->_destroy_mat_on_exit = destroy;
+}
+
+
+template <typename T>
+void PetscMatrixBase<T>::swap(PetscMatrixBase<T> & m_in)
+{
+  std::swap(_mat, m_in._mat);
+  std::swap(_destroy_mat_on_exit, m_in._destroy_mat_on_exit);
+}
+
+template <typename T>
+void PetscMatrixBase<T>::set_context()
+{
+  libmesh_assert(this->_mat);
+  PetscContainer container;
+  LibmeshPetscCall(PetscContainerCreate(this->comm().get(), &container));
+  LibmeshPetscCall(PetscContainerSetPointer(container, this));
+  LibmeshPetscCall(PetscObjectCompose((PetscObject)(Mat)this->_mat, "PetscMatrixCtx", (PetscObject)container));
+  LibmeshPetscCall(PetscContainerDestroy(&container));
+}
+
+template <typename T>
+PetscMatrixBase<T> * PetscMatrixBase<T>::get_context(Mat mat)
+{
+  void * ctx;
+  PetscContainer container;
+  LibmeshPetscCall(PetscObjectQuery((PetscObject)mat, "PetscMatrixCtx", (PetscObject *)&container));
+  if (!container)
+    return nullptr;
+
+  LibmeshPetscCall(PetscContainerGetPointer(container, &ctx));
+  libmesh_assert(ctx);
+  return static_cast<PetscMatrixBase<T> *>(ctx);
+}
+
+template <typename T>
+numeric_index_type PetscMatrixBase<T>::m () const
+{
+  libmesh_assert (this->initialized());
+
+  PetscInt petsc_m=0, petsc_n=0;
+  PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
+
+  ierr = MatGetSize (this->_mat, &petsc_m, &petsc_n);
+  LIBMESH_CHKERR(ierr);
+
+  return static_cast<numeric_index_type>(petsc_m);
+}
+
+template <typename T>
+numeric_index_type PetscMatrixBase<T>::local_m () const
+{
+  libmesh_assert (this->initialized());
+
+  PetscInt m = 0;
+
+  auto ierr = MatGetLocalSize (this->_mat, &m, NULL);
+  LIBMESH_CHKERR(ierr);
+
+  return static_cast<numeric_index_type>(m);
+}
+
+template <typename T>
+numeric_index_type PetscMatrixBase<T>::n () const
+{
+  libmesh_assert (this->initialized());
+
+  PetscInt petsc_m=0, petsc_n=0;
+  PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
+
+  ierr = MatGetSize (this->_mat, &petsc_m, &petsc_n);
+  LIBMESH_CHKERR(ierr);
+
+  return static_cast<numeric_index_type>(petsc_n);
+}
+
+template <typename T>
+numeric_index_type PetscMatrixBase<T>::local_n () const
+{
+  libmesh_assert (this->initialized());
+
+  PetscInt n = 0;
+
+  auto ierr = MatGetLocalSize (this->_mat, NULL, &n);
+  LIBMESH_CHKERR(ierr);
+
+  return static_cast<numeric_index_type>(n);
+}
+
+template <typename T>
+numeric_index_type PetscMatrixBase<T>::row_start () const
+{
+  libmesh_assert (this->initialized());
+
+  PetscInt start=0, stop=0;
+  PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
+
+  ierr = MatGetOwnershipRange(this->_mat, &start, &stop);
+  LIBMESH_CHKERR(ierr);
+
+  return static_cast<numeric_index_type>(start);
+}
+
+template <typename T>
+numeric_index_type PetscMatrixBase<T>::row_stop () const
+{
+  libmesh_assert (this->initialized());
+
+  PetscInt start=0, stop=0;
+  PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
+
+  ierr = MatGetOwnershipRange(this->_mat, &start, &stop);
+  LIBMESH_CHKERR(ierr);
+
+  return static_cast<numeric_index_type>(stop);
+}
+
+template <typename T>
+numeric_index_type PetscMatrixBase<T>::col_start () const
+{
+  libmesh_assert (this->initialized());
+
+  PetscInt start=0, stop=0;
+  PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
+
+  ierr = MatGetOwnershipRangeColumn(this->_mat, &start, &stop);
+  LIBMESH_CHKERR(ierr);
+
+  return static_cast<numeric_index_type>(start);
+}
+
+template <typename T>
+numeric_index_type PetscMatrixBase<T>::col_stop () const
+{
+  libmesh_assert (this->initialized());
+
+  PetscInt start=0, stop=0;
+  PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
+
+  ierr = MatGetOwnershipRangeColumn(this->_mat, &start, &stop);
+  LIBMESH_CHKERR(ierr);
+
+  return static_cast<numeric_index_type>(stop);
+}
+
+template <typename T>
+void PetscMatrixBase<T>::close ()
+{
+  semiparallel_only();
+
+  // BSK - 1/19/2004
+  // strictly this check should be OK, but it seems to
+  // fail on matrix-free matrices.  Do they falsely
+  // state they are assembled?  Check with the developers...
+  //   if (this->closed())
+  //     return;
+
+  MatAssemblyBeginEnd(this->comm(), this->_mat, MAT_FINAL_ASSEMBLY);
+}
+
+template <typename T>
+bool PetscMatrixBase<T>::closed() const
+{
+  libmesh_assert (this->initialized());
+
+  PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
+  PetscBool assembled;
+
+  ierr = MatAssembled(this->_mat, &assembled);
+  LIBMESH_CHKERR(ierr);
+
+  return (assembled == PETSC_TRUE);
+}
+
+//------------------------------------------------------------------
+// Explicit instantiations
+template class LIBMESH_EXPORT PetscMatrixBase<Number>;
+
+} // namespace libMesh
+
+
+#endif // #ifdef LIBMESH_HAVE_PETSC

--- a/src/numerics/petsc_matrix_shell_matrix.C
+++ b/src/numerics/petsc_matrix_shell_matrix.C
@@ -1,0 +1,56 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2024 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#include "libmesh/libmesh_config.h"
+
+#ifdef LIBMESH_HAVE_PETSC
+
+// Local includes
+#include "libmesh/petsc_matrix_shell_matrix.h"
+
+namespace libMesh
+{
+
+template <typename T>
+void
+PetscMatrixShellMatrix<T>::init(const numeric_index_type m,
+                                const numeric_index_type n,
+                                const numeric_index_type m_l,
+                                const numeric_index_type n_l,
+                                const numeric_index_type,
+                                const numeric_index_type,
+                                const numeric_index_type blocksize)
+{
+  init_shell_mat(*this, m, n, m_l, n_l, blocksize);
+
+  this->set_context();
+}
+
+template <typename T>
+void
+PetscMatrixShellMatrix<T>::init(ParallelType)
+{
+  init_shell_mat(*this);
+
+  this->set_context();
+}
+
+template class LIBMESH_EXPORT PetscMatrixShellMatrix<Number>;
+
+} // namespace libMesh
+
+#endif

--- a/src/numerics/petsc_preconditioner.C
+++ b/src/numerics/petsc_preconditioner.C
@@ -22,7 +22,7 @@
 // Local Includes
 #include "libmesh/petsc_preconditioner.h"
 #include "libmesh/petsc_macro.h"
-#include "libmesh/petsc_matrix.h"
+#include "libmesh/petsc_matrix_base.h"
 #include "libmesh/petsc_vector.h"
 #include "libmesh/libmesh_common.h"
 #include "libmesh/enum_preconditioner_type.h"
@@ -68,7 +68,7 @@ void PetscPreconditioner<T>::init ()
       PetscErrorCode ierr = PCCreate(this->comm().get(), _pc.get());
       LIBMESH_CHKERR(ierr);
 
-      auto pmatrix = cast_ptr<PetscMatrix<T> *>(this->_matrix);
+      auto pmatrix = cast_ptr<PetscMatrixBase<T> *>(this->_matrix);
       _mat = pmatrix->mat();
     }
 

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -20,7 +20,7 @@
 #ifdef LIBMESH_HAVE_PETSC
 
 // libMesh includes
-#include "libmesh/petsc_matrix.h"
+#include "libmesh/petsc_matrix_base.h"
 #include "libmesh/dense_subvector.h"
 #include "libmesh/dense_vector.h"
 #include "libmesh/int_range.h"
@@ -244,7 +244,7 @@ void PetscVector<T>::add_vector (const NumericVector<T> & v_in,
   this->_restore_array();
   // Make sure the data passed in are really of Petsc types
   const PetscVector<T> * v = cast_ptr<const PetscVector<T> *>(&v_in);
-  const PetscMatrix<T> * A = cast_ptr<const PetscMatrix<T> *>(&A_in);
+  const PetscMatrixBase<T> * A = cast_ptr<const PetscMatrixBase<T> *>(&A_in);
 
   PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
 
@@ -254,12 +254,12 @@ void PetscVector<T>::add_vector (const NumericVector<T> & v_in,
       libmesh_warning("Matrix A must be assembled before calling PetscVector::add_vector(v, A).\n"
                       "Please update your code, as this warning will become an error in a future release.");
       libmesh_deprecated();
-      const_cast<PetscMatrix<T> *>(A)->close();
+      const_cast<PetscMatrixBase<T> *>(A)->close();
     }
 
   // The const_cast<> is not elegant, but it is required since PETSc
   // expects a non-const Mat.
-  ierr = MatMultAdd(const_cast<PetscMatrix<T> *>(A)->mat(), v->_vec, _vec, _vec);
+  ierr = MatMultAdd(const_cast<PetscMatrixBase<T> *>(A)->mat(), v->_vec, _vec, _vec);
   LIBMESH_CHKERR(ierr);
 }
 
@@ -274,7 +274,7 @@ void PetscVector<T>::add_vector_transpose (const NumericVector<T> & v_in,
   this->_restore_array();
   // Make sure the data passed in are really of Petsc types
   const PetscVector<T> * v = cast_ptr<const PetscVector<T> *>(&v_in);
-  const PetscMatrix<T> * A = cast_ptr<const PetscMatrix<T> *>(&A_in);
+  const PetscMatrixBase<T> * A = cast_ptr<const PetscMatrixBase<T> *>(&A_in);
 
   PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
 
@@ -284,12 +284,12 @@ void PetscVector<T>::add_vector_transpose (const NumericVector<T> & v_in,
       libmesh_warning("Matrix A must be assembled before calling PetscVector::add_vector_transpose(v, A).\n"
                       "Please update your code, as this warning will become an error in a future release.");
       libmesh_deprecated();
-      const_cast<PetscMatrix<T> *>(A)->close();
+      const_cast<PetscMatrixBase<T> *>(A)->close();
     }
 
   // The const_cast<> is not elegant, but it is required since PETSc
   // expects a non-const Mat.
-  ierr = MatMultTransposeAdd(const_cast<PetscMatrix<T> *>(A)->mat(), v->_vec, _vec, _vec);
+  ierr = MatMultTransposeAdd(const_cast<PetscMatrixBase<T> *>(A)->mat(), v->_vec, _vec, _vec);
   LIBMESH_CHKERR(ierr);
 }
 
@@ -304,7 +304,7 @@ void PetscVector<T>::add_vector_conjugate_transpose (const NumericVector<T> & v_
   this->_restore_array();
   // Make sure the data passed in are really of Petsc types
   const PetscVector<T> * v = cast_ptr<const PetscVector<T> *>(&v_in);
-  const PetscMatrix<T> * A = cast_ptr<const PetscMatrix<T> *>(&A_in);
+  const PetscMatrixBase<T> * A = cast_ptr<const PetscMatrixBase<T> *>(&A_in);
 
   // We shouldn't close() the matrix for you, as that would potentially modify the state of a const object.
   if (!A->closed())
@@ -312,7 +312,7 @@ void PetscVector<T>::add_vector_conjugate_transpose (const NumericVector<T> & v_
       libmesh_warning("Matrix A must be assembled before calling PetscVector::add_vector_conjugate_transpose(v, A).\n"
                       "Please update your code, as this warning will become an error in a future release.");
       libmesh_deprecated();
-      const_cast<PetscMatrix<T> *>(A)->close();
+      const_cast<PetscMatrixBase<T> *>(A)->close();
     }
 
   // Store a temporary copy since MatMultHermitianTransposeAdd doesn't seem to work
@@ -321,7 +321,7 @@ void PetscVector<T>::add_vector_conjugate_transpose (const NumericVector<T> & v_
 
   // The const_cast<> is not elegant, but it is required since PETSc
   // expects a non-const Mat.
-  PetscErrorCode ierr = MatMultHermitianTranspose(const_cast<PetscMatrix<T> *>(A)->mat(), v->_vec, _vec);
+  PetscErrorCode ierr = MatMultHermitianTranspose(const_cast<PetscMatrixBase<T> *>(A)->mat(), v->_vec, _vec);
   LIBMESH_CHKERR(ierr);
 
   // Add the temporary copy to the matvec result

--- a/src/numerics/shell_matrix.C
+++ b/src/numerics/shell_matrix.C
@@ -18,7 +18,6 @@
 
 
 // Local Includes
-#include "libmesh/petsc_matrix_base.h"
 #include "libmesh/shell_matrix.h"
 #include "libmesh/petsc_shell_matrix.h"
 #include "libmesh/enum_solver_package.h"

--- a/src/numerics/shell_matrix.C
+++ b/src/numerics/shell_matrix.C
@@ -18,7 +18,7 @@
 
 
 // Local Includes
-#include "libmesh/petsc_matrix.h"
+#include "libmesh/petsc_matrix_base.h"
 #include "libmesh/shell_matrix.h"
 #include "libmesh/petsc_shell_matrix.h"
 #include "libmesh/enum_solver_package.h"

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -40,6 +40,7 @@
 #include "libmesh/partitioner.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/elem.h"
+#include "libmesh/petsc_matrix.h"
 
 namespace libMesh
 {

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -194,10 +194,10 @@ void PetscLinearSolver<T>::init (const char * name)
       LIBMESH_CHKERR(ierr);
 
       if (strcmp(ksp_type, "preonly"))
-        {
-          ierr = KSPSetInitialGuessNonzero (_ksp, PETSC_TRUE);
-          LIBMESH_CHKERR(ierr);
-        }
+      {
+        ierr = KSPSetInitialGuessNonzero (_ksp, PETSC_TRUE);
+        LIBMESH_CHKERR(ierr);
+      }
 
       // Notify PETSc of location to store residual history.
       // This needs to be called before any solves, since
@@ -228,7 +228,7 @@ void PetscLinearSolver<T>::init (const char * name)
 
 
 template <typename T>
-void PetscLinearSolver<T>::init (PetscMatrix<T> * matrix,
+void PetscLinearSolver<T>::init (PetscMatrixBase<T> * matrix,
                                  const char * name)
 {
   // Initialize the data structures if not done so already.
@@ -417,8 +417,8 @@ PetscLinearSolver<T>::solve_common (SparseMatrix<T> &  matrix_in,
                                     ksp_solve_func_type solve_func)
 {
   // Make sure the data passed in are really of Petsc types
-  PetscMatrix<T> * matrix   = cast_ptr<PetscMatrix<T> *>(&matrix_in);
-  PetscMatrix<T> * precond  = cast_ptr<PetscMatrix<T> *>(&precond_in);
+  PetscMatrixBase<T> * matrix   = cast_ptr<PetscMatrixBase<T> *>(&matrix_in);
+  PetscMatrixBase<T> * precond  = cast_ptr<PetscMatrixBase<T> *>(&precond_in);
 
   this->init (matrix);
 
@@ -472,10 +472,10 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
   const double max_its = this->get_int_solver_setting("max_its", m_its);
 
   // Make sure the data passed in are really of Petsc types
-  const PetscMatrix<T> * precond  = cast_ptr<const PetscMatrix<T> *>(&precond_matrix);
+  const PetscMatrixBase<T> * precond  = cast_ptr<const PetscMatrixBase<T> *>(&precond_matrix);
 
   return this->shell_solve_common
-    (shell_matrix, const_cast<PetscMatrix<T> *>(precond), solution_in,
+    (shell_matrix, const_cast<PetscMatrixBase<T> *>(precond), solution_in,
      rhs_in, rel_tol, abs_tol, max_its);
 }
 
@@ -484,7 +484,7 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
 template <typename T>
 std::pair<unsigned int, Real>
 PetscLinearSolver<T>::shell_solve_common (const ShellMatrix<T> & shell_matrix,
-                                          PetscMatrix<T> * precond,
+                                          PetscMatrixBase<T> * precond,
                                           NumericVector<T> & solution_in,
                                           NumericVector<T> & rhs_in,
                                           const double rel_tol,
@@ -531,7 +531,7 @@ PetscLinearSolver<T>::shell_solve_common (const ShellMatrix<T> & shell_matrix,
 template <typename T>
 std::pair<unsigned int, Real>
 PetscLinearSolver<T>::solve_base (SparseMatrix<T> * matrix,
-                                  PetscMatrix<T> * precond,
+                                  PetscMatrixBase<T> * precond,
                                   Mat mat,
                                   NumericVector<T> & solution_in,
                                   NumericVector<T> & rhs_in,
@@ -552,7 +552,7 @@ PetscLinearSolver<T>::solve_base (SparseMatrix<T> * matrix,
   PetscInt its=0, max_its = static_cast<PetscInt>(m_its);
   PetscReal final_resid=0.;
 
-  std::unique_ptr<PetscMatrix<Number>> subprecond_matrix;
+  std::unique_ptr<PetscMatrixBase<Number>> subprecond_matrix;
   WrappedPetsc<Mat> subprecond;
 
   WrappedPetsc<Mat> submat;
@@ -595,7 +595,7 @@ PetscLinearSolver<T>::solve_base (SparseMatrix<T> * matrix,
 
       if (precond)
         {
-          ierr = LibMeshCreateSubMatrix(const_cast<PetscMatrix<T> *>(precond)->mat(),
+          ierr = LibMeshCreateSubMatrix(const_cast<PetscMatrixBase<T> *>(precond)->mat(),
                                         _restrict_solve_to_is,
                                         _restrict_solve_to_is,
                                         MAT_INITIAL_MATRIX,
@@ -668,7 +668,7 @@ PetscLinearSolver<T>::solve_base (SparseMatrix<T> * matrix,
 
       if (precond)
         {
-          ierr = KSPSetOperators(_ksp, mat, const_cast<PetscMatrix<T> *>(precond)->mat());
+          ierr = KSPSetOperators(_ksp, mat, const_cast<PetscMatrixBase<T> *>(precond)->mat());
           LIBMESH_CHKERR(ierr);
         }
       else
@@ -682,7 +682,7 @@ PetscLinearSolver<T>::solve_base (SparseMatrix<T> * matrix,
           if (matrix)
             this->_preconditioner->set_matrix(*matrix);
           else if (precond)
-            this->_preconditioner->set_matrix(const_cast<PetscMatrix<Number> &>(*precond));
+            this->_preconditioner->set_matrix(const_cast<PetscMatrixBase<Number> &>(*precond));
 
           this->_preconditioner->init();
         }

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -194,10 +194,10 @@ void PetscLinearSolver<T>::init (const char * name)
       LIBMESH_CHKERR(ierr);
 
       if (strcmp(ksp_type, "preonly"))
-      {
-        ierr = KSPSetInitialGuessNonzero (_ksp, PETSC_TRUE);
-        LIBMESH_CHKERR(ierr);
-      }
+        {
+          ierr = KSPSetInitialGuessNonzero (_ksp, PETSC_TRUE);
+          LIBMESH_CHKERR(ierr);
+        }
 
       // Notify PETSc of location to store residual history.
       // This needs to be called before any solves, since

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -27,7 +27,7 @@
 #include "libmesh/petsc_nonlinear_solver.h"
 #include "libmesh/petsc_linear_solver.h"
 #include "libmesh/petsc_vector.h"
-#include "libmesh/petsc_matrix.h"
+#include "libmesh/petsc_mffd_matrix.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/preconditioner.h"
 #include "libmesh/solver_configuration.h"
@@ -467,28 +467,43 @@ extern "C"
 
     NonlinearImplicitSystem & sys = solver->system();
 
-    PetscMatrix<Number> PC(pc, sys.comm());
-    PetscMatrix<Number> Jac(jac, sys.comm());
+    PetscMatrixBase<Number> * PC = pc ? PetscMatrixBase<Number>::get_context(pc) : nullptr;
+    PetscMatrixBase<Number> * Jac = jac ? PetscMatrixBase<Number>::get_context(jac) : nullptr;
     PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
     PetscVector<Number> X_global(x, sys.comm());
+
+    PetscBool pisshell = PETSC_FALSE;
+    PetscBool jismffd = PETSC_FALSE;
+    PetscBool jisshell = PETSC_FALSE;
+    if (pc)
+      LibmeshPetscCall(PetscObjectTypeCompare((PetscObject)pc, MATSHELL, &pisshell));
+    libmesh_assert(jac);
+    LibmeshPetscCall(PetscObjectTypeCompare((PetscObject)jac, MATMFFD, &jismffd));
+    LibmeshPetscCall(PetscObjectTypeCompare((PetscObject)jac, MATSHELL, &jisshell));
+    if (jismffd == PETSC_TRUE)
+      {
+        libmesh_assert(!Jac);
+        Jac = &solver->_mffd_jac;
+        solver->_mffd_jac = jac;
+      }
 
     // We already computed the Jacobian during the residual evaluation
     if (solver->residual_and_jacobian_object)
     {
-      auto & sys_mat = static_cast<PetscMatrix<Number> &>(sys.get_system_matrix());
+      // We could be doing matrix-free in which case we cannot rely on closing of explicit matrices
+      // that occurs during the PETSc residual callback
+      if ((jisshell == PETSC_TRUE) || (jismffd == PETSC_TRUE))
+        Jac->close();
 
-      // We could be doing matrix-free
-      if (jac && jac != sys_mat.mat())
-        Jac.close();
-      if (pc && pc != sys_mat.mat())
-        PC.close();
+      if (pc && (pisshell == PETSC_TRUE))
+        PC->close();
 
       PetscFunctionReturn(LIBMESH_PETSC_SUCCESS);
     }
 
     // Set the dof maps
-    PC.attach_dof_map(sys.get_dof_map());
-    Jac.attach_dof_map(sys.get_dof_map());
+    PC->attach_dof_map(sys.get_dof_map());
+    Jac->attach_dof_map(sys.get_dof_map());
 
     // Use the systems update() to get a good local version of the parallel solution
     X_global.swap(X_sys);
@@ -503,29 +518,35 @@ extern "C"
       sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
 
     if (solver->_zero_out_jacobian)
-      PC.zero();
+      PC->zero();
 
 
     if (solver->jacobian != nullptr)
-      solver->jacobian(*sys.current_local_solution.get(), PC, sys);
+      solver->jacobian(*sys.current_local_solution.get(), *PC, sys);
 
     else if (solver->jacobian_object != nullptr)
-      solver->jacobian_object->jacobian(*sys.current_local_solution.get(), PC, sys);
+      solver->jacobian_object->jacobian(*sys.current_local_solution.get(), *PC, sys);
 
     else if (solver->matvec != nullptr)
-      solver->matvec(*sys.current_local_solution.get(), nullptr, &PC, sys);
+      solver->matvec(*sys.current_local_solution.get(), nullptr, PC, sys);
 
     else
       libmesh_error_msg("Error! Unable to compute residual and/or Jacobian!");
 
-    PC.close();
+    PC->close();
     if (solver->_exact_constraint_enforcement)
       {
-        sys.get_dof_map().enforce_constraints_on_jacobian(sys, &PC);
-        PC.close();
+        sys.get_dof_map().enforce_constraints_on_jacobian(sys, PC);
+        PC->close();
       }
 
-    Jac.close();
+    if (Jac != PC)
+      {
+        // Assume that shells know what they're doing
+        libmesh_assert(!solver->_exact_constraint_enforcement || (jismffd == PETSC_TRUE) ||
+                       (jisshell == PETSC_TRUE));
+        Jac->close();
+      }
 
     PetscFunctionReturn(LIBMESH_PETSC_SUCCESS);
   }
@@ -727,7 +748,8 @@ PetscNonlinearSolver<T>::PetscNonlinearSolver (sys_type & system_in) :
   _default_monitor(true),
   _snesmf_reuse_base(true),
   _computing_base_vector(true),
-  _setup_reuse(false)
+  _setup_reuse(false),
+  _mffd_jac(this->_communicator)
 {
 }
 
@@ -932,7 +954,7 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  pre_in,  // System Preconditi
   this->init ();
 
   // Make sure the data passed in are really of Petsc types
-  PetscMatrix<T> * pre = cast_ptr<PetscMatrix<T> *>(&pre_in);
+  PetscMatrixBase<T> * pre = cast_ptr<PetscMatrixBase<T> *>(&pre_in);
   PetscVector<T> * x   = cast_ptr<PetscVector<T> *>(&x_in);
   PetscVector<T> * r   = cast_ptr<PetscVector<T> *>(&r_in);
 

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -32,6 +32,7 @@
 #include "libmesh/preconditioner.h"
 #include "libmesh/solver_configuration.h"
 #include "libmesh/petscdmlibmesh.h"
+#include "libmesh/petsc_mffd_matrix.h"
 
 namespace libMesh
 {
@@ -472,6 +473,7 @@ extern "C"
     PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
     PetscVector<Number> X_global(x, sys.comm());
 
+    PetscMFFDMatrix<Number> mffd_jac(sys.comm());
     PetscBool p_is_shell = PETSC_FALSE;
     PetscBool j_is_mffd = PETSC_FALSE;
     PetscBool j_is_shell = PETSC_FALSE;
@@ -483,8 +485,8 @@ extern "C"
     if (j_is_mffd == PETSC_TRUE)
       {
         libmesh_assert(!Jac);
-        Jac = &solver->_mffd_jac;
-        solver->_mffd_jac = jac;
+        Jac = &mffd_jac;
+        mffd_jac = jac;
       }
 
     // We already computed the Jacobian during the residual evaluation
@@ -748,8 +750,7 @@ PetscNonlinearSolver<T>::PetscNonlinearSolver (sys_type & system_in) :
   _default_monitor(true),
   _snesmf_reuse_base(true),
   _computing_base_vector(true),
-  _setup_reuse(false),
-  _mffd_jac(this->_communicator)
+  _setup_reuse(false)
 {
 }
 

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -472,15 +472,15 @@ extern "C"
     PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
     PetscVector<Number> X_global(x, sys.comm());
 
-    PetscBool pisshell = PETSC_FALSE;
-    PetscBool jismffd = PETSC_FALSE;
-    PetscBool jisshell = PETSC_FALSE;
+    PetscBool p_is_shell = PETSC_FALSE;
+    PetscBool j_is_mffd = PETSC_FALSE;
+    PetscBool j_is_shell = PETSC_FALSE;
     if (pc)
-      LibmeshPetscCall(PetscObjectTypeCompare((PetscObject)pc, MATSHELL, &pisshell));
+      LibmeshPetscCall(PetscObjectTypeCompare((PetscObject)pc, MATSHELL, &p_is_shell));
     libmesh_assert(jac);
-    LibmeshPetscCall(PetscObjectTypeCompare((PetscObject)jac, MATMFFD, &jismffd));
-    LibmeshPetscCall(PetscObjectTypeCompare((PetscObject)jac, MATSHELL, &jisshell));
-    if (jismffd == PETSC_TRUE)
+    LibmeshPetscCall(PetscObjectTypeCompare((PetscObject)jac, MATMFFD, &j_is_mffd));
+    LibmeshPetscCall(PetscObjectTypeCompare((PetscObject)jac, MATSHELL, &j_is_shell));
+    if (j_is_mffd == PETSC_TRUE)
       {
         libmesh_assert(!Jac);
         Jac = &solver->_mffd_jac;
@@ -492,10 +492,10 @@ extern "C"
     {
       // We could be doing matrix-free in which case we cannot rely on closing of explicit matrices
       // that occurs during the PETSc residual callback
-      if ((jisshell == PETSC_TRUE) || (jismffd == PETSC_TRUE))
+      if ((j_is_shell == PETSC_TRUE) || (j_is_mffd == PETSC_TRUE))
         Jac->close();
 
-      if (pc && (pisshell == PETSC_TRUE))
+      if (pc && (p_is_shell == PETSC_TRUE))
         PC->close();
 
       PetscFunctionReturn(LIBMESH_PETSC_SUCCESS);
@@ -543,8 +543,8 @@ extern "C"
     if (Jac != PC)
       {
         // Assume that shells know what they're doing
-        libmesh_assert(!solver->_exact_constraint_enforcement || (jismffd == PETSC_TRUE) ||
-                       (jisshell == PETSC_TRUE));
+        libmesh_assert(!solver->_exact_constraint_enforcement || (j_is_mffd == PETSC_TRUE) ||
+                       (j_is_shell == PETSC_TRUE));
         Jac->close();
       }
 

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -468,7 +468,7 @@ extern "C"
 
     NonlinearImplicitSystem & sys = solver->system();
 
-    PetscMatrixBase<Number> * PC = pc ? PetscMatrixBase<Number>::get_context(pc) : nullptr;
+    PetscMatrixBase<Number> * const PC = pc ? PetscMatrixBase<Number>::get_context(pc) : nullptr;
     PetscMatrixBase<Number> * Jac = jac ? PetscMatrixBase<Number>::get_context(jac) : nullptr;
     PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
     PetscVector<Number> X_global(x, sys.comm());

--- a/src/solvers/petscdmlibmeshimpl.C
+++ b/src/solvers/petscdmlibmeshimpl.C
@@ -38,7 +38,7 @@
 #include "libmesh/petsc_nonlinear_solver.h"
 #include "libmesh/petsc_linear_solver.h"
 #include "libmesh/petsc_vector.h"
-#include "libmesh/petsc_matrix.h"
+#include "libmesh/petsc_matrix_base.h"
 #include "libmesh/petscdmlibmesh.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/preconditioner.h"
@@ -689,27 +689,29 @@ static PetscErrorCode DMlibMeshJacobian(DM dm, Vec x, Mat jac, Mat pc)
   ierr = DMlibMeshGetSystem(dm, _sys); CHKERRQ(ierr);
   NonlinearImplicitSystem & sys = *_sys;
 
-  PetscMatrix<Number> the_pc(pc,sys.comm());
-  PetscMatrix<Number> Jac(jac,sys.comm());
+  libmesh_assert(pc);
+  libmesh_assert(jac);
+  PetscMatrixBase<Number> * the_pc = PetscMatrixBase<Number>::get_context(pc);
+  PetscMatrixBase<Number> * Jac = PetscMatrixBase<Number>::get_context(jac);
   PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
-  PetscMatrix<Number> & Jac_sys = *cast_ptr<PetscMatrix<Number> *>(sys.matrix);
+  PetscMatrixBase<Number> & Jac_sys = *cast_ptr<PetscMatrixBase<Number> *>(sys.matrix);
   PetscVector<Number> X_global(x, sys.comm());
 
   // Set the dof maps
-  the_pc.attach_dof_map(sys.get_dof_map());
-  Jac.attach_dof_map(sys.get_dof_map());
+  the_pc->attach_dof_map(sys.get_dof_map());
+  Jac->attach_dof_map(sys.get_dof_map());
 
   // Use the systems update() to get a good local version of the parallel solution
   X_global.swap(X_sys);
-  Jac.swap(Jac_sys);
+  Jac->swap(Jac_sys);
 
   sys.get_dof_map().enforce_constraints_exactly(sys);
   sys.update();
 
   X_global.swap(X_sys);
-  Jac.swap(Jac_sys);
+  Jac->swap(Jac_sys);
 
-  the_pc.zero();
+  the_pc->zero();
 
   // if the user has provided both function pointers and objects only the pointer
   // will be used, so catch that as an error
@@ -720,22 +722,22 @@ static PetscErrorCode DMlibMeshJacobian(DM dm, Vec x, Mat jac, Mat pc)
                        "ERROR: cannot specify both a function and object to compute the combined Residual & Jacobian!");
 
   if (sys.nonlinear_solver->jacobian != nullptr)
-    sys.nonlinear_solver->jacobian(*(sys.current_local_solution.get()), the_pc, sys);
+    sys.nonlinear_solver->jacobian(*(sys.current_local_solution.get()), *the_pc, sys);
 
   else if (sys.nonlinear_solver->jacobian_object != nullptr)
-    sys.nonlinear_solver->jacobian_object->jacobian(*(sys.current_local_solution.get()), the_pc, sys);
+    sys.nonlinear_solver->jacobian_object->jacobian(*(sys.current_local_solution.get()), *the_pc, sys);
 
   else if (sys.nonlinear_solver->matvec != nullptr)
-    sys.nonlinear_solver->matvec(*(sys.current_local_solution.get()), nullptr, &the_pc, sys);
+    sys.nonlinear_solver->matvec(*(sys.current_local_solution.get()), nullptr, the_pc, sys);
 
   else if (sys.nonlinear_solver->residual_and_jacobian_object != nullptr)
-    sys.nonlinear_solver->residual_and_jacobian_object->residual_and_jacobian(*(sys.current_local_solution.get()), nullptr, &the_pc, sys);
+    sys.nonlinear_solver->residual_and_jacobian_object->residual_and_jacobian(*(sys.current_local_solution.get()), nullptr, the_pc, sys);
 
   else
     libmesh_error_msg("Error! Unable to compute residual and/or Jacobian!");
 
-  the_pc.close();
-  Jac.close();
+  the_pc->close();
+  Jac->close();
   X_global.close();
   PetscFunctionReturn(LIBMESH_PETSC_SUCCESS);
 }
@@ -841,7 +843,7 @@ static PetscErrorCode DMCreateMatrix_libMesh(DM dm, Mat * A)
   if (!dlm->sys)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No libMesh system set for DM_libMesh");
 
-  *A = (dynamic_cast<PetscMatrix<Number> *>(dlm->sys->matrix))->mat();
+  *A = (dynamic_cast<PetscMatrixBase<Number> *>(dlm->sys->matrix))->mat();
   ierr = PetscObjectReference((PetscObject)(*A)); CHKERRQ(ierr);
   PetscFunctionReturn(LIBMESH_PETSC_SUCCESS);
 }

--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -23,7 +23,7 @@
 
 // Local Includes
 #include "libmesh/libmesh_logging.h"
-#include "libmesh/petsc_matrix.h"
+#include "libmesh/petsc_matrix_base.h"
 #include "libmesh/petsc_vector.h"
 #include "libmesh/slepc_eigen_solver.h"
 #include "libmesh/shell_matrix.h"
@@ -119,9 +119,9 @@ SlepcEigenSolver<T>::solve_standard (SparseMatrix<T> & matrix_A_in,
   this->init ();
 
   // Make sure the SparseMatrix passed in is really a PetscMatrix
-  PetscMatrix<T> * matrix_A = dynamic_cast<PetscMatrix<T> *>(&matrix_A_in);
+  PetscMatrixBase<T> * matrix_A = dynamic_cast<PetscMatrixBase<T> *>(&matrix_A_in);
 
-  libmesh_error_msg_if(!matrix_A, "Error: input matrix to solve_standard() must be a PetscMatrix.");
+  libmesh_error_msg_if(!matrix_A, "Error: input matrix to solve_standard() must be a PetscMatrixBase.");
 
   // Close the matrix and vectors in case this wasn't already done.
   if (this->_close_matrix_before_solve)
@@ -181,9 +181,9 @@ SlepcEigenSolver<T>::solve_standard (ShellMatrix<T> & shell_matrix,
   this->init ();
 
   // Make sure the SparseMatrix passed in is really a PetscMatrix
-  PetscMatrix<T> * precond = dynamic_cast<PetscMatrix<T> *>(&precond_in);
+  PetscMatrixBase<T> * precond = dynamic_cast<PetscMatrixBase<T> *>(&precond_in);
 
-  libmesh_error_msg_if(!precond, "Error: input preconditioning matrix to solve_standard() must be a PetscMatrix.");
+  libmesh_error_msg_if(!precond, "Error: input preconditioning matrix to solve_standard() must be a PetscMatrixBase.");
 
   PetscShellMatrix<T> * matrix = dynamic_cast<PetscShellMatrix<T> *> (&shell_matrix);
 
@@ -253,11 +253,11 @@ SlepcEigenSolver<T>::solve_generalized (SparseMatrix<T> & matrix_A_in,
   this->init ();
 
   // Make sure the data passed in are really of Petsc types
-  PetscMatrix<T> * matrix_A = dynamic_cast<PetscMatrix<T> *>(&matrix_A_in);
-  PetscMatrix<T> * matrix_B = dynamic_cast<PetscMatrix<T> *>(&matrix_B_in);
+  PetscMatrixBase<T> * matrix_A = dynamic_cast<PetscMatrixBase<T> *>(&matrix_A_in);
+  PetscMatrixBase<T> * matrix_B = dynamic_cast<PetscMatrixBase<T> *>(&matrix_B_in);
 
   libmesh_error_msg_if(!matrix_A || !matrix_B,
-                       "Error: inputs to solve_generalized() must be of type PetscMatrix.");
+                       "Error: inputs to solve_generalized() must be of type PetscMatrixBase.");
 
   // Close the matrix and vectors in case this wasn't already done.
   if (this->_close_matrix_before_solve)
@@ -298,9 +298,9 @@ SlepcEigenSolver<T>::solve_generalized (ShellMatrix<T> & shell_matrix_A,
                         &mat_A);
   LIBMESH_CHKERR(ierr);
 
-  PetscMatrix<T> * matrix_B = dynamic_cast<PetscMatrix<T> *>(&matrix_B_in);
+  PetscMatrixBase<T> * matrix_B = dynamic_cast<PetscMatrixBase<T> *>(&matrix_B_in);
 
-  libmesh_error_msg_if(!matrix_B, "Error: inputs to solve_generalized() must be of type PetscMatrix.");
+  libmesh_error_msg_if(!matrix_B, "Error: inputs to solve_generalized() must be of type PetscMatrixBase.");
 
   // Close the matrix and vectors in case this wasn't already done.
   if (this->_close_matrix_before_solve)
@@ -329,9 +329,9 @@ SlepcEigenSolver<T>::solve_generalized (SparseMatrix<T> & matrix_A_in,
 
   PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
 
-  PetscMatrix<T> * matrix_A = dynamic_cast<PetscMatrix<T> *>(&matrix_A_in);
+  PetscMatrixBase<T> * matrix_A = dynamic_cast<PetscMatrixBase<T> *>(&matrix_A_in);
 
-  libmesh_error_msg_if(!matrix_A, "Error: inputs to solve_generalized() must be of type PetscMatrix.");
+  libmesh_error_msg_if(!matrix_A, "Error: inputs to solve_generalized() must be of type PetscMatrixBase.");
 
   // Close the matrix and vectors in case this wasn't already done.
   if (this->_close_matrix_before_solve)
@@ -427,9 +427,9 @@ SlepcEigenSolver<T>::solve_generalized (ShellMatrix<T> & shell_matrix_A,
   this->init ();
 
   // Make sure the SparseMatrix passed in is really a PetscMatrix
-  PetscMatrix<T> * precond = dynamic_cast<PetscMatrix<T> *>(&precond_in);
+  PetscMatrixBase<T> * precond = dynamic_cast<PetscMatrixBase<T> *>(&precond_in);
 
-  libmesh_error_msg_if(!precond, "Error: input preconditioning matrix to solve_generalized() must be of type PetscMatrix.");
+  libmesh_error_msg_if(!precond, "Error: input preconditioning matrix to solve_generalized() must be of type PetscMatrixBase.");
 
   PetscShellMatrix<T> * matrix_A = dynamic_cast<PetscShellMatrix<T> *> (&shell_matrix_A);
 

--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -119,7 +119,7 @@ SlepcEigenSolver<T>::solve_standard (SparseMatrix<T> & matrix_A_in,
   this->init ();
 
   // Make sure the SparseMatrix passed in is really a PetscMatrix
-  PetscMatrixBase<T> * matrix_A = dynamic_cast<PetscMatrixBase<T> *>(&matrix_A_in);
+  auto * const matrix_A = cast_ptr<PetscMatrixBase<T> *>(&matrix_A_in);
 
   libmesh_error_msg_if(!matrix_A, "Error: input matrix to solve_standard() must be a PetscMatrixBase.");
 
@@ -181,11 +181,11 @@ SlepcEigenSolver<T>::solve_standard (ShellMatrix<T> & shell_matrix,
   this->init ();
 
   // Make sure the SparseMatrix passed in is really a PetscMatrix
-  PetscMatrixBase<T> * precond = dynamic_cast<PetscMatrixBase<T> *>(&precond_in);
+  auto * const precond = cast_ptr<PetscMatrixBase<T> *>(&precond_in);
 
   libmesh_error_msg_if(!precond, "Error: input preconditioning matrix to solve_standard() must be a PetscMatrixBase.");
 
-  PetscShellMatrix<T> * matrix = dynamic_cast<PetscShellMatrix<T> *> (&shell_matrix);
+  auto * const matrix = cast_ptr<PetscShellMatrix<T> *> (&shell_matrix);
 
   libmesh_error_msg_if(!matrix, "Error: input operator matrix to solve_standard() must be a PetscShellMatrix.");
 
@@ -206,11 +206,11 @@ SlepcEigenSolver<T>::solve_standard (ShellMatrix<T> & shell_matrix,
   this->init ();
 
   // Make sure the SparseMatrix passed in is really a PetscMatrix
-  PetscShellMatrix<T> * precond = dynamic_cast<PetscShellMatrix<T> *>(&precond_in);
+  auto * const precond = cast_ptr<PetscShellMatrix<T> *>(&precond_in);
 
   libmesh_error_msg_if(!precond, "Error: input preconditioning matrix to solve_standard() must be a PetscShellMatrix.");
 
-  PetscShellMatrix<T> * matrix = dynamic_cast<PetscShellMatrix<T> *> (&shell_matrix);
+  auto * const matrix = cast_ptr<PetscShellMatrix<T> *> (&shell_matrix);
 
   libmesh_error_msg_if(!matrix, "Error: input operator matrix to solve_standard() must be a PetscShellMatrix.");
 
@@ -253,8 +253,8 @@ SlepcEigenSolver<T>::solve_generalized (SparseMatrix<T> & matrix_A_in,
   this->init ();
 
   // Make sure the data passed in are really of Petsc types
-  PetscMatrixBase<T> * matrix_A = dynamic_cast<PetscMatrixBase<T> *>(&matrix_A_in);
-  PetscMatrixBase<T> * matrix_B = dynamic_cast<PetscMatrixBase<T> *>(&matrix_B_in);
+  auto * const matrix_A = cast_ptr<PetscMatrixBase<T> *>(&matrix_A_in);
+  auto * const matrix_B = cast_ptr<PetscMatrixBase<T> *>(&matrix_B_in);
 
   libmesh_error_msg_if(!matrix_A || !matrix_B,
                        "Error: inputs to solve_generalized() must be of type PetscMatrixBase.");
@@ -298,7 +298,7 @@ SlepcEigenSolver<T>::solve_generalized (ShellMatrix<T> & shell_matrix_A,
                         &mat_A);
   LIBMESH_CHKERR(ierr);
 
-  PetscMatrixBase<T> * matrix_B = dynamic_cast<PetscMatrixBase<T> *>(&matrix_B_in);
+  auto * const matrix_B = cast_ptr<PetscMatrixBase<T> *>(&matrix_B_in);
 
   libmesh_error_msg_if(!matrix_B, "Error: inputs to solve_generalized() must be of type PetscMatrixBase.");
 
@@ -329,7 +329,7 @@ SlepcEigenSolver<T>::solve_generalized (SparseMatrix<T> & matrix_A_in,
 
   PetscErrorCode ierr = LIBMESH_PETSC_SUCCESS;
 
-  PetscMatrixBase<T> * matrix_A = dynamic_cast<PetscMatrixBase<T> *>(&matrix_A_in);
+  auto * const matrix_A = cast_ptr<PetscMatrixBase<T> *>(&matrix_A_in);
 
   libmesh_error_msg_if(!matrix_A, "Error: inputs to solve_generalized() must be of type PetscMatrixBase.");
 
@@ -427,15 +427,15 @@ SlepcEigenSolver<T>::solve_generalized (ShellMatrix<T> & shell_matrix_A,
   this->init ();
 
   // Make sure the SparseMatrix passed in is really a PetscMatrix
-  PetscMatrixBase<T> * precond = dynamic_cast<PetscMatrixBase<T> *>(&precond_in);
+  auto * const precond = cast_ptr<PetscMatrixBase<T> *>(&precond_in);
 
   libmesh_error_msg_if(!precond, "Error: input preconditioning matrix to solve_generalized() must be of type PetscMatrixBase.");
 
-  PetscShellMatrix<T> * matrix_A = dynamic_cast<PetscShellMatrix<T> *> (&shell_matrix_A);
+  auto * const matrix_A = cast_ptr<PetscShellMatrix<T> *> (&shell_matrix_A);
 
   libmesh_error_msg_if(!matrix_A, "Error: input operator A to solve_generalized() must be of type PetscShellMatrix.");
 
-  PetscShellMatrix<T> * matrix_B = dynamic_cast<PetscShellMatrix<T> *> (&shell_matrix_B);
+  auto * const matrix_B = cast_ptr<PetscShellMatrix<T> *> (&shell_matrix_B);
 
   libmesh_error_msg_if(!matrix_B, "Error: input operator B to solve_generalized() must be of type PetscShellMatrix.");
 
@@ -457,15 +457,15 @@ SlepcEigenSolver<T>::solve_generalized (ShellMatrix<T> & shell_matrix_A,
   this->init ();
 
   // Make sure the ShellMatrix passed in is really a PetscShellMatrix
-  PetscShellMatrix<T> * precond = dynamic_cast<PetscShellMatrix<T> *>(&precond_in);
+  auto * const precond = cast_ptr<PetscShellMatrix<T> *>(&precond_in);
 
   libmesh_error_msg_if(!precond, "Error: input preconditioning matrix to solve_generalized() must be of type PetscShellMatrix.");
 
-  PetscShellMatrix<T> * matrix_A = dynamic_cast<PetscShellMatrix<T> *> (&shell_matrix_A);
+  auto * const matrix_A = cast_ptr<PetscShellMatrix<T> *> (&shell_matrix_A);
 
   libmesh_error_msg_if(!matrix_A, "Error: input operator A to solve_generalized() must be of type PetscShellMatrix.");
 
-  PetscShellMatrix<T> * matrix_B = dynamic_cast<PetscShellMatrix<T> *> (&shell_matrix_B);
+  auto * const matrix_B = cast_ptr<PetscShellMatrix<T> *> (&shell_matrix_B);
 
   libmesh_error_msg_if(!matrix_B, "Error: input operator B to solve_generalized() must be of type PetscShellMatrix.");
 

--- a/src/solvers/tao_optimization_solver.C
+++ b/src/solvers/tao_optimization_solver.C
@@ -181,7 +181,7 @@ extern "C"
     sys.update();
     X.swap(X_sys);
 
-    // Let's also wrap pc and h in PetscMatrixBase objects for convenience
+    // Let's also wrap pc and h in PetscMatrix objects for convenience
     PetscMatrix<Number> PC(pc, sys.comm());
     PetscMatrix<Number> hessian(h, sys.comm());
     PC.attach_dof_map(sys.get_dof_map());
@@ -293,7 +293,7 @@ extern "C"
     sys.update();
     X.swap(X_sys);
 
-    // Let's also wrap J and Jpre in PetscMatrixBase objects for convenience
+    // Let's also wrap J and Jpre in PetscMatrix objects for convenience
     PetscMatrix<Number> J_petsc(J, sys.comm());
     PetscMatrix<Number> Jpre_petsc(Jpre, sys.comm());
 
@@ -398,7 +398,7 @@ extern "C"
     sys.update();
     X.swap(X_sys);
 
-    // Let's also wrap J and Jpre in PetscMatrixBase objects for convenience
+    // Let's also wrap J and Jpre in PetscMatrix objects for convenience
     PetscMatrix<Number> J_petsc(J, sys.comm());
     PetscMatrix<Number> Jpre_petsc(Jpre, sys.comm());
 

--- a/src/solvers/tao_optimization_solver.C
+++ b/src/solvers/tao_optimization_solver.C
@@ -181,7 +181,7 @@ extern "C"
     sys.update();
     X.swap(X_sys);
 
-    // Let's also wrap pc and h in PetscMatrix objects for convenience
+    // Let's also wrap pc and h in PetscMatrixBase objects for convenience
     PetscMatrix<Number> PC(pc, sys.comm());
     PetscMatrix<Number> hessian(h, sys.comm());
     PC.attach_dof_map(sys.get_dof_map());
@@ -293,7 +293,7 @@ extern "C"
     sys.update();
     X.swap(X_sys);
 
-    // Let's also wrap J and Jpre in PetscMatrix objects for convenience
+    // Let's also wrap J and Jpre in PetscMatrixBase objects for convenience
     PetscMatrix<Number> J_petsc(J, sys.comm());
     PetscMatrix<Number> Jpre_petsc(Jpre, sys.comm());
 
@@ -398,7 +398,7 @@ extern "C"
     sys.update();
     X.swap(X_sys);
 
-    // Let's also wrap J and Jpre in PetscMatrix objects for convenience
+    // Let's also wrap J and Jpre in PetscMatrixBase objects for convenience
     PetscMatrix<Number> J_petsc(J, sys.comm());
     PetscMatrix<Number> Jpre_petsc(Jpre, sys.comm());
 
@@ -479,13 +479,13 @@ void TaoOptimizationSolver<T>::solve ()
 
   this->system().solution->zero();
 
-  PetscMatrix<T> * hessian  = cast_ptr<PetscMatrix<T> *>(this->system().matrix);
+  PetscMatrixBase<T> * hessian  = cast_ptr<PetscMatrixBase<T> *>(this->system().matrix);
   // PetscVector<T> * gradient = cast_ptr<PetscVector<T> *>(this->system().rhs);
   PetscVector<T> * x         = cast_ptr<PetscVector<T> *>(this->system().solution.get());
   PetscVector<T> * ceq       = cast_ptr<PetscVector<T> *>(this->system().C_eq.get());
-  PetscMatrix<T> * ceq_jac   = cast_ptr<PetscMatrix<T> *>(this->system().C_eq_jac.get());
+  PetscMatrixBase<T> * ceq_jac   = cast_ptr<PetscMatrixBase<T> *>(this->system().C_eq_jac.get());
   PetscVector<T> * cineq     = cast_ptr<PetscVector<T> *>(this->system().C_ineq.get());
-  PetscMatrix<T> * cineq_jac = cast_ptr<PetscMatrix<T> *>(this->system().C_ineq_jac.get());
+  PetscMatrixBase<T> * cineq_jac = cast_ptr<PetscMatrixBase<T> *>(this->system().C_ineq_jac.get());
   PetscVector<T> * lb        = cast_ptr<PetscVector<T> *>(&this->system().get_vector("lower_bounds"));
   PetscVector<T> * ub        = cast_ptr<PetscVector<T> *>(&this->system().get_vector("upper_bounds"));
 


### PR DESCRIPTION
And critically, always allow retrieving a PetscMatrix context from a PETSc mat. Eventually we may be able to remove the PetscMatrix from Mat constructors entirely. That would be good

This change was strongly suggested by the need to convert LinearSolver to be able to handle StaticCondensation