### PR TITLE
Add generic `Elem::quality(MIN,MAX_ANGLE)` implementation

### DIFF
--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1613,6 +1613,88 @@ Real Elem::quality (const ElemQuality q) const
           return *max / *min;
       }
 
+    case MIN_ANGLE:
+    case MAX_ANGLE:
+      {
+        // 1D elements don't have interior angles, so just return some
+        // dummy value in that case.
+        if (this->dim() < 2)
+          return 0.;
+
+        // Initialize return values
+        Real min_angle = std::numeric_limits<Real>::max();
+        Real max_angle = -std::numeric_limits<Real>::max();
+
+        for (auto n : this->node_index_range())
+          {
+            // Get list of edge ids adjacent to this node.
+            auto adjacent_edge_ids = this->edges_adjacent_to_node(n);
+
+            // Skip any nodes with fewer than 2 adjacent edges. You
+            // need at least two adjacent edges to form an interior
+            // element angle.
+            auto N = adjacent_edge_ids.size();
+            if (N < 2)
+              continue;
+
+            // Consider all possible pairs of edges adjacent to node n
+            for (unsigned int first = 0; first < N-1; ++first)
+              for (unsigned int second = first+1; second < N; ++second)
+                {
+                  // Get ids of first and second edges
+                  auto first_edge = adjacent_edge_ids[first];
+                  auto second_edge = adjacent_edge_ids[second];
+
+                  // Get node ids of first and second edge
+                  auto first_edge_node_0 = this->local_edge_node(first_edge, 0);
+                  auto first_edge_node_1 = this->local_edge_node(first_edge, 1);
+                  auto second_edge_node_0 = this->local_edge_node(second_edge, 0);
+                  auto second_edge_node_1 = this->local_edge_node(second_edge, 1);
+
+                  // Orient both edges so that edge node 0 == n
+                  if (first_edge_node_0 != n)
+                    std::swap(first_edge_node_0, first_edge_node_1);
+                  if (second_edge_node_0 != n)
+                    std::swap(second_edge_node_0, second_edge_node_1);
+
+                  libmesh_assert_equal_to(first_edge_node_0, n);
+                  libmesh_assert_equal_to(second_edge_node_0, n);
+
+                  // Locally oriented edge vectors
+                  Point
+                    first_ev = this->point(first_edge_node_1) - this->point(first_edge_node_0),
+                    second_ev = this->point(second_edge_node_1) - this->point(second_edge_node_0);
+
+                  // Angle between them in the range [0, pi]
+                  Real theta = std::acos(first_ev.unit() * second_ev.unit());
+
+                  // Track min and max angles seen
+                  min_angle = std::min(theta, min_angle);
+                  max_angle = std::max(theta, max_angle);
+
+                  // Debugging
+                  std::cout << "first = " << first << std::endl;
+                  std::cout << "second = " << second << std::endl;
+                  std::cout << "first_edge = " << first_edge << std::endl;
+                  std::cout << "second_edge = " << second_edge << std::endl;
+                  std::cout << "first_edge_node_0 = " << first_edge_node_0 << std::endl;
+                  std::cout << "first_edge_node_1 = " << first_edge_node_1 << std::endl;
+                  std::cout << "second_edge_node_0 = " << second_edge_node_0 << std::endl;
+                  std::cout << "second_edge_node_1 = " << second_edge_node_1 << std::endl;
+                  std::cout << "first_ev = " << first_ev << std::endl;
+                  std::cout << "second_ev = " << second_ev << std::endl;
+                  std::cout << "theta = " << theta << std::endl;
+                }
+          }
+
+        // Debugging
+        std::cout << "min_angle = " << min_angle << std::endl;
+        std::cout << "max_angle = " << max_angle << std::endl;
+
+        // Return requested extreme value (in degrees)
+        return Real(180)/libMesh::pi * ((q == MIN_ANGLE) ? min_angle : max_angle);
+      }
+
       // Return 1 if we made it here
     default:
       {

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1671,25 +1671,8 @@ Real Elem::quality (const ElemQuality q) const
                   // Track min and max angles seen
                   min_angle = std::min(theta, min_angle);
                   max_angle = std::max(theta, max_angle);
-
-                  // Debugging
-                  std::cout << "first = " << first << std::endl;
-                  std::cout << "second = " << second << std::endl;
-                  std::cout << "first_edge = " << first_edge << std::endl;
-                  std::cout << "second_edge = " << second_edge << std::endl;
-                  std::cout << "first_edge_node_0 = " << first_edge_node_0 << std::endl;
-                  std::cout << "first_edge_node_1 = " << first_edge_node_1 << std::endl;
-                  std::cout << "second_edge_node_0 = " << second_edge_node_0 << std::endl;
-                  std::cout << "second_edge_node_1 = " << second_edge_node_1 << std::endl;
-                  std::cout << "first_ev = " << first_ev << std::endl;
-                  std::cout << "second_ev = " << second_ev << std::endl;
-                  std::cout << "theta = " << theta << std::endl;
                 }
           }
-
-        // Debugging
-        std::cout << "min_angle = " << min_angle << std::endl;
-        std::cout << "max_angle = " << max_angle << std::endl;
 
         // Return requested extreme value (in degrees)
         return Real(180)/libMesh::pi * ((q == MIN_ANGLE) ? min_angle : max_angle);

