### PR TITLE
NetCDF configure help

### DIFF
--- a/configure
+++ b/configure
@@ -2141,6 +2141,8 @@ Optional Features:
   --enable-hdf5-required  Error if HDF5 is not detected by configure
   --disable-xmltest       Do not try to compile and run a test LIBXML program
   --disable-netcdf        build without netCDF binary I/O
+  --enable-netcdf=all     build with multiple netCDF, for source distribution
+  --enable-netcdf=v492    build with netCDF v4.9.2 binary I/O
   --disable-exodus        build without ExodusII API support
   --enable-exodus-fortran build with ExodusII Fortran API support
   --disable-nemesis       build without NemesisII API support
@@ -58422,6 +58424,7 @@ fi
 
   configure_netcdf_v462=''
   configure_netcdf_v492=''
+
   # Check whether --enable-netcdf was given.
 if test ${enable_netcdf+y}
 then :

--- a/m4/netcdf.m4
+++ b/m4/netcdf.m4
@@ -5,9 +5,16 @@ AC_DEFUN([CONFIGURE_NETCDF],
 [
   configure_netcdf_v462=''
   configure_netcdf_v492=''
+
+dnl The extra help strings here need to have no indentation.  Yes this
+dnl is a gross hack.
   AC_ARG_ENABLE(netcdf,
                 AS_HELP_STRING([--disable-netcdf],
-                               [build without netCDF binary I/O]),
+                               [build without netCDF binary I/O])
+AS_HELP_STRING([--enable-netcdf=all],
+[build with multiple netCDF, for source distribution])
+AS_HELP_STRING([--enable-netcdf=v492],
+[build with netCDF v4.9.2 binary I/O]),
                 [AS_CASE("${enableval}",
                   [v492],       [enablenetcdf=yes
                                  netcdfversion="v4.9.2"


### PR DESCRIPTION
This isn't a substitute for adding the ability to build against third-party NetCDF installs, but it was a lot easier to implement and it at least helps with [this reasonable complaint](https://github.com/libMesh/libmesh/issues/3708#issuecomment-2455798644)