### PR TITLE
Variational Smoother: QUAD4 and TRI3 tests working

### DIFF
--- a/include/mesh/mesh_smoother_vsmoother.h
+++ b/include/mesh/mesh_smoother_vsmoother.h
@@ -253,6 +253,12 @@ private:
   };
 
 
+  /**
+   * Updates the _mesh attribute with the smoothed mesh.
+   * \param R array of smoothed points to update the mesh.
+   *
+   * \return dist_norm average distance that each node was moved.
+  */
   Real writegr(const Array2D<Real> & R);
 
   int readgr(Array2D<Real> & R,

--- a/include/mesh/mesh_smoother_vsmoother.h
+++ b/include/mesh/mesh_smoother_vsmoother.h
@@ -159,11 +159,6 @@ private:
   const Real _percent_to_move;
 
   /**
-   * Records a relative "distance moved"
-   */
-  Real _dist_norm;
-
-  /**
    * Map for hanging_nodes
    */
   std::map<dof_id_type, std::vector<dof_id_type>> _hanging_nodes;
@@ -176,7 +171,7 @@ private:
   /**
    * Smoother control variables
    */
-  const unsigned _dim;
+  unsigned _dim;
   const unsigned _miniter;
   const unsigned _maxiter;
   const unsigned _miniterBC;
@@ -258,7 +253,7 @@ private:
   };
 
 
-  int writegr(const Array2D<Real> & R);
+  Real writegr(const Array2D<Real> & R);
 
   int readgr(Array2D<Real> & R,
              std::vector<int> & mask,

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -125,6 +125,11 @@ Real VariationalMeshSmoother::smooth(unsigned int)
 {
   // Update the mesh dimension, since the mesh may have changed since initialization
   _dim = _mesh.mesh_dimension();
+
+  // Check for multiple dimensions
+  if (_mesh.elem_dimensions().size() > 1)
+    libmesh_not_implemented_msg("Meshes containing elements of differing dimension are not yet supported.");
+
   // Records the relative "distance moved"
   Real dist_norm = 0.;
 

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -2458,15 +2458,15 @@ Real VariationalMeshSmoother::minJ_BC(Array2D<Real> & R,
   {
       std::vector<boundary_id_type> boundary_ids;
       boundary_info.boundary_ids(boundary_node, boundary_ids);
-      bool has_common_bid = false;
+      bool common_bid = false;
       for (const auto & bid : boundary_ids)
         if (boundary_info.has_boundary_id(neighbor_node, bid))
         {
-          has_common_bid = true;
+          common_bid = true;
           break;
         }
 
-      return has_common_bid;
+      return common_bid;
   };
 
   for (int I=0; I<NCN; I++)


### PR DESCRIPTION
Previously, attempting to run the tests resulted in a segfault. The issue was traced to the fact that the smoother's (const) _dim attribute was initialized based on the given mesh before the tester had finished setting up said mesh. Thus, the _dim attribute held the wrong value, resulting in a segfault when trying to access a vector element that did not exist.

The issue has been (for now) fixed by reinitializing _dim at the beginning of the smooth method to ensure that the correct dimension is used.

Some sliding boundary nodes in the TRI3 tests were not honoring their constraints to keep them on their respective boundaries. The issue was that neighbor nodes on adjacent boundaries were being used to formulate the constraints.

The fix was to add a check to ensure that only neighbor nodes that share a boundary id with the constrained node are used to formulate the constraint.

Ref. #4082