### PR TITLE
SimplexRefiner for mesh refinement via edge bisection

### DIFF
--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -826,6 +826,7 @@ include_HEADERS = \
         mesh/replicated_mesh.h \
         mesh/serial_mesh.h \
         mesh/sides_to_elem_map.h \
+        mesh/simplex_refiner.h \
         mesh/stl_io.h \
         mesh/sync_refinement_flags.h \
         mesh/tecplot_io.h \

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -226,6 +226,7 @@ include_HEADERS =  \
         mesh/replicated_mesh.h \
         mesh/serial_mesh.h \
         mesh/sides_to_elem_map.h \
+        mesh/simplex_refiner.h \
         mesh/stl_io.h \
         mesh/sync_refinement_flags.h \
         mesh/tecplot_io.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -217,6 +217,7 @@ BUILT_SOURCES = \
         replicated_mesh.h \
         serial_mesh.h \
         sides_to_elem_map.h \
+        simplex_refiner.h \
         stl_io.h \
         sync_refinement_flags.h \
         tecplot_io.h \
@@ -1237,6 +1238,9 @@ serial_mesh.h: $(top_srcdir)/include/mesh/serial_mesh.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 sides_to_elem_map.h: $(top_srcdir)/include/mesh/sides_to_elem_map.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+simplex_refiner.h: $(top_srcdir)/include/mesh/simplex_refiner.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 stl_io.h: $(top_srcdir)/include/mesh/stl_io.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -587,10 +587,10 @@ BUILT_SOURCES = auto_ptr.h dirichlet_boundaries.h dof_map.h \
 	namebased_io.h nemesis_io.h nemesis_io_helper.h off_io.h \
 	parallel_mesh.h patch.h poly2tri_triangulator.h \
 	postscript_io.h replicated_mesh.h serial_mesh.h \
-	sides_to_elem_map.h stl_io.h sync_refinement_flags.h \
-	tecplot_io.h tetgen_io.h triangulator_interface.h ucd_io.h \
-	unstructured_mesh.h unv_io.h vtk_io.h xdr_io.h \
-	analytic_function.h composite_fem_function.h \
+	sides_to_elem_map.h simplex_refiner.h stl_io.h \
+	sync_refinement_flags.h tecplot_io.h tetgen_io.h \
+	triangulator_interface.h ucd_io.h unstructured_mesh.h unv_io.h \
+	vtk_io.h xdr_io.h analytic_function.h composite_fem_function.h \
 	composite_function.h const_fem_function.h const_function.h \
 	coupling_matrix.h dense_matrix.h dense_matrix_base.h \
 	dense_matrix_base_impl.h dense_matrix_impl.h dense_submatrix.h \
@@ -1571,6 +1571,9 @@ serial_mesh.h: $(top_srcdir)/include/mesh/serial_mesh.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 sides_to_elem_map.h: $(top_srcdir)/include/mesh/sides_to_elem_map.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+simplex_refiner.h: $(top_srcdir)/include/mesh/simplex_refiner.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 stl_io.h: $(top_srcdir)/include/mesh/stl_io.h