--- a/tests/geom/elem_test.C
+++ b/tests/geom/elem_test.C
@@ -684,12 +684,44 @@ public:
         }
   }
 
+  void test_node_edge_map_consistency()
+  {
+    LOG_UNIT_TEST;
+
+    for (const auto & elem : this->_mesh->active_local_element_ptr_range())
+      {
+        for (const auto nd : elem->node_index_range())
+          {
+            auto adjacent_edge_ids = elem->edges_adjacent_to_node(nd);
+
+            if (elem->dim() < 2)
+              {
+                // 0D elements don't have edges.
+                // 1D elements *are* "edges", but we don't consider
+                // them to *have* edges, so assert that here.
+                CPPUNIT_ASSERT(adjacent_edge_ids.empty());
+              }
+            else
+              {
+                // For 2D and 3D elements, on each edge which is
+                // claimed to be adjacent, check that "nd" is indeed
+                // on it
+                for (const auto & edge_id : adjacent_edge_ids)
+                  {
+                    auto node_ids_on_edge = elem->nodes_on_edge(edge_id);
+                    CPPUNIT_ASSERT(std::find(node_ids_on_edge.begin(), node_ids_on_edge.end(), nd) != node_ids_on_edge.end());
+                  }
+              }
+          }
+      }
+  }
 
 };
 
 #define ELEMTEST                                \
   CPPUNIT_TEST( test_bounding_box );            \
   CPPUNIT_TEST( test_quality );                 \
+  CPPUNIT_TEST( test_node_edge_map_consistency ); \
   CPPUNIT_TEST( test_maps );                    \
   CPPUNIT_TEST( test_static_data );             \
   CPPUNIT_TEST( test_permute );                 \

--- a/tests/geom/elem_test.C
+++ b/tests/geom/elem_test.C
@@ -54,19 +54,40 @@ public:
 
     for (const auto & elem : this->_mesh->active_local_element_ptr_range())
       {
-        // We only have one metric defined on all elements
-        const Real q = elem->quality(ASPECT_RATIO);
+        // EDGE_LENGTH_RATIO is one metric that is defined on all elements
+        const Real edge_length_ratio = elem->quality(EDGE_LENGTH_RATIO);
 
         // We use "0" to mean infinity rather than inf or NaN, and
         // every quality other than that should be 1 or larger (worse)
-        CPPUNIT_ASSERT_LESSEQUAL(q, Real(1)); // 1 <= q
+        CPPUNIT_ASSERT_LESSEQUAL(edge_length_ratio, Real(1)); // 1 <= edge_length_ratio
 
         // We're building isotropic meshes, where even elements
         // dissected from cubes ought to have tolerable quality.
         //
         // Worst I see is 2 on tets, but let's add a little tolerance
         // in case we decide to play with rotated meshes here later
-        CPPUNIT_ASSERT_LESSEQUAL(Real(2+TOLERANCE), q); // q <= 2
+        CPPUNIT_ASSERT_LESSEQUAL(Real(2+TOLERANCE), edge_length_ratio); // edge_length_ratio <= 2
+
+        // The MIN_ANGLE and MAX_ANGLE quality metrics are also defined on all elements
+        const Real min_angle = elem->quality(MIN_ANGLE);
+        const Real max_angle = elem->quality(MAX_ANGLE);
+
+        // Reference Quads/Hexes have maximum internal angles of 90
+        // degrees, but pyramids actually have an obtuse interior
+        // angle of acos(-1/3) ~ 109.47 deg formed by edge pairs
+        // {(0, 4), (2, 4)} and {(1,4), (3,4)}.
+        CPPUNIT_ASSERT_LESSEQUAL((std::acos(Real(-1)/3) * 180 / libMesh::pi) + TOLERANCE, max_angle);
+
+        // Notes on minimum angle we expect to see:
+        // 1.) 1D Elements don't have interior angles, so the base
+        //     class implementation currently returns 0 for those
+        //     elements.
+        // 2.) Reference triangles/tetrahedra have min interior angle
+        //     of 45 degrees, however, here we are checking Tets in a
+        //     build_cube() mesh which have angles as small as
+        //     acos(2/sqrt(6)) so we use that as our lower bound here.
+        if (elem->dim() > 1)
+          CPPUNIT_ASSERT_GREATEREQUAL((std::acos(Real(2)/std::sqrt(Real(6))) * 180 / libMesh::pi) - TOLERANCE, min_angle);
       }
   }
 

--- a/tests/geom/elem_test.h
+++ b/tests/geom/elem_test.h
@@ -117,8 +117,8 @@ public:
         _mesh->prepare_for_use();
       }
     else
-#endif
-#endif
+#endif // LIBMESH_DIM > 1
+#endif // LIBMESH_ENABLE_INFINITE_ELEMENTS
       {
         const unsigned int dim = test_elem->dim();
         const unsigned int use_y = dim > 1;


### PR DESCRIPTION
* Add specific unit tests for `MIN_ANGLE` and `MAX_ANGLE` metric for Quads.
* Add unit test that calls the new `Elem::quality()` implementation for all element types in the `elem_test.C` unit test suite, and check that the return values make sense.
* As requested in #3920, this PR also adds a unit test of the basic `Elem::edges_adjacent_to_node()` functionality that was added in #3920.
