### PR TITLE
Handle unprepared distributed meshes in all_tri()

### DIFF
--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -405,7 +405,8 @@ void MeshTools::Modification::scale (MeshBase & mesh,
 
 void MeshTools::Modification::all_tri (MeshBase & mesh)
 {
-  libmesh_assert(mesh.is_prepared() || mesh.is_replicated());
+  if (!mesh.is_replicated() && !mesh.is_prepared())
+    mesh.prepare_for_use();
 
   // The number of elements in the original mesh before any additions
   // or deletions.


### PR DESCRIPTION
This is more flexible, and it will let us run the tests in https://github.com/idaholab/moose/pull/28834 distributed without having to add anything to the code on that side.