--- a/include/mesh/mesh_generation.h
+++ b/include/mesh/mesh_generation.h
@@ -145,6 +145,18 @@ void build_delaunay_square(UnstructuredMesh & mesh,
 #endif // LIBMESH_HAVE_TRIANGLE && LIBMESH_DIM > 1
 
 /**
+ * Meshes the surface of an octahedron with 8 Tri3 elements, with
+ * counter-clockwise (libMesh default) node ordering as viewed from
+ * the octahedron exterior if \p flip_tris is false or from the
+ * interior otherwise.
+ */
+void surface_octahedron (UnstructuredMesh & mesh,
+                         Real xmin, Real xmax,
+                         Real ymin, Real ymax,
+                         Real zmin, Real zmax,
+                         bool flip_tris = false);
+
+/**
  * Class for receiving the callback during extrusion generation and providing user-defined
  * subdomains based on the old (existing) element id and the current layer.
  */

--- a/include/mesh/mesh_modification.h
+++ b/include/mesh/mesh_modification.h
@@ -132,12 +132,12 @@ void scale (MeshBase & mesh,
             const Real xs, const Real ys=0., const Real zs=0.);
 
 /**
- * Converts the 2D quadrilateral elements of a Mesh into
- * triangular elements.
+ * Subdivides any non-simplex elements in a Mesh to produce simplex
+ * (triangular in 2D, tetrahedral in 3D) elements.
  *
- * \note Only works for 2D elements!  3D elements are ignored.
- * \note Probably won't do the right thing for meshes which
- * have been refined previously.
+ * \note Only supports coarse / unrefined meshes.  A uniformly
+ * refined mesh can be used only after a \p flatten() removes its
+ * coarser layers.
  */
 void all_tri (MeshBase & mesh);
 

--- a/include/mesh/simplex_refiner.h
+++ b/include/mesh/simplex_refiner.h
@@ -1,0 +1,151 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2024 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+#ifndef LIBMESH_SIMPLEX_REFINER_H
+#define LIBMESH_SIMPLEX_REFINER_H
+
+#include "libmesh/libmesh_config.h"
+
+// Local Includes
+#include "libmesh/elem.h"
+#include "libmesh/function_base.h"
+
+#include <map>
+#include <memory>
+
+namespace libMesh
+{
+
+// Forward Declarations
+class UnstructuredMesh;
+class Node;
+
+/**
+ * A C++ class to refine a simplicial mesh via splitting edges that
+ * exceed a given metric.
+ *
+ * \author Roy H. Stogner
+ * \date 2024
+ */
+class SimplexRefiner
+{
+public:
+  /**
+   * The constructor.  A reference to the mesh containing the elements
+   * which are to be split by edge subdivision must be provided.
+   *
+   * At the time of refining this mesh should be conforming.
+   */
+  explicit
+  SimplexRefiner(UnstructuredMesh & mesh);
+
+  /**
+   * Finds elements which exceed the requested metric and refines them
+   * via subdivision into new simplices as necessary.
+   *
+   * \returns \p true iff the mesh actually changed.
+   */
+  bool refine_elements ();
+
+  /**
+   * Set a function giving desired element volume as a function of
+   * position.  Set this to nullptr to disable position-dependent volume
+   * constraint (falling back on desired_volume()).
+   */
+  virtual void set_desired_volume_function (FunctionBase<Real> * desired);
+
+  /**
+   * Get the function giving desired element volume as a function of
+   * position, or \p nullptr if no such function has been set.
+   */
+  virtual FunctionBase<Real> * get_desired_volume_function ();
+
+  /**
+   * Sets and/or gets the desired element volume. Set to zero to disable
+   * volume constraint.
+   *
+   * If a \p desired_volume_function is set, then \p desired_volume()
+   * should be used to set a *minimum* desired volume; this will reduce
+   * "false negatives" by suggesting how finely to sample \p
+   * desired_volume_function inside large elements, where ideally the
+   * \p desired_volume_function will be satisfied in the element
+   * interior and not just at the element vertices.
+   */
+  Real & desired_volume() {return _desired_volume;}
+
+protected:
+
+  /**
+   * Finds elements which exceed the requested metric and refines them
+   * via inserting new midedge nodes and bisecting as necessary.
+   *
+   * \returns the number of refined elements
+   */
+  std::size_t refine_via_edges();
+
+  /**
+   * Checks if an element exceeds the requested metric
+   */
+  bool should_refine_elem(Elem & elem);
+
+  /**
+   * Checks if an element exceeds the requested metric or if it
+   * has an edge which was split by a neighboring metric and refines
+   * it (bisecting it, removing it from the mesh to be replaced by the
+   * two subelements, and recursing into those) if necessary.
+   *
+   * \returns the number of refinements done; this may be greater than
+   * 1 if subelements were themselves refined.
+   */
+ 
+  std::size_t refine_via_edges(Elem & elem);
+
+private:
+
+  /**
+   * Reference to the mesh which is to be refined.
+   */
+  UnstructuredMesh & _mesh;
+
+  /**
+   * The desired volume for the elements in the resulting mesh.
+   */
+  Real _desired_volume;
+
+  /**
+   * Location-dependent volume requirements
+   */
+  std::unique_ptr<FunctionBase<Real>> _desired_volume_func;
+
+  /**
+   * Keep track of new nodes on edges.  A new node x in between node y
+   * and node z (with y<z) will be reflected by new_nodes[(y,z)]=x
+   */
+  std::map<std::pair<Point *, Point *>, Node *> new_nodes;
+
+  /**
+   * Keep track of elements to add so we don't invalidate iterators
+   * during an iteration over elements.
+   */
+  std::vector<std::unique_ptr<Elem>> new_elements;
+};
+
+
+} // namespace libMesh
+
+#endif // ifndef LIBMESH_SIMPLEX_REFINER_H

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -238,6 +238,7 @@ libmesh_SOURCES =  \
         src/mesh/postscript_io.C \
         src/mesh/replicated_mesh.C \
         src/mesh/sides_to_elem_map.C \
+        src/mesh/simplex_refiner.C \
         src/mesh/stl_io.C \
         src/mesh/tecplot_io.C \
         src/mesh/tetgen_io.C \

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -747,6 +747,10 @@ void DistributedMesh::delete_elem(Elem * e)
 void DistributedMesh::renumber_elem(const dof_id_type old_id,
                                     const dof_id_type new_id)
 {
+  // This could be a no-op
+  if (old_id == new_id)
+    return;
+
   Elem * el = _elements[old_id];
   libmesh_assert (el);
   libmesh_assert_equal_to (el->id(), old_id);
@@ -956,6 +960,10 @@ void DistributedMesh::delete_node(Node * n)
 void DistributedMesh::renumber_node(const dof_id_type old_id,
                                     const dof_id_type new_id)
 {
+  // This could be a no-op
+  if (old_id == new_id)
+    return;
+
   Node * nd = _nodes[old_id];
   libmesh_assert (nd);
   libmesh_assert_equal_to (nd->id(), old_id);

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -2752,5 +2752,44 @@ void MeshTools::Generation::build_delaunay_square(UnstructuredMesh & mesh,
 #endif // LIBMESH_HAVE_TRIANGLE && LIBMESH_DIM > 1
 
 
+void MeshTools::Generation::surface_octahedron
+  (UnstructuredMesh & mesh,
+   Real xmin, Real xmax,
+   Real ymin, Real ymax,
+   Real zmin, Real zmax,
+   bool flip_tris)
+{
+  const Real xavg = (xmin + xmax)/2;
+  const Real yavg = (ymin + ymax)/2;
+  const Real zavg = (zmin + zmax)/2;
+  mesh.add_point(Point(xavg,yavg,zmin), 0);
+  mesh.add_point(Point(xmax,yavg,zavg), 1);
+  mesh.add_point(Point(xavg,ymax,zavg), 2);
+  mesh.add_point(Point(xmin,yavg,zavg), 3);
+  mesh.add_point(Point(xavg,ymin,zavg), 4);
+  mesh.add_point(Point(xavg,yavg,zmax), 5);
+
+  auto add_tri = [&mesh, flip_tris](std::array<dof_id_type,3> nodes)
+  {
+    auto elem = mesh.add_elem(Elem::build(TRI3));
+    elem->set_node(0) = mesh.node_ptr(nodes[0]);
+    elem->set_node(1) = mesh.node_ptr(nodes[1]);
+    elem->set_node(2) = mesh.node_ptr(nodes[2]);
+    if (flip_tris)
+      elem->flip(&mesh.get_boundary_info());
+  };
+
+  add_tri({0,2,1});
+  add_tri({0,3,2});
+  add_tri({0,4,3});
+  add_tri({0,1,4});
+  add_tri({5,4,1});
+  add_tri({5,3,4});
+  add_tri({5,2,3});
+  add_tri({5,1,2});
+
+  mesh.prepare_for_use();
+}
+
 
 } // namespace libMesh

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -466,7 +466,8 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
         const ElemType etype = elem->type();
 
         // all_tri currently only works on coarse meshes
-        libmesh_assert (!elem->parent());
+        if (elem->parent())
+          libmesh_not_implemented_msg("Cannot convert a refined element into simplices\n");
 
         // The new elements we will split the quad into.
         // In 3D we may need as many as 6 tets per hex

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -425,6 +425,10 @@ void ReplicatedMesh::delete_elem(Elem * e)
 void ReplicatedMesh::renumber_elem(const dof_id_type old_id,
                                    const dof_id_type new_id)
 {
+  // This could be a no-op
+  if (old_id == new_id)
+    return;
+
   // This doesn't get used in serial yet
   Elem * el = _elements[old_id];
   libmesh_assert (el);
@@ -642,6 +646,10 @@ void ReplicatedMesh::delete_node(Node * n)
 void ReplicatedMesh::renumber_node(const dof_id_type old_id,
                                    const dof_id_type new_id)
 {
+  // This could be a no-op
+  if (old_id == new_id)
+    return;
+
   // This doesn't get used in serial yet
   Node * nd = _nodes[old_id];
   libmesh_assert (nd);

--- a/src/mesh/simplex_refiner.C
+++ b/src/mesh/simplex_refiner.C
@@ -51,7 +51,7 @@ SimplexRefiner::SimplexRefiner (UnstructuredMesh & mesh) :
 
 bool SimplexRefiner::refine_elements()
 {
-  if (_mesh.is_prepared())
+  if (!_mesh.is_prepared())
     _mesh.prepare_for_use();
 
   // We should add more options later: to refine via circumcenter

--- a/src/mesh/simplex_refiner.C
+++ b/src/mesh/simplex_refiner.C
@@ -25,12 +25,16 @@
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/mesh_communication.h"
+#include "libmesh/mesh_tools.h"
 #include "libmesh/node.h"
-#include "libmesh/partitioner.h"
+#include "libmesh/parallel_algebra.h"
 #include "libmesh/remote_elem.h"
-#include "libmesh/sync_refinement_flags.h"
 #include "libmesh/unstructured_mesh.h"
+#include "libmesh/utility.h"
 
+// TIMPI includes
+#include "timpi/parallel_implementation.h"
+#include "timpi/parallel_sync.h"
 
 
 namespace libMesh
@@ -47,6 +51,9 @@ SimplexRefiner::SimplexRefiner (UnstructuredMesh & mesh) :
 
 bool SimplexRefiner::refine_elements()
 {
+  if (_mesh.is_prepared())
+    _mesh.prepare_for_use();
+
   // We should add more options later: to refine via circumcenter
   // insertion instead of edge center insertion, to do Delaunay swaps,
   // etc.
@@ -100,11 +107,12 @@ bool SimplexRefiner::should_refine_elem(Elem & elem)
     ("Combining a minimum desired_volume with an volume function isn't yet supported.");
 }
 
-std::size_t SimplexRefiner::refine_via_edges(Elem & elem)
+
+std::size_t SimplexRefiner::refine_via_edges(Elem & elem,
+                                             dof_id_type coarse_id)
 {
   // Do we need to be refined for our own sake, or only if our
   // neighbors were refined?
-
   const bool should_refine = this->should_refine_elem(elem);
 
   // We only currently handle coarse conforming meshes here.
@@ -115,20 +123,40 @@ std::size_t SimplexRefiner::refine_via_edges(Elem & elem)
   // other elements will get tricky.
   libmesh_assert_equal_to(elem.type(), TRI3);
 
+  const int n_sides = elem.n_sides();
   int side_to_refine = 0;
   Real length_to_refine = 0;
-  std::pair<Point *, Point *> vertices_to_refine;
-  for (int side : make_range(3))
+  std::pair<Node *, Node *> vertices_to_refine;
+
+  // Find the longest side and refine it first.  We might change that
+  // heuristic at some point, to enable anisotropic refinement.
+  for (int side : make_range(n_sides))
     {
-      std::pair<Point *, Point *> vertices
-        {elem.node_ptr((side+1)%3),
+      std::pair<Node *, Node *> vertices
+        {elem.node_ptr((side+1)%n_sides),
          elem.node_ptr(side)};
 
-      if (vertices.first > vertices.second)
+      if ((Point&)(*vertices.first) >
+          (Point&)(*vertices.second))
         std::swap(vertices.first, vertices.second);
 
-      const auto sidevec = *vertices.first - *vertices.second;
+      const auto sidevec = *(Point*)vertices.first -
+                           *(Point*)vertices.second;
       Real length = sidevec.norm();
+
+      // We might need to ask the owner of a coarse ghost element
+      // about whether it saw any refinement forced by a coarse
+      // neighbor with a smaller desired area.
+      if (const processor_id_type pid = elem.processor_id();
+          pid != _mesh.processor_id() && !_mesh.is_serial() &&
+          !_desired_volume_func.get() &&
+          elem.id() == coarse_id)
+        edge_queries[pid].emplace_back(vertices.first->id(),
+                                       vertices.second->id());
+
+      // Test should_refine, but also test for any edges that were
+      // already refined by neighbors, which might happen even if
+      // !should_refine in cases where we're refining non-uniformly.
       if (length > length_to_refine &&
           (should_refine ||
            new_nodes.find(vertices) != new_nodes.end()))
@@ -139,93 +167,148 @@ std::size_t SimplexRefiner::refine_via_edges(Elem & elem)
         }
     }
 
-  if (length_to_refine)
+  // We might not refine anything.
+  if (!length_to_refine)
+    return 0;
+
+  // But if we must, then do it.
+  //
+  // Find all the edge neighbors we can.  For a triangle there'll just
+  // be the one, but we want to extend to tets later.
+  std::vector<Elem *> neighbors;
+  if (Elem * neigh = elem.neighbor_ptr(side_to_refine); neigh)
+    neighbors.push_back(neigh);
+
+  Node * midedge_node;
+  if (auto it = new_nodes.find(vertices_to_refine);
+      it != new_nodes.end())
     {
-      Node * midedge_node;
-      if (auto it = new_nodes.find(vertices_to_refine);
-          it != new_nodes.end())
-        {
-          midedge_node = it->second;
-        }
-      else
-        {
-          midedge_node =
-            _mesh.add_point((*vertices_to_refine.first +
-                             *vertices_to_refine.second)/2);
-          new_nodes[vertices_to_refine] = midedge_node;
-        }
+      midedge_node = it->second;
+    }
+  else
+    {
+      // Add with our own processor id first, so we can request a temporary
+      // id that won't conflict with anyone else's canonical ids later
+      midedge_node =
+        _mesh.add_point((*(Point*)vertices_to_refine.first +
+                         *(Point*)vertices_to_refine.second)/2,
+                        DofObject::invalid_id,
+                        _mesh.processor_id());
 
-      constexpr int max_subelems = 2;
-      std::unique_ptr<Tri3> subelem[max_subelems];
+      // Then give the new node the best pid we can.
+      midedge_node->processor_id() = elem.processor_id();
+      for (const Elem * neigh : neighbors)
+        if (neigh != remote_elem)
+          midedge_node->processor_id() = std::min(midedge_node->processor_id(),
+                                                  neigh->processor_id());
 
-      std::vector<boundary_id_type> bc_ids;
-
-      // We'll switch(elem->type()) here eventually
-      subelem[0] = std::make_unique<Tri3>();
-      subelem[0]->set_node(0) = elem.node_ptr(side_to_refine);
-      subelem[0]->set_node(1) = midedge_node;
-      subelem[0]->set_node(2) = elem.node_ptr((side_to_refine+2)%3);
-
-      subelem[1] = std::make_unique<Tri3>();
-      subelem[1]->set_node(0) = elem.node_ptr((side_to_refine+2)%3);
-      subelem[1]->set_node(1) = midedge_node;
-      subelem[1]->set_node(2) = elem.node_ptr((side_to_refine+1)%3);
-
-      BoundaryInfo & boundary_info = _mesh.get_boundary_info();
-      boundary_info.boundary_ids(&elem, side_to_refine, bc_ids);
-      boundary_info.add_side(subelem[0].get(), 0, bc_ids);
-      boundary_info.add_side(subelem[1].get(), 1, bc_ids);
-      boundary_info.boundary_ids(&elem, (side_to_refine+1)%3, bc_ids);
-      boundary_info.add_side(subelem[1].get(), 2, bc_ids);
-      boundary_info.boundary_ids(&elem, (side_to_refine+2)%3, bc_ids);
-      boundary_info.add_side(subelem[0].get(), 2, bc_ids);
-
-      // Be sure the correct data is set for all subelems.
-      const unsigned int nei = elem.n_extra_integers();
-      for (unsigned int i=0; i != max_subelems; ++i)
-        if (subelem[i])
-          {
-            // We'd love to assert that we don't have a sliver here,
-            // but maybe our input had a sliver and we can't fix it.
-            libmesh_assert_greater_equal(subelem[i]->volume() + TOLERANCE,
-                                         elem.volume() / 2);
-            subelem[i]->processor_id() = elem.processor_id();
-            subelem[i]->subdomain_id() = elem.subdomain_id();
-
-            // Copy any extra element data.  Since the subelements
-            // haven't been added to the mesh yet any allocation has
-            // to be done manually.
-            subelem[i]->add_extra_integers(nei);
-            for (unsigned int ei=0; ei != nei; ++ei)
-              subelem[ei]->set_extra_integer(ei, elem.get_extra_integer(ei));
-
-            // Copy any mapping data.
-            subelem[i]->set_mapping_type(elem.mapping_type());
-            subelem[i]->set_mapping_data(elem.mapping_data());
-          }
-
-      boundary_info.remove(&elem);
-      if (!this->new_elements.empty() &&
-          &elem == this->new_elements.back().get())
-        this->new_elements.pop_back();
-      else
-        _mesh.delete_elem(&elem);
-
-      // We refined at least ourselves
-      std::size_t n_refined_elements = 1;
-
-      for (unsigned int i=0; i != max_subelems; ++i)
-        {
-          this->new_elements.push_back(std::move(subelem[i]));
-          n_refined_elements +=
-            this->refine_via_edges(*(this->new_elements.back()));
-        }
-
-      return n_refined_elements;
+      new_nodes[vertices_to_refine] = midedge_node;
     }
 
-  // We didn't refine anything
-  return 0;
+  // Good for Tris and Tets; we'll need more for Quads.
+  constexpr int max_subelems = 2;
+  std::unique_ptr<Tri3> subelem[max_subelems];
+
+  // We'll switch(elem->type()) here eventually
+  subelem[0] = std::make_unique<Tri3>();
+  subelem[0]->set_node(0) = elem.node_ptr(side_to_refine);
+  subelem[0]->set_node(1) = midedge_node;
+  subelem[0]->set_node(2) = elem.node_ptr((side_to_refine+2)%3);
+
+  subelem[1] = std::make_unique<Tri3>();
+  subelem[1]->set_node(0) = elem.node_ptr((side_to_refine+2)%3);
+  subelem[1]->set_node(1) = midedge_node;
+  subelem[1]->set_node(2) = elem.node_ptr((side_to_refine+1)%3);
+
+  // Preserve boundary and sort-of-preserve neighbor information.  We
+  // need remote_elem neighbors to avoid breaking distributed meshes
+  // (which can't reconstruct them from scratch), and we need at least
+  // placeholder neighbors to make sure we'll have good processor_id()
+  // options for new nodes in future splits of the same edge.
+  subelem[0]->set_neighbor(1, subelem[1].get());
+  subelem[1]->set_neighbor(0, subelem[0].get());
+
+  BoundaryInfo & boundary_info = _mesh.get_boundary_info();
+  std::vector<boundary_id_type> bc_ids;
+  boundary_info.boundary_ids(&elem, side_to_refine, bc_ids);
+  boundary_info.add_side(subelem[0].get(), 0, bc_ids);
+  boundary_info.add_side(subelem[1].get(), 1, bc_ids);
+  subelem[0]->set_neighbor(0, elem.neighbor_ptr(side_to_refine));
+  subelem[1]->set_neighbor(1, elem.neighbor_ptr(side_to_refine));
+
+  boundary_info.boundary_ids(&elem, (side_to_refine+1)%3, bc_ids);
+  boundary_info.add_side(subelem[1].get(), 2, bc_ids);
+  subelem[1]->set_neighbor(2, elem.neighbor_ptr((side_to_refine+1)%3));
+
+  boundary_info.boundary_ids(&elem, (side_to_refine+2)%3, bc_ids);
+  boundary_info.add_side(subelem[0].get(), 2, bc_ids);
+  subelem[0]->set_neighbor(2, elem.neighbor_ptr((side_to_refine+2)%3));
+
+  // Be sure the correct data is set for all subelems.
+  const unsigned int nei = elem.n_extra_integers();
+  for (unsigned int i=0; i != max_subelems; ++i)
+    if (subelem[i])
+      {
+        // We'd love to assert that we don't have a sliver here,
+        // but maybe our input had a sliver and we can't fix it.
+        libmesh_assert_greater_equal(subelem[i]->volume() + TOLERANCE,
+                                     elem.volume() / 2);
+        subelem[i]->processor_id() = elem.processor_id();
+        subelem[i]->subdomain_id() = elem.subdomain_id();
+
+        // Copy any extra element data.  Since the subelements
+        // haven't been added to the mesh yet any allocation has
+        // to be done manually.
+        subelem[i]->add_extra_integers(nei);
+        for (unsigned int ei=0; ei != nei; ++ei)
+          subelem[ei]->set_extra_integer(ei, elem.get_extra_integer(ei));
+
+        // Copy any mapping data.
+        subelem[i]->set_mapping_type(elem.mapping_type());
+        subelem[i]->set_mapping_data(elem.mapping_data());
+      }
+
+  boundary_info.remove(&elem);
+
+  if (auto it = this->added_elements.find(coarse_id);
+      it != this->added_elements.end())
+    {
+      auto & added = it->second;
+      if (auto sub_it = added.find(elem.vertex_average());
+          sub_it != added.end())
+        {
+          if (&elem == sub_it->second)
+            added.erase(sub_it);
+        }
+    }
+
+  // We only add an element to new_elements *right* before
+  // checking it for further refinement, so we only need to check the
+  // back() to see where the elem here came from.
+  if (!this->new_elements.empty() &&
+      &elem == this->new_elements.back().get())
+    {
+      this->new_elements.pop_back();
+      this->coarse_parent.erase(&elem);
+    }
+  else
+    _mesh.delete_elem(&elem);
+
+  // We refined at least ourselves
+  std::size_t n_refined_elements = 1;
+
+  for (unsigned int i=0; i != max_subelems; ++i)
+    {
+      Elem * add_elem = subelem[i].get();
+      added_elements[coarse_id].emplace(add_elem->vertex_average(),
+                                        add_elem);
+      this->new_elements.push_back(std::move(subelem[i]));
+      this->coarse_parent[add_elem] = coarse_id;
+      n_refined_elements +=
+        this->refine_via_edges(*add_elem, coarse_id);
+    }
+
+  return n_refined_elements;
 }
 
 
@@ -235,22 +318,233 @@ std::size_t SimplexRefiner::refine_via_edges()
   this->new_nodes.clear();
   this->new_elements.clear();
 
+  // We need to look at neighbors' pids to determine new node pids,
+  // but we might be deleting elements and leaving dangling neighbor
+  // pointers.  Put proxy neighbors in those pointers places instead.
+  for (auto & elem : _mesh.element_ptr_range())
+    for (auto n : make_range(elem->n_neighbors()))
+      {
+        Elem * neigh = elem->neighbor_ptr(n);
+        if (!neigh || neigh == remote_elem)
+          continue;
+
+        const processor_id_type p = neigh->processor_id();
+        std::unique_ptr<Elem> & proxy_neighbor = proxy_elements[p];
+        if (!proxy_neighbor.get())
+          proxy_neighbor = Elem::build(NODEELEM);
+
+        elem->set_neighbor(n, proxy_neighbor.get());
+      }
+
+  // If we have a _desired_volume_func then we might still have
+  // some unsplit edges that could have been split by their
+  // remote_elem neighbors, and we'll need to query those.
+  auto edge_gather_functor =
+    [this]
+    (processor_id_type,
+     const std::vector<std::pair<dof_id_type, dof_id_type>> & edges,
+     std::vector<refinement_datum> & edge_refinements)
+    {
+      // Fill those requests
+      const std::size_t query_size = edges.size();
+      edge_refinements.resize(query_size);
+      for (std::size_t i=0; i != query_size; ++i)
+        {
+          auto vertex_ids = edges[i];
+          std::pair<Node *, Node *> vertices
+            {_mesh.node_ptr(vertex_ids.first),
+             _mesh.node_ptr(vertex_ids.second)};
+          fill_refinement_datum(vertices, edge_refinements[i]);
+        }
+    };
+
+  auto edge_action_functor =
+    [this]
+    (processor_id_type,
+     const std::vector<std::pair<dof_id_type, dof_id_type>> &,
+     const std::vector<refinement_datum> & edge_refinements
+    )
+    {
+      for (const auto & one_edges_refinements : edge_refinements)
+        for (const auto & refinement : one_edges_refinements)
+          {
+            std::pair<Node *, Node *> vertices
+              {_mesh.node_ptr(std::get<0>(refinement)),
+               _mesh.node_ptr(std::get<1>(refinement))};
+
+            if ((Point&)(*vertices.first) >
+                (Point&)(*vertices.second))
+              std::swap(vertices.first, vertices.second);
+
+            if (auto it = new_nodes.find(vertices);
+                it != new_nodes.end())
+              {
+                _mesh.renumber_node(it->second->id(),
+                                    std::get<2>(refinement));
+                it->second->processor_id() = std::get<3>(refinement);
+              }
+            else
+              {
+                Node * new_node =
+                  _mesh.add_point((*(Point*)vertices.first +
+                                   *(Point*)vertices.second)/2,
+                                  std::get<2>(refinement),
+                                  std::get<3>(refinement));
+                new_nodes[vertices] = new_node;
+              }
+          }
+    };
+
   std::size_t refined_elements = 0;
   std::size_t newly_refined_elements = 0;
   do
     {
       newly_refined_elements = 0;
-      for (auto & elem : _mesh.local_element_ptr_range())
+
+      // Refinement results should agree on ghost elements, except for
+      // id and unique_id assignment
+      for (auto & elem : _mesh.element_ptr_range())
         {
+          auto it = coarse_parent.find(elem);
+          const dof_id_type coarse_id =
+            (it == coarse_parent.end()) ?
+            elem->id() : it->second;
+
           newly_refined_elements +=
-            this->refine_via_edges(*elem);
+            this->refine_via_edges(*elem, coarse_id);
         }
       refined_elements += newly_refined_elements;
       for (auto & elem : this->new_elements)
         _mesh.add_elem(std::move(elem));
       this->new_elements.clear();
+
+      // Yeah, this is just a lower bound in parallel
+      _mesh.comm().max(newly_refined_elements);
+
+      if (newly_refined_elements && !_mesh.is_replicated())
+        {
+          bool have_edge_queries = !edge_queries.empty();
+          _mesh.comm().max(have_edge_queries);
+          refinement_datum * refinement_data_ex = nullptr;
+          if (have_edge_queries)
+            Parallel::pull_parallel_vector_data
+              (_mesh.comm(), edge_queries, edge_gather_functor,
+               edge_action_functor, refinement_data_ex);
+        }
     }
   while (newly_refined_elements);
+
+  // If we're replicated then we should be done here.
+  if (!_mesh.is_replicated())
+    {
+      // If we're not replicated then we might have a bunch of nodes
+      // and elements that still have temporary id and unique_id
+      // values.  Give them permanent ones.
+      std::unordered_map<processor_id_type, std::vector<dof_id_type>> elems_to_query;
+      for (const auto & [coarse_id, added_elem_map] : added_elements)
+        {
+          if (added_elem_map.empty())
+            continue;
+
+          const processor_id_type pid =
+            added_elem_map.begin()->second->processor_id();
+          if (pid == _mesh.processor_id())
+            continue;
+
+          elems_to_query[pid].push_back(coarse_id);
+        }
+
+      // Return fine element data based on vertex_average()
+      typedef
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+        std::vector<std::tuple<Point, dof_id_type, unique_id_type>>
+#else
+        std::vector<std::tuple<Point, dof_id_type>>
+#endif
+        elem_refinement_datum;
+
+      auto added_gather_functor =
+        [this]
+        (processor_id_type,
+         const std::vector<dof_id_type> & coarse_elems,
+         std::vector<elem_refinement_datum> & coarse_refinements)
+        {
+          // Fill those requests
+          const std::size_t query_size = coarse_elems.size();
+          coarse_refinements.resize(query_size);
+          for (auto i : make_range(query_size))
+            {
+              const dof_id_type coarse_id = coarse_elems[i];
+              const auto & added =
+                libmesh_map_find(added_elements, coarse_id);
+
+              for (auto [vertex_avg, elem] : added)
+                {
+                  coarse_refinements[i].emplace_back
+                    (vertex_avg,
+                     elem->id()
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+                     , elem->unique_id()
+#endif
+                    );
+                }
+            }
+        };
+
+      auto added_action_functor =
+        [this]
+        (processor_id_type,
+         const std::vector<dof_id_type> & coarse_elems,
+         const std::vector<elem_refinement_datum> & coarse_refinements)
+        {
+          const std::size_t query_size = coarse_elems.size();
+          for (auto i : make_range(query_size))
+            {
+              const dof_id_type coarse_id = coarse_elems[i];
+              const auto & refinement_data = coarse_refinements[i];
+              const auto & our_added =
+                libmesh_map_find(added_elements, coarse_id);
+              for (auto [vertex_avg, id
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+                         , unique_id
+#endif
+                   ] : refinement_data)
+                {
+                  Elem & our_elem = *libmesh_map_find(our_added,
+                                                      vertex_avg);
+                  libmesh_assert_equal_to(our_elem.vertex_average(),
+                                          vertex_avg);
+
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+                  our_elem.set_unique_id(unique_id);
+#endif
+                  _mesh.renumber_elem(our_elem.id(), id);
+                }
+            }
+        };
+
+      elem_refinement_datum * refinement_data_ex = nullptr;
+      Parallel::pull_parallel_vector_data
+        (_mesh.comm(), elems_to_query, added_gather_functor,
+         added_action_functor, refinement_data_ex);
+
+      // That took care of our element ids; now get node ids.
+      MeshCommunication mc;
+      mc.make_node_proc_ids_parallel_consistent (_mesh);
+      mc.make_node_ids_parallel_consistent (_mesh);
+      mc.make_node_unique_ids_parallel_consistent (_mesh);
+    }
+
+  // In theory the operations on ghost elements are, after remote edge
+  // splittings are known, embarrassingly parallel.  In practice ...
+  // let's verify that we haven't just desynchronized our mesh.
+#ifdef DEBUG
+  MeshTools::libmesh_assert_equal_points(_mesh);
+  MeshTools::libmesh_assert_equal_connectivity (_mesh);
+#  ifdef LIBMESH_ENABLE_UNIQUE_ID
+  MeshTools::libmesh_assert_valid_unique_ids(_mesh);
+#  endif
+#endif
 
   return refined_elements;
 }
@@ -271,6 +565,32 @@ void SimplexRefiner::set_desired_volume_function
 FunctionBase<Real> * SimplexRefiner::get_desired_volume_function ()
 {
   return _desired_volume_func.get();
+}
+
+
+void SimplexRefiner::fill_refinement_datum(std::pair<Node *, Node *> vertices,
+                                           refinement_datum & vec)
+{
+  auto it = new_nodes.find(vertices);
+  if (it == new_nodes.end())
+    return;
+
+  vec.emplace_back(vertices.first->id(),
+                   vertices.second->id(),
+                   it->second->id(),
+                   it->second->processor_id());
+
+  std::pair<Node *, Node *> subedge {vertices.first, it->second};
+  if ((Point&)(*subedge.first) >
+      (Point&)(*subedge.second))
+    std::swap(subedge.first, subedge.second);
+  fill_refinement_datum(subedge, vec);
+
+  subedge = std::make_pair(it->second, vertices.second);
+  if ((Point&)(*subedge.first) >
+      (Point&)(*subedge.second))
+    std::swap(subedge.first, subedge.second);
+  fill_refinement_datum(subedge, vec);
 }
 
 

--- a/src/mesh/simplex_refiner.C
+++ b/src/mesh/simplex_refiner.C
@@ -1,0 +1,278 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2024 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+// Local includes
+#include "libmesh/simplex_refiner.h"
+
+#include "libmesh/boundary_info.h"
+#include "libmesh/face_tri3.h"
+#include "libmesh/int_range.h"
+#include "libmesh/libmesh_logging.h"
+#include "libmesh/mesh_base.h"
+#include "libmesh/mesh_communication.h"
+#include "libmesh/node.h"
+#include "libmesh/partitioner.h"
+#include "libmesh/remote_elem.h"
+#include "libmesh/sync_refinement_flags.h"
+#include "libmesh/unstructured_mesh.h"
+
+
+
+namespace libMesh
+{
+
+//-----------------------------------------------------------------
+// Mesh refinement methods
+SimplexRefiner::SimplexRefiner (UnstructuredMesh & mesh) :
+  _mesh(mesh),
+  _desired_volume(0.1)
+{}
+
+
+
+bool SimplexRefiner::refine_elements()
+{
+  // We should add more options later: to refine via circumcenter
+  // insertion instead of edge center insertion, to do Delaunay swaps,
+  // etc.
+  return this->refine_via_edges();
+}
+
+
+
+bool SimplexRefiner::should_refine_elem(Elem & elem)
+{
+  const Real min_volume_target = this->desired_volume();
+  FunctionBase<Real> *volume_func = this->get_desired_volume_function();
+
+  // If this isn't a question, why are we here?
+  libmesh_assert(min_volume_target > 0 ||
+                 volume_func != nullptr);
+
+  // If we don't have position-dependent volume targets we can make a
+  // decision quickly
+  const Real volume = elem.volume();
+
+  if (volume < TOLERANCE*TOLERANCE)
+    libmesh_warning
+      ("Warning: trying to refine sliver element with volume " <<
+       volume << "!\n");
+
+  if (!volume_func)
+    return (volume > min_volume_target);
+
+  // If we do?
+  //
+  // See if we're meeting the local volume target at all the elem
+  // vertices first
+  for (auto v : make_range(elem.n_vertices()))
+    {
+      // If we have an auto volume function, we'll use it and override other volume options
+      const Real local_volume_target = (*volume_func)(elem.point(v));
+      libmesh_error_msg_if
+        (local_volume_target <= 0,
+         "Non-positive desired element volumes are unachievable");
+      if (volume > local_volume_target)
+        return true;
+    }
+
+  // If our vertices are happy, it's still possible that our interior
+  // isn't.  Are we allowed not to bother checking it?
+  if (!min_volume_target)
+    return false;
+
+  libmesh_not_implemented_msg
+    ("Combining a minimum desired_volume with an volume function isn't yet supported.");
+}
+
+std::size_t SimplexRefiner::refine_via_edges(Elem & elem)
+{
+  // Do we need to be refined for our own sake, or only if our
+  // neighbors were refined?
+
+  const bool should_refine = this->should_refine_elem(elem);
+
+  // We only currently handle coarse conforming meshes here.
+  // Uniformly refined meshes should be flattened before using this.
+  libmesh_assert_equal_to(elem.level(), 0u);
+
+  // Adding Tets or Tri6/Tri7 wouldn't be too much harder.  Quads or
+  // other elements will get tricky.
+  libmesh_assert_equal_to(elem.type(), TRI3);
+
+  int side_to_refine = 0;
+  Real length_to_refine = 0;
+  std::pair<Point *, Point *> vertices_to_refine;
+  for (int side : make_range(3))
+    {
+      std::pair<Point *, Point *> vertices
+        {elem.node_ptr((side+1)%3),
+         elem.node_ptr(side)};
+
+      if (vertices.first > vertices.second)
+        std::swap(vertices.first, vertices.second);
+
+      const auto sidevec = *vertices.first - *vertices.second;
+      Real length = sidevec.norm();
+      if (length > length_to_refine &&
+          (should_refine ||
+           new_nodes.find(vertices) != new_nodes.end()))
+        {
+          side_to_refine = side;
+          length_to_refine = length;
+          vertices_to_refine = vertices;
+        }
+    }
+
+  if (length_to_refine)
+    {
+      Node * midedge_node;
+      if (auto it = new_nodes.find(vertices_to_refine);
+          it != new_nodes.end())
+        {
+          midedge_node = it->second;
+        }
+      else
+        {
+          midedge_node =
+            _mesh.add_point((*vertices_to_refine.first +
+                             *vertices_to_refine.second)/2);
+          new_nodes[vertices_to_refine] = midedge_node;
+        }
+
+      constexpr int max_subelems = 2;
+      std::unique_ptr<Tri3> subelem[max_subelems];
+
+      std::vector<boundary_id_type> bc_ids;
+
+      // We'll switch(elem->type()) here eventually
+      subelem[0] = std::make_unique<Tri3>();
+      subelem[0]->set_node(0) = elem.node_ptr(side_to_refine);
+      subelem[0]->set_node(1) = midedge_node;
+      subelem[0]->set_node(2) = elem.node_ptr((side_to_refine+2)%3);
+
+      subelem[1] = std::make_unique<Tri3>();
+      subelem[1]->set_node(0) = elem.node_ptr((side_to_refine+2)%3);
+      subelem[1]->set_node(1) = midedge_node;
+      subelem[1]->set_node(2) = elem.node_ptr((side_to_refine+1)%3);
+
+      BoundaryInfo & boundary_info = _mesh.get_boundary_info();
+      boundary_info.boundary_ids(&elem, side_to_refine, bc_ids);
+      boundary_info.add_side(subelem[0].get(), 0, bc_ids);
+      boundary_info.add_side(subelem[1].get(), 1, bc_ids);
+      boundary_info.boundary_ids(&elem, (side_to_refine+1)%3, bc_ids);
+      boundary_info.add_side(subelem[1].get(), 2, bc_ids);
+      boundary_info.boundary_ids(&elem, (side_to_refine+2)%3, bc_ids);
+      boundary_info.add_side(subelem[0].get(), 2, bc_ids);
+
+      // Be sure the correct data is set for all subelems.
+      const unsigned int nei = elem.n_extra_integers();
+      for (unsigned int i=0; i != max_subelems; ++i)
+        if (subelem[i])
+          {
+            // We'd love to assert that we don't have a sliver here,
+            // but maybe our input had a sliver and we can't fix it.
+            libmesh_assert_greater_equal(subelem[i]->volume() + TOLERANCE,
+                                         elem.volume() / 2);
+            subelem[i]->processor_id() = elem.processor_id();
+            subelem[i]->subdomain_id() = elem.subdomain_id();
+
+            // Copy any extra element data.  Since the subelements
+            // haven't been added to the mesh yet any allocation has
+            // to be done manually.
+            subelem[i]->add_extra_integers(nei);
+            for (unsigned int ei=0; ei != nei; ++ei)
+              subelem[ei]->set_extra_integer(ei, elem.get_extra_integer(ei));
+
+            // Copy any mapping data.
+            subelem[i]->set_mapping_type(elem.mapping_type());
+            subelem[i]->set_mapping_data(elem.mapping_data());
+          }
+
+      boundary_info.remove(&elem);
+      if (!this->new_elements.empty() &&
+          &elem == this->new_elements.back().get())
+        this->new_elements.pop_back();
+      else
+        _mesh.delete_elem(&elem);
+
+      // We refined at least ourselves
+      std::size_t n_refined_elements = 1;
+
+      for (unsigned int i=0; i != max_subelems; ++i)
+        {
+          this->new_elements.push_back(std::move(subelem[i]));
+          n_refined_elements +=
+            this->refine_via_edges(*(this->new_elements.back()));
+        }
+
+      return n_refined_elements;
+    }
+
+  // We didn't refine anything
+  return 0;
+}
+
+
+
+std::size_t SimplexRefiner::refine_via_edges()
+{
+  this->new_nodes.clear();
+  this->new_elements.clear();
+
+  std::size_t refined_elements = 0;
+  std::size_t newly_refined_elements = 0;
+  do
+    {
+      newly_refined_elements = 0;
+      for (auto & elem : _mesh.local_element_ptr_range())
+        {
+          newly_refined_elements +=
+            this->refine_via_edges(*elem);
+        }
+      refined_elements += newly_refined_elements;
+      for (auto & elem : this->new_elements)
+        _mesh.add_elem(std::move(elem));
+      this->new_elements.clear();
+    }
+  while (newly_refined_elements);
+
+  return refined_elements;
+}
+
+
+
+void SimplexRefiner::set_desired_volume_function
+  (FunctionBase<Real> * desired)
+{
+  if (desired)
+    _desired_volume_func = desired->clone();
+  else
+    _desired_volume_func.reset();
+}
+
+
+
+FunctionBase<Real> * SimplexRefiner::get_desired_volume_function ()
+{
+  return _desired_volume_func.get();
+}
+
+
+} // namespace libMesh
+

--- a/src/mesh/stl_io.C
+++ b/src/mesh/stl_io.C
@@ -401,6 +401,10 @@ void STLIO::read_ascii (std::istream & file)
              "Found an 'endloop' line with no matching 'loop'.");
           in_vertex_loop = false;
 
+          if (triangle->volume() < TOLERANCE * TOLERANCE)
+            libmesh_warning
+              ("Warning: STL file contained sliver element with volume " <<
+               volume << "!\n");
           mesh.add_elem(std::move(triangle));
         }
     }
@@ -496,6 +500,10 @@ void STLIO::read_binary (std::istream & file,
     // 0, or sometimes triangle color.  Ignore it.
     file.read(ignored_buffer, 2);
 
+    if (triangle->volume() < TOLERANCE * TOLERANCE)
+      libmesh_warning
+        ("Warning: STL file contained sliver element with volume " <<
+         volume << "!\n");
     mesh.add_elem(std::move(triangle));
   }
 }

--- a/src/mesh/stl_io.C
+++ b/src/mesh/stl_io.C
@@ -44,6 +44,22 @@
 #include <regex>
 #endif
 
+namespace {
+
+void test_and_add(std::unique_ptr<libMesh::Elem> e,
+                  libMesh::MeshBase & mesh)
+{
+  const libMesh::Real volume = e->volume();
+  if (volume < libMesh::TOLERANCE * libMesh::TOLERANCE)
+    libmesh_warning
+      ("Warning: STL file contained sliver element with volume " <<
+       volume << "!\n");
+  mesh.add_elem(std::move(e));
+}
+
+}
+
+
 namespace libMesh
 {
 
@@ -401,11 +417,7 @@ void STLIO::read_ascii (std::istream & file)
              "Found an 'endloop' line with no matching 'loop'.");
           in_vertex_loop = false;
 
-          if (triangle->volume() < TOLERANCE * TOLERANCE)
-            libmesh_warning
-              ("Warning: STL file contained sliver element with volume " <<
-               volume << "!\n");
-          mesh.add_elem(std::move(triangle));
+          test_and_add(std::move(triangle), mesh);
         }
     }
 
