### PR TITLE
Add --with-xdr-libdir configure option

### DIFF
--- a/configure
+++ b/configure
@@ -2206,8 +2206,8 @@ Optional Packages:
                           objects per DistributedMesh mapvector chunk [1]
   --with-xdr-include=PATH Specify the path for RPC headers required by XDR
   --with-xdr-libdir=/foo/bar
-                          Specify directory of the XDR library to be appended
-                          to -L when linking
+                          Specify XDR library directory to be searched when
+                          linking
   --with-xdr-libname=foo  Specify name of the XDR library to be appended to -l
                           when linking
   --with-boost[=ARG]      use Boost library from a standard location
@@ -49749,9 +49749,8 @@ fi
 
 
   # Support for --with-xdr-libname configure option.  If the user does
-  # not specify this option, it defaults to "tirpc" since that seems
-  # to be the current standard way of linking "external" RPC
-  # libraries.
+  # not specify this option, we do check "tirpc" since that seems to
+  # be the most common way of linking "external" RPC libraries.
 
 # Check whether --with-xdr-libname was given.
 if test ${with_xdr_libname+y}
@@ -49779,7 +49778,7 @@ then :
   as_fn_error $? "xdr-libdir was set to $withxdrlibdir, but no xdr-libname was set" "$LINENO" 5
 
 fi
-          XDRLINKLIBS="-L$withxdrlibdir $XDRLINKLIBS"
+          XDRLINKLIBS="${RPATHFLAG}$withxdrlibdir $XDRLINKLIBS"
 
 fi
 
@@ -49964,6 +49963,62 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
     CPPFLAGS="$old_CPPFLAGS"
   LIBS="$old_LIBS"
 
+
+                    if test "x$enablexdr" = "xno" && test "x$withxdrlibname" = "xno"
+then :
+
+                  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for XDR support via libtirpc" >&5
+printf %s "checking for XDR support via libtirpc... " >&6; }
+                  XDRLINKLIBS="-ltirpc"
+
+
+  old_CPPFLAGS="$CPPFLAGS"
+  old_LIBS="$LIBS"
+  CPPFLAGS="$CPPFLAGS $XDRINCLUDES"
+  LIBS="$LIBS $XDRLINKLIBS"
+
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdio.h>
+                                   #include <rpc/rpc.h>
+                                   #include <rpc/xdr.h>
+int
+main (void)
+{
+
+                                    XDR * xdr;
+                                    FILE * fp;
+                                    xdrstdio_create(xdr, fp, XDR_ENCODE);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"
+then :
+
+                   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+
+printf "%s\n" "#define HAVE_XDR 1" >>confdefs.h
+
+                   enablexdr=yes
+
+else $as_nop
+
+                   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+                   enablexdr=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+
+    CPPFLAGS="$old_CPPFLAGS"
+  LIBS="$old_LIBS"
+
+
+fi
 
                     if test "x$enablexdr" = "xno" && test "x$withxdrlibdir" = "xno"
 then :

--- a/configure
+++ b/configure
@@ -1264,6 +1264,7 @@ enable_nested
 enable_xdr_required
 enable_xdr
 with_xdr_include
+with_xdr_libdir
 with_xdr_libname
 enable_boost
 with_boost
@@ -2204,6 +2205,9 @@ Optional Packages:
   --with-mapvector-chunk-size=<uint, e.g. 64>
                           objects per DistributedMesh mapvector chunk [1]
   --with-xdr-include=PATH Specify the path for RPC headers required by XDR
+  --with-xdr-libdir=/foo/bar
+                          Specify directory of the XDR library to be appended
+                          to -L when linking
   --with-xdr-libname=foo  Specify name of the XDR library to be appended to -l
                           when linking
   --with-boost[=ARG]      use Boost library from a standard location
@@ -49709,14 +49713,18 @@ else $as_nop
 fi
 
 
-if test "x${TIRPC_DIR}" != "x"
+if test "x$enablexdr" != "xno"
+then :
+
+
+      if test "x${TIRPC_DIR}" != "x"
 then :
   withxdrinc_default=${TIRPC_DIR}
 else $as_nop
   withxdrinc_default=no
 fi
 
-# Support for --with-xdr-include configure option
+  # Support for --with-xdr-include configure option
 
 # Check whether --with-xdr-include was given.
 if test ${with_xdr_include+y}
@@ -49727,34 +49735,73 @@ else $as_nop
 fi
 
 
-# Support for --with-xdr-libname configure option. Note that we currently
-# do not provide a way to specify a library PATH, but that could potentially
-# be added. If the user does not specify this option, it defaults to "tirpc"
-# since that seems to be the current standard way of linking "external" RPC
-# libraries.
+  # Support for --with-xdr-libdir configure option.  If the user does
+  # not specify this option, we assume the desired RPC libraries are
+  # already in the user's linker path.
+
+# Check whether --with-xdr-libdir was given.
+if test ${with_xdr_libdir+y}
+then :
+  withval=$with_xdr_libdir; withxdrlibdir=$withval
+else $as_nop
+  withxdrlibdir=no
+fi
+
+
+  # Support for --with-xdr-libname configure option.  If the user does
+  # not specify this option, it defaults to "tirpc" since that seems
+  # to be the current standard way of linking "external" RPC
+  # libraries.
 
 # Check whether --with-xdr-libname was given.
 if test ${with_xdr_libname+y}
 then :
   withval=$with_xdr_libname; withxdrlibname=$withval
 else $as_nop
-  withxdrlibname=tirpc
+  withxdrlibname=no
 fi
 
 
-if test "$enablexdr" != no
+  XDRINCLUDES=''
+  XDRLINKLIBS=''
+  if test "x$withxdrlibname" != "xno"
 then :
 
-                        if test "x$withxdrinc" != "xno"
+          XDRLINKLIBS="-l$withxdrlibname"
+
+fi
+
+  if test "x$withxdrlibdir" != "xno"
 then :
 
-              { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for XDR support in $withxdrinc" >&5
+          if test "x$withxdrlibname" = "xno"
+then :
+  as_fn_error $? "xdr-libdir was set to $withxdrlibdir, but no xdr-libname was set" "$LINENO" 5
+
+fi
+          XDRLINKLIBS="-L$withxdrlibdir $XDRLINKLIBS"
+
+fi
+
+        if test "x$withxdrinc" != "xno"
+then :
+
+          XDRINCLUDES="-I$withxdrinc"
+
+          if test "x$withxdrlibdir" != "xno"
+then :
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for XDR support in $withxdrinc and $withxdrlibdir" >&5
+printf %s "checking for XDR support in $withxdrinc and $withxdrlibdir... " >&6; }
+else $as_nop
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for XDR support in $withxdrinc" >&5
 printf %s "checking for XDR support in $withxdrinc... " >&6; }
