### PR TITLE
Add a parameter object on the system, use it in derived classes

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex7/biharmonic_jr.C
+++ b/examples/miscellaneous/miscellaneous_ex7/biharmonic_jr.C
@@ -99,18 +99,18 @@ void Biharmonic::JR::initialize()
   if (_biharmonic._verbose)
     libMesh::out << ">>> Initializing Biharmonic::JR\n";
 
-  Parameters parameters;
-  parameters.set<Point>("center") = _biharmonic._initialCenter;
-  parameters.set<Real>("width")   = _biharmonic._initialWidth;
+  Parameters params;
+  params.set<Point>("center") = _biharmonic._initialCenter;
+  params.set<Real>("width")   = _biharmonic._initialWidth;
 
   if (_biharmonic._initialState == Biharmonic::BALL)
-    project_solution(Biharmonic::JR::InitialDensityBall, Biharmonic::JR::InitialGradientZero, parameters);
+    project_solution(Biharmonic::JR::InitialDensityBall, Biharmonic::JR::InitialGradientZero, params);
 
   if (_biharmonic._initialState == Biharmonic::ROD)
-    project_solution(Biharmonic::JR::InitialDensityRod, Biharmonic::JR::InitialGradientZero, parameters);
+    project_solution(Biharmonic::JR::InitialDensityRod, Biharmonic::JR::InitialGradientZero, params);
 
   if (_biharmonic._initialState == Biharmonic::STRIP)
-    project_solution(Biharmonic::JR::InitialDensityStrip, Biharmonic::JR::InitialGradientZero, parameters);
+    project_solution(Biharmonic::JR::InitialDensityStrip, Biharmonic::JR::InitialGradientZero, params);
 
   // both states are equal
   *(old_local_solution) = *(current_local_solution);
