### PR TITLE
Updates to EIM basis function plotting functionality

### DIFF
--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -587,25 +587,23 @@ public:
                                bool read_binary_basis_functions = true);
 
   /**
-   * Project the specified variable of \p bf_data into the solution
-   * vector of System. This method is virtual so that it can be overridden in
-   * sub-classes, e.g. to perform a specialized type of projection.
+   * Project the EIM basis function data stored in \p bf_data onto
+   * sys.solution. The intent of this function is to work with the
+   * data format provided by get_interior_basis_functions_as_vecs().
+   * That format can be easily serialized, if needed, and hence can
+   * be used to provide \p bf_data after reading in data from disk,
+   * for example.
+   *
+   * This is a no-op by default, implement in sub-classes if needed.
    */
-  virtual void project_qp_data_map_onto_system(System & sys,
-                                               const QpDataMap & bf_data,
-                                               const EIMVarGroupPlottingInfo & eim_vargroup);
+  virtual void project_qp_data_vector_onto_system(System & sys,
+                                                  const std::vector<Number> & bf_data,
+                                                  const EIMVarGroupPlottingInfo & eim_vargroup);
 
   /**
    * Get _eim_vars_to_project_and_write.
    */
   const std::vector<EIMVarGroupPlottingInfo> & get_eim_vars_to_project_and_write() const;
-
-  /**
-   * Project all basis functions using project_qp_data_map_onto_system() and
-   * then write out the resulting vectors.
-   */
-  void write_out_projected_basis_functions(EquationSystems & es,
-                                           const std::string & directory_name = "offline_data");
 
   /**
    * Get _scale_components_in_enrichment.
@@ -635,7 +633,6 @@ public:
    */
   const DenseVector<Number> & get_error_indicator_interpolation_row() const;
   void set_error_indicator_interpolation_row(const DenseVector<Number> & error_indicator_row);
-
 
   /**
    * Evaluates the EIM error indicator based on \p error_indicator_rhs, \p eim_solution,

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -594,11 +594,15 @@ public:
    * be used to provide \p bf_data after reading in data from disk,
    * for example.
    *
+   * \p extra_options can be used to pass extra information to this
+   * method, e.g. options related to how to perform the projection.
+   *
    * This is a no-op by default, implement in sub-classes if needed.
    */
   virtual void project_qp_data_vector_onto_system(System & sys,
                                                   const std::vector<Number> & bf_data,
-                                                  const EIMVarGroupPlottingInfo & eim_vargroup);
+                                                  const EIMVarGroupPlottingInfo & eim_vargroup,
+                                                  const std::map<std::string,std::string> & extra_options);
 
   /**
    * Get _eim_vars_to_project_and_write.

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -670,6 +670,12 @@ public:
   std::vector<std::vector<std::vector<Number>>> get_interior_basis_functions_as_vecs();
 
   /**
+   * Get data that defines the sizes of interior EIM basis functions.
+   */
+  std::map<std::string,std::size_t>
+    get_interior_basis_function_sizes(std::vector<unsigned int> & n_qp_per_elem);
+
+  /**
    * Here we store an enum that defines the type of EIM error indicator
    * normalization that we use in get_eim_error_indicator(). The enum
    * is public so that it can be set in user code.
@@ -773,13 +779,6 @@ private:
   void read_in_node_basis_functions(const System & sys,
                                     const std::string & directory_name,
                                     bool read_binary_basis_functions);
-
-  /**
-   * Helper function called by write_out_interior_basis_functions() to
-   * determine the sizes of interior basis function data.
-   */
-  std::map<std::string,std::size_t>
-    get_interior_basis_function_sizes_helper(std::vector<unsigned int> & n_qp_per_elem);
 
   /**
    * Helper function called by write_out_interior_basis_functions() to

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -707,8 +707,8 @@ public:
 protected:
 
   /**
-   * This vector specifies which EIM variables will be projected and written
-   * out in write_out_projected_basis_functions(). By default this is an empty
+   * This vector specifies which EIM variables we want to write to disk and/or
+   * project to nodes for plotting purposes. By default this is an empty
    * set, but can be updated in subclasses to specify the EIM variables that
    * are relevant for visualization.
    *

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -657,6 +657,19 @@ public:
   const VectorizedEvalInput & get_vec_eval_input() const;
 
   /**
+   * Get all interior basis functions in the form of std::vectors.
+   * This can provide a convenient format for processing the basis
+   * function data, or writing it to disk.
+   *
+   * Indexing is as follows:
+   *  basis function index --> variable index --> data at qps per elems
+   *
+   * In parallel we gather basis functions to processor 0 and hence
+   * we only return non-empty data on processor 0.
+   */
+  std::vector<std::vector<std::vector<Number>>> get_interior_basis_functions_as_vecs();
+
+  /**
    * Here we store an enum that defines the type of EIM error indicator
    * normalization that we use in get_eim_error_indicator(). The enum
    * is public so that it can be set in user code.
@@ -760,6 +773,22 @@ private:
   void read_in_node_basis_functions(const System & sys,
                                     const std::string & directory_name,
                                     bool read_binary_basis_functions);
+
+  /**
+   * Helper function called by write_out_interior_basis_functions() to
+   * determine the sizes of interior basis function data.
+   */
+  std::map<std::string,unsigned int>
+    get_interior_basis_function_sizes_helper(std::vector<unsigned int> & n_qp_per_elem);
+
+  /**
+   * Helper function called by write_out_interior_basis_functions() to
+   * get basis function \p bf_index stored as a std::vector per variable.
+   */
+  std::vector<std::vector<Number>> get_interior_basis_function_as_vec_helper(
+    unsigned int n_vars,
+    unsigned int n_qp_data,
+    unsigned int bf_index);
 
   /**
    * The EIM solution coefficients from the most recent call to rb_eim_solves().

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -778,7 +778,7 @@ private:
    * Helper function called by write_out_interior_basis_functions() to
    * determine the sizes of interior basis function data.
    */
