### PR TITLE
Fix bad calls to LibmeshPetscCall when we don't have this->comm()

### DIFF
--- a/examples/eigenproblems/eigenproblems_ex4/eigenproblems_ex4.C
+++ b/examples/eigenproblems/eigenproblems_ex4/eigenproblems_ex4.C
@@ -707,7 +707,7 @@ form_matrixA(SNES /*snes*/, Vec x, Mat jac, Mat pc, void * ctx)
     PetscMatrix<Number> sub(pc, eigen_system.comm());
     eigen_system.copy_super_to_sub(pc_super, sub);
 #else
-    auto sub = PetscMatrixBase<Number>::get_context(pc);
+    auto sub = PetscMatrixBase<Number>::get_context(pc, eigen_system.comm());
     libmesh_assert(sub);
     eigen_system.copy_super_to_sub(pc_super, *sub);
 #endif

--- a/include/numerics/petsc_matrix_base.h
+++ b/include/numerics/petsc_matrix_base.h
@@ -146,7 +146,7 @@ public:
   /**
    * @returns The context for \p mat if it exists, else a \p nullptr
    */
-  static PetscMatrixBase<T> * get_context(Mat mat);
+  static PetscMatrixBase<T> * get_context(Mat mat, const TIMPI::Communicator & comm);
 
   virtual numeric_index_type m () const override;
 

--- a/src/numerics/petsc_matrix_base.C
+++ b/src/numerics/petsc_matrix_base.C
@@ -116,12 +116,15 @@ PetscMatrixBase<T> * PetscMatrixBase<T>::get_context(Mat mat)
 {
   void * ctx;
   PetscContainer container;
+  MPI_Comm mat_mpi_comm;
   TIMPI::Communicator world(PETSC_COMM_WORLD);
-  LibmeshPetscCall2(world, PetscObjectQuery((PetscObject)mat, "PetscMatrixCtx", (PetscObject *)&container));
+  LibmeshPetscCall2(world, PetscObjectGetComm((PetscObject)mat, &mat_mpi_comm));
+  TIMPI::Communicator mat_comm(mat_mpi_comm);
+  LibmeshPetscCall2(mat_comm, PetscObjectQuery((PetscObject)mat, "PetscMatrixCtx", (PetscObject *)&container));
   if (!container)
     return nullptr;
 
-  LibmeshPetscCall2(world, PetscContainerGetPointer(container, &ctx));
+  LibmeshPetscCall2(mat_comm, PetscContainerGetPointer(container, &ctx));
   libmesh_assert(ctx);
   return static_cast<PetscMatrixBase<T> *>(ctx);
 }

--- a/src/numerics/petsc_matrix_base.C
+++ b/src/numerics/petsc_matrix_base.C
@@ -116,11 +116,12 @@ PetscMatrixBase<T> * PetscMatrixBase<T>::get_context(Mat mat)
 {
   void * ctx;
   PetscContainer container;
-  LibmeshPetscCall(PetscObjectQuery((PetscObject)mat, "PetscMatrixCtx", (PetscObject *)&container));
+  TIMPI::Communicator world(PETSC_COMM_WORLD);
+  LibmeshPetscCall2(world, PetscObjectQuery((PetscObject)mat, "PetscMatrixCtx", (PetscObject *)&container));
   if (!container)
     return nullptr;
 
-  LibmeshPetscCall(PetscContainerGetPointer(container, &ctx));
+  LibmeshPetscCall2(world, PetscContainerGetPointer(container, &ctx));
   libmesh_assert(ctx);
   return static_cast<PetscMatrixBase<T> *>(ctx);
 }

--- a/src/numerics/petsc_matrix_base.C
+++ b/src/numerics/petsc_matrix_base.C
@@ -112,19 +112,15 @@ void PetscMatrixBase<T>::set_context()
 }
 
 template <typename T>
