### PR TITLE
Fix for EIM tangent derivatives with mixed elem dimensions

### DIFF
--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -2603,6 +2603,8 @@ bool RBEIMConstruction::enrich_eim_approximation_on_interiors(const QpDataMap & 
       auto fe = con.get_element_fe(/*var=*/0, dim);
       fe->get_phi();
       fe->get_JxW();
+      fe->get_dxyzdxi();
+      fe->get_dxyzdeta();
     }
 
   for (const auto & [elem_id, comp_and_qp] : local_pf)
@@ -2684,8 +2686,14 @@ bool RBEIMConstruction::enrich_eim_approximation_on_interiors(const QpDataMap & 
                       std::vector<Point> nodes = { elem_ref.reference_elem()->vertex_average() };
                       elem_fe->reinit (&elem_ref, &nodes);
 
-                      optimal_dxyzdxi_elem_center = dxyzdxi[0];
-                      optimal_dxyzdeta_elem_center = dxyzdeta[0];
+                      Point dxyzdxi_pt, dxyzdeta_pt;
+                      if (con.get_elem_dim()>0)
+                        dxyzdxi_pt = dxyzdxi[0];
+                      if (con.get_elem_dim()>1)
+                        dxyzdeta_pt = dxyzdeta[0];
+
+                      optimal_dxyzdxi_elem_center = dxyzdxi_pt;
+                      optimal_dxyzdeta_elem_center = dxyzdeta_pt;
 
                       elem_fe->reinit(&elem_ref);
                     }

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -995,6 +995,9 @@ void RBEIMEvaluation::add_side_interpolation_data(
   _vec_eval_input.elem_types.emplace_back(INVALID_ELEM);
   _vec_eval_input.JxW_all_qp.emplace_back();
   _vec_eval_input.phi_i_all_qp.emplace_back();
+  _vec_eval_input.qrule_orders.emplace_back(INVALID_ORDER);
+  _vec_eval_input.dxyzdxi_elem_center.emplace_back();
+  _vec_eval_input.dxyzdeta_elem_center.emplace_back();
 }
 
 void RBEIMEvaluation::add_node_basis_function(
@@ -1025,6 +1028,9 @@ void RBEIMEvaluation::add_node_interpolation_data(
   _vec_eval_input.elem_types.emplace_back(INVALID_ELEM);
   _vec_eval_input.JxW_all_qp.emplace_back();
   _vec_eval_input.phi_i_all_qp.emplace_back();
+  _vec_eval_input.qrule_orders.emplace_back(INVALID_ORDER);
+  _vec_eval_input.dxyzdxi_elem_center.emplace_back();
+  _vec_eval_input.dxyzdeta_elem_center.emplace_back();
 }
 
 void RBEIMEvaluation::

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -533,14 +533,19 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh(const RBP
               // We add qrule_order in this loop as it is used in conjunction with elem center
               // quantities for now.
               v.qrule_orders[counter] = qrule_order;
+              Point dxyzdxi_pt, dxyzdeta_pt;
+              if (con.get_elem_dim()>0)
+                dxyzdxi_pt = dxyzdxi[0];
+              if (con.get_elem_dim()>1)
+                dxyzdeta_pt = dxyzdeta[0];
               // Here we do an implicit conversion from RealGradient which is a VectorValue<Real>
               // which in turn is a TypeVector<T> to a Point which is a TypeVector<Real>.
               // They are essentially the same thing. This helps us limiting the number of includes
               // in serialization and deserialization as RealGradient is a typedef and we cannot
               // forward declare typedefs. As a result we leverage the fact that point.h is already
               // included in most places we need RealGradient.
-              v.dxyzdxi_elem_center[counter] = dxyzdxi[0];
-              v.dxyzdeta_elem_center[counter] = dxyzdeta[0];
+              v.dxyzdxi_elem_center[counter] = dxyzdxi_pt;
+              v.dxyzdeta_elem_center[counter] = dxyzdeta_pt;
 
               counter++;
             }


### PR DESCRIPTION
This PR includes a fix when elements of dimension 0 or 1 are used with elements of dimension 2 and tangent derivatives are requested.
It also includes a fix for when node interpolation and side interpolation are used in conjunction with interior interpolation when tangent derivatives are requested. 