-              old_CPPFLAGS="$CPPFLAGS"
-              old_LIBS="$LIBS"
-              CPPFLAGS="$CPPFLAGS -I$withxdrinc"
-              LIBS="$LIBS -l$withxdrlibname"
+fi
 
+
+  old_CPPFLAGS="$CPPFLAGS"
+  old_LIBS="$LIBS"
+  CPPFLAGS="$CPPFLAGS $XDRINCLUDES"
+  LIBS="$LIBS $XDRLINKLIBS"
 
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -49793,23 +49840,89 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
 
+    CPPFLAGS="$old_CPPFLAGS"
+  LIBS="$old_LIBS"
 
-                            if test "x$enablexdr" = "xyes"
+
+                              if test "x$withxdrlibname" = "xno"
 then :
 
-                      libmesh_optional_INCLUDES="$libmesh_optional_INCLUDES -I$withxdrinc"
-                      libmesh_optional_LIBS="$libmesh_optional_LIBS -l$withxdrlibname"
+                  if test "x$withxdrlibdir" != "xno"
+then :
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for XDR support in $withxdrinc and $withxdrlibdir with -ltirpc" >&5
+printf %s "checking for XDR support in $withxdrinc and $withxdrlibdir with -ltirpc... " >&6; }
+else $as_nop
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for XDR support in $withxdrinc with -ltirpc" >&5
+printf %s "checking for XDR support in $withxdrinc with -ltirpc... " >&6; }
+fi
+                  XDRLINKLIBS="$XDRLINKLIBS -ltirpc"
+
+
+  old_CPPFLAGS="$CPPFLAGS"
+  old_LIBS="$LIBS"
+  CPPFLAGS="$CPPFLAGS $XDRINCLUDES"
+  LIBS="$LIBS $XDRLINKLIBS"
+
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdio.h>
+                                   #include <rpc/rpc.h>
+                                   #include <rpc/xdr.h>
+int
+main (void)
+{
+
+                                    XDR * xdr;
+                                    FILE * fp;
+                                    xdrstdio_create(xdr, fp, XDR_ENCODE);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"
+then :
+
+                   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+
+printf "%s\n" "#define HAVE_XDR 1" >>confdefs.h
+
+                   enablexdr=yes
+
+else $as_nop
+
+                   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+                   enablexdr=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+
+    CPPFLAGS="$old_CPPFLAGS"
+  LIBS="$old_LIBS"
+
 
 fi
 
-                            CPPFLAGS="$old_CPPFLAGS"
-              LIBS="$old_LIBS"
+else $as_nop
 
-elif test "x$withxdrinc" = "xno"
+
+          if test "x$withxdrlibdir" != "xno"
 then :
-
-                                                                      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for built-in XDR support" >&5
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for XDR library in $withxdrlibdir" >&5
+printf %s "checking for XDR library in $withxdrlibdir... " >&6; }
+else $as_nop
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for built-in XDR support" >&5
 printf %s "checking for built-in XDR support... " >&6; }
