### PR TITLE
Normal normals

### DIFF
--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -664,7 +664,7 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
     {
     case 1:
       {
-        // A 1D finite element, currently assumed to be in 1D space
+        // A 1D finite element, potentially in 2D or 3D space.
         // This means the boundary is a "0D finite element", a
         // NODEELEM.
 
@@ -690,12 +690,18 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
         if (calculate_dxyz)
           {
             if (side->node_id(0) == elem->node_id(0))
-              normals[0] = Point(-1.);
+              {
+                const Point reference_point = Point(-1.);
+                Point dx_dxi = FEMap::map_deriv (1, elem, 0, reference_point);
+                normals[0] = -dx_dxi.unit();
+              }
             else
               {
                 libmesh_assert_equal_to (side->node_id(0),
                                          elem->node_id(1));
-                normals[0] = Point(1.);
+                const Point reference_point = Point(1.);
+                Point dx_dxi = FEMap::map_deriv (1, elem, 0, reference_point);
+                normals[0] = dx_dxi.unit();
               }
           }
 

--- a/tests/fe/fe_side_test.C
+++ b/tests/fe/fe_side_test.C
@@ -199,6 +199,8 @@ public:
       auto normals = this->_fe_side->get_normals();
       CPPUNIT_ASSERT_EQUAL(n_qp, normals.size());
 
+      const Point c =  this->_elem->vertex_average();
+
       for (auto qp : index_range(dphi[0]))
         {
           Gradient grad_u = 0;
@@ -206,6 +208,17 @@ public:
             grad_u += dphi[d][qp] * (*this->_sys->current_local_solution)(this->_dof_indices[d]);
 
           const Point p = xyz[qp];
+          const Point n = normals[qp];
+
+          // All our normals should be unit normals.
+          LIBMESH_ASSERT_FP_EQUAL(Real(n.norm()),
+                                  Real(1),
+                                  this->_grad_tol);
+
+          // All our normals should be outward-facing.  For the simple
+          // meshes here this is sufficient to make sure they're not
+          // flipped:
+          CPPUNIT_ASSERT_GREATER(Real(0), (p-c)*n);
 
           // We can only trust the tangential component of gradient to
           // match!  The gradient in the normal direction should be 0
@@ -213,7 +226,6 @@ public:
           // transformation, and could be just about anything for a
           // skew transformation (as occurs when we build meshes with
           // triangles, tets, prisms, pyramids...)
-          Point n = normals[qp];
 
           const Gradient tangential_grad_u = grad_u - ((grad_u * n) * n);
 

--- a/tests/fe/fe_side_test.C
+++ b/tests/fe/fe_side_test.C
@@ -49,6 +49,13 @@ public:
   {
     FETestBase<order,family,elem_type,N_x>::setUp();
 
+    // If we're a 2D mesh on a 3D libMesh build we should be able to
+    // handle inverted elements just fine.  Let's test that.
+    BoundaryInfo & bdy_info = this->_mesh->get_boundary_info();
+    for (auto e : this->_mesh->element_ptr_range())
+      if (!(e->id() % 3) && e->dim() < LIBMESH_DIM)
+        e->flip(&bdy_info);
+
     FEType fe_type = this->_sys->variable_type(0);
     _fe_side = FEBase::build(this->_dim, fe_type);
 


### PR DESCRIPTION
A user suggested that they might have seen normal vectors inverted on a flipped Tri element.  I couldn't reproduce that, but I *did* see normal vectors inverted on a flipped Edge element.  This PR fixes that, and adds more unit tests to make sure such a gross error shouldn't recur.  More subtle potential errors are going to need more subtle tests at some point.