### PR TITLE
Add some data storage used for assumed stress in RB-EIM with shells 

### DIFF
--- a/contrib/capnproto/rb_data.capnp
+++ b/contrib/capnproto/rb_data.capnp
@@ -129,6 +129,8 @@ struct RBEIMEvaluationReal @0xf8121d2237427a80 {
   interpolationJxWAllQp       @19 :List(List(Real));
   interpolationPhiValuesAllQp @20 :List(List(List(Real)));
   eimErrorIndicatorInterpData @21 :List(Real);
+  interpolationDxyzDxiElem    @22 :List(Point3D);
+  interpolationDxyzDetaElem   @23 :List(Point3D);
 }
 struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   nBfs                        @0  :Integer;
@@ -153,4 +155,6 @@ struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   interpolationJxWAllQp       @19 :List(List(Real));
   interpolationPhiValuesAllQp @20 :List(List(List(Real)));
   eimErrorIndicatorInterpData @21 :List(Complex);
+  interpolationDxyzDxiElem    @22 :List(Point3D);
+  interpolationDxyzDetaElem   @23 :List(Point3D);
 }

--- a/contrib/capnproto/rb_data.capnp
+++ b/contrib/capnproto/rb_data.capnp
@@ -129,8 +129,9 @@ struct RBEIMEvaluationReal @0xf8121d2237427a80 {
   interpolationJxWAllQp       @19 :List(List(Real));
   interpolationPhiValuesAllQp @20 :List(List(List(Real)));
   eimErrorIndicatorInterpData @21 :List(Real);
-  interpolationDxyzDxiElem    @22 :List(Point3D);
-  interpolationDxyzDetaElem   @23 :List(Point3D);
+  interpolationQruleOrder     @22 :List(Integer);
+  interpolationDxyzDxiElem    @23 :List(Point3D);
+  interpolationDxyzDetaElem   @24 :List(Point3D);
 }
 struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   nBfs                        @0  :Integer;
@@ -155,6 +156,7 @@ struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   interpolationJxWAllQp       @19 :List(List(Real));
   interpolationPhiValuesAllQp @20 :List(List(List(Real)));
   eimErrorIndicatorInterpData @21 :List(Complex);
-  interpolationDxyzDxiElem    @22 :List(Point3D);
-  interpolationDxyzDetaElem   @23 :List(Point3D);
+  interpolationQruleOrder     @22 :List(Integer);
+  interpolationDxyzDxiElem    @23 :List(Point3D);
+  interpolationDxyzDetaElem   @24 :List(Point3D);
 }

--- a/contrib/capnproto/rb_data.capnp
+++ b/contrib/capnproto/rb_data.capnp
@@ -132,6 +132,7 @@ struct RBEIMEvaluationReal @0xf8121d2237427a80 {
   interpolationQruleOrder     @22 :List(Integer);
   interpolationDxyzDxiElem    @23 :List(Point3D);
   interpolationDxyzDetaElem   @24 :List(Point3D);
+  interpolationDxyzDzetaElem  @25 :List(Point3D);
 }
 struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   nBfs                        @0  :Integer;
@@ -159,4 +160,5 @@ struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   interpolationQruleOrder     @22 :List(Integer);
   interpolationDxyzDxiElem    @23 :List(Point3D);
   interpolationDxyzDetaElem   @24 :List(Point3D);
+  interpolationDxyzDzetaElem  @25 :List(Point3D);
 }

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -456,6 +456,8 @@ public:
   void add_interpolation_points_phi_i_qp(const std::vector<Real> & phi_i_qp);
   void add_interpolation_points_JxW_all_qp(const std::vector<Real> & JxW_all_qp);
   void add_interpolation_points_phi_i_all_qp(const std::vector<std::vector<Real>> & phi_i_all_qp);
