### PR TITLE
Add comments with approximate floating point values of magic constants

### DIFF
--- a/src/quadrature/quadrature_gauss_2D.C
+++ b/src/quadrature/quadrature_gauss_2D.C
@@ -240,16 +240,16 @@ void QGauss::init_2D()
               const unsigned int n_wts = 3;
               const Real wts[n_wts] =
                 {
-                  Real(9)/80,
-                  Real(31)/480 + std::sqrt(Real(15.0L))/2400,
-                  Real(31)/480 - std::sqrt(Real(15.0L))/2400
+                  Real(9)/80,                              // ~0.1125
+                  Real(31)/480 + std::sqrt(Real(15))/2400, // ~0.06619707639
+                  Real(31)/480 - std::sqrt(Real(15))/2400  // ~0.06296959027
                 };
 
               const Real a[n_wts] =
                 {
                   0., // 'a' parameter not used for origin permutation
-                  Real(2)/7 + std::sqrt(Real(15.0L))/21,
-                  Real(2)/7 - std::sqrt(Real(15.0L))/21
+                  Real(2)/7 + std::sqrt(Real(15))/21, // ~0.4701420641
+                  Real(2)/7 - std::sqrt(Real(15))/21  // ~0.1012865073
                 };
 
               const Real b[n_wts] = {0., 0., 0.}; // not used

--- a/src/quadrature/quadrature_gauss_lobatto_1D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_1D.C
@@ -76,7 +76,7 @@ void QGaussLobatto::init_1D()
         _weights.resize(4);
 
         _points[ 0](0) = -1.0L;
-        _points[ 1](0) = -std::sqrt(Real(1)/5);
+        _points[ 1](0) = -std::sqrt(Real(1)/5); // ~ -0.4472135955
         _points[ 2]    = -_points[1];
         _points[ 3]    = -_points[0];
 
@@ -97,7 +97,7 @@ void QGaussLobatto::init_1D()
         _weights.resize(5);
 
         _points[ 0](0) = -1.0L;
-        _points[ 1](0) = -std::sqrt(Real(3)/7);
+        _points[ 1](0) = -std::sqrt(Real(3)/7); // ~ -0.6546536707
         _points[ 2](0) = 0.;
         _points[ 3]    = -_points[1];
         _points[ 4]    = -_points[0];

--- a/src/quadrature/quadrature_monomial_2D.C
+++ b/src/quadrature/quadrature_monomial_2D.C
@@ -54,8 +54,8 @@ void QMonomial::init_2D()
               // Luckily it's fairly easy to derive, which is what I've done
               // here [JWP].
               const Real