@@ -500,11 +512,7 @@ void STLIO::read_binary (std::istream & file,
     // 0, or sometimes triangle color.  Ignore it.
     file.read(ignored_buffer, 2);
 
-    if (triangle->volume() < TOLERANCE * TOLERANCE)
-      libmesh_warning
-        ("Warning: STL file contained sliver element with volume " <<
-         volume << "!\n");
-    mesh.add_elem(std::move(triangle));
+    test_and_add(std::move(triangle), mesh);
   }
 }
 

--- a/src/mesh/stl_io.C
+++ b/src/mesh/stl_io.C
@@ -117,7 +117,10 @@ void STLIO::write (const std::string & fname)
                            "Tried to write a non-triangle to an STL file");
 
       auto n = (elem->point(1)-elem->point(0)).cross(elem->point(2)-elem->point(0));
-      n = n.unit();
+
+      // Other STL files have slivers, I guess ours can too
+      if (auto length = n.norm())
+        n /= length;
 
       out_stream << "facet normal " <<
         n(0) << ' ' <<

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -83,6 +83,7 @@ unit_tests_sources = \
   mesh/nodal_neighbors.C \
   mesh/libmesh_poly2tri.C \
   mesh/libmesh_netgen.C \
+  mesh/simplex_refinement_test.C \
   mesh/slit_mesh_test.C \
   mesh/spatial_dimension_test.C \
   mesh/mapped_subdomain_partitioner_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -215,8 +215,8 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/mesh_tet_test.C mesh/mesh_triangulation.C \
 	mesh/mixed_dim_mesh_test.C mesh/mixed_order_test.C \
 	mesh/nodal_neighbors.C mesh/libmesh_poly2tri.C \
