### PR TITLE
nvc++ updates, sanitizer updates

### DIFF
--- a/configure
+++ b/configure
@@ -26497,6 +26497,8 @@ esac
 
                                 ACSM_NODEPRECATEDFLAG="-Wno-deprecated-declarations"
 
+                                                                                                ACSM_FPE_SAFETY_FLAGS="-Kieee -Mnovect"
+
                                 ACSM_CFLAGS_DBG="$ACSM_CFLAGS_DBG -O0 -g"
                                 ACSM_CFLAGS_DEVEL="$ACSM_CFLAGS_DEVEL -O2 -g"
                                 ACSM_CFLAGS_OPT="$ACSM_CFLAGS_OPT -O2"
@@ -27316,7 +27318,13 @@ then :
            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: <<< Disabling extra paranoid compiler warnings >>>" >&5
 printf "%s\n" "<<< Disabling extra paranoid compiler warnings >>>" >&6; }
 else $as_nop
-  old_CXXFLAGS="$CXXFLAGS"
+  ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+           old_CXXFLAGS="$CXXFLAGS"
            CXXFLAGS="$CXXFLAGS $WERROR_FLAGS $PARANOID_FLAGS"
            cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -27342,6 +27350,12 @@ printf "%s\n" "<<< Disabling extra paranoid compiler warnings >>>" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
            CXXFLAGS="$old_CXXFLAGS"
+           ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
 fi
 
 

--- a/fsanitize_ignorelist.txt
+++ b/fsanitize_ignorelist.txt
@@ -5,6 +5,9 @@
 # -fsanitize=integer on clang++ 14 with g++ 12.1.0 headers
 fun:*basic_string_view*rfind*
 fun:*basic_string*compare*
+fun:*CppUnit*
+fun:*suite*
+src:*netgen/*
 src:*hashing.h
 src:*hashword.h
 src:*libHilbert*SetBits*

--- a/include/enums/enum_order.h
+++ b/include/enums/enum_order.h
@@ -88,9 +88,36 @@ enum Order : int {
 
   // Standardize this so nvc++ and clang -fsanitize=integer don't
   // complain about all the ways in which we might do it wrong
-  inline Order sum(Order o, int p)
+  template <typename T>
+  inline Order operator+(Order o, T p)
   {
-    return static_cast<Order>(static_cast<int>(o) + p);
+    return static_cast<Order>(static_cast<int>(o) + int(p));
+  }
+
+  template <typename T>
+  inline Order operator-(Order o, T p)
+  {
+    return static_cast<Order>(static_cast<int>(o) - int(p));
+  }
+
+  template <typename T>
+  inline Order operator+(T p, Order o)
+  {
+    return o + p;
+  }
+
+  template <typename T>
+  inline Order & operator+=(Order &o, T p)
+  {
+    o = o + p;
+    return o;
+  }
+
+  template <typename T>
+  inline Order & operator-=(Order &o, T p)
+  {
+    o = o - p;
+    return o;
   }
 
 }

--- a/include/enums/enum_order.h
+++ b/include/enums/enum_order.h
@@ -86,6 +86,13 @@ enum Order : int {
             // Invalid
             INVALID_ORDER};
 
+  // Standardize this so nvc++ and clang -fsanitize=integer don't
+  // complain about all the ways in which we might do it wrong
+  inline Order sum(Order o, int p)
+  {
+    return static_cast<Order>(static_cast<int>(o) + p);
+  }
+
 }
 
 #endif

--- a/include/fe/fe_abstract.h
+++ b/include/fe/fe_abstract.h
@@ -502,7 +502,7 @@ public:
    * \returns The approximation order of the finite element.
    */
   Order get_order() const
-  { return sum(fe_type.order, _p_level); }
+  { return fe_type.order + _p_level; }
 
   /**
    * Sets the *base* FE order of the finite element.

--- a/include/fe/fe_abstract.h
+++ b/include/fe/fe_abstract.h
@@ -502,7 +502,7 @@ public:
    * \returns The approximation order of the finite element.
    */
   Order get_order() const
