### PR TITLE
Add check if tangent derivative RB-EIM data exist before accessing it

### DIFF
--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -907,14 +907,17 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
     auto elem_center_dxyzdxi =
       rb_eim_evaluation_reader.getInterpolationDxyzDxiElem();
 
-    libmesh_error_msg_if(elem_center_dxyzdxi.size() != n_bfs,
-                         "Size error while reading the eim interpolation points.");
-
-    Point dxyzdxi_buffer;
-    for (const auto i : make_range(n_bfs))
+    if (elem_center_dxyzdxi.size() > 0)
       {
-        load_point(elem_center_dxyzdxi[i], dxyzdxi_buffer);
-        rb_eim_evaluation.add_elem_center_dxyzdxi(dxyzdxi_buffer);
+        libmesh_error_msg_if(elem_center_dxyzdxi.size() != n_bfs,
+                             "Size error while reading the eim interpolation points.");
+
+        Point dxyzdxi_buffer;
+        for (const auto i : make_range(n_bfs))
+          {
+            load_point(elem_center_dxyzdxi[i], dxyzdxi_buffer);
+            rb_eim_evaluation.add_elem_center_dxyzdxi(dxyzdxi_buffer);
+          }
       }
   }
 
@@ -923,14 +926,17 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
     auto elem_center_dxyzdeta =
       rb_eim_evaluation_reader.getInterpolationDxyzDetaElem();
 
-    libmesh_error_msg_if(elem_center_dxyzdeta.size() != n_bfs,
-                         "Size error while reading the eim interpolation points.");
-
-    Point dxyzdeta_buffer;
-    for (const auto i : make_range(n_bfs))
+    if (elem_center_dxyzdeta.size() > 0)
       {
-        load_point(elem_center_dxyzdeta[i], dxyzdeta_buffer);
-        rb_eim_evaluation.add_elem_center_dxyzdeta(dxyzdeta_buffer);
+        libmesh_error_msg_if(elem_center_dxyzdeta.size() != n_bfs,
+                             "Size error while reading the eim interpolation points.");
+
+        Point dxyzdeta_buffer;
+        for (const auto i : make_range(n_bfs))
+          {
+            load_point(elem_center_dxyzdeta[i], dxyzdeta_buffer);
+            rb_eim_evaluation.add_elem_center_dxyzdeta(dxyzdeta_buffer);
+          }
       }
   }
 


### PR DESCRIPTION
Fix to maintain backward compatibility with older training data. 