+  void add_elem_center_dxyzdxi(const Point & dxyzdxi);
+  void add_elem_center_dxyzdeta(const Point & dxyzdxi);
   void add_interpolation_points_spatial_indices(const std::vector<unsigned int> & spatial_indices);
 
   /**
@@ -474,6 +476,8 @@ public:
   const std::vector<Real> & get_interpolation_points_phi_i_qp(unsigned int index) const;
   const std::vector<Real> & get_interpolation_points_JxW_all_qp(unsigned int index) const;
   const std::vector<std::vector<Real>> & get_interpolation_points_phi_i_all_qp(unsigned int index) const;
+  const Point & get_elem_center_dxyzdxi(unsigned int index) const;
+  const Point & get_elem_center_dxyzdeta(unsigned int index) const;
   const std::vector<unsigned int> & get_interpolation_points_spatial_indices(unsigned int index) const;
 
   /**
@@ -512,7 +516,9 @@ public:
     const std::vector<Real> & phi_i_qp,
     ElemType elem_type,
     const std::vector<Real> & JxW_all_qp,
-    const std::vector<std::vector<Real>> & phi_i_all_qp);
+    const std::vector<std::vector<Real>> & phi_i_all_qp,
+    const Point & dxyz_dxi_elem_center,
+    const Point & dxyz_deta_elem_center);
 
   /**
    * Add \p side_bf to our EIM basis.

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -456,6 +456,7 @@ public:
   void add_interpolation_points_phi_i_qp(const std::vector<Real> & phi_i_qp);
   void add_interpolation_points_JxW_all_qp(const std::vector<Real> & JxW_all_qp);
   void add_interpolation_points_phi_i_all_qp(const std::vector<std::vector<Real>> & phi_i_all_qp);
+  void add_interpolation_points_qrule_order(Order qrule_order);
   void add_elem_center_dxyzdxi(const Point & dxyzdxi);
   void add_elem_center_dxyzdeta(const Point & dxyzdxi);
   void add_interpolation_points_spatial_indices(const std::vector<unsigned int> & spatial_indices);
@@ -476,6 +477,7 @@ public:
   const std::vector<Real> & get_interpolation_points_phi_i_qp(unsigned int index) const;
   const std::vector<Real> & get_interpolation_points_JxW_all_qp(unsigned int index) const;
   const std::vector<std::vector<Real>> & get_interpolation_points_phi_i_all_qp(unsigned int index) const;
+  Order get_interpolation_points_qrule_order(unsigned int index) const;
   const Point & get_elem_center_dxyzdxi(unsigned int index) const;
   const Point & get_elem_center_dxyzdeta(unsigned int index) const;
   const std::vector<unsigned int> & get_interpolation_points_spatial_indices(unsigned int index) const;
@@ -517,6 +519,7 @@ public:
     ElemType elem_type,
     const std::vector<Real> & JxW_all_qp,
     const std::vector<std::vector<Real>> & phi_i_all_qp,
+    Order qrule_order,
     const Point & dxyz_dxi_elem_center,
     const Point & dxyz_deta_elem_center);
 

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -82,6 +82,8 @@ struct VectorizedEvalInput
   std::vector<ElemType> elem_types;
   std::vector<std::vector<Real>> JxW_all_qp;
   std::vector<std::vector<std::vector<Real>>> phi_i_all_qp;
+  std::vector<Point> dxyzdxi_elem_center;
+  std::vector<Point> dxyzdeta_elem_center;
 };
 
 /**
@@ -401,6 +403,12 @@ public:
    * average" quantities.
    */
   bool requires_all_elem_qp_data;
