### PR TITLE
Scrape Fortran compiler from PETSc too

### DIFF
--- a/configure
+++ b/configure
@@ -5734,6 +5734,7 @@ then :
                   PETSCINCLUDEDIRS=`make -s -C ${PETSC_DIR} SHELL=/bin/sh getincludedirs`
                   PETSC_CXX=`make -s -C $PETSC_DIR SHELL=/bin/sh getcxxcompiler`
                   PETSC_CC=`make -s -C $PETSC_DIR SHELL=/bin/sh getccompiler`
+                  PETSC_FC=`make -s -C $PETSC_DIR SHELL=/bin/sh getfortrancompiler`
                   PETSC_MPI_INCLUDE_DIRS=`make -s -C $PETSC_DIR SHELL=/bin/sh getmpiincludedirs`
                   PETSC_MPI_LINK_LIBS=`make -s -C $PETSC_DIR SHELL=/bin/sh getmpilinklibs`
                   printf '%s\n' "include $PETSC_VARS_FILE" > Makefile_config_petsc
@@ -5769,6 +5770,8 @@ fi
                   printf '\t%s\n' "echo \$(CXX)" >> Makefile_config_petsc
                   printf '%s\n' "getccompiler:" >> Makefile_config_petsc
                   printf '\t%s\n' "echo \$(CC)" >> Makefile_config_petsc
+                  printf '%s\n' "getfortrancompiler:" >> Makefile_config_petsc
+                  printf '\t%s\n' "echo \$(FC)" >> Makefile_config_petsc
                   printf '%s\n' "getmpiincludedirs:" >> Makefile_config_petsc
                   printf '\t%s\n' "echo \$(MPI_INCLUDE)" >> Makefile_config_petsc
                   printf '%s\n' "getmpilinklibs:" >> Makefile_config_petsc
@@ -5779,6 +5782,7 @@ fi
                   PETSC_FC_INCLUDES=`make -s -f Makefile_config_petsc SHELL=/bin/sh getPETSC_FC_INCLUDES`
                   PETSC_CXX=`make -s -f Makefile_config_petsc SHELL=/bin/sh getcxxcompiler`
                   PETSC_CC=`make -s -f Makefile_config_petsc SHELL=/bin/sh getccompiler`
+                  PETSC_FC=`make -s -f Makefile_config_petsc SHELL=/bin/sh getfortrancompiler`
                   PETSC_MPI_INCLUDE_DIRS=`make -s -f Makefile_config_petsc SHELL=/bin/sh getmpiincludedirs`
                   PETSC_MPI_LINK_LIBS=`make -s -f Makefile_config_petsc SHELL=/bin/sh getmpilinklibs`
                   rm -f Makefile_config_petsc
@@ -6895,6 +6899,12 @@ then :
   withval=$with_fc; FC="$withval"
 fi
 
+
+                                                                                if test -z "$FC" && test x"$PETSC_HAVE_MPI" = x1 && test x"$PETSC_FC" != x
+then :
+  FC="$PETSC_FC"
+                 F77="$PETSC_FC"
+fi
 
                                         ac_ext=${ac_fc_srcext-f}
 ac_compile='$FC -c $FCFLAGS $ac_fcflags_srcext conftest.$ac_ext >&5'

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -89,6 +89,17 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
                       [FC="$withval"],
                       [])
 
+          dnl See whether we are using PETSC_FC. Unfortunately PETSC_FC may
+          dnl be prefixed with a PATH, and its not straightforward to strip it off.
+          dnl If FC is not set AC_PROG_FC will call AC_CHECK_TOOLS which will prefix
+          dnl every argument in FC_TRY_LIST with values in $PATH, so we will
+          dnl not find something like PATH/PETSC_PREFIX/mpicxx. The solution
+          dnl then is just to set FC to PETSC_FC so that AC_CHECK_TOOLS
+          dnl never gets called
+          AS_IF([test -z "$FC" && test x"$PETSC_HAVE_MPI" = x1 && test x"$PETSC_FC" != x],
+                [FC="$PETSC_FC"
+                 F77="$PETSC_FC"])
+
           dnl --------------------------------------------------------------
           dnl Determine a F90+ compiler to use.
           dnl --------------------------------------------------------------


### PR DESCRIPTION
Failing to do this was causing me a ton of linker problems in MOOSE modules on a system that had both a /usr/bin/mpif90 and a PETSc-specific mpif90.