### PR TITLE
Fix side p-level caching

### DIFF
--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -183,9 +183,8 @@ void FE<Dim,T>::reinit(const Elem * elem,
           this->shapes_need_reinit()            ||
           !this->shapes_on_quadrature)
         {
-          // Set the element type and p_level
+          // Set the element type
           this->elem_type = elem->type();
-          this->_elem_p_level = side_p_level;
 
           // Set the last_side
           last_side = side->type();
@@ -226,6 +225,8 @@ void FE<Dim,T>::reinit(const Elem * elem,
   this->reinit  (elem, &qp);
 
   this->shapes_on_quadrature = shapes_on_quadrature_side;
+
+  this->_elem_p_level = side_p_level;
 
   // copy back old data
   this->_fe_map->get_JxW() = JxW_int;


### PR DESCRIPTION
There are conditions when FE does not properly `reinit` on sides where it should. One condition is when FE is `reinit`ed on an element (`p_level = 0`) for a side whose neighbor has `p_level = 1`. If the FE is `reinit`ed again on the same element but for another side with the same type whose neighbor is `nullptr` or has `p_level = 0`, `init_face_shape_functions` is not called properly leading to wrong physical quadrature points. The primary reason is because `_elem_p_level` which is used to cache `side_p_level` is reset to `elem->p_level()` when calling `this->reinit (elem, &qp)`, which makes the conditional unable to detect that the side p-level has changed.

To break down the conditions:
```
if ((this->get_type() != elem->type())    ||
    (side->type() != last_side)           ||
    (this->_elem_p_level != side_p_level) ||
    this->shapes_need_reinit()            ||
    !this->shapes_on_quadrature)
```
- The first condition is false as FE is operating on the same element.
- The second condition is false as FE is operating on the sides with same type.
- The third condition is false as `_elem_p_level` was reset to `elem->p_level()` which is zero.
- The fourth condition is false if the shape functions are of `MONOMIAL` or `L2_LAGRANGE` family.
- The last condition is always false as far as we are operating on quadrature points.