### PR TITLE
Disable ConnectedComponentsTest tests when there is no solver package available

### DIFF
--- a/tests/mesh/connected_components.C
+++ b/tests/mesh/connected_components.C
@@ -5,6 +5,7 @@
 #include <libmesh/mesh.h>
 #include <libmesh/node.h>
 #include <libmesh/sparse_matrix.h>
+#include <libmesh/system.h>
 
 #include <timpi/parallel_implementation.h>
 
@@ -24,9 +25,16 @@ class ConnectedComponentsTest : public CppUnit::TestCase
 public:
   LIBMESH_CPPUNIT_TEST_SUITE( ConnectedComponentsTest );
 
+  /**
+   * These tests require a valid solver package to be enabled because
+   * they build a SparseMatrix.
+   * Note: LIBMESH_HAVE_SOLVER is actually defined in libmesh/system.h
+   */
+#ifdef LIBMESH_HAVE_SOLVER
   CPPUNIT_TEST( testEdge2 );
   CPPUNIT_TEST( testEdge3 );
   CPPUNIT_TEST( testEdge4 );
+#endif
 
   CPPUNIT_TEST_SUITE_END();
 


### PR DESCRIPTION
Otherwise, we get the following failure during the "Test No Optional" testing:

```
1) test: ConnectedComponentsTest::testEdge2 (E) 
uncaught exception of type std::exception (or derived).
- ERROR:  Unrecognized solver package: 7
Stack frames: 20
0: libMesh::print_trace(std::ostream&)
1: libMesh::MacroFunctions::report_error(char const*, int, char const*, char const*, std::ostream&)
2: libMesh::SparseMatrix<double>::build(libMesh::Parallel::Communicator const&, libMesh::SolverPackage, libMesh::MatrixBuildType)
3: /tmp/build/libmesh/build/tests/.libs/lt-unit_tests-opt() [0xf486d3]
4: /tmp/build/libmesh/build/tests/.libs/lt-unit_tests-opt() [0xf49226]
5: CppUnit::TestCaseMethodFunctor::operator()() const
6: CppUnit::DefaultProtector::protect(CppUnit::Functor const&, CppUnit::ProtectorContext const&)
7: CppUnit::ProtectorChain::protect(CppUnit::Functor const&, CppUnit::ProtectorContext const&)
8: CppUnit::TestResult::protect(CppUnit::Functor const&, CppUnit::Test*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
9: CppUnit::TestCase::run(CppUnit::TestResult*)
10: CppUnit::TestComposite::doRunChildTests(CppUnit::TestResult*)
11: CppUnit::TestComposite::run(CppUnit::TestResult*)
12: CppUnit::TestComposite::doRunChildTests(CppUnit::TestResult*)
13: CppUnit::TestComposite::run(CppUnit::TestResult*)
14: CppUnit::TestResult::runTest(CppUnit::Test*)
15: CppUnit::TestRunner::run(CppUnit::TestResult&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
16: CppUnit::TextTestRunner::run(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, bool, bool)
17: /tmp/build/libmesh/build/tests/.libs/lt-unit_tests-opt() [0x43d362]
18: __libc_start_main
19: /tmp/build/libmesh/build/tests/.libs/lt-unit_tests-opt() [0x44d1ee]
[0] ../src/numerics/sparse_matrix.C, line 204, compiled Jan  7 2025 at 14:26:29
```