-                s=std::sqrt(Real(1)/3),
-                t=std::sqrt(Real(2)/3);
+                s=std::sqrt(Real(1)/3), // ~0.57735026919
+                t=std::sqrt(Real(2)/3); // ~0.81649658092
 
               const Real data[2][3] =
                 {
@@ -128,6 +128,9 @@ void QMonomial::init_2D()
               //
               // This rule is provably minimal in the number of points.
               // A tensor-product rule accurate for "bi-quintic" polynomials would have 9 points.
+              //              0,              0, ~1.14285714286
+              //              0, ~0.96609178307, ~0.31746031746
+              // ~0.77459666924, ~0.57735026919, ~0.55555555555
               const Real data[3][3] =
                 {
                   {                 0.L,                    0.L, Real(8)/7  }, // 1
@@ -207,12 +210,12 @@ void QMonomial::init_2D()
               // This rule is fully-symmetric and provably minimal in the number of points.
               // A tensor-product rule accurate for "bi-septic" polynomials would have 16 points.
               const Real
-                r  = std::sqrt(Real(6)/7),
-                s  = std::sqrt( (114 - 3*std::sqrt(Real(583))) / 287 ),
-                t  = std::sqrt( (114 + 3*std::sqrt(Real(583))) / 287 ),
-                B1 = Real(196)/810,
-                B2 = 4 * (178981 + 2769*std::sqrt(Real(583))) / 1888920,
-                B3 = 4 * (178981 - 2769*std::sqrt(Real(583))) / 1888920;
+                r  = std::sqrt(Real(6)/7),                                    // ~0.92582009977
+                s  = std::sqrt( (Real(114) - 3*std::sqrt(Real(583))) / 287 ), // ~0.38055443320
+                t  = std::sqrt( (Real(114) + 3*std::sqrt(Real(583))) / 287 ), // ~0.80597978291
+                B1 = Real(196)/810,                                           // ~0.24197530864
+                B2 = 4 * (178981 + 2769*std::sqrt(Real(583))) / 1888920,      // ~0.52059291666
+                B3 = 4 * (178981 - 2769*std::sqrt(Real(583))) / 1888920;      // ~0.23743177469
 
               const Real data[3][3] =
                 {

--- a/src/quadrature/quadrature_monomial_3D.C
+++ b/src/quadrature/quadrature_monomial_3D.C
@@ -53,7 +53,7 @@ void QMonomial::init_3D()
               // would be a 2x2x2 Gauss product rule.
               const Real data[1][4] =
                 {
-                  {1.0L, 0.0L, 0.0L, Real(4)/3}
+                  {Real(1), Real(0), Real(0), Real(4)/3}
                 };
 
               const unsigned int rule_id[1] = {
@@ -79,30 +79,30 @@ void QMonomial::init_3D()
               // the n=3 case.  The analytical values given here were computed by me [JWP] in Maple.
 
               // Convenient intermediate values.
-              const Real sqrt19 = Real(std::sqrt(19.L));
-              const Real tp     = Real(std::sqrt(71440 + 6802*sqrt19));
+              const Real sqrt19 = std::sqrt(Real(19));            // ~4.35889894354
+              const Real tp     = std::sqrt(71440 + 6802*sqrt19); // ~317.945326454
 
               // Point data for permutations.
               const Real eta    =  0;
 
-              const Real lambda =  Real(std::sqrt(1919.L/3285.L - 148.L*sqrt19/3285.L + 4.L*tp/3285.L));
+              const Real lambda =  std::sqrt(Real(1919)/3285 - 148*sqrt19/3285 + 4*tp/3285);
               // 8.8030440669930978047737818209860e-01L;
 
-              const Real xi     = Real(-std::sqrt(1121.L/3285.L +  74.L*sqrt19/3285.L - 2.L*tp/3285.L));
+              const Real xi     = -std::sqrt(Real(1121)/3285 +  74*sqrt19/3285 - 2*tp/3285);
               // -4.9584817142571115281421242364290e-01L;
 
-              const Real mu     =  Real(std::sqrt(1121.L/3285.L +  74.L*sqrt19/3285.L + 2.L*tp/3285.L));
+              const Real mu     =  std::sqrt(Real(1121)/3285 +  74*sqrt19/3285 + 2*tp/3285);
               // 7.9562142216409541542982482567580e-01L;
 
-              const Real gamma  =  Real(std::sqrt(1919.L/3285.L - 148.L*sqrt19/3285.L - 4.L*tp/3285.L));
+              const Real gamma  =  std::sqrt(Real(1919)/3285 - 148*sqrt19/3285 - 4*tp/3285);
               // 2.5293711744842581347389255929324e-02L;
 
               // Weights: the centroid weight is given analytically.  Weight B (resp C) goes
               // with the {lambda,xi} (resp {gamma,mu}) permutation.  The single-precision
               // results reported by Stroud are given for reference.
 
-              const Real A      = Real(32)/19;
-              // Stroud: 0.21052632  * 8.0 = 1.684210560;
+              const Real A      = Real(32)/19; // ~1.684210560
+              // Stroud: 0.21052632  * 8.0;
 
               const Real B      = Real(1) / (Real(260072)/133225  - 1520*sqrt19/133225 + (133 - 37*sqrt19)*tp/133225);
               // 5.4498735127757671684690782180890e-01L; // Stroud: 0.068123420 * 8.0 = 0.544987360;
@@ -219,13 +219,13 @@ void QMonomial::init_3D()
               // (which integrates tri-7th order polynomials) would
               // have 4^3=64 points.
               const Real
-                r  = Real(std::sqrt(6.L/7.L)),
-                s  = Real(std::sqrt((960.L - 3.L*std::sqrt(28798.L)) / 2726.L)),
-                t  = Real(std::sqrt((960.L + 3.L*std::sqrt(28798.L)) / 2726.L)),
-                B1 = Real(8624)/29160,
-                B2 = Real(2744)/29160,
-                B3 = 8*(774*t*t - 230)/(9720*(t*t-s*s)),
-                B4 = 8*(230 - 774*s*s)/(9720*(t*t-s*s));
+                r  = std::sqrt(Real(6)/7),                                     // ~0.92582009977
+                s  = std::sqrt((Real(960) - 3*std::sqrt(Real(28798))) / 2726), // ~0.40670318642
+                t  = std::sqrt((Real(960) + 3*std::sqrt(Real(28798))) / 2726), // ~0.73411252875
+                B1 = Real(8624)/29160,                                         // ~0.29574759945
+                B2 = Real(2744)/29160,                                         // ~0.09410150891
+                B3 = 8*(774*t*t - 230)/(9720*(t*t-s*s)),                       // ~0.41233386227
+                B4 = 8*(230 - 774*s*s)/(9720*(t*t-s*s));                       // ~0.22470317477
 
               const Real data[4][4] =
                 {


### PR DESCRIPTION
This is also related to a brief discussion I had with @roystgnr where it was pointed out that some of our "L" suffixes are redundant while others aren't.

