### PR TITLE
Make sure to destroy PetscShellMatrix `_mat`

### DIFF
--- a/include/numerics/petsc_shell_matrix.h
+++ b/include/numerics/petsc_shell_matrix.h
@@ -78,7 +78,7 @@ public:
 
   PetscShellMatrix (const Parallel::Communicator & comm_in);
 
-  virtual ~PetscShellMatrix () = default;
+  virtual ~PetscShellMatrix ();
 
   virtual numeric_index_type m () const override;
 

--- a/src/numerics/petsc_shell_matrix.C
+++ b/src/numerics/petsc_shell_matrix.C
@@ -24,10 +24,15 @@
 
 namespace libMesh
 {
+template <typename T>
+PetscShellMatrix<T>::~PetscShellMatrix()
+{
+  this->clear();
+}
 
 template <typename T>
 void PetscShellMatrix<T>::vector_mult (NumericVector<T> & dest,
-                                        const NumericVector<T> & arg) const
+                                       const NumericVector<T> & arg) const
 {
   PetscVector<T> & petsc_dest = cast_ref<PetscVector<T> &>(dest);
   const PetscVector<T> & petsc_arg = cast_ref<const PetscVector<T> &>(arg);
@@ -40,7 +45,7 @@ void PetscShellMatrix<T>::vector_mult (NumericVector<T> & dest,
 
 template <typename T>
 void PetscShellMatrix<T>::vector_mult_add (NumericVector<T> & dest,
-                                            const NumericVector<T> & arg) const
+                                           const NumericVector<T> & arg) const
 {
   PetscVector<T> & petsc_dest = cast_ref<PetscVector<T> &>(dest);
   const PetscVector<T> & petsc_arg = cast_ref<const PetscVector<T> &>(arg);


### PR DESCRIPTION
With the change in #3914 to make the `_mat` data member the same as the `PetscMatrix(Base)` class, the manual destruction is now required. This refs the valgrind failures on idaholab/moose#28411