### PR TITLE
Avoid SIGFPE in HDF5 1.14.3 init

### DIFF
--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -49,8 +49,9 @@ extern "C" {
 
 // C++ includes
 #include <algorithm>
-#include <sstream>
+#include <cfenv> // workaround for HDF5 bug
 #include <cstdlib> // std::strtol
+#include <sstream>
 #include <unordered_map>
 
 // Anonymous namespace for file local data and helper functions
@@ -242,6 +243,23 @@ const std::vector<int> prism_inverse_face_map = {4, 1, 2, 3, 5};
 
     return subdomain_map;
   }
+
+
+  // Workaround for https://github.com/HDFGroup/hdf5/issues/4381
+  // (A floating point exception when initializing HDF5 1.14.4) We
+  // should get rid of this again when that's a distant memory, but
+  // for now we have systems that don't have 1.14.4 available and that
+  // are having problems with 1.14.2
+  struct HDF5FPEWorkaround {
+    HDF5FPEWorkaround() {
+      std::feholdexcept(&old_env);
+    }
+    ~HDF5FPEWorkaround() {
+      std::fesetenv(&old_env);
+    }
+
+    std::fenv_t old_env;
+  };
 
 } // end anonymous namespace
 
@@ -678,11 +696,14 @@ void ExodusII_IO_Helper::open(const char * filename, bool read_only)
   // floating point data already stored in the file is returned"
   int io_ws = 0;
 
-  ex_id = exII::ex_open(filename,
-                        read_only ? EX_READ : EX_WRITE,
-                        &comp_ws,
-                        &io_ws,
-                        &ex_version);
+  {
+    HDF5FPEWorkaround disable_fpes;
+    ex_id = exII::ex_open(filename,
+                          read_only ? EX_READ : EX_WRITE,
+                          &comp_ws,
+                          &io_ws,
+                          &ex_version);
+  }
 
   std::string err_msg = std::string("Error opening ExodusII mesh file: ") + std::string(filename);
   EX_CHECK_ERR(ex_id, err_msg);
@@ -2180,7 +2201,10 @@ void ExodusII_IO_Helper::create(std::string filename)
         }
 #endif
 
-      ex_id = exII::ex_create(filename.c_str(), mode, &comp_ws, &io_ws);
+      {
+        HDF5FPEWorkaround disable_fpes;
+        ex_id = exII::ex_create(filename.c_str(), mode, &comp_ws, &io_ws);
+      }
 
       EX_CHECK_ERR(ex_id, "Error creating ExodusII/Nemesis mesh file.");
 

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -250,11 +250,15 @@ const std::vector<int> prism_inverse_face_map = {4, 1, 2, 3, 5};
   // should get rid of this again when that's a distant memory, but
   // for now we have systems that don't have 1.14.4 available and that
   // are having problems with 1.14.2
-  struct HDF5FPEWorkaround {
-    HDF5FPEWorkaround() {
+  struct HDF5FPEWorkaround
+  {
+    HDF5FPEWorkaround()
+    {
       std::feholdexcept(&old_env);
     }
-    ~HDF5FPEWorkaround() {
+
+    ~HDF5FPEWorkaround()
+    {
       std::fesetenv(&old_env);
     }
 


### PR DESCRIPTION
This was a short-lived bug (nonexistent in 1.14.2, fixed in 1.14.4) but it's biting MOOSE users right now and we're having trouble (for other reasons) downgrading or upgrading to a non-buggy version

This patch fixes the problem for me, as tested with `LIBMESH_OPTIONS='--re ExodusTest_EDGE2 --enable-fpe' make check -C tests` before and after.