### PR TITLE
Disable -march=native in Netgen

### DIFF
--- a/configure
+++ b/configure
@@ -55395,7 +55395,7 @@ then :
                                         mkdir -p contrib/netgen/install
 
                                         if (cd contrib/netgen/build && \
-                   cmake -DUSE_PYTHON=OFF -DUSE_GUI=OFF -DUSE_OCC=OFF -DCMAKE_INSTALL_PREFIX:PATH=$my_top_builddir/contrib/netgen/install \
+                   cmake -DUSE_NATIVE_ARCH=OFF -DUSE_PYTHON=OFF -DUSE_GUI=OFF -DUSE_OCC=OFF -DCMAKE_INSTALL_PREFIX:PATH=$my_top_builddir/contrib/netgen/install \
                    $my_top_srcdir/contrib/netgen/netgen)
 then :
 

--- a/m4/netgen.m4
+++ b/m4/netgen.m4
@@ -60,7 +60,7 @@ AC_DEFUN([CONFIGURE_NETGEN],
           dnl than a relative path, because cmake emits errors if
           dnl given the latter.  Guess why?
           AS_IF([(cd contrib/netgen/build && \
-                   cmake -DUSE_PYTHON=OFF -DUSE_GUI=OFF -DUSE_OCC=OFF -DCMAKE_INSTALL_PREFIX:PATH=$my_top_builddir/contrib/netgen/install \
+                   cmake -DUSE_NATIVE_ARCH=OFF -DUSE_PYTHON=OFF -DUSE_GUI=OFF -DUSE_OCC=OFF -DCMAKE_INSTALL_PREFIX:PATH=$my_top_builddir/contrib/netgen/install \
                    $my_top_srcdir/contrib/netgen/netgen)],
                 [
                   NETGEN_INCLUDE="-I\$(top_srcdir)/contrib/netgen/ -I\$(top_builddir)/contrib/netgen/build/"


### PR DESCRIPTION
This should definitely not be enabled by default, as it causes builds compiled on newer architecture versions to die with illegal instruction errors on older architecture versions.  And since Netgen has static objects with non-trivial constructors, we can see those failures even in codes that don't ever call Netgen!