### PR TITLE
Fix timesteps in exodus output

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -314,6 +314,16 @@ public:
                        const std::set<std::string> * system_names=nullptr);
 
   /**
+   * Writes out the solution for no specific time or timestep.
+   * \param fname Name of the file to write to
+   * \param es EquationSystems object which contains the solution vector.
+   * \param system_names Optional list of systems to write solutions for.
+   */
+  virtual void write_equation_systems (const std::string & fname,
+                                       const EquationSystems & es,
+                                       const std::set<std::string> * system_names=nullptr) override;
+
+  /**
    * Write elemsets stored on the Mesh to file.
    *
    * \note An elemset is a concept which is related to (but distinct

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -2001,12 +2001,20 @@ void ExodusII_IO::write_timestep (const std::string & fname,
                                   const std::set<std::string> * system_names)
 {
   _timestep = timestep;
-  write_equation_systems(fname,es,system_names);
+  MeshOutput<MeshBase>::write_equation_systems(fname,es,system_names);
 
   if (MeshOutput<MeshBase>::mesh().processor_id())
     return;
 
   exio_helper->write_timestep(timestep, time);
+}
+
+
+void ExodusII_IO::write_equation_systems (const std::string & fname,
+                                          const EquationSystems & es,
+                                          const std::set<std::string> * system_names)
+{
+  write_timestep(fname, es, 1, 0, system_names);
 }
 
 
@@ -2554,6 +2562,13 @@ void ExodusII_IO::write_timestep (const std::string &,
   libmesh_error_msg("ERROR, ExodusII API is not defined.");
 }
 
+
+void ExodusII_IO::write_equation_systems (const std::string &,
+                                          const EquationSystems &,
+                                          const std::set<std::string> *)
+{
+  libmesh_error_msg("ERROR, ExodusII API is not defined.");
+}
 
 
 void ExodusII_IO::write_elemsets()


### PR DESCRIPTION
This fixes the 9.96921e+36 timestamp in ParaView for exodus outputs with a single time step: we now set it to time 0, instead of leaving it undefined.

This only affects builds configured with `--enable-hdf5` such that `LIBMESH_HAVE_HDF5` is defined, which in turn causes the Exodus output to be in NETCDF4-compatible format. In those cases, `ncdump` revealed that `time_whole = _ ;` which then caused the problem. We now write `time_whole = 0 ;`.

I believe the ten redundant time steps are a separate issue, and an issue with ParaView itself, which I reported here: https://gitlab.kitware.com/paraview/paraview/-/issues/22854.

![Screenshot 2025-01-14 at 15 17 17](https://github.com/user-attachments/assets/391f29dc-62e6-491d-95fa-59df2a250524)
