### PR TITLE
Precondition constraint matrix

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1723,13 +1723,19 @@ public:
    * existing node, a new NodeElem will be added to the mesh on which
    * to store the new unconstrained degree(s) of freedom.
    *
+   * If \p precondition_constraint_operator is true, then the values
+   * of those new unconstrained degrees of freedom may be scaled to
+   * improve the conditioning of typical PDE matrices integrated on
+   * constrained mesh elements.
+   *
    * \p T for the constraint_operator in this function should be \p
    * Real or \p Number ... and the data should be \p Real - we just
    * allow complex \p T for the sake of subclasses which have to be
    * configured and compiled with only one runtime option.
    */
   template <typename T>
-  void copy_constraint_rows(const SparseMatrix<T> & constraint_operator);
+  void copy_constraint_rows(const SparseMatrix<T> & constraint_operator,
+                            bool precondition_constraint_operator = true);
 
   /**
    * Prints (from processor 0) all mesh constraint rows.  If \p

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1735,7 +1735,7 @@ public:
    */
   template <typename T>
   void copy_constraint_rows(const SparseMatrix<T> & constraint_operator,
-                            bool precondition_constraint_operator = true);
+                            bool precondition_constraint_operator = false);
 
   /**
    * Prints (from processor 0) all mesh constraint rows.  If \p

--- a/src/apps/calculator.C
+++ b/src/apps/calculator.C
@@ -261,6 +261,8 @@ int main(int argc, char ** argv)
 
       old_es.init();
 
+      old_es.print_info();
+
       goal_function =
         std::make_unique<WrappedFunctor<Number>>(ParsedFunction<Number>(calcfunc));
     }


### PR DESCRIPTION
I'm hoping to add more sophisticated options soon, but this simple diagonal preconditioning seems to be extremely helpful for some Coreform mesh+extraction-operator combinations.

We're not going to be able to merge this until https://github.com/idaholab/moose/pull/29861 hits MOOSE devel - I really want to be sure that it doesn't break any of the test cases there in any configuration.