### PR TITLE
Add `Quad::quality(WARP)` implementation

### DIFF
--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -37,7 +37,6 @@ namespace libMesh
 // Hex class static member initializations
 
 
-// We need to require C++11...
 const Real Hex::_master_points[27][3] =
   {
     {-1, -1, -1},

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -43,7 +43,6 @@ namespace libMesh
 // InfHex class static member initializations
 
 
-// We need to require C++11...
 const Real InfHex::_master_points[18][3] =
   {
     {-1, -1, 0},

--- a/src/geom/cell_inf_prism.C
+++ b/src/geom/cell_inf_prism.C
@@ -37,7 +37,6 @@ namespace libMesh
 // InfPrism class static member initializations
 
 
-// We need to require C++11...
 const Real InfPrism::_master_points[12][3] =
   {
     {0, 0, 0},

--- a/src/geom/cell_prism.C
+++ b/src/geom/cell_prism.C
@@ -32,7 +32,6 @@ namespace libMesh
 // Prism class static member initializations
 
 
-// We need to require C++11...
 const Real Prism::_master_points[18][3] =
   {
     {0, 0, -1},

--- a/src/geom/cell_pyramid.C
+++ b/src/geom/cell_pyramid.C
@@ -31,7 +31,6 @@ namespace libMesh
 // Pyramid class static member initializations
 
 
-// We need to require C++11...
 const Real Pyramid::_master_points[14][3] =
   {
     {-1, -1, 0},

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1599,29 +1599,21 @@ Real Elem::quality (const ElemQuality q) const
         if (this->dim() < 2)
           return 1;
 
-        std::vector<Real> edge_lengths;
-        for (auto e : make_range(this->n_edges()))
-          {
-            const Point p0 = this->point(this->local_edge_node(e,0)),
-                        p1 = this->point(this->local_edge_node(e,1));
+        std::vector<Real> edge_lengths(this->n_edges());
+        for (auto e : index_range(edge_lengths))
+          edge_lengths[e] = (this->point(this->local_edge_node(e,1)) -
+                             this->point(this->local_edge_node(e,0))).norm();
 
-            edge_lengths.push_back((p1-p0).norm());
-          }
+        auto [min, max] =
+          std::minmax_element(edge_lengths.begin(), edge_lengths.end());
 
-        const Real max = *std::max_element(edge_lengths.begin(),
-                                           edge_lengths.end()),
-                   min = *std::min_element(edge_lengths.begin(),
-                                           edge_lengths.end());
-
-        if (min == 0.)
+        if (*min == 0.)
           return 0.;
         else
-          return max / min;
+          return *max / *min;
       }
-      /**
-       * I don't know what to do for any other metric in general;
-       * subclasses may have specific overrides.
-       */
+
+      // Return 1 if we made it here
     default:
       {
         libmesh_do_once( libmesh_here();

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1592,8 +1592,9 @@ Real Elem::quality (const ElemQuality q) const
 {
   switch (q)
     {
-      // Aspect Ratio: Maximum edge length ratios
-    case ASPECT_RATIO:
+      // Return the maximum ratio of edge lengths, or zero if that
+      // maximum would otherwise be infinity.
+    case EDGE_LENGTH_RATIO:
       {
         if (this->dim() < 2)
           return 1;

--- a/src/geom/face_inf_quad.C
+++ b/src/geom/face_inf_quad.C
@@ -35,7 +35,6 @@ namespace libMesh
 // InfQuad class static member initializations
 
 
-// We need to require C++11...
 const Real InfQuad::_master_points[6][3] =
   {
     {-1, 0},

--- a/src/geom/face_inf_quad.C
+++ b/src/geom/face_inf_quad.C
@@ -33,8 +33,8 @@ namespace libMesh
 
 // ------------------------------------------------------------
 // InfQuad class static member initializations
-
-
+// Note: we can omit initialization of the third entry of each row because
+// static variables are automatically zero-initialized.
 const Real InfQuad::_master_points[6][3] =
   {
     {-1, 0},

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -189,33 +189,21 @@ Real Quad::quality (const ElemQuality q) const
 {
   switch (q)
     {
-    case EDGE_LENGTH_RATIO:
-      {
-        // The CUBIT 15.1 User Documentation refers to this as the
-        // "Aspect Ratio" metric, however, we prefer the slightly more
-        // robust aspect ratio formula employed by Ansys, and have
-        // designated that as our ASPECT_RATIO metric here. We
-        // therefore refer to this quality metric as EDGE_LENGTH_RATIO
-        // instead.
-        //
-        // Note: consider a "rhombus". All four side lengths are
-        // equal, so the aspect ratio of this element, according to
-        // the EDGE_LENGTH_RATIO formula, is always 1.0, regardless of
-        // the internal angle "theta" of the rhombus. A more sensitive
-        // aspect ratio should take this internal angle into account,
-        // so that very thin "diamond" Quads are considered to have a
-        // "high" aspect ratio.
-        Real lengths[4] = {this->length(0,1), this->length(1,2), this->length(2,3), this->length(3,0)};
-        Real
-          max = *std::max_element(lengths, lengths+4),
-          min = *std::min_element(lengths, lengths+4);
-
-        // Return 0. instead of dividing by zero.
-        if (min == 0.)
-          return 0.;
-        else
-          return max / min;
-      }
+      // The EDGE_LENGTH_RATIO metric is handled by the base class.
+      //
+      // The CUBIT 15.1 User Documentation refers to the
+      // EDGE_LENGTH_RATIO as the "Aspect Ratio" metric for Quads,
+      // however, we prefer the slightly more robust aspect ratio
+      // formula employed by Ansys, and have therefore designated that
+      // as our ASPECT_RATIO metric here.
+      //
+      // As a counter-example for employing the EDGE_LENGTH_RATIO in
+      // Quads, consider a "rhombus". All four side lengths are equal,
+      // so the EDGE_LENGTH_RATIO of this element is always (the
+      // optimal value) 1.0, regardless of the internal angle "theta"
+      // of the rhombus. A more sensitive shape quality metric should
+      // take this internal angle into account, so that very thin
+      // rhombus-shaped Quads are not considered optimal.
 
     case ASPECT_RATIO:
       {

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -442,6 +442,26 @@ Real Quad::quality (const ElemQuality q) const
         return 1.;
       }
 
+    case WARP:
+      {
+        // We compute the angle between the two planes formed by
+        // drawing an imaginary diagonal separating opposite vertices
+        // A and B, where (A,B) = (0,2) and (1,3). The element warpage
+        // is then taken to be the smaller of these two angles. For a
+        // flat quadrilateral, the planes are parallel, thus the angle
+        // between them is zero, and the element warpage is therefore
+        // 1.
+        //
+        // Reference: https://cubit.sandia.gov/files/cubit/16.08/help_manual/WebHelp/mesh_generation/mesh_quality_assessment/quadrilateral_metrics.htm
+        Point
+          n0 = (this->point(1) - this->point(0)).cross(this->point(3) - this->point(0)).unit(),
+          n1 = (this->point(2) - this->point(1)).cross(this->point(0) - this->point(1)).unit(),
+          n2 = (this->point(3) - this->point(2)).cross(this->point(1) - this->point(2)).unit(),
+          n3 = (this->point(0) - this->point(3)).cross(this->point(2) - this->point(3)).unit();
+
+        return std::min(n0*n2, n1*n3);
+      }
+
     default:
       return Elem::quality(q);
     }

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -28,12 +28,10 @@
 namespace libMesh
 {
 
-
-
 // ------------------------------------------------------------
 // Quad class static member initializations
-
-
+// Note: we can omit initialization of the third entry of each row because
+// static variables are automatically zero-initialized.
 const Real Quad::_master_points[9][3] =
   {
     {-1, -1},

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -34,7 +34,6 @@ namespace libMesh
 // Quad class static member initializations
 
 
-// We need to require C++11...
 const Real Quad::_master_points[9][3] =
   {
     {-1, -1},

--- a/src/geom/face_tri.C
+++ b/src/geom/face_tri.C
@@ -31,8 +31,6 @@ namespace libMesh
 // ------------------------------------------------------------
 // Tri class static member initializations
 
-
-// We need to require C++11...
 const Real Tri::_master_points[6][3] =
   {
     {0, 0},
@@ -42,10 +40,6 @@ const Real Tri::_master_points[6][3] =
     {0.5, 0.5},
     {0, 0.5}
   };
-
-
-
-
 
 
 

--- a/src/geom/face_tri.C
+++ b/src/geom/face_tri.C
@@ -30,7 +30,8 @@ namespace libMesh
 
 // ------------------------------------------------------------
 // Tri class static member initializations
-
+// Note: we can omit initialization of the third entry of each row because
+// static variables are automatically zero-initialized.
 const Real Tri::_master_points[6][3] =
   {
     {0, 0},


### PR DESCRIPTION
Also, drop the existing `Quad::quality(EDGE_LENGTH_RATIO)` code since that is handled generically in the base class.