### PR TITLE
Fix reduced_basis_ex4 compilation

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
@@ -16,6 +16,8 @@
 using libMesh::EquationSystems;
 using libMesh::RBEIMEvaluation;
 using libMesh::RBEIMConstruction;
+using libMesh::System;
+using libMesh::EIMVarGroupPlottingInfo;
 
 // A simple subclass of RBEIMEvaluation. Overload
 // evaluate_parametrized_function to define the
@@ -34,6 +36,18 @@ public:
   {
     // Indicate that we do use the EIM error indicator here.
     return true;
+  }
+
+  /**
+   * Project the specified variable of \p bf_data into the solution
+   * vector of System.
+   */
+  virtual void project_qp_data_vector_onto_system(
+    System & sys,
+    const std::vector<Number> & bf_data,
+    const EIMVarGroupPlottingInfo & eim_vargroup,
+    const std::map<std::string, std::string> & extra_options) override
+  {
   }
 };
 

--- a/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
@@ -16,8 +16,6 @@
 using libMesh::EquationSystems;
 using libMesh::RBEIMEvaluation;
 using libMesh::RBEIMConstruction;
-using libMesh::System;
-using libMesh::EIMVarGroupPlottingInfo;
 
 // A simple subclass of RBEIMEvaluation. Overload
 // evaluate_parametrized_function to define the
@@ -36,18 +34,6 @@ public:
   {
     // Indicate that we do use the EIM error indicator here.
     return true;
-  }
-
-  /**
-   * Project the specified variable of \p bf_data into the solution
-   * vector of System.
-   */
-  virtual void project_qp_data_vector_onto_system(
-    System & sys,
-    const std::vector<Number> & bf_data,
-    const EIMVarGroupPlottingInfo & eim_vargroup,
-    const std::map<std::string, std::string> & extra_options) override
-  {
   }
 };
 

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -152,17 +152,35 @@ int main (int argc, char ** argv)
         eim_rb_eval.write_out_basis_functions("eim_data", eim_binary_io);
 
 #ifdef LIBMESH_HAVE_EXODUS_API
-        // Plot one of the parametrized functions from the training set
-        eim_rb_eval.project_qp_data_map_onto_system(eim_construction,
-                                                    eim_construction.get_parametrized_function_from_training_set(eim_training_function_to_plot),
-                                                    /*eim_var*/ 0);
+
+        // Inputs needed by our RBEIMEvaluation::project_qp_data_vector_onto_system() override
+        std::vector<Number> bf_data;
+        EIMVarGroupPlottingInfo eim_vargroup;
+        std::map<std::string, std::string> extra_options;
         std::set<std::string> system_names = {eim_construction.name()};
+
+        // Plot one of the parametrized functions from the training set
+        // FIXME: Set up the inputs correctly to plot f_qp
+        const RBEIMEvaluation::QpDataMap & f_qp =
+          eim_construction.get_parametrized_function_from_training_set(eim_training_function_to_plot);
+        eim_rb_eval.project_qp_data_vector_onto_system(
+          eim_construction,
+          bf_data,
+          eim_vargroup,
+          extra_options);
+
         ExodusII_IO(mesh).write_equation_systems("eim_parametrized_function.e", equation_systems, &system_names);
 
         // Plot one of the basis functions
-        eim_rb_eval.project_qp_data_map_onto_system(eim_construction,
-                                                    eim_rb_eval.get_basis_function(eim_basis_function_to_plot),
-                                                    /*eim_var*/ 0);
+        // FIXME: Set up the inputs correctly to plot bf_qp
+        const RBEIMEvaluation::QpDataMap & bf_qp =
+          eim_rb_eval.get_basis_function(eim_basis_function_to_plot);
+        eim_rb_eval.project_qp_data_vector_onto_system(
+          eim_construction,
+          bf_data,
+          eim_vargroup,
+          extra_options);
+
         ExodusII_IO(mesh).write_equation_systems("eim_basis_function.e", equation_systems, &system_names);
 #endif
       }
@@ -322,9 +340,14 @@ int main (int argc, char ** argv)
       // can now print out the EIM error indicator values.
       const auto & eim_error_indicators =
         eim_rb_eval.get_rb_eim_error_indicators();
+
+      libMesh::out << std::scientific;
       for (auto idx : index_range(eim_error_indicators))
-        libMesh::out << "EIM error indicator for step: " << idx << ": "
-                     << std::scientific << eim_error_indicators[idx] << std::endl;
+        libMesh::out << "EIM (error indicator, normalization factor) for step "
+                     << idx << ": "
+                     << "(" << eim_error_indicators[idx].first
+                     << ", " << eim_error_indicators[idx].second
+                     << ")" << std::endl;
       libMesh::out << std::endl;
 
       // 3.) Evaluate "output" thetas at all samples: in this case, the

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -150,39 +150,6 @@ int main (int argc, char ** argv)
 
         // Write out the EIM basis functions
         eim_rb_eval.write_out_basis_functions("eim_data", eim_binary_io);
-
-#ifdef LIBMESH_HAVE_EXODUS_API
-
-        // Inputs needed by our RBEIMEvaluation::project_qp_data_vector_onto_system() override
-        std::vector<Number> bf_data;
-        EIMVarGroupPlottingInfo eim_vargroup;
-        std::map<std::string, std::string> extra_options;
-        std::set<std::string> system_names = {eim_construction.name()};
-
-        // Plot one of the parametrized functions from the training set
-        // FIXME: Set up the inputs correctly to plot f_qp
-        const RBEIMEvaluation::QpDataMap & f_qp =
-          eim_construction.get_parametrized_function_from_training_set(eim_training_function_to_plot);
-        eim_rb_eval.project_qp_data_vector_onto_system(
-          eim_construction,
-          bf_data,
-          eim_vargroup,
-          extra_options);
-
-        ExodusII_IO(mesh).write_equation_systems("eim_parametrized_function.e", equation_systems, &system_names);
-
-        // Plot one of the basis functions
-        // FIXME: Set up the inputs correctly to plot bf_qp
-        const RBEIMEvaluation::QpDataMap & bf_qp =
-          eim_rb_eval.get_basis_function(eim_basis_function_to_plot);
-        eim_rb_eval.project_qp_data_vector_onto_system(
-          eim_construction,
-          bf_data,
-          eim_vargroup,
-          extra_options);
-
-        ExodusII_IO(mesh).write_equation_systems("eim_basis_function.e", equation_systems, &system_names);
-#endif
       }
 
       {


### PR DESCRIPTION
`RBEIMEvaluation::project_qp_data_map_onto_system()` was removed in 5fd32f3, but reduced_basis_ex4, an example that used it, was never updated accordingly. We didn't see any issues on the libMesh CI because the example requires Cap'n'Proto, and that software is not available on the CI build machines.
