### PR TITLE
Optimize optional RB-EIM data storage

### DIFF
--- a/contrib/capnproto/rb_data.capnp
+++ b/contrib/capnproto/rb_data.capnp
@@ -40,6 +40,11 @@ struct Point3D @0xde7dfcf8ecccaa90 {
   z @2 :Real;
 }
 
+struct IntPair @0xa9e786708685aed5 {
+  first  @0 :Integer;
+  second @1 :Integer;
+}
+
 struct RBSCMEvaluation @0xb8dd038628a64b16 {
   parameterRanges    @0 :ParameterRanges;
   discreteParameters @1 :DiscreteParameterList;
@@ -133,6 +138,8 @@ struct RBEIMEvaluationReal @0xf8121d2237427a80 {
   interpolationDxyzDxiElem    @23 :List(Point3D);
   interpolationDxyzDetaElem   @24 :List(Point3D);
   interpolationDxyzDzetaElem  @25 :List(Point3D);
+  nElems                      @26 :Integer;
+  elemIdToLocalIndex          @27 :List(IntPair);
 }
 struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   nBfs                        @0  :Integer;
@@ -161,4 +168,6 @@ struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   interpolationDxyzDxiElem    @23 :List(Point3D);
   interpolationDxyzDetaElem   @24 :List(Point3D);
   interpolationDxyzDzetaElem  @25 :List(Point3D);
+  nElems                      @26 :Integer;
+  elemIdToLocalIndex          @27 :List(IntPair);
 }

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -214,6 +214,11 @@ public:
   unsigned int get_n_interpolation_points() const;
 
   /**
+   * Return the number of unique elements containing interpolation points
+   */
+  unsigned int get_n_elems() const;
+
+  /**
    * Set the number of basis functions. Useful when reading in
    * stored data.
    */
@@ -447,6 +452,7 @@ public:
   void add_elem_center_dxyzdxi(const Point & dxyzdxi);
   void add_elem_center_dxyzdeta(const Point & dxyzdxi);
   void add_interpolation_points_spatial_indices(const std::vector<unsigned int> & spatial_indices);
+  void add_elem_id_local_index_map_entry(dof_id_type elem_id, unsigned int local_index);
 
   /**
    * Get the data associated with EIM interpolation points.
@@ -468,6 +474,7 @@ public:
   const Point & get_elem_center_dxyzdxi(unsigned int index) const;
   const Point & get_elem_center_dxyzdeta(unsigned int index) const;
   const std::vector<unsigned int> & get_interpolation_points_spatial_indices(unsigned int index) const;
+  const std::map<dof_id_type, unsigned int> & get_elem_id_to_local_index_map() const;
 
   /**
    * _interpolation_points_spatial_indices is optional data, so we need to be able to

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -81,6 +81,11 @@ struct VectorizedEvalInput
   std::vector<boundary_id_type> boundary_ids;
   std::vector<dof_id_type> node_ids;
   std::vector<ElemType> elem_types;
+  /**
+   * The following containers are indexed by element id to avoid duplicated data.
+   * The elements have a local indexing as elem_ids might not always be contiguous.
+   */
+  std::map<dof_id_type, unsigned int> elem_id_to_local_index;
   std::vector<std::vector<Real>> JxW_all_qp;
   std::vector<std::vector<std::vector<Real>>> phi_i_all_qp;
   std::vector<Point> dxyzdxi_elem_center;

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -850,6 +850,24 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
       }
   }
 
