### PR TITLE
JumpErrorEstimator::integrate_slits option

### DIFF
--- a/examples/transient/transient_ex3/Makefile.in
+++ b/examples/transient/transient_ex3/Makefile.in
@@ -184,7 +184,7 @@ example_dbg_OBJECTS = $(am_example_dbg_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
-am__v_lt_1 =
+am__v_lt_1 = 
 example_dbg_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CXXLD) $(example_dbg_CXXFLAGS) \
 	$(CXXFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
@@ -253,11 +253,11 @@ am__v_P_1 = :
 AM_V_GEN = $(am__v_GEN_@AM_V@)
 am__v_GEN_ = $(am__v_GEN_@AM_DEFAULT_V@)
 am__v_GEN_0 = @echo "  GEN     " $@;
-am__v_GEN_1 =
+am__v_GEN_1 = 
 AM_V_at = $(am__v_at_@AM_V@)
 am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
 am__v_at_0 = @
-am__v_at_1 =
+am__v_at_1 = 
 DEFAULT_INCLUDES = -I.@am__isrc@ -I$(top_builddir)/include
 depcomp = $(SHELL) $(top_srcdir)/build-aux/depcomp
 am__maybe_remake_depfiles = depfiles
@@ -286,7 +286,7 @@ LTCXXCOMPILE = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
 AM_V_CXX = $(am__v_CXX_@AM_V@)
 am__v_CXX_ = $(am__v_CXX_@AM_DEFAULT_V@)
 am__v_CXX_0 = @echo "  CXX     " $@;
-am__v_CXX_1 =
+am__v_CXX_1 = 
 CXXLD = $(CXX)
 CXXLINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CXXLD) $(AM_CXXFLAGS) \
@@ -294,7 +294,7 @@ CXXLINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
 AM_V_CXXLD = $(am__v_CXXLD_@AM_V@)
 am__v_CXXLD_ = $(am__v_CXXLD_@AM_DEFAULT_V@)
 am__v_CXXLD_0 = @echo "  CXXLD   " $@;
-am__v_CXXLD_1 =
+am__v_CXXLD_1 = 
 COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
 LTCOMPILE = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
@@ -304,7 +304,7 @@ LTCOMPILE = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 AM_V_CC = $(am__v_CC_@AM_V@)
 am__v_CC_ = $(am__v_CC_@AM_DEFAULT_V@)
 am__v_CC_0 = @echo "  CC      " $@;
-am__v_CC_1 =
+am__v_CC_1 = 
 CCLD = $(CC)
 LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(AM_CFLAGS) $(CFLAGS) \
@@ -312,7 +312,7 @@ LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 AM_V_CCLD = $(am__v_CCLD_@AM_V@)
 am__v_CCLD_ = $(am__v_CCLD_@AM_DEFAULT_V@)
 am__v_CCLD_0 = @echo "  CCLD    " $@;
-am__v_CCLD_1 =
+am__v_CCLD_1 = 
 SOURCES = $(example_dbg_SOURCES) $(example_devel_SOURCES) \
 	$(example_oprof_SOURCES) $(example_opt_SOURCES) \
 	$(example_prof_SOURCES)
@@ -841,23 +841,23 @@ clean-checkPROGRAMS:
 	echo " rm -f" $$list; \
 	rm -f $$list
 
-example-dbg$(EXEEXT): $(example_dbg_OBJECTS) $(example_dbg_DEPENDENCIES) $(EXTRA_example_dbg_DEPENDENCIES)
+example-dbg$(EXEEXT): $(example_dbg_OBJECTS) $(example_dbg_DEPENDENCIES) $(EXTRA_example_dbg_DEPENDENCIES) 
 	@rm -f example-dbg$(EXEEXT)
 	$(AM_V_CXXLD)$(example_dbg_LINK) $(example_dbg_OBJECTS) $(example_dbg_LDADD) $(LIBS)
 
-example-devel$(EXEEXT): $(example_devel_OBJECTS) $(example_devel_DEPENDENCIES) $(EXTRA_example_devel_DEPENDENCIES)
+example-devel$(EXEEXT): $(example_devel_OBJECTS) $(example_devel_DEPENDENCIES) $(EXTRA_example_devel_DEPENDENCIES) 
 	@rm -f example-devel$(EXEEXT)
 	$(AM_V_CXXLD)$(example_devel_LINK) $(example_devel_OBJECTS) $(example_devel_LDADD) $(LIBS)
 
