### PR TITLE
Error in opt mode for HIERARCHIC p=0

### DIFF
--- a/src/fe/fe_hierarchic_shape_1D.C
+++ b/src/fe/fe_hierarchic_shape_1D.C
@@ -428,11 +428,15 @@ namespace
 using namespace libMesh;
 
 Real fe_hierarchic_1D_shape(const ElemType,
-                            const Order libmesh_dbg_var(order),
+                            const Order order,
                             const unsigned int i,
                             const Point & p)
 {
   libmesh_assert_less (i, order+1u);
+
+  // If we were to define p=0 here, it wouldn't be hierarchic
+  libmesh_error_msg_if (order <= 0,
+                        "HIERARCHIC FE families do not support p=0");
 
   // Declare that we are using our own special power function
   // from the Utility namespace.  This saves typing later.
@@ -495,15 +499,18 @@ Real fe_hierarchic_1D_shape(const ElemType,
 
 
 Real fe_hierarchic_1D_shape_deriv(const ElemType,
-                                  const Order libmesh_dbg_var(order),
+                                  const Order order,
                                   const unsigned int i,
                                   const unsigned int libmesh_dbg_var(j),
                                   const Point & p)
 {
   // only d()/dxi in 1D!
-
   libmesh_assert_equal_to (j, 0);
   libmesh_assert_less (i, order+1u);
+
+  // If we were to define p=0 here, it wouldn't be hierarchic
+  libmesh_error_msg_if (order <= 0,
+                        "HIERARCHIC FE families do not support p=0");
 
   // Declare that we are using our own special power function
   // from the Utility namespace.  This saves typing later.
@@ -567,15 +574,18 @@ Real fe_hierarchic_1D_shape_deriv(const ElemType,
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 Real fe_hierarchic_1D_shape_second_deriv(const ElemType,
-                                         const Order libmesh_dbg_var(order),
+                                         const Order order,
                                          const unsigned int i,
                                          const unsigned int libmesh_dbg_var(j),
                                          const Point & p)
 {
   // only d2()/d2xi in 1D!
-
   libmesh_assert_equal_to (j, 0);
   libmesh_assert_less (i, order+1u);
+
+  // If we were to define p=0 here, it wouldn't be hierarchic
+  libmesh_error_msg_if (order <= 0,
+                        "HIERARCHIC FE families do not support p=0");
 
   // Declare that we are using our own special power function
   // from the Utility namespace.  This saves typing later.


### PR DESCRIPTION
We can't support constants and still have a hierarchic basis that can potentially be C0 ... but application users can typically request a p=0 `L2_HIERARCHIC` basis and we really need to put a stop to that *before* we hand back the i=1 `FIRST` basis function and let them get incorrect results.