### PR TITLE
Fix range estimation bug

### DIFF
--- a/contrib/fparser/examples/optimizer_bug.cc
+++ b/contrib/fparser/examples/optimizer_bug.cc
@@ -2,7 +2,8 @@
 // (c) 2014 by Daniel Schwen
 // ========================================================
 
-// $CXX -o optimizer_bug optimizer_bug.cc -I ../../../installed/include/libmesh/ ../../../build/contrib/fparser/.libs/libfparser_la-fp* 
+// $CXX -o optimizer_bug optimizer_bug.cc -I ../../../installed/include/
+// ../../../build/contrib/fparser/.libs/libdbg.a
 
 #include "../fparser.hh"
 
@@ -14,11 +15,20 @@ int main()
 {
   std::ofstream myfile;
   double p[3] = {0.0, 2.0, 0.1};
-  const double step = 0.01;
+  const double step = 0.001;
   FunctionParser fparser;
 
-  // The White Whale
-  std::string func = "c*2*(1-c)^2 - c^2*(1-c)*2";
+  // // fails:
+  // std::string func = "a := 1.81e+16* exp(-1000*abs(c)); 1- 1/(1 + a)";
+  // std::string func = "1 - (2e+16 * (3 ^ (-abs(c)) )) ^ -1";
+  std::string func = "1 - (5e-17 * (0.3 ^ (-abs(c))))";
+  // std::string func = "a := 1.81e+16* exp(-1000*abs(c)); 1- (1/(1 + a))";
+  // std::string func = "a := exp(-1000*(abs(c)-0.03742995)); 1- (1/(1 + a))";
+  // std::string func = "exp(-100*(abs(c)-8))";
+
+  // // works:
+  // std::string func = "a := 1.8e+16* exp(-1000*abs(c)); 1- (1/(1 + a))";
+  // std::string func = "a := exp(-1000*(abs(c)-0.03742994)); 1- (1/(1 + a))";
 
   // Parse the input expression into bytecode
   fparser.Parse(func, "c");
@@ -45,13 +55,16 @@ int main()
 
   // eval into file
   myfile.open ("post.dat");
-  for (p[0]=0.0; p[0]<=1.0; p[0]+=0.01) myfile << p[0] << ' ' << fparser.Eval(p) << std::endl;
+  for (p[0] = -0.1; p[0] <= 0.1; p[0] += step)
+    myfile << p[0] << ' ' << fparser.Eval(p) << std::endl;
   myfile.close();
 
   // compute difference
   double diff = 0.0;
-  for (p[0]=0.0; p[0]<=1.0; p[0]+=step) diff+=step*(fparser.Eval(p)-fparser2.Eval(p));
+  for (p[0] = -0.1; p[0] <= 0.1; p[0] += step)
+    diff += step * (fparser.Eval(p) - fparser2.Eval(p));
 
-  std::cout << "Integral of f_optimized()-f_original() on [0,1] = " << diff << "  (should be ~0.0)" << std::endl;
+  std::cout << "Integral of f_optimized()-f_original() over [-0.1,0.1] = "
+            << diff << "  (should be ~0.0)" << std::endl;
   return 0;
 }

