### PR TITLE
Skip misc_ex17 when PETSc is not enabled

### DIFF
--- a/doc/html/src/examples.html
+++ b/doc/html/src/examples.html
@@ -203,10 +203,7 @@ library features they demonstrate.
 
 <li><L1><a href="examples/miscellaneous_ex16.html">Static Condensation with Second Order Lagrange Elements</a></L1></li>
 
-<li>
-    <L1><a href="examples/miscellaneous_ex17.html">Demonstrating mix of preallocated/hash-table matrix assemblies</a>
-    </L1>
-</li>
+<li><L1><a href="examples/miscellaneous_ex17.html">Demonstrating mix of preallocated/hash-table matrix assemblies</a></L1></li>
 
 </ol> </li>
 

--- a/doc/html/src/examples.html
+++ b/doc/html/src/examples.html
@@ -164,7 +164,7 @@ library features they demonstrate.
 
 <li><L1><a href="examples/vector_fe_ex8.html">Hybridized Local Discontinuous Galerkin Elements for Poisson</a></L1></li>
 
-<li><L1><a href="examples/vector_fe_ex8.html">Hybridized Local Discontinuous Galerkin Elements for Navier-Stokes</a></L1></li>
+<li><L1><a href="examples/vector_fe_ex9.html">Hybridized Local Discontinuous Galerkin Elements for Navier-Stokes</a></L1></li>
 
 </ol> </li>
 

--- a/examples/miscellaneous/miscellaneous_ex17/miscellaneous_ex17.C
+++ b/examples/miscellaneous/miscellaneous_ex17/miscellaneous_ex17.C
@@ -81,6 +81,10 @@ int main (int argc, char ** argv)
   // Skip this 2D example if libMesh was compiled as 1D-only.
   libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");
 
+  // This example is meant to test a PETSc-specific feature, so let's just skip it if
+  // libmesh is not built with Petsc support.
+  libmesh_example_requires(libMesh::default_solver_package() == PETSC_SOLVERS, "--enable-petsc");
+
   // Create a mesh, with dimension to be overridden later, distributed
   // across the default MPI communicator.
   Mesh mesh(init.comm());


### PR DESCRIPTION
FYI @lindsayad something like this is necessary to fix the libmesh devel -> master merge. I think the easiest thing is to skip the example when PETSc is not available.