-example-oprof$(EXEEXT): $(example_oprof_OBJECTS) $(example_oprof_DEPENDENCIES) $(EXTRA_example_oprof_DEPENDENCIES)
+example-oprof$(EXEEXT): $(example_oprof_OBJECTS) $(example_oprof_DEPENDENCIES) $(EXTRA_example_oprof_DEPENDENCIES) 
 	@rm -f example-oprof$(EXEEXT)
 	$(AM_V_CXXLD)$(example_oprof_LINK) $(example_oprof_OBJECTS) $(example_oprof_LDADD) $(LIBS)
 
-example-opt$(EXEEXT): $(example_opt_OBJECTS) $(example_opt_DEPENDENCIES) $(EXTRA_example_opt_DEPENDENCIES)
+example-opt$(EXEEXT): $(example_opt_OBJECTS) $(example_opt_DEPENDENCIES) $(EXTRA_example_opt_DEPENDENCIES) 
 	@rm -f example-opt$(EXEEXT)
 	$(AM_V_CXXLD)$(example_opt_LINK) $(example_opt_OBJECTS) $(example_opt_LDADD) $(LIBS)
 
-example-prof$(EXEEXT): $(example_prof_OBJECTS) $(example_prof_DEPENDENCIES) $(EXTRA_example_prof_DEPENDENCIES)
+example-prof$(EXEEXT): $(example_prof_OBJECTS) $(example_prof_DEPENDENCIES) $(EXTRA_example_prof_DEPENDENCIES) 
 	@rm -f example-prof$(EXEEXT)
 	$(AM_V_CXXLD)$(example_prof_LINK) $(example_prof_OBJECTS) $(example_prof_LDADD) $(LIBS)
 

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -775,6 +775,7 @@ include_HEADERS = \
         ghosting/ghost_point_neighbors.h \
         ghosting/ghosting_functor.h \
         ghosting/non_manifold_coupling.h \
+        ghosting/overlap_coupling.h \
         ghosting/point_neighbor_coupling.h \
         ghosting/sibling_coupling.h \
         mesh/abaqus_io.h \

--- a/include/error_estimation/jump_error_estimator.h
+++ b/include/error_estimation/jump_error_estimator.h
@@ -57,6 +57,7 @@ public:
       scale_by_n_flux_faces(false),
       use_unweighted_quadrature_rules(false),
       integrate_boundary_sides(false),
+      integrate_slits(false),
       fine_context(),
       coarse_context(),
       fine_error(0),
@@ -150,6 +151,17 @@ protected:
    * with boundary_side_integration() should be performed
    */
   bool integrate_boundary_sides;
+
+  /**
+   * A boolean flag, by default false, to be set to true if integrations
+   * should be performed on "slits" where two elements' faces overlap
+   * even if those elements are not connected by neighbor links.
+   *
+   * This may only be useful for flex-IGA meshes, where
+   * highly-nonconforming meshes are given pseudo-conforming solutions
+   * via nodal constraints.
+   */
+  bool integrate_slits;
 
   /**
    * Context objects for integrating on the fine and coarse elements

--- a/include/error_estimation/jump_error_estimator.h
+++ b/include/error_estimation/jump_error_estimator.h
@@ -56,8 +56,8 @@ public:
     : ErrorEstimator(),
       scale_by_n_flux_faces(false),
       use_unweighted_quadrature_rules(false),
-      integrate_boundary_sides(false),
       integrate_slits(false),
+      integrate_boundary_sides(false),
       fine_context(),
       coarse_context(),
       fine_error(0),
@@ -113,6 +113,17 @@ public:
    */
   bool use_unweighted_quadrature_rules;
 
+  /**
+   * A boolean flag, by default false, to be set to true if integrations
+   * should be performed on "slits" where two elements' faces overlap
+   * even if those elements are not connected by neighbor links.
+   *
+   * This may only be useful for flex-IGA meshes, where
+   * highly-nonconforming meshes are given pseudo-conforming solutions
+   * via nodal constraints.
+   */
+  bool integrate_slits;
+
 protected:
   /**
    * A utility function to reinit the finite element data on elements sharing a
@@ -151,17 +162,6 @@ protected:
    * with boundary_side_integration() should be performed
    */
   bool integrate_boundary_sides;
-
-  /**
-   * A boolean flag, by default false, to be set to true if integrations
-   * should be performed on "slits" where two elements' faces overlap
-   * even if those elements are not connected by neighbor links.
-   *
-   * This may only be useful for flex-IGA meshes, where
-   * highly-nonconforming meshes are given pseudo-conforming solutions
-   * via nodal constraints.
-   */
-  bool integrate_slits;
 
   /**
    * Context objects for integrating on the fine and coarse elements

--- a/include/error_estimation/jump_error_estimator.h
+++ b/include/error_estimation/jump_error_estimator.h
@@ -121,6 +121,11 @@ public:
    * This may only be useful for flex-IGA meshes, where
    * highly-nonconforming meshes are given pseudo-conforming solutions
    * via nodal constraints.
+   *
+   * Note that, to safely use this option in parallel, it is also
+   * necessary to expand the default algebraic ghosting requirements
+   * to include elements on the opposite sides of slits from local
+   * elements.
    */
   bool integrate_slits;
 

