### PR TITLE
Add `operator[]` for `DenseVector`

### DIFF
--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -121,6 +121,16 @@ public:
    */
   T & operator() (const unsigned int i);
 
+  /**
+   * \returns Entry \p i of the vector as a const reference.
+   */
+  const T & operator[] (const unsigned int i) const { return (*this)(i); }
+
+  /**
+   * \returns Entry \p i of the vector as a writable reference.
+   */
+  T & operator[] (const unsigned int i) { return (*this)(i); }
+
   virtual T el(const unsigned int i) const override final
   { return (*this)(i); }
 


### PR DESCRIPTION
I think of `operator[]` as being most appropriate for already allocated data whereas I usually associate `operator()` with on-the-fly functor evaluations. Obviously we are not going to remote `operator()` (and I believe some would make a math notation argument for keeping it anyway which I'm not against), but I think we should support `operator[]`. This allows some templated code that takes things like `std::vector` and `std::array` to also work with `DenseVector`