### PR TITLE
Simplify set_petsc_preconditioner_type

### DIFF
--- a/include/numerics/petsc_preconditioner.h
+++ b/include/numerics/petsc_preconditioner.h
@@ -93,16 +93,6 @@ protected:
    * aren't responsible for cleaning up this one.
    */
   Mat _mat;
-
-private:
-  /**
-   * Some PETSc preconditioners (ILU, LU) don't work in parallel.  This function
-   * is called from set_petsc_preconditioner_type() to set additional options
-   * for those so-called sub-preconditioners.  This method ends up being static
-   * so that it can be called from set_petsc_preconditioner_type().  Not sure
-   * why set_petsc_preconditioner_type() needs to be static though...
-   */
-  static void set_petsc_subpreconditioner_type(const PCType type, PC & pc);
 };
 
 } // namespace libMesh


### PR DESCRIPTION
Hi John (@jwpeterson),

I removed/simplified this code, which I believe has been broken for nearly 12 years (surely the if condition is ill-written?):

https://github.com/libMesh/libmesh/blob/8f371cf6ea4beef0210f48c4c8ee02e7ee991bc0/src/numerics/petsc_preconditioner.C#L130-L164

-Nuno

