### PR TITLE
When we reinit when the mesh changes, previous condensed dofs are invalid

### DIFF
--- a/include/systems/condensed_eigen_system.h
+++ b/include/systems/condensed_eigen_system.h
@@ -205,6 +205,8 @@ public:
   bool have_condensed_dofs() const
   { libmesh_assert(_condensed_dofs_initialized); return _have_condensed_dofs; }
 
+  virtual void reinit() override;
+
 protected:
   virtual void add_matrices () override;
 

--- a/src/systems/condensed_eigen_system.C
+++ b/src/systems/condensed_eigen_system.C
@@ -80,6 +80,13 @@ CondensedEigenSystem::initialize_condensed_dofs(const std::set<dof_id_type> & gl
 }
 
 void
+CondensedEigenSystem::reinit()
+{
+  Parent::reinit();
+  _condensed_dofs_initialized = false;
+}
+
+void
 CondensedEigenSystem::initialize_condensed_matrices()
 {
   if (!_condensed_dofs_initialized)


### PR DESCRIPTION
Refs Griffin test failure after the incorporation of idaholab/moose#28452

This feels a little kludgy to me. What would feel a little more natural is to actually reinitailize the data in `reinit`. But our tradition for this system is that we require users to manually call APIs like `initialize_condensed_dofs` with optional sets corresponding to the Dirichlet dofs (which will change when the mesh changes) in order to initialize the condensed degrees of freedom. So this maintains that tradition of requiring the user to tell us when/what dofs to condense as opposed to doing something automatic