### PR TITLE
Fix for Tri7::is_face()

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -730,11 +730,14 @@ public:
 
   /**
    * \returns \p true if the specified (local) node number is an edge node.
+   * For 1D elements, is_edge() is equivalent to is_internal().
    */
   virtual bool is_edge(const unsigned int i) const = 0;
 
   /**
    * \returns \p true if the specified (local) node number is a face node.
+   * For 2D elements, is_face() is equivalent to is_internal().
+   * For 1D elements, is_face() == false.
    */
   virtual bool is_face(const unsigned int i) const = 0;
 

--- a/src/geom/face_tri7.C
+++ b/src/geom/face_tri7.C
@@ -133,8 +133,10 @@ bool Tri7::is_edge(const unsigned int i) const
   return true;
 }
 
-bool Tri7::is_face(const unsigned int) const
+bool Tri7::is_face(const unsigned int i) const
 {
+  if (i > 5)
+    return true;
   return false;
 }
 


### PR DESCRIPTION
This makes it consistent with Quad9::is_face() which returns true for the central Node of the Quad9.

Also improve the documentation for Elem::is_face() and Elem::is_edge() to make our conventions clear for elements of specific dimension.