-  std::map<std::string,unsigned int>
+  std::map<std::string,std::size_t>
     get_interior_basis_function_sizes_helper(std::vector<unsigned int> & n_qp_per_elem);
 
   /**

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -81,22 +81,9 @@ struct EIMVarGroupPlottingInfo
   unsigned int n_eim_vars;
 
   /**
-   * The FEType for the variables in this group.
-   */
-  FEType eim_var_fe_type;
-
-  /**
    * The name of the System we use for plotting this EIM variable group.
    */
   std::string eim_sys_name;
-
-  /**
-   * A string that specifies how we plot this variable. This string
-   * will be interpreted as needed in subclasses that perform the
-   * plotting. Some plotting options are whether we extrapolate data
-   * or copy data from qps to nodes.
-   */
-  std::string plotting_type;
 
   /**
    * These booleans indicate if we should clamp the resulting output

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -2914,146 +2914,16 @@ void RBEIMEvaluation::node_distribute_bfs(const System & sys)
     } // if (rank == 0)
 }
 
-void RBEIMEvaluation::project_qp_data_map_onto_system(System & sys,
-                                                      const QpDataMap & qp_data_map,
-                                                      const EIMVarGroupPlottingInfo & eim_vargroup)
+void RBEIMEvaluation::project_qp_data_vector_onto_system(System & sys,
+                                                         const std::vector<Number> & bf_data,
+                                                         const EIMVarGroupPlottingInfo & eim_vargroup)
 {
-  LOG_SCOPE("project_basis_function_onto_system()", "RBEIMEvaluation");
-
-  libmesh_error_msg_if(sys.n_vars() == 0, "System must have at least one variable");
-
-  // TODO: Currently only implemented for the case of one variable in a variable group
-  unsigned int var = eim_vargroup.first_eim_var_index;
-
-  FEMContext context(sys);
-  {
-    // Pre-request relevant data for all dimensions
-    for (unsigned int dim=1; dim<=3; ++dim)
-      if (sys.get_mesh().elem_dimensions().count(dim))
-        for (auto init_var : make_range(sys.n_vars()))
-        {
-          auto fe = context.get_element_fe(init_var, dim);
-          fe->get_JxW();
-          fe->get_phi();
-        }
-  }
-
-  FEBase * elem_fe = nullptr;
-  context.get_element_fe( 0, elem_fe );
-  const std::vector<Real> & JxW = elem_fe->get_JxW();
-  const std::vector<std::vector<Real>> & phi = elem_fe->get_phi();
-
-  // Get a reference to the current_local_solution vector, which has
-  // GHOSTED DOFs. Make sure it is initially zeroed, since we will now
-  // accumulate values into it.
-  auto & current_local_soln = *(sys.current_local_solution);
-  current_local_soln.zero();
-
-  // The repeat_count vector will store the number of times a
-  // projected value has been assigned to a node. We get a reference
-  // to it for convenience in the code below.
-  std::unique_ptr<NumericVector<Number>> repeat_count_ptr = current_local_soln.zero_clone();
-  auto & repeat_count = *repeat_count_ptr;
-
-  for (const auto & elem : sys.get_mesh().active_local_element_ptr_range())
-    {
-      context.pre_fe_reinit(sys, elem);
-      context.elem_fe_reinit();
-
-      const std::vector<dof_id_type> & dof_indices = context.get_dof_indices(/*var=*/0);
-      unsigned int n_proj_dofs = dof_indices.size();
-      unsigned int n_qpoints = context.get_element_qrule().n_points();
-
-      const std::vector<std::vector<Number>> & var_and_qp_data = libmesh_map_find(qp_data_map, elem->id());
-      libmesh_error_msg_if(var >= var_and_qp_data.size(), "Invalid EIM variable number: " << var);
-      const std::vector<Number> & qp_data = var_and_qp_data[var];
-
-      // If qp_data doesn't match n_qpoints then we skip this element since this means
-      // that the EIM basis function is not applicable on this element. This can happen,
-      // for example, if we have 1D and 3D elements in the same mesh and the EIM basis
-      // functions have been set up for the 3D elements only. Note that the EIM is
-      // necessarily dependent on the element dimension since it is based on the number
-      // of quad. points per element. If multiple dimensions need to be supported then
-      // one can add a separate EIM for each dimension.
-      if (qp_data.size() != n_qpoints)
-        continue;
-
-      DenseMatrix<Number> Me(n_proj_dofs, n_proj_dofs);
-      DenseVector<Number> Fe(n_proj_dofs);
-      for (auto qp : make_range(n_qpoints))
-        for (auto i : make_range(n_proj_dofs))
-          {
-            Fe(i) += JxW[qp] * qp_data[qp] * phi[i][qp];
-
-            for (auto j : make_range(n_proj_dofs))
-              Me(i,j) += JxW[qp] * phi[i][qp] * phi[j][qp];
-          }
-
-      DenseVector<Number> projected_data;
-      Me.cholesky_solve(Fe, projected_data);
-
-      for (auto i : make_range(n_proj_dofs))
-        {
-          current_local_soln.add(dof_indices[i], projected_data(i));
-          repeat_count.add(dof_indices[i], 1.);
-        }
-    }
-
-  current_local_soln.close();
-  repeat_count.close();
-
-  // Average the projected QP values to get nodal values
-  current_local_soln /= repeat_count;
-  current_local_soln.close();
-
-  // Copy values from the GHOSTED current_local_solution vector into
-  // sys.solution, since that is what will ultimately be plotted/used
-  // by other parts of the code.
-  (*sys.solution) = current_local_soln;
+  // No-op by default, implement in subclasses if needed
 }
 
 const std::vector<EIMVarGroupPlottingInfo> & RBEIMEvaluation::get_eim_vars_to_project_and_write() const
 {
   return _eim_vars_to_project_and_write;
-}
-
-void RBEIMEvaluation::write_out_projected_basis_functions(EquationSystems & es,
-                                                          const std::string & directory_name)
-{
-  if (get_eim_vars_to_project_and_write().empty())
-    return;
-
-  unsigned int var_group_idx = 0;
-  for (const auto & eim_vargroup : get_eim_vars_to_project_and_write())
-    {
-      std::vector<std::unique_ptr<NumericVector<Number>>> projected_bfs;
-
-      const auto & sys_name = eim_vargroup.eim_sys_name;
-      System & sys = es.get_system(sys_name);
-
-      for (unsigned int bf_index : make_range(get_n_basis_functions()))
-        {
-          project_qp_data_map_onto_system(
-            sys,
-            get_basis_function(bf_index),
-            eim_vargroup);
-
-          projected_bfs.emplace_back(sys.solution->clone());
-        }
-
-      // Create projected_bfs_ptrs so that we can call RBEvaluation::write_out_vectors()
-      std::vector<NumericVector<Number>*> projected_bfs_ptrs(projected_bfs.size());
-      for (unsigned int i : index_range(projected_bfs))
-        {
-          projected_bfs_ptrs[i] = projected_bfs[i].get();
-        }
-
-      RBEvaluation::write_out_vectors(sys,
-                                      projected_bfs_ptrs,
-                                      directory_name,
-                                      "projected_bf_vargroup_" + std::to_string(var_group_idx));
-      var_group_idx++;
-    }
 }
 
 const std::set<unsigned int> & RBEIMEvaluation::scale_components_in_enrichment() const

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -2916,7 +2916,8 @@ void RBEIMEvaluation::node_distribute_bfs(const System & sys)
 
 void RBEIMEvaluation::project_qp_data_vector_onto_system(System & sys,
                                                          const std::vector<Number> & bf_data,
-                                                         const EIMVarGroupPlottingInfo & eim_vargroup)
+                                                         const EIMVarGroupPlottingInfo & eim_vargroup,
+                                                         const std::map<std::string,std::string> & extra_options)
 {
   // No-op by default, implement in subclasses if needed
 }

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -1078,10 +1078,10 @@ write_out_interior_basis_functions(const std::string & directory_name,
     }
 }
 
