### PR TITLE
Add generic `Elem::quality(MIN,MAX_DIHEDRAL_ANGLE)` implementation

### DIFF
--- a/include/enums/enum_elem_quality.h
+++ b/include/enums/enum_elem_quality.h
@@ -38,6 +38,8 @@ enum ElemQuality : int {
                   SHAPE,
                   MAX_ANGLE,
                   MIN_ANGLE,
+                  MAX_DIHEDRAL_ANGLE,
+                  MIN_DIHEDRAL_ANGLE,
                   CONDITION,
                   DISTORTION,
                   TAPER,

--- a/include/enums/enum_elem_quality.h
+++ b/include/enums/enum_elem_quality.h
@@ -38,8 +38,6 @@ enum ElemQuality : int {
                   SHAPE,
                   MAX_ANGLE,
                   MIN_ANGLE,
-                  MAX_DIHEDRAL_ANGLE,
-                  MIN_DIHEDRAL_ANGLE,
                   CONDITION,
                   DISTORTION,
                   TAPER,
@@ -51,7 +49,9 @@ enum ElemQuality : int {
                   SIZE,
                   JACOBIAN,
                   TWIST,
-                  EDGE_LENGTH_RATIO};
+                  EDGE_LENGTH_RATIO,
+                  MAX_DIHEDRAL_ANGLE,
+                  MIN_DIHEDRAL_ANGLE};
 }
 
 #endif

--- a/src/geom/elem_quality.C
+++ b/src/geom/elem_quality.C
@@ -70,6 +70,14 @@ std::string Quality::name (const ElemQuality q)
       its_name = "Minimum Angle";
       break;
 
+    case MAX_DIHEDRAL_ANGLE:
+      its_name = "Maximum Dihedral Angle";
+      break;
+
+    case MIN_DIHEDRAL_ANGLE:
+      its_name = "Minimum Dihedral Angle";
+      break;
+
     case CONDITION:
       its_name = "Condition Number";
       break;
@@ -191,6 +199,22 @@ std::string Quality::describe (const ElemQuality q)
 
     case MIN_ANGLE:
       desc << "Smallest angle between all adjacent pairs of edges (in 2D, sides).\n"
+           << '\n'
+           << "Suggested ranges:\n"
+           << "Quads: (45 -> 90)\n"
+           << "Triangles: (30 -> 60)";
+      break;
+
+    case MAX_DIHEDRAL_ANGLE:
+      desc << "Largest angle between all adjacent pairs of sides (in 2D, equivalent to MAX_ANGLE).\n"
+           << '\n'
+           << "Suggested ranges:\n"
+           << "Quads: (90 -> 135)\n"
+           << "Triangles: (60 -> 90)";
+      break;
+
+    case MIN_DIHEDRAL_ANGLE:
+      desc << "Smallest angle between all adjacent pairs of sides (in 2D, equivalent to MIN_ANGLE).\n"
            << '\n'
            << "Suggested ranges:\n"
            << "Quads: (45 -> 90)\n"
@@ -344,6 +368,8 @@ std::vector<ElemQuality> Quality::valid(const ElemType t)
           JACOBIAN,
           MAX_ANGLE,
           MIN_ANGLE,
+          MAX_DIHEDRAL_ANGLE,
+          MIN_DIHEDRAL_ANGLE,
           SHAPE,
           SIZE
         };
@@ -366,6 +392,8 @@ std::vector<ElemQuality> Quality::valid(const ElemType t)
           JACOBIAN,
           MAX_ANGLE,
           MIN_ANGLE,
+          MAX_DIHEDRAL_ANGLE,
+          MIN_DIHEDRAL_ANGLE,
           SHAPE,
           SHEAR,
           SIZE,
@@ -388,6 +416,10 @@ std::vector<ElemQuality> Quality::valid(const ElemType t)
           CONDITION,
           DISTORTION,
           JACOBIAN,
+          MAX_ANGLE,
+          MIN_ANGLE,
+          MAX_DIHEDRAL_ANGLE,
+          MIN_DIHEDRAL_ANGLE,
           SHAPE,
           SIZE
         };
@@ -405,6 +437,10 @@ std::vector<ElemQuality> Quality::valid(const ElemType t)
           DIAGONAL,
           DISTORTION,
           JACOBIAN,
+          MAX_ANGLE,
+          MIN_ANGLE,
+          MAX_DIHEDRAL_ANGLE,
+          MIN_DIHEDRAL_ANGLE,
           SHAPE,
           SHEAR,
           SIZE,
@@ -421,7 +457,14 @@ std::vector<ElemQuality> Quality::valid(const ElemType t)
     case PRISM20:
     case PRISM21:
       {
-        // None yet
+        v = {
+          EDGE_LENGTH_RATIO,
+          MAX_ANGLE,
+          MIN_ANGLE,
+          MAX_DIHEDRAL_ANGLE,
+          MIN_DIHEDRAL_ANGLE,
+        };
+
         break;
       }
 