+
+  /**
+   * Boolean to indicate whether this parametrized function requires data
+   * from the center on the current element.
+   */
+  bool requires_all_elem_center_data;
 
   /**
    * Boolean to indicate if this parametrized function is defined based on a lookup

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -23,6 +23,7 @@
 // libMesh includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/enum_elem_type.h"
+#include "libmesh/enum_order.h"
 
 // C++ includes
 #include <unordered_map>
@@ -84,6 +85,7 @@ struct VectorizedEvalInput
   std::vector<std::vector<std::vector<Real>>> phi_i_all_qp;
   std::vector<Point> dxyzdxi_elem_center;
   std::vector<Point> dxyzdeta_elem_center;
+  std::vector<Order> qrule_orders;
 };
 
 /**

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -902,6 +902,7 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
       }
   }
 
+  // Dxyzdxi at the element center for the element that contains each interpolation point.
   {
     auto elem_center_dxyzdxi =
       rb_eim_evaluation_reader.getInterpolationDxyzDxiElem();
@@ -917,6 +918,7 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
       }
   }
 
+  // Dxyzdxi at the element center for the element that contains each interpolation point.
   {
     auto elem_center_dxyzdeta =
       rb_eim_evaluation_reader.getInterpolationDxyzDetaElem();
@@ -929,6 +931,23 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
       {
         load_point(elem_center_dxyzdeta[i], dxyzdeta_buffer);
         rb_eim_evaluation.add_elem_center_dxyzdeta(dxyzdeta_buffer);
+      }
+  }
+
+  // Quadrature rule order associated to the element that contains each interpolation point.
+  {
+    auto interpolation_points_qrule_order_list =
+      rb_eim_evaluation_reader.getInterpolationQruleOrder();
+
+    if (interpolation_points_qrule_order_list.size() > 0)
+      {
+        libmesh_error_msg_if(interpolation_points_qrule_order_list.size() != n_bfs,
+                            "Size error while reading the eim interpolation element types.");
+
+        for (unsigned int i=0; i<n_bfs; ++i)
+          {
+            rb_eim_evaluation.add_interpolation_points_qrule_order(static_cast<Order>(interpolation_points_qrule_order_list[i]));
+          }
       }
   }
 

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -902,6 +902,36 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
       }
   }
 
+  {
+    auto elem_center_dxyzdxi =
+      rb_eim_evaluation_reader.getInterpolationDxyzDxiElem();
+
+    libmesh_error_msg_if(elem_center_dxyzdxi.size() != n_bfs,
+                         "Size error while reading the eim interpolation points.");
+
+    Point dxyzdxi_buffer;
+    for (const auto i : make_range(n_bfs))
+      {
+        load_point(elem_center_dxyzdxi[i], dxyzdxi_buffer);
+        rb_eim_evaluation.add_elem_center_dxyzdxi(dxyzdxi_buffer);
+      }
+  }
+
+  {
+    auto elem_center_dxyzdeta =
+      rb_eim_evaluation_reader.getInterpolationDxyzDetaElem();
+
+    libmesh_error_msg_if(elem_center_dxyzdeta.size() != n_bfs,
+                         "Size error while reading the eim interpolation points.");
+
+    Point dxyzdeta_buffer;
+    for (const auto i : make_range(n_bfs))
+      {
+        load_point(elem_center_dxyzdeta[i], dxyzdeta_buffer);
+        rb_eim_evaluation.add_elem_center_dxyzdeta(dxyzdeta_buffer);
+      }
+  }
+
   // Interpolation points element types
   {
     auto interpolation_points_elem_type_list =

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -804,7 +804,7 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
       rb_eim_evaluation_builder.initInterpolationQruleOrder(n_bfs);
     for (unsigned int i=0; i<n_bfs; ++i)
       interpolation_points_qrule_order_list.set(i,
-                                              rb_eim_evaluation.get_interpolation_points_qrule_order(i));
+                                                rb_eim_evaluation.get_interpolation_points_qrule_order(i));
   }
 
   // Element type for the element that contains each interpolation point

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -778,6 +778,24 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
       }
   }
 
+  {
+    auto dxyzdxi_elem_center =
+      rb_eim_evaluation_builder.initInterpolationDxyzDxiElem(n_bfs);
+    for (auto i : make_range(n_bfs))
+      {
+        add_point_to_builder(rb_eim_evaluation.get_elem_center_dxyzdxi(i), dxyzdxi_elem_center[i]);
+      }
+  }
+
+  {
+    auto dxyzdeta_elem_center =
+      rb_eim_evaluation_builder.initInterpolationDxyzDetaElem(n_bfs);
+    for (auto i : make_range(n_bfs))
+      {
+        add_point_to_builder(rb_eim_evaluation.get_elem_center_dxyzdeta(i), dxyzdeta_elem_center[i]);
+      }
+  }
+
   // Element type for the element that contains each interpolation point
   {
     auto interpolation_points_elem_type_list =

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -778,6 +778,7 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
       }
   }
 
+  // Dxyzdxi at the element center for the element that contains each interpolation point.
   {
     auto dxyzdxi_elem_center =
       rb_eim_evaluation_builder.initInterpolationDxyzDxiElem(n_bfs);
@@ -787,6 +788,7 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
       }
   }
 
+  // Dxyzdeta at the element center for the element that contains each interpolation point.
   {
     auto dxyzdeta_elem_center =
       rb_eim_evaluation_builder.initInterpolationDxyzDetaElem(n_bfs);
@@ -794,6 +796,15 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
       {
         add_point_to_builder(rb_eim_evaluation.get_elem_center_dxyzdeta(i), dxyzdeta_elem_center[i]);
       }
+  }
+
+  // Quadrature rule order associated to the element that contains each interpolation point.
+  {
+    auto interpolation_points_qrule_order_list =
+      rb_eim_evaluation_builder.initInterpolationQruleOrder(n_bfs);
+    for (unsigned int i=0; i<n_bfs; ++i)
+      interpolation_points_qrule_order_list.set(i,
+                                              rb_eim_evaluation.get_interpolation_points_qrule_order(i));
   }
 
   // Element type for the element that contains each interpolation point

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -2679,15 +2679,15 @@ bool RBEIMConstruction::enrich_eim_approximation_on_interiors(const QpDataMap & 
 
                   if (get_rb_eim_evaluation().get_parametrized_function().requires_all_elem_center_data)
                     {
-                        optimal_qrule_order = con.get_element_qrule().get_order();
-                        // Get data derivatives at vertex average
-                        std::vector<Point> nodes = { elem_ref.reference_elem()->vertex_average() };
-                        elem_fe->reinit (&elem_ref, &nodes);
+                      optimal_qrule_order = con.get_element_qrule().get_order();
+                      // Get data derivatives at vertex average
+                      std::vector<Point> nodes = { elem_ref.reference_elem()->vertex_average() };
+                      elem_fe->reinit (&elem_ref, &nodes);
 
-                        optimal_dxyzdxi_elem_center = dxyzdxi[0];
-                        optimal_dxyzdeta_elem_center = dxyzdeta[0];
+                      optimal_dxyzdxi_elem_center = dxyzdxi[0];
+                      optimal_dxyzdeta_elem_center = dxyzdeta[0];
 
-                        elem_fe->reinit(&elem_ref);
+                      elem_fe->reinit(&elem_ref);
                     }
                 }
             }

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -2589,6 +2589,8 @@ bool RBEIMConstruction::enrich_eim_approximation_on_interiors(const QpDataMap & 
   ElemType optimal_elem_type = INVALID_ELEM;
   std::vector<Real> optimal_JxW_all_qp;
   std::vector<std::vector<Real>> optimal_phi_i_all_qp;
+  Point optimal_dxyzdxi_elem_center;
+  Point optimal_dxyzdeta_elem_center;
 
   // Initialize largest_abs_value to be negative so that it definitely gets updated.
   Real largest_abs_value = -1.;
@@ -2611,6 +2613,8 @@ bool RBEIMConstruction::enrich_eim_approximation_on_interiors(const QpDataMap & 
       auto elem_fe = con.get_element_fe(/*var=*/0, elem_ref.dim());
       const std::vector<std::vector<Real>> & phi = elem_fe->get_phi();
       const auto & JxW = elem_fe->get_JxW();
