### PR TITLE
Allow instantiation of print with dual numbers

### DIFF
--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -31,6 +31,8 @@
 #include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
 #include <cmath>
 #include <complex>
+#include <iostream>
+#include <iomanip> // for std::setw, std::setiosflags
 
 namespace libMesh
 {
@@ -1098,6 +1100,30 @@ TypeVector<T> TypeVector<T>::unit() const
                        _coords[2]/length);
 #endif
 
+}
+
+template <typename T>
+void TypeVector<T>::print(std::ostream & os) const
+{
+#if LIBMESH_DIM == 1
+
+  os << "x=" << (*this)(0);
+
+#endif
+#if LIBMESH_DIM == 2
+
+  os << "(x,y)=("
+     << std::setw(8) << (*this)(0) << ", "
+     << std::setw(8) << (*this)(1) << ")";
+
+#endif
+#if LIBMESH_DIM == 3
+
+  os <<  "(x,y,z)=("
+     << std::setw(8) << (*this)(0) << ", "
+     << std::setw(8) << (*this)(1) << ", "
+     << std::setw(8) << (*this)(2) << ")";
+#endif
 }
 
 template <typename T>

--- a/src/numerics/type_vector.C
+++ b/src/numerics/type_vector.C
@@ -22,8 +22,6 @@
 #include "libmesh/type_vector.h"
 
 // C++ includes
-#include <iostream>
-#include <iomanip> // for std::setw, std::setiosflags
 #include <type_traits> // std::is_trivially_copyable
 
 
@@ -43,32 +41,6 @@ namespace libMesh
 
 // ------------------------------------------------------------
 // TypeVector<T> class member functions
-template <typename T>
-void TypeVector<T>::print(std::ostream & os) const
-{
-#if LIBMESH_DIM == 1
-
-  os << "x=" << (*this)(0);
-
-#endif
-#if LIBMESH_DIM == 2
-
-  os << "(x,y)=("
-     << std::setw(8) << (*this)(0) << ", "
-     << std::setw(8) << (*this)(1) << ")";
-
-#endif
-#if LIBMESH_DIM == 3
-
-  os <<  "(x,y,z)=("
-     << std::setw(8) << (*this)(0) << ", "
-     << std::setw(8) << (*this)(1) << ", "
-     << std::setw(8) << (*this)(2) << ")";
-#endif
-}
-
-
-
 
 
 template <typename T>


### PR DESCRIPTION
New versions of google test appear to make use of `operator <<` which calls `print` for `TypeVector`. We have MOOSE unit tests that instantiate `TypeVector` with dual numbers, e.g. something other than `Real` or `Complex` for which we have explicit instantiations for