-	mesh/libmesh_netgen.C mesh/slit_mesh_test.C \
-	mesh/spatial_dimension_test.C \
+	mesh/libmesh_netgen.C mesh/simplex_refinement_test.C \
+	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/write_elemset_data.C mesh/write_sideset_data.C \
 	mesh/write_nodeset_data.C mesh/write_edgeset_data.C \
@@ -318,6 +318,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	mesh/unit_tests_dbg-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_dbg-libmesh_poly2tri.$(OBJEXT) \
 	mesh/unit_tests_dbg-libmesh_netgen.$(OBJEXT) \
+	mesh/unit_tests_dbg-simplex_refinement_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-spatial_dimension_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.$(OBJEXT) \
@@ -413,8 +414,8 @@ am__unit_tests_devel_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/mesh_tet_test.C mesh/mesh_triangulation.C \
 	mesh/mixed_dim_mesh_test.C mesh/mixed_order_test.C \
 	mesh/nodal_neighbors.C mesh/libmesh_poly2tri.C \
-	mesh/libmesh_netgen.C mesh/slit_mesh_test.C \
-	mesh/spatial_dimension_test.C \
+	mesh/libmesh_netgen.C mesh/simplex_refinement_test.C \
+	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/write_elemset_data.C mesh/write_sideset_data.C \
 	mesh/write_nodeset_data.C mesh/write_edgeset_data.C \
