### PR TITLE
Keep SimplexRefiner tests small for now

### DIFF
--- a/tests/mesh/simplex_refinement_test.C
+++ b/tests/mesh/simplex_refinement_test.C
@@ -70,6 +70,12 @@ public:
 
   void test3DTriRefinement()
   {
+    // We may have a bug when trying to edge refine on more processors
+    // than elements?  I can't reproduce it and it seems intermittent
+    // in CI.
+    if (TestCommWorld->size() > 8)
+      return;
+
     Mesh trimesh(*TestCommWorld);
 
     MeshTools::Generation::surface_octahedron

--- a/tests/mesh/simplex_refinement_test.C
+++ b/tests/mesh/simplex_refinement_test.C
@@ -59,6 +59,8 @@ public:
 
   void testTriRefinement()
   {
+    LOG_UNIT_TEST;
+
     Mesh trimesh(*TestCommWorld);
 
     MeshTools::Generation::build_square (trimesh, 2, 2,
@@ -75,6 +77,8 @@ public:
     // in CI.
     if (TestCommWorld->size() > 8)
       return;
+
+    LOG_UNIT_TEST;
 
     Mesh trimesh(*TestCommWorld);
 


### PR DESCRIPTION
Hopefully this fixes the complaints CI has been having with distributed meshes on this test; I can't seem to reproduce the failure locally.