### PR TITLE
Netgen handling for unprepared inputs, non-contained holes

### DIFF
--- a/include/geom/bounding_box.h
+++ b/include/geom/bounding_box.h
@@ -59,7 +59,8 @@ public:
   }
 
   /**
-   * Sets the bounding box to encompass the universe.
+   * Sets the bounding box to be "inverted".  This is a useful
+   * starting point for future \p union_with operations.
    */
   void invalidate ()
   {

--- a/include/geom/bounding_box.h
+++ b/include/geom/bounding_box.h
@@ -90,6 +90,12 @@ public:
   { return this->second; }
 
   /**
+   * \returns \p true if the other bounding box is contained in this
+   * bounding box. Exact floating point <= comparisons are performed.
+   */
+  bool contains (const BoundingBox &) const;
+
+  /**
    * \returns \p true if the other bounding box has a non-empty
    * intersection with this bounding box. Exact floating point <=
    * comparisons are performed.
@@ -197,6 +203,26 @@ public:
 
 // ------------------------------------------------------------
 // BoundingBox class member functions
+
+inline
+bool
+BoundingBox::contains(const BoundingBox & other_box) const
+{
+  const libMesh::Point & my_lower = this->first;
+  const libMesh::Point & my_upper = this->second;
+
+  const libMesh::Point & other_lower = other_box.first;
+  const libMesh::Point & other_upper = other_box.second;
+
+  for (unsigned int dir=0; dir<LIBMESH_DIM; ++dir)
+    if (my_lower(dir) > other_lower(dir) ||
+        other_upper(dir) > my_upper(dir))
+      return false;
+
+  return true;
+}
+
+
 
 // BoundingBox::intersects() is about 30% faster when inlined, so its definition
 // is here instead of in the source file.

--- a/include/mesh/mesh_tet_interface.h
+++ b/include/mesh/mesh_tet_interface.h
@@ -22,6 +22,7 @@
 #include "libmesh/libmesh_config.h"
 
 // Local includes
+#include "libmesh/bounding_box.h"
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/point.h" // used for specifying holes
 
@@ -96,8 +97,11 @@ protected:
   /**
    * Remove volume elements from the given mesh, after converting
    * their outer boundary faces to surface elements.
+   *
+   * Returns the bounding box of the mesh; this is useful for
+   * detecting misplaced holes later.
    */
-  static void volume_to_surface_mesh (UnstructuredMesh & mesh);
+  static BoundingBox volume_to_surface_mesh (UnstructuredMesh & mesh);
 
   /**
    * This function checks the integrity of the current set of

--- a/src/mesh/mesh_netgen_interface.C
+++ b/src/mesh/mesh_netgen_interface.C
@@ -83,14 +83,14 @@ void NetGenMeshInterface::triangulate ()
   // can use them in serial.
 
   const BoundingBox mesh_bb =
-    this->volume_to_surface_mesh(this->_mesh);
+    MeshTetInterface::volume_to_surface_mesh(this->_mesh);
 
   std::vector<MeshSerializer> hole_serializers;
   if (_holes)
     for (std::unique_ptr<UnstructuredMesh> & hole : *_holes)
       {
         const BoundingBox hole_bb =
-          this->volume_to_surface_mesh(*hole);
+          MeshTetInterface::volume_to_surface_mesh(*hole);
 
         libmesh_error_msg_if
           (!mesh_bb.contains(hole_bb),

--- a/src/mesh/mesh_tet_interface.C
+++ b/src/mesh/mesh_tet_interface.C
@@ -113,6 +113,11 @@ void MeshTetInterface::attach_hole_list
 
 void MeshTetInterface::volume_to_surface_mesh(UnstructuredMesh & mesh)
 {
+  // If we've been handed an unprepared mesh then we need to fix that;
+  // we're relying on neighbor pointers here.
+  if (!mesh.is_prepared())
+    mesh.prepare_for_use();
+
   // First convert all volume boundaries to surface elements; this
   // gives us a manifold bounding the mesh, though it may not be a
   // connected manifold even if the volume mesh was connected.


### PR DESCRIPTION
If we have an unprepared input mesh we want to prepare it, not die in confusing ways inside Netgen code.

If we have a hole that definitely isn't contained in the boundary we're trying to tetrahedralize, we want to give a sensible error message, not die in confusing ways inside Netgen code.

Refs https://github.com/idaholab/moose/pull/28298