### PR TITLE
Add support for Cap'n'Proto "packing"

### DIFF
--- a/include/reduced_basis/rb_data_deserialization.h
+++ b/include/reduced_basis/rb_data_deserialization.h
@@ -80,9 +80,13 @@ public:
   virtual ~RBEvaluationDeserialization();
 
   /**
-   * Write the Cap'n'Proto buffer to disk.
+   * Read the Cap'n'Proto buffer from disk.
+   * If \p use_packing is true, the file is read using the "packed"
+   * scheme, which can reduce the filesize on disk.
    */
-  void read_from_file(const std::string & path, bool read_error_bound_data);
+  void read_from_file(const std::string & path,
+                      bool read_error_bound_data,
+                      bool use_packing = false);
 
 private:
 
@@ -121,9 +125,13 @@ public:
   virtual ~TransientRBEvaluationDeserialization();
 
   /**
-   * Write the Cap'n'Proto buffer to disk.
+   * Read the Cap'n'Proto buffer from disk.
+   * If \p use_packing is true, the file is read using the "packed"
+   * scheme, which can reduce the filesize on disk.
    */
-  void read_from_file(const std::string & path, bool read_error_bound_data);
+  void read_from_file(const std::string &path,
+                      bool read_error_bound_data,
+                      bool use_packing = false);
 
 private:
 
@@ -162,9 +170,12 @@ public:
   virtual ~RBEIMEvaluationDeserialization();
 
   /**
-   * Write the Cap'n'Proto buffer to disk.
+   * Read the Cap'n'Proto buffer from disk.
+   * If \p use_packing is true, the file is read using the "packed"
+   * scheme, which can reduce the filesize on disk.
    */
-  void read_from_file(const std::string & path);
+  void read_from_file(const std::string & path,
+                      bool use_packing = false);
 
 private:
 
@@ -207,9 +218,12 @@ public:
   virtual ~RBSCMEvaluationDeserialization();
 
   /**
-   * Write the Cap'n'Proto buffer to disk.
+   * Read the Cap'n'Proto buffer from disk.
+   * If \p use_packing is true, the file is read using the "packed"
+   * scheme, which can reduce the filesize on disk.
    */
-  void read_from_file(const std::string & path);
+  void read_from_file(const std::string & path,
+                      bool use_packing = false);
 
 private:
 

--- a/include/reduced_basis/rb_data_serialization.h
+++ b/include/reduced_basis/rb_data_serialization.h
@@ -79,8 +79,10 @@ public:
 
   /**
    * Write the Cap'n'Proto buffer to disk.
+   * If \p use_packing is true, the file is written using the "packed"
+   * scheme, which can reduce the filesize on disk.
    */
-  void write_to_file(const std::string & path);
+  void write_to_file(const std::string & path, bool use_packing = false);
 
 private:
 
@@ -120,8 +122,10 @@ public:
 
   /**
    * Write the Cap'n'Proto buffer to disk.
+   * If \p use_packing is true, the file is written using the "packed"
+   * scheme, which can reduce the filesize on disk.
    */
-  void write_to_file(const std::string & path);
+  void write_to_file(const std::string & path, bool use_packing = false);
 
 private:
 
@@ -161,8 +165,10 @@ public:
 
   /**
    * Write the Cap'n'Proto buffer to disk.
+   * If \p use_packing is true, the file is written using the "packed"
+   * scheme, which can reduce the filesize on disk.
    */
-  void write_to_file(const std::string & path);
+  void write_to_file(const std::string & path, bool use_packing = false);
 
 private:
 
@@ -206,8 +212,10 @@ public:
 
   /**
    * Write the Cap'n'Proto buffer to disk.
+   * If \p use_packing is true, the file is written using the "packed"
+   * scheme, which can reduce the filesize on disk.
    */
-  void write_to_file(const std::string & path);
+  void write_to_file(const std::string & path, bool use_packing = false);
 
 private:
 

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -35,6 +35,7 @@
 
 // Cap'n'Proto includes
 #include "capnp/serialize.h"
+#include "capnp/serialize-packed.h"   // for PackedFdMessageReader()
 
 // C++ includes
 #ifdef LIBMESH_HAVE_UNISTD_H
@@ -78,8 +79,9 @@ RBEvaluationDeserialization::RBEvaluationDeserialization(RBEvaluation & rb_eval)
 
 RBEvaluationDeserialization::~RBEvaluationDeserialization() = default;
 
