### PR TITLE
Added error when stitching fails

### DIFF
--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -2164,6 +2164,7 @@ UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
               node_to_elems_map.clear();
             }
         }
+      libmesh_error_msg_if(node_to_node_map.empty(), "Error: Stitch failed, no matching nodes found. Ensure boundaries are properly aligned before trying again.");
     }
   else
     {


### PR DESCRIPTION
In no matching nodes are found, libmesh throws an error now

refs idaholab/moose#27758