### PR TITLE
Generalize MeshFunction::find_element()

### DIFF
--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -354,6 +354,14 @@ protected:
                                        const std::set<subdomain_id_type> * subdomain_ids = nullptr) const;
 
   /**
+   * Helper function that is called by MeshFunction::find_element()
+   * and MeshFunction::find_elements() to ensure that Elems found by
+   * the PointLocator are actually "evaluable" on the processor where
+   * they are found.
+   */
+  const Elem * check_found_elem(const Elem * element, const Point & p) const;
+
+  /**
    * Helper function for finding a gradient as evaluated from a
    * specific element
    */

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -252,20 +252,16 @@ void MeshFunction::operator() (const Point & p,
         const unsigned int dim = element->dim();
 
 
-        /*
-         * Get local coordinates to feed these into compute_data().
-         * Note that the fe_type can safely be used from the 0-variable,
-         * since the inverse mapping is the same for all FEFamilies
-         */
+        // Get local coordinates to feed these into compute_data().
+        // Note that the fe_type can safely be used from the 0-variable,
+        // since the inverse mapping is the same for all FEFamilies
         const Point mapped_point (FEMap::inverse_map (dim, element,
                                                       p));
 
         // loop over all vars
         for (auto index : index_range(this->_system_vars))
           {
-            /*
-             * the data for this variable
-             */
+            // the data for this variable
             const unsigned int var = _system_vars[index];
 
             if (var == libMesh::invalid_uint)
@@ -278,10 +274,8 @@ void MeshFunction::operator() (const Point & p,
 
             const FEType & fe_type = this->_dof_map.variable_type(var);
 
-            /**
-             * Build an FEComputeData that contains both input and output data
-             * for the specific compute_data method.
-             */
+            // Build an FEComputeData that contains both input and output data
+            // for the specific compute_data method.
             {
               FEComputeData data (this->_eqn_systems, mapped_point);
 
@@ -341,19 +335,15 @@ void MeshFunction::discontinuous_value (const Point & p,
       // define a temporary vector to store all values
       DenseVector<Number> temp_output (cast_int<unsigned int>(this->_system_vars.size()));
 
-      /*
-       * Get local coordinates to feed these into compute_data().
-       * Note that the fe_type can safely be used from the 0-variable,
-       * since the inverse mapping is the same for all FEFamilies
-       */
+      // Get local coordinates to feed these into compute_data().
+      // Note that the fe_type can safely be used from the 0-variable,
+      // since the inverse mapping is the same for all FEFamilies
       const Point mapped_point (FEMap::inverse_map (dim, element, p));
 
       // loop over all vars
       for (auto index : index_range(this->_system_vars))
         {
-          /*
-           * the data for this variable
-           */
+          // the data for this variable
           const unsigned int var = _system_vars[index];
 
           if (var == libMesh::invalid_uint)
@@ -366,10 +356,8 @@ void MeshFunction::discontinuous_value (const Point & p,
 
           const FEType & fe_type = this->_dof_map.variable_type(var);
 
-          /**
-           * Build an FEComputeData that contains both input and output data
-           * for the specific compute_data method.
-           */
+          // Build an FEComputeData that contains both input and output data
+          // for the specific compute_data method.
           {
             FEComputeData data (this->_eqn_systems, mapped_point);
 
@@ -476,11 +464,9 @@ void MeshFunction::_gradient_on_elem (const Point & p,
 
   const unsigned int dim = element->dim();
 
-  /*
-   * Get local coordinates to feed these into compute_data().
-   * Note that the fe_type can safely be used from the 0-variable,
-   * since the inverse mapping is the same for all FEFamilies
-   */
+  // Get local coordinates to feed these into compute_data().
+  // Note that the fe_type can safely be used from the 0-variable,
+  // since the inverse mapping is the same for all FEFamilies
   const Point mapped_point (FEMap::inverse_map (dim, element,
                                                 p));
 
@@ -489,9 +475,7 @@ void MeshFunction::_gradient_on_elem (const Point & p,
   // loop over all vars
   for (auto index : index_range(this->_system_vars))
     {
-      /*
-       * the data for this variable
-       */
+      // the data for this variable
       const unsigned int var = _system_vars[index];
 
       if (var == libMesh::invalid_uint)
@@ -527,15 +511,15 @@ void MeshFunction::_gradient_on_elem (const Point & p,
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
       else
         {
-          /**
-           * Build an FEComputeData that contains both input and output data
-           * for the specific compute_data method.
-           */
-          //TODO: enable this for a vector of points as well...
+          // Build an FEComputeData that contains both input and output data
+          // for the specific compute_data method.
+          //
+          // TODO: enable this for a vector of points as well...
           FEComputeData data (this->_eqn_systems, mapped_point);
           data.enable_derivative();
           FEInterface::compute_data (dim, fe_type, element, data);
-          //grad [x] = data.dshape[i](v) * dv/dx  * dof_index [i]
+
+          // grad [x] = data.dshape[i](v) * dv/dx  * dof_index [i]
           // sum over all indices
           for (auto i : index_range(dof_indices))
             {
@@ -596,11 +580,9 @@ void MeshFunction::hessian (const Point & p,
         const unsigned int dim = element->dim();
 
 
-        /*
-         * Get local coordinates to feed these into compute_data().
-         * Note that the fe_type can safely be used from the 0-variable,
-         * since the inverse mapping is the same for all FEFamilies
-         */
+        // Get local coordinates to feed these into compute_data().
+        // Note that the fe_type can safely be used from the 0-variable,
+        // since the inverse mapping is the same for all FEFamilies
         const Point mapped_point (FEMap::inverse_map (dim, element,
                                                       p));
 
@@ -609,9 +591,7 @@ void MeshFunction::hessian (const Point & p,
         // loop over all vars
         for (auto index : index_range(this->_system_vars))
           {
-            /*
-             * the data for this variable
-             */
+            // the data for this variable
             const unsigned int var = _system_vars[index];
 
             if (var == libMesh::invalid_uint)
@@ -648,11 +628,11 @@ void MeshFunction::hessian (const Point & p,
 const Elem * MeshFunction::find_element(const Point & p,
                                         const std::set<subdomain_id_type> * subdomain_ids) const
 {
-  /* Ensure that in the case of a master mesh function, the
-     out-of-mesh mode is enabled either for both or for none.  This is
-     important because the out-of-mesh mode is also communicated to
-     the point locator.  Since this is time consuming, enable it only
-     in debug mode.  */
+  // Ensure that in the case of a master mesh function, the
+  // out-of-mesh mode is enabled either for both or for none.  This is
+  // important because the out-of-mesh mode is also communicated to
+  // the point locator.  Since this is time consuming, enable it only
+  // in debug mode.
 #ifdef DEBUG
   if (this->_master != nullptr)
     {
@@ -707,11 +687,11 @@ const Elem * MeshFunction::find_element(const Point & p,
 std::set<const Elem *> MeshFunction::find_elements(const Point & p,
                                                    const std::set<subdomain_id_type> * subdomain_ids) const
 {
-  /* Ensure that in the case of a master mesh function, the
-     out-of-mesh mode is enabled either for both or for none.  This is
-     important because the out-of-mesh mode is also communicated to
-     the point locator.  Since this is time consuming, enable it only
-     in debug mode.  */
+  // Ensure that in the case of a master mesh function, the
+  // out-of-mesh mode is enabled either for both or for none.  This is
+  // important because the out-of-mesh mode is also communicated to
+  // the point locator.  Since this is time consuming, enable it only
+  // in debug mode.
 #ifdef DEBUG
   if (this->_master != nullptr)
     {


### PR DESCRIPTION
Previously, we handled the case of non-local Elems being returned by the `MeshFunction`'s `PointLocator` differently depending on whether the `MeshFunction`'s `_vector` was `SERIAL` or not. In the case where it was not `SERIAL`, we searched the point neighbors of the non-local Elem returned by the PointLocator until a local one was found, or returned `nullptr` if no such local point neighbor could be found. 

There is another important case, however, which is where `MeshFunction`'s `_vector` is `GHOSTED`, and the non-local Elem is still "evaluable" on the local processor, due to e.g. additional ghosting set up by the user. In that case, it should be safe to return the non-local Elem from `MeshFunction::find_element()`. 

This change (together with the one in #3975) fixes an issue in our internal code, but it is possible that it will cause some existing tests to break, since it changes slightly the behavior of `MeshFunction::find_element()`.