+fi
+
+
+  old_CPPFLAGS="$CPPFLAGS"
+  old_LIBS="$LIBS"
+  CPPFLAGS="$CPPFLAGS $XDRINCLUDES"
+  LIBS="$LIBS $XDRLINKLIBS"
 
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -49848,17 +49961,23 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
 
+    CPPFLAGS="$old_CPPFLAGS"
+  LIBS="$old_LIBS"
 
-                            if test "x$enablexdr" = "xno"
+
+                    if test "x$enablexdr" = "xno" && test "x$withxdrlibdir" = "xno"
 then :
 
-                      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for XDR support in /usr/include/tirpc" >&5
+                  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for XDR support in /usr/include/tirpc" >&5
 printf %s "checking for XDR support in /usr/include/tirpc... " >&6; }
-                      old_CPPFLAGS="$CPPFLAGS"
-                      old_LIBS="$LIBS"
-                      CPPFLAGS="$CPPFLAGS -I/usr/include/tirpc"
-                      LIBS="$LIBS -ltirpc"
+                  XDRINCLUDES="-I/usr/include/tirpc"
+                  XDRLINKLIBS="-ltirpc"
 
+
+  old_CPPFLAGS="$CPPFLAGS"
+  old_LIBS="$LIBS"
+  CPPFLAGS="$CPPFLAGS $XDRINCLUDES"
+  LIBS="$LIBS $XDRLINKLIBS"
 
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -49897,21 +50016,30 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
 
+    CPPFLAGS="$old_CPPFLAGS"
+  LIBS="$old_LIBS"
 
-                                            if test "x$enablexdr" = "xyes"
+
+fi
+
+fi
+
+    if test "x$enablexdr" = "xno"
 then :
 
-                              libmesh_optional_INCLUDES="$libmesh_optional_INCLUDES -I/usr/include/tirpc"
-                              libmesh_optional_LIBS="$libmesh_optional_LIBS -ltirpc"
+          XDRINCLUDES=''
+          XDRLINKLIBS=''
 
 fi
 
-                                            CPPFLAGS="$old_CPPFLAGS"
-                      LIBS="$old_LIBS"
 
 fi
 
-fi
+if test "x$enablexdr" != "xno"
+then :
+
+        libmesh_optional_INCLUDES="$XDRINCLUDES $libmesh_optional_INCLUDES"
+        libmesh_optional_LIBS="$XDRLINKLIBS $libmesh_optional_LIBS"
 
 fi
 

--- a/m4/libmesh_optional_packages.m4
+++ b/m4/libmesh_optional_packages.m4
@@ -123,84 +123,15 @@ AC_ARG_ENABLE(xdr,
               enablexdr=$enableval,
               enablexdr=yes)
 