--- a/include/ghosting/overlap_coupling.h
+++ b/include/ghosting/overlap_coupling.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2024 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2025 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/ghosting/overlap_coupling.h
+++ b/include/ghosting/overlap_coupling.h
@@ -1,0 +1,131 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2024 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#ifndef LIBMESH_OVERLAP_COUPLING_H
+#define LIBMESH_OVERLAP_COUPLING_H
+
+// Local Includes
+#include "libmesh/ghosting_functor.h"
+
+#include "libmesh/fe_map.h"
+#include "libmesh/quadrature.h"
+
+// C++ Includes
+#include <memory>
+
+namespace libMesh
+{
+
+// Forward declarations
+class PeriodicBoundaries;
+
+
+/**
+ * This class implements ghosting of elements that overlap or touch at
+ * at least one sampled point, even if no topological connection
+ * between the elements exists.  This may be useful for immersed
+ * methods, or for integration along both sides of mesh "slits" with
+ * no neighbor information.
+ *
+ * \author Roy H. Stogner
+ * \date 2025
+ */
+class OverlapCoupling : public GhostingFunctor
+{
+public:
+
+  /**
+   * Constructor.  Defaults to using a Simpson's Rule quadrature to
+   * choose sampling points.  Users may wish to attach custom
+   * quadrature rules matching those used for their system
+   * integration.
+   */
+  OverlapCoupling();
+
+  /**
+   * Copy constructor.
+   */
+  OverlapCoupling(const OverlapCoupling & other) :
+    GhostingFunctor(other),
+    _dof_coupling(other._dof_coupling)
+  {
+    for (auto i : make_range(2))
+      if (other._q_rules[i].get())
+        _q_rules[i] = other._q_rules[i]->clone();
+  }
+
+  /**
+   * A clone() is needed because GhostingFunctor can not be shared between
+   * different meshes. The operations in GhostingFunctor are mesh dependent.
+   */
+  virtual std::unique_ptr<GhostingFunctor> clone () const override
+  { return std::make_unique<OverlapCoupling>(*this); }
+
+  // Change coupling matrix after construction
+  void set_dof_coupling(const CouplingMatrix * dof_coupling)
+  { _dof_coupling = dof_coupling; }
+
+  // Change quadrature rule after construction.  This function takes
+  // ownership of the rule object and uses it for elements of the
+  // appropriate dimension.
+  void set_quadrature_rule(std::unique_ptr<QBase> new_q_rule)
+  {
+    libmesh_assert(new_q_rule.get());
+    const unsigned int dim = new_q_rule->get_dim();
+    _q_rules[dim-1] = std::move(new_q_rule);
+  }
+
+  /**
+   * We need an updated point locator to see what other elements might
+   * share each quadrature point.
+   */
+  virtual void mesh_reinit () override;
+
+  virtual void redistribute () override
+  { this->mesh_reinit(); }
+
+  virtual void delete_remote_elements() override
+  { this->mesh_reinit(); }
+
+  /**
+   * For the specified range of active elements, find the elements
+   * which will be coupled to them in the sparsity pattern.
+   *
+   * This will include whatever the point locator finds at each
+   * quadrature point in the range.
+   */
+  virtual void operator() (const MeshBase::const_element_iterator & range_begin,
+                           const MeshBase::const_element_iterator & range_end,
+                           processor_id_type p,
+                           map_type & coupled_elements) override;
+
+private:
+
+  const CouplingMatrix * _dof_coupling;
+
+  // Quadrature rules for different element dimensions
+  std::array<std::unique_ptr<QBase>, 3> _q_rules;
+
+  // FE Map from quadrature space to physical space
+  FEMap _fe_map;
+};
+
+} // namespace libMesh
+
+#endif // LIBMESH_OVERLAP_COUPLING_H

--- a/include/ghosting/overlap_coupling.h
+++ b/include/ghosting/overlap_coupling.h
@@ -61,14 +61,7 @@ public:
   /**
    * Copy constructor.
    */