-void RBEvaluationDeserialization::read_from_file(const std::string & path,
-                                                 bool read_error_bound_data)
+void RBEvaluationDeserialization::read_from_file(const std::string &path,
+                                                 bool read_error_bound_data,
+                                                 bool use_packing)
 {
   LOG_SCOPE("read_from_file()", "RBEvaluationDeserialization");
 
@@ -90,10 +92,14 @@ void RBEvaluationDeserialization::read_from_file(const std::string & path,
   capnp::ReaderOptions reader_options;
   reader_options.traversalLimitInWords = std::numeric_limits<uint64_t>::max();
 
-  std::unique_ptr<capnp::StreamFdMessageReader> message;
+  std::unique_ptr<capnp::InputStreamMessageReader> message;
   libmesh_try
     {
-      message = std::make_unique<capnp::StreamFdMessageReader>(fd, reader_options);
+      // Define the reader type, based on whether or not packing is used.
+      if(use_packing)
+        message = std::make_unique<capnp::PackedFdMessageReader>(fd, reader_options);
+      else
+        message = std::make_unique<capnp::StreamFdMessageReader>(fd, reader_options);
     }
   libmesh_catch(...)
     {
@@ -127,7 +133,8 @@ TransientRBEvaluationDeserialization(TransientRBEvaluation & trans_rb_eval) :
 TransientRBEvaluationDeserialization::~TransientRBEvaluationDeserialization() = default;
 
 void TransientRBEvaluationDeserialization::read_from_file(const std::string & path,
-                                                          bool read_error_bound_data)
+                                                          bool read_error_bound_data,
+                                                          bool use_packing)
 {
   LOG_SCOPE("read_from_file()", "TransientRBEvaluationDeserialization");
 
@@ -138,10 +145,13 @@ void TransientRBEvaluationDeserialization::read_from_file(const std::string & pa
   capnp::ReaderOptions reader_options;
   reader_options.traversalLimitInWords = std::numeric_limits<uint64_t>::max();
 
-  std::unique_ptr<capnp::StreamFdMessageReader> message;
+  std::unique_ptr<capnp::InputStreamMessageReader> message;
   libmesh_try
     {
-      message = std::make_unique<capnp::StreamFdMessageReader>(fd, reader_options);
+      if(use_packing)
+        message = std::make_unique<capnp::PackedFdMessageReader>(fd, reader_options);
+      else
+        message = std::make_unique<capnp::StreamFdMessageReader>(fd, reader_options);
     }
   libmesh_catch(...)
     {
@@ -181,7 +191,8 @@ RBEIMEvaluationDeserialization(RBEIMEvaluation & rb_eim_eval) :
 
 RBEIMEvaluationDeserialization::~RBEIMEvaluationDeserialization() = default;
 
-void RBEIMEvaluationDeserialization::read_from_file(const std::string & path)
+void RBEIMEvaluationDeserialization::read_from_file(const std::string & path,
+                                                    bool use_packing)
 {
   LOG_SCOPE("read_from_file()", "RBEIMEvaluationDeserialization");
 
@@ -192,10 +203,13 @@ void RBEIMEvaluationDeserialization::read_from_file(const std::string & path)
   capnp::ReaderOptions reader_options;
   reader_options.traversalLimitInWords = std::numeric_limits<uint64_t>::max();
 
-  std::unique_ptr<capnp::StreamFdMessageReader> message;
+  std::unique_ptr<capnp::InputStreamMessageReader> message;
   libmesh_try
     {
-      message = std::make_unique<capnp::StreamFdMessageReader>(fd, reader_options);
+      if(use_packing)
+        message = std::make_unique<capnp::PackedFdMessageReader>(fd, reader_options);
+      else
+        message = std::make_unique<capnp::StreamFdMessageReader>(fd, reader_options);
     }
   libmesh_catch(...)
     {
@@ -233,7 +247,8 @@ RBSCMEvaluationDeserialization(RBSCMEvaluation & rb_scm_eval) :
 
 RBSCMEvaluationDeserialization::~RBSCMEvaluationDeserialization() = default;
 
-void RBSCMEvaluationDeserialization::read_from_file(const std::string & path)
+void RBSCMEvaluationDeserialization::read_from_file(const std::string & path,
+                                                    bool use_packing)
 {
   LOG_SCOPE("read_from_file()", "RBSCMEvaluationDeserialization");
 
@@ -244,10 +259,13 @@ void RBSCMEvaluationDeserialization::read_from_file(const std::string & path)
   capnp::ReaderOptions reader_options;
   reader_options.traversalLimitInWords = std::numeric_limits<uint64_t>::max();
 
-  std::unique_ptr<capnp::StreamFdMessageReader> message;
+  std::unique_ptr<capnp::InputStreamMessageReader> message;
   libmesh_try
     {
-      message = std::make_unique<capnp::StreamFdMessageReader>(fd, reader_options);
+      if(use_packing)
+        message = std::make_unique<capnp::PackedFdMessageReader>(fd, reader_options);
+      else
+        message = std::make_unique<capnp::StreamFdMessageReader>(fd, reader_options);
     }
   libmesh_catch(...)
     {

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -36,6 +36,7 @@
 
 // Cap'n'Proto includes
 #include <capnp/serialize.h>
+#include <capnp/serialize-packed.h>   // for writePackedMessageToFd()
 
 // C++ includes
 #include <iostream>
@@ -81,7 +82,7 @@ RBEvaluationSerialization::RBEvaluationSerialization(RBEvaluation & rb_eval)
 
 RBEvaluationSerialization::~RBEvaluationSerialization() = default;
 
-void RBEvaluationSerialization::write_to_file(const std::string & path)
+void RBEvaluationSerialization::write_to_file(const std::string & path, bool use_packing)
 {
   LOG_SCOPE("write_to_file()", "RBEvaluationSerialization");
 
@@ -102,7 +103,10 @@ void RBEvaluationSerialization::write_to_file(const std::string & path)
       int fd = open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0664);
       libmesh_error_msg_if(!fd, "Error opening a write-only file descriptor to " + path);
 
-      capnp::writeMessageToFd(fd, message);
+      if(use_packing)
+        capnp::writePackedMessageToFd(fd, message);
+      else
+        capnp::writeMessageToFd(fd, message);
 
       int error = close(fd);
       libmesh_error_msg_if(error, "Error closing a write-only file descriptor to " + path);
@@ -122,7 +126,7 @@ TransientRBEvaluationSerialization(TransientRBEvaluation & trans_rb_eval) :
 
 TransientRBEvaluationSerialization::~TransientRBEvaluationSerialization() = default;
 
-void TransientRBEvaluationSerialization::write_to_file(const std::string & path)
+void TransientRBEvaluationSerialization::write_to_file(const std::string & path, bool use_packing)
 {
   LOG_SCOPE("write_to_file()", "TransientRBEvaluationSerialization");
 
@@ -149,7 +153,10 @@ void TransientRBEvaluationSerialization::write_to_file(const std::string & path)
       int fd = open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0664);
       libmesh_error_msg_if(!fd, "Error opening a write-only file descriptor to " + path);
 
-      capnp::writeMessageToFd(fd, message);
+      if(use_packing)
+        capnp::writePackedMessageToFd(fd, message);
+      else
+        capnp::writeMessageToFd(fd, message);
 
       int error = close(fd);
       libmesh_error_msg_if(error, "Error closing a write-only file descriptor to " + path);
@@ -169,8 +176,7 @@ RBEIMEvaluationSerialization::RBEIMEvaluationSerialization(RBEIMEvaluation & rb_
 
 RBEIMEvaluationSerialization::~RBEIMEvaluationSerialization() = default;
 
-void RBEIMEvaluationSerialization::write_to_file(const std::string & path)
-{
+void RBEIMEvaluationSerialization::write_to_file(const std::string & path, bool use_packing) {
   LOG_SCOPE("write_to_file()", "RBEIMEvaluationSerialization");
 
   if (_rb_eim_eval.comm().rank() == 0)
@@ -191,7 +197,10 @@ void RBEIMEvaluationSerialization::write_to_file(const std::string & path)
       int fd = open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0664);
       libmesh_error_msg_if(!fd, "Error opening a write-only file descriptor to " + path);
 
-      capnp::writeMessageToFd(fd, message);
+      if(use_packing)
+        capnp::writePackedMessageToFd(fd, message);
+      else
+        capnp::writeMessageToFd(fd, message);
 
       int error = close(fd);
       libmesh_error_msg_if(error, "Error closing a write-only file descriptor to " + path);
@@ -213,7 +222,7 @@ RBSCMEvaluationSerialization::RBSCMEvaluationSerialization(RBSCMEvaluation & rb_
 
 RBSCMEvaluationSerialization::~RBSCMEvaluationSerialization() = default;
 
-void RBSCMEvaluationSerialization::write_to_file(const std::string & path)
+void RBSCMEvaluationSerialization::write_to_file(const std::string & path, bool use_packing)
 {
   LOG_SCOPE("write_to_file()", "RBSCMEvaluationSerialization");
 
@@ -229,7 +238,10 @@ void RBSCMEvaluationSerialization::write_to_file(const std::string & path)
       int fd = open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0664);
       libmesh_error_msg_if(!fd, "Error opening a write-only file descriptor to " + path);
 
-      capnp::writeMessageToFd(fd, message);
+      if(use_packing)
+        capnp::writePackedMessageToFd(fd, message);
+      else
+        capnp::writeMessageToFd(fd, message);
 
       int error = close(fd);
       libmesh_error_msg_if(error, "Error closing a write-only file descriptor to " + path);


### PR DESCRIPTION
"Packing", as described in the Cap'n'Proto docs (https://capnproto.org/encoding.html#packing):

> For cases where bandwidth usage matters, Cap’n Proto defines a simple compression scheme called “packing”. This scheme is based on the observation that Cap’n Proto messages contain lots of zero bytes: padding bytes, unset fields, and high-order bytes of small-valued integers.
> 
> In packed format, each word of the message is reduced to a tag byte followed by zero to eight content bytes. The bits of the tag byte correspond to the bytes of the unpacked word, with the least-significant bit corresponding to the first byte. Each zero bit indicates that the corresponding byte is zero. The non-zero bytes are packed following the tag.

This small PR adds a new `use_packing` option to existing `read_from_file()` and `write_to_file()` functions. The option defaults to `false`, so no API breakages or change in default behavior. Setting the `use_packing` parameter to `true` reads/writes files using the "packed" format.