@@ -515,6 +516,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	mesh/unit_tests_devel-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_devel-libmesh_poly2tri.$(OBJEXT) \
 	mesh/unit_tests_devel-libmesh_netgen.$(OBJEXT) \
+	mesh/unit_tests_devel-simplex_refinement_test.$(OBJEXT) \
 	mesh/unit_tests_devel-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_devel-spatial_dimension_test.$(OBJEXT) \
 	mesh/unit_tests_devel-mapped_subdomain_partitioner_test.$(OBJEXT) \
@@ -606,8 +608,8 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/mesh_tet_test.C mesh/mesh_triangulation.C \
 	mesh/mixed_dim_mesh_test.C mesh/mixed_order_test.C \
 	mesh/nodal_neighbors.C mesh/libmesh_poly2tri.C \
-	mesh/libmesh_netgen.C mesh/slit_mesh_test.C \
-	mesh/spatial_dimension_test.C \
+	mesh/libmesh_netgen.C mesh/simplex_refinement_test.C \
+	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/write_elemset_data.C mesh/write_sideset_data.C \
 	mesh/write_nodeset_data.C mesh/write_edgeset_data.C \
@@ -708,6 +710,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	mesh/unit_tests_oprof-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_oprof-libmesh_poly2tri.$(OBJEXT) \
 	mesh/unit_tests_oprof-libmesh_netgen.$(OBJEXT) \