-  OverlapCoupling(const OverlapCoupling & other) :
-    GhostingFunctor(other),
-    _dof_coupling(other._dof_coupling)
-  {
-    for (auto i : make_range(2))
-      if (other._q_rules[i].get())
-        _q_rules[i] = other._q_rules[i]->clone();
-  }
+  OverlapCoupling(const OverlapCoupling & other);
 
   /**
    * A clone() is needed because GhostingFunctor can not be shared between
@@ -84,12 +77,7 @@ public:
   // Change quadrature rule after construction.  This function takes
   // ownership of the rule object and uses it for elements of the
   // appropriate dimension.
-  void set_quadrature_rule(std::unique_ptr<QBase> new_q_rule)
-  {
-    libmesh_assert(new_q_rule.get());
-    const unsigned int dim = new_q_rule->get_dim();
-    _q_rules[dim-1] = std::move(new_q_rule);
-  }
+  void set_quadrature_rule(std::unique_ptr<QBase> new_q_rule);
 
   /**
    * We need an updated point locator to see what other elements might

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -174,6 +174,7 @@ include_HEADERS =  \
         ghosting/ghost_point_neighbors.h \
         ghosting/ghosting_functor.h \
         ghosting/non_manifold_coupling.h \
+        ghosting/overlap_coupling.h \
         ghosting/point_neighbor_coupling.h \
         ghosting/sibling_coupling.h \
         mesh/abaqus_io.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -164,6 +164,7 @@ BUILT_SOURCES = \
         ghost_point_neighbors.h \
         ghosting_functor.h \
         non_manifold_coupling.h \
+        overlap_coupling.h \
         point_neighbor_coupling.h \
         sibling_coupling.h \
         abaqus_io.h \
@@ -1080,6 +1081,9 @@ ghosting_functor.h: $(top_srcdir)/include/ghosting/ghosting_functor.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 non_manifold_coupling.h: $(top_srcdir)/include/ghosting/non_manifold_coupling.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+overlap_coupling.h: $(top_srcdir)/include/ghosting/overlap_coupling.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 point_neighbor_coupling.h: $(top_srcdir)/include/ghosting/point_neighbor_coupling.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -571,12 +571,13 @@ BUILT_SOURCES = auto_ptr.h dirichlet_boundaries.h dof_map.h \
 	plane.h point.h reference_elem.h remote_elem.h side.h sphere.h \
 	stored_range.h surface.h default_coupling.h \
 	ghost_point_neighbors.h ghosting_functor.h \
-	non_manifold_coupling.h point_neighbor_coupling.h \
-	sibling_coupling.h abaqus_io.h boundary_info.h boundary_mesh.h \
-	checkpoint_io.h distributed_mesh.h dyna_io.h ensight_io.h \
-	exodusII_io.h exodusII_io_helper.h exodus_header_info.h \
-	fro_io.h gmsh_io.h gmv_io.h gnuplot_io.h inf_elem_builder.h \
-	matlab_io.h medit_io.h mesh.h mesh_base.h mesh_communication.h \
+	non_manifold_coupling.h overlap_coupling.h \
+	point_neighbor_coupling.h sibling_coupling.h abaqus_io.h \
+	boundary_info.h boundary_mesh.h checkpoint_io.h \
+	distributed_mesh.h dyna_io.h ensight_io.h exodusII_io.h \
+	exodusII_io_helper.h exodus_header_info.h fro_io.h gmsh_io.h \
+	gmv_io.h gnuplot_io.h inf_elem_builder.h matlab_io.h \
+	medit_io.h mesh.h mesh_base.h mesh_communication.h \
 	mesh_function.h mesh_generation.h mesh_input.h \
 	mesh_inserter_iterator.h mesh_modification.h \
 	mesh_netgen_interface.h mesh_output.h mesh_refinement.h \
@@ -1413,6 +1414,9 @@ ghosting_functor.h: $(top_srcdir)/include/ghosting/ghosting_functor.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 non_manifold_coupling.h: $(top_srcdir)/include/ghosting/non_manifold_coupling.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+overlap_coupling.h: $(top_srcdir)/include/ghosting/overlap_coupling.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 point_neighbor_coupling.h: $(top_srcdir)/include/ghosting/point_neighbor_coupling.h

--- a/include/systems/system_norm.h
+++ b/include/systems/system_norm.h
@@ -39,6 +39,10 @@ enum FEMNormType : int;
  * Discrete vector norms and weighted l2 combinations of Sobolev norms and
  * seminorms are representable.
  *
+ * For ease of use, if a norm or weight is queried for variable n but
+ * has not been set for variable n, then the norm or weight set for
+ * the highest-numbered variable below n is returned.
+ *
  * \author Roy H. Stogner
  * \date 2008
  */
@@ -47,7 +51,7 @@ class SystemNorm
 public:
 
   /**
-   * Constructor, defaults to DISCRETE_L2
+   * Constructor, defaults to DISCRETE_L2 with weight of 1.0.
    */
   SystemNorm();
 
