### PR TITLE
Enable entities (elems, nodes, etc) to be flagged during RB mesh pre-evaluation

### DIFF
--- a/contrib/capnproto/rb_data.capnp
+++ b/contrib/capnproto/rb_data.capnp
@@ -45,6 +45,11 @@ struct IntPair @0xa9e786708685aed5 {
   second @1 :Integer;
 }
 
+struct GenericProperty @0xb5dd548f04016706 {
+  name       @0 : Text;
+  entityIds  @1 : List(Integer);
+}
+
 struct RBSCMEvaluation @0xb8dd038628a64b16 {
   parameterRanges    @0 :ParameterRanges;
   discreteParameters @1 :DiscreteParameterList;
@@ -140,6 +145,7 @@ struct RBEIMEvaluationReal @0xf8121d2237427a80 {
   interpolationDxyzDzetaElem  @25 :List(Point3D);
   nElems                      @26 :Integer;
   elemIdToLocalIndex          @27 :List(IntPair);
+  propertyMap                 @28 :List(GenericProperty);
 }
 struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   nBfs                        @0  :Integer;
@@ -170,4 +176,5 @@ struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   interpolationDxyzDzetaElem  @25 :List(Point3D);
   nElems                      @26 :Integer;
   elemIdToLocalIndex          @27 :List(IntPair);
+  propertyMap                 @28 :List(GenericProperty);
 }

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -219,6 +219,11 @@ public:
   unsigned int get_n_elems() const;
 
   /**
+   * Return the number of properties stored in the rb_property_map
+   */
+  unsigned int get_n_properties() const;
+
+  /**
    * Set the number of basis functions. Useful when reading in
    * stored data.
    */
@@ -453,6 +458,7 @@ public:
   void add_elem_center_dxyzdeta(const Point & dxyzdxi);
   void add_interpolation_points_spatial_indices(const std::vector<unsigned int> & spatial_indices);
   void add_elem_id_local_index_map_entry(dof_id_type elem_id, unsigned int local_index);
+  void add_rb_property_map_entry(std::string & property_name, std::set<dof_id_type> & entity_ids);
 
   /**
    * Get the data associated with EIM interpolation points.
@@ -475,6 +481,7 @@ public:
   const Point & get_elem_center_dxyzdeta(unsigned int index) const;
   const std::vector<unsigned int> & get_interpolation_points_spatial_indices(unsigned int index) const;
   const std::map<dof_id_type, unsigned int> & get_elem_id_to_local_index_map() const;
+  const std::unordered_map<std::string, std::set<dof_id_type>> & get_rb_property_map() const;
 
   /**
    * _interpolation_points_spatial_indices is optional data, so we need to be able to
@@ -659,6 +666,12 @@ public:
    * Get the VectorizedEvalInput data.
    */
   const VectorizedEvalInput & get_vec_eval_input() const;
+
+  /**
+   * Initialize the rb_property_map of RBEIMEvaluation (this) from the rb_property_map stored in
+   * RBParametrizedFunction with empty entries but identical keys.
+   */
+  void initialize_rb_property_map();
 
   /**
    * Get all interior basis functions in the form of std::vectors.

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -493,9 +493,8 @@ protected:
 
   /**
    * Generic property map used to store data during mesh pre-evaluation. It should be initialized
-   * from a VectorizedEvalInput rb_property_map during the mesh pre-evaluation stage as VectorizedEvalInput
-   * goes out of scope quickly after pre-evluation. Then this RBParametrizedFunction rb_property_map
-   * is used to fill the RBEIMEvaluation VectorizedEvalInput rb_property_map with the same properties but
+   * from a vectorized_evaluate() call during the mesh pre-evaluation. Then this RBParametrizedFunction
+   * rb_property_map is used to fill the RBEIMEvaluation VectorizedEvalInput rb_property_map with the same properties but
    * interpolation point data only instead of the entire mesh.
    */
   std::unordered_map<std::string, std::set<dof_id_type>> _rb_property_map;

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -377,9 +377,14 @@ public:
 
   /**
    * Function that returns a reference to the rb_property_map stored in the RBParametrizedFunction.
-   * Note: We use the fact that rb_property_map can be set to nullptr when it is not used.
    */
   const std::unordered_map<std::string, std::set<dof_id_type>> &  get_rb_property_map() const;
