### PR TITLE
Fix in enrich_eim_approximation_on_sides().

### DIFF
--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -2390,6 +2390,7 @@ bool RBEIMConstruction::enrich_eim_approximation_on_sides(const SideQpDataMap & 
   this->comm().broadcast(optimal_point, proc_ID_index);
   this->comm().broadcast(optimal_comp, proc_ID_index);
   this->comm().broadcast(optimal_elem_id, proc_ID_index);
+  this->comm().broadcast(optimal_side_index, proc_ID_index);
   this->comm().broadcast(optimal_subdomain_id, proc_ID_index);
   this->comm().broadcast(optimal_boundary_id, proc_ID_index);
   this->comm().broadcast(optimal_qp, proc_ID_index);


### PR DESCRIPTION
The broadcast of optimal_side_index was missing, which could give invalid results in parallel. Fix is to add the broadcast in for this property, similar to the other properties that we broadcast.