-std::map<std::string,unsigned int> RBEIMEvaluation::
+std::map<std::string,std::size_t> RBEIMEvaluation::
 get_interior_basis_function_sizes_helper(std::vector<unsigned int> & n_qp_per_elem)
 {
-  std::map<std::string,unsigned int> interior_basis_function_sizes;
+  std::map<std::string,std::size_t> interior_basis_function_sizes;
 
   // Write number of basis functions to file. Note: the
   // Xdr::data() function takes non-const references, so you can't
@@ -1192,7 +1192,7 @@ get_interior_basis_functions_as_vecs()
   if (this->processor_id() == 0)
     {
       std::vector<unsigned int> n_qp_per_elem;
-      std::map<std::string,unsigned int> interior_basis_function_sizes =
+      std::map<std::string,std::size_t> interior_basis_function_sizes =
         get_interior_basis_function_sizes_helper(n_qp_per_elem);
 
       for (auto bf_index : index_range(_local_eim_basis_functions))

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -2914,10 +2914,10 @@ void RBEIMEvaluation::node_distribute_bfs(const System & sys)
     } // if (rank == 0)
 }
 
-void RBEIMEvaluation::project_qp_data_vector_onto_system(System & sys,
-                                                         const std::vector<Number> & bf_data,
-                                                         const EIMVarGroupPlottingInfo & eim_vargroup,
-                                                         const std::map<std::string,std::string> & extra_options)
+void RBEIMEvaluation::project_qp_data_vector_onto_system(System & /*sys*/,
+                                                         const std::vector<Number> & /*bf_data*/,
+                                                         const EIMVarGroupPlottingInfo & /*eim_vargroup*/,
+                                                         const std::map<std::string,std::string> & /*extra_options*/)
 {
   // No-op by default, implement in subclasses if needed
 }

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -1023,7 +1023,7 @@ write_out_interior_basis_functions(const std::string & directory_name,
     {
       std::vector<unsigned int> n_qp_per_elem;
       auto interior_basis_function_sizes =
-        get_interior_basis_function_sizes_helper(n_qp_per_elem);
+        get_interior_basis_function_sizes(n_qp_per_elem);
 
       // Make a directory to store all the data files
       Utility::mkdir(directory_name.c_str());
@@ -1079,7 +1079,7 @@ write_out_interior_basis_functions(const std::string & directory_name,
 }
 
 std::map<std::string,std::size_t> RBEIMEvaluation::
-get_interior_basis_function_sizes_helper(std::vector<unsigned int> & n_qp_per_elem)
+get_interior_basis_function_sizes(std::vector<unsigned int> & n_qp_per_elem)
 {
   std::map<std::string,std::size_t> interior_basis_function_sizes;
 
@@ -1193,7 +1193,7 @@ get_interior_basis_functions_as_vecs()
     {
       std::vector<unsigned int> n_qp_per_elem;
       std::map<std::string,std::size_t> interior_basis_function_sizes =
-        get_interior_basis_function_sizes_helper(n_qp_per_elem);
+        get_interior_basis_function_sizes(n_qp_per_elem);
 
       for (auto bf_index : index_range(_local_eim_basis_functions))
         interior_basis_functions.emplace_back(


### PR DESCRIPTION
Update some recent functionality for plotting EIM basis functions. This provides some convenience functions for getting vector-based representations of EIM data, and changes the EIM projection data to be no-op by default (to be overridden in subclasses) since the default is not general enough to handle all cases so it's better to defer to the user via subclasses.