### PR TITLE
Fix ParameterProxy=ParameterProxy deep copy

### DIFF
--- a/include/systems/parameter_accessor.h
+++ b/include/systems/parameter_accessor.h
@@ -112,7 +112,7 @@ public:
   /**
    * Setter: change the value of the parameter we access.
    */
-  ParameterProxy & operator = (const ParameterProxy<T> & new_value) { _accessor.set(new_value.get()); }
+  ParameterProxy & operator = (const ParameterProxy<T> & new_value) { _accessor.set(new_value._accessor.get()); return *this; }
 
   /**
    * Setter: change the value of the parameter we access.
@@ -143,6 +143,11 @@ public:
    * Getter: get the value of the parameter we access.
    */
   operator T () const { return _accessor.get(); }
+
+  /**
+   * Getter: get the value of the parameter we access.
+   */
+  T get() const { return _accessor.get(); }
 
 #ifdef LIBMESH_DEFAULT_QUADRUPLE_PRECISION
   operator boost::multiprecision::backends::float128_backend () const { return _accessor.get().backend(); }


### PR DESCRIPTION
We weren't returning `*this`, *and* we were trying to use an accessor that only exists for ConstParameterProxy.

This fixes compilation with clang++ 19 for me.  Thanks to yurivict for catching that.

This should fix #3991