### PR TITLE
Add prefix parameter to the `snes()` method in PetscNonlinearSolver

### DIFF
--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -110,9 +110,10 @@ public:
   virtual void init (const char * name = nullptr) override;
 
   /**
-   * \returns The raw PETSc snes context pointer.
+   * \returns The raw PETSc snes context pointer. This method calls init() so in that vein, we have
+   * an optional name prefix argument that if provided will be given to the SNES context
    */
-  SNES snes();
+  SNES snes(const char * name = nullptr);
 
   /**
    * Call the Petsc solver.  It calls the method below, using the

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -811,12 +811,16 @@ void PetscNonlinearSolver<T>::init (const char * name)
       // even on an old snes instance from the last solve
 
       if (name)
-        LibmeshPetscCall(SNESSetOptionsPrefix(_snes, name));
+        {
+          libmesh_assert(std::string(name).front() != '-');
+          libmesh_assert(std::string(name).back() == '_');
+          LibmeshPetscCall(SNESSetOptionsPrefix(_snes, name));
+        }
 
       // Attaching a DM to SNES.
 #if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_METAPHYSICL)
-      const auto prefix = name ? std::string(name) + "_" : std::string("");
-      bool use_petsc_dm = libMesh::on_command_line("--" + prefix + "use_petsc_dm");
+      bool use_petsc_dm = libMesh::on_command_line(
+          "--" + (name ? std::string(name) : std::string("")) + "use_petsc_dm");
 
       // This needs to be called before SNESSetFromOptions
       if (use_petsc_dm)
@@ -889,9 +893,9 @@ void PetscNonlinearSolver<T>::init (const char * name)
 
 
 template <typename T>
-SNES PetscNonlinearSolver<T>::snes()
+SNES PetscNonlinearSolver<T>::snes(const char * name)
 {
-  this->init();
+  this->init(name);
   return _snes;
 }
 


### PR DESCRIPTION
Since `snes()` calls through to `init()`, developers need a way to pass a prefix if they want to