### PR TITLE
Revert LibmeshPetscCall workarounds

### DIFF
--- a/include/numerics/petsc_solver_exception.h
+++ b/include/numerics/petsc_solver_exception.h
@@ -89,10 +89,6 @@ public:
     LIBMESH_CHKERRQ(ierr);                      \
   } while (0)
 
-// Remove me: for backward compatibility with MOOSE only
-#define LIBMESH_CHKERR(ierr) LIBMESH_CHKERRQ(ierr)
-#define LIBMESH_CHKERR2(comm, ierr) LIBMESH_CHKERRA(comm, ierr)
-
 #else
 
 // If we don't have exceptions enabled, just fall back on calling

--- a/include/numerics/petsc_solver_exception.h
+++ b/include/numerics/petsc_solver_exception.h
@@ -92,13 +92,6 @@ public:
 // Remove me: for backward compatibility with MOOSE only
 #define LIBMESH_CHKERR(ierr) LIBMESH_CHKERRQ(ierr)
 #define LIBMESH_CHKERR2(comm, ierr) LIBMESH_CHKERRA(comm, ierr)
-#define LibmeshPetscCall(...)                                           \
-  do                                                                    \
-  {                                                                     \
-    PetscErrorCode libmesh_petsc_call_ierr;                             \
-    libmesh_petsc_call_ierr = __VA_ARGS__;                              \
-    LIBMESH_CHKERRQ(libmesh_petsc_call_ierr);                           \
-  } while (0)
 
 #else
 
@@ -146,10 +139,8 @@ PETSC_BEGIN_END(VecGhostUpdate) // VecGhostUpdateBeginEnd
 
 // Shortcut for LibmeshPetscCallA for use within a ParallelObject, i.e. when
 // we can rely on the communicator being available from the "this" pointer.
-/*
 #define LibmeshPetscCall(...)                                           \
   LibmeshPetscCallA(this->comm().get(), __VA_ARGS__)
-*/
 
 // Shortcut for LibmeshPetscCallA for use when we have a Parallel::Communicator
 // available instead of just a bare MPI communicator.

--- a/include/numerics/petsc_solver_exception.h
+++ b/include/numerics/petsc_solver_exception.h
@@ -107,15 +107,6 @@ public:
 #define LIBMESH_CHKERRQ(ierr) CHKERRQ(ierr);
 #define LIBMESH_CHKERRA(comm, ierr) CHKERRABORT(comm, ierr);
 
-// Remove me: for backward compatibility with MOOSE only
-#define LibmeshPetscCall(...)                                           \
-  do                                                                    \
-  {                                                                     \
-    PetscErrorCode libmesh_petsc_call_ierr;                             \
-    libmesh_petsc_call_ierr = __VA_ARGS__;                              \
-    LIBMESH_CHKERRA(this->comm().get(), libmesh_petsc_call_ierr);       \
-  } while (0)
-
 #endif
 
 #define PETSC_BEGIN_END(Function)                                       \


### PR DESCRIPTION
Now MOOSE has been updated, we should remove all backward compatibility workarounds.
Unfortunately, this will break any MOOSE apps that haven't been updated yet.
If we mirror this branch on this repo, I can test using idaholab/moose#28969 just as I did before.

This corresponds to steps 5-7 in https://github.com/libMesh/libmesh/pull/3984#issuecomment-2477138087.