+
+  /**
+   * Function that adds a property to the RBParametrizedFunction rb_property_map.
+   * The function checks that there is no duplicated properties before adding the property to the map.
+   */
+  void add_rb_property_map_entry(std::string & property_name, std::set<dof_id_type> & entity_ids);
 
   /**
    * Virtual function that can be overridden in RBParametrizedFunction subclasses to store

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -38,6 +38,10 @@ class RBParameters;
 class Point;
 class System;
 
+namespace Parallel {
+  class Communicator;
+}
+
 /**
  * Define a struct for the input to the "vectorized evaluate" functions below.
  * This encapsulates the arguments into a class to prevent having many function
@@ -91,6 +95,13 @@ struct VectorizedEvalInput
   std::vector<Point> dxyzdxi_elem_center;
   std::vector<Point> dxyzdeta_elem_center;
   std::vector<Order> qrule_orders;
+
+  /**
+   * Generic map that can be used to store any list of ids (elements, nodes, elemsets, subdomains...)
+   * corresponding to a property (string) that can be used to apply a specific treatment to a group
+   * of entities.
+   */
+  std::unordered_map<std::string, std::set<dof_id_type>> rb_property_map;
 };
 
 /**
@@ -365,6 +376,21 @@ public:
   virtual void preevaluate_parametrized_function_cleanup();
 
   /**
+   * Function that returns a pointer to the rb_property_map stored in the RBParametrizedFunction.
+   * Note: We use the fact that rb_property_map can be set to nullptr when it is not used.
+   */
+  const std::unordered_map<std::string, std::set<dof_id_type>> * get_rb_property_map() const;
+
+  /**
+   * Virtual function that can be overridden in RBParametrizedFunction subclasses to store
+   * properties in the rb_property_map.
+   */
+  virtual void add_interpolation_data_to_rb_property_map(
+    const Parallel::Communicator & comm,
+    std::unordered_map<std::string, std::set<dof_id_type>> & rb_property_map,
+    dof_id_type elem_id);
+
+  /**
    * Storage for pre-evaluated values. The indexing is given by:
    *   parameter index --> point index --> component index --> value.
    */
@@ -460,6 +486,14 @@ protected:
    */
   bool _is_nodal_boundary;
 
+  /**
+   * Generic property map used to store data during mesh pre-evaluation. It should be initialized
+   * from a VectorizedEvalInput rb_property_map during the mesh pre-evaluation stage as VectorizedEvalInput
+   * goes out of scope quickly after pre-evluation. Then this RBParametrizedFunction rb_property_map
+   * is used to fill the RBEIMEvaluation VectorizedEvalInput rb_property_map with the same properties but
+   * interpolation point data only instead of the entire mesh.
+   */
+  std::unique_ptr<std::unordered_map<std::string, std::set<dof_id_type>>> _rb_property_map;
 };
 
 }

--- a/include/reduced_basis/rb_parametrized_function.h
+++ b/include/reduced_basis/rb_parametrized_function.h
@@ -376,10 +376,10 @@ public:
   virtual void preevaluate_parametrized_function_cleanup();
 
   /**
-   * Function that returns a pointer to the rb_property_map stored in the RBParametrizedFunction.
+   * Function that returns a reference to the rb_property_map stored in the RBParametrizedFunction.
    * Note: We use the fact that rb_property_map can be set to nullptr when it is not used.
    */
-  const std::unordered_map<std::string, std::set<dof_id_type>> * get_rb_property_map() const;
+  const std::unordered_map<std::string, std::set<dof_id_type>> &  get_rb_property_map() const;
 
   /**
    * Virtual function that can be overridden in RBParametrizedFunction subclasses to store
@@ -493,7 +493,7 @@ protected:
    * is used to fill the RBEIMEvaluation VectorizedEvalInput rb_property_map with the same properties but
    * interpolation point data only instead of the entire mesh.
    */
