### PR TITLE
Clean up new log file

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -419,7 +419,8 @@ CLEANFILES = cube_mesh.xda \
              write_exodus_TRI3.e \
              write_exodus_TRI6.e \
              write_exodus_TRI7.e \
-             write_exodus_TRISHELL3.e
+             write_exodus_TRISHELL3.e \
+             smoother.out
 
 # need to link any data files for VPATH builds
 if LIBMESH_VPATH_BUILD

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -2436,7 +2436,8 @@ CLEANFILES = cube_mesh.xda slit_mesh.xda slit_solution.xda out.e \
 	write_exodus_QUADSHELL9.e write_exodus_TET10.e \
 	write_exodus_TET14.e write_exodus_TET4.e write_exodus_TRI3.e \
 	write_exodus_TRI6.e write_exodus_TRI7.e \
-	write_exodus_TRISHELL3.e $(am__append_8) $(am__append_9)
+	write_exodus_TRISHELL3.e smoother.out $(am__append_8) \
+	$(am__append_9)
 
 # need to link any data files for VPATH builds
 @LIBMESH_VPATH_BUILD_TRUE@BUILT_SOURCES = .linkstamp


### PR DESCRIPTION
Our distcheck recipe in CI is complaining, e.g. https://civet.inl.gov/job/2741387/ , about

```
ERROR: files left in build directory after distclean:
./tests/smoother.out
```