### PR TITLE
Better error when asked to tetrahedralize a broken boundary

### DIFF
--- a/src/mesh/mesh_tet_interface.C
+++ b/src/mesh/mesh_tet_interface.C
@@ -38,7 +38,10 @@ namespace {
                         std::unordered_set<Elem *> & current_component,
                         Elem * elem)
   {
-    libmesh_assert(elem);
+    libmesh_error_msg_if
+      (!elem,
+       "Missing element when trying to identify boundary component to mesh.\n"
+       "Perhaps a boundary element does not have all neighbor pointers set?\n");
 
     if (current_component.count(elem))
       return;

--- a/tests/mesh/mesh_tet_test.C
+++ b/tests/mesh/mesh_tet_test.C
@@ -271,7 +271,7 @@ public:
   }
 
 
-#ifdef LIBMESH_HAVE_TRIANGLE
+#ifdef LIBMESH_HAVE_TETGEN
   void testTetGen()
   {
     LOG_UNIT_TEST;

--- a/tests/mesh/mesh_tet_test.C
+++ b/tests/mesh/mesh_tet_test.C
@@ -54,6 +54,8 @@ Real build_octahedron (MeshBase & mesh, bool flip_tris,
   add_tri({5,3,2});
   add_tri({5,2,1});
 
+  // Keep node ids unchanged so we can use them later
+  mesh.allow_renumbering(false);
   mesh.prepare_for_use();
 
   // Octahedron volume

--- a/tests/mesh/mesh_tet_test.C
+++ b/tests/mesh/mesh_tet_test.C
@@ -75,6 +75,7 @@ public:
 #ifdef LIBMESH_HAVE_NETGEN
   // The most basic test to start with
   CPPUNIT_TEST( testNetGen );
+  CPPUNIT_TEST( testNetGenError );
   CPPUNIT_TEST( testNetGenTets );
   CPPUNIT_TEST( testNetGenFlippedTris );
   CPPUNIT_TEST( testNetGenHole );
@@ -98,6 +99,7 @@ public:
 #ifdef LIBMESH_HAVE_TETGEN
   /*
   CPPUNIT_TEST( testTetGen );
+  CPPUNIT_TEST( testTetGenError );
   CPPUNIT_TEST( testTetGenInterp );
   CPPUNIT_TEST( testTetGenInterp2 );
   */
@@ -235,6 +237,43 @@ public:
   }
 
 
+  void testTrisToTetsError(MeshBase & mesh,
+                           MeshTetInterface & triangulator,
+                           bool flip_tris = false)
+  {
+#ifdef LIBMESH_ENABLE_EXCEPTIONS
+    const Real expected_volume =
+      build_octahedron(mesh, false, -1, 1, -1, 1, -0.1, 0.1);
+
+    // Remove one tri, breaking the mesh
+    for (auto elem : mesh.element_ptr_range())
+      if (elem->node_id(0) == 0 &&
+          elem->node_id(1) == 1 &&
+          elem->node_id(2) == 2)
+        mesh.delete_elem(elem);
+    mesh.prepare_for_use();
+
+    bool threw_desired_exception = false;
+    try {
+      this->testTetInterfaceBase(mesh, triangulator, /* n_elem = */ 4,
+                                 /* n_nodes = */ 6, expected_volume);
+    }
+    catch (libMesh::LogicError & e) {
+      std::regex msg_regex("neighbor pointers set");
+      CPPUNIT_ASSERT(std::regex_search(e.what(), msg_regex));
+      threw_desired_exception = true;
+    }
+    catch (CppUnit::Exception & e) {
+      throw e;
+    }
+    catch (...) {
+      CPPUNIT_ASSERT_MESSAGE("Unexpected exception type thrown", false);
+    }
+    CPPUNIT_ASSERT(threw_desired_exception);
+#endif
+  }
+
+
   void testTetsToTets(MeshBase & mesh,
                       MeshTetInterface & triangulator)
   {
@@ -282,6 +321,17 @@ public:
   }
 
 
+  void testTetGenError()
+  {
+    LOG_UNIT_TEST;
+
+    Mesh mesh(*TestCommWorld);
+    TetGenMeshInterface tet_tet(mesh);
+      testTrisToTetsError(mesh, tet_tet);
+  }
+
+
+
   /*
   void testTetGenInterp()
   {
@@ -314,6 +364,16 @@ public:
     Mesh mesh(*TestCommWorld);
     NetGenMeshInterface net_tet(mesh);
     testTrisToTets(mesh, net_tet);
+  }
+
+
+  void testNetGenError()
+  {
+    LOG_UNIT_TEST;
+
+    Mesh mesh(*TestCommWorld);
+    NetGenMeshInterface net_tet(mesh);
+    testTrisToTetsError(mesh, net_tet);
   }
 
 


### PR DESCRIPTION
In https://github.com/idaholab/moose/pull/28298#discussion_r1707391079 @miaoyinb reported a segfault from such user input, and the naked assertion failure we'd report in dbg/devel modes wasn't much better.  Hopefully the new error message here is meaningful enough for most users.