### PR TITLE
Add begin/end members to DenseVector

### DIFF
--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -282,6 +282,18 @@ public:
    */
   const std::vector<T> & get_values() const { return _val; }
 
+  /**
+   * \returns An iterator pointing to the beginning of the vector
+   */
+  auto begin() const { return _val.begin(); }
+  auto begin() { return _val.begin(); }
+
+  /**
+   * \returns An iterator pointing to the end of the vector
+   */
+   auto end() const { return _val.end(); }
+   auto end() { return _val.end(); }
+
 private:
 
   /**

--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -285,14 +285,14 @@ public:
   /**
    * \returns An iterator pointing to the beginning of the vector
    */
-  auto begin() const { return _val.begin(); }
-  auto begin() { return _val.begin(); }
+  typename std::vector<T>::const_iterator begin() const { return _val.begin(); }
+  typename std::vector<T>::iterator begin() { return _val.begin(); }
 
   /**
    * \returns An iterator pointing to the end of the vector
    */
-   auto end() const { return _val.end(); }
-   auto end() { return _val.end(); }
+  typename std::vector<T>::const_iterator end() const { return _val.end(); }
+  typename std::vector<T>::iterator end() { return _val.end(); }
 
 private:
 


### PR DESCRIPTION
Serves me right for not compiling https://github.com/idaholab/moose/pull/29889 in debug mode. This further helps me to use `DenseVector` in templated code