-PetscMatrixBase<T> * PetscMatrixBase<T>::get_context(Mat mat)
+PetscMatrixBase<T> * PetscMatrixBase<T>::get_context(Mat mat, const TIMPI::Communicator & comm)
 {
   void * ctx;
   PetscContainer container;
-  MPI_Comm mat_mpi_comm;
-  TIMPI::Communicator world(PETSC_COMM_WORLD);
-  LibmeshPetscCall2(world, PetscObjectGetComm((PetscObject)mat, &mat_mpi_comm));
-  TIMPI::Communicator mat_comm(mat_mpi_comm);
-  LibmeshPetscCall2(mat_comm, PetscObjectQuery((PetscObject)mat, "PetscMatrixCtx", (PetscObject *)&container));
+  LibmeshPetscCall2(comm, PetscObjectQuery((PetscObject)mat, "PetscMatrixCtx", (PetscObject *)&container));
   if (!container)
     return nullptr;
 
-  LibmeshPetscCall2(mat_comm, PetscContainerGetPointer(container, &ctx));
+  LibmeshPetscCall2(comm, PetscContainerGetPointer(container, &ctx));
   libmesh_assert(ctx);
   return static_cast<PetscMatrixBase<T> *>(ctx);
 }

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -478,10 +478,10 @@ extern "C"
     PetscBool j_is_mffd = PETSC_FALSE;
     PetscBool j_is_shell = PETSC_FALSE;
     if (pc)
-      LibmeshPetscCall(PetscObjectTypeCompare((PetscObject)pc, MATSHELL, &p_is_shell));
+      LibmeshPetscCall2(sys.comm(), PetscObjectTypeCompare((PetscObject)pc, MATSHELL, &p_is_shell));
     libmesh_assert(jac);
-    LibmeshPetscCall(PetscObjectTypeCompare((PetscObject)jac, MATMFFD, &j_is_mffd));
-    LibmeshPetscCall(PetscObjectTypeCompare((PetscObject)jac, MATSHELL, &j_is_shell));
+    LibmeshPetscCall2(sys.comm(), PetscObjectTypeCompare((PetscObject)jac, MATMFFD, &j_is_mffd));
+    LibmeshPetscCall2(sys.comm(), PetscObjectTypeCompare((PetscObject)jac, MATSHELL, &j_is_shell));
     if (j_is_mffd == PETSC_TRUE)
       {
         libmesh_assert(!Jac);

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -468,8 +468,8 @@ extern "C"
 
     NonlinearImplicitSystem & sys = solver->system();
 
-    PetscMatrixBase<Number> * const PC = pc ? PetscMatrixBase<Number>::get_context(pc) : nullptr;
-    PetscMatrixBase<Number> * Jac = jac ? PetscMatrixBase<Number>::get_context(jac) : nullptr;
+    PetscMatrixBase<Number> * const PC = pc ? PetscMatrixBase<Number>::get_context(pc, sys.comm()) : nullptr;
+    PetscMatrixBase<Number> * Jac = jac ? PetscMatrixBase<Number>::get_context(jac, sys.comm()) : nullptr;
     PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
     PetscVector<Number> X_global(x, sys.comm());
 

--- a/src/solvers/petscdmlibmeshimpl.C
+++ b/src/solvers/petscdmlibmeshimpl.C
@@ -691,8 +691,8 @@ static PetscErrorCode DMlibMeshJacobian(DM dm, Vec x, Mat jac, Mat pc)
 
   libmesh_assert(pc);
   libmesh_assert(jac);
-  PetscMatrixBase<Number> & the_pc = *PetscMatrixBase<Number>::get_context(pc);
-  PetscMatrixBase<Number> & Jac = *PetscMatrixBase<Number>::get_context(jac);
+  PetscMatrixBase<Number> & the_pc = *PetscMatrixBase<Number>::get_context(pc, sys.comm());
+  PetscMatrixBase<Number> & Jac = *PetscMatrixBase<Number>::get_context(jac, sys.comm());
   PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
   PetscMatrixBase<Number> & Jac_sys = *cast_ptr<PetscMatrixBase<Number> *>(sys.matrix);
   PetscVector<Number> X_global(x, sys.comm());


### PR DESCRIPTION
For the static method we don't have a communicator from anyone so we choose to except/abort across all ranks