### PR TITLE
Deprecate NumericVector::type() that returns a writable reference

### DIFF
--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -153,11 +153,6 @@ public:
   ParallelType type() const { return _type; }
 
   /**
-   * \returns The type (SERIAL, PARALLEL, GHOSTED) of the vector.
-   */
-  ParallelType & type() { return _type; }
-
-  /**
    * \returns \p true if the vector is closed and ready for
    * computation, false otherwise.
    */

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -139,7 +139,8 @@ public:
    */
   static std::unique_ptr<NumericVector<T>>
   build(const Parallel::Communicator & comm,
-        const SolverPackage solver_package = libMesh::default_solver_package());
+        SolverPackage solver_package = libMesh::default_solver_package(),
+        ParallelType parallel_type = AUTOMATIC);
 
   /**
    * \returns \p true if the vector has been initialized,

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -153,6 +153,14 @@ public:
   ParallelType type() const { return _type; }
 
   /**
+   * If this vector's type() is PARALLEL and it is not yet
+   * initialized, change the type() to GHOSTED.
+   *
+   * \returns \p true if the upgrade was performed, false otherwise.
+   */
+  bool upgrade_to_ghosted();
+
+  /**
    * \returns \p true if the vector is closed and ready for
    * computation, false otherwise.
    */

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -154,12 +154,15 @@ public:
   ParallelType type() const { return _type; }
 
   /**
-   * If this vector's type() is PARALLEL and it is not yet
-   * initialized, change the type() to GHOSTED.
-   *
-   * \returns \p true if the upgrade was performed, false otherwise.
+   * Allow the user to change the ParallelType of the NumericVector
+   * under some circumstances. If the NumericVector has not been
+   * initialized yet, then it is generally safe to change the
+   * ParallelType. otherwise, if the NumericVector has already been
+   * initialized with a specific type, we cannot change it without
+   * doing some extra copying/reinitialization work, and we currently
+   * throw an error if this is requested.
    */