-dnl If the user sets ${TIRPC_DIR} in their environment, then use that as the
-dnl default value for --with-xdr-include
-AS_IF([test "x${TIRPC_DIR}" != "x"], [withxdrinc_default=${TIRPC_DIR}], [withxdrinc_default=no])
-
-# Support for --with-xdr-include configure option
-AC_ARG_WITH(xdr-include,
-            AS_HELP_STRING([--with-xdr-include=PATH],[Specify the path for RPC headers required by XDR]),
-            withxdrinc=$withval,
-            withxdrinc=$withxdrinc_default)
-
-# Support for --with-xdr-libname configure option. Note that we currently
-# do not provide a way to specify a library PATH, but that could potentially
-# be added. If the user does not specify this option, it defaults to "tirpc"
-# since that seems to be the current standard way of linking "external" RPC
-# libraries.
-AC_ARG_WITH(xdr-libname,
-            AS_HELP_STRING([--with-xdr-libname=foo],[Specify name of the XDR library to be appended to -l when linking]),
-            withxdrlibname=$withval,
-            withxdrlibname=tirpc)
-
-AS_IF([test "$enablexdr" != no],
+AS_IF([test "x$enablexdr" != "xno"],
       [
-      dnl If there is a user-provided XDR include/library provided, then we only
-      dnl try compiling/linking against those, to avoid accidentally bringing in
-      dnl any unwanted system RPC headers.
-      AS_IF([test "x$withxdrinc" != "xno"],
-            [
-              AC_MSG_CHECKING([for XDR support in $withxdrinc])
-              old_CPPFLAGS="$CPPFLAGS"
-              old_LIBS="$LIBS"
-              CPPFLAGS="$CPPFLAGS -I$withxdrinc"
-              LIBS="$LIBS -l$withxdrlibname"
+        CONFIGURE_XDR
+      ])
 
-              CONFIGURE_XDR
-
-              dnl If that worked, append the required include paths and libraries as necessary.
-              AS_IF([test "x$enablexdr" = "xyes"],
-                    [
-                      libmesh_optional_INCLUDES="$libmesh_optional_INCLUDES -I$withxdrinc"
-                      libmesh_optional_LIBS="$libmesh_optional_LIBS -l$withxdrlibname"
-                    ])
-
-              dnl Reset flags after testing
-              CPPFLAGS="$old_CPPFLAGS"
-              LIBS="$old_LIBS"
-            ],
-            [test "x$withxdrinc" = "xno"],
-            [
-              dnl The user did not provide a custom XDR include/header path, so we
-              dnl instead check whether the system/compiler has built-in support for
-              dnl compiling/linking a code that includes xdr.h, followed by checking
-              dnl other known locations.
-              AC_MSG_CHECKING([for built-in XDR support])
-              CONFIGURE_XDR
-
-              dnl Check for headers in /usr/include/tirpc. (Fedora 28 does this.)
-              AS_IF([test "x$enablexdr" = "xno"],
-                    [
-                      AC_MSG_CHECKING([for XDR support in /usr/include/tirpc])
-                      old_CPPFLAGS="$CPPFLAGS"
-                      old_LIBS="$LIBS"
-                      CPPFLAGS="$CPPFLAGS -I/usr/include/tirpc"
-                      LIBS="$LIBS -ltirpc"
-
-                      CONFIGURE_XDR
-
-                      dnl If that worked, append the required include paths and libraries as necessary.
-                      AS_IF([test "x$enablexdr" = "xyes"],
-                            [
-                              libmesh_optional_INCLUDES="$libmesh_optional_INCLUDES -I/usr/include/tirpc"
-                              libmesh_optional_LIBS="$libmesh_optional_LIBS -ltirpc"
-                            ])
-
-                      dnl Reset flags after testing
-                      CPPFLAGS="$old_CPPFLAGS"
-                      LIBS="$old_LIBS"
-                   ])
-            ])
+AS_IF([test "x$enablexdr" != "xno"],
+      [
+        libmesh_optional_INCLUDES="$XDRINCLUDES $libmesh_optional_INCLUDES"
+        libmesh_optional_LIBS="$XDRLINKLIBS $libmesh_optional_LIBS"
       ])
 
 AS_IF([test "x$enablexdr" = "xno" && test "x$xdrrequired" = "xyes"],

--- a/m4/xdr.m4
+++ b/m4/xdr.m4
@@ -1,5 +1,13 @@
-AC_DEFUN([CONFIGURE_XDR],
+# ----------------------------------------------------------------
+# Test compilation against XDR with $XDRINCLUDES and $XDRLINKLIBS,
+# ----------------------------------------------------------------
+AC_DEFUN([TEST_XDR],
 [
+  old_CPPFLAGS="$CPPFLAGS"
+  old_LIBS="$LIBS"
+  CPPFLAGS="$CPPFLAGS $XDRINCLUDES"
+  LIBS="$LIBS $XDRLINKLIBS"
+
   AC_LINK_IFELSE([AC_LANG_PROGRAM([@%:@include <stdio.h>
                                    @%:@include <rpc/rpc.h>
                                    @%:@include <rpc/xdr.h>],
@@ -17,4 +25,116 @@ AC_DEFUN([CONFIGURE_XDR],
                    AC_MSG_RESULT(no)
                    enablexdr=no
                  ])
+
+  dnl Reset flags after testing
+  CPPFLAGS="$old_CPPFLAGS"
+  LIBS="$old_LIBS"
+])
+
+
+# --------------------------------------------------------------------
+# Attempt to find a working XDR configuration, based on user options
+# if supplied or checking common defaults if not.
+#
+# Return the status of the attempt in $enablexdr.  Return the
+# necessary flags in $XDRINCLUDES and $XDRLINKLIBS
+# --------------------------------------------------------------------
+AC_DEFUN([CONFIGURE_XDR],
+[
+  dnl If the user sets ${TIRPC_DIR} in their environment, then use that as the
+  dnl default value for --with-xdr-include
+  AS_IF([test "x${TIRPC_DIR}" != "x"], [withxdrinc_default=${TIRPC_DIR}], [withxdrinc_default=no])
+
+  # Support for --with-xdr-include configure option
+  AC_ARG_WITH(xdr-include,
+              AS_HELP_STRING([--with-xdr-include=PATH],[Specify the path for RPC headers required by XDR]),
+              withxdrinc=$withval,
+              withxdrinc=$withxdrinc_default)
+
+  # Support for --with-xdr-libdir configure option.  If the user does
+  # not specify this option, we assume the desired RPC libraries are
+  # already in the user's linker path.
+  AC_ARG_WITH(xdr-libdir,
+              AS_HELP_STRING([--with-xdr-libdir=/foo/bar],[Specify directory of the XDR library to be appended to -L when linking]),
+              withxdrlibdir=$withval,
+              withxdrlibdir=no)
+
+  # Support for --with-xdr-libname configure option.  If the user does
+  # not specify this option, it defaults to "tirpc" since that seems
+  # to be the current standard way of linking "external" RPC
+  # libraries.
+  AC_ARG_WITH(xdr-libname,
+              AS_HELP_STRING([--with-xdr-libname=foo],[Specify name of the XDR library to be appended to -l when linking]),
+              withxdrlibname=$withval,
+              withxdrlibname=no)
+
+  XDRINCLUDES=''
+  XDRLINKLIBS=''
+  AS_IF([test "x$withxdrlibname" != "xno"],
+        [
+          XDRLINKLIBS="-l$withxdrlibname"
+        ])
+
+  AS_IF([test "x$withxdrlibdir" != "xno"],
+        [
+          AS_IF([test "x$withxdrlibname" = "xno"],
+                [AC_MSG_ERROR([xdr-libdir was set to $withxdrlibdir, but no xdr-libname was set])
+                ])
+          XDRLINKLIBS="-L$withxdrlibdir $XDRLINKLIBS"
+        ])
+
+  dnl If there is a user-provided XDR include/library provided, then we only
+  dnl try compiling/linking against those, to avoid accidentally bringing in
+  dnl any unwanted system RPC headers.
+  AS_IF([test "x$withxdrinc" != "xno"],
+        [
+          XDRINCLUDES="-I$withxdrinc"
+
+          AS_IF([test "x$withxdrlibdir" != "xno"],
+                [ AC_MSG_CHECKING([for XDR support in $withxdrinc and $withxdrlibdir]) ],
+                [ AC_MSG_CHECKING([for XDR support in $withxdrinc]) ])
+
+          TEST_XDR
+
+          dnl Check again, specifically for libtirpc, if the user
+          dnl didn't specify a library name.
+          AS_IF([test "x$withxdrlibname" = "xno"],
+                [
+                  AS_IF([test "x$withxdrlibdir" != "xno"],
+                        [ AC_MSG_CHECKING([for XDR support in $withxdrinc and $withxdrlibdir with -ltirpc]) ],
+                        [ AC_MSG_CHECKING([for XDR support in $withxdrinc with -ltirpc]) ])
+                  XDRLINKLIBS="$XDRLINKLIBS -ltirpc"
+
+                  TEST_XDR
+               ])
+        ],
+        [
+          dnl The user did not provide a custom XDR include/header path, so we
+          dnl instead check whether the system/compiler has built-in support for
+          dnl compiling/linking a code that includes xdr.h, followed by checking
+          dnl other known locations.
+
+          AS_IF([test "x$withxdrlibdir" != "xno"],
+                [ AC_MSG_CHECKING([for XDR library in $withxdrlibdir]) ],
+                [ AC_MSG_CHECKING([for built-in XDR support]) ])
+
+          TEST_XDR
+
+          dnl Check again for headers in /usr/include/tirpc. (Fedora 28 does this.)
+          AS_IF([test "x$enablexdr" = "xno" && test "x$withxdrlibdir" = "xno"],
+                [
+                  AC_MSG_CHECKING([for XDR support in /usr/include/tirpc])
+                  XDRINCLUDES="-I/usr/include/tirpc"
+                  XDRLINKLIBS="-ltirpc"
+
+                  TEST_XDR
+               ])
+        ])
+
+  dnl If nothing worked, don't report any flags that didn't work.
+  AS_IF([test "x$enablexdr" = "xno"],
+        [
+          XDRINCLUDES=''
+          XDRLINKLIBS=''
+        ])
 ])

--- a/m4/xdr.m4
+++ b/m4/xdr.m4
@@ -55,7 +55,7 @@ AC_DEFUN([CONFIGURE_XDR],
   # not specify this option, we assume the desired RPC libraries are
   # already in the user's linker path.
   AC_ARG_WITH(xdr-libdir,
-              AS_HELP_STRING([--with-xdr-libdir=/foo/bar],[Specify directory of the XDR library to be appended to -L when linking]),
+              AS_HELP_STRING([--with-xdr-libdir=/foo/bar],[Specify XDR library directory to be searched when linking]),
               withxdrlibdir=$withval,
               withxdrlibdir=no)
 
@@ -80,7 +80,7 @@ AC_DEFUN([CONFIGURE_XDR],
           AS_IF([test "x$withxdrlibname" = "xno"],
                 [AC_MSG_ERROR([xdr-libdir was set to $withxdrlibdir, but no xdr-libname was set])
                 ])
-          XDRLINKLIBS="-L$withxdrlibdir $XDRLINKLIBS"
+          XDRLINKLIBS="${RPATHFLAG}$withxdrlibdir $XDRLINKLIBS"
         ])
 
   dnl If there is a user-provided XDR include/library provided, then we only

--- a/m4/xdr.m4
+++ b/m4/xdr.m4
@@ -119,6 +119,15 @@ AC_DEFUN([CONFIGURE_XDR],
 
           TEST_XDR
 
+          dnl Check again for an explicitly named library.
+          AS_IF([test "x$enablexdr" = "xno" && test "x$withxdrlibname" = "xno"],
+                [
+                  AC_MSG_CHECKING([for XDR support via libtirpc])
+                  XDRLINKLIBS="-ltirpc"
+
+                  TEST_XDR
+               ])
+
           dnl Check again for headers in /usr/include/tirpc. (Fedora 28 does this.)
           AS_IF([test "x$enablexdr" = "xno" && test "x$withxdrlibdir" = "xno"],
                 [

--- a/m4/xdr.m4
+++ b/m4/xdr.m4
@@ -60,9 +60,8 @@ AC_DEFUN([CONFIGURE_XDR],
               withxdrlibdir=no)
 
   # Support for --with-xdr-libname configure option.  If the user does
-  # not specify this option, it defaults to "tirpc" since that seems
-  # to be the current standard way of linking "external" RPC
-  # libraries.
+  # not specify this option, we do check "tirpc" since that seems to
+  # be the most common way of linking "external" RPC libraries.
   AC_ARG_WITH(xdr-libname,
               AS_HELP_STRING([--with-xdr-libname=foo],[Specify name of the XDR library to be appended to -l when linking]),
               withxdrlibname=$withval,


### PR DESCRIPTION
This is starting to pass my own tests, so we'll see what CI thinks of it.  (by looking at CI results manually; AFAIK MOOSE has replaced all its XDR/CPR-based tests with XDA/CPA versions now, though it still uses --enable-xdr-required for downstream's sake)