### PR TITLE
Call netgen only on rank 0

### DIFF
--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1235,6 +1235,9 @@ void MeshCommunication::broadcast (MeshBase & mesh) const
   // Make sure mesh_dimension and elem_dimensions are consistent.
   mesh.cache_elem_data();
 
+  // Make sure mesh id counts are consistent.
+  mesh.update_parallel_id_counts();
+
   // We may have constraint rows on IsoGeometric Analysis meshes.  We
   // don't want to send these along with constrained nodes (like we
   // send boundary info for those nodes) because the associated rows'


### PR DESCRIPTION
At around 6 ranks on DistributedMesh we were starting to see Netgen (or
ourselves) operate in different ways on different processors, leading to
overlapping garbage when the different meshes were interpreted as one
mesh.

There's no reason we should even take the risk of differing Netgen
results or churn redundant clock cycles; since we have to serialize
anyway, let's just run Netgen on rank 0.