### PR TITLE
MeshBase::get_info(): Print all Orders using Utility::enum_to_string()

### DIFF
--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -1081,7 +1081,7 @@ std::string MeshBase::get_info(const unsigned int verbosity /* = 0 */, const boo
                      std::ostream_iterator<std::string>(oss, ", "),
                      [](Order o)
                        { return Utility::enum_to_string<Order>(o); });
-      oss << cast_int<unsigned int>(*_elem_default_orders.rbegin());
+      oss << Utility::enum_to_string<Order>(*_elem_default_orders.rbegin());
       oss << "}\n";
     }
 


### PR DESCRIPTION
Previously, we cast the final entry to an unsigned int before printing, which gave inconsistent looking results like the following:
```
  Mesh Information:
   elem_dimensions()={1, 3}
   elem_default_orders()={FIRST, 2}
```