### PR TITLE
Output EDGE to exodus as BAR

### DIFF
--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -348,9 +348,9 @@ void ExodusII_IO_Helper::init_conversion_map()
   };
 
   convert_type(NODEELEM, "SPHERE");
-  convert_type(EDGE2, "EDGE2");
-  convert_type(EDGE3, "EDGE3");
-  convert_type(EDGE4, "EDGE4");
+  convert_type(EDGE2, "BAR2");
+  convert_type(EDGE3, "BAR3");
+  convert_type(EDGE4, "BAR4");
   convert_type(QUAD4, "QUAD4");
   convert_type(QUAD8, "QUAD8");
   convert_type(QUAD9, "QUAD9");


### PR DESCRIPTION
"EDGE" isn't actually in the ExodusII standard, as far as I can tell, despite Paraview and even *exodiff* seemingly supporting it.  But apparently Python meshio is stricter, so we should be more standards-conforming here.

Thanks to Adriaan Riet (@ke7kto) for catching this.