+  unsigned int n_elems = rb_eim_evaluation_reader.getNElems();
+  // Elem id to local index map
+  {
+    auto elem_id_to_local_index_list =
+      rb_eim_evaluation_reader.getElemIdToLocalIndex();
+
+    if (elem_id_to_local_index_list.size() > 0)
+      {
+        libmesh_error_msg_if(elem_id_to_local_index_list.size() != n_elems,
+                             "Size error while reading the eim elem id to local index map.");
+
+        for (unsigned int i=0; i<n_elems; ++i)
+          {
+            rb_eim_evaluation.add_elem_id_local_index_map_entry(elem_id_to_local_index_list[i].getFirst(), elem_id_to_local_index_list[i].getSecond());
+          }
+      }
+  }
+
   // Interpolation points JxW all qp values
   {
     auto interpolation_points_list_outer =
@@ -857,10 +875,10 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
 
     if (interpolation_points_list_outer.size() > 0)
       {
-        libmesh_error_msg_if(interpolation_points_list_outer.size() != n_bfs,
-                            "Size error while reading the eim JxW values.");
+        libmesh_error_msg_if(interpolation_points_list_outer.size() != n_elems,
+                             "Size error while reading the eim JxW values.");
 
-        for (unsigned int i=0; i<n_bfs; ++i)
+        for (unsigned int i=0; i<n_elems; ++i)
           {
             auto interpolation_points_list_inner = interpolation_points_list_outer[i];
 
@@ -881,10 +899,10 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
 
     if (interpolation_points_list_outer.size() > 0)
       {
-        libmesh_error_msg_if(interpolation_points_list_outer.size() != n_bfs,
-                            "Size error while reading the eim phi_i all qp values.");
+        libmesh_error_msg_if(interpolation_points_list_outer.size() != n_elems,
+                             "Size error while reading the eim phi_i all qp values.");
 
-        for (unsigned int i=0; i<n_bfs; ++i)
+        for (unsigned int i=0; i<n_elems; ++i)
           {
             auto interpolation_points_list_middle = interpolation_points_list_outer[i];
 
@@ -909,11 +927,11 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
 
     if (elem_center_dxyzdxi.size() > 0)
       {
-        libmesh_error_msg_if(elem_center_dxyzdxi.size() != n_bfs,
-                             "Size error while reading the eim interpolation points.");
+        libmesh_error_msg_if(elem_center_dxyzdxi.size() != n_elems,
+                             "Size error while reading the eim elem center tangent derivative dxyzdxi.");
 
         Point dxyzdxi_buffer;
-        for (const auto i : make_range(n_bfs))
+        for (const auto i : make_range(n_elems))
           {
             load_point(elem_center_dxyzdxi[i], dxyzdxi_buffer);
             rb_eim_evaluation.add_elem_center_dxyzdxi(dxyzdxi_buffer);
@@ -928,11 +946,11 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
 
     if (elem_center_dxyzdeta.size() > 0)
       {
-        libmesh_error_msg_if(elem_center_dxyzdeta.size() != n_bfs,
-                             "Size error while reading the eim interpolation points.");
+        libmesh_error_msg_if(elem_center_dxyzdeta.size() != n_elems,
+                             "Size error while reading the eim elem center tangent derivative dxyzdeta.");
 
         Point dxyzdeta_buffer;
-        for (const auto i : make_range(n_bfs))
+        for (const auto i : make_range(n_elems))
           {
             load_point(elem_center_dxyzdeta[i], dxyzdeta_buffer);
             rb_eim_evaluation.add_elem_center_dxyzdeta(dxyzdeta_buffer);
@@ -947,10 +965,10 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
 
     if (interpolation_points_qrule_order_list.size() > 0)
       {
-        libmesh_error_msg_if(interpolation_points_qrule_order_list.size() != n_bfs,
-                            "Size error while reading the eim interpolation element types.");
+        libmesh_error_msg_if(interpolation_points_qrule_order_list.size() != n_elems,
+                             "Size error while reading the eim elem qrule order.");
 
-        for (unsigned int i=0; i<n_bfs; ++i)
+        for (unsigned int i=0; i<n_elems; ++i)
           {
             rb_eim_evaluation.add_interpolation_points_qrule_order(static_cast<Order>(interpolation_points_qrule_order_list[i]));
           }
@@ -965,7 +983,7 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
     if (interpolation_points_elem_type_list.size() > 0)
       {
         libmesh_error_msg_if(interpolation_points_elem_type_list.size() != n_bfs,
-                            "Size error while reading the eim interpolation element types.");
+                             "Size error while reading the eim interpolation element types.");
 
         for (unsigned int i=0; i<n_bfs; ++i)
           {

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -740,11 +740,26 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
       }
   }
 
+  unsigned int n_elems = rb_eim_evaluation.get_n_elems();
+  rb_eim_evaluation_builder.setNElems(n_elems);
+  // Elem id to local index map
+  {
+    auto elem_id_to_local_index_list =
+      rb_eim_evaluation_builder.initElemIdToLocalIndex(n_elems);
+    unsigned int counter = 0;
+    for (auto const & [elem_id, local_index] : rb_eim_evaluation.get_elem_id_to_local_index_map())
+      {
+        elem_id_to_local_index_list[counter].setFirst(elem_id);
+        elem_id_to_local_index_list[counter].setSecond(local_index);
+        counter++;
+      }
+  }
+
   // Interpolation points JxW values at each qp
   {
     auto interpolation_points_list_outer =
-      rb_eim_evaluation_builder.initInterpolationJxWAllQp(n_bfs);
-    for (unsigned int i=0; i < n_bfs; ++i)
+      rb_eim_evaluation_builder.initInterpolationJxWAllQp(n_elems);
+    for (unsigned int i=0; i < n_elems; ++i)
       {
         const std::vector<Real> & JxW = rb_eim_evaluation.get_interpolation_points_JxW_all_qp(i);
         auto interpolation_points_list_inner = interpolation_points_list_outer.init(i, JxW.size());
@@ -761,9 +776,9 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
   // Interpolation points phi values at each qp
   {
     auto interpolation_points_list_outer =
-      rb_eim_evaluation_builder.initInterpolationPhiValuesAllQp(n_bfs);
+      rb_eim_evaluation_builder.initInterpolationPhiValuesAllQp(n_elems);
 
-    for (unsigned int i=0; i < n_bfs; ++i)
+    for (unsigned int i=0; i < n_elems; ++i)
       {
         const auto & phi_i_all_qp = rb_eim_evaluation.get_interpolation_points_phi_i_all_qp(i);
         auto interpolation_points_list_middle = interpolation_points_list_outer.init(i, phi_i_all_qp.size());
@@ -781,8 +796,8 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
   // Dxyzdxi at the element center for the element that contains each interpolation point.
   {
     auto dxyzdxi_elem_center =
-      rb_eim_evaluation_builder.initInterpolationDxyzDxiElem(n_bfs);
-    for (auto i : make_range(n_bfs))
+      rb_eim_evaluation_builder.initInterpolationDxyzDxiElem(n_elems);
+    for (auto i : make_range(n_elems))
       {
         add_point_to_builder(rb_eim_evaluation.get_elem_center_dxyzdxi(i), dxyzdxi_elem_center[i]);
       }
@@ -791,8 +806,8 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
   // Dxyzdeta at the element center for the element that contains each interpolation point.
   {
     auto dxyzdeta_elem_center =
-      rb_eim_evaluation_builder.initInterpolationDxyzDetaElem(n_bfs);
-    for (auto i : make_range(n_bfs))
+      rb_eim_evaluation_builder.initInterpolationDxyzDetaElem(n_elems);
+    for (auto i : make_range(n_elems))
       {
         add_point_to_builder(rb_eim_evaluation.get_elem_center_dxyzdeta(i), dxyzdeta_elem_center[i]);
       }
@@ -801,8 +816,8 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
   // Quadrature rule order associated to the element that contains each interpolation point.
   {
     auto interpolation_points_qrule_order_list =
-      rb_eim_evaluation_builder.initInterpolationQruleOrder(n_bfs);
-    for (unsigned int i=0; i<n_bfs; ++i)
+      rb_eim_evaluation_builder.initInterpolationQruleOrder(n_elems);
+    for (unsigned int i=0; i<n_elems; ++i)
       interpolation_points_qrule_order_list.set(i,
                                                 rb_eim_evaluation.get_interpolation_points_qrule_order(i));
   }

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -317,6 +317,11 @@ unsigned int RBEIMEvaluation::get_n_interpolation_points() const
   return _vec_eval_input.all_xyz.size();
 }
 
+unsigned int RBEIMEvaluation::get_n_elems() const
+{
+  return _vec_eval_input.elem_id_to_local_index.size();
+}
+
 void RBEIMEvaluation::set_n_basis_functions(unsigned int n_bfs)
 {
   if (get_parametrized_function().on_mesh_sides())
@@ -780,6 +785,13 @@ void RBEIMEvaluation::add_interpolation_points_spatial_indices(const std::vector
   _interpolation_points_spatial_indices.emplace_back(spatial_indices);
 }
 
+void RBEIMEvaluation::add_elem_id_local_index_map_entry(dof_id_type elem_id, unsigned int local_index)
+{
+  libmesh_error_msg_if(_vec_eval_input.elem_id_to_local_index.count(elem_id) == 1, "Entry already added, duplicate detected.");
+
+  _vec_eval_input.elem_id_to_local_index[elem_id] = local_index;
+}
+
 Point RBEIMEvaluation::get_interpolation_points_xyz(unsigned int index) const
 {
   libmesh_error_msg_if(index >= _vec_eval_input.all_xyz.size(), "Error: Invalid index");
@@ -855,6 +867,11 @@ const std::vector<Real> & RBEIMEvaluation::get_interpolation_points_JxW_all_qp(u
   libmesh_error_msg_if(index >= _vec_eval_input.JxW_all_qp.size(), "Error: Invalid index");
 
   return _vec_eval_input.JxW_all_qp[index];
+}
+
+const std::map<dof_id_type, unsigned int> & RBEIMEvaluation::get_elem_id_to_local_index_map() const
+{
+  return _vec_eval_input.elem_id_to_local_index;
 }
 
 const std::vector<std::vector<Real>> & RBEIMEvaluation::get_interpolation_points_phi_i_all_qp(unsigned int index) const
@@ -956,11 +973,21 @@ void RBEIMEvaluation::add_interpolation_data(
   _vec_eval_input.all_xyz_perturb.emplace_back(perturbs);
   _vec_eval_input.phi_i_qp.emplace_back(phi_i_qp);
   _vec_eval_input.elem_types.emplace_back(elem_type);
-  _vec_eval_input.JxW_all_qp.emplace_back(JxW_all_qp);
-  _vec_eval_input.phi_i_all_qp.emplace_back(phi_i_all_qp);
-  _vec_eval_input.qrule_orders.emplace_back(qrule_order);
-  _vec_eval_input.dxyzdxi_elem_center.emplace_back(dxyzdxi_elem_center);
-  _vec_eval_input.dxyzdeta_elem_center.emplace_back(dxyzdeta_elem_center);
+
+  // The following quantities are indexed by elem id to prevent duplicated data
+  // If an entry is already present then we should not need to add that data again as it is element
+  // based so it should be identical between 2 points if they refer to the same element id.
+  if (_vec_eval_input.elem_id_to_local_index.count(elem_id) == 0)
+  {
+    unsigned int local_index = _vec_eval_input.JxW_all_qp.size();
+    // Maybe check that getting local index from a a different source is still ok.
+    _vec_eval_input.elem_id_to_local_index[elem_id] = local_index;
+    _vec_eval_input.JxW_all_qp.emplace_back(JxW_all_qp);
+    _vec_eval_input.phi_i_all_qp.emplace_back(phi_i_all_qp);
+    _vec_eval_input.qrule_orders.emplace_back(qrule_order);
+    _vec_eval_input.dxyzdxi_elem_center.emplace_back(dxyzdxi_elem_center);
+    _vec_eval_input.dxyzdeta_elem_center.emplace_back(dxyzdeta_elem_center);
+  }
 }
 
 void RBEIMEvaluation::add_side_basis_function(


### PR DESCRIPTION
In this update we reshape RB-EIM optional data to be element based instead of quadrature point based in their indexing. 
This helps reducing the number of entries as we remove duplicates. 

This update only affects optional data as it would break too many existing training data if we port that change to other data structure that are not optional (ElemType for instance). 