--- a/contrib/fparser/fpoptimizer.cc
+++ b/contrib/fparser/fpoptimizer.cc
@@ -698,7 +698,7 @@ namespace FPoptimizer_Grammar
 
     extern "C" {
         extern const Rule      grammar_rules[];
-        /* 
+        /*
         extern const Grammar   grammar_optimize_round1;
         extern const Grammar   grammar_optimize_round2;
         extern const Grammar   grammar_optimize_round3;
@@ -2139,7 +2139,7 @@ namespace FPoptimizer_ByteCode
     }
 }
 
-/* 
+/*
 // line removed for fpoptimizer.cc: #include "instantiate.hh"
 namespace FPoptimizer_ByteCode
 {
@@ -4933,7 +4933,7 @@ namespace FPoptimizer_CodeTree
 #endif
 }
 
-/* 
+/*
 // line removed for fpoptimizer.cc: #include "instantiate.hh"
 namespace FPoptimizer_CodeTree
 {
@@ -5093,7 +5093,7 @@ namespace FPoptimizer_Grammar
     }
 }
 
-/* 
+/*
 // line removed for fpoptimizer.cc: #include "instantiate.hh"
 #include <complex>
 namespace FPoptimizer_Grammar
@@ -5113,7 +5113,7 @@ namespace FPoptimizer_Grammar
 // line removed for fpoptimizer.cc: #include "extrasrc/fptypes.hh"
 #include <algorithm>
 
-/* 
+/*
 #define grammar_optimize_abslogical grammar_optimize_abslogical_tweak
 #define grammar_optimize_ignore_if_sideeffects grammar_optimize_ignore_if_sideeffects_tweak
 #define grammar_optimize_nonshortcut_logical_evaluation grammar_optimize_nonshortcut_logical_evaluation_tweak
@@ -6694,7 +6694,7 @@ namespace FPoptimizer_Grammar
         return ParamSpec(ParamHolder,(const void*)&plist_p[index]);
     }
 }
-/* 
+/*
 // line removed for fpoptimizer.cc: #include "instantiate.hh"
 namespace FPoptimizer_Grammar
 {
@@ -7142,7 +7142,7 @@ namespace FPoptimizer_Optimize
     }
 }
 
-/* 
+/*
 // line removed for fpoptimizer.cc: #include "instantiate.hh"
 namespace FPoptimizer_Optimize
 {
@@ -7900,7 +7900,7 @@ namespace FPoptimizer_Optimize
 }
 
 
-/* 
+/*
 // line removed for fpoptimizer.cc: #include "instantiate.hh"
 namespace FPoptimizer_Optimize
 {
@@ -8047,7 +8047,7 @@ namespace FPoptimizer_Optimize
     }
 }
 
-/* 
+/*
 // line removed for fpoptimizer.cc: #include "instantiate.hh"
 namespace FPoptimizer_Optimize
 {
@@ -8144,7 +8144,7 @@ namespace FPoptimizer_Grammar
     }
 }
 
-/* 
+/*
 // line removed for fpoptimizer.cc: #include "instantiate.hh"
 namespace FPoptimizer_Grammar
 {
@@ -8410,7 +8410,7 @@ namespace FPoptimizer_CodeTree
     }
 }
 
-/* 
+/*
 // line removed for fpoptimizer.cc: #include "instantiate.hh"
 namespace FPoptimizer_CodeTree
 {
@@ -8896,7 +8896,7 @@ namespace
     }
 }
 
-/* 
+/*
 // line removed for fpoptimizer.cc: #include "instantiate.hh"
 namespace FPoptimizer_CodeTree
 {
@@ -9674,7 +9674,7 @@ namespace FPoptimizer_CodeTree
     }
 }
 
-/* 
+/*
 // line removed for fpoptimizer.cc: #include "instantiate.hh"
 namespace FPoptimizer_CodeTree
 {
@@ -10620,7 +10620,7 @@ namespace FPoptimizer_CodeTree
     }
 }
 
-/* 
+/*
 // line removed for fpoptimizer.cc: #include "instantiate.hh"
 namespace FPoptimizer_CodeTree
 {
@@ -10714,7 +10714,7 @@ namespace FPoptimizer_CodeTree
     }
 }
 
-/* 
+/*
 // line removed for fpoptimizer.cc: #include "instantiate.hh"
 namespace FPoptimizer_CodeTree
 {
@@ -11384,7 +11384,13 @@ namespace FPoptimizer_CodeTree
                                     min = Value_t(0);
                             }
                         }
-                        if(p0.min.known && p0.min.val >= Value_t(0) && p0.max.known && p1.max.known)
+                        // D.Schwen 2/25/25  0 < p0 < 1 and p1 < 0
+                        else if(p0.min.known && p0.min.val > Value_t(0) && p0.max.val < Value_t(1) && p1.max.known && p1.max.val == Value_t(0))
+                        {
+                            min = Value_t(1);
+                        }
+                        // D.Schwen 2/25/25 (min.val >= Value_t(0) -> p0.min.val >= Value_t(1))
+                        if(p0.min.known && p0.min.val >= Value_t(1) && p0.max.known && p1.max.known)
                         {
                             Value_t max = fp_pow(p0.max.val, p1.max.val);
                             if(min > max) std::swap(min, max);
@@ -11692,7 +11698,7 @@ namespace FPoptimizer_CodeTree
     }
 }
 
-/* 
+/*
 // line removed for fpoptimizer.cc: #include "instantiate.hh"
 namespace FPoptimizer_CodeTree
 {
@@ -12665,7 +12671,7 @@ namespace FPoptimizer_CodeTree
     }
 }
 
-/* 
+/*
 // line removed for fpoptimizer.cc: #include "instantiate.hh"
 namespace FPoptimizer_CodeTree
 {
@@ -13167,7 +13173,7 @@ namespace FPoptimizer_CodeTree
     }
 }
 
-/* 
+/*
 // line removed for fpoptimizer.cc: #include "instantiate.hh"
 namespace FPoptimizer_CodeTree
 {

--- a/contrib/fparser/fpoptimizer/rangeestimation.cc
+++ b/contrib/fparser/fpoptimizer/rangeestimation.cc
@@ -652,7 +652,13 @@ namespace FPoptimizer_CodeTree
                                     min = Value_t(0);
                             }
                         }
-                        if(p0.min.known && p0.min.val >= Value_t(0) && p0.max.known && p1.max.known)
+                        // D.Schwen 2/25/25  0 < p0 < 1 and p1 < 0
+                        else if(p0.min.known && p0.min.val > Value_t(0) && p0.max.val < Value_t(1) && p1.max.known && p1.max.val == Value_t(0))
+                        {
+                            min = Value_t(1);
+                        }
+                        // D.Schwen 2/25/25 (min.val >= Value_t(0) -> p0.min.val >= Value_t(1))
+                        if(p0.min.known && p0.min.val >= Value_t(1) && p0.max.known && p1.max.known)
                         {
                             Value_t max = fp_pow(p0.max.val, p1.max.val);
                             if(min > max) std::swap(min, max);


### PR DESCRIPTION
Closes #4087

We should update from 4.5.1 to 4.5.2 (that release from 2015 includes an optimizer fix that I patched in and reported and several other regressions. In fact 4.5.2 might fix this range estimation bug, too. At first glance it will avoid the issue by not estimating the range at all).