### PR TITLE
Set the HYPRE memory location

### DIFF
--- a/include/numerics/petsc_solver_exception.h
+++ b/include/numerics/petsc_solver_exception.h
@@ -137,6 +137,22 @@ PETSC_BEGIN_END(VecGhostUpdate) // VecGhostUpdateBeginEnd
     LIBMESH_CHKERR2(comm, libmesh_petsc_call_ierr);                                                \
   } while (0)
 
+#ifdef LIBMESH_ENABLE_EXCEPTIONS
+#define LibmeshPetscCallExternal(func, ...)                             \
+  do {                                                                  \
+    const auto libmesh_petsc_call_external_ierr = cast_int<int>(func(__VA_ARGS__)); \
+    if (libmesh_petsc_call_external_ierr != 0)                          \
+      throw PetscSolverException(libmesh_petsc_call_external_ierr);     \
+  } while (0)
+#else
+#define LibmeshPetscCallExternal(func, ...)                             \
+  do {                                                                  \
+    const auto libmesh_petsc_call_external_ierr = cast_int<int>func(__VA_ARGS__); \
+    MPI_Abort(this->comm(), libmesh_petsc_call_external_ierr);          \
+  } while (0)
+#endif
+
+
 } // namespace libMesh
 
 #endif // LIBMESH_HAVE_PETSC

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -1071,7 +1071,7 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  pre_in,  // System Preconditi
 #endif
   LibmeshPetscCall(SNESSetFromOptions(_snes));
 
-#ifdef LIBMESH_HAVE_PETSC_HYPRE
+#if defined(LIBMESH_HAVE_PETSC_HYPRE) && !PETSC_VERSION_LESS_THAN(3,12,0)
   // The above call set our PC type. If we're a hypre type we have to ensure that hypre is deployed
   // in the same memory space as our vector types
   PC pc;

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -1085,7 +1085,7 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  pre_in,  // System Preconditi
       LibmeshPetscCall(VecGetArrayAndMemType(x->vec(), &dummyarray, &mtype));
       LibmeshPetscCall(VecRestoreArrayAndMemType(x->vec(), &dummyarray));
       if (PetscMemTypeHost(mtype))
-        PetscCallExternalAbort(HYPRE_SetMemoryLocation, HYPRE_MEMORY_HOST);
+        LibmeshPetscCallExternal(HYPRE_SetMemoryLocation, HYPRE_MEMORY_HOST);
     }
 #endif
 


### PR DESCRIPTION
If our vector is on the host, then we want to ensure that hypre is told to run on the host or else we will get runtime errors about the mismatch