-  { return static_cast<Order>(fe_type.order + _p_level); }
+  { return sum(fe_type.order, _p_level); }
 
   /**
    * Sets the *base* FE order of the finite element.

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -82,6 +82,20 @@ public:
     return _order;
   }
 
+  template <typename T>
+  inline OrderWrapper & operator+=(T p)
+  {
+    _order += int(p);
+    return *this;
+  }
+
+  template <typename T>
+  inline OrderWrapper & operator-=(T p)
+  {
+    _order -= int(p);
+    return *this;
+  }
+
 private:
 
   /**

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -2383,8 +2383,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectEdge
           FEType fe_type = base_fe_type;
 
           // This may be a p refined element
-          fe_type.order =
-            libMesh::Order (fe_type.order + elem.p_level());
+          fe_type.order = sum(fe_type.order, elem.p_level());
 
           // If this is a Lagrange element with DoFs on edges then by
           // convention we interpolate at the node rather than project
@@ -2566,8 +2565,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectSide
           const bool add_p_level = dof_map.should_p_refine_var(var);
 
           // This may be a p refined element
-          fe_type.order =
-            libMesh::Order (fe_type.order + add_p_level*elem.p_level());
+          fe_type.order = sum(fe_type.order, add_p_level*elem.p_level());
 
           // If this is a Lagrange element with DoFs on sides then by
           // convention we interpolate at the node rather than project
@@ -2728,8 +2726,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectInte
           const bool add_p_level = dof_map.should_p_refine(vg);
 
           // This may be a p refined element
-          fe_type.order =
-            libMesh::Order (fe_type.order + add_p_level * elem->p_level());
+          fe_type.order = sum(fe_type.order, add_p_level * elem->p_level());
 
           const unsigned int var_component =
             system.variable_scalar_number(var, 0);

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -2383,7 +2383,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectEdge
           FEType fe_type = base_fe_type;
 
           // This may be a p refined element
-          fe_type.order = sum(fe_type.order, elem.p_level());
+          fe_type.order = fe_type.order + elem.p_level();
 
           // If this is a Lagrange element with DoFs on edges then by
           // convention we interpolate at the node rather than project
@@ -2565,7 +2565,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectSide
           const bool add_p_level = dof_map.should_p_refine_var(var);
 
           // This may be a p refined element
-          fe_type.order = sum(fe_type.order, add_p_level*elem.p_level());
+          fe_type.order = fe_type.order + add_p_level*elem.p_level();
 
           // If this is a Lagrange element with DoFs on sides then by
           // convention we interpolate at the node rather than project
@@ -2726,7 +2726,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectInte
           const bool add_p_level = dof_map.should_p_refine(vg);
 
           // This may be a p refined element
-          fe_type.order = sum(fe_type.order, add_p_level * elem->p_level());
+          fe_type.order = fe_type.order + add_p_level * elem->p_level();
 
           const unsigned int var_component =
             system.variable_scalar_number(var, 0);

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -657,7 +657,7 @@ void DofMap::reinit(MeshBase & mesh)
 #ifdef LIBMESH_ENABLE_AMR
           // Make sure we haven't done more p refinement than we can
           // handle
-          if (sum(base_fe_type.order, add_p_level*elem->p_level()) >
+          if (base_fe_type.order + add_p_level*elem->p_level() >
               FEInterface::max_order(base_fe_type, type))
             {
 #  ifdef DEBUG
@@ -2454,7 +2454,7 @@ void DofMap::_dof_indices (const Elem & elem,
             is_inf ?
             FEInterface::n_dofs_at_node(fe_type, add_p_level*p_level, &elem, n) :
 #endif
-            ndan (type, sum(fe_type.order, add_p_level*p_level), n);
+            ndan (type, fe_type.order + add_p_level*p_level, n);
 
           // If this is a non-vertex on a hanging node with extra
           // degrees of freedom, we use the non-vertex dofs (which
@@ -2742,7 +2742,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
                           is_inf ?
                           FEInterface::n_dofs_at_node(var.type(), extra_order, elem, n) :
 #endif
-                          ndan (type, sum(var.type().order, extra_order), n);
+                          ndan (type, var.type().order + extra_order, n);
 
                         const int n_comp = old_dof_obj.n_comp_group(sys_num,vg);
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -669,8 +669,8 @@ void DofMap::reinit(MeshBase & mesh)
                            << FEInterface::max_order(base_fe_type,type)
                            << std::endl;
 #  endif
-              elem->set_p_level(FEInterface::max_order(base_fe_type,type)
-                                - base_fe_type.order);
+              elem->set_p_level(int(FEInterface::max_order(base_fe_type,type))
+                                - int(base_fe_type.order));
             }
 #endif
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -657,7 +657,7 @@ void DofMap::reinit(MeshBase & mesh)
 #ifdef LIBMESH_ENABLE_AMR
           // Make sure we haven't done more p refinement than we can
           // handle
-          if (add_p_level*elem->p_level() + base_fe_type.order >
+          if (sum(base_fe_type.order, add_p_level*elem->p_level()) >
               FEInterface::max_order(base_fe_type, type))
             {
 #  ifdef DEBUG
@@ -2454,7 +2454,7 @@ void DofMap::_dof_indices (const Elem & elem,
             is_inf ?
             FEInterface::n_dofs_at_node(fe_type, add_p_level*p_level, &elem, n) :
 #endif
-            ndan (type, static_cast<Order>(fe_type.order + add_p_level*p_level), n);
+            ndan (type, sum(fe_type.order, add_p_level*p_level), n);
 
           // If this is a non-vertex on a hanging node with extra
           // degrees of freedom, we use the non-vertex dofs (which
@@ -2742,7 +2742,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
                           is_inf ?
                           FEInterface::n_dofs_at_node(var.type(), extra_order, elem, n) :
 #endif
-                          ndan (type, static_cast<Order>(var.type().order + extra_order), n);
+                          ndan (type, sum(var.type().order, extra_order), n);
 
                         const int n_comp = old_dof_obj.n_comp_group(sys_num,vg);
 

--- a/src/error_estimation/patch_recovery_error_estimator.C
+++ b/src/error_estimation/patch_recovery_error_estimator.C
@@ -316,8 +316,8 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
           // The type of finite element to use for this variable
           const FEType & fe_type = dof_map.variable_type (var);
 
-          const Order element_order  = static_cast<Order>
-            (fe_type.order + elem->p_level());
+          const Order element_order = sum(fe_type.order,
+                                          elem->p_level());
 
           // Finite element object for use in this patch
           std::unique_ptr<FEBase> fe (FEBase::build (dim, fe_type));
@@ -700,8 +700,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
               // Variable to hold the error on the current element
               Real element_error = 0;
 
-              const Order qorder =
-                static_cast<Order>(fe_type.order + e_p->p_level());
+              const Order qorder = sum(fe_type.order, e_p->p_level());
 
               // A quadrature rule for this element
               QGrid samprule (dim, qorder);

--- a/src/error_estimation/patch_recovery_error_estimator.C
+++ b/src/error_estimation/patch_recovery_error_estimator.C
@@ -316,8 +316,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
           // The type of finite element to use for this variable
           const FEType & fe_type = dof_map.variable_type (var);
 
-          const Order element_order = sum(fe_type.order,
-                                          elem->p_level());
+          const Order element_order = fe_type.order + elem->p_level();
 
           // Finite element object for use in this patch
           std::unique_ptr<FEBase> fe (FEBase::build (dim, fe_type));
@@ -700,7 +699,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
               // Variable to hold the error on the current element
               Real element_error = 0;
 
-              const Order qorder = sum(fe_type.order, e_p->p_level());
+              const Order qorder = fe_type.order + e_p->p_level();
 
               // A quadrature rule for this element
               QGrid samprule (dim, qorder);

--- a/src/error_estimation/weighted_patch_recovery_error_estimator.C
+++ b/src/error_estimation/weighted_patch_recovery_error_estimator.C
@@ -216,8 +216,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
           // The type of finite element to use for this variable
           const FEType & fe_type = dof_map.variable_type (var);
 
-          const Order element_order  = static_cast<Order>
-            (fe_type.order + elem->p_level());
+          const Order element_order = sum(fe_type.order, elem->p_level());
 
           // Finite element object for use in this patch
           std::unique_ptr<FEBase> fe (FEBase::build (dim, fe_type));
@@ -622,8 +621,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
               // Variable to hold the error on the current element
               Real element_error = 0;
 
-              const Order qorder =
-                static_cast<Order>(fe_type.order + e_p->p_level());
+              const Order qorder = sum(fe_type.order, e_p->p_level());
 
               // A quadrature rule for this element
               QGrid samprule (dim, qorder);

--- a/src/error_estimation/weighted_patch_recovery_error_estimator.C
+++ b/src/error_estimation/weighted_patch_recovery_error_estimator.C
@@ -216,7 +216,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
           // The type of finite element to use for this variable
           const FEType & fe_type = dof_map.variable_type (var);
 
-          const Order element_order = sum(fe_type.order, elem->p_level());
+          const Order element_order = fe_type.order + elem->p_level();
 
           // Finite element object for use in this patch
           std::unique_ptr<FEBase> fe (FEBase::build (dim, fe_type));
@@ -621,7 +621,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
               // Variable to hold the error on the current element
               Real element_error = 0;
 
-              const Order qorder = sum(fe_type.order, e_p->p_level());
+              const Order qorder = fe_type.order + e_p->p_level();
 
               // A quadrature rule for this element
               QGrid samprule (dim, qorder);

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -61,7 +61,7 @@ template <unsigned int Dim, FEFamily T>
 unsigned int FE<Dim,T>::n_shape_functions () const
 {
   return FE<Dim,T>::n_dofs (this->elem_type,
-                            sum(this->fe_type.order, this->_p_level));
+                            this->fe_type.order + this->_p_level);
 }
 
 

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -61,7 +61,7 @@ template <unsigned int Dim, FEFamily T>
 unsigned int FE<Dim,T>::n_shape_functions () const
 {
   return FE<Dim,T>::n_dofs (this->elem_type,
-                            static_cast<Order>(this->fe_type.order + this->_p_level));
+                            sum(this->fe_type.order, this->_p_level));
 }
 
 

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -1138,7 +1138,7 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
   }
 
   FEType fe_type = base_fe_type, temp_fe_type;
-  fe_type.order = sum(fe_type.order, elem->max_descendant_p_level());
+  fe_type.order = fe_type.order + elem->max_descendant_p_level();
 
   // In 3D, project any edge values next
   if (dim > 2 && cont != DISCONTINUOUS)
@@ -1181,8 +1181,7 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
               (child_dof_indices.size());
 
             temp_fe_type = base_fe_type;
-            temp_fe_type.order = sum(temp_fe_type.order,
-                                     child->p_level());
+            temp_fe_type.order = temp_fe_type.order + child->p_level();
 
             FEInterface::dofs_on_edge(child, dim,
                                       temp_fe_type, e, old_side_dofs);
@@ -1320,8 +1319,7 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
               (child_dof_indices.size());
 
             temp_fe_type = base_fe_type;
-            temp_fe_type.order = sum(temp_fe_type.order,
-                                     child->p_level());
+            temp_fe_type.order = temp_fe_type.order + child->p_level();
 
             FEInterface::dofs_on_side(child, dim,
                                       temp_fe_type, s, old_side_dofs);

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -1138,8 +1138,7 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
   }
 
   FEType fe_type = base_fe_type, temp_fe_type;
-  fe_type.order = static_cast<Order>(fe_type.order +
-                                     elem->max_descendant_p_level());
+  fe_type.order = sum(fe_type.order, elem->max_descendant_p_level());
 
   // In 3D, project any edge values next
   if (dim > 2 && cont != DISCONTINUOUS)
@@ -1182,9 +1181,8 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
               (child_dof_indices.size());
 
             temp_fe_type = base_fe_type;
-            temp_fe_type.order =
-              static_cast<Order>(temp_fe_type.order +
-                                 child->p_level());
+            temp_fe_type.order = sum(temp_fe_type.order,
+                                     child->p_level());
 
             FEInterface::dofs_on_edge(child, dim,
                                       temp_fe_type, e, old_side_dofs);
@@ -1322,9 +1320,8 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
               (child_dof_indices.size());
 
             temp_fe_type = base_fe_type;
-            temp_fe_type.order =
-              static_cast<Order>(temp_fe_type.order +
-                                 child->p_level());
+            temp_fe_type.order = sum(temp_fe_type.order,
+                                     child->p_level());
 
             FEInterface::dofs_on_side(child, dim,
                                       temp_fe_type, s, old_side_dofs);

--- a/src/fe/fe_bernstein.C
+++ b/src/fe/fe_bernstein.C
@@ -49,7 +49,7 @@ void bernstein_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, BERNSTEIN);

--- a/src/fe/fe_bernstein.C
+++ b/src/fe/fe_bernstein.C
@@ -49,7 +49,7 @@ void bernstein_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, BERNSTEIN);

--- a/src/fe/fe_bernstein_shape_1D.C
+++ b/src/fe/fe_bernstein_shape_1D.C
@@ -200,7 +200,7 @@ Real FE<1,BERNSTEIN>::shape(const Elem * elem,
 
   return FE<1,BERNSTEIN>::shape
     (elem->type(),
-     sum(order, add_p_level*elem->p_level()), i, p);
+     order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -214,7 +214,7 @@ Real FE<1,BERNSTEIN>::shape(const FEType fet,
   libmesh_assert(elem);
   return FE<1,BERNSTEIN>::shape
     (elem->type(),
-     sum(fet.order, add_p_level*elem->p_level()), i, p);
+     fet.order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -388,7 +388,7 @@ Real FE<1,BERNSTEIN>::shape_deriv(const Elem * elem,
 
   return FE<1,BERNSTEIN>::shape_deriv
     (elem->type(),
-     sum(order, add_p_level*elem->p_level()), i, j, p);
+     order + add_p_level*elem->p_level(), i, j, p);
 }
 
 template <>
@@ -402,7 +402,7 @@ Real FE<1,BERNSTEIN>::shape_deriv(const FEType fet,
   libmesh_assert(elem);
   return FE<1,BERNSTEIN>::shape_deriv
     (elem->type(),
-     sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+     fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -601,7 +601,7 @@ Real FE<1,BERNSTEIN>::shape_second_deriv(const Elem * elem,
 
   return FE<1,BERNSTEIN>::shape_second_deriv
     (elem->type(),
-     sum(order, add_p_level*elem->p_level()), i, j, p);
+     order + add_p_level*elem->p_level(), i, j, p);
 }
 
 template <>
@@ -615,7 +615,7 @@ Real FE<1,BERNSTEIN>::shape_second_deriv(const FEType fet,
   libmesh_assert(elem);
   return FE<1,BERNSTEIN>::shape_second_deriv
     (elem->type(),
-     sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+     fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 #endif

--- a/src/fe/fe_bernstein_shape_1D.C
+++ b/src/fe/fe_bernstein_shape_1D.C
@@ -200,7 +200,7 @@ Real FE<1,BERNSTEIN>::shape(const Elem * elem,
 
   return FE<1,BERNSTEIN>::shape
     (elem->type(),
-     static_cast<Order>(order + add_p_level*elem->p_level()), i, p);
+     sum(order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -214,7 +214,7 @@ Real FE<1,BERNSTEIN>::shape(const FEType fet,
   libmesh_assert(elem);
   return FE<1,BERNSTEIN>::shape
     (elem->type(),
-     static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, p);
+     sum(fet.order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -388,7 +388,7 @@ Real FE<1,BERNSTEIN>::shape_deriv(const Elem * elem,
 
   return FE<1,BERNSTEIN>::shape_deriv
     (elem->type(),
-     static_cast<Order>(order + add_p_level*elem->p_level()), i, j, p);
+     sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 template <>
@@ -402,7 +402,7 @@ Real FE<1,BERNSTEIN>::shape_deriv(const FEType fet,
   libmesh_assert(elem);
   return FE<1,BERNSTEIN>::shape_deriv
     (elem->type(),
-     static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+     sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -601,7 +601,7 @@ Real FE<1,BERNSTEIN>::shape_second_deriv(const Elem * elem,
 
   return FE<1,BERNSTEIN>::shape_second_deriv
     (elem->type(),
-     static_cast<Order>(order + add_p_level*elem->p_level()), i, j, p);
+     sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 template <>
@@ -615,7 +615,7 @@ Real FE<1,BERNSTEIN>::shape_second_deriv(const FEType fet,
   libmesh_assert(elem);
   return FE<1,BERNSTEIN>::shape_second_deriv
     (elem->type(),
-     static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+     sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 #endif

--- a/src/fe/fe_bernstein_shape_2D.C
+++ b/src/fe/fe_bernstein_shape_2D.C
@@ -105,7 +105,7 @@ Real FE<2,BERNSTEIN>::shape(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    sum(order, add_p_level*elem->p_level());
+    order + add_p_level*elem->p_level();
 
   // Declare that we are using our own special power function
   // from the Utility namespace.  This saves typing later.
@@ -425,7 +425,7 @@ Real FE<2,BERNSTEIN>::shape_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    sum(order, add_p_level*elem->p_level());
+    order + add_p_level*elem->p_level();
 
   switch (type)
     {
@@ -553,7 +553,7 @@ Real FE<2,BERNSTEIN>::shape_second_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    sum(order, add_p_level*elem->p_level());
+    order + add_p_level*elem->p_level();
 
   switch (type)
     {

--- a/src/fe/fe_bernstein_shape_2D.C
+++ b/src/fe/fe_bernstein_shape_2D.C
@@ -105,7 +105,7 @@ Real FE<2,BERNSTEIN>::shape(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    static_cast<Order>(order + add_p_level * elem->p_level());
+    sum(order, add_p_level*elem->p_level());
 
   // Declare that we are using our own special power function
   // from the Utility namespace.  This saves typing later.
@@ -425,7 +425,7 @@ Real FE<2,BERNSTEIN>::shape_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    static_cast<Order>(order + add_p_level * elem->p_level());
+    sum(order, add_p_level*elem->p_level());
 
   switch (type)
     {
@@ -553,7 +553,7 @@ Real FE<2,BERNSTEIN>::shape_second_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    static_cast<Order>(order + add_p_level * elem->p_level());
+    sum(order, add_p_level*elem->p_level());
 
   switch (type)
     {

--- a/src/fe/fe_bernstein_shape_3D.C
+++ b/src/fe/fe_bernstein_shape_3D.C
@@ -77,7 +77,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    sum(order, add_p_level*elem->p_level());
+    order + add_p_level*elem->p_level();
 
   auto hex_remap = [i, elem] (const Point & p_in,
                               const unsigned int * hex_i0,
@@ -930,7 +930,7 @@ Real FE<3,BERNSTEIN>::shape_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    sum(order, add_p_level*elem->p_level());
+    order + add_p_level*elem->p_level();
 
   libmesh_assert_less (j, 3);
 

--- a/src/fe/fe_bernstein_shape_3D.C
+++ b/src/fe/fe_bernstein_shape_3D.C
@@ -77,7 +77,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    static_cast<Order>(order + add_p_level * elem->p_level());
+    sum(order, add_p_level*elem->p_level());
 
   auto hex_remap = [i, elem] (const Point & p_in,
                               const unsigned int * hex_i0,
@@ -930,7 +930,7 @@ Real FE<3,BERNSTEIN>::shape_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    static_cast<Order>(order + add_p_level * elem->p_level());
+    sum(order, add_p_level*elem->p_level());
 
   libmesh_assert_less (j, 3);
 

--- a/src/fe/fe_clough.C
+++ b/src/fe/fe_clough.C
@@ -45,7 +45,7 @@ void clough_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, CLOUGH);

--- a/src/fe/fe_clough.C
+++ b/src/fe/fe_clough.C
@@ -45,7 +45,7 @@ void clough_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, CLOUGH);

--- a/src/fe/fe_clough_shape_1D.C
+++ b/src/fe/fe_clough_shape_1D.C
@@ -236,7 +236,7 @@ Real FE<1,CLOUGH>::shape(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    sum(order, add_p_level*elem->p_level());
+    order + add_p_level*elem->p_level();
 
   switch (totalorder)
     {
@@ -328,7 +328,7 @@ Real FE<1,CLOUGH>::shape_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    sum(order, add_p_level*elem->p_level());
+    order + add_p_level*elem->p_level();
 
   switch (totalorder)
     {
@@ -396,7 +396,7 @@ Real FE<1,CLOUGH>::shape_second_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    sum(order, add_p_level*elem->p_level());
+    order + add_p_level*elem->p_level();
 
   switch (totalorder)
     {

--- a/src/fe/fe_clough_shape_1D.C
+++ b/src/fe/fe_clough_shape_1D.C
@@ -236,7 +236,7 @@ Real FE<1,CLOUGH>::shape(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    static_cast<Order>(order + add_p_level * elem->p_level());
+    sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
     {
@@ -328,7 +328,7 @@ Real FE<1,CLOUGH>::shape_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    static_cast<Order>(order + add_p_level * elem->p_level());
+    sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
     {
@@ -396,7 +396,7 @@ Real FE<1,CLOUGH>::shape_second_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    static_cast<Order>(order + add_p_level * elem->p_level());
+    sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
     {

--- a/src/fe/fe_clough_shape_2D.C
+++ b/src/fe/fe_clough_shape_2D.C
@@ -1772,7 +1772,7 @@ Real FE<2,CLOUGH>::shape(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    static_cast<Order>(order + add_p_level * elem->p_level());
+    sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
     {
@@ -1982,7 +1982,7 @@ Real FE<2,CLOUGH>::shape_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    static_cast<Order>(order + add_p_level * elem->p_level());
+    sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
     {
@@ -2195,7 +2195,7 @@ Real FE<2,CLOUGH>::shape_second_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    static_cast<Order>(order + add_p_level * elem->p_level());
+    sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
     {

--- a/src/fe/fe_clough_shape_2D.C
+++ b/src/fe/fe_clough_shape_2D.C
@@ -1772,7 +1772,7 @@ Real FE<2,CLOUGH>::shape(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    sum(order, add_p_level*elem->p_level());
+    order + add_p_level*elem->p_level();
 
   switch (totalorder)
     {
@@ -1982,7 +1982,7 @@ Real FE<2,CLOUGH>::shape_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    sum(order, add_p_level*elem->p_level());
+    order + add_p_level*elem->p_level();
 
   switch (totalorder)
     {
@@ -2195,7 +2195,7 @@ Real FE<2,CLOUGH>::shape_second_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    sum(order, add_p_level*elem->p_level());
+    order + add_p_level*elem->p_level();
 
   switch (totalorder)
     {

--- a/src/fe/fe_hermite_shape_2D.C
+++ b/src/fe/fe_hermite_shape_2D.C
@@ -215,7 +215,7 @@ Real FE<2,HERMITE>::shape(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    sum(order, add_p_level*elem->p_level());
+    order + add_p_level*elem->p_level();
 
   switch (type)
     {
@@ -292,7 +292,7 @@ Real FE<2,HERMITE>::shape_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    sum(order, add_p_level*elem->p_level());
+    order + add_p_level*elem->p_level();
 
   switch (type)
     {
@@ -386,7 +386,7 @@ Real FE<2,HERMITE>::shape_second_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    sum(order, add_p_level*elem->p_level());
+    order + add_p_level*elem->p_level();
 
   switch (type)
     {

--- a/src/fe/fe_hermite_shape_2D.C
+++ b/src/fe/fe_hermite_shape_2D.C
@@ -215,7 +215,7 @@ Real FE<2,HERMITE>::shape(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    static_cast<Order>(order + add_p_level * elem->p_level());
+    sum(order, add_p_level*elem->p_level());
 
   switch (type)
     {
@@ -292,7 +292,7 @@ Real FE<2,HERMITE>::shape_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    static_cast<Order>(order + add_p_level * elem->p_level());
+    sum(order, add_p_level*elem->p_level());
 
   switch (type)
     {
@@ -386,7 +386,7 @@ Real FE<2,HERMITE>::shape_second_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    static_cast<Order>(order + add_p_level * elem->p_level());
+    sum(order, add_p_level*elem->p_level());
 
   switch (type)
     {

--- a/src/fe/fe_hermite_shape_3D.C
+++ b/src/fe/fe_hermite_shape_3D.C
@@ -404,7 +404,7 @@ Real FE<3,HERMITE>::shape(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    sum(order, add_p_level*elem->p_level());
+    order + add_p_level*elem->p_level();
 
   switch (totalorder)
     {
@@ -488,7 +488,7 @@ Real FE<3,HERMITE>::shape_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    sum(order, add_p_level*elem->p_level());
+    order + add_p_level*elem->p_level();
 
   switch (totalorder)
     {
@@ -597,7 +597,7 @@ Real FE<3,HERMITE>::shape_second_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    sum(order, add_p_level*elem->p_level());
+    order + add_p_level*elem->p_level();
 
   switch (totalorder)
     {

--- a/src/fe/fe_hermite_shape_3D.C
+++ b/src/fe/fe_hermite_shape_3D.C
@@ -404,7 +404,7 @@ Real FE<3,HERMITE>::shape(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    static_cast<Order>(order + add_p_level * elem->p_level());
+    sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
     {
@@ -488,7 +488,7 @@ Real FE<3,HERMITE>::shape_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    static_cast<Order>(order + add_p_level * elem->p_level());
+    sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
     {
@@ -597,7 +597,7 @@ Real FE<3,HERMITE>::shape_second_deriv(const Elem * elem,
   const ElemType type = elem->type();
 
   const Order totalorder =
-    static_cast<Order>(order + add_p_level * elem->p_level());
+    sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
     {

--- a/src/fe/fe_hierarchic.C
+++ b/src/fe/fe_hierarchic.C
@@ -45,7 +45,7 @@ void hierarchic_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, HIERARCHIC);

--- a/src/fe/fe_hierarchic.C
+++ b/src/fe/fe_hierarchic.C
@@ -45,7 +45,7 @@ void hierarchic_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, HIERARCHIC);

--- a/src/fe/fe_hierarchic_shape_1D.C
+++ b/src/fe/fe_hierarchic_shape_1D.C
@@ -106,7 +106,7 @@ Real FE<1,HIERARCHIC>::shape(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_hierarchic_1D_shape(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, p);
+  return fe_hierarchic_1D_shape(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -119,7 +119,7 @@ Real FE<1,HIERARCHIC>::shape(const FEType fet,
                              const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_hierarchic_1D_shape(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, p);
+  return fe_hierarchic_1D_shape(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -135,7 +135,7 @@ Real FE<1,L2_HIERARCHIC>::shape(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_hierarchic_1D_shape(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, p);
+  return fe_hierarchic_1D_shape(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
 }
 
 template <>
@@ -146,7 +146,7 @@ Real FE<1,L2_HIERARCHIC>::shape(const FEType fet,
                                 const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_hierarchic_1D_shape(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, p);
+  return fe_hierarchic_1D_shape(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -221,7 +221,7 @@ Real FE<1,HIERARCHIC>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   return fe_hierarchic_1D_shape_deriv(elem->type(),
-                                      static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+                                      sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -235,7 +235,7 @@ Real FE<1,HIERARCHIC>::shape_deriv(const FEType fet,
                                    const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_hierarchic_1D_shape_deriv(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+  return fe_hierarchic_1D_shape_deriv(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -252,7 +252,7 @@ Real FE<1,L2_HIERARCHIC>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   return fe_hierarchic_1D_shape_deriv(elem->type(),
-                                      static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+                                      sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -266,7 +266,7 @@ Real FE<1,L2_HIERARCHIC>::shape_deriv(const FEType fet,
                                       const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_hierarchic_1D_shape_deriv(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+  return fe_hierarchic_1D_shape_deriv(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -346,7 +346,7 @@ Real FE<1,HIERARCHIC>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   return fe_hierarchic_1D_shape_second_deriv(elem->type(),
-                                             static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+                                             sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -361,7 +361,7 @@ Real FE<1,HIERARCHIC>::shape_second_deriv(const FEType fet,
 {
   libmesh_assert(elem);
   return fe_hierarchic_1D_shape_second_deriv(elem->type(),
-                                             static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+                                             sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -376,7 +376,7 @@ Real FE<1,L2_HIERARCHIC>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   return fe_hierarchic_1D_shape_second_deriv(elem->type(),
-                                             static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+                                             sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -390,7 +390,7 @@ Real FE<1,L2_HIERARCHIC>::shape_second_deriv(const FEType fet,
 {
   libmesh_assert(elem);
   return fe_hierarchic_1D_shape_second_deriv(elem->type(),
-                                             static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+                                             sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 

--- a/src/fe/fe_hierarchic_shape_1D.C
+++ b/src/fe/fe_hierarchic_shape_1D.C
@@ -106,7 +106,7 @@ Real FE<1,HIERARCHIC>::shape(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_hierarchic_1D_shape(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
+  return fe_hierarchic_1D_shape(elem->type(), order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -119,7 +119,7 @@ Real FE<1,HIERARCHIC>::shape(const FEType fet,
                              const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_hierarchic_1D_shape(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
+  return fe_hierarchic_1D_shape(elem->type(), fet.order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -135,7 +135,7 @@ Real FE<1,L2_HIERARCHIC>::shape(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_hierarchic_1D_shape(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
+  return fe_hierarchic_1D_shape(elem->type(), order + add_p_level*elem->p_level(), i, p);
 }
 
 template <>
@@ -146,7 +146,7 @@ Real FE<1,L2_HIERARCHIC>::shape(const FEType fet,
                                 const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_hierarchic_1D_shape(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
+  return fe_hierarchic_1D_shape(elem->type(), fet.order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -221,7 +221,7 @@ Real FE<1,HIERARCHIC>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   return fe_hierarchic_1D_shape_deriv(elem->type(),
-                                      sum(order, add_p_level*elem->p_level()), i, j, p);
+                                      order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -235,7 +235,7 @@ Real FE<1,HIERARCHIC>::shape_deriv(const FEType fet,
                                    const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_hierarchic_1D_shape_deriv(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+  return fe_hierarchic_1D_shape_deriv(elem->type(), fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -252,7 +252,7 @@ Real FE<1,L2_HIERARCHIC>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   return fe_hierarchic_1D_shape_deriv(elem->type(),
-                                      sum(order, add_p_level*elem->p_level()), i, j, p);
+                                      order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -266,7 +266,7 @@ Real FE<1,L2_HIERARCHIC>::shape_deriv(const FEType fet,
                                       const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_hierarchic_1D_shape_deriv(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+  return fe_hierarchic_1D_shape_deriv(elem->type(), fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -346,7 +346,7 @@ Real FE<1,HIERARCHIC>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   return fe_hierarchic_1D_shape_second_deriv(elem->type(),
-                                             sum(order, add_p_level*elem->p_level()), i, j, p);
+                                             order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -361,7 +361,7 @@ Real FE<1,HIERARCHIC>::shape_second_deriv(const FEType fet,
 {
   libmesh_assert(elem);
   return fe_hierarchic_1D_shape_second_deriv(elem->type(),
-                                             sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+                                             fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -376,7 +376,7 @@ Real FE<1,L2_HIERARCHIC>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   return fe_hierarchic_1D_shape_second_deriv(elem->type(),
-                                             sum(order, add_p_level*elem->p_level()), i, j, p);
+                                             order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -390,7 +390,7 @@ Real FE<1,L2_HIERARCHIC>::shape_second_deriv(const FEType fet,
 {
   libmesh_assert(elem);
   return fe_hierarchic_1D_shape_second_deriv(elem->type(),
-                                             sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+                                             fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 

--- a/src/fe/fe_hierarchic_shape_2D.C
+++ b/src/fe/fe_hierarchic_shape_2D.C
@@ -224,7 +224,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape(const Elem * elem,
   libmesh_assert(elem);
   const ElemType type = elem->type();
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   const unsigned int dofs_per_side = totalorder+1u;
 
@@ -500,7 +500,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape_deriv(const Elem * elem,
 
   const ElemType type = elem->type();
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   if (totalorder == 0) // special case since raw HIERARCHIC lacks CONSTANTs
     return 0;
@@ -789,7 +789,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
   const ElemType type = elem->type();
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   if (totalorder == 0) // special case since raw HIERARCHIC lacks CONSTANTs
     return 0;
@@ -956,7 +956,7 @@ Real fe_hierarchic_2D_shape(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
   libmesh_assert_greater (totalorder, 0);
 
   switch (elem->type())
@@ -1067,7 +1067,7 @@ Real fe_hierarchic_2D_shape_deriv(const Elem * elem,
 
   const ElemType type = elem->type();
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   libmesh_assert_greater (totalorder, 0);
 

--- a/src/fe/fe_hierarchic_shape_2D.C
+++ b/src/fe/fe_hierarchic_shape_2D.C
@@ -224,8 +224,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape(const Elem * elem,
   libmesh_assert(elem);
   const ElemType type = elem->type();
 
-  const Order totalorder =
-    static_cast<Order>(order+add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   const unsigned int dofs_per_side = totalorder+1u;
 
@@ -501,8 +500,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape_deriv(const Elem * elem,
 
   const ElemType type = elem->type();
 
-  const Order totalorder =
-    static_cast<Order>(order+add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   if (totalorder == 0) // special case since raw HIERARCHIC lacks CONSTANTs
     return 0;
@@ -791,8 +789,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
   const ElemType type = elem->type();
 
-  const Order totalorder =
-    static_cast<Order>(order+add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   if (totalorder == 0) // special case since raw HIERARCHIC lacks CONSTANTs
     return 0;
@@ -959,8 +956,7 @@ Real fe_hierarchic_2D_shape(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  const Order totalorder =
-    static_cast<Order>(order+add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
   libmesh_assert_greater (totalorder, 0);
 
   switch (elem->type())
@@ -1071,8 +1067,7 @@ Real fe_hierarchic_2D_shape_deriv(const Elem * elem,
 
   const ElemType type = elem->type();
 
-  const Order totalorder =
-    static_cast<Order>(order+add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   libmesh_assert_greater (totalorder, 0);
 

--- a/src/fe/fe_hierarchic_shape_3D.C
+++ b/src/fe/fe_hierarchic_shape_3D.C
@@ -1257,7 +1257,7 @@ Real FE<3,SIDE_HIERARCHIC>::shape(const Elem * elem,
   libmesh_assert(elem);
   const ElemType type = elem->type();
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   switch (type)
     {
@@ -1608,7 +1608,7 @@ Real FE<3,SIDE_HIERARCHIC>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
   const ElemType type = elem->type();
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   if (totalorder == 0) // special case since raw HIERARCHIC lacks CONSTANTs
     return 0; // constants have zero derivative
@@ -1867,7 +1867,7 @@ Real FE<3,SIDE_HIERARCHIC>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
   const ElemType type = elem->type();
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   if (totalorder == 0) // special case since raw HIERARCHIC lacks CONSTANTs
     return 0; // constants have zero derivative
@@ -2259,7 +2259,7 @@ Real fe_hierarchic_3D_shape(const Elem * elem,
   libmesh_assert(elem);
   const ElemType type = elem->type();
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   switch (type)
     {

--- a/src/fe/fe_hierarchic_shape_3D.C
+++ b/src/fe/fe_hierarchic_shape_3D.C
@@ -1257,8 +1257,7 @@ Real FE<3,SIDE_HIERARCHIC>::shape(const Elem * elem,
   libmesh_assert(elem);
   const ElemType type = elem->type();
 
-  const Order totalorder =
-    static_cast<Order>(order+add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   switch (type)
     {
@@ -1609,8 +1608,7 @@ Real FE<3,SIDE_HIERARCHIC>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
   const ElemType type = elem->type();
 
-  const Order totalorder =
-    static_cast<Order>(order+add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   if (totalorder == 0) // special case since raw HIERARCHIC lacks CONSTANTs
     return 0; // constants have zero derivative
@@ -1869,8 +1867,7 @@ Real FE<3,SIDE_HIERARCHIC>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
   const ElemType type = elem->type();
 
-  const Order totalorder =
-    static_cast<Order>(order+add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   if (totalorder == 0) // special case since raw HIERARCHIC lacks CONSTANTs
     return 0; // constants have zero derivative
@@ -2262,8 +2259,7 @@ Real fe_hierarchic_3D_shape(const Elem * elem,
   libmesh_assert(elem);
   const ElemType type = elem->type();
 
-  const Order totalorder =
-    static_cast<Order>(order+add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   switch (type)
     {

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -559,7 +559,7 @@ FEInterface::n_shape_functions(const FEType & fe_t,
 #endif
 
   // Account for Elem::p_level() when computing total_order
-  auto total_order = static_cast<Order>(fe_t.order + add_p_level*elem->p_level());
+  auto total_order = sum(fe_t.order, add_p_level*elem->p_level());
 
   fe_with_vec_switch(n_shape_functions(elem->type(), total_order));
 }
@@ -587,7 +587,7 @@ FEInterface::n_shape_functions(const FEType & fe_t,
 #endif
 
   // Ignore Elem::p_level() and instead use extra_order to compute total_order.
-  auto total_order = static_cast<Order>(fe_t.order + extra_order);
+  auto total_order = sum(fe_t.order, extra_order);
 
   fe_with_vec_switch(n_shape_functions(elem->type(), total_order));
 }
@@ -623,7 +623,7 @@ FEInterface::n_dofs (const unsigned int dim,
   libmesh_deprecated();
 
   FEType p_refined_fe_t = fe_t;
-  p_refined_fe_t.order = static_cast<Order>(p_refined_fe_t.order + elem->p_level());
+  p_refined_fe_t.order = sum(p_refined_fe_t.order, elem->p_level());
   return FEInterface::n_dofs(dim, p_refined_fe_t, elem->type());
 }
 
@@ -646,7 +646,7 @@ FEInterface::n_dofs(const FEType & fe_t,
 #endif
 
   // Account for Elem::p_level() when computing total_order
-  auto total_order = static_cast<Order>(fe_t.order + add_p_level*elem->p_level());
+  auto total_order = sum(fe_t.order, add_p_level*elem->p_level());
 
   fe_with_vec_switch(n_dofs(elem->type(), total_order));
 }
@@ -670,7 +670,7 @@ FEInterface::n_dofs(const FEType & fe_t,
 #endif
 
   // Elem::p_level() is ignored, extra_order is used instead.
-  auto total_order = static_cast<Order>(fe_t.order + extra_order);
+  auto total_order = sum(fe_t.order, extra_order);
 
   fe_with_vec_switch(n_dofs(elem->type(), total_order));
 }
@@ -739,7 +739,7 @@ FEInterface::n_dofs_at_node(const FEType & fe_t,
 #endif
 
   // Account for Elem::p_level() when computing total_order
-  auto total_order = static_cast<Order>(fe_t.order + add_p_level*elem->p_level());
+  auto total_order = sum(fe_t.order, add_p_level*elem->p_level());
 
   fe_with_vec_switch(n_dofs_at_node(elem->type(), total_order, n));
 }
@@ -763,7 +763,7 @@ FEInterface::n_dofs_at_node(const FEType & fe_t,
 #endif
 
   // Ignore Elem::p_level() and instead use extra_order to compute total_order.
-  auto total_order = static_cast<Order>(fe_t.order + extra_order);
+  auto total_order = sum(fe_t.order, extra_order);
 
   fe_with_vec_switch(n_dofs_at_node(elem->type(), total_order, n));
 }
@@ -807,7 +807,7 @@ FEInterface::n_dofs_per_elem(const FEType & fe_t,
 #endif
 
   // Account for Elem::p_level() when computing total_order
-  auto total_order = static_cast<Order>(fe_t.order + add_p_level*elem->p_level());
+  auto total_order = sum(fe_t.order, add_p_level*elem->p_level());
 
   fe_with_vec_switch(n_dofs_per_elem(elem->type(), total_order));
 }
@@ -830,7 +830,7 @@ FEInterface::n_dofs_per_elem(const FEType & fe_t,
 #endif
 
   // Ignore Elem::p_level() and instead use extra_order to compute total_order.
-  auto total_order = static_cast<Order>(fe_t.order + extra_order);
+  auto total_order = sum(fe_t.order, extra_order);
 
   fe_with_vec_switch(n_dofs_per_elem(elem->type(), total_order));
 }
@@ -1093,7 +1093,7 @@ FEInterface::shape(const FEType & fe_t,
   // with the last parameter set to "false" so that the
   // Elem::p_level() is not used internally and the "total_order" that
   // we compute is used instead. See fe.h for more details.
-  auto total_order = static_cast<Order>(fe_t.order + extra_order);
+  auto total_order = sum(fe_t.order, extra_order);
 
   fe_switch(shape(elem, total_order, i, p, false));
 }
@@ -1254,7 +1254,7 @@ void FEInterface::shape<Real>(const FEType & fe_t,
 #endif
 
   // Ignore Elem::p_level() and instead use extra_order to compute total_order
-  auto total_order = static_cast<Order>(fe_t.order + extra_order);
+  auto total_order = sum(fe_t.order, extra_order);
 
   // Below we call
   //
@@ -1297,7 +1297,7 @@ void FEInterface::shapes<Real>(const unsigned int dim,
   if (elem && is_InfFE_elem(elem->type()))
     {
       FEType elevated = fe_t;
-      elevated.order = static_cast<Order>(fe_t.order + add_p_level * elem->p_level());
+      elevated.order = sum(fe_t.order, add_p_level * elem->p_level());
       for (auto qpi : index_range(p))
         phi[qpi] = ifem_shape(elevated, elem, i, p[qpi]);
       return;
@@ -1484,7 +1484,7 @@ void FEInterface::shape<RealGradient>(const FEType & fe_t,
   // with the last parameter set to "false" so that the
   // Elem::p_level() is not used internally and the "total_order" that
   // we compute is used instead. See fe.h for more details.
-  auto total_order = static_cast<Order>(fe_t.order + extra_order);
+  auto total_order = sum(fe_t.order, extra_order);
 
   switch(dim)
     {
@@ -1727,7 +1727,7 @@ Real FEInterface::shape_deriv(const FEType & fe_t,
 
   // Ignore Elem::p_level() when computing total order, use
   // extra_order instead.
-  auto total_order = static_cast<Order>(fe_t.order + extra_order);
+  auto total_order = sum(fe_t.order, extra_order);
 
   // We call shape_deriv() with the final argument == false so that
   // the Elem::p_level() is ignored internally.
@@ -2025,7 +2025,7 @@ Real FEInterface::shape_second_deriv(const FEType & fe_t,
 
   // Ignore Elem::p_level() when computing total order, use
   // extra_order instead.
-  auto total_order = static_cast<Order>(fe_t.order + extra_order);
+  auto total_order = sum(fe_t.order, extra_order);
 
   // We are calling FE::shape_second_deriv() with the final argument
   // == false so that the Elem::p_level() is ignored and the

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -559,7 +559,7 @@ FEInterface::n_shape_functions(const FEType & fe_t,
 #endif
 
   // Account for Elem::p_level() when computing total_order
-  auto total_order = sum(fe_t.order, add_p_level*elem->p_level());
+  auto total_order = fe_t.order + add_p_level*elem->p_level();
 
   fe_with_vec_switch(n_shape_functions(elem->type(), total_order));
 }
@@ -587,7 +587,7 @@ FEInterface::n_shape_functions(const FEType & fe_t,
 #endif
 
   // Ignore Elem::p_level() and instead use extra_order to compute total_order.
-  auto total_order = sum(fe_t.order, extra_order);
+  auto total_order = fe_t.order + extra_order;
 
   fe_with_vec_switch(n_shape_functions(elem->type(), total_order));
 }
@@ -623,7 +623,7 @@ FEInterface::n_dofs (const unsigned int dim,
   libmesh_deprecated();
 
   FEType p_refined_fe_t = fe_t;
-  p_refined_fe_t.order = sum(p_refined_fe_t.order, elem->p_level());
+  p_refined_fe_t.order = p_refined_fe_t.order + elem->p_level();
   return FEInterface::n_dofs(dim, p_refined_fe_t, elem->type());
 }
 
@@ -646,7 +646,7 @@ FEInterface::n_dofs(const FEType & fe_t,
 #endif
 
   // Account for Elem::p_level() when computing total_order
-  auto total_order = sum(fe_t.order, add_p_level*elem->p_level());
+  auto total_order = fe_t.order + add_p_level*elem->p_level();
 
   fe_with_vec_switch(n_dofs(elem->type(), total_order));
 }
@@ -670,7 +670,7 @@ FEInterface::n_dofs(const FEType & fe_t,
 #endif
 
   // Elem::p_level() is ignored, extra_order is used instead.
-  auto total_order = sum(fe_t.order, extra_order);
+  auto total_order = fe_t.order + extra_order;
 
   fe_with_vec_switch(n_dofs(elem->type(), total_order));
 }
@@ -739,7 +739,7 @@ FEInterface::n_dofs_at_node(const FEType & fe_t,
 #endif
 
   // Account for Elem::p_level() when computing total_order
-  auto total_order = sum(fe_t.order, add_p_level*elem->p_level());
+  auto total_order = fe_t.order + add_p_level*elem->p_level();
 
   fe_with_vec_switch(n_dofs_at_node(elem->type(), total_order, n));
 }
@@ -763,7 +763,7 @@ FEInterface::n_dofs_at_node(const FEType & fe_t,
 #endif
 
   // Ignore Elem::p_level() and instead use extra_order to compute total_order.
-  auto total_order = sum(fe_t.order, extra_order);
+  auto total_order = fe_t.order + extra_order;
 
   fe_with_vec_switch(n_dofs_at_node(elem->type(), total_order, n));
 }
@@ -807,7 +807,7 @@ FEInterface::n_dofs_per_elem(const FEType & fe_t,
 #endif
 
   // Account for Elem::p_level() when computing total_order
-  auto total_order = sum(fe_t.order, add_p_level*elem->p_level());
+  auto total_order = fe_t.order + add_p_level*elem->p_level();
 
   fe_with_vec_switch(n_dofs_per_elem(elem->type(), total_order));
 }
@@ -830,7 +830,7 @@ FEInterface::n_dofs_per_elem(const FEType & fe_t,
 #endif
 
   // Ignore Elem::p_level() and instead use extra_order to compute total_order.
-  auto total_order = sum(fe_t.order, extra_order);
+  auto total_order = fe_t.order + extra_order;
 
   fe_with_vec_switch(n_dofs_per_elem(elem->type(), total_order));
 }
@@ -1093,7 +1093,7 @@ FEInterface::shape(const FEType & fe_t,
   // with the last parameter set to "false" so that the
   // Elem::p_level() is not used internally and the "total_order" that
   // we compute is used instead. See fe.h for more details.
-  auto total_order = sum(fe_t.order, extra_order);
+  auto total_order = fe_t.order + extra_order;
 
   fe_switch(shape(elem, total_order, i, p, false));
 }
@@ -1254,7 +1254,7 @@ void FEInterface::shape<Real>(const FEType & fe_t,
 #endif
 
   // Ignore Elem::p_level() and instead use extra_order to compute total_order
-  auto total_order = sum(fe_t.order, extra_order);
+  auto total_order = fe_t.order + extra_order;
 
   // Below we call
   //
@@ -1297,7 +1297,7 @@ void FEInterface::shapes<Real>(const unsigned int dim,
   if (elem && is_InfFE_elem(elem->type()))
     {
       FEType elevated = fe_t;
-      elevated.order = sum(fe_t.order, add_p_level * elem->p_level());
+      elevated.order = fe_t.order + add_p_level * elem->p_level();
       for (auto qpi : index_range(p))
         phi[qpi] = ifem_shape(elevated, elem, i, p[qpi]);
       return;
@@ -1484,7 +1484,7 @@ void FEInterface::shape<RealGradient>(const FEType & fe_t,
   // with the last parameter set to "false" so that the
   // Elem::p_level() is not used internally and the "total_order" that
   // we compute is used instead. See fe.h for more details.
-  auto total_order = sum(fe_t.order, extra_order);
+  auto total_order = fe_t.order + extra_order;
 
   switch(dim)
     {
@@ -1727,7 +1727,7 @@ Real FEInterface::shape_deriv(const FEType & fe_t,
 
   // Ignore Elem::p_level() when computing total order, use
   // extra_order instead.
-  auto total_order = sum(fe_t.order, extra_order);
+  auto total_order = fe_t.order + extra_order;
 
   // We call shape_deriv() with the final argument == false so that
   // the Elem::p_level() is ignored internally.
@@ -2025,7 +2025,7 @@ Real FEInterface::shape_second_deriv(const FEType & fe_t,
 
   // Ignore Elem::p_level() when computing total order, use
   // extra_order instead.
-  auto total_order = sum(fe_t.order, extra_order);
+  auto total_order = fe_t.order + extra_order;
 
   // We are calling FE::shape_second_deriv() with the final argument
   // == false so that the Elem::p_level() is ignored and the

--- a/src/fe/fe_l2_hierarchic.C
+++ b/src/fe/fe_l2_hierarchic.C
@@ -45,7 +45,7 @@ void l2_hierarchic_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, L2_HIERARCHIC);

--- a/src/fe/fe_l2_hierarchic.C
+++ b/src/fe/fe_l2_hierarchic.C
@@ -45,7 +45,7 @@ void l2_hierarchic_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, L2_HIERARCHIC);

--- a/src/fe/fe_lagrange.C
+++ b/src/fe/fe_lagrange.C
@@ -49,7 +49,7 @@ void lagrange_nodal_soln(const Elem * elem,
   const unsigned int n_nodes = elem->n_nodes();
   const ElemType type        = elem->type();
 
-  const Order totalorder = static_cast<Order>(order+add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   nodal_soln.resize(n_nodes);
 

--- a/src/fe/fe_lagrange.C
+++ b/src/fe/fe_lagrange.C
@@ -49,7 +49,7 @@ void lagrange_nodal_soln(const Elem * elem,
   const unsigned int n_nodes = elem->n_nodes();
   const ElemType type        = elem->type();
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   nodal_soln.resize(n_nodes);
 

--- a/src/fe/fe_lagrange_shape_1D.C
+++ b/src/fe/fe_lagrange_shape_1D.C
@@ -58,7 +58,7 @@ Real FE<1,LAGRANGE>::shape(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_lagrange_1D_shape(sum(order, add_p_level*elem->p_level()), i, p(0));
+  return fe_lagrange_1D_shape(order + add_p_level*elem->p_level(), i, p(0));
 }
 
 
@@ -71,7 +71,7 @@ Real FE<1,LAGRANGE>::shape(const FEType fet,
                            const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_1D_shape(sum(fet.order, add_p_level*elem->p_level()), i, p(0));
+  return fe_lagrange_1D_shape(fet.order + add_p_level*elem->p_level(), i, p(0));
 }
 
 template <>
@@ -83,7 +83,7 @@ Real FE<1,L2_LAGRANGE>::shape(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_lagrange_1D_shape(sum(order, add_p_level*elem->p_level()), i, p(0));
+  return fe_lagrange_1D_shape(order + add_p_level*elem->p_level(), i, p(0));
 }
 
 template <>
@@ -94,7 +94,7 @@ Real FE<1,L2_LAGRANGE>::shape(const FEType fet,
                               const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_1D_shape(sum(fet.order, add_p_level*elem->p_level()), i, p(0));
+  return fe_lagrange_1D_shape(fet.order + add_p_level*elem->p_level(), i, p(0));
 }
 
 
@@ -133,7 +133,7 @@ Real FE<1,LAGRANGE>::shape_deriv(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_lagrange_1D_shape_deriv(sum(order, add_p_level*elem->p_level()), i, j, p(0));
+  return fe_lagrange_1D_shape_deriv(order + add_p_level*elem->p_level(), i, j, p(0));
 }
 
 
@@ -148,7 +148,7 @@ Real FE<1,L2_LAGRANGE>::shape_deriv(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_lagrange_1D_shape_deriv(sum(order, add_p_level*elem->p_level()), i, j, p(0));
+  return fe_lagrange_1D_shape_deriv(order + add_p_level*elem->p_level(), i, j, p(0));
 }
 
 
@@ -161,7 +161,7 @@ Real FE<1,LAGRANGE>::shape_deriv(const FEType fet,
                                  const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_1D_shape_deriv(sum(fet.order, add_p_level*elem->p_level()), i, j, p(0));
+  return fe_lagrange_1D_shape_deriv(fet.order + add_p_level*elem->p_level(), i, j, p(0));
 }
 
 
@@ -174,7 +174,7 @@ Real FE<1,L2_LAGRANGE>::shape_deriv(const FEType fet,
                                     const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_1D_shape_deriv(sum(fet.order, add_p_level*elem->p_level()), i, j, p(0));
+  return fe_lagrange_1D_shape_deriv(fet.order + add_p_level*elem->p_level(), i, j, p(0));
 }
 
 
@@ -214,7 +214,7 @@ Real FE<1,LAGRANGE>::shape_second_deriv(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_lagrange_1D_shape_second_deriv(sum(order, add_p_level*elem->p_level()), i, j, p(0));
+  return fe_lagrange_1D_shape_second_deriv(order + add_p_level*elem->p_level(), i, j, p(0));
 }
 
 
@@ -229,7 +229,7 @@ Real FE<1,L2_LAGRANGE>::shape_second_deriv(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_lagrange_1D_shape_second_deriv(sum(order, add_p_level*elem->p_level()), i, j, p(0));
+  return fe_lagrange_1D_shape_second_deriv(order + add_p_level*elem->p_level(), i, j, p(0));
 }
 
 
@@ -242,7 +242,7 @@ Real FE<1,LAGRANGE>::shape_second_deriv(const FEType fet,
                                         const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_1D_shape_second_deriv(sum(fet.order, add_p_level*elem->p_level()), i, j, p(0));
+  return fe_lagrange_1D_shape_second_deriv(fet.order + add_p_level*elem->p_level(), i, j, p(0));
 }
 
 
@@ -255,7 +255,7 @@ Real FE<1,L2_LAGRANGE>::shape_second_deriv(const FEType fet,
                                            const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_1D_shape_second_deriv(sum(fet.order, add_p_level*elem->p_level()), i, j, p(0));
+  return fe_lagrange_1D_shape_second_deriv(fet.order + add_p_level*elem->p_level(), i, j, p(0));
 }
 
 #endif // LIBMESH_ENABLE_SECOND_DERIVATIVES

--- a/src/fe/fe_lagrange_shape_1D.C
+++ b/src/fe/fe_lagrange_shape_1D.C
@@ -58,7 +58,7 @@ Real FE<1,LAGRANGE>::shape(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_lagrange_1D_shape(static_cast<Order>(order + add_p_level * elem->p_level()), i, p(0));
+  return fe_lagrange_1D_shape(sum(order, add_p_level*elem->p_level()), i, p(0));
 }
 
 
@@ -71,7 +71,7 @@ Real FE<1,LAGRANGE>::shape(const FEType fet,
                            const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_1D_shape(static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, p(0));
+  return fe_lagrange_1D_shape(sum(fet.order, add_p_level*elem->p_level()), i, p(0));
 }
 
 template <>
@@ -83,7 +83,7 @@ Real FE<1,L2_LAGRANGE>::shape(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_lagrange_1D_shape(static_cast<Order>(order + add_p_level * elem->p_level()), i, p(0));
+  return fe_lagrange_1D_shape(sum(order, add_p_level*elem->p_level()), i, p(0));
 }
 
 template <>
@@ -94,7 +94,7 @@ Real FE<1,L2_LAGRANGE>::shape(const FEType fet,
                               const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_1D_shape(static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, p(0));
+  return fe_lagrange_1D_shape(sum(fet.order, add_p_level*elem->p_level()), i, p(0));
 }
 
 
@@ -133,7 +133,7 @@ Real FE<1,LAGRANGE>::shape_deriv(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_lagrange_1D_shape_deriv(static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p(0));
+  return fe_lagrange_1D_shape_deriv(sum(order, add_p_level*elem->p_level()), i, j, p(0));
 }
 
 
@@ -148,7 +148,7 @@ Real FE<1,L2_LAGRANGE>::shape_deriv(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_lagrange_1D_shape_deriv(static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p(0));
+  return fe_lagrange_1D_shape_deriv(sum(order, add_p_level*elem->p_level()), i, j, p(0));
 }
 
 
@@ -161,7 +161,7 @@ Real FE<1,LAGRANGE>::shape_deriv(const FEType fet,
                                  const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_1D_shape_deriv(static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p(0));
+  return fe_lagrange_1D_shape_deriv(sum(fet.order, add_p_level*elem->p_level()), i, j, p(0));
 }
 
 
@@ -174,7 +174,7 @@ Real FE<1,L2_LAGRANGE>::shape_deriv(const FEType fet,
                                     const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_1D_shape_deriv(static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p(0));
+  return fe_lagrange_1D_shape_deriv(sum(fet.order, add_p_level*elem->p_level()), i, j, p(0));
 }
 
 
@@ -214,7 +214,7 @@ Real FE<1,LAGRANGE>::shape_second_deriv(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_lagrange_1D_shape_second_deriv(static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p(0));
+  return fe_lagrange_1D_shape_second_deriv(sum(order, add_p_level*elem->p_level()), i, j, p(0));
 }
 
 
@@ -229,7 +229,7 @@ Real FE<1,L2_LAGRANGE>::shape_second_deriv(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return fe_lagrange_1D_shape_second_deriv(static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p(0));
+  return fe_lagrange_1D_shape_second_deriv(sum(order, add_p_level*elem->p_level()), i, j, p(0));
 }
 
 
@@ -242,7 +242,7 @@ Real FE<1,LAGRANGE>::shape_second_deriv(const FEType fet,
                                         const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_1D_shape_second_deriv(static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p(0));
+  return fe_lagrange_1D_shape_second_deriv(sum(fet.order, add_p_level*elem->p_level()), i, j, p(0));
 }
 
 
@@ -255,7 +255,7 @@ Real FE<1,L2_LAGRANGE>::shape_second_deriv(const FEType fet,
                                            const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_1D_shape_second_deriv(static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p(0));
+  return fe_lagrange_1D_shape_second_deriv(sum(fet.order, add_p_level*elem->p_level()), i, j, p(0));
 }
 
 #endif // LIBMESH_ENABLE_SECOND_DERIVATIVES

--- a/src/fe/fe_lagrange_shape_2D.C
+++ b/src/fe/fe_lagrange_shape_2D.C
@@ -96,7 +96,7 @@ Real FE<2,LAGRANGE>::shape(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape functions
-  return fe_lagrange_2D_shape<LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
+  return fe_lagrange_2D_shape<LAGRANGE>(elem->type(), order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -111,7 +111,7 @@ Real FE<2,L2_LAGRANGE>::shape(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape functions
-  return fe_lagrange_2D_shape<L2_LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
+  return fe_lagrange_2D_shape<L2_LAGRANGE>(elem->type(), order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -123,7 +123,7 @@ Real FE<2,LAGRANGE>::shape(const FEType fet,
                            const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_2D_shape<LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
+  return fe_lagrange_2D_shape<LAGRANGE>(elem->type(), fet.order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -136,7 +136,7 @@ Real FE<2,L2_LAGRANGE>::shape(const FEType fet,
                               const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_2D_shape<L2_LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
+  return fe_lagrange_2D_shape<L2_LAGRANGE>(elem->type(), fet.order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -175,7 +175,7 @@ Real FE<2,LAGRANGE>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape functions
-  return fe_lagrange_2D_shape_deriv<LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+  return fe_lagrange_2D_shape_deriv<LAGRANGE>(elem->type(), order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -192,7 +192,7 @@ Real FE<2,L2_LAGRANGE>::shape_deriv(const Elem * elem,
 
 
   // call the orientation-independent shape functions
-  return fe_lagrange_2D_shape_deriv<L2_LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+  return fe_lagrange_2D_shape_deriv<L2_LAGRANGE>(elem->type(), order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -205,7 +205,7 @@ Real FE<2,LAGRANGE>::shape_deriv(const FEType fet,
                                  const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_2D_shape_deriv<LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+  return fe_lagrange_2D_shape_deriv<LAGRANGE>(elem->type(), fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -219,7 +219,7 @@ Real FE<2,L2_LAGRANGE>::shape_deriv(const FEType fet,
                                     const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_2D_shape_deriv<L2_LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+  return fe_lagrange_2D_shape_deriv<L2_LAGRANGE>(elem->type(), fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -261,7 +261,7 @@ Real FE<2,LAGRANGE>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape functions
-  return fe_lagrange_2D_shape_second_deriv<LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+  return fe_lagrange_2D_shape_second_deriv<LAGRANGE>(elem->type(), order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -277,7 +277,7 @@ Real FE<2,L2_LAGRANGE>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape functions
-  return fe_lagrange_2D_shape_second_deriv<L2_LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+  return fe_lagrange_2D_shape_second_deriv<L2_LAGRANGE>(elem->type(), order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -290,7 +290,7 @@ Real FE<2,LAGRANGE>::shape_second_deriv(const FEType fet,
                                         const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_2D_shape_second_deriv<LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+  return fe_lagrange_2D_shape_second_deriv<LAGRANGE>(elem->type(), fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -304,7 +304,7 @@ Real FE<2,L2_LAGRANGE>::shape_second_deriv(const FEType fet,
                                            const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_2D_shape_second_deriv<L2_LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+  return fe_lagrange_2D_shape_second_deriv<L2_LAGRANGE>(elem->type(), fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 #endif // LIBMESH_ENABLE_SECOND_DERIVATIVES

--- a/src/fe/fe_lagrange_shape_2D.C
+++ b/src/fe/fe_lagrange_shape_2D.C
@@ -96,7 +96,7 @@ Real FE<2,LAGRANGE>::shape(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape functions
-  return fe_lagrange_2D_shape<LAGRANGE>(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, p);
+  return fe_lagrange_2D_shape<LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -111,7 +111,7 @@ Real FE<2,L2_LAGRANGE>::shape(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape functions
-  return fe_lagrange_2D_shape<L2_LAGRANGE>(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, p);
+  return fe_lagrange_2D_shape<L2_LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -123,7 +123,7 @@ Real FE<2,LAGRANGE>::shape(const FEType fet,
                            const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_2D_shape<LAGRANGE>(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, p);
+  return fe_lagrange_2D_shape<LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -136,7 +136,7 @@ Real FE<2,L2_LAGRANGE>::shape(const FEType fet,
                               const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_2D_shape<L2_LAGRANGE>(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, p);
+  return fe_lagrange_2D_shape<L2_LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -175,7 +175,7 @@ Real FE<2,LAGRANGE>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape functions
-  return fe_lagrange_2D_shape_deriv<LAGRANGE>(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+  return fe_lagrange_2D_shape_deriv<LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -192,7 +192,7 @@ Real FE<2,L2_LAGRANGE>::shape_deriv(const Elem * elem,
 
 
   // call the orientation-independent shape functions
-  return fe_lagrange_2D_shape_deriv<L2_LAGRANGE>(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+  return fe_lagrange_2D_shape_deriv<L2_LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -205,7 +205,7 @@ Real FE<2,LAGRANGE>::shape_deriv(const FEType fet,
                                  const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_2D_shape_deriv<LAGRANGE>(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+  return fe_lagrange_2D_shape_deriv<LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -219,7 +219,7 @@ Real FE<2,L2_LAGRANGE>::shape_deriv(const FEType fet,
                                     const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_2D_shape_deriv<L2_LAGRANGE>(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+  return fe_lagrange_2D_shape_deriv<L2_LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -261,7 +261,7 @@ Real FE<2,LAGRANGE>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape functions
-  return fe_lagrange_2D_shape_second_deriv<LAGRANGE>(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+  return fe_lagrange_2D_shape_second_deriv<LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -277,7 +277,7 @@ Real FE<2,L2_LAGRANGE>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape functions
-  return fe_lagrange_2D_shape_second_deriv<L2_LAGRANGE>(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+  return fe_lagrange_2D_shape_second_deriv<L2_LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -290,7 +290,7 @@ Real FE<2,LAGRANGE>::shape_second_deriv(const FEType fet,
                                         const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_2D_shape_second_deriv<LAGRANGE>(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+  return fe_lagrange_2D_shape_second_deriv<LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -304,7 +304,7 @@ Real FE<2,L2_LAGRANGE>::shape_second_deriv(const FEType fet,
                                            const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_2D_shape_second_deriv<L2_LAGRANGE>(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+  return fe_lagrange_2D_shape_second_deriv<L2_LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 #endif // LIBMESH_ENABLE_SECOND_DERIVATIVES

--- a/src/fe/fe_lagrange_shape_3D.C
+++ b/src/fe/fe_lagrange_shape_3D.C
@@ -442,7 +442,7 @@ Real FE<3,LAGRANGE>::shape(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape functions
-  return fe_lagrange_3D_shape<LAGRANGE>(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, p);
+  return fe_lagrange_3D_shape<LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -457,7 +457,7 @@ Real FE<3,L2_LAGRANGE>::shape(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape functions
-  return fe_lagrange_3D_shape<L2_LAGRANGE>(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, p);
+  return fe_lagrange_3D_shape<L2_LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -470,7 +470,7 @@ Real FE<3,LAGRANGE>::shape(const FEType fet,
                            const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_3D_shape<LAGRANGE>(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, p);
+  return fe_lagrange_3D_shape<LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -483,7 +483,7 @@ Real FE<3,L2_LAGRANGE>::shape(const FEType fet,
                               const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_3D_shape<L2_LAGRANGE>(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, p);
+  return fe_lagrange_3D_shape<L2_LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
 }
 
 template <>
@@ -521,7 +521,7 @@ Real FE<3,LAGRANGE>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape function derivatives
-  return fe_lagrange_3D_shape_deriv<LAGRANGE>(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+  return fe_lagrange_3D_shape_deriv<LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -536,7 +536,7 @@ Real FE<3,L2_LAGRANGE>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape function derivatives
-  return fe_lagrange_3D_shape_deriv<L2_LAGRANGE>(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+  return fe_lagrange_3D_shape_deriv<L2_LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -549,7 +549,7 @@ Real FE<3,LAGRANGE>::shape_deriv(const FEType fet,
                                  const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_3D_shape_deriv<LAGRANGE>(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+  return fe_lagrange_3D_shape_deriv<LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -562,7 +562,7 @@ Real FE<3,L2_LAGRANGE>::shape_deriv(const FEType fet,
                                     const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_3D_shape_deriv<L2_LAGRANGE>(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+  return fe_lagrange_3D_shape_deriv<L2_LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
@@ -603,7 +603,7 @@ Real FE<3,LAGRANGE>::shape_second_deriv(const Elem * elem,
 
   // call the orientation-independent shape function derivatives
   return fe_lagrange_3D_shape_second_deriv<LAGRANGE>
-    (elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+    (elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -620,7 +620,7 @@ Real FE<3,L2_LAGRANGE>::shape_second_deriv(const Elem * elem,
 
   // call the orientation-independent shape function derivatives
   return fe_lagrange_3D_shape_second_deriv<L2_LAGRANGE>
-    (elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+    (elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -634,7 +634,7 @@ Real FE<3,LAGRANGE>::shape_second_deriv(const FEType fet,
 {
   libmesh_assert(elem);
   return fe_lagrange_3D_shape_second_deriv<LAGRANGE>
-    (elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+    (elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -649,7 +649,7 @@ Real FE<3,L2_LAGRANGE>::shape_second_deriv(const FEType fet,
 {
   libmesh_assert(elem);
   return fe_lagrange_3D_shape_second_deriv<L2_LAGRANGE>
-    (elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+    (elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 

--- a/src/fe/fe_lagrange_shape_3D.C
+++ b/src/fe/fe_lagrange_shape_3D.C
@@ -442,7 +442,7 @@ Real FE<3,LAGRANGE>::shape(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape functions
-  return fe_lagrange_3D_shape<LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
+  return fe_lagrange_3D_shape<LAGRANGE>(elem->type(), order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -457,7 +457,7 @@ Real FE<3,L2_LAGRANGE>::shape(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape functions
-  return fe_lagrange_3D_shape<L2_LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
+  return fe_lagrange_3D_shape<L2_LAGRANGE>(elem->type(), order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -470,7 +470,7 @@ Real FE<3,LAGRANGE>::shape(const FEType fet,
                            const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_3D_shape<LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
+  return fe_lagrange_3D_shape<LAGRANGE>(elem->type(), fet.order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -483,7 +483,7 @@ Real FE<3,L2_LAGRANGE>::shape(const FEType fet,
                               const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_3D_shape<L2_LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
+  return fe_lagrange_3D_shape<L2_LAGRANGE>(elem->type(), fet.order + add_p_level*elem->p_level(), i, p);
 }
 
 template <>
@@ -521,7 +521,7 @@ Real FE<3,LAGRANGE>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape function derivatives
-  return fe_lagrange_3D_shape_deriv<LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+  return fe_lagrange_3D_shape_deriv<LAGRANGE>(elem->type(), order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -536,7 +536,7 @@ Real FE<3,L2_LAGRANGE>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape function derivatives
-  return fe_lagrange_3D_shape_deriv<L2_LAGRANGE>(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+  return fe_lagrange_3D_shape_deriv<L2_LAGRANGE>(elem->type(), order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -549,7 +549,7 @@ Real FE<3,LAGRANGE>::shape_deriv(const FEType fet,
                                  const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_3D_shape_deriv<LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+  return fe_lagrange_3D_shape_deriv<LAGRANGE>(elem->type(), fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -562,7 +562,7 @@ Real FE<3,L2_LAGRANGE>::shape_deriv(const FEType fet,
                                     const bool add_p_level)
 {
   libmesh_assert(elem);
-  return fe_lagrange_3D_shape_deriv<L2_LAGRANGE>(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+  return fe_lagrange_3D_shape_deriv<L2_LAGRANGE>(elem->type(), fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
@@ -603,7 +603,7 @@ Real FE<3,LAGRANGE>::shape_second_deriv(const Elem * elem,
 
   // call the orientation-independent shape function derivatives
   return fe_lagrange_3D_shape_second_deriv<LAGRANGE>
-    (elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+    (elem->type(), order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -620,7 +620,7 @@ Real FE<3,L2_LAGRANGE>::shape_second_deriv(const Elem * elem,
 
   // call the orientation-independent shape function derivatives
   return fe_lagrange_3D_shape_second_deriv<L2_LAGRANGE>
-    (elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+    (elem->type(), order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -634,7 +634,7 @@ Real FE<3,LAGRANGE>::shape_second_deriv(const FEType fet,
 {
   libmesh_assert(elem);
   return fe_lagrange_3D_shape_second_deriv<LAGRANGE>
-    (elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+    (elem->type(), fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -649,7 +649,7 @@ Real FE<3,L2_LAGRANGE>::shape_second_deriv(const FEType fet,
 {
   libmesh_assert(elem);
   return fe_lagrange_3D_shape_second_deriv<L2_LAGRANGE>
-    (elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+    (elem->type(), fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 

--- a/src/fe/fe_lagrange_vec.C
+++ b/src/fe/fe_lagrange_vec.C
@@ -57,7 +57,7 @@ void lagrange_vec_nodal_soln(const Elem * elem,
   const unsigned int n_nodes = elem->n_nodes();
   const ElemType type        = elem->type();
 
-  const Order totalorder = static_cast<Order>(order+add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   nodal_soln.resize(dim*n_nodes);
 
@@ -997,7 +997,7 @@ template <> RealGradient FE<0,LAGRANGE_VEC>::shape(const Elem * elem, const Orde
                                                    const unsigned int i, const Point & p,
                                                    const bool add_p_level)
 {
-  Real value = FE<0,LAGRANGE>::shape( elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, p);
+  Real value = FE<0,LAGRANGE>::shape( elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
   return libMesh::RealGradient( value );
 }
 template <> RealGradient FE<0,LAGRANGE_VEC>::shape_deriv(const Elem * elem, const Order order,
@@ -1005,7 +1005,7 @@ template <> RealGradient FE<0,LAGRANGE_VEC>::shape_deriv(const Elem * elem, cons
                                                          const Point & p,
                                                          const bool add_p_level)
 {
-  Real value = FE<0,LAGRANGE>::shape_deriv( elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+  Real value = FE<0,LAGRANGE>::shape_deriv( elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
   return libMesh::RealGradient( value );
 }
 
@@ -1016,7 +1016,7 @@ template <> RealGradient FE<0,LAGRANGE_VEC>::shape_second_deriv(const Elem * ele
                                                                 const Point & p,
                                                                 const bool add_p_level)
 {
-  Real value = FE<0,LAGRANGE>::shape_second_deriv( elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+  Real value = FE<0,LAGRANGE>::shape_second_deriv( elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
   return libMesh::RealGradient( value );
 }
 
@@ -1053,7 +1053,7 @@ template <> RealGradient FE<1,LAGRANGE_VEC>::shape(const Elem * elem, const Orde
                                                    const unsigned int i, const Point & p,
                                                    const bool add_p_level)
 {
-  Real value = FE<1,LAGRANGE>::shape( elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, p);
+  Real value = FE<1,LAGRANGE>::shape( elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
   return libMesh::RealGradient( value );
 }
 template <> RealGradient FE<1,LAGRANGE_VEC>::shape_deriv(const Elem * elem, const Order order,
@@ -1061,7 +1061,7 @@ template <> RealGradient FE<1,LAGRANGE_VEC>::shape_deriv(const Elem * elem, cons
                                                          const Point & p,
                                                          const bool add_p_level)
 {
-  Real value = FE<1,LAGRANGE>::shape_deriv( elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+  Real value = FE<1,LAGRANGE>::shape_deriv( elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
   return libMesh::RealGradient( value );
 }
 
@@ -1071,7 +1071,7 @@ template <> RealGradient FE<1,LAGRANGE_VEC>::shape_second_deriv(const Elem * ele
                                                                 const Point & p,
                                                                 const bool add_p_level)
 {
-  Real value = FE<1,LAGRANGE>::shape_second_deriv( elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+  Real value = FE<1,LAGRANGE>::shape_second_deriv( elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
   return libMesh::RealGradient( value );
 }
 
@@ -1108,7 +1108,7 @@ template <> RealGradient FE<2,LAGRANGE_VEC>::shape(const Elem * elem, const Orde
                                                    const unsigned int i, const Point & p,
                                                    const bool add_p_level)
 {
-  Real value = FE<2,LAGRANGE>::shape( elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i/2, p );
+  Real value = FE<2,LAGRANGE>::shape( elem->type(), sum(order, add_p_level*elem->p_level()), i/2, p );
 
   switch( i%2 )
     {
@@ -1130,7 +1130,7 @@ template <> RealGradient FE<2,LAGRANGE_VEC>::shape_deriv(const Elem * elem, cons
                                                          const Point & p,
                                                          const bool add_p_level)
 {
-  Real value = FE<2,LAGRANGE>::shape_deriv( elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i/2, j, p );
+  Real value = FE<2,LAGRANGE>::shape_deriv( elem->type(), sum(order, add_p_level*elem->p_level()), i/2, j, p );
 
   switch( i%2 )
     {
@@ -1154,7 +1154,7 @@ template <> RealGradient FE<2,LAGRANGE_VEC>::shape_second_deriv(const Elem * ele
                                                                 const Point & p,
                                                                 const bool add_p_level)
 {
-  Real value = FE<2,LAGRANGE>::shape_second_deriv( elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i/2, j, p );
+  Real value = FE<2,LAGRANGE>::shape_second_deriv( elem->type(), sum(order, add_p_level*elem->p_level()), i/2, j, p );
 
   switch( i%2 )
     {
@@ -1205,7 +1205,7 @@ template <> RealGradient FE<3,LAGRANGE_VEC>::shape(const Elem * elem, const Orde
                                                    const unsigned int i, const Point & p,
                                                    const bool add_p_level)
 {
-  Real value = FE<3,LAGRANGE>::shape( elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i/3, p );
+  Real value = FE<3,LAGRANGE>::shape( elem->type(), sum(order, add_p_level*elem->p_level()), i/3, p );
 
   switch( i%3 )
     {
@@ -1230,7 +1230,7 @@ template <> RealGradient FE<3,LAGRANGE_VEC>::shape_deriv(const Elem * elem, cons
                                                          const Point & p,
                                                          const bool add_p_level)
 {
-  Real value = FE<3,LAGRANGE>::shape_deriv( elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i/3, j, p );
+  Real value = FE<3,LAGRANGE>::shape_deriv( elem->type(), sum(order, add_p_level*elem->p_level()), i/3, j, p );
 
   switch( i%3 )
     {
@@ -1258,7 +1258,7 @@ template <> RealGradient FE<3,LAGRANGE_VEC>::shape_second_deriv(const Elem * ele
                                                                 const Point & p,
                                                                 const bool add_p_level)
 {
-  Real value = FE<3,LAGRANGE>::shape_second_deriv( elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i/3, j, p );
+  Real value = FE<3,LAGRANGE>::shape_second_deriv( elem->type(), sum(order, add_p_level*elem->p_level()), i/3, j, p );
 
   switch( i%3 )
     {

--- a/src/fe/fe_lagrange_vec.C
+++ b/src/fe/fe_lagrange_vec.C
@@ -57,7 +57,7 @@ void lagrange_vec_nodal_soln(const Elem * elem,
   const unsigned int n_nodes = elem->n_nodes();
   const ElemType type        = elem->type();
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   nodal_soln.resize(dim*n_nodes);
 
@@ -997,7 +997,7 @@ template <> RealGradient FE<0,LAGRANGE_VEC>::shape(const Elem * elem, const Orde
                                                    const unsigned int i, const Point & p,
                                                    const bool add_p_level)
 {
-  Real value = FE<0,LAGRANGE>::shape( elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
+  Real value = FE<0,LAGRANGE>::shape( elem->type(), order + add_p_level*elem->p_level(), i, p);
   return libMesh::RealGradient( value );
 }
 template <> RealGradient FE<0,LAGRANGE_VEC>::shape_deriv(const Elem * elem, const Order order,
@@ -1005,7 +1005,7 @@ template <> RealGradient FE<0,LAGRANGE_VEC>::shape_deriv(const Elem * elem, cons
                                                          const Point & p,
                                                          const bool add_p_level)
 {
-  Real value = FE<0,LAGRANGE>::shape_deriv( elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+  Real value = FE<0,LAGRANGE>::shape_deriv( elem->type(), order + add_p_level*elem->p_level(), i, j, p);
   return libMesh::RealGradient( value );
 }
 
@@ -1016,7 +1016,7 @@ template <> RealGradient FE<0,LAGRANGE_VEC>::shape_second_deriv(const Elem * ele
                                                                 const Point & p,
                                                                 const bool add_p_level)
 {
-  Real value = FE<0,LAGRANGE>::shape_second_deriv( elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+  Real value = FE<0,LAGRANGE>::shape_second_deriv( elem->type(), order + add_p_level*elem->p_level(), i, j, p);
   return libMesh::RealGradient( value );
 }
 
@@ -1053,7 +1053,7 @@ template <> RealGradient FE<1,LAGRANGE_VEC>::shape(const Elem * elem, const Orde
                                                    const unsigned int i, const Point & p,
                                                    const bool add_p_level)
 {
-  Real value = FE<1,LAGRANGE>::shape( elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
+  Real value = FE<1,LAGRANGE>::shape( elem->type(), order + add_p_level*elem->p_level(), i, p);
   return libMesh::RealGradient( value );
 }
 template <> RealGradient FE<1,LAGRANGE_VEC>::shape_deriv(const Elem * elem, const Order order,
@@ -1061,7 +1061,7 @@ template <> RealGradient FE<1,LAGRANGE_VEC>::shape_deriv(const Elem * elem, cons
                                                          const Point & p,
                                                          const bool add_p_level)
 {
-  Real value = FE<1,LAGRANGE>::shape_deriv( elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+  Real value = FE<1,LAGRANGE>::shape_deriv( elem->type(), order + add_p_level*elem->p_level(), i, j, p);
   return libMesh::RealGradient( value );
 }
 
@@ -1071,7 +1071,7 @@ template <> RealGradient FE<1,LAGRANGE_VEC>::shape_second_deriv(const Elem * ele
                                                                 const Point & p,
                                                                 const bool add_p_level)
 {
-  Real value = FE<1,LAGRANGE>::shape_second_deriv( elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+  Real value = FE<1,LAGRANGE>::shape_second_deriv( elem->type(), order + add_p_level*elem->p_level(), i, j, p);
   return libMesh::RealGradient( value );
 }
 
@@ -1108,7 +1108,7 @@ template <> RealGradient FE<2,LAGRANGE_VEC>::shape(const Elem * elem, const Orde
                                                    const unsigned int i, const Point & p,
                                                    const bool add_p_level)
 {
-  Real value = FE<2,LAGRANGE>::shape( elem->type(), sum(order, add_p_level*elem->p_level()), i/2, p );
+  Real value = FE<2,LAGRANGE>::shape( elem->type(), order + add_p_level*elem->p_level(), i/2, p );
 
   switch( i%2 )
     {
@@ -1130,7 +1130,7 @@ template <> RealGradient FE<2,LAGRANGE_VEC>::shape_deriv(const Elem * elem, cons
                                                          const Point & p,
                                                          const bool add_p_level)
 {
-  Real value = FE<2,LAGRANGE>::shape_deriv( elem->type(), sum(order, add_p_level*elem->p_level()), i/2, j, p );
+  Real value = FE<2,LAGRANGE>::shape_deriv( elem->type(), order + add_p_level*elem->p_level(), i/2, j, p );
 
   switch( i%2 )
     {
@@ -1154,7 +1154,7 @@ template <> RealGradient FE<2,LAGRANGE_VEC>::shape_second_deriv(const Elem * ele
                                                                 const Point & p,
                                                                 const bool add_p_level)
 {
-  Real value = FE<2,LAGRANGE>::shape_second_deriv( elem->type(), sum(order, add_p_level*elem->p_level()), i/2, j, p );
+  Real value = FE<2,LAGRANGE>::shape_second_deriv( elem->type(), order + add_p_level*elem->p_level(), i/2, j, p );
 
   switch( i%2 )
     {
@@ -1205,7 +1205,7 @@ template <> RealGradient FE<3,LAGRANGE_VEC>::shape(const Elem * elem, const Orde
                                                    const unsigned int i, const Point & p,
                                                    const bool add_p_level)
 {
-  Real value = FE<3,LAGRANGE>::shape( elem->type(), sum(order, add_p_level*elem->p_level()), i/3, p );
+  Real value = FE<3,LAGRANGE>::shape( elem->type(), order + add_p_level*elem->p_level(), i/3, p );
 
   switch( i%3 )
     {
@@ -1230,7 +1230,7 @@ template <> RealGradient FE<3,LAGRANGE_VEC>::shape_deriv(const Elem * elem, cons
                                                          const Point & p,
                                                          const bool add_p_level)
 {
-  Real value = FE<3,LAGRANGE>::shape_deriv( elem->type(), sum(order, add_p_level*elem->p_level()), i/3, j, p );
+  Real value = FE<3,LAGRANGE>::shape_deriv( elem->type(), order + add_p_level*elem->p_level(), i/3, j, p );
 
   switch( i%3 )
     {
@@ -1258,7 +1258,7 @@ template <> RealGradient FE<3,LAGRANGE_VEC>::shape_second_deriv(const Elem * ele
                                                                 const Point & p,
                                                                 const bool add_p_level)
 {
-  Real value = FE<3,LAGRANGE>::shape_second_deriv( elem->type(), sum(order, add_p_level*elem->p_level()), i/3, j, p );
+  Real value = FE<3,LAGRANGE>::shape_second_deriv( elem->type(), order + add_p_level*elem->p_level(), i/3, j, p );
 
   switch( i%3 )
     {

--- a/src/fe/fe_monomial.C
+++ b/src/fe/fe_monomial.C
@@ -310,7 +310,7 @@ void monomial_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   switch (totalorder)
     {

--- a/src/fe/fe_monomial.C
+++ b/src/fe/fe_monomial.C
@@ -310,7 +310,7 @@ void monomial_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = static_cast<Order>(order+add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
     {

--- a/src/fe/fe_monomial_shape_1D.C
+++ b/src/fe/fe_monomial_shape_1D.C
@@ -77,7 +77,7 @@ Real FE<1,MONOMIAL>::shape(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return FE<1,MONOMIAL>::shape(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, p);
+  return FE<1,MONOMIAL>::shape(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -89,7 +89,7 @@ Real FE<1,MONOMIAL>::shape(const FEType fet,
                            const bool add_p_level)
 {
   libmesh_assert(elem);
-  return FE<1,MONOMIAL>::shape(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, p);
+  return FE<1,MONOMIAL>::shape(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -147,7 +147,7 @@ Real FE<1,MONOMIAL>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   return FE<1,MONOMIAL>::shape_deriv(elem->type(),
-                                     static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+                                     sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -160,7 +160,7 @@ Real FE<1,MONOMIAL>::shape_deriv(const FEType fet,
                                  const bool add_p_level)
 {
   libmesh_assert(elem);
-  return FE<1,MONOMIAL>::shape_deriv(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+  return FE<1,MONOMIAL>::shape_deriv(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 
 
 }
@@ -218,7 +218,7 @@ Real FE<1,MONOMIAL>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   return FE<1,MONOMIAL>::shape_second_deriv(elem->type(),
-                                            static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+                                            sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 template <>
@@ -230,7 +230,7 @@ Real FE<1,MONOMIAL>::shape_second_deriv(const FEType fet,
                                         const bool add_p_level)
 {
   libmesh_assert(elem);
-  return FE<1,MONOMIAL>::shape_second_deriv(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+  return FE<1,MONOMIAL>::shape_second_deriv(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 #endif

--- a/src/fe/fe_monomial_shape_1D.C
+++ b/src/fe/fe_monomial_shape_1D.C
@@ -77,7 +77,7 @@ Real FE<1,MONOMIAL>::shape(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return FE<1,MONOMIAL>::shape(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
+  return FE<1,MONOMIAL>::shape(elem->type(), order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -89,7 +89,7 @@ Real FE<1,MONOMIAL>::shape(const FEType fet,
                            const bool add_p_level)
 {
   libmesh_assert(elem);
-  return FE<1,MONOMIAL>::shape(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
+  return FE<1,MONOMIAL>::shape(elem->type(), fet.order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -147,7 +147,7 @@ Real FE<1,MONOMIAL>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   return FE<1,MONOMIAL>::shape_deriv(elem->type(),
-                                     sum(order, add_p_level*elem->p_level()), i, j, p);
+                                     order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -160,7 +160,7 @@ Real FE<1,MONOMIAL>::shape_deriv(const FEType fet,
                                  const bool add_p_level)
 {
   libmesh_assert(elem);
-  return FE<1,MONOMIAL>::shape_deriv(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+  return FE<1,MONOMIAL>::shape_deriv(elem->type(), fet.order + add_p_level*elem->p_level(), i, j, p);
 
 
 }
@@ -218,7 +218,7 @@ Real FE<1,MONOMIAL>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   return FE<1,MONOMIAL>::shape_second_deriv(elem->type(),
-                                            sum(order, add_p_level*elem->p_level()), i, j, p);
+                                            order + add_p_level*elem->p_level(), i, j, p);
 }
 
 template <>
@@ -230,7 +230,7 @@ Real FE<1,MONOMIAL>::shape_second_deriv(const FEType fet,
                                         const bool add_p_level)
 {
   libmesh_assert(elem);
-  return FE<1,MONOMIAL>::shape_second_deriv(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+  return FE<1,MONOMIAL>::shape_second_deriv(elem->type(), fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 #endif

--- a/src/fe/fe_monomial_shape_2D.C
+++ b/src/fe/fe_monomial_shape_2D.C
@@ -128,7 +128,7 @@ Real FE<2,MONOMIAL>::shape(const Elem * elem,
   libmesh_assert(elem);
 
   // by default call the orientation-independent shape functions
-  return FE<2,MONOMIAL>::shape(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
+  return FE<2,MONOMIAL>::shape(elem->type(), order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -141,7 +141,7 @@ Real FE<2,MONOMIAL>::shape(const FEType fet,
 {
   libmesh_assert(elem);
   // by default call the orientation-independent shape functions
-  return FE<2,MONOMIAL>::shape(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
+  return FE<2,MONOMIAL>::shape(elem->type(), fet.order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -331,7 +331,7 @@ Real FE<2,MONOMIAL>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   // by default call the orientation-independent shape functions
-  return FE<2,MONOMIAL>::shape_deriv(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+  return FE<2,MONOMIAL>::shape_deriv(elem->type(), order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -346,7 +346,7 @@ Real FE<2,MONOMIAL>::shape_deriv(const FEType fet,
 {
   libmesh_assert(elem);
   // by default call the orientation-independent shape functions
-  return FE<2,MONOMIAL>::shape_deriv(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+  return FE<2,MONOMIAL>::shape_deriv(elem->type(), fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -584,7 +584,7 @@ Real FE<2,MONOMIAL>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   // by default call the orientation-independent shape functions
-  return FE<2,MONOMIAL>::shape_second_deriv(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+  return FE<2,MONOMIAL>::shape_second_deriv(elem->type(), order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -598,7 +598,7 @@ Real FE<2,MONOMIAL>::shape_second_deriv(const FEType fet,
 {
   libmesh_assert(elem);
   // by default call the orientation-independent shape functions
-  return FE<2,MONOMIAL>::shape_second_deriv(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+  return FE<2,MONOMIAL>::shape_second_deriv(elem->type(), fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 #endif

--- a/src/fe/fe_monomial_shape_2D.C
+++ b/src/fe/fe_monomial_shape_2D.C
@@ -128,7 +128,7 @@ Real FE<2,MONOMIAL>::shape(const Elem * elem,
   libmesh_assert(elem);
 
   // by default call the orientation-independent shape functions
-  return FE<2,MONOMIAL>::shape(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, p);
+  return FE<2,MONOMIAL>::shape(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -141,7 +141,7 @@ Real FE<2,MONOMIAL>::shape(const FEType fet,
 {
   libmesh_assert(elem);
   // by default call the orientation-independent shape functions
-  return FE<2,MONOMIAL>::shape(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, p);
+  return FE<2,MONOMIAL>::shape(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -331,7 +331,7 @@ Real FE<2,MONOMIAL>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   // by default call the orientation-independent shape functions
-  return FE<2,MONOMIAL>::shape_deriv(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+  return FE<2,MONOMIAL>::shape_deriv(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -346,7 +346,7 @@ Real FE<2,MONOMIAL>::shape_deriv(const FEType fet,
 {
   libmesh_assert(elem);
   // by default call the orientation-independent shape functions
-  return FE<2,MONOMIAL>::shape_deriv(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+  return FE<2,MONOMIAL>::shape_deriv(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -584,7 +584,7 @@ Real FE<2,MONOMIAL>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   // by default call the orientation-independent shape functions
-  return FE<2,MONOMIAL>::shape_second_deriv(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+  return FE<2,MONOMIAL>::shape_second_deriv(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -598,7 +598,7 @@ Real FE<2,MONOMIAL>::shape_second_deriv(const FEType fet,
 {
   libmesh_assert(elem);
   // by default call the orientation-independent shape functions
-  return FE<2,MONOMIAL>::shape_second_deriv(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+  return FE<2,MONOMIAL>::shape_second_deriv(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 #endif

--- a/src/fe/fe_monomial_shape_3D.C
+++ b/src/fe/fe_monomial_shape_3D.C
@@ -196,7 +196,7 @@ Real FE<3,MONOMIAL>::shape(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape functions
-  return FE<3,MONOMIAL>::shape(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, p);
+  return FE<3,MONOMIAL>::shape(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -210,7 +210,7 @@ Real FE<3,MONOMIAL>::shape(const FEType fet,
 {
   libmesh_assert(elem);
   // by default call the orientation-independent shape functions
-  return FE<3,MONOMIAL>::shape(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, p);
+  return FE<3,MONOMIAL>::shape(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -666,7 +666,7 @@ Real FE<3,MONOMIAL>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape function derivatives
-  return FE<3,MONOMIAL>::shape_deriv(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+  return FE<3,MONOMIAL>::shape_deriv(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -680,7 +680,7 @@ Real FE<3,MONOMIAL>::shape_deriv(const FEType fet,
 {
   libmesh_assert(elem);
   // by default call the orientation-independent shape functions
-  return FE<3,MONOMIAL>::shape_deriv(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+  return FE<3,MONOMIAL>::shape_deriv(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -1347,7 +1347,7 @@ Real FE<3,MONOMIAL>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape function derivatives
-  return FE<3,MONOMIAL>::shape_second_deriv(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+  return FE<3,MONOMIAL>::shape_second_deriv(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -1361,7 +1361,7 @@ Real FE<3,MONOMIAL>::shape_second_deriv(const FEType fet,
 {
   libmesh_assert(elem);
   // by default call the orientation-independent shape functions
-  return FE<3,MONOMIAL>::shape_second_deriv(elem->type(), static_cast<Order>(fet.order + add_p_level * elem->p_level()), i, j, p);
+  return FE<3,MONOMIAL>::shape_second_deriv(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
 }
 
 #endif

--- a/src/fe/fe_monomial_shape_3D.C
+++ b/src/fe/fe_monomial_shape_3D.C
@@ -196,7 +196,7 @@ Real FE<3,MONOMIAL>::shape(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape functions
-  return FE<3,MONOMIAL>::shape(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
+  return FE<3,MONOMIAL>::shape(elem->type(), order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -210,7 +210,7 @@ Real FE<3,MONOMIAL>::shape(const FEType fet,
 {
   libmesh_assert(elem);
   // by default call the orientation-independent shape functions
-  return FE<3,MONOMIAL>::shape(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
+  return FE<3,MONOMIAL>::shape(elem->type(), fet.order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -666,7 +666,7 @@ Real FE<3,MONOMIAL>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape function derivatives
-  return FE<3,MONOMIAL>::shape_deriv(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+  return FE<3,MONOMIAL>::shape_deriv(elem->type(), order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -680,7 +680,7 @@ Real FE<3,MONOMIAL>::shape_deriv(const FEType fet,
 {
   libmesh_assert(elem);
   // by default call the orientation-independent shape functions
-  return FE<3,MONOMIAL>::shape_deriv(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+  return FE<3,MONOMIAL>::shape_deriv(elem->type(), fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -1347,7 +1347,7 @@ Real FE<3,MONOMIAL>::shape_second_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   // call the orientation-independent shape function derivatives
-  return FE<3,MONOMIAL>::shape_second_deriv(elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+  return FE<3,MONOMIAL>::shape_second_deriv(elem->type(), order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -1361,7 +1361,7 @@ Real FE<3,MONOMIAL>::shape_second_deriv(const FEType fet,
 {
   libmesh_assert(elem);
   // by default call the orientation-independent shape functions
-  return FE<3,MONOMIAL>::shape_second_deriv(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, j, p);
+  return FE<3,MONOMIAL>::shape_second_deriv(elem->type(), fet.order + add_p_level*elem->p_level(), i, j, p);
 }
 
 #endif

--- a/src/fe/fe_monomial_vec.C
+++ b/src/fe/fe_monomial_vec.C
@@ -54,7 +54,7 @@ monomial_vec_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(dim * n_nodes);
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   switch (totalorder)
   {
@@ -430,7 +430,7 @@ FE<0, MONOMIAL_VEC>::shape(const Elem * elem,
                            const bool add_p_level)
 {
   Real value =
-      FE<0, MONOMIAL>::shape(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
+      FE<0, MONOMIAL>::shape(elem->type(), order + add_p_level*elem->p_level(), i, p);
   return libMesh::RealVectorValue(value);
 }
 template <>
@@ -443,7 +443,7 @@ FE<0, MONOMIAL_VEC>::shape_deriv(const Elem * elem,
                                  const bool add_p_level)
 {
   Real value = FE<0, MONOMIAL>::shape_deriv(
-      elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+      elem->type(), order + add_p_level*elem->p_level(), i, j, p);
   return libMesh::RealVectorValue(value);
 }
 
@@ -459,7 +459,7 @@ FE<0, MONOMIAL_VEC>::shape_second_deriv(const Elem * elem,
                                         const bool add_p_level)
 {
   Real value = FE<0, MONOMIAL>::shape_second_deriv(
-      elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+      elem->type(), order + add_p_level*elem->p_level(), i, j, p);
   return libMesh::RealVectorValue(value);
 }
 
@@ -475,7 +475,7 @@ FE<1, MONOMIAL_VEC>::shape(const Elem * elem,
                            const bool add_p_level)
 {
   Real value =
-      FE<1, MONOMIAL>::shape(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
+      FE<1, MONOMIAL>::shape(elem->type(), order + add_p_level*elem->p_level(), i, p);
   return libMesh::RealVectorValue(value);
 }
 template <>
@@ -488,7 +488,7 @@ FE<1, MONOMIAL_VEC>::shape_deriv(const Elem * elem,
                                  const bool add_p_level)
 {
   Real value = FE<1, MONOMIAL>::shape_deriv(
-      elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+      elem->type(), order + add_p_level*elem->p_level(), i, j, p);
   return libMesh::RealVectorValue(value);
 }
 
@@ -503,7 +503,7 @@ FE<1, MONOMIAL_VEC>::shape_second_deriv(const Elem * elem,
                                         const bool add_p_level)
 {
   Real value = FE<1, MONOMIAL>::shape_second_deriv(
-      elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
+      elem->type(), order + add_p_level*elem->p_level(), i, j, p);
   return libMesh::RealVectorValue(value);
 }
 
@@ -519,7 +519,7 @@ FE<2, MONOMIAL_VEC>::shape(const Elem * elem,
                            const bool add_p_level)
 {
   Real value =
-      FE<2, MONOMIAL>::shape(elem->type(), sum(order, add_p_level*elem->p_level()), i / 2, p);
+      FE<2, MONOMIAL>::shape(elem->type(), order + add_p_level*elem->p_level(), i / 2, p);
 
   switch (i % 2)
   {
@@ -546,7 +546,7 @@ FE<2, MONOMIAL_VEC>::shape_deriv(const Elem * elem,
                                  const bool add_p_level)
 {
   Real value = FE<2, MONOMIAL>::shape_deriv(
-      elem->type(), sum(order, add_p_level*elem->p_level()), i / 2, j, p);
+      elem->type(), order + add_p_level*elem->p_level(), i / 2, j, p);
 
   switch (i % 2)
   {
@@ -575,7 +575,7 @@ FE<2, MONOMIAL_VEC>::shape_second_deriv(const Elem * elem,
                                         const bool add_p_level)
 {
   Real value = FE<2, MONOMIAL>::shape_second_deriv(
-      elem->type(), sum(order, add_p_level*elem->p_level()), i / 2, j, p);
+      elem->type(), order + add_p_level*elem->p_level(), i / 2, j, p);
 
   switch (i % 2)
   {
@@ -605,7 +605,7 @@ FE<3, MONOMIAL_VEC>::shape(const Elem * elem,
                            const bool add_p_level)
 {
   Real value =
-      FE<3, MONOMIAL>::shape(elem->type(), sum(order, add_p_level*elem->p_level()), i / 3, p);
+      FE<3, MONOMIAL>::shape(elem->type(), order + add_p_level*elem->p_level(), i / 3, p);
 
   switch (i % 3)
   {
@@ -635,7 +635,7 @@ FE<3, MONOMIAL_VEC>::shape_deriv(const Elem * elem,
                                  const bool add_p_level)
 {
   Real value = FE<3, MONOMIAL>::shape_deriv(
-      elem->type(), sum(order, add_p_level*elem->p_level()), i / 3, j, p);
+      elem->type(), order + add_p_level*elem->p_level(), i / 3, j, p);
 
   switch (i % 3)
   {
@@ -668,7 +668,7 @@ FE<3, MONOMIAL_VEC>::shape_second_deriv(const Elem * elem,
                                         const bool add_p_level)
 {
   Real value = FE<3, MONOMIAL>::shape_second_deriv(
-      elem->type(), sum(order, add_p_level*elem->p_level()), i / 3, j, p);
+      elem->type(), order + add_p_level*elem->p_level(), i / 3, j, p);
 
   switch (i % 3)
   {

--- a/src/fe/fe_monomial_vec.C
+++ b/src/fe/fe_monomial_vec.C
@@ -54,7 +54,7 @@ monomial_vec_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(dim * n_nodes);
 
-  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
   {
@@ -430,7 +430,7 @@ FE<0, MONOMIAL_VEC>::shape(const Elem * elem,
                            const bool add_p_level)
 {
   Real value =
-      FE<0, MONOMIAL>::shape(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, p);
+      FE<0, MONOMIAL>::shape(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
   return libMesh::RealVectorValue(value);
 }
 template <>
@@ -443,7 +443,7 @@ FE<0, MONOMIAL_VEC>::shape_deriv(const Elem * elem,
                                  const bool add_p_level)
 {
   Real value = FE<0, MONOMIAL>::shape_deriv(
-      elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+      elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
   return libMesh::RealVectorValue(value);
 }
 
@@ -459,7 +459,7 @@ FE<0, MONOMIAL_VEC>::shape_second_deriv(const Elem * elem,
                                         const bool add_p_level)
 {
   Real value = FE<0, MONOMIAL>::shape_second_deriv(
-      elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+      elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
   return libMesh::RealVectorValue(value);
 }
 
@@ -475,7 +475,7 @@ FE<1, MONOMIAL_VEC>::shape(const Elem * elem,
                            const bool add_p_level)
 {
   Real value =
-      FE<1, MONOMIAL>::shape(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, p);
+      FE<1, MONOMIAL>::shape(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
   return libMesh::RealVectorValue(value);
 }
 template <>
@@ -488,7 +488,7 @@ FE<1, MONOMIAL_VEC>::shape_deriv(const Elem * elem,
                                  const bool add_p_level)
 {
   Real value = FE<1, MONOMIAL>::shape_deriv(
-      elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+      elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
   return libMesh::RealVectorValue(value);
 }
 
@@ -503,7 +503,7 @@ FE<1, MONOMIAL_VEC>::shape_second_deriv(const Elem * elem,
                                         const bool add_p_level)
 {
   Real value = FE<1, MONOMIAL>::shape_second_deriv(
-      elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+      elem->type(), sum(order, add_p_level*elem->p_level()), i, j, p);
   return libMesh::RealVectorValue(value);
 }
 
@@ -519,7 +519,7 @@ FE<2, MONOMIAL_VEC>::shape(const Elem * elem,
                            const bool add_p_level)
 {
   Real value =
-      FE<2, MONOMIAL>::shape(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i / 2, p);
+      FE<2, MONOMIAL>::shape(elem->type(), sum(order, add_p_level*elem->p_level()), i / 2, p);
 
   switch (i % 2)
   {
@@ -546,7 +546,7 @@ FE<2, MONOMIAL_VEC>::shape_deriv(const Elem * elem,
                                  const bool add_p_level)
 {
   Real value = FE<2, MONOMIAL>::shape_deriv(
-      elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i / 2, j, p);
+      elem->type(), sum(order, add_p_level*elem->p_level()), i / 2, j, p);
 
   switch (i % 2)
   {
@@ -575,7 +575,7 @@ FE<2, MONOMIAL_VEC>::shape_second_deriv(const Elem * elem,
                                         const bool add_p_level)
 {
   Real value = FE<2, MONOMIAL>::shape_second_deriv(
-      elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i / 2, j, p);
+      elem->type(), sum(order, add_p_level*elem->p_level()), i / 2, j, p);
 
   switch (i % 2)
   {
@@ -605,7 +605,7 @@ FE<3, MONOMIAL_VEC>::shape(const Elem * elem,
                            const bool add_p_level)
 {
   Real value =
-      FE<3, MONOMIAL>::shape(elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i / 3, p);
+      FE<3, MONOMIAL>::shape(elem->type(), sum(order, add_p_level*elem->p_level()), i / 3, p);
 
   switch (i % 3)
   {
@@ -635,7 +635,7 @@ FE<3, MONOMIAL_VEC>::shape_deriv(const Elem * elem,
                                  const bool add_p_level)
 {
   Real value = FE<3, MONOMIAL>::shape_deriv(
-      elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i / 3, j, p);
+      elem->type(), sum(order, add_p_level*elem->p_level()), i / 3, j, p);
 
   switch (i % 3)
   {
@@ -668,7 +668,7 @@ FE<3, MONOMIAL_VEC>::shape_second_deriv(const Elem * elem,
                                         const bool add_p_level)
 {
   Real value = FE<3, MONOMIAL>::shape_second_deriv(
-      elem->type(), static_cast<Order>(order + add_p_level * elem->p_level()), i / 3, j, p);
+      elem->type(), sum(order, add_p_level*elem->p_level()), i / 3, j, p);
 
   switch (i % 3)
   {

--- a/src/fe/fe_nedelec_one.C
+++ b/src/fe/fe_nedelec_one.C
@@ -49,7 +49,7 @@ void nedelec_one_nodal_soln(const Elem * elem,
   const unsigned int n_nodes = elem->n_nodes();
   const ElemType elem_type   = elem->type();
 
-  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   nodal_soln.resize(n_nodes*dim);
 

--- a/src/fe/fe_nedelec_one.C
+++ b/src/fe/fe_nedelec_one.C
@@ -49,7 +49,7 @@ void nedelec_one_nodal_soln(const Elem * elem,
   const unsigned int n_nodes = elem->n_nodes();
   const ElemType elem_type   = elem->type();
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   nodal_soln.resize(n_nodes*dim);
 

--- a/src/fe/fe_nedelec_one_shape_2D.C
+++ b/src/fe/fe_nedelec_one_shape_2D.C
@@ -38,7 +38,7 @@ RealGradient FE<2,NEDELEC_ONE>::shape(const Elem * elem,
 #if LIBMESH_DIM > 1
   libmesh_assert(elem);
 
-  const Order total_order = sum(order, add_p_level*elem->p_level());
+  const Order total_order = order + add_p_level*elem->p_level();
   libmesh_assert_less(i, n_dofs(elem->type(), total_order));
   const char sign = i >= total_order * elem->n_edges() || elem->point(i / total_order) > elem->point((i / total_order + 1) % elem->n_vertices()) ? 1 : -1;
   const unsigned int ii = sign > 0 ? i : (i / total_order * 2 + 1) * total_order - 1 - i;
@@ -713,7 +713,7 @@ RealGradient FE<2,NEDELEC_ONE>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
   libmesh_assert_less (j, 2);
 
-  const Order total_order = sum(order, add_p_level*elem->p_level());
+  const Order total_order = order + add_p_level*elem->p_level();
   libmesh_assert_less(i, n_dofs(elem->type(), total_order));
 
   const char sign = i >= total_order * elem->n_edges() || elem->point(i / total_order) > elem->point((i / total_order + 1) % elem->n_vertices()) ? 1 : -1;
@@ -2017,7 +2017,7 @@ RealGradient FE<2,NEDELEC_ONE>::shape_second_deriv(const Elem * elem,
   // j = 2 ==> d^2 phi / deta^2
   libmesh_assert_less (j, 3);
 
-  const Order total_order = sum(order, add_p_level*elem->p_level());
+  const Order total_order = order + add_p_level*elem->p_level();
   libmesh_assert_less(i, n_dofs(elem->type(), total_order));
 
   const char sign = i >= total_order * elem->n_edges() || elem->point(i / total_order) > elem->point((i / total_order + 1) % elem->n_vertices()) ? 1 : -1;

--- a/src/fe/fe_nedelec_one_shape_2D.C
+++ b/src/fe/fe_nedelec_one_shape_2D.C
@@ -38,9 +38,8 @@ RealGradient FE<2,NEDELEC_ONE>::shape(const Elem * elem,
 #if LIBMESH_DIM > 1
   libmesh_assert(elem);
 
-  const Order total_order = static_cast<Order>(order + add_p_level * elem->p_level());
+  const Order total_order = sum(order, add_p_level*elem->p_level());
   libmesh_assert_less(i, n_dofs(elem->type(), total_order));
-
   const char sign = i >= total_order * elem->n_edges() || elem->point(i / total_order) > elem->point((i / total_order + 1) % elem->n_vertices()) ? 1 : -1;
   const unsigned int ii = sign > 0 ? i : (i / total_order * 2 + 1) * total_order - 1 - i;
 
@@ -714,7 +713,7 @@ RealGradient FE<2,NEDELEC_ONE>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
   libmesh_assert_less (j, 2);
 
-  const Order total_order = static_cast<Order>(order + add_p_level * elem->p_level());
+  const Order total_order = sum(order, add_p_level*elem->p_level());
   libmesh_assert_less(i, n_dofs(elem->type(), total_order));
 
   const char sign = i >= total_order * elem->n_edges() || elem->point(i / total_order) > elem->point((i / total_order + 1) % elem->n_vertices()) ? 1 : -1;
@@ -2018,7 +2017,7 @@ RealGradient FE<2,NEDELEC_ONE>::shape_second_deriv(const Elem * elem,
   // j = 2 ==> d^2 phi / deta^2
   libmesh_assert_less (j, 3);
 
-  const Order total_order = static_cast<Order>(order + add_p_level * elem->p_level());
+  const Order total_order = sum(order, add_p_level*elem->p_level());
   libmesh_assert_less(i, n_dofs(elem->type(), total_order));
 
   const char sign = i >= total_order * elem->n_edges() || elem->point(i / total_order) > elem->point((i / total_order + 1) % elem->n_vertices()) ? 1 : -1;

--- a/src/fe/fe_nedelec_one_shape_3D.C
+++ b/src/fe/fe_nedelec_one_shape_3D.C
@@ -34,7 +34,7 @@ RealGradient FE<3,NEDELEC_ONE>::shape(const Elem * elem,
 #if LIBMESH_DIM == 3
   libmesh_assert(elem);
 
-  const Order totalorder = static_cast<Order>(order + add_p_level * elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
     {
@@ -264,7 +264,7 @@ RealGradient FE<3,NEDELEC_ONE>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
   libmesh_assert_less (j, 3);
 
-  const Order totalorder = static_cast<Order>(order + add_p_level * elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
     {
@@ -744,7 +744,7 @@ RealGradient FE<3,NEDELEC_ONE>::shape_second_deriv(const Elem * elem,
   // j = 5 ==> d^2 phi / dzeta^2
   libmesh_assert_less (j, 6);
 
-  const Order totalorder = static_cast<Order>(order + add_p_level * elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
     {

--- a/src/fe/fe_nedelec_one_shape_3D.C
+++ b/src/fe/fe_nedelec_one_shape_3D.C
@@ -34,7 +34,7 @@ RealGradient FE<3,NEDELEC_ONE>::shape(const Elem * elem,
 #if LIBMESH_DIM == 3
   libmesh_assert(elem);
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   switch (totalorder)
     {
@@ -264,7 +264,7 @@ RealGradient FE<3,NEDELEC_ONE>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
   libmesh_assert_less (j, 3);
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   switch (totalorder)
     {
@@ -744,7 +744,7 @@ RealGradient FE<3,NEDELEC_ONE>::shape_second_deriv(const Elem * elem,
   // j = 5 ==> d^2 phi / dzeta^2
   libmesh_assert_less (j, 6);
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   switch (totalorder)
     {

--- a/src/fe/fe_rational.C
+++ b/src/fe/fe_rational.C
@@ -46,7 +46,7 @@ void rational_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, _underlying_fe_family);

--- a/src/fe/fe_rational.C
+++ b/src/fe/fe_rational.C
@@ -46,7 +46,7 @@ void rational_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, _underlying_fe_family);

--- a/src/fe/fe_raviart.C
+++ b/src/fe/fe_raviart.C
@@ -53,7 +53,7 @@ void raviart_thomas_nodal_soln(const Elem * elem,
   const unsigned int n_nodes = elem->n_nodes();
   const ElemType elem_type   = elem->type();
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   nodal_soln.resize(n_nodes*dim);
 

--- a/src/fe/fe_raviart.C
+++ b/src/fe/fe_raviart.C
@@ -53,7 +53,7 @@ void raviart_thomas_nodal_soln(const Elem * elem,
   const unsigned int n_nodes = elem->n_nodes();
   const ElemType elem_type   = elem->type();
 
-  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   nodal_soln.resize(n_nodes*dim);
 

--- a/src/fe/fe_raviart_shape_3D.C
+++ b/src/fe/fe_raviart_shape_3D.C
@@ -49,7 +49,7 @@ RealGradient FE<3,RAVIART_THOMAS>::shape(const Elem * elem,
 #if LIBMESH_DIM == 3
   libmesh_assert(elem);
 
-  const Order totalorder = static_cast<Order>(order + add_p_level * elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
     {
@@ -260,7 +260,7 @@ RealGradient FE<3,RAVIART_THOMAS>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
   libmesh_assert_less (j, 3);
 
-  const Order totalorder = static_cast<Order>(order + add_p_level * elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
     {
@@ -617,7 +617,7 @@ RealGradient FE<3,RAVIART_THOMAS>::shape_second_deriv(const Elem * elem,
   // j = 5 ==> d^2 phi / dzeta^2
   libmesh_assert_less (j, 6);
 
-  const Order totalorder = static_cast<Order>(order + add_p_level * elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
     {

--- a/src/fe/fe_raviart_shape_3D.C
+++ b/src/fe/fe_raviart_shape_3D.C
@@ -49,7 +49,7 @@ RealGradient FE<3,RAVIART_THOMAS>::shape(const Elem * elem,
 #if LIBMESH_DIM == 3
   libmesh_assert(elem);
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   switch (totalorder)
     {
@@ -260,7 +260,7 @@ RealGradient FE<3,RAVIART_THOMAS>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
   libmesh_assert_less (j, 3);
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   switch (totalorder)
     {
@@ -617,7 +617,7 @@ RealGradient FE<3,RAVIART_THOMAS>::shape_second_deriv(const Elem * elem,
   // j = 5 ==> d^2 phi / dzeta^2
   libmesh_assert_less (j, 6);
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   switch (totalorder)
     {

--- a/src/fe/fe_subdivision_2D.C
+++ b/src/fe/fe_subdivision_2D.C
@@ -738,7 +738,7 @@ Real FE<2,SUBDIVISION>::shape(const Elem * elem,
                               const bool add_p_level)
 {
   libmesh_assert(elem);
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
   return FE<2,SUBDIVISION>::shape(elem->type(), totalorder, i, p);
 }
 
@@ -751,7 +751,7 @@ Real FE<2,SUBDIVISION>::shape(const FEType fet,
                               const bool add_p_level)
 {
   libmesh_assert(elem);
-  const Order totalorder = sum(fet.order, add_p_level*elem->p_level());
+  const Order totalorder = fet.order + add_p_level*elem->p_level();
   return FE<2,SUBDIVISION>::shape(elem->type(), totalorder, i, p);
 }
 
@@ -793,7 +793,7 @@ Real FE<2,SUBDIVISION>::shape_deriv(const Elem * elem,
                                     const bool add_p_level)
 {
   libmesh_assert(elem);
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
   return FE<2,SUBDIVISION>::shape_deriv(elem->type(), totalorder, i, j, p);
 }
 
@@ -807,7 +807,7 @@ Real FE<2,SUBDIVISION>::shape_deriv(const FEType fet,
                                     const bool add_p_level)
 {
   libmesh_assert(elem);
-  const Order totalorder = sum(fet.order, add_p_level*elem->p_level());
+  const Order totalorder = fet.order + add_p_level*elem->p_level();
   return FE<2,SUBDIVISION>::shape_deriv(elem->type(), totalorder, i, j, p);
 }
 
@@ -850,7 +850,7 @@ Real FE<2,SUBDIVISION>::shape_second_deriv(const Elem * elem,
                                            const bool add_p_level)
 {
   libmesh_assert(elem);
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
   return FE<2,SUBDIVISION>::shape_second_deriv(elem->type(), totalorder, i, j, p);
 }
 
@@ -865,7 +865,7 @@ Real FE<2,SUBDIVISION>::shape_second_deriv(const FEType fet,
                                            const bool add_p_level)
 {
   libmesh_assert(elem);
-  const Order totalorder = sum(fet.order, add_p_level*elem->p_level());
+  const Order totalorder = fet.order + add_p_level*elem->p_level();
   return FE<2,SUBDIVISION>::shape_second_deriv(elem->type(), totalorder, i, j, p);
 }
 

--- a/src/fe/fe_subdivision_2D.C
+++ b/src/fe/fe_subdivision_2D.C
@@ -738,8 +738,7 @@ Real FE<2,SUBDIVISION>::shape(const Elem * elem,
                               const bool add_p_level)
 {
   libmesh_assert(elem);
-  const Order totalorder =
-    static_cast<Order>(order+add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
   return FE<2,SUBDIVISION>::shape(elem->type(), totalorder, i, p);
 }
 
@@ -752,8 +751,7 @@ Real FE<2,SUBDIVISION>::shape(const FEType fet,
                               const bool add_p_level)
 {
   libmesh_assert(elem);
-  const Order totalorder =
-    static_cast<Order>(fet.order+add_p_level*elem->p_level());
+  const Order totalorder = sum(fet.order, add_p_level*elem->p_level());
   return FE<2,SUBDIVISION>::shape(elem->type(), totalorder, i, p);
 }
 
@@ -795,8 +793,7 @@ Real FE<2,SUBDIVISION>::shape_deriv(const Elem * elem,
                                     const bool add_p_level)
 {
   libmesh_assert(elem);
-  const Order totalorder =
-    static_cast<Order>(order+add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
   return FE<2,SUBDIVISION>::shape_deriv(elem->type(), totalorder, i, j, p);
 }
 
@@ -810,8 +807,7 @@ Real FE<2,SUBDIVISION>::shape_deriv(const FEType fet,
                                     const bool add_p_level)
 {
   libmesh_assert(elem);
-  const Order totalorder =
-    static_cast<Order>(fet.order+add_p_level*elem->p_level());
+  const Order totalorder = sum(fet.order, add_p_level*elem->p_level());
   return FE<2,SUBDIVISION>::shape_deriv(elem->type(), totalorder, i, j, p);
 }
 
@@ -854,8 +850,7 @@ Real FE<2,SUBDIVISION>::shape_second_deriv(const Elem * elem,
                                            const bool add_p_level)
 {
   libmesh_assert(elem);
-  const Order totalorder =
-    static_cast<Order>(order+add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
   return FE<2,SUBDIVISION>::shape_second_deriv(elem->type(), totalorder, i, j, p);
 }
 
@@ -870,8 +865,7 @@ Real FE<2,SUBDIVISION>::shape_second_deriv(const FEType fet,
                                            const bool add_p_level)
 {
   libmesh_assert(elem);
-  const Order totalorder =
-    static_cast<Order>(fet.order+add_p_level*elem->p_level());
+  const Order totalorder = sum(fet.order, add_p_level*elem->p_level());
   return FE<2,SUBDIVISION>::shape_second_deriv(elem->type(), totalorder, i, j, p);
 }
 

--- a/src/fe/fe_szabab.C
+++ b/src/fe/fe_szabab.C
@@ -48,7 +48,7 @@ void szabab_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, SZABAB);

--- a/src/fe/fe_szabab.C
+++ b/src/fe/fe_szabab.C
@@ -48,7 +48,7 @@ void szabab_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   // FEType object to be passed to various FEInterface functions below.
   FEType fe_type(order, SZABAB);

--- a/src/fe/fe_szabab_shape_1D.C
+++ b/src/fe/fe_szabab_shape_1D.C
@@ -88,7 +88,7 @@ Real FE<1,SZABAB>::shape(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return FE<1,SZABAB>::shape(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
+  return FE<1,SZABAB>::shape(elem->type(), order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -101,7 +101,7 @@ Real FE<1,SZABAB>::shape(const FEType fet,
 {
   libmesh_assert(elem);
 
-  return FE<1,SZABAB>::shape(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
+  return FE<1,SZABAB>::shape(elem->type(), fet.order + add_p_level*elem->p_level(), i, p);
 }
 
 
@@ -163,7 +163,7 @@ Real FE<1,SZABAB>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   return FE<1,SZABAB>::shape_deriv(elem->type(),
-                                   sum(order, add_p_level*elem->p_level()), i, j, p);
+                                   order + add_p_level*elem->p_level(), i, j, p);
 }
 
 
@@ -179,7 +179,7 @@ Real FE<1,SZABAB>::shape_deriv(const FEType fet,
   libmesh_assert(elem);
 
   return FE<1,SZABAB>::shape_deriv(elem->type(),
-                                   sum(fet.order, add_p_level*elem->p_level()),
+                                   fet.order + add_p_level*elem->p_level(),
                                    i,
                                    j,
                                    p);
@@ -238,7 +238,7 @@ Real FE<1,SZABAB>::shape_second_deriv(const FEType fet,
   libmesh_assert(elem);
 
   return FE<1,SZABAB>::shape_second_deriv(elem->type(),
-                                          sum(fet.order, add_p_level*elem->p_level()),
+                                          fet.order + add_p_level*elem->p_level(),
                                           i,
                                           j,
                                           p);

--- a/src/fe/fe_szabab_shape_1D.C
+++ b/src/fe/fe_szabab_shape_1D.C
@@ -88,7 +88,7 @@ Real FE<1,SZABAB>::shape(const Elem * elem,
 {
   libmesh_assert(elem);
 
-  return FE<1,SZABAB>::shape(elem->type(), static_cast<Order>(order + add_p_level * add_p_level * elem->p_level()), i, p);
+  return FE<1,SZABAB>::shape(elem->type(), sum(order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -101,7 +101,7 @@ Real FE<1,SZABAB>::shape(const FEType fet,
 {
   libmesh_assert(elem);
 
-  return FE<1,SZABAB>::shape(elem->type(), static_cast<Order>(fet.order + add_p_level * add_p_level * elem->p_level()), i, p);
+  return FE<1,SZABAB>::shape(elem->type(), sum(fet.order, add_p_level*elem->p_level()), i, p);
 }
 
 
@@ -163,7 +163,7 @@ Real FE<1,SZABAB>::shape_deriv(const Elem * elem,
   libmesh_assert(elem);
 
   return FE<1,SZABAB>::shape_deriv(elem->type(),
-                                   static_cast<Order>(order + add_p_level * elem->p_level()), i, j, p);
+                                   sum(order, add_p_level*elem->p_level()), i, j, p);
 }
 
 
@@ -179,7 +179,7 @@ Real FE<1,SZABAB>::shape_deriv(const FEType fet,
   libmesh_assert(elem);
 
   return FE<1,SZABAB>::shape_deriv(elem->type(),
-                                   static_cast<Order>(fet.order + add_p_level * add_p_level * elem->p_level()),
+                                   sum(fet.order, add_p_level*elem->p_level()),
                                    i,
                                    j,
                                    p);
@@ -238,7 +238,7 @@ Real FE<1,SZABAB>::shape_second_deriv(const FEType fet,
   libmesh_assert(elem);
 
   return FE<1,SZABAB>::shape_second_deriv(elem->type(),
-                                          static_cast<Order>(fet.order + add_p_level * add_p_level * elem->p_level()),
+                                          sum(fet.order, add_p_level*elem->p_level()),
                                           i,
                                           j,
                                           p);

--- a/src/fe/fe_szabab_shape_2D.C
+++ b/src/fe/fe_szabab_shape_2D.C
@@ -94,7 +94,7 @@ Real FE<2,SZABAB>::shape(const Elem * elem,
 
   const ElemType type = elem->type();
 
-  const Order totalorder = static_cast<Order>(order + add_p_level * elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   // Declare that we are using our own special power function
   // from the Utility namespace.  This saves typing later.
@@ -680,7 +680,7 @@ Real FE<2,SZABAB>::shape_deriv(const Elem * elem,
 
   const ElemType type = elem->type();
 
-  const Order totalorder = static_cast<Order>(order + add_p_level * elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
     {

--- a/src/fe/fe_szabab_shape_2D.C
+++ b/src/fe/fe_szabab_shape_2D.C
@@ -94,7 +94,7 @@ Real FE<2,SZABAB>::shape(const Elem * elem,
 
   const ElemType type = elem->type();
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   // Declare that we are using our own special power function
   // from the Utility namespace.  This saves typing later.
@@ -680,7 +680,7 @@ Real FE<2,SZABAB>::shape_deriv(const Elem * elem,
 
   const ElemType type = elem->type();
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   switch (totalorder)
     {

--- a/src/fe/fe_xyz.C
+++ b/src/fe/fe_xyz.C
@@ -45,7 +45,7 @@ void xyz_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = sum(order, add_p_level*elem->p_level());
+  const Order totalorder = order + add_p_level*elem->p_level();
 
   switch (totalorder)
     {

--- a/src/fe/fe_xyz.C
+++ b/src/fe/fe_xyz.C
@@ -45,7 +45,7 @@ void xyz_nodal_soln(const Elem * elem,
 
   nodal_soln.resize(n_nodes);
 
-  const Order totalorder = static_cast<Order>(order + add_p_level*elem->p_level());
+  const Order totalorder = sum(order, add_p_level*elem->p_level());
 
   switch (totalorder)
     {

--- a/src/fe/fe_xyz_shape_3D.C
+++ b/src/fe/fe_xyz_shape_3D.C
@@ -276,7 +276,7 @@ Real FE<3,XYZ>::shape_deriv(const Elem * elem,
 #ifndef NDEBUG
   // totalorder is only used in the assertion below, so
   // we avoid declaring it when asserts are not active.
-  const unsigned int totalorder = sum(order, add_p_level*elem->p_level());
+  const unsigned int totalorder = order + add_p_level*elem->p_level();
 #endif
   libmesh_assert_less (i, (totalorder+1) * (totalorder+2) *
                        (totalorder+3)/6);
@@ -772,7 +772,7 @@ Real FE<3,XYZ>::shape_second_deriv(const Elem * elem,
 #ifndef NDEBUG
   // totalorder is only used in the assertion below, so
   // we avoid declaring it when asserts are not active.
-  const unsigned int totalorder = sum(order, add_p_level*elem->p_level());
+  const unsigned int totalorder = order + add_p_level*elem->p_level();
 #endif
   libmesh_assert_less (i, (totalorder+1) * (totalorder+2) *
                        (totalorder+3)/6);

--- a/src/fe/fe_xyz_shape_3D.C
+++ b/src/fe/fe_xyz_shape_3D.C
@@ -276,7 +276,7 @@ Real FE<3,XYZ>::shape_deriv(const Elem * elem,
 #ifndef NDEBUG
   // totalorder is only used in the assertion below, so
   // we avoid declaring it when asserts are not active.
-  const unsigned int totalorder = static_cast<Order>(order + add_p_level * elem->p_level());
+  const unsigned int totalorder = sum(order, add_p_level*elem->p_level());
 #endif
   libmesh_assert_less (i, (totalorder+1) * (totalorder+2) *
                        (totalorder+3)/6);
@@ -772,7 +772,7 @@ Real FE<3,XYZ>::shape_second_deriv(const Elem * elem,
 #ifndef NDEBUG
   // totalorder is only used in the assertion below, so
   // we avoid declaring it when asserts are not active.
-  const unsigned int totalorder = static_cast<Order>(order + add_p_level * elem->p_level());
+  const unsigned int totalorder = sum(order, add_p_level*elem->p_level());
 #endif
   libmesh_assert_less (i, (totalorder+1) * (totalorder+2) *
                        (totalorder+3)/6);

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -315,7 +315,7 @@ Real InfFE<Dim,T_radial,T_map>::shape(const FEType fet,
   if (add_p_level)
     {
       FEType tmp_fet=fet;
-      tmp_fet = static_cast<Order>(fet.order + add_p_level * inf_elem->p_level());
+      tmp_fet = sum(fet.order, add_p_level * inf_elem->p_level());
       return InfFE<Dim,T_radial,T_map>::shape(tmp_fet, inf_elem, i, p);
     }
   return InfFE<Dim,T_radial,T_map>::shape(fet, inf_elem, i, p);
@@ -614,7 +614,7 @@ Real InfFE<Dim,T_radial,T_map>::shape_deriv(const FEType fet,
   if (add_p_level)
     {
       FEType tmp_fet=fet;
-      tmp_fet = static_cast<Order>(fet.order + add_p_level * inf_elem->p_level());
+      tmp_fet = sum(fet.order, add_p_level * inf_elem->p_level());
       return InfFE<Dim,T_radial,T_map>::shape_deriv(tmp_fet, inf_elem, i, j, p);
     }
   return InfFE<Dim,T_radial,T_map>::shape_deriv(fet, inf_elem, i, j, p);

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -315,7 +315,7 @@ Real InfFE<Dim,T_radial,T_map>::shape(const FEType fet,
   if (add_p_level)
     {
       FEType tmp_fet=fet;
-      tmp_fet = sum(fet.order, add_p_level * inf_elem->p_level());
+      tmp_fet = fet.order + add_p_level * inf_elem->p_level();
       return InfFE<Dim,T_radial,T_map>::shape(tmp_fet, inf_elem, i, p);
     }
   return InfFE<Dim,T_radial,T_map>::shape(fet, inf_elem, i, p);
@@ -614,7 +614,7 @@ Real InfFE<Dim,T_radial,T_map>::shape_deriv(const FEType fet,
   if (add_p_level)
     {
       FEType tmp_fet=fet;
-      tmp_fet = sum(fet.order, add_p_level * inf_elem->p_level());
+      tmp_fet = fet.order + add_p_level * inf_elem->p_level();
       return InfFE<Dim,T_radial,T_map>::shape_deriv(tmp_fet, inf_elem, i, j, p);
     }
   return InfFE<Dim,T_radial,T_map>::shape_deriv(fet, inf_elem, i, j, p);

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -2033,9 +2033,9 @@ FEMContext::build_new_fe( const FEGenericBase<OutputShape>* fe,
       this->has_elem())
     {
       if (this->get_elem().p_refinement_flag() == Elem::JUST_REFINED)
-        fe_type.order = sum(fe_type.order, -add_p_level);
+        fe_type.order -= add_p_level;
       else if (this->get_elem().p_refinement_flag() == Elem::JUST_COARSENED)
-        fe_type.order = sum(fe_type.order, add_p_level);
+        fe_type.order += add_p_level;
     }
 #endif // LIBMESH_ENABLE_AMR
 

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -2028,14 +2028,14 @@ FEMContext::build_new_fe( const FEGenericBase<OutputShape>* fe,
   libmesh_assert(this->has_elem() || fe_type.family == SCALAR);
 
 #ifdef LIBMESH_ENABLE_AMR
-  const bool add_p_level = fe->add_p_level_in_reinit();
+  const int add_p_level = fe->add_p_level_in_reinit();
   if ((algebraic_type() == OLD) &&
       this->has_elem())
     {
       if (this->get_elem().p_refinement_flag() == Elem::JUST_REFINED)
-        fe_type.order = static_cast<Order>(fe_type.order - add_p_level);
+        fe_type.order = sum(fe_type.order, -add_p_level);
       else if (this->get_elem().p_refinement_flag() == Elem::JUST_COARSENED)
-        fe_type.order = static_cast<Order>(fe_type.order + add_p_level);
+        fe_type.order = sum(fe_type.order, add_p_level);
     }
 #endif // LIBMESH_ENABLE_AMR
 

--- a/tests/mesh/mesh_tet_test.C
+++ b/tests/mesh/mesh_tet_test.C
@@ -232,7 +232,7 @@ public:
     // An asymmetric octahedron, so we hopefully have an unambiguous
     // choice of shortest diagonal for a Delaunay algorithm to pick.
     const Real expected_volume =
-      build_octahedron(mesh, false, -1, 1, -1, 1, -0.1, 0.1);
+      build_octahedron(mesh, flip_tris, -1, 1, -1, 1, -0.1, 0.1);
 
     this->testTetInterfaceBase(mesh, triangulator, /* n_elem = */ 4,
                                /* n_nodes = */ 6, expected_volume);
@@ -245,7 +245,7 @@ public:
   {
 #ifdef LIBMESH_ENABLE_EXCEPTIONS
     const Real expected_volume =
-      build_octahedron(mesh, false, -1, 1, -1, 1, -0.1, 0.1);
+      build_octahedron(mesh, flip_tris, -1, 1, -1, 1, -0.1, 0.1);
 
     // Remove one tri, breaking the mesh
     for (auto elem : mesh.element_ptr_range())


### PR DESCRIPTION
Lots of workarounds and fixes here for issues that clang `-fsanitize` and the NVidia HPC SDK brought up.

We still can't use nvc++, because with -O2 they still can't make it through our unit test suite (though it's giving bad results on a *different* test this time!), but I am liking having another perspective on code smells.