-  bool upgrade_to_ghosted();
+  void set_type(ParallelType t);
 
   /**
    * \returns \p true if the vector is closed and ready for

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -154,6 +154,17 @@ public:
   ParallelType type() const { return _type; }
 
   /**
+   * \returns The type (SERIAL, PARALLEL, GHOSTED) of the vector.
+   *
+   * \deprecated because it is dangerous to change the ParallelType
+   * of an already-initialized NumericVector. See NumericVector::set_type()
+   * for a safer, non-deprecated setter.
+   */
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  ParallelType & type() { return _type; }
+#endif
+
+  /**
    * Allow the user to change the ParallelType of the NumericVector
    * under some circumstances. If the NumericVector has not been
    * initialized yet, then it is generally safe to change the

--- a/src/numerics/numeric_vector.C
+++ b/src/numerics/numeric_vector.C
@@ -47,7 +47,9 @@ namespace libMesh
 // Full specialization for Real datatypes
 template <typename T>
 std::unique_ptr<NumericVector<T>>
-NumericVector<T>::build(const Parallel::Communicator & comm, const SolverPackage solver_package)
+NumericVector<T>::build(const Parallel::Communicator & comm,
+                        SolverPackage solver_package,
+                        ParallelType parallel_type)
 {
   // Build the appropriate vector
   switch (solver_package)
@@ -55,26 +57,26 @@ NumericVector<T>::build(const Parallel::Communicator & comm, const SolverPackage
 
 #ifdef LIBMESH_HAVE_LASPACK
     case LASPACK_SOLVERS:
-      return std::make_unique<LaspackVector<T>>(comm, AUTOMATIC);
+      return std::make_unique<LaspackVector<T>>(comm, parallel_type);
 #endif
 
 #ifdef LIBMESH_HAVE_PETSC
     case PETSC_SOLVERS:
-      return std::make_unique<PetscVector<T>>(comm, AUTOMATIC);
+      return std::make_unique<PetscVector<T>>(comm, parallel_type);
 #endif
 
 #ifdef LIBMESH_TRILINOS_HAVE_EPETRA
     case TRILINOS_SOLVERS:
-      return std::make_unique<EpetraVector<T>>(comm, AUTOMATIC);
+      return std::make_unique<EpetraVector<T>>(comm, parallel_type);
 #endif
 
 #ifdef LIBMESH_HAVE_EIGEN
     case EIGEN_SOLVERS:
-      return std::make_unique<EigenSparseVector<T>>(comm, AUTOMATIC);
+      return std::make_unique<EigenSparseVector<T>>(comm, parallel_type);
 #endif
 
     default:
-      return std::make_unique<DistributedVector<T>>(comm, AUTOMATIC);
+      return std::make_unique<DistributedVector<T>>(comm, parallel_type);
     }
 }
 

--- a/src/numerics/numeric_vector.C
+++ b/src/numerics/numeric_vector.C
@@ -81,6 +81,27 @@ NumericVector<T>::build(const Parallel::Communicator & comm, const SolverPackage
 
 
 template <typename T>
+bool NumericVector<T>::upgrade_to_ghosted()
+{
+  // Can't upgrade to GHOSTED if libMesh was configured with --disable-ghosted
+#ifndef LIBMESH_ENABLE_GHOSTED
+  return false;
+#endif
+
+  // We can only upgrade NumericVectors that are currently PARALLEL type
+  // and not yet initialized.
+  if (this->type() == PARALLEL && !this->initialized())
+  {
+    _type = GHOSTED;
+    return true;
+  }
+
+  // If we made it here, then the upgrade to GHOSTED could not be
+  // performed for some reason, so return false.
+  return false;
+}
+
+template <typename T>
 void NumericVector<T>::insert (const T * v,
                                const std::vector<numeric_index_type> & dof_indices)
 {

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -792,8 +792,9 @@ NumericVector<Number> & System::add_vector (std::string_view vec_name,
                   vec.swap(*new_vec);
                 }
               else
-                // The PARALLEL vec is not yet initialized, so we can just "upgrade" it to GHOSTED
-                vec.upgrade_to_ghosted();
+                // The PARALLEL vec is not yet initialized, so we can
+                // just "upgrade" it to GHOSTED.
+                vec.set_type(type);
             }
         }
 

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -792,7 +792,8 @@ NumericVector<Number> & System::add_vector (std::string_view vec_name,
                   vec.swap(*new_vec);
                 }
               else
-                vec.type() = type;
+                // The PARALLEL vec is not yet initialized, so we can just "upgrade" it to GHOSTED
+                vec.upgrade_to_ghosted();
             }
         }
 
@@ -800,11 +801,19 @@ NumericVector<Number> & System::add_vector (std::string_view vec_name,
       return vec;
     }
 
-  // Otherwise build the vector
-  auto pr = _vectors.emplace(vec_name, NumericVector<Number>::build(this->comm()));
+  // Otherwise, build the vector. The following emplace() is
+  // guaranteed to succeed because, if we made it here, we don't
+  // already have a vector named "vec_name". We pass the user's
+  // requested ParallelType directly to NumericVector::build() so
+  // that, even if the vector is not initialized now, it will get the
+  // right type when it is initialized later.
+  auto pr =
+    _vectors.emplace(vec_name,
+                     NumericVector<Number>::build(this->comm(),
+                                                  libMesh::default_solver_package(),
+                                                  type));
   auto buf = pr.first->second.get();
   _vector_projections.emplace(vec_name, projections);
-  buf->type() = type;
 
   // Vectors are primal by default
   _vector_is_adjoint.emplace(vec_name, -1);


### PR DESCRIPTION
And add `NumericVector::set_type(t)` that allows the user to change the `NumericVector` `ParallelType` in some situations. I'm going to attach a `--disable-deprecated` build to this PR to see whether there is any downstream code that is currently using the API. I only located two instances of it (in the same function) within libmesh itself. 