### PR TITLE
Instantiate (+ fix) NodeElem unit tests

### DIFF
--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -203,8 +203,7 @@ public:
 
   virtual std::vector<unsigned int> edges_adjacent_to_node(const unsigned int) const override
   {
-    libmesh_not_implemented();
-    return {0};
+    return {};
   }
 
   virtual std::vector<unsigned int> sides_on_edge(const unsigned int) const override
@@ -278,7 +277,7 @@ public:
 
   virtual void permute(unsigned int) override final { libmesh_error(); }
 
-  virtual void flip(BoundaryInfo *) override final { libmesh_error(); }
+  virtual void flip(BoundaryInfo *) override final { return; /* no-op */ }
   virtual bool is_flipped() const override final { return false; }
 
   virtual ElemType side_type (const unsigned int) const override

--- a/tests/geom/elem_test.C
+++ b/tests/geom/elem_test.C
@@ -41,7 +41,7 @@ public:
 
         wide_bbox.scale(1. / 3.);
 
-        if (!elem->infinite())
+        if (!elem->infinite() && elem->dim())
           {
             CPPUNIT_ASSERT(!bbox.contains_point(wide_bbox.min()));
             CPPUNIT_ASSERT(!bbox.contains_point(wide_bbox.max()));
@@ -130,9 +130,9 @@ public:
 
         // The smallest actual nodal areas in this test are found in
         // tetrahedra, which have a minimum value of 2.0. However, we
-        // return a default value of 1.0 for 1D elements here, so
-        // we also handle that case.
-        if (elem->dim() == 1)
+        // return a default value of 1.0 for 0D and 1D elements here,
+        // so we also handle that case.
+        if (elem->dim() < 2)
           CPPUNIT_ASSERT_GREATEREQUAL(1 - TOLERANCE, jac);
         else
           CPPUNIT_ASSERT_GREATEREQUAL(2 - TOLERANCE, jac);
@@ -293,7 +293,7 @@ public:
           CPPUNIT_ASSERT(elem->has_affine_map());
 
         // The neighbors and bcids should have flipped in a way
-        // consistently with the nodes.
+        // consistently with the nodes (unless this is a 0D NodeElem)
         bool something_changed = false;
         for (auto s : make_range(n_sides))
           {
@@ -319,7 +319,7 @@ public:
 
             CPPUNIT_ASSERT(bcids[old_side] == new_bcids);
           }
-        CPPUNIT_ASSERT(something_changed);
+        CPPUNIT_ASSERT(!elem->dim() || something_changed);
 
         const Point new_vertex_avg = elem->vertex_average();
         for (const auto d : make_range(LIBMESH_DIM))

--- a/tests/geom/elem_test.C
+++ b/tests/geom/elem_test.C
@@ -816,6 +816,8 @@ public:
                                                                 \
   CPPUNIT_TEST_SUITE_REGISTRATION( ElemTest_##elemtype )
 
+INSTANTIATE_ELEMTEST(NODEELEM);
+
 INSTANTIATE_ELEMTEST(EDGE2);
 INSTANTIATE_ELEMTEST(EDGE3);
 INSTANTIATE_ELEMTEST(EDGE4);

--- a/tests/geom/elem_test.h
+++ b/tests/geom/elem_test.h
@@ -121,11 +121,12 @@ public:
 #endif // LIBMESH_ENABLE_INFINITE_ELEMENTS
       {
         const unsigned int dim = test_elem->dim();
+        const unsigned int use_x = dim > 0;
         const unsigned int use_y = dim > 1;
         const unsigned int use_z = dim > 2;
 
         MeshTools::Generation::build_cube (*_mesh,
-                                           N, N*use_y, N*use_z,
+                                           N*use_x, N*use_y, N*use_z,
                                            minpos, maxpos,
                                            minpos, use_y*maxpos,
                                            minpos, use_z*maxpos,


### PR DESCRIPTION
I was hoping that we'd see refinement test failures here, so that we could fix them and thereby fix idaholab/moose#28538, but no such luck.

There are a couple actual bug fixes here, for NodeElem methods that were throwing an error when they should have been returning a no-op, but those shouldn't be related to the application bug, and most of the fixes here are just to the unit tests themselves.