+      const auto & dxyzdxi = elem_fe->get_dxyzdxi();
+      const auto & dxyzdeta = elem_fe->get_dxyzdeta();
 
       elem_fe->reinit(&elem_ref);
 
@@ -2671,6 +2675,18 @@ bool RBEIMConstruction::enrich_eim_approximation_on_interiors(const QpDataMap & 
                       optimal_JxW_all_qp = JxW;
                       optimal_phi_i_all_qp = phi;
                     }
+
+                  if (get_rb_eim_evaluation().get_parametrized_function().requires_all_elem_center_data)
+                    {
+                        // Get data derivatives at vertex average
+                        std::vector<Point> nodes = { elem_ref.reference_elem()->vertex_average() };
+                        elem_fe->reinit (&elem_ref, &nodes);
+
+                        optimal_dxyzdxi_elem_center = dxyzdxi[0];
+                        optimal_dxyzdeta_elem_center = dxyzdeta[0];
+
+                        elem_fe->reinit(&elem_ref);
+                    }
                 }
             }
         }
@@ -2691,6 +2707,8 @@ bool RBEIMConstruction::enrich_eim_approximation_on_interiors(const QpDataMap & 
   this->comm().broadcast(optimal_point_phi_i_qp, proc_ID_index);
   this->comm().broadcast(optimal_JxW_all_qp, proc_ID_index);
   this->comm().broadcast(optimal_phi_i_all_qp, proc_ID_index);
+  this->comm().broadcast(optimal_dxyzdxi_elem_center, proc_ID_index);
+  this->comm().broadcast(optimal_dxyzdeta_elem_center, proc_ID_index);
 
   // Cast optimal_elem_type to an int in order to broadcast it
   {
@@ -2726,7 +2744,9 @@ bool RBEIMConstruction::enrich_eim_approximation_on_interiors(const QpDataMap & 
                                   optimal_point_phi_i_qp,
                                   optimal_elem_type,
                                   optimal_JxW_all_qp,
-                                  optimal_phi_i_all_qp);
+                                  optimal_phi_i_all_qp,
+                                  optimal_dxyzdxi_elem_center,
+                                  optimal_dxyzdeta_elem_center);
 
   // In this case we did not encounter a linearly dependent basis function, so return false
   return false;

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -770,6 +770,11 @@ void RBEIMEvaluation::add_elem_center_dxyzdeta(const Point & dxyzdeta)
   _vec_eval_input.dxyzdeta_elem_center.emplace_back(dxyzdeta);
 }
 
