### PR TITLE
Remove phony make code

### DIFF
--- a/contrib/netgen/Makefile.am
+++ b/contrib/netgen/Makefile.am
@@ -47,8 +47,6 @@ install-data-local: install-ngliblibDATA
 	  echo "If linking fails we may need install_name_tool/patchelf/chrpath installed"; \
 	fi
 
-.PHONY : .buildstamp
-
 .buildstamp:
 	$(MAKE) -C build $(AM_MAKEFLAGS)
 	touch .buildstamp

--- a/contrib/netgen/Makefile.in
+++ b/contrib/netgen/Makefile.in
@@ -949,8 +949,6 @@ uninstall-am: uninstall-netgenincludeHEADERS uninstall-netgenlibDATA \
 @LIBMESH_ENABLE_NETGEN_TRUE@	  echo "If linking fails we may need install_name_tool/patchelf/chrpath installed"; \
 @LIBMESH_ENABLE_NETGEN_TRUE@	fi
 
-@LIBMESH_ENABLE_NETGEN_TRUE@.PHONY : .buildstamp
-
 @LIBMESH_ENABLE_NETGEN_TRUE@.buildstamp:
 @LIBMESH_ENABLE_NETGEN_TRUE@	$(MAKE) -C build $(AM_MAKEFLAGS)
 @LIBMESH_ENABLE_NETGEN_TRUE@	touch .buildstamp


### PR DESCRIPTION
This appears to fix my issue where I saw netgen build 5 times when doing `make -j32 && make -j32 install`