@@ -430,7 +473,14 @@ std::vector<ElemQuality> Quality::valid(const ElemType t)
     case PYRAMID14:
     case PYRAMID18:
       {
-        // None yet
+        v = {
+          EDGE_LENGTH_RATIO,
+          MAX_ANGLE,
+          MIN_ANGLE,
+          MAX_DIHEDRAL_ANGLE,
+          MIN_DIHEDRAL_ANGLE,
+        };
+
         break;
       }
 
@@ -446,23 +496,19 @@ std::vector<ElemQuality> Quality::valid(const ElemType t)
 
     case INFQUAD4:
     case INFQUAD6:
-      {
-        // None yet
-        break;
-      }
-
     case INFHEX8:
     case INFHEX16:
     case INFHEX18:
-      {
-        // None yet
-        break;
-      }
-
     case INFPRISM6:
     case INFPRISM12:
       {
-        // None yet
+        v = {
+          MAX_ANGLE,
+          MIN_ANGLE,
+          MAX_DIHEDRAL_ANGLE,
+          MIN_DIHEDRAL_ANGLE,
+        };
+
         break;
       }
 

--- a/src/utils/string_to_enum.C
+++ b/src/utils/string_to_enum.C
@@ -410,6 +410,8 @@ std::map<std::string, ElemQuality> elemquality_to_enum {
    {"SHAPE"              , SHAPE},
    {"MAX_ANGLE"          , MAX_ANGLE},
    {"MIN_ANGLE"          , MIN_ANGLE},
+   {"MAX_DIHEDRAL_ANGLE" , MAX_DIHEDRAL_ANGLE},
+   {"MIN_DIHEDRAL_ANGLE" , MIN_DIHEDRAL_ANGLE},
    {"CONDITION"          , CONDITION},
    {"DISTORTION"         , DISTORTION},
    {"TAPER"              , TAPER},

--- a/tests/geom/elem_test.C
+++ b/tests/geom/elem_test.C
@@ -6,6 +6,7 @@
 #include <libmesh/mesh_modification.h>
 #include <libmesh/mesh_refinement.h>
 #include <libmesh/parallel_implementation.h>
+#include <libmesh/enum_to_string.h>
 
 using namespace libMesh;
 
@@ -88,6 +89,31 @@ public:
         //     acos(2/sqrt(6)) so we use that as our lower bound here.
         if (elem->dim() > 1)
           CPPUNIT_ASSERT_GREATEREQUAL((std::acos(Real(2)/std::sqrt(Real(6))) * 180 / libMesh::pi) - TOLERANCE, min_angle);
+
+        // MIN,MAX_DIHEDRAL_ANGLE are implemented for all 3D elements
+        if (elem->dim() > 2)
+          {
+            const Real min_dihedral_angle = elem->quality(MIN_DIHEDRAL_ANGLE);
+            const Real max_dihedral_angle = elem->quality(MAX_DIHEDRAL_ANGLE);
+
+            // Debugging
+            // libMesh::out << "Elem type: " << Utility::enum_to_string(elem->type())
+            //              << ", min_dihedral_angle = " << min_dihedral_angle
+            //              << ", max_dihedral_angle = " << max_dihedral_angle
+            //              << std::endl;
+
+            // Assert that we match expected values for build_cube() meshes.
+            // * build_cube() meshes of hexes, tetrahedra, and prisms have max_dihedral_angle == 90
+            // * build_cube() meshes of pyramids have max_dihedral_angle == 60 between adjacent triangular faces
+            CPPUNIT_ASSERT_LESSEQUAL   (90 + TOLERANCE, max_dihedral_angle);
+
+            // * build_cube() meshes of hexes have min_dihedral_angle == 90
+            // * build_cube() meshes of prisms, tets, and pyramids have min_dihedral_angle == 45
+            // * For the InfPrism tests, we construct a single
+            //   InfPrism by hand with interior angle ~53.13 deg. so that
+            //   is the minimum dihedral angle we expect in that case.
+            CPPUNIT_ASSERT_GREATEREQUAL(45 - TOLERANCE, min_dihedral_angle);
+          }
       }
   }
 


### PR DESCRIPTION
After some discussion with @roystgnr, it seems clear to me that, for 3D elements, the dihedral angles (angles between adjacent Elem sides, where the sides are approximated by planes) are a more fundamental measure of Elem quality than the edge angles implemented in #3922. For example, it is easy to imagine a "squashed" tetrahedral element that has "nice" edge angles, but arbitrarily small dihedral angles, while the converse is not possible. This PR adds new `ElemQuality` enumerations `MIN_DIHEDRAL_ANGLE` and `MAX_DIHEDRAL_ANGLE` and a generic implementation for computing them, which falls back on the `MIN_ANGLE` and `MAX_ANGLE` code for 2D Elems. The new metrics are also unit tested for all Elem types, and give the expected results.