@@ -125,13 +125,13 @@ void Biharmonic::JR::initialize()
 
 
 Number Biharmonic::JR::InitialDensityBall(const Point & p,
-                                          const Parameters & parameters,
+                                          const Parameters & params,
                                           const std::string &,
                                           const std::string &)
 {
   // Initialize with a ball in the middle, which is a segment in 1D, a disk in 2D and a ball in 3D.
-  Point center = parameters.get<Point>("center");
-  Real width = parameters.get<Real>("width");
+  Point center = params.get<Point>("center");
+  Real width = params.get<Real>("width");
   Point pc = p-center;
   Real r = pc.norm();
   return (r < width) ? 1.0 : -0.5;
@@ -141,13 +141,13 @@ Number Biharmonic::JR::InitialDensityBall(const Point & p,
 
 
 Number Biharmonic::JR::InitialDensityRod(const Point & p,
-                                         const Parameters & parameters,
+                                         const Parameters & params,
                                          const std::string &,
                                          const std::string &)
 {
   // Initialize with a rod in the middle so that we have a z-homogeneous system to model the 2D disk.
-  Point center = parameters.get<Point>("center");
-  Real width = parameters.get<Real>("width");
+  Point center = params.get<Point>("center");
+  Real width = params.get<Real>("width");
   Point pc = p-center;
 #if LIBMESH_DIM > 2
   pc(2) = 0;
@@ -161,13 +161,13 @@ Number Biharmonic::JR::InitialDensityRod(const Point & p,
 
 
 Number Biharmonic::JR::InitialDensityStrip(const Point & p,
-                                           const Parameters & parameters,
+                                           const Parameters & params,
                                            const std::string &,
                                            const std::string &)
 {
   // Initialize with a wide strip in the middle so that we have a yz-homogeneous system to model the 1D.
-  Point center = parameters.get<Point>("center");
-  Real width = parameters.get<Real>("width");
+  Point center = params.get<Point>("center");
+  Real width = params.get<Real>("width");
   Real r = sqrt((p(0)-center(0))*(p(0)-center(0)));
   return (r < width) ? 1.0 : -0.5;
 }

--- a/examples/miscellaneous/miscellaneous_ex7/biharmonic_jr.h
+++ b/examples/miscellaneous/miscellaneous_ex7/biharmonic_jr.h
@@ -46,17 +46,17 @@ public:
    * Static functions to be used for initialization
    */
   static Number InitialDensityBall(const Point & p,
-                                   const Parameters & parameters,
+                                   const Parameters & params,
                                    const std::string &,
                                    const std::string &);
 
   static Number InitialDensityRod(const Point & p,
-                                  const Parameters & parameters,
+                                  const Parameters & params,
                                   const std::string &,
                                   const std::string &);
 
   static Number InitialDensityStrip(const Point & p,
-                                    const Parameters & parameters,
+                                    const Parameters & params,
                                     const std::string &,
                                     const std::string &);
 

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -27,6 +27,7 @@
 #include "libmesh/fem_function_base.h"
 #include "libmesh/libmesh_common.h"
 #include "libmesh/parallel_object.h"
+#include "libmesh/parameters.h"
 #include "libmesh/qoi_set.h"
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/tensor_value.h" // For point_hessian
@@ -60,7 +61,6 @@ class MeshBase;
 class Xdr;
 class DofMap;
 template <typename Output> class FunctionBase;
-class Parameters;
 class ParameterVector;
 class Point;
 class SensitivityData;
@@ -510,8 +510,6 @@ public:
    * user-provided cloneable functors.
    * A gradient \p g is only required/used for projecting onto finite
    * element spaces with continuous derivatives.
-   * If non-default \p Parameters are to be used, they can be provided
-   * in the \p parameters argument.
    */
   void project_solution (FunctionBase<Number> * f,
                          FunctionBase<Gradient> * g = nullptr) const;
@@ -522,8 +520,6 @@ public:
    * user-provided cloneable functors.
    * A gradient \p g is only required/used for projecting onto finite
    * element spaces with continuous derivatives.
-   * If non-default \p Parameters are to be used, they can be provided
-   * in the \p parameters argument.
    */
   void project_solution (FEMFunctionBase<Number> * f,
                          FEMFunctionBase<Gradient> * g = nullptr) const;
@@ -554,8 +550,6 @@ public:
    * user-provided cloneable functors.
    * A gradient \p g is only required/used for projecting onto finite
    * element spaces with continuous derivatives.
-   * If non-default \p Parameters are to be used, they can be provided
-   * in the \p parameters argument.
    *
    * Constrain the new vector using the requested adjoint rather than
    * primal constraints if is_adjoint is non-negative.
@@ -572,8 +566,6 @@ public:
    * user-provided cloneable functors.
    * A gradient \p g is only required/used for projecting onto finite
    * element spaces with continuous derivatives.
-   * If non-default \p Parameters are to be used, they can be provided
-   * in the \p parameters argument.
    *
    * Constrain the new vector using the requested adjoint rather than
    * primal constraints if is_adjoint is non-negative.
@@ -611,8 +603,6 @@ public:
    * user-provided cloneable functors.
    * A gradient \p g is only required/used for projecting onto finite
    * element spaces with continuous derivatives.
-   * If non-default \p Parameters are to be used, they can be provided
-   * in the \p parameters argument.
    */
   void boundary_project_solution (const std::set<boundary_id_type> & b,
                                   const std::vector<unsigned int> & variables,
@@ -648,8 +638,6 @@ public:
    * user-provided cloneable functors.
    * A gradient \p g is only required/used for projecting onto finite
    * element spaces with continuous derivatives.
-   * If non-default \p Parameters are to be used, they can be provided
-   * in the \p parameters argument.
    *
    * Constrain the new vector using the requested adjoint rather than
    * primal constraints if is_adjoint is non-negative.
@@ -1530,6 +1518,9 @@ public:
    * Prolong vectors after the mesh has refined
    */
   virtual void prolong_vectors ();
+
+  /// Parameters for the system. If a parameter is not provided, it should be retrieved from the EquationSystems
+  Parameters parameters;
 
   /**
    * Flag which tells the system to whether or not to

--- a/src/systems/eigen_system.C
+++ b/src/systems/eigen_system.C
@@ -222,16 +222,20 @@ EigenSystem::solve_helper(SparseMatrix<Number> * const A,
   // Get the tolerance for the solver and the maximum
   // number of iterations. Here, we simply adopt the linear solver
   // specific parameters.
-  const double tol          =
+  const double tol          =  parameters.have_parameter<Real>("linear solver tolerance") ?
+    double(parameters.get<Real>("linear solver tolerance")) :
     double(es.parameters.get<Real>("linear solver tolerance"));
 
-  const unsigned int maxits =
+  const unsigned int maxits = parameters.have_parameter<unsigned int>("linear solver maximum iterations") ?
+    parameters.get<unsigned int>("linear solver maximum iterations") :
     es.parameters.get<unsigned int>("linear solver maximum iterations");
 
-  const unsigned int nev    =
+  const unsigned int nev    = parameters.have_parameter<unsigned int>("eigenpairs") ?
+    parameters.get<unsigned int>("eigenpairs") :
     es.parameters.get<unsigned int>("eigenpairs");
 
-  const unsigned int ncv    =
+  const unsigned int ncv    = parameters.have_parameter<unsigned int>("basis vectors") ?
+    parameters.get<unsigned int>("basis vectors") :
     es.parameters.get<unsigned int>("basis vectors");
 
   std::pair<unsigned int, unsigned int> solve_data;

--- a/src/systems/frequency_system.C
+++ b/src/systems/frequency_system.C
@@ -123,7 +123,7 @@ void FrequencySystem::init_data ()
         {
 #ifndef NDEBUG
           const unsigned int n_freq =
-            es.parameters:<unsigned int>("n_frequencies");
+            es.parameters.get<unsigned int>("n_frequencies");
 
           libmesh_assert_greater (n_freq, 0);
 #endif
@@ -308,7 +308,7 @@ void FrequencySystem::set_frequencies (const std::vector<Number> & frequencies,
 unsigned int FrequencySystem::n_frequencies () const
 {
   libmesh_assert(_finished_set_frequencies);
-  return this->get_equation_systems().parameters:<unsigned int>("n_frequencies");
+  return this->get_equation_systems().parameters.get<unsigned int>("n_frequencies");
 }
 
 

--- a/src/systems/frequency_system.C
+++ b/src/systems/frequency_system.C
@@ -112,6 +112,10 @@ void FrequencySystem::init_data ()
   // make sure we have frequencies to solve for
   if (!_finished_set_frequencies)
     {
+      // not supported for now
+      if (parameters.have_parameter<unsigned int> ("n_frequencies"))
+        libmesh_not_implemented_msg("ERROR: Setting the n_frequencies parameter on the system is not supported");
+
       // when this system was read from file, check
       // if this has a "n_frequencies" parameter,
       // and initialize us with these.
@@ -119,7 +123,7 @@ void FrequencySystem::init_data ()
         {
 #ifndef NDEBUG
           const unsigned int n_freq =
-            es.parameters.get<unsigned int>("n_frequencies");
+            es.parameters:<unsigned int>("n_frequencies");
 
           libmesh_assert_greater (n_freq, 0);
 #endif
@@ -304,7 +308,7 @@ void FrequencySystem::set_frequencies (const std::vector<Number> & frequencies,
 unsigned int FrequencySystem::n_frequencies () const
 {
   libmesh_assert(_finished_set_frequencies);
-  return this->get_equation_systems().parameters.get<unsigned int>("n_frequencies");
+  return this->get_equation_systems().parameters:<unsigned int>("n_frequencies");
 }
 
 
@@ -339,9 +343,11 @@ void FrequencySystem::solve (const unsigned int n_start,
   // Get the user-specified linear solver tolerance,
   //     the user-specified maximum # of linear solver iterations,
   //     the user-specified wave speed
-  const Real tol            =
+  const Real tol            = parameters.have_parameter<Real>("linear solver tolerance") ?
+    double(parameters.get<Real>("linear solver tolerance")) :
     es.parameters.get<Real>("linear solver tolerance");
-  const unsigned int maxits =
+  const unsigned int maxits = parameters.have_parameter<unsigned int>("linear solver maximum iterations") ?
+    parameters.get<unsigned int>("linear solver maximum iterations") :
     es.parameters.get<unsigned int>("linear solver maximum iterations");
 
   // start solver loop

--- a/src/systems/frequency_system.C
+++ b/src/systems/frequency_system.C
@@ -343,12 +343,7 @@ void FrequencySystem::solve (const unsigned int n_start,
   // Get the user-specified linear solver tolerance,
   //     the user-specified maximum # of linear solver iterations,
   //     the user-specified wave speed
-  const Real tol            = parameters.have_parameter<Real>("linear solver tolerance") ?
-    double(parameters.get<Real>("linear solver tolerance")) :
-    es.parameters.get<Real>("linear solver tolerance");
-  const unsigned int maxits = parameters.have_parameter<unsigned int>("linear solver maximum iterations") ?
-    parameters.get<unsigned int>("linear solver maximum iterations") :
-    es.parameters.get<unsigned int>("linear solver maximum iterations");
+  const auto [maxits, tol] = this->get_linear_solve_parameters();
 
   // start solver loop
   for (unsigned int n=n_start; n<= n_stop; n++)

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -1222,16 +1222,14 @@ LinearSolver<Number> * ImplicitSystem::get_linear_solver() const
 
 std::pair<unsigned int, Real> ImplicitSystem::get_linear_solve_parameters() const
 {
-  if (parameters.have_parameter<unsigned int>("linear solver maximum iterations") &&
-     parameters.have_parameter<Real>("linear solver tolerance"))
-    return std::make_pair(parameters.get<unsigned int>("linear solver maximum iterations"),
-                          parameters.get<Real>("linear solver tolerance"));
-  else if (!parameters.have_parameter<unsigned int>("linear solver maximum iterations") &&
-     !parameters.have_parameter<Real>("linear solver tolerance"))
-    return std::make_pair(this->get_equation_systems().parameters.get<unsigned int>("linear solver maximum iterations"),
-                          this->get_equation_systems().parameters.get<Real>("linear solver tolerance"));
-  else
-    libmesh_error_msg("ERROR: Insufficient linear solver parameters");
+  return std::make_pair(
+      parameters.have_parameter<unsigned int>("linear solver maximum iterations")
+          ? parameters.get<unsigned int>("linear solver maximum iterations")
+          : this->get_equation_systems().parameters.get<unsigned int>(
+                "linear solver maximum iterations"),
+      parameters.have_parameter<Real>("linear solver tolerance")
+          ? parameters.get<Real>("linear solver tolerance")
+          : this->get_equation_systems().parameters.get<Real>("linear solver tolerance"));
 }
 
 

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -1222,8 +1222,16 @@ LinearSolver<Number> * ImplicitSystem::get_linear_solver() const
 
 std::pair<unsigned int, Real> ImplicitSystem::get_linear_solve_parameters() const
 {
-  return std::make_pair(this->get_equation_systems().parameters.get<unsigned int>("linear solver maximum iterations"),
-                        this->get_equation_systems().parameters.get<Real>("linear solver tolerance"));
+  if (parameters.have_parameter<unsigned int>("linear solver maximum iterations") &&
+     parameters.have_parameter<Real>("linear solver tolerance"))
+    return std::make_pair(parameters.get<unsigned int>("linear solver maximum iterations"),
+                          parameters.get<Real>("linear solver tolerance"));
+  else if (!parameters.have_parameter<unsigned int>("linear solver maximum iterations") &&
+     !parameters.have_parameter<Real>("linear solver tolerance"))
+    return std::make_pair(this->get_equation_systems().parameters.get<unsigned int>("linear solver maximum iterations"),
+                          this->get_equation_systems().parameters.get<Real>("linear solver tolerance"));
+  else
+    libmesh_error_msg("ERROR: Insufficient linear solver parameters");
 }
 
 

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -123,7 +123,7 @@ void ImplicitSystem::disable_cache () {
 
 
 std::pair<unsigned int, Real>
-ImplicitSystem::sensitivity_solve (const ParameterVector & parameters)
+ImplicitSystem::sensitivity_solve (const ParameterVector & parameters_vec)
 {
   // Log how long the linear solve takes.
   LOG_SCOPE("sensitivity_solve()", "ImplicitSystem");
@@ -138,7 +138,7 @@ ImplicitSystem::sensitivity_solve (const ParameterVector & parameters)
       this->matrix->close();
 
       // Reset and build the RHS from the residual derivatives
-      this->assemble_residual_derivatives(parameters);
+      this->assemble_residual_derivatives(parameters_vec);
     }
 
   // The sensitivity problem is linear
@@ -152,7 +152,7 @@ ImplicitSystem::sensitivity_solve (const ParameterVector & parameters)
 
   // Solve the linear system.
   SparseMatrix<Number> * pc = this->request_matrix("Preconditioner");
-  for (auto p : make_range(parameters.size()))
+  for (auto p : make_range(parameters_vec.size()))
     {
       std::pair<unsigned int, Real> rval =
         solver->solve (*matrix, pc,
@@ -167,7 +167,7 @@ ImplicitSystem::sensitivity_solve (const ParameterVector & parameters)
 
   // The linear solver may not have fit our constraints exactly
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
-  for (auto p : make_range(parameters.size()))
+  for (auto p : make_range(parameters_vec.size()))
     this->get_dof_map().enforce_constraints_exactly
       (*this, &this->get_sensitivity_solution(p),
        /* homogeneous = */ true);
@@ -240,7 +240,7 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
   // We currently get partial derivatives via central differencing
   const Real delta_p = TOLERANCE;
 
-  ParameterVector & parameters =
+  ParameterVector & parameters_vec =
     const_cast<ParameterVector &>(parameters_in);
 
   // The forward system should now already be solved.
@@ -280,10 +280,10 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
   // then finally dividing by 2*dp.
 
   ParameterVector oldparameters, parameterperturbation;
-  parameters.deep_copy(oldparameters);
+  parameters_vec.deep_copy(oldparameters);
   weights.deep_copy(parameterperturbation);
   parameterperturbation *= delta_p;
-  parameters += parameterperturbation;
+  parameters_vec += parameterperturbation;
 
   this->assembly(false, true);
   this->matrix->close();
@@ -304,9 +304,9 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
         *(temprhs[i]) *= -1.0;
       }
 
-  oldparameters.value_copy(parameters);
+  oldparameters.value_copy(parameters_vec);
   parameterperturbation *= -1.0;
-  parameters += parameterperturbation;
+  parameters_vec += parameterperturbation;
 
   this->assembly(false, true);
   this->matrix->close();
@@ -327,7 +327,7 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
   // Finally, assemble the jacobian at the non-perturbed parameter
   // values.  Ignore assemble_before_solve; if we had a good
   // non-perturbed matrix before we've already overwritten it.
-  oldparameters.value_copy(parameters);
+  oldparameters.value_copy(parameters_vec);
 
   // if (this->assemble_before_solve)
   {
@@ -385,7 +385,7 @@ ImplicitSystem::weighted_sensitivity_solve (const ParameterVector & parameters_i
   // We currently get partial derivatives via central differencing
   const Real delta_p = TOLERANCE;
 
-  ParameterVector & parameters =
+  ParameterVector & parameters_vec =
     const_cast<ParameterVector &>(parameters_in);
 
   // The forward system should now already be solved.
@@ -405,19 +405,19 @@ ImplicitSystem::weighted_sensitivity_solve (const ParameterVector & parameters_i
   // sum_l(w_l*v_l) ~= (v(p + dp*w_l*e_l) - v(p - dp*w_l*e_l))/(2*dp)
 
   ParameterVector oldparameters, parameterperturbation;
-  parameters.deep_copy(oldparameters);
+  parameters_vec.deep_copy(oldparameters);
   weights.deep_copy(parameterperturbation);
   parameterperturbation *= delta_p;
-  parameters += parameterperturbation;
+  parameters_vec += parameterperturbation;
 
   this->assembly(true, false, true);
   this->rhs->close();
 
   std::unique_ptr<NumericVector<Number>> temprhs = this->rhs->clone();
 
-  oldparameters.value_copy(parameters);
+  oldparameters.value_copy(parameters_vec);
   parameterperturbation *= -1.0;
-  parameters += parameterperturbation;
+  parameters_vec += parameterperturbation;
 
   this->assembly(true, false, true);
   this->rhs->close();
@@ -427,7 +427,7 @@ ImplicitSystem::weighted_sensitivity_solve (const ParameterVector & parameters_i
 
   // Finally, assemble the jacobian at the non-perturbed parameter
   // values
-  oldparameters.value_copy(parameters);
+  oldparameters.value_copy(parameters_vec);
 
   // Build the Jacobian
   this->assembly(false, true);
@@ -459,11 +459,11 @@ ImplicitSystem::weighted_sensitivity_solve (const ParameterVector & parameters_i
 
 void ImplicitSystem::assemble_residual_derivatives(const ParameterVector & parameters_in)
 {
-  ParameterVector & parameters =
+  ParameterVector & parameters_vec =
     const_cast<ParameterVector &>(parameters_in);
 
   const unsigned int Np = cast_int<unsigned int>
-    (parameters.size());
+    (parameters_vec.size());
 
   for (unsigned int p=0; p != Np; ++p)
     {
@@ -472,19 +472,19 @@ void ImplicitSystem::assemble_residual_derivatives(const ParameterVector & param
       // Approximate -(partial R / partial p) by
       // (R(p-dp) - R(p+dp)) / (2*dp)
 
-      Number old_parameter = *parameters[p];
+      Number old_parameter = *parameters_vec[p];
 
       const Real delta_p =
         TOLERANCE * std::max(std::abs(old_parameter), 1e-3);
 
-      *parameters[p] -= delta_p;
+      *parameters_vec[p] -= delta_p;
 
       //      this->assembly(true, false, true);
       this->assembly(true, false, false);
       this->rhs->close();
       sensitivity_rhs = *this->rhs;
 
-      *parameters[p] = old_parameter + delta_p;
+      *parameters_vec[p] = old_parameter + delta_p;
 
       //      this->assembly(true, false, true);
       this->assembly(true, false, false);
@@ -494,7 +494,7 @@ void ImplicitSystem::assemble_residual_derivatives(const ParameterVector & param
       sensitivity_rhs /= (2*delta_p);
       sensitivity_rhs.close();
 
-      *parameters[p] = old_parameter;
+      *parameters_vec[p] = old_parameter;
     }
 }
 
@@ -504,11 +504,11 @@ void ImplicitSystem::adjoint_qoi_parameter_sensitivity (const QoISet & qoi_indic
                                                         const ParameterVector & parameters_in,
                                                         SensitivityData & sensitivities)
 {
-  ParameterVector & parameters =
+  ParameterVector & parameters_vec =
     const_cast<ParameterVector &>(parameters_in);
 
   const unsigned int Np = cast_int<unsigned int>
-    (parameters.size());
+    (parameters_vec.size());
   const unsigned int Nq = this->n_qois();
 
   // An introduction to the problem:
@@ -532,7 +532,7 @@ void ImplicitSystem::adjoint_qoi_parameter_sensitivity (const QoISet & qoi_indic
   this->assemble_residual_derivatives(parameters_in);
 
   // Get ready to fill in sensitivities:
-  sensitivities.allocate_data(qoi_indices, *this, parameters);
+  sensitivities.allocate_data(qoi_indices, *this, parameters_vec);
 
   // We use the identities:
   // dq/dp = (partial q / partial p) + (partial q / partial u) *
@@ -573,18 +573,18 @@ void ImplicitSystem::adjoint_qoi_parameter_sensitivity (const QoISet & qoi_indic
       // (partial q / partial p) ~= (q(p+dp)-q(p-dp))/(2*dp)
       // (partial R / partial p) ~= (rhs(p+dp) - rhs(p-dp))/(2*dp)
 
-      Number old_parameter = *parameters[j];
+      Number old_parameter = *parameters_vec[j];
 
       const Real delta_p =
         TOLERANCE * std::max(std::abs(old_parameter), 1e-3);
 
-      *parameters[j] = old_parameter - delta_p;
+      *parameters_vec[j] = old_parameter - delta_p;
       this->assemble_qoi(qoi_indices);
       const std::vector<Number> qoi_minus = this->get_qoi_values();
 
       NumericVector<Number> & neg_partialR_partialp = this->get_sensitivity_rhs(j);
 
-      *parameters[j] = old_parameter + delta_p;
+      *parameters_vec[j] = old_parameter + delta_p;
       this->assemble_qoi(qoi_indices);
       const std::vector<Number> qoi_plus = this->get_qoi_values();
 
@@ -594,7 +594,7 @@ void ImplicitSystem::adjoint_qoi_parameter_sensitivity (const QoISet & qoi_indic
           partialq_partialp[i] = (qoi_plus[i] - qoi_minus[i]) / (2.*delta_p);
 
       // Don't leave the parameter changed
-      *parameters[j] = old_parameter;
+      *parameters_vec[j] = old_parameter;
 
       for (unsigned int i=0; i != Nq; ++i)
         if (qoi_indices.has_index(i))
@@ -602,7 +602,7 @@ void ImplicitSystem::adjoint_qoi_parameter_sensitivity (const QoISet & qoi_indic
             neg_partialR_partialp.dot(this->get_adjoint_solution(i));
     }
 
-  // All parameters have been reset.
+  // All parameters_vec have been reset.
   // Reset the original qoi.
 
   this->assemble_qoi(qoi_indices);
@@ -614,11 +614,11 @@ void ImplicitSystem::forward_qoi_parameter_sensitivity (const QoISet & qoi_indic
                                                         const ParameterVector & parameters_in,
                                                         SensitivityData & sensitivities)
 {
-  ParameterVector & parameters =
+  ParameterVector & parameters_vec =
     const_cast<ParameterVector &>(parameters_in);
 
   const unsigned int Np = cast_int<unsigned int>
-    (parameters.size());
+    (parameters_vec.size());
   const unsigned int Nq = this->n_qois();
 
   // An introduction to the problem:
@@ -634,10 +634,10 @@ void ImplicitSystem::forward_qoi_parameter_sensitivity (const QoISet & qoi_indic
   // We first solve for (partial u / partial p) for each parameter:
   // J * (partial u / partial p) = - (partial R / partial p)
 
-  this->sensitivity_solve(parameters);
+  this->sensitivity_solve(parameters_vec);
 
   // Get ready to fill in sensitivities:
-  sensitivities.allocate_data(qoi_indices, *this, parameters);
+  sensitivities.allocate_data(qoi_indices, *this, parameters_vec);
 
   // We use the identity:
   // dq/dp = (partial q / partial p) + (partial q / partial u) *
@@ -661,16 +661,16 @@ void ImplicitSystem::forward_qoi_parameter_sensitivity (const QoISet & qoi_indic
 
       // (partial q / partial p) ~= (q(p+dp)-q(p-dp))/(2*dp)
 
-      Number old_parameter = *parameters[j];
+      Number old_parameter = *parameters_vec[j];
 
       const Real delta_p =
         TOLERANCE * std::max(std::abs(old_parameter), 1e-3);
 
-      *parameters[j] = old_parameter - delta_p;
+      *parameters_vec[j] = old_parameter - delta_p;
       this->assemble_qoi(qoi_indices);
       const std::vector<Number> qoi_minus = this->get_qoi_values();
 
-      *parameters[j] = old_parameter + delta_p;
+      *parameters_vec[j] = old_parameter + delta_p;
       this->assemble_qoi(qoi_indices);
       const std::vector<Number> qoi_plus = this->get_qoi_values();
 
@@ -680,7 +680,7 @@ void ImplicitSystem::forward_qoi_parameter_sensitivity (const QoISet & qoi_indic
           partialq_partialp[i] = (qoi_plus[i] - qoi_minus[i]) / (2.*delta_p);
 
       // Don't leave the parameter changed
-      *parameters[j] = old_parameter;
+      *parameters_vec[j] = old_parameter;
 
       for (unsigned int i=0; i != Nq; ++i)
         if (qoi_indices.has_index(i))
@@ -688,7 +688,7 @@ void ImplicitSystem::forward_qoi_parameter_sensitivity (const QoISet & qoi_indic
             this->get_adjoint_rhs(i).dot(this->get_sensitivity_solution(j));
     }
 
-  // All parameters have been reset.
+  // All parameters_vec have been reset.
   // We didn't cache the original rhs or matrix for memory reasons,
   // but we can restore them to a state consistent solution -
   // principle of least surprise.
@@ -708,14 +708,14 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product (const QoISet & qoi_in
   // We currently get partial derivatives via finite differencing
   const Real delta_p = TOLERANCE;
 
-  ParameterVector & parameters =
+  ParameterVector & parameters_vec =
     const_cast<ParameterVector &>(parameters_in);
 
   // We'll use a single temporary vector for matrix-vector-vector products
   std::unique_ptr<NumericVector<Number>> tempvec = this->solution->zero_clone();
 
   const unsigned int Np = cast_int<unsigned int>
-    (parameters.size());
+    (parameters_vec.size());
   const unsigned int Nq = this->n_qois();
 
   // For each quantity of interest q, the parameter sensitivity
@@ -743,7 +743,7 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product (const QoISet & qoi_in
     }
 
   // Get ready to fill in sensitivities:
-  sensitivities.allocate_data(qoi_indices, *this, parameters);
+  sensitivities.allocate_data(qoi_indices, *this, parameters_vec);
 
   // We can't solve for all the solution sensitivities u'_l or for all
   // of the parameter sensitivity adjoint solutions z^l without
@@ -751,10 +751,10 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product (const QoISet & qoi_in
   // weighted sum - this is just O(Nq) solves.
 
   // First solve for sum_l(w_l u'_l).
-  this->weighted_sensitivity_solve(parameters, vector);
+  this->weighted_sensitivity_solve(parameters_vec, vector);
 
   // Then solve for sum_l(w_l z^l).
-  this->weighted_sensitivity_adjoint_solve(parameters, vector, qoi_indices);
+  this->weighted_sensitivity_adjoint_solve(parameters_vec, vector, qoi_indices);
 
   for (unsigned int k=0; k != Np; ++k)
     {
@@ -771,14 +771,14 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product (const QoISet & qoi_in
       // R(p + dp*w_l*e_l - dp*e_k) + R(p - dp*w_l*e_l - dp*e_k))/(4*dp^2)
 
       ParameterVector oldparameters, parameterperturbation;
-      parameters.deep_copy(oldparameters);
+      parameters_vec.deep_copy(oldparameters);
       vector.deep_copy(parameterperturbation);
       parameterperturbation *= delta_p;
-      parameters += parameterperturbation;
+      parameters_vec += parameterperturbation;
 
-      Number old_parameter = *parameters[k];
+      Number old_parameter = *parameters_vec[k];
 
-      *parameters[k] = old_parameter + delta_p;
+      *parameters_vec[k] = old_parameter + delta_p;
       this->assemble_qoi(qoi_indices);
       this->assembly(true, false, true);
       this->rhs->close();
@@ -788,7 +788,7 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product (const QoISet & qoi_in
         if (qoi_indices.has_index(i))
           partial2R_term[i] = this->rhs->dot(this->get_adjoint_solution(i));
 
-      *parameters[k] = old_parameter - delta_p;
+      *parameters_vec[k] = old_parameter - delta_p;
       this->assemble_qoi(qoi_indices);
       this->assembly(true, false, true);
       this->rhs->close();
@@ -799,14 +799,14 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product (const QoISet & qoi_in
             partial2R_term[i] -= this->rhs->dot(this->get_adjoint_solution(i));
           }
 
-      oldparameters.value_copy(parameters);
+      oldparameters.value_copy(parameters_vec);
       parameterperturbation *= -1.0;
-      parameters += parameterperturbation;
+      parameters_vec += parameterperturbation;
 
       // Re-center old_parameter, which may be affected by vector
-      old_parameter = *parameters[k];
+      old_parameter = *parameters_vec[k];
 
-      *parameters[k] = old_parameter + delta_p;
+      *parameters_vec[k] = old_parameter + delta_p;
       this->assemble_qoi(qoi_indices);
       this->assembly(true, false, true);
       this->rhs->close();
@@ -817,7 +817,7 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product (const QoISet & qoi_in
             partial2R_term[i] -= this->rhs->dot(this->get_adjoint_solution(i));
           }
 
-      *parameters[k] = old_parameter - delta_p;
+      *parameters_vec[k] = old_parameter - delta_p;
       this->assemble_qoi(qoi_indices);
       this->assembly(true, false, true);
       this->rhs->close();
@@ -855,7 +855,7 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product (const QoISet & qoi_in
       // FIXME: this is probably a bad order of operations for
       // controlling floating point error.
 
-      *parameters[k] = old_parameter + delta_p;
+      *parameters_vec[k] = old_parameter + delta_p;
       this->assembly(true, true);
       this->rhs->close();
       this->matrix->close();
@@ -874,7 +874,7 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product (const QoISet & qoi_in
                                     this->get_adjoint_solution(i).dot(*tempvec)) / (2.*delta_p);
           }
 
-      *parameters[k] = old_parameter - delta_p;
+      *parameters_vec[k] = old_parameter - delta_p;
       this->assembly(true, true);
       this->rhs->close();
       this->matrix->close();
@@ -912,7 +912,7 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
   // We currently get partial derivatives via finite differencing
   const Real delta_p = TOLERANCE;
 
-  ParameterVector & parameters =
+  ParameterVector & parameters_vec =
     const_cast<ParameterVector &>(parameters_in);
 
   // We'll use one temporary vector for matrix-vector-vector products
@@ -923,7 +923,7 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
   std::unique_ptr<NumericVector<Number>> oldsolution = this->solution->clone();
 
   const unsigned int Np = cast_int<unsigned int>
-    (parameters.size());
+    (parameters_vec.size());
   const unsigned int Nq = this->n_qois();
 
   // For each quantity of interest q, the parameter sensitivity
@@ -951,14 +951,14 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
     }
 
   // And a sensitivity solve to get u_k for each parameter
-  this->sensitivity_solve(parameters);
+  this->sensitivity_solve(parameters_vec);
 
   // Get ready to fill in second derivatives:
-  sensitivities.allocate_hessian_data(qoi_indices, *this, parameters);
+  sensitivities.allocate_hessian_data(qoi_indices, *this, parameters_vec);
 
   for (unsigned int k=0; k != Np; ++k)
     {
-      Number old_parameterk = *parameters[k];
+      Number old_parameterk = *parameters_vec[k];
 
       // The Hessian is symmetric, so we just calculate the lower
       // triangle and the diagonal, and we get the upper triangle from
@@ -966,7 +966,7 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
 
       for (unsigned int l=0; l != k+1; ++l)
         {
-          // The second partial derivatives with respect to parameters
+          // The second partial derivatives with respect to parameters_vec
           // are all calculated via a central finite difference
           // stencil:
           // F''_{kl} ~= (F(p+dp*e_k+dp*e_l) - F(p+dp*e_k-dp*e_l) -
@@ -977,10 +977,10 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
           // We have to be careful with the perturbations to handle
           // the k=l case
 
-          Number old_parameterl = *parameters[l];
+          Number old_parameterl = *parameters_vec[l];
 
-          *parameters[k] += delta_p;
-          *parameters[l] += delta_p;
+          *parameters_vec[k] += delta_p;
+          *parameters_vec[l] += delta_p;
           this->assemble_qoi(qoi_indices);
           this->assembly(true, false, true);
           this->rhs->close();
@@ -990,7 +990,7 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
             if (qoi_indices.has_index(i))
               partial2R_term[i] = this->rhs->dot(this->get_adjoint_solution(i));
 
-          *parameters[l] -= 2.*delta_p;
+          *parameters_vec[l] -= 2.*delta_p;
           this->assemble_qoi(qoi_indices);
           this->assembly(true, false, true);
           this->rhs->close();
@@ -1001,7 +1001,7 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
                 partial2R_term[i] -= this->rhs->dot(this->get_adjoint_solution(i));
               }
 
-          *parameters[k] -= 2.*delta_p;
+          *parameters_vec[k] -= 2.*delta_p;
           this->assemble_qoi(qoi_indices);
           this->assembly(true, false, true);
           this->rhs->close();
@@ -1012,7 +1012,7 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
                 partial2R_term[i] += this->rhs->dot(this->get_adjoint_solution(i));
               }
 
-          *parameters[l] += 2.*delta_p;
+          *parameters_vec[l] += 2.*delta_p;
           this->assemble_qoi(qoi_indices);
           this->assembly(true, false, true);
           this->rhs->close();
@@ -1034,9 +1034,9 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
                   sensitivities.second_derivative(i,l,k) += current_terms;
               }
 
-          // Don't leave the parameters perturbed
-          *parameters[l] = old_parameterl;
-          *parameters[k] = old_parameterk;
+          // Don't leave the parameters_vec perturbed
+          *parameters_vec[l] = old_parameterl;
+          *parameters_vec[k] = old_parameterk;
         }
 
       // We get (partial q / partial u) and
@@ -1052,7 +1052,7 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
       // FIXME: this is probably a bad order of operations for
       // controlling floating point error.
 
-      *parameters[k] = old_parameterk + delta_p;
+      *parameters_vec[k] = old_parameterk + delta_p;
       this->assembly(false, true);
       this->matrix->close();
       this->assemble_qoi_derivative(qoi_indices,
@@ -1078,7 +1078,7 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
               }
         }
 
-      *parameters[k] = old_parameterk - delta_p;
+      *parameters_vec[k] = old_parameterk - delta_p;
       this->assembly(false, true);
       this->matrix->close();
       this->assemble_qoi_derivative(qoi_indices,
@@ -1105,7 +1105,7 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
         }
 
       // Don't leave the parameter perturbed
-      *parameters[k] = old_parameterk;
+      *parameters_vec[k] = old_parameterk;
 
       // Our last remaining terms are -R_uu(u,z)*u_k*u_l and
       // Q_uu(u)*u_k*u_l
@@ -1184,7 +1184,7 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
       *this->solution = *oldsolution;
     }
 
-  // All parameters have been reset.
+  // All parameters_vec have been reset.
   // Don't leave the qoi or system changed - principle of least
   // surprise.
   // We've modified solution, so we need to update before calling

--- a/src/systems/linear_implicit_system.C
+++ b/src/systems/linear_implicit_system.C
@@ -118,10 +118,6 @@ void LinearImplicitSystem::solve ()
     // Assemble the linear system
     this->assemble ();
 
-  // Get a reference to the EquationSystems
-  const EquationSystems & es =
-    this->get_equation_systems();
-
   // If the linear solver hasn't been initialized, we do so here.
   if (this->prefix_with_name())
     linear_solver->init(this->prefix().c_str());
@@ -131,14 +127,7 @@ void LinearImplicitSystem::solve ()
   linear_solver->init_names(*this);
 
   // Get the user-specified linear solver tolerance
-  const double tol = parameters.have_parameter<Real>("linear solver tolerance") ?
-    double(parameters.get<Real>("linear solver tolerance")) :
-    double(es.parameters.get<Real>("linear solver tolerance"));
-
-  // Get the user-specified maximum # of linear solver iterations
-  const unsigned int maxits = parameters.have_parameter<unsigned int>("linear solver maximum iterations") ?
-    parameters.get<unsigned int>("linear solver maximum iterations") :
-    es.parameters.get<unsigned int>("linear solver maximum iterations");
+  const auto [maxits, tol] = this->get_linear_solve_parameters();
 
   if (_subset != nullptr)
     linear_solver->restrict_solve_to(&_subset->dof_ids(),_subset_solve_mode);

--- a/src/systems/linear_implicit_system.C
+++ b/src/systems/linear_implicit_system.C
@@ -131,11 +131,13 @@ void LinearImplicitSystem::solve ()
   linear_solver->init_names(*this);
 
   // Get the user-specified linear solver tolerance
-  const double tol =
+  const double tol = parameters.have_parameter<Real>("linear solver tolerance") ?
+    double(parameters.get<Real>("linear solver tolerance")) :
     double(es.parameters.get<Real>("linear solver tolerance"));
 
   // Get the user-specified maximum # of linear solver iterations
-  const unsigned int maxits =
+  const unsigned int maxits = parameters.have_parameter<unsigned int>("linear solver maximum iterations") ?
+    parameters.get<unsigned int>("linear solver maximum iterations") :
     es.parameters.get<unsigned int>("linear solver maximum iterations");
 
   if (_subset != nullptr)

--- a/src/systems/nonlinear_implicit_system.C
+++ b/src/systems/nonlinear_implicit_system.C
@@ -147,7 +147,7 @@ void NonlinearImplicitSystem::set_solver_parameters ()
     double(es.parameters.get<Real>("nonlinear solver relative step tolerance"));
 
   // Get the user-specified linear solver tolerances
-  const auto [maxlinearits, linear_tol] = this->get_linear_solve_parameters();
+  const auto [maxlinearits, linear_tol] = this->Parent::get_linear_solve_parameters();
 
   const double linear_min_tol = parameters.have_parameter<Real>("linear solver minimum tolerance") ?
     double(parameters.get<Real>("linear solver minimum tolerance")) :

--- a/src/systems/nonlinear_implicit_system.C
+++ b/src/systems/nonlinear_implicit_system.C
@@ -118,40 +118,53 @@ void NonlinearImplicitSystem::set_solver_parameters ()
     this->get_equation_systems();
 
   // Get the user-specified nonlinear solver tolerances
-  const unsigned int maxits =
+  const unsigned int maxits = parameters.have_parameter<unsigned int>("nonlinear solver maximum iterations") ?
+    parameters.get<unsigned int>("nonlinear solver maximum iterations") :
     es.parameters.get<unsigned int>("nonlinear solver maximum iterations");
 
-  const unsigned int maxfuncs =
+  const unsigned int maxfuncs = parameters.have_parameter<unsigned int>("nonlinear solver maximum function evaluations") ?
+    parameters.get<unsigned int>("nonlinear solver maximum function evaluations") :
     es.parameters.get<unsigned int>("nonlinear solver maximum function evaluations");
 
-  const double abs_resid_tol =
+  const double abs_resid_tol = parameters.have_parameter<Real>("nonlinear solver absolute residual tolerance") ?
+    double(parameters.get<Real>("nonlinear solver absolute residual tolerance")) :
     double(es.parameters.get<Real>("nonlinear solver absolute residual tolerance"));
 
-  const double rel_resid_tol =
+  const double rel_resid_tol = parameters.have_parameter<Real>("nonlinear solver relative residual tolerance") ?
+    double(parameters.get<Real>("nonlinear solver relative residual tolerance")) :
     double(es.parameters.get<Real>("nonlinear solver relative residual tolerance"));
 
-  const double div_tol =
+  const double div_tol = parameters.have_parameter<Real>("nonlinear solver divergence tolerance") ?
+    double(parameters.get<Real>("nonlinear solver divergence tolerance")) :
     double(es.parameters.get<Real>("nonlinear solver divergence tolerance"));
 
-  const double abs_step_tol =
+  const double abs_step_tol = parameters.have_parameter<Real>("nonlinear solver absolute step tolerance") ?
+    double(parameters.get<Real>("nonlinear solver absolute step tolerance")) :
     double(es.parameters.get<Real>("nonlinear solver absolute step tolerance"));
 
-  const double rel_step_tol =
+  const double rel_step_tol = parameters.have_parameter<Real>("nonlinear solver relative step tolerance")?
+    double(parameters.get<Real>("nonlinear solver relative step tolerance")) :
     double(es.parameters.get<Real>("nonlinear solver relative step tolerance"));
 
   // Get the user-specified linear solver tolerances
-  const unsigned int maxlinearits =
+  const unsigned int maxlinearits = parameters.have_parameter<unsigned int>("linear solver maximum iterations") ?
+    parameters.get<unsigned int>("linear solver maximum iterations") :
     es.parameters.get<unsigned int>("linear solver maximum iterations");
 
-  const double linear_tol =
+  const double linear_tol = parameters.have_parameter<Real>("linear solver tolerance") ?
+    double(parameters.get<Real>("linear solver tolerance")) :
     double(es.parameters.get<Real>("linear solver tolerance"));
 
-  const double linear_min_tol =
+  const double linear_min_tol = parameters.have_parameter<Real>("linear solver minimum tolerance") ?
+    double(parameters.get<Real>("linear solver minimum tolerance")) :
     double(es.parameters.get<Real>("linear solver minimum tolerance"));
 
-  const bool reuse_preconditioner =
+  const bool reuse_preconditioner = parameters.have_parameter<unsigned int>("reuse preconditioner") ?
+    parameters.get<unsigned int>("reuse preconditioner") :
       es.parameters.get<bool>("reuse preconditioner");
   const unsigned int reuse_preconditioner_max_linear_its =
+    parameters.have_parameter<unsigned int>("reuse preconditioner maximum linear iterations") ?
+    parameters.get<unsigned int>("reuse preconditioner maximum linear iterations") :
       es.parameters.get<unsigned int>("reuse preconditioner maximum linear iterations");
 
   // Set all the parameters on the NonlinearSolver

--- a/src/systems/nonlinear_implicit_system.C
+++ b/src/systems/nonlinear_implicit_system.C
@@ -147,13 +147,7 @@ void NonlinearImplicitSystem::set_solver_parameters ()
     double(es.parameters.get<Real>("nonlinear solver relative step tolerance"));
 
   // Get the user-specified linear solver tolerances
-  const unsigned int maxlinearits = parameters.have_parameter<unsigned int>("linear solver maximum iterations") ?
-    parameters.get<unsigned int>("linear solver maximum iterations") :
-    es.parameters.get<unsigned int>("linear solver maximum iterations");
-
-  const double linear_tol = parameters.have_parameter<Real>("linear solver tolerance") ?
-    double(parameters.get<Real>("linear solver tolerance")) :
-    double(es.parameters.get<Real>("linear solver tolerance"));
+  const auto [maxlinearits, linear_tol] = this->get_linear_solve_parameters();
 
   const double linear_min_tol = parameters.have_parameter<Real>("linear solver minimum tolerance") ?
     double(parameters.get<Real>("linear solver minimum tolerance")) :

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -587,17 +587,17 @@ void System::assemble_qoi_derivative(const QoISet & qoi_indices,
 
 
 void System::qoi_parameter_sensitivity (const QoISet & qoi_indices,
-                                        const ParameterVector & parameters,
+                                        const ParameterVector & parameters_vec,
                                         SensitivityData & sensitivities)
 {
   // Forward sensitivities are more efficient for Nq > Np
-  if (qoi_indices.size(*this) > parameters.size())
-    forward_qoi_parameter_sensitivity(qoi_indices, parameters, sensitivities);
+  if (qoi_indices.size(*this) > parameters_vec.size())
+    forward_qoi_parameter_sensitivity(qoi_indices, parameters_vec, sensitivities);
   // Adjoint sensitivities are more efficient for Np > Nq,
   // and an adjoint may be more reusable than a forward
   // solution sensitivity in the Np == Nq case.
   else
-    adjoint_qoi_parameter_sensitivity(qoi_indices, parameters, sensitivities);
+    adjoint_qoi_parameter_sensitivity(qoi_indices, parameters_vec, sensitivities);
 }
 
 

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -1026,10 +1026,10 @@ void System::projection_matrix (SparseMatrix<Number> & proj_mat) const
  */
 void System::project_solution (ValueFunctionPointer fptr,
                                GradientFunctionPointer gptr,
-                               const Parameters & parameters) const
+                               const Parameters & function_parameters) const
 {
-  WrappedFunction<Number> f(*this, fptr, &parameters);
-  WrappedFunction<Gradient> g(*this, gptr, &parameters);
+  WrappedFunction<Number> f(*this, fptr, &function_parameters);
+  WrappedFunction<Gradient> g(*this, gptr, &function_parameters);
   this->project_solution(&f, &g);
 }
 
@@ -1066,12 +1066,12 @@ void System::project_solution (FEMFunctionBase<Number> * f,
  */
 void System::project_vector (ValueFunctionPointer fptr,
                              GradientFunctionPointer gptr,
-                             const Parameters & parameters,
+                             const Parameters & function_parameters,
                              NumericVector<Number> & new_vector,
                              int is_adjoint) const
 {
-  WrappedFunction<Number> f(*this, fptr, &parameters);
-  WrappedFunction<Gradient> g(*this, gptr, &parameters);
+  WrappedFunction<Number> f(*this, fptr, &function_parameters);
+  WrappedFunction<Gradient> g(*this, gptr, &function_parameters);
   this->project_vector(new_vector, &f, &g, is_adjoint);
 }
 
@@ -1237,10 +1237,10 @@ void System::boundary_project_solution (const std::set<boundary_id_type> & b,
                                         const std::vector<unsigned int> & variables,
                                         ValueFunctionPointer fptr,
                                         GradientFunctionPointer gptr,
-                                        const Parameters & parameters)
+                                        const Parameters & function_parameters)
 {
-  WrappedFunction<Number> f(*this, fptr, &parameters);
-  WrappedFunction<Gradient> g(*this, gptr, &parameters);
+  WrappedFunction<Number> f(*this, fptr, &function_parameters);
+  WrappedFunction<Gradient> g(*this, gptr, &function_parameters);
   this->boundary_project_solution(b, variables, &f, &g);
 }
 
@@ -1272,12 +1272,12 @@ void System::boundary_project_vector (const std::set<boundary_id_type> & b,
                                       const std::vector<unsigned int> & variables,
                                       ValueFunctionPointer fptr,
                                       GradientFunctionPointer gptr,
-                                      const Parameters & parameters,
+                                      const Parameters & function_parameters,
                                       NumericVector<Number> & new_vector,
                                       int is_adjoint) const
 {
-  WrappedFunction<Number> f(*this, fptr, &parameters);
-  WrappedFunction<Gradient> g(*this, gptr, &parameters);
+  WrappedFunction<Number> f(*this, fptr, &function_parameters);
+  WrappedFunction<Gradient> g(*this, gptr, &function_parameters);
   this->boundary_project_vector(b, variables, new_vector, &f, &g,
                                 is_adjoint);
 }

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -472,6 +472,7 @@ public:
   CPPUNIT_TEST( test3DProjectVectorFEHex20 );
   CPPUNIT_TEST( test3DProjectVectorFEHex27 );
 #ifdef LIBMESH_HAVE_SOLVER
+  CPPUNIT_TEST( testSetSystemParameterOverEquationSystem);
   CPPUNIT_TEST( testAssemblyWithDgFemContext );
 #endif
 #endif // LIBMESH_DIM > 2
@@ -1292,8 +1293,9 @@ public:
     // Create an equation systems object.
     EquationSystems equation_systems (mesh);
 
-    // Set some parameters to the equation system that would cause a failed solve
+    // Set some parameters to the equation system that would cause a failed test
     equation_systems.parameters.set<unsigned int>("linear solver maximum iterations") = 0;
+    equation_systems.parameters.set<unsigned int>("nonlinear solver absolute residual tolerance") = 1e8;
 
     // Setup Linear Implicit system
     LinearImplicitSystem & li_system =
@@ -1312,25 +1314,23 @@ public:
     nli_system.add_variable ("v", libMesh::FIRST);
     nli_system.add_variable ("w", libMesh::FIRST);
     nli_system.attach_assemble_function (assemble_matrix_and_rhs);
-    nli_system.get_linear_solver()->set_solver_type(JACOBI);
-    nli_system.get_linear_solver()->set_preconditioner_type(IDENTITY_PRECOND);
 
     // Set some parameters to the system that work for the solve
-    li_system.parameters.set<unsigned int>("linear solver maximum iterations") = 100;
-    nli_system.parameters.set<unsigned int>("linear solver maximum iterations") = 100;
+    li_system.parameters.set<unsigned int>("linear solver maximum iterations") = 5;
+    nli_system.parameters.set<unsigned int>("nonlinear solver absolute residual tolerance") = 1e-10;
 
     // See the solve pass, indicating system parameters are used over equation system parameters
     equation_systems.init ();
     li_system.solve();
     nli_system.solve();
 
-    // We set the solution to be 1 everywhere, so the final l1 norm of the
-    // solution is the product of the number of variables and number of nodes.
-    Real ref_l1_norm = static_cast<Real>(mesh.n_nodes() * li_system.n_vars());
+    // Check that the number of iterations from the systems got obeyed
+    CPPUNIT_ASSERT_EQUAL(li_system.n_linear_iterations(), 5u);
 
-    LIBMESH_ASSERT_FP_EQUAL(li_system.solution->l1_norm(), ref_l1_norm, TOLERANCE*TOLERANCE);
-    LIBMESH_ASSERT_FP_EQUAL(nli_system.solution->l1_norm(), ref_l1_norm, TOLERANCE*TOLERANCE);
-  }
+    // Check that the solution for the nonlinear system is converged
+    Real ref_l1_norm = static_cast<Real>(mesh.n_nodes() * li_system.n_vars());
+    LIBMESH_ASSERT_FP_EQUAL(nli_system.solution->l1_norm(), ref_l1_norm, TOLERANCE);
+}
 
   void testAssemblyWithDgFemContext()
   {

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -13,7 +13,6 @@
 #include <libmesh/cell_tet4.h>
 #include <libmesh/zero_function.h>
 #include <libmesh/linear_implicit_system.h>
-#include <libmesh/nonlinear_implicit_system.h>
 #include <libmesh/transient_system.h>
 #include <libmesh/quadrature_gauss.h>
 #include <libmesh/node_elem.h>
@@ -1295,41 +1294,37 @@ public:
 
     // Set some parameters to the equation system that would cause a failed test
     equation_systems.parameters.set<unsigned int>("linear solver maximum iterations") = 0;
-    equation_systems.parameters.set<unsigned int>("nonlinear solver absolute residual tolerance") = 1e8;
 
     // Setup Linear Implicit system
     LinearImplicitSystem & li_system =
       equation_systems.add_system<LinearImplicitSystem> ("test");
-    li_system.add_variable ("u", libMesh::FIRST);
-    li_system.add_variable ("v", libMesh::FIRST);
-    li_system.add_variable ("w", libMesh::FIRST);
-    li_system.attach_assemble_function (assemble_matrix_and_rhs);
-    li_system.get_linear_solver()->set_solver_type(JACOBI);
-    li_system.get_linear_solver()->set_preconditioner_type(IDENTITY_PRECOND);
 
-    // Setup nonlinear Implicit system
-    NonlinearImplicitSystem & nli_system =
-      equation_systems.add_system<NonlinearImplicitSystem> ("test");
-    nli_system.add_variable ("u", libMesh::FIRST);
-    nli_system.add_variable ("v", libMesh::FIRST);
-    nli_system.add_variable ("w", libMesh::FIRST);
-    nli_system.attach_assemble_function (assemble_matrix_and_rhs);
+    // We must use a discontinuous variable type in this test or
+    // else the sparsity pattern will not be correct
+    li_system.add_variable("u", FIRST, L2_LAGRANGE);
+
+    MeshTools::Generation::build_cube (mesh,
+                                       5, 5, 5,
+                                       0., 1., 0., 1., 0., 1.,
+                                       HEX8);
+
+    li_system.attach_assemble_function (assembly_with_dg_fem_context);
+    li_system.get_linear_solver()->set_solver_type(GMRES);
+    // Need 5 iterations, dont overdo the preconditioning
+    li_system.get_linear_solver()->set_preconditioner_type(IDENTITY_PRECOND);
 
     // Set some parameters to the system that work for the solve
     li_system.parameters.set<unsigned int>("linear solver maximum iterations") = 5;
-    nli_system.parameters.set<unsigned int>("nonlinear solver absolute residual tolerance") = 1e-10;
+    li_system.parameters.set<Real>("linear solver tolerance") = 1e-100;
+
+    // Need to init before we can access the system matrix
+    equation_systems.init ();
 
     // See the solve pass, indicating system parameters are used over equation system parameters
-    equation_systems.init ();
     li_system.solve();
-    nli_system.solve();
 
     // Check that the number of iterations from the systems got obeyed
     CPPUNIT_ASSERT_EQUAL(li_system.n_linear_iterations(), 5u);
-
-    // Check that the solution for the nonlinear system is converged
-    Real ref_l1_norm = static_cast<Real>(mesh.n_nodes() * li_system.n_vars());
-    LIBMESH_ASSERT_FP_EQUAL(nli_system.solution->l1_norm(), ref_l1_norm, TOLERANCE);
 }
 
   void testAssemblyWithDgFemContext()


### PR DESCRIPTION
refs #4006

If this is too much, I could scale this down to just the nonlinear_implicit_system. That's all I need. 
We could consider a getParam routine that does this 3-liner operation instead.