### PR TITLE
Fix error reporting without LibMeshInit in use

### DIFF
--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -397,9 +397,7 @@ struct casting_compare {
   do {                                                                  \
     std::stringstream message_stream;                                   \
     message_stream << msg << '\n';                                      \
-    libMesh::Threads::lock_singleton_spin_mutex();                      \
     libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME, message_stream); \
-    libMesh::Threads::unlock_singleton_spin_mutex();                    \
     LIBMESH_THROW(libMesh::LogicError(message_stream.str()));           \
   } while (0)
 
@@ -415,9 +413,9 @@ struct casting_compare {
   do {                                                                  \
     libMesh::Threads::lock_singleton_spin_mutex();                      \
     libMesh::err << msg << '\n';                                        \
+    libMesh::Threads::unlock_singleton_spin_mutex();                    \
     libmesh_try { libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME); } \
     libmesh_catch (...) {}                                              \
-    libMesh::Threads::unlock_singleton_spin_mutex();                    \
     std::terminate();                                                   \
   } while (0)
 
@@ -427,9 +425,7 @@ struct casting_compare {
   do {                                                                  \
     std::stringstream message_stream;                                   \
     message_stream << msg << '\n';                                      \
-    libMesh::Threads::lock_singleton_spin_mutex();                      \
     libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME, message_stream); \
-    libMesh::Threads::unlock_singleton_spin_mutex();                    \
     LIBMESH_THROW(libMesh::NotImplemented(message_stream.str()));       \
   } while (0)
 
@@ -439,9 +435,7 @@ struct casting_compare {
   do {                                                                  \
     std::stringstream message_stream;                                   \
     message_stream << msg << '\n';                                      \
-    libMesh::Threads::lock_singleton_spin_mutex();                      \
     libMesh::MacroFunctions::report_error(__FILE__, __LINE__, LIBMESH_DATE, LIBMESH_TIME, message_stream); \
-    libMesh::Threads::unlock_singleton_spin_mutex();                    \
     LIBMESH_THROW(libMesh::FileError(filename, message_stream.str()));  \
   } while (0)
 

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -948,8 +948,12 @@ std::vector<std::string> command_line_names()
 
 bool on_command_line (std::string arg)
 {
-  // Make sure the command line parser is ready for use
-  libmesh_assert(command_line.get());
+  // Make sure the command line parser is ready for use.  If it's not,
+  // then we'll have to treat the command line as empty, for maximum
+  // compatibility with programs that don't use LibMeshInit but
+  // indirectly (e.g. via error handling code) query the command line.
+  if (!command_line.get())
+    return false;
 
   // Keep track of runtime queries, for later
   add_command_line_name(arg);

--- a/src/base/libmesh_common.C
+++ b/src/base/libmesh_common.C
@@ -68,6 +68,9 @@ void stop(const char * file, int line, const char * date, const char * time)
 
 void report_error(const char * file, int line, const char * date, const char * time, std::ostream & os)
 {
+  // Avoid a race condition on that static bool
+  libMesh::Threads::lock_singleton_spin_mutex();                      \
+
   // It is possible to have an error *inside* report_error; e.g. from
   // print_trace.  We don't want to infinitely recurse.
   static bool reporting_error = false;
@@ -88,6 +91,7 @@ void report_error(const char * file, int line, const char * date, const char * t
   libMesh::MacroFunctions::here(file, line, date, time, os);
 
   reporting_error = false;
+  libMesh::Threads::unlock_singleton_spin_mutex();                    \
 }
 
 } // namespace MacroFunctions


### PR DESCRIPTION
And I cleaned up a bit of code while I was at it.

This fixes #4022 for me.