### PR TITLE
Get metaphysicl config include

### DIFF
--- a/configure
+++ b/configure
@@ -59691,8 +59691,8 @@ then :
 else $as_nop
   if test "x$build_metaphysicl" = "xyes"
 then :
-  METAPHYSICL_INCLUDE="-I\$(top_srcdir)/contrib/metaphysicl/src/numerics/include -I\$(top_srcdir)/contrib/metaphysicl/src/core/include -I\$(top_srcdir)/contrib/metaphysicl/src/utilities/include"
-                      METAPHYSICL_INC="-I$top_srcdir/contrib/metaphysicl/src/numerics/include -I$top_srcdir/contrib/metaphysicl/src/core/include -I$top_srcdir/contrib/metaphysicl/src/utilities/include"
+  METAPHYSICL_INCLUDE="-I\$(top_srcdir)/contrib/metaphysicl/src/numerics/include -I\$(top_srcdir)/contrib/metaphysicl/src/core/include -I\$(top_srcdir)/contrib/metaphysicl/src/utilities/include -I\$(top_builddir)/contrib/metaphysicl/src/utilities/include"
+                      METAPHYSICL_INC="-I$top_srcdir/contrib/metaphysicl/src/numerics/include -I$top_srcdir/contrib/metaphysicl/src/core/include -I$top_srcdir/contrib/metaphysicl/src/utilities/include -I$top_builddir/contrib/metaphysicl/src/utilities/include"
 else $as_nop
   METAPHYSICL_INCLUDE="-I$METAPHYSICL_DIR/include"
                       METAPHYSICL_INC="-I$METAPHYSICL_DIR/include"

--- a/m4/libmesh_metaphysicl.m4
+++ b/m4/libmesh_metaphysicl.m4
@@ -30,8 +30,8 @@ AC_DEFUN([CONFIGURE_METAPHYSICL],
                enablemetaphysicl=yes
                build_metaphysicl=no],
               [AS_IF([test "x$build_metaphysicl" = "xyes"],
-                     [METAPHYSICL_INCLUDE="-I\$(top_srcdir)/contrib/metaphysicl/src/numerics/include -I\$(top_srcdir)/contrib/metaphysicl/src/core/include -I\$(top_srcdir)/contrib/metaphysicl/src/utilities/include"
-                      METAPHYSICL_INC="-I$top_srcdir/contrib/metaphysicl/src/numerics/include -I$top_srcdir/contrib/metaphysicl/src/core/include -I$top_srcdir/contrib/metaphysicl/src/utilities/include"],
+                     [METAPHYSICL_INCLUDE="-I\$(top_srcdir)/contrib/metaphysicl/src/numerics/include -I\$(top_srcdir)/contrib/metaphysicl/src/core/include -I\$(top_srcdir)/contrib/metaphysicl/src/utilities/include -I\$(top_builddir)/contrib/metaphysicl/src/utilities/include"
+                      METAPHYSICL_INC="-I$top_srcdir/contrib/metaphysicl/src/numerics/include -I$top_srcdir/contrib/metaphysicl/src/core/include -I$top_srcdir/contrib/metaphysicl/src/utilities/include -I$top_builddir/contrib/metaphysicl/src/utilities/include"],
                      [METAPHYSICL_INCLUDE="-I$METAPHYSICL_DIR/include"
                       METAPHYSICL_INC="-I$METAPHYSICL_DIR/include"])]
              )


### PR DESCRIPTION
I wanted to track down where I was getting `TypeVector::print` instantiations with `MetaPhysicL` types (see https://github.com/libMesh/libmesh/pull/4103) so I tried to include `metaphyscl/dualnumbersemidynamicarray.h` in `type_vector.h` but that lead to a build error in which `metaphysicl_config.h` couldn't be found. Hence this PR