+	mesh/unit_tests_oprof-simplex_refinement_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-spatial_dimension_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.$(OBJEXT) \
@@ -799,8 +802,8 @@ am__unit_tests_opt_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/mesh_tet_test.C mesh/mesh_triangulation.C \
 	mesh/mixed_dim_mesh_test.C mesh/mixed_order_test.C \
 	mesh/nodal_neighbors.C mesh/libmesh_poly2tri.C \
-	mesh/libmesh_netgen.C mesh/slit_mesh_test.C \
-	mesh/spatial_dimension_test.C \
+	mesh/libmesh_netgen.C mesh/simplex_refinement_test.C \
+	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/write_elemset_data.C mesh/write_sideset_data.C \
 	mesh/write_nodeset_data.C mesh/write_edgeset_data.C \
@@ -901,6 +904,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	mesh/unit_tests_opt-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_opt-libmesh_poly2tri.$(OBJEXT) \
 	mesh/unit_tests_opt-libmesh_netgen.$(OBJEXT) \
+	mesh/unit_tests_opt-simplex_refinement_test.$(OBJEXT) \
 	mesh/unit_tests_opt-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_opt-spatial_dimension_test.$(OBJEXT) \
 	mesh/unit_tests_opt-mapped_subdomain_partitioner_test.$(OBJEXT) \
@@ -992,8 +996,8 @@ am__unit_tests_prof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/mesh_tet_test.C mesh/mesh_triangulation.C \
 	mesh/mixed_dim_mesh_test.C mesh/mixed_order_test.C \
 	mesh/nodal_neighbors.C mesh/libmesh_poly2tri.C \
-	mesh/libmesh_netgen.C mesh/slit_mesh_test.C \
-	mesh/spatial_dimension_test.C \
+	mesh/libmesh_netgen.C mesh/simplex_refinement_test.C \
+	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/write_elemset_data.C mesh/write_sideset_data.C \
 	mesh/write_nodeset_data.C mesh/write_edgeset_data.C \
@@ -1094,6 +1098,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	mesh/unit_tests_prof-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_prof-libmesh_poly2tri.$(OBJEXT) \
 	mesh/unit_tests_prof-libmesh_netgen.$(OBJEXT) \
+	mesh/unit_tests_prof-simplex_refinement_test.$(OBJEXT) \
 	mesh/unit_tests_prof-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_prof-spatial_dimension_test.$(OBJEXT) \
 	mesh/unit_tests_prof-mapped_subdomain_partitioner_test.$(OBJEXT) \
