### PR TITLE
Add thread safety for when multiple threads are failing point inversion

### DIFF
--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -1042,6 +1042,11 @@ private:
    * Work vector for compute_affine_map()
    */
   std::vector<const Node *> _elem_nodes;
+
+  /**
+   * A mutex for locking the error stream for failed point inversions
+   */
+  static Threads::spin_mutex _point_inv_err_mutex;
 };
 
 


### PR DESCRIPTION
Refs a failure that briefly cropped up on idaholab/moose#29700 and that I can get to trigger 100% of the time with a build with thread sanitizer