+void RBEIMEvaluation::add_interpolation_points_qrule_order(Order qrule_order)
+{
+  _vec_eval_input.qrule_orders.emplace_back(qrule_order);
+}
+
 void RBEIMEvaluation::add_interpolation_points_spatial_indices(const std::vector<unsigned int> & spatial_indices)
 {
   _interpolation_points_spatial_indices.emplace_back(spatial_indices);
@@ -880,6 +885,13 @@ const Point & RBEIMEvaluation::get_elem_center_dxyzdeta(unsigned int index) cons
   return _vec_eval_input.dxyzdeta_elem_center[index];
 }
 
+Order RBEIMEvaluation::get_interpolation_points_qrule_order(unsigned int index) const
+{
+  libmesh_error_msg_if(index >= _vec_eval_input.qrule_orders.size(), "Error: Invalid index");
+
+  return _vec_eval_input.qrule_orders[index];
+}
+
 const std::vector<unsigned int> & RBEIMEvaluation::get_interpolation_points_spatial_indices(unsigned int index) const
 {
   libmesh_error_msg_if(index >= _interpolation_points_spatial_indices.size(), "Error: Invalid index");
@@ -932,6 +944,7 @@ void RBEIMEvaluation::add_interpolation_data(
   ElemType elem_type,
   const std::vector<Real> & JxW_all_qp,
   const std::vector<std::vector<Real>> & phi_i_all_qp,
+  Order qrule_order,
   const Point & dxyzdxi_elem_center,
   const Point & dxyzdeta_elem_center)
 {
@@ -945,6 +958,7 @@ void RBEIMEvaluation::add_interpolation_data(
   _vec_eval_input.elem_types.emplace_back(elem_type);
   _vec_eval_input.JxW_all_qp.emplace_back(JxW_all_qp);
   _vec_eval_input.phi_i_all_qp.emplace_back(phi_i_all_qp);
+  _vec_eval_input.qrule_orders.emplace_back(qrule_order);
   _vec_eval_input.dxyzdxi_elem_center.emplace_back(dxyzdxi_elem_center);
   _vec_eval_input.dxyzdeta_elem_center.emplace_back(dxyzdeta_elem_center);
 }

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -760,6 +760,16 @@ void RBEIMEvaluation::add_interpolation_points_phi_i_qp(const std::vector<Real> 
   _vec_eval_input.phi_i_qp.emplace_back(phi_i_qp);
 }
 
+void RBEIMEvaluation::add_elem_center_dxyzdxi(const Point & dxyzdxi)
+{
+  _vec_eval_input.dxyzdxi_elem_center.emplace_back(dxyzdxi);
+}
+
+void RBEIMEvaluation::add_elem_center_dxyzdeta(const Point & dxyzdeta)
+{
+  _vec_eval_input.dxyzdeta_elem_center.emplace_back(dxyzdeta);
+}
+
 void RBEIMEvaluation::add_interpolation_points_spatial_indices(const std::vector<unsigned int> & spatial_indices)
 {
   _interpolation_points_spatial_indices.emplace_back(spatial_indices);
@@ -856,6 +866,20 @@ const std::vector<Real> & RBEIMEvaluation::get_interpolation_points_phi_i_qp(uns
   return _vec_eval_input.phi_i_qp[index];
 }
 
+const Point & RBEIMEvaluation::get_elem_center_dxyzdxi(unsigned int index) const
+{
+  libmesh_error_msg_if(index >= _vec_eval_input.dxyzdxi_elem_center.size(), "Error: Invalid index");
+
+  return _vec_eval_input.dxyzdxi_elem_center[index];
+}
+
+const Point & RBEIMEvaluation::get_elem_center_dxyzdeta(unsigned int index) const
+{
+  libmesh_error_msg_if(index >= _vec_eval_input.dxyzdeta_elem_center.size(), "Error: Invalid index");
+
+  return _vec_eval_input.dxyzdeta_elem_center[index];
+}
+
 const std::vector<unsigned int> & RBEIMEvaluation::get_interpolation_points_spatial_indices(unsigned int index) const
 {
   libmesh_error_msg_if(index >= _interpolation_points_spatial_indices.size(), "Error: Invalid index");
@@ -907,7 +931,9 @@ void RBEIMEvaluation::add_interpolation_data(
   const std::vector<Real> & phi_i_qp,
   ElemType elem_type,
   const std::vector<Real> & JxW_all_qp,
-  const std::vector<std::vector<Real>> & phi_i_all_qp)
+  const std::vector<std::vector<Real>> & phi_i_all_qp,
+  const Point & dxyzdxi_elem_center,
+  const Point & dxyzdeta_elem_center)
 {
   _vec_eval_input.all_xyz.emplace_back(p);
   _interpolation_points_comp.emplace_back(comp);
@@ -919,6 +945,8 @@ void RBEIMEvaluation::add_interpolation_data(
   _vec_eval_input.elem_types.emplace_back(elem_type);
   _vec_eval_input.JxW_all_qp.emplace_back(JxW_all_qp);
   _vec_eval_input.phi_i_all_qp.emplace_back(phi_i_all_qp);
+  _vec_eval_input.dxyzdxi_elem_center.emplace_back(dxyzdxi_elem_center);
+  _vec_eval_input.dxyzdeta_elem_center.emplace_back(dxyzdeta_elem_center);
 }
 
 void RBEIMEvaluation::add_side_basis_function(

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -27,6 +27,7 @@
 #include "libmesh/system.h"
 #include "libmesh/elem.h"
 #include "libmesh/fem_context.h"
+#include "libmesh/quadrature.h"
 
 namespace libMesh
 {
@@ -428,6 +429,9 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh(const RBP
     {
       v.dxyzdxi_elem_center.resize(n_points);
       v.dxyzdeta_elem_center.resize(n_points);
+      // At the time of writing, the quadrature order is only used in conjunction with element
+      // center data so we should not compute it elsewhere for now.
+      v.qrule_orders.resize(n_points);
     }
 
   // Empty vector to be used when xyz perturbations are not required
@@ -513,6 +517,7 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh(const RBP
             }
             if (requires_all_elem_center_data)
               {
+                v.qrule_orders[counter] = con.get_element_qrule().get_order();
                 // We try to minimize the number of reinit so we only do it once per elem for
                 // center quantities.
                 if (!elem_center_quantities_set)


### PR DESCRIPTION
This PR adds additional data (elem center derivatives and qrule order) to VectorizedEvalInput to enable assumed stress for shells in RB EIM. 
These additions follow the current way of storing data per EIM point even if we end-up with duplicates when evaluating parameters on every quadrature point of the entire mesh.
This problem will be addressed in a later PR.