@@ -1360,6 +1365,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mixed_order_test.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po \
+	mesh/$(DEPDIR)/unit_tests_dbg-simplex_refinement_test.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-spatial_dimension_test.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-write_edgeset_data.Po \
@@ -1397,6 +1403,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mixed_order_test.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po \
+	mesh/$(DEPDIR)/unit_tests_devel-simplex_refinement_test.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-spatial_dimension_test.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-write_edgeset_data.Po \
@@ -1434,6 +1441,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mixed_order_test.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po \
+	mesh/$(DEPDIR)/unit_tests_oprof-simplex_refinement_test.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-spatial_dimension_test.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-write_edgeset_data.Po \
@@ -1471,6 +1479,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mixed_order_test.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po \
+	mesh/$(DEPDIR)/unit_tests_opt-simplex_refinement_test.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-spatial_dimension_test.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-write_edgeset_data.Po \
@@ -1508,6 +1517,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mixed_order_test.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po \
+	mesh/$(DEPDIR)/unit_tests_prof-simplex_refinement_test.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-spatial_dimension_test.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-write_edgeset_data.Po \
@@ -2236,8 +2246,8 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 	mesh/mesh_tet_test.C mesh/mesh_triangulation.C \
 	mesh/mixed_dim_mesh_test.C mesh/mixed_order_test.C \
 	mesh/nodal_neighbors.C mesh/libmesh_poly2tri.C \
-	mesh/libmesh_netgen.C mesh/slit_mesh_test.C \
-	mesh/spatial_dimension_test.C \
+	mesh/libmesh_netgen.C mesh/simplex_refinement_test.C \
+	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/write_elemset_data.C mesh/write_sideset_data.C \
 	mesh/write_nodeset_data.C mesh/write_edgeset_data.C \
@@ -2602,6 +2612,8 @@ mesh/unit_tests_dbg-libmesh_poly2tri.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-libmesh_netgen.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_dbg-simplex_refinement_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-spatial_dimension_test.$(OBJEXT):  \
@@ -2890,6 +2902,8 @@ mesh/unit_tests_devel-libmesh_poly2tri.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-libmesh_netgen.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_devel-simplex_refinement_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-spatial_dimension_test.$(OBJEXT):  \
@@ -3130,6 +3144,8 @@ mesh/unit_tests_oprof-libmesh_poly2tri.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-libmesh_netgen.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_oprof-simplex_refinement_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-spatial_dimension_test.$(OBJEXT):  \
@@ -3370,6 +3386,8 @@ mesh/unit_tests_opt-libmesh_poly2tri.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-libmesh_netgen.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_opt-simplex_refinement_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-spatial_dimension_test.$(OBJEXT):  \
@@ -3610,6 +3628,8 @@ mesh/unit_tests_prof-libmesh_poly2tri.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-libmesh_netgen.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_prof-simplex_refinement_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-spatial_dimension_test.$(OBJEXT):  \
@@ -3941,6 +3961,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mixed_order_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-simplex_refinement_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-spatial_dimension_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-write_edgeset_data.Po@am__quote@ # am--include-marker
@@ -3978,6 +3999,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mixed_order_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-simplex_refinement_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-spatial_dimension_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-write_edgeset_data.Po@am__quote@ # am--include-marker
@@ -4015,6 +4037,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mixed_order_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-simplex_refinement_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-spatial_dimension_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-write_edgeset_data.Po@am__quote@ # am--include-marker
@@ -4052,6 +4075,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mixed_order_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-simplex_refinement_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-spatial_dimension_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-write_edgeset_data.Po@am__quote@ # am--include-marker
@@ -4089,6 +4113,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mixed_order_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-simplex_refinement_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-spatial_dimension_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-write_edgeset_data.Po@am__quote@ # am--include-marker
@@ -5196,6 +5221,20 @@ mesh/unit_tests_dbg-libmesh_netgen.obj: mesh/libmesh_netgen.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/libmesh_netgen.C' object='mesh/unit_tests_dbg-libmesh_netgen.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-libmesh_netgen.obj `if test -f 'mesh/libmesh_netgen.C'; then $(CYGPATH_W) 'mesh/libmesh_netgen.C'; else $(CYGPATH_W) '$(srcdir)/mesh/libmesh_netgen.C'; fi`
+
+mesh/unit_tests_dbg-simplex_refinement_test.o: mesh/simplex_refinement_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-simplex_refinement_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-simplex_refinement_test.Tpo -c -o mesh/unit_tests_dbg-simplex_refinement_test.o `test -f 'mesh/simplex_refinement_test.C' || echo '$(srcdir)/'`mesh/simplex_refinement_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-simplex_refinement_test.Tpo mesh/$(DEPDIR)/unit_tests_dbg-simplex_refinement_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/simplex_refinement_test.C' object='mesh/unit_tests_dbg-simplex_refinement_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-simplex_refinement_test.o `test -f 'mesh/simplex_refinement_test.C' || echo '$(srcdir)/'`mesh/simplex_refinement_test.C
+
+mesh/unit_tests_dbg-simplex_refinement_test.obj: mesh/simplex_refinement_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-simplex_refinement_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-simplex_refinement_test.Tpo -c -o mesh/unit_tests_dbg-simplex_refinement_test.obj `if test -f 'mesh/simplex_refinement_test.C'; then $(CYGPATH_W) 'mesh/simplex_refinement_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/simplex_refinement_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-simplex_refinement_test.Tpo mesh/$(DEPDIR)/unit_tests_dbg-simplex_refinement_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/simplex_refinement_test.C' object='mesh/unit_tests_dbg-simplex_refinement_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-simplex_refinement_test.obj `if test -f 'mesh/simplex_refinement_test.C'; then $(CYGPATH_W) 'mesh/simplex_refinement_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/simplex_refinement_test.C'; fi`
 
 mesh/unit_tests_dbg-slit_mesh_test.o: mesh/slit_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-slit_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Tpo -c -o mesh/unit_tests_dbg-slit_mesh_test.o `test -f 'mesh/slit_mesh_test.C' || echo '$(srcdir)/'`mesh/slit_mesh_test.C
@@ -6807,6 +6846,20 @@ mesh/unit_tests_devel-libmesh_netgen.obj: mesh/libmesh_netgen.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-libmesh_netgen.obj `if test -f 'mesh/libmesh_netgen.C'; then $(CYGPATH_W) 'mesh/libmesh_netgen.C'; else $(CYGPATH_W) '$(srcdir)/mesh/libmesh_netgen.C'; fi`
 
+mesh/unit_tests_devel-simplex_refinement_test.o: mesh/simplex_refinement_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-simplex_refinement_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-simplex_refinement_test.Tpo -c -o mesh/unit_tests_devel-simplex_refinement_test.o `test -f 'mesh/simplex_refinement_test.C' || echo '$(srcdir)/'`mesh/simplex_refinement_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-simplex_refinement_test.Tpo mesh/$(DEPDIR)/unit_tests_devel-simplex_refinement_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/simplex_refinement_test.C' object='mesh/unit_tests_devel-simplex_refinement_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-simplex_refinement_test.o `test -f 'mesh/simplex_refinement_test.C' || echo '$(srcdir)/'`mesh/simplex_refinement_test.C
+
+mesh/unit_tests_devel-simplex_refinement_test.obj: mesh/simplex_refinement_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-simplex_refinement_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-simplex_refinement_test.Tpo -c -o mesh/unit_tests_devel-simplex_refinement_test.obj `if test -f 'mesh/simplex_refinement_test.C'; then $(CYGPATH_W) 'mesh/simplex_refinement_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/simplex_refinement_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-simplex_refinement_test.Tpo mesh/$(DEPDIR)/unit_tests_devel-simplex_refinement_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/simplex_refinement_test.C' object='mesh/unit_tests_devel-simplex_refinement_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-simplex_refinement_test.obj `if test -f 'mesh/simplex_refinement_test.C'; then $(CYGPATH_W) 'mesh/simplex_refinement_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/simplex_refinement_test.C'; fi`
+
 mesh/unit_tests_devel-slit_mesh_test.o: mesh/slit_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-slit_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Tpo -c -o mesh/unit_tests_devel-slit_mesh_test.o `test -f 'mesh/slit_mesh_test.C' || echo '$(srcdir)/'`mesh/slit_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po
@@ -8416,6 +8469,20 @@ mesh/unit_tests_oprof-libmesh_netgen.obj: mesh/libmesh_netgen.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/libmesh_netgen.C' object='mesh/unit_tests_oprof-libmesh_netgen.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-libmesh_netgen.obj `if test -f 'mesh/libmesh_netgen.C'; then $(CYGPATH_W) 'mesh/libmesh_netgen.C'; else $(CYGPATH_W) '$(srcdir)/mesh/libmesh_netgen.C'; fi`
+
+mesh/unit_tests_oprof-simplex_refinement_test.o: mesh/simplex_refinement_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-simplex_refinement_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-simplex_refinement_test.Tpo -c -o mesh/unit_tests_oprof-simplex_refinement_test.o `test -f 'mesh/simplex_refinement_test.C' || echo '$(srcdir)/'`mesh/simplex_refinement_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-simplex_refinement_test.Tpo mesh/$(DEPDIR)/unit_tests_oprof-simplex_refinement_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/simplex_refinement_test.C' object='mesh/unit_tests_oprof-simplex_refinement_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-simplex_refinement_test.o `test -f 'mesh/simplex_refinement_test.C' || echo '$(srcdir)/'`mesh/simplex_refinement_test.C
+
+mesh/unit_tests_oprof-simplex_refinement_test.obj: mesh/simplex_refinement_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-simplex_refinement_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-simplex_refinement_test.Tpo -c -o mesh/unit_tests_oprof-simplex_refinement_test.obj `if test -f 'mesh/simplex_refinement_test.C'; then $(CYGPATH_W) 'mesh/simplex_refinement_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/simplex_refinement_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-simplex_refinement_test.Tpo mesh/$(DEPDIR)/unit_tests_oprof-simplex_refinement_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/simplex_refinement_test.C' object='mesh/unit_tests_oprof-simplex_refinement_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-simplex_refinement_test.obj `if test -f 'mesh/simplex_refinement_test.C'; then $(CYGPATH_W) 'mesh/simplex_refinement_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/simplex_refinement_test.C'; fi`
 
 mesh/unit_tests_oprof-slit_mesh_test.o: mesh/slit_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-slit_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Tpo -c -o mesh/unit_tests_oprof-slit_mesh_test.o `test -f 'mesh/slit_mesh_test.C' || echo '$(srcdir)/'`mesh/slit_mesh_test.C
@@ -10027,6 +10094,20 @@ mesh/unit_tests_opt-libmesh_netgen.obj: mesh/libmesh_netgen.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-libmesh_netgen.obj `if test -f 'mesh/libmesh_netgen.C'; then $(CYGPATH_W) 'mesh/libmesh_netgen.C'; else $(CYGPATH_W) '$(srcdir)/mesh/libmesh_netgen.C'; fi`
 
+mesh/unit_tests_opt-simplex_refinement_test.o: mesh/simplex_refinement_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-simplex_refinement_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-simplex_refinement_test.Tpo -c -o mesh/unit_tests_opt-simplex_refinement_test.o `test -f 'mesh/simplex_refinement_test.C' || echo '$(srcdir)/'`mesh/simplex_refinement_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-simplex_refinement_test.Tpo mesh/$(DEPDIR)/unit_tests_opt-simplex_refinement_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/simplex_refinement_test.C' object='mesh/unit_tests_opt-simplex_refinement_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-simplex_refinement_test.o `test -f 'mesh/simplex_refinement_test.C' || echo '$(srcdir)/'`mesh/simplex_refinement_test.C
+
+mesh/unit_tests_opt-simplex_refinement_test.obj: mesh/simplex_refinement_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-simplex_refinement_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-simplex_refinement_test.Tpo -c -o mesh/unit_tests_opt-simplex_refinement_test.obj `if test -f 'mesh/simplex_refinement_test.C'; then $(CYGPATH_W) 'mesh/simplex_refinement_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/simplex_refinement_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-simplex_refinement_test.Tpo mesh/$(DEPDIR)/unit_tests_opt-simplex_refinement_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/simplex_refinement_test.C' object='mesh/unit_tests_opt-simplex_refinement_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-simplex_refinement_test.obj `if test -f 'mesh/simplex_refinement_test.C'; then $(CYGPATH_W) 'mesh/simplex_refinement_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/simplex_refinement_test.C'; fi`
+
 mesh/unit_tests_opt-slit_mesh_test.o: mesh/slit_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-slit_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Tpo -c -o mesh/unit_tests_opt-slit_mesh_test.o `test -f 'mesh/slit_mesh_test.C' || echo '$(srcdir)/'`mesh/slit_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po
@@ -11637,6 +11718,20 @@ mesh/unit_tests_prof-libmesh_netgen.obj: mesh/libmesh_netgen.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-libmesh_netgen.obj `if test -f 'mesh/libmesh_netgen.C'; then $(CYGPATH_W) 'mesh/libmesh_netgen.C'; else $(CYGPATH_W) '$(srcdir)/mesh/libmesh_netgen.C'; fi`
 
+mesh/unit_tests_prof-simplex_refinement_test.o: mesh/simplex_refinement_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-simplex_refinement_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-simplex_refinement_test.Tpo -c -o mesh/unit_tests_prof-simplex_refinement_test.o `test -f 'mesh/simplex_refinement_test.C' || echo '$(srcdir)/'`mesh/simplex_refinement_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-simplex_refinement_test.Tpo mesh/$(DEPDIR)/unit_tests_prof-simplex_refinement_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/simplex_refinement_test.C' object='mesh/unit_tests_prof-simplex_refinement_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-simplex_refinement_test.o `test -f 'mesh/simplex_refinement_test.C' || echo '$(srcdir)/'`mesh/simplex_refinement_test.C
+
+mesh/unit_tests_prof-simplex_refinement_test.obj: mesh/simplex_refinement_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-simplex_refinement_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-simplex_refinement_test.Tpo -c -o mesh/unit_tests_prof-simplex_refinement_test.obj `if test -f 'mesh/simplex_refinement_test.C'; then $(CYGPATH_W) 'mesh/simplex_refinement_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/simplex_refinement_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-simplex_refinement_test.Tpo mesh/$(DEPDIR)/unit_tests_prof-simplex_refinement_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/simplex_refinement_test.C' object='mesh/unit_tests_prof-simplex_refinement_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-simplex_refinement_test.obj `if test -f 'mesh/simplex_refinement_test.C'; then $(CYGPATH_W) 'mesh/simplex_refinement_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/simplex_refinement_test.C'; fi`
+
 mesh/unit_tests_prof-slit_mesh_test.o: mesh/slit_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-slit_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Tpo -c -o mesh/unit_tests_prof-slit_mesh_test.o `test -f 'mesh/slit_mesh_test.C' || echo '$(srcdir)/'`mesh/slit_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po
@@ -12959,6 +13054,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mixed_order_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-simplex_refinement_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_edgeset_data.Po
@@ -12996,6 +13092,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mixed_order_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_devel-simplex_refinement_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_edgeset_data.Po
@@ -13033,6 +13130,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mixed_order_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-simplex_refinement_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_edgeset_data.Po
@@ -13070,6 +13168,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mixed_order_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_opt-simplex_refinement_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_edgeset_data.Po
@@ -13107,6 +13206,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mixed_order_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_prof-simplex_refinement_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_edgeset_data.Po
@@ -13581,6 +13681,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mixed_order_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-simplex_refinement_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_edgeset_data.Po
@@ -13618,6 +13719,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mixed_order_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_devel-simplex_refinement_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_edgeset_data.Po
@@ -13655,6 +13757,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mixed_order_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-simplex_refinement_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_edgeset_data.Po
@@ -13692,6 +13795,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mixed_order_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_opt-simplex_refinement_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_edgeset_data.Po
@@ -13729,6 +13833,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mixed_order_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_prof-simplex_refinement_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-spatial_dimension_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_edgeset_data.Po

--- a/tests/mesh/simplex_refinement_test.C
+++ b/tests/mesh/simplex_refinement_test.C
@@ -1,0 +1,83 @@
+#include <libmesh/boundary_info.h>
+#include <libmesh/elem.h>
+#include <libmesh/mesh.h>
+#include <libmesh/mesh_generation.h>
+#include <libmesh/mesh_tools.h>
+#include <libmesh/parallel_implementation.h> // max()
+#include <libmesh/simplex_refiner.h>
+
+#include "test_comm.h"
+#include "libmesh_cppunit.h"
+
+#include <cmath>
+
+
+using namespace libMesh;
+
+
+class SimplexRefinementTest : public CppUnit::TestCase
+{
+  /**
+   * The goal of this test is to verify proper operation of the
+   * interfaces to tetrahedralization libraries
+   */
+public:
+  LIBMESH_CPPUNIT_TEST_SUITE( SimplexRefinementTest );
+
+  CPPUNIT_TEST( testTriRefinement );
+  CPPUNIT_TEST( test3DTriRefinement );
+
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp() {}
+
+  void tearDown() {}
+
+  void testRefinement(UnstructuredMesh & mesh,
+                      Real desired_measure,
+                      Real expected_total_measure)
+  {
+    SimplexRefiner simplex_refiner(mesh);
+    simplex_refiner.desired_volume() = desired_measure;
+
+    simplex_refiner.refine_elements();
+
+    Real total_measure = 0;
+    for (const Elem * elem : mesh.local_element_ptr_range())
+      {
+        Real measure = elem->volume();
+        CPPUNIT_ASSERT_LESSEQUAL(desired_measure, measure);
+        total_measure += measure;
+      }
+
+    TestCommWorld->sum(total_measure);
+    LIBMESH_ASSERT_FP_EQUAL(total_measure, expected_total_measure,
+                            TOLERANCE*TOLERANCE);
+  }
+
+
+  void testTriRefinement()
+  {
+    Mesh trimesh(*TestCommWorld);
+
+    MeshTools::Generation::build_square (trimesh, 2, 2,
+                                         0.0, 2.0, 0.0, 2.0, TRI3);
+
+    testRefinement(trimesh, 0.05, 4);
+  }
+
+
+  void test3DTriRefinement()
+  {
+    Mesh trimesh(*TestCommWorld);
+
+    MeshTools::Generation::surface_octahedron
+      (trimesh, -1, 1, -1, 1, -1, 1);
+
+    testRefinement(trimesh, 0.05, 4*std::sqrt(Real(3)));
+  }
+};
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION( SimplexRefinementTest );


### PR DESCRIPTION
Playing around with STL files revealed how many of them are good at capturing a geometry with the fewest triangles possible, which is good for file size but not good for constructing a good tetrahedralization.  This lets us fix that, and is the first step toward doing similar things on tets directly.