@@ -125,21 +129,31 @@ public:
 
   /**
    * \returns The type of the norm in variable \p var
+   *
+   * If no norm has been explicitly set for \p var, then the
+   * highest-index norm explicitly set is returned, or DISCRETE_L2
+   * is returned if no norms have been explicitly set.
    */
   FEMNormType type(unsigned int var) const;
 
   /**
-   * Sets the type of the norm in variable \p var
+   * Sets the type of the norm in variable \p var, as well as for any
+   * unset variables with index less than \p var
    */
   void set_type(unsigned int var, const FEMNormType & t);
 
   /**
    * \returns The weight corresponding to the norm in variable \p var
+   *
+   * If no weight has been explicitly set for \p var, then the
+   * highest-index weight explicitly set is returned, or 1.0 is
+   * returned if no weights have been explicitly set.
    */
   Real weight(unsigned int var) const;
 
   /**
-   * Sets the weight corresponding to the norm in variable \p var
+   * Sets the weight corresponding to the norm in variable \p var, as
+   * well as for any unset variables with index less than \p var.
    */
   void set_weight(unsigned int var, Real w);
 

--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -98,8 +98,9 @@ public:
                                    const std::set<subdomain_id_type> * allowed_subdomains = nullptr) const = 0;
 
   /**
-   * Locates a set of elements in proximity to the point with global coordinates
-   * \p p  Pure virtual. Optionally allows the user to restrict the subdomains searched.
+   * Finds elements in proximity to the point with global coordinates
+   * \p p and adds them to a set of candidate elements.  Pure virtual.
+   * Optionally allows the user to restrict the subdomains searched.
    */
   virtual void operator() (const Point & p,
                            std::set<const Elem *> & candidate_elements,

--- a/include/utils/tree.h
+++ b/include/utils/tree.h
@@ -88,7 +88,7 @@ public:
                                     Real relative_tol = TOLERANCE) const override;
 
   /**
-   * Fills \p candidate_elements with any elements containing the
+   * Adds to \p candidate_elements any elements containing the
    * specified point \p p,
    * optionally restricted to a set of allowed subdomains,
    * optionally using a non-zero relative tolerance for searches.

--- a/include/utils/tree_node.h
+++ b/include/utils/tree_node.h
@@ -168,7 +168,7 @@ public:
                              Real relative_tol = TOLERANCE) const;
 
   /**
-   * Fills \p candidate_elements with any elements containing the
+   * Adds to \p candidate_elements any elements containing the
    * specified point \p p,
    * optionally restricted to a set of allowed subdomains,
    * optionally using a non-default relative tolerance for searches.

--- a/src/apps/calculator.C
+++ b/src/apps/calculator.C
@@ -61,25 +61,26 @@ using namespace libMesh;
 void usage_error(const char * progname)
 {
   libMesh::out << "Options: " << progname << '\n'
-               << " --dim d                mesh dimension              [default: autodetect]\n"
+               << " --dim        d         mesh dimension               [default: autodetect]\n"
                << " --inmesh     filename  input mesh file\n"
-               << " --inmat      filename  input constraint matrix     [default: none]\n"
+               << " --inmat      filename  input constraint matrix      [default: none]\n"
                << " --mattol     filename  constraint tolerance when testing mesh connectivity\n"
-               << "                                                    [default: 0]\n"
+               << "                                                     [default: 0]\n"
                << " --insoln     filename  input solution file\n"
                << " --calc       func      function to calculate\n"
-               << " --insys      sysnum    input system number         [default: 0]\n"
-               << " --outsoln    filename  output solution file        [default: out_<insoln>]\n"
-               << " --family     famname   output FEM family           [default: LAGRANGE]\n"
-               << " --order      p         output FEM order            [default: 1]\n"
-               << " --subdomain  sbd_id    each subdomain to check     [default: all subdomains]\n"
-               << " --hilbert    order     Hilbert space to project in [default: 0 => H0]\n"
-               << " --fdm_eps    eps       Central diff for dfunc/dx   [default: " << TOLERANCE << "]\n"
+               << " --insys      sysnum    input system number          [default: 0]\n"
+               << " --outsoln    filename  output solution file         [default: out_<insoln>]\n"
+               << " --family     famname   output FEM family            [default: LAGRANGE]\n"
+               << " --order      p         output FEM order             [default: 1]\n"
+               << " --subdomain  sbd_id    each subdomain to check      [default: all subdomains]\n"
+               << " --hilbert    order     Hilbert space to project in  [default: 0 => H0]\n"
+               << " --fdm_eps    eps       Central diff for dfunc/dx    [default: " << TOLERANCE << "]\n"
                << " --error_q    extra_q   integrate projection error, with adjusted\n"
-               << "                       (extra) quadrature order     [default: off, suggested: 0]\n"
+               << "                       (extra) quadrature order      [default: off, suggested: 0]\n"
                << " --jump_error order     calculate jump error indicator, for specified\n"
-               << "                       Hilbert order                [default: off]\n"
-               << " --integral            only calculate func integral, not projection\n"
+               << "                       Hilbert order                 [default: off]\n"
+               << " --jump_slits           calculate jumps across slits [default: off]\n"
+               << " --integral             only calculate func integral, not projection\n"
                << std::endl;
 
   exit(1);
@@ -403,12 +404,15 @@ int main(int argc, char ** argv)
               else
                 libmesh_not_implemented();
 
+              if (cl.search(1, "--jump_slits"))
+                error_estimator->integrate_slits = true;
+
               ErrorVector error_per_cell;
               error_estimator->error_norm = error_norm;
               error_estimator->estimate_error(new_sys, error_per_cell);
 
               const std::string var_name = new_sys.variable_name(v);
-              libMesh::out << "H" << jump_error_hilbert << " norm of " << var_name << ": " <<
+              libMesh::out << "H" << jump_error_hilbert << " error estimate for " << var_name << ": " <<
                 std::reduce(error_per_cell.begin(), error_per_cell.end()) <<
                 std::endl;
             }

--- a/src/apps/calculator.C
+++ b/src/apps/calculator.C
@@ -51,7 +51,6 @@
 
 // C++ includes
 #include <memory>
-#include <numeric>  // std::reduce
 #include <string>
 
 
@@ -409,9 +408,16 @@ int main(int argc, char ** argv)
               error_estimator->estimate_error(new_sys, error_per_cell);
 
               const std::string var_name = new_sys.variable_name(v);
+
+              // I really want to just stop supporting libstdc++-8.
+              // const Real total_error = std::reduce(error_per_cell.begin(), error_per_cell.end());
+
+              ErrorVectorReal total_error = 0;
+              for (auto cell_error : error_per_cell)
+                total_error += cell_error;
+
               libMesh::out << "H" << jump_error_hilbert << " error estimate for " << var_name << ": " <<
-                std::reduce(error_per_cell.begin(), error_per_cell.end()) <<
-                std::endl;
+                total_error << std::endl;
             }
         }
 

--- a/src/apps/calculator.C
+++ b/src/apps/calculator.C
@@ -51,6 +51,7 @@
 
 // C++ includes
 #include <memory>
+#include <numeric>  // std::reduce
 #include <string>
 
 

--- a/src/error_estimation/discontinuity_measure.C
+++ b/src/error_estimation/discontinuity_measure.C
@@ -97,8 +97,6 @@ DiscontinuityMeasure::internal_side_integration ()
   Real error = 1.e-30;
   unsigned int n_qp = fe_fine->n_quadrature_points();
 
-  const std::vector<std::vector<Real>> & phi_coarse = fe_coarse->get_phi();
-  const std::vector<std::vector<Real>> & phi_fine = fe_fine->get_phi();
   const std::vector<Real> & JxW_face = fe_fine->get_JxW();
 
   for (unsigned int qp=0; qp != n_qp; ++qp)
@@ -136,7 +134,6 @@ DiscontinuityMeasure::boundary_side_integration ()
   const std::string & var_name =
     fine_context->get_system().variable_name(var);
 
-  const std::vector<std::vector<Real>> & phi_fine = fe_fine->get_phi();
   const std::vector<Real> & JxW_face = fe_fine->get_JxW();
   const std::vector<Point> & qface_point = fe_fine->get_xyz();
 

--- a/src/error_estimation/discontinuity_measure.C
+++ b/src/error_estimation/discontinuity_measure.C
@@ -74,8 +74,13 @@ DiscontinuityMeasure::init_context(FEMContext & c)
         {
           c.get_side_fe( v, side_fe, dim );
 
-          // We'll need values on both sides for discontinuity computation
+          // We'll need values and mapping Jacobians on both sides for
+          // discontinuity computation
           side_fe->get_phi();
+
+          // But we only need mapping Jacobians from one side
+          if (&c != coarse_context.get())
+            side_fe->get_JxW();
         }
     }
 }

--- a/src/error_estimation/discontinuity_measure.C
+++ b/src/error_estimation/discontinuity_measure.C
@@ -97,9 +97,9 @@ DiscontinuityMeasure::internal_side_integration ()
   Real error = 1.e-30;
   unsigned int n_qp = fe_fine->n_quadrature_points();
 
-  std::vector<std::vector<Real>> phi_coarse = fe_coarse->get_phi();
-  std::vector<std::vector<Real>> phi_fine = fe_fine->get_phi();
-  std::vector<Real> JxW_face = fe_fine->get_JxW();
+  const std::vector<std::vector<Real>> & phi_coarse = fe_coarse->get_phi();
+  const std::vector<std::vector<Real>> & phi_fine = fe_fine->get_phi();
+  const std::vector<Real> & JxW_face = fe_fine->get_JxW();
 
   for (unsigned int qp=0; qp != n_qp; ++qp)
     {
@@ -136,9 +136,9 @@ DiscontinuityMeasure::boundary_side_integration ()
   const std::string & var_name =
     fine_context->get_system().variable_name(var);
 
-  std::vector<std::vector<Real>> phi_fine = fe_fine->get_phi();
-  std::vector<Real> JxW_face = fe_fine->get_JxW();
-  std::vector<Point> qface_point = fe_fine->get_xyz();
+  const std::vector<std::vector<Real>> & phi_fine = fe_fine->get_phi();
+  const std::vector<Real> & JxW_face = fe_fine->get_JxW();
+  const std::vector<Point> & qface_point = fe_fine->get_xyz();
 
   // The reinitialization also recomputes the locations of
   // the quadrature points on the side.  By checking if the

--- a/src/error_estimation/fourth_error_estimators.C
+++ b/src/error_estimation/fourth_error_estimators.C
@@ -106,9 +106,9 @@ LaplacianErrorEstimator::internal_side_integration ()
   Real error = 1.e-30;
   unsigned int n_qp = fe_fine->n_quadrature_points();
 
-  std::vector<std::vector<RealTensor>> d2phi_coarse = fe_coarse->get_d2phi();
-  std::vector<std::vector<RealTensor>> d2phi_fine = fe_fine->get_d2phi();
-  std::vector<Real> JxW_face = fe_fine->get_JxW();
+  const std::vector<std::vector<RealTensor>> & d2phi_coarse = fe_coarse->get_d2phi();
+  const std::vector<std::vector<RealTensor>> & d2phi_fine = fe_fine->get_d2phi();
+  const std::vector<Real> & JxW_face = fe_fine->get_JxW();
 
   for (unsigned int qp=0; qp != n_qp; ++qp)
     {

--- a/src/error_estimation/kelly_error_estimator.C
+++ b/src/error_estimation/kelly_error_estimator.C
@@ -101,10 +101,10 @@ KellyErrorEstimator::internal_side_integration ()
   Real error = 1.e-30;
   unsigned int n_qp = fe_fine->n_quadrature_points();
 
-  std::vector<std::vector<RealGradient>> dphi_coarse = fe_coarse->get_dphi();
-  std::vector<std::vector<RealGradient>> dphi_fine = fe_fine->get_dphi();
-  std::vector<Point> face_normals = fe_fine->get_normals();
-  std::vector<Real> JxW_face = fe_fine->get_JxW();
+  const std::vector<std::vector<RealGradient>> & dphi_coarse = fe_coarse->get_dphi();
+  const std::vector<std::vector<RealGradient>> & dphi_fine = fe_fine->get_dphi();
+  const std::vector<Point> & face_normals = fe_fine->get_normals();
+  const std::vector<Real> & JxW_face = fe_fine->get_JxW();
 
   for (unsigned int qp=0; qp != n_qp; ++qp)
     {
@@ -142,10 +142,10 @@ KellyErrorEstimator::boundary_side_integration ()
   const std::string & var_name =
     fine_context->get_system().variable_name(var);
 
-  std::vector<std::vector<RealGradient>> dphi_fine = fe_fine->get_dphi();
-  std::vector<Point> face_normals = fe_fine->get_normals();
-  std::vector<Real> JxW_face = fe_fine->get_JxW();
-  std::vector<Point> qface_point = fe_fine->get_xyz();
+  const std::vector<std::vector<RealGradient>> & dphi_fine = fe_fine->get_dphi();
+  const std::vector<Point> & face_normals = fe_fine->get_normals();
+  const std::vector<Real> & JxW_face = fe_fine->get_JxW();
+  const std::vector<Point> & qface_point = fe_fine->get_xyz();
 
   // The reinitialization also recomputes the locations of
   // the quadrature points on the side.  By checking if the

--- a/src/error_estimation/kelly_error_estimator.C
+++ b/src/error_estimation/kelly_error_estimator.C
@@ -101,8 +101,6 @@ KellyErrorEstimator::internal_side_integration ()
   Real error = 1.e-30;
   unsigned int n_qp = fe_fine->n_quadrature_points();
 
-  const std::vector<std::vector<RealGradient>> & dphi_coarse = fe_coarse->get_dphi();
-  const std::vector<std::vector<RealGradient>> & dphi_fine = fe_fine->get_dphi();
   const std::vector<Point> & face_normals = fe_fine->get_normals();
   const std::vector<Real> & JxW_face = fe_fine->get_JxW();
 
@@ -142,7 +140,6 @@ KellyErrorEstimator::boundary_side_integration ()
   const std::string & var_name =
     fine_context->get_system().variable_name(var);
 
-  const std::vector<std::vector<RealGradient>> & dphi_fine = fe_fine->get_dphi();
   const std::vector<Point> & face_normals = fe_fine->get_normals();
   const std::vector<Real> & JxW_face = fe_fine->get_JxW();
   const std::vector<Point> & qface_point = fe_fine->get_xyz();

--- a/src/ghosting/overlap_coupling.C
+++ b/src/ghosting/overlap_coupling.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2024 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2025 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/ghosting/overlap_coupling.C
+++ b/src/ghosting/overlap_coupling.C
@@ -41,6 +41,28 @@ OverlapCoupling::OverlapCoupling() :
 }
 
 
+
+OverlapCoupling::OverlapCoupling(const OverlapCoupling & other) :
+  GhostingFunctor(other),
+  _dof_coupling(other._dof_coupling)
+{
+  for (auto i : make_range(2))
+    if (other._q_rules[i].get())
+      _q_rules[i] = other._q_rules[i]->clone();
+}
+
+
+
+void OverlapCoupling::set_quadrature_rule
+  (std::unique_ptr<QBase> new_q_rule)
+{
+  libmesh_assert(new_q_rule.get());
+  const unsigned int dim = new_q_rule->get_dim();
+  _q_rules[dim-1] = std::move(new_q_rule);
+}
+
+
+
 void OverlapCoupling::mesh_reinit()
 {
   // We'll need a master point locator, so we'd better have a mesh

--- a/src/ghosting/overlap_coupling.C
+++ b/src/ghosting/overlap_coupling.C
@@ -1,0 +1,94 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2024 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public  License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+// Local Includes
+#include "libmesh/overlap_coupling.h"
+
+#include "libmesh/elem.h"
+#include "libmesh/enum_quadrature_type.h"
+#include "libmesh/periodic_boundaries.h"
+#include "libmesh/remote_elem.h"
+#include "libmesh/libmesh_logging.h"
+
+// C++ Includes
+#include <unordered_set>
+
+namespace libMesh
+{
+
+OverlapCoupling::OverlapCoupling() :
+  _dof_coupling(nullptr)
+{
+  _q_rules[0] = QBase::build(QSIMPSON, 1, SECOND);
+  _q_rules[1] = QBase::build(QSIMPSON, 2, SECOND);
+  _q_rules[2] = QBase::build(QSIMPSON, 3, SECOND);
+}
+
+
+void OverlapCoupling::mesh_reinit()
+{
+  // We'll need a master point locator, so we'd better have a mesh
+  // to build it on.
+  libmesh_assert(_mesh);
+
+  // Make sure an up-to-date master point locator has been
+  // constructed; we'll need to grab sub-locators soon.
+  _mesh->sub_point_locator();
+}
+
+
+
+void OverlapCoupling::operator()
+  (const MeshBase::const_element_iterator & range_begin,
+   const MeshBase::const_element_iterator & range_end,
+   processor_id_type p,
+   map_type & coupled_elements)
+{
+  LOG_SCOPE("operator()", "OverlapCoupling");
+
+  std::unique_ptr<PointLocatorBase> point_locator
+    = _mesh->sub_point_locator();
+
+  const std::vector<Point> & xyz = this->_fe_map.get_xyz();
+
+  for (const auto & elem : as_range(range_begin, range_end))
+  {
+    const unsigned int dim = elem->dim();
+
+    QBase & qrule = *_q_rules[dim-1];
+    qrule.init(*elem);
+
+    _fe_map.init_reference_to_physical_map(dim, qrule.get_points(), elem);
+    _fe_map.compute_map(dim, qrule.get_weights(), elem, /*d2phi=*/ false);
+
+    std::set<const Elem *> overlapping_elements;
+    for (const Point & qp : xyz)
+      (*point_locator)(qp, overlapping_elements);
+
+    // We should at least find ourselves
+    libmesh_assert(overlapping_elements.count(elem));
+
+    for (const Elem * e : overlapping_elements)
+      if (e->processor_id() != p)
+        coupled_elements.emplace(e, _dof_coupling);
+  }
+}
+
+
+} // namespace libMesh

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -187,6 +187,7 @@ libmesh_SOURCES =  \
         src/ghosting/default_coupling.C \
         src/ghosting/ghost_point_neighbors.C \
         src/ghosting/non_manifold_coupling.C \
+        src/ghosting/overlap_coupling.C \
         src/ghosting/point_neighbor_coupling.C \
         src/ghosting/sibling_coupling.C \
         src/mesh/abaqus_io.C \


### PR DESCRIPTION
This was a bit of a red herring for the flex-IGA bug hunt I wrote it for, but it could still be useful for making our error indicators work properly on flex-IGA meshes.