-  std::unique_ptr<std::unordered_map<std::string, std::set<dof_id_type>>> _rb_property_map;
+  std::unordered_map<std::string, std::set<dof_id_type>> _rb_property_map;
 };
 
 }

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -992,6 +992,28 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
       }
   }
 
+  // Property map used to store generic properties by flaging entites like elements, nodes etc...
+  {
+    auto interpolation_points_property_list =
+      rb_eim_evaluation_reader.getPropertyMap();
+
+    if (interpolation_points_property_list.size() > 0)
+      {
+        unsigned int n_properties = interpolation_points_property_list.size();
+        for (unsigned int i=0; i<n_properties; ++i)
+          {
+            std::string property_name = interpolation_points_property_list[i].getName();
+            const auto entity_ids_list = interpolation_points_property_list[i].getEntityIds();
+            std::set<dof_id_type> entity_ids_set;
+            for (unsigned int j=0; j<entity_ids_list.size(); ++j)
+            {
+              entity_ids_set.insert(static_cast<dof_id_type>(entity_ids_list[j]));
+            }
+            rb_eim_evaluation.add_rb_property_map_entry(property_name, entity_ids_set);
+          }
+      }
+  }
+
   // Interpolation points perturbations
   {
     auto interpolation_points_list_outer =

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -831,6 +831,27 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
                                               rb_eim_evaluation.get_interpolation_points_elem_type(i));
   }
 
+  unsigned int n_properties = rb_eim_evaluation.get_n_properties();
+  // Property map used to store generic properties by flaging entites like elements, nodes etc...
+  {
+    auto interpolation_points_property_list =
+      rb_eim_evaluation_builder.initPropertyMap(n_properties);
+    unsigned int property_counter = 0;
+    for (const auto& [property_name, entity_ids] : rb_eim_evaluation.get_rb_property_map())
+      {
+        interpolation_points_property_list[property_counter].setName(property_name);
+
+        unsigned int entity_counter = 0;
+        auto property_entity_ids = interpolation_points_property_list[property_counter].initEntityIds(entity_ids.size());
+        for (const auto entity_id : entity_ids)
+        {
+          property_entity_ids.set(entity_counter, entity_id);
+          entity_counter++;
+        }
+        property_counter++;
+      }
+  }
+
   // Optionally store EIM solutions for the training set
   if (rb_eim_evaluation.get_parametrized_function().is_lookup_table)
     {

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -1664,6 +1664,10 @@ void RBEIMConstruction::initialize_parametrized_functions_in_training_set()
             _component_scaling_in_training_set[i] = _max_abs_value_in_training_set / max_abs_value_per_component_in_training_set[i];
         }
     }
+    // This function does nothing if rb_property_map from VectorizedEvalInput in RBParametrizedFunction
+    // is empty (= nullptr because ownership has not been transfered from VectorizedEvalInput of
+    // pre-evaluation to RBParametrizedFunction).
+    eim_eval.initialize_rb_property_map();
 }
 
 void RBEIMConstruction::initialize_qp_data()

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -1664,9 +1664,9 @@ void RBEIMConstruction::initialize_parametrized_functions_in_training_set()
             _component_scaling_in_training_set[i] = _max_abs_value_in_training_set / max_abs_value_per_component_in_training_set[i];
         }
     }
-    // This function does nothing if rb_property_map from VectorizedEvalInput in RBParametrizedFunction
-    // is empty (= nullptr because ownership has not been transfered from VectorizedEvalInput of
-    // pre-evaluation to RBParametrizedFunction).
+    // This function does nothing if rb_property_map from RBParametrizedFunction
+    // is empty which would result in an empty rb_property_map in VectorizedEvalInput
+    // stored in RBEIMEvaluation.
     eim_eval.initialize_rb_property_map();
 }
 

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -322,6 +322,11 @@ unsigned int RBEIMEvaluation::get_n_elems() const
   return _vec_eval_input.elem_id_to_local_index.size();
 }
 
+unsigned int RBEIMEvaluation::get_n_properties() const
+{
+  return _vec_eval_input.rb_property_map.size();
+}
+
 void RBEIMEvaluation::set_n_basis_functions(unsigned int n_bfs)
 {
   if (get_parametrized_function().on_mesh_sides())
@@ -787,9 +792,15 @@ void RBEIMEvaluation::add_interpolation_points_spatial_indices(const std::vector
 
 void RBEIMEvaluation::add_elem_id_local_index_map_entry(dof_id_type elem_id, unsigned int local_index)
 {
-  libmesh_error_msg_if(_vec_eval_input.elem_id_to_local_index.count(elem_id) == 1, "Entry already added, duplicate detected.");
+  // Try to insert object and return an error if object already inserted as duplicated should not happen.
+  bool insert_succeed = _vec_eval_input.elem_id_to_local_index.insert({elem_id, local_index}).second;
+  libmesh_error_msg_if(!insert_succeed, "Entry already added, duplicate detected.");
+}
 
-  _vec_eval_input.elem_id_to_local_index[elem_id] = local_index;
+void RBEIMEvaluation::add_rb_property_map_entry(std::string & property_name, std::set<dof_id_type> & entity_ids)
+{
+  bool insert_succeed = _vec_eval_input.rb_property_map.insert({property_name, entity_ids}).second;
+  libmesh_error_msg_if(!insert_succeed, "Entry already added, duplicate detected.");
 }
 
 Point RBEIMEvaluation::get_interpolation_points_xyz(unsigned int index) const
@@ -872,6 +883,11 @@ const std::vector<Real> & RBEIMEvaluation::get_interpolation_points_JxW_all_qp(u
 const std::map<dof_id_type, unsigned int> & RBEIMEvaluation::get_elem_id_to_local_index_map() const
 {
   return _vec_eval_input.elem_id_to_local_index;
+}
+
+const std::unordered_map<std::string, std::set<dof_id_type>> & RBEIMEvaluation::get_rb_property_map() const
+{
+  return _vec_eval_input.rb_property_map;
 }
 
 const std::vector<std::vector<Real>> & RBEIMEvaluation::get_interpolation_points_phi_i_all_qp(unsigned int index) const
@@ -988,6 +1004,15 @@ void RBEIMEvaluation::add_interpolation_data(
     _vec_eval_input.dxyzdxi_elem_center.emplace_back(dxyzdxi_elem_center);
     _vec_eval_input.dxyzdeta_elem_center.emplace_back(dxyzdeta_elem_center);
   }
+
+  // add_interpolation_data_to_property_map is a virtual function that aims to add only the property data
+  // required by the corresponding rb_parametrized_function.
+  // Right now, only elem_ids are supported but if subdomain_ids need to be stored for a property
+  // it can be added to the list of arguments and used in the overridden subclass function, the map type
+  // might also required an update to support various id types.
+  get_parametrized_function().add_interpolation_data_to_rb_property_map(this->comm(),
+                                                                        _vec_eval_input.rb_property_map,
+                                                                        elem_id);
 }
 
 void RBEIMEvaluation::add_side_basis_function(
@@ -3092,6 +3117,16 @@ std::pair<Real,Real> RBEIMEvaluation::get_eim_error_indicator(
 const VectorizedEvalInput & RBEIMEvaluation::get_vec_eval_input() const
 {
   return _vec_eval_input;
+}
+
+void RBEIMEvaluation::initialize_rb_property_map()
+{
+  const auto * rb_property_map_ptr = get_parametrized_function().get_rb_property_map();
+  // Initialize rb_eim_eval VectorizedEvaluateInput from the one in rb_parametrized_function with
+  // empty sets as it will be filled by subclasses virtual functions.
+  if (rb_property_map_ptr)
+    for (auto const& [key, val] : *rb_property_map_ptr)
+      _vec_eval_input.rb_property_map[key] = {};
 }
 
 const DenseVector<Number> & RBEIMEvaluation::get_error_indicator_interpolation_row() const

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -3121,12 +3121,11 @@ const VectorizedEvalInput & RBEIMEvaluation::get_vec_eval_input() const
 
 void RBEIMEvaluation::initialize_rb_property_map()
 {
-  const auto * rb_property_map_ptr = get_parametrized_function().get_rb_property_map();
+  const auto & rb_property_map = get_parametrized_function().get_rb_property_map();
   // Initialize rb_eim_eval VectorizedEvaluateInput from the one in rb_parametrized_function with
   // empty sets as it will be filled by subclasses virtual functions.
-  if (rb_property_map_ptr)
-    for (auto const& [key, val] : *rb_property_map_ptr)
-      _vec_eval_input.rb_property_map[key] = {};
+  for (const auto & [key, val] : rb_property_map)
+    _vec_eval_input.rb_property_map[key] = {};
 }
 
 const DenseVector<Number> & RBEIMEvaluation::get_error_indicator_interpolation_row() const

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -838,6 +838,12 @@ const std::unordered_map<std::string, std::set<dof_id_type>> & RBParametrizedFun
   return _rb_property_map;
 }
 
+void RBParametrizedFunction::add_rb_property_map_entry(std::string & property_name, std::set<dof_id_type> & entity_ids)
+{
+  bool insert_succeed = _rb_property_map.insert({property_name, entity_ids}).second;
+  libmesh_error_msg_if(!insert_succeed, "Entry already added, duplicate detected.");
+}
+
 void RBParametrizedFunction::add_interpolation_data_to_rb_property_map(
   const Parallel::Communicator & /*comm*/,
   std::unordered_map<std::string, std::set<dof_id_type>> & /*rb_property_map*/,

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -63,8 +63,7 @@ requires_all_elem_qp_data(false),
 requires_all_elem_center_data(false),
 is_lookup_table(false),
 fd_delta(1.e-6),
-_is_nodal_boundary(false),
-_rb_property_map(nullptr)
+_is_nodal_boundary(false)
 {}
 
 RBParametrizedFunction::~RBParametrizedFunction() = default;
@@ -570,7 +569,7 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh(const RBP
   vectorized_evaluate(mus, v, preevaluated_values);
 
   // Transfer from VectorizedEvaluate to RBParametrizedFunction as v will go out of scope after this function.
-  this->_rb_property_map = std::make_unique<std::unordered_map<std::string, std::set<dof_id_type>>>(v.rb_property_map);
+  this->_rb_property_map = std::move(v.rb_property_map);
 
   preevaluate_parametrized_function_cleanup();
 }
@@ -834,10 +833,10 @@ void RBParametrizedFunction::preevaluate_parametrized_function_cleanup()
   // No-op by default
 }
 
-const std::unordered_map<std::string, std::set<dof_id_type>> * RBParametrizedFunction::get_rb_property_map() const
+const std::unordered_map<std::string, std::set<dof_id_type>> & RBParametrizedFunction::get_rb_property_map() const
 {
-  return _rb_property_map.get();
-};
+  return _rb_property_map;
+}
 
 void RBParametrizedFunction::add_interpolation_data_to_rb_property_map(
   const Parallel::Communicator & /*comm*/,

--- a/src/reduced_basis/rb_parametrized_function.C
+++ b/src/reduced_basis/rb_parametrized_function.C
@@ -568,9 +568,6 @@ void RBParametrizedFunction::preevaluate_parametrized_function_on_mesh(const RBP
   std::vector<RBParameters> mus {mu};
   vectorized_evaluate(mus, v, preevaluated_values);
 
-  // Transfer from VectorizedEvaluate to RBParametrizedFunction as v will go out of scope after this function.
-  this->_rb_property_map = std::move(v.rb_property_map);
-
   preevaluate_parametrized_function_cleanup();
 }
 


### PR DESCRIPTION
* This update introduces a generic map in RB that can store various sets of dof_id_types. This can be used to identify elems, nodes, components and apply a specific treatment to those entities during EIM assembly.
* The map is stored in VectorizedEvalInput and transferred to RBParametrizedFunctions during mesh pre-evaluation (all qp data).
* This map is then used to fill a second map that will store the same properties but only for EIM points. This second map is stored in RBEIMEvaluation and can be serialized and deserialized during the training.