### PR TITLE
QBase::get_base_order()

### DIFF
--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -249,6 +249,15 @@ public:
   Order get_order() const { return static_cast<Order>(_order + 2 * _p_level); }
 
   /**
+   * \returns The "base" order of the quadrature rule, independent of
+   * element.
+   *
+   * This function should be used when comparing quadrature objects
+   * independently of their last initialization.
+   */
+  Order get_base_order() const { return static_cast<Order>(_order); }
+
+  /**
    * Prints information relevant to the quadrature rule, by default to
    * libMesh::out.
    */

--- a/tests/quadrature/quadrature_test.C
+++ b/tests/quadrature/quadrature_test.C
@@ -512,6 +512,14 @@ public:
     CPPUNIT_ASSERT_EQUAL ( qtype, qrule2D->type() );
     CPPUNIT_ASSERT_EQUAL ( qtype, qrule3D->type() );
 
+    // Simpson's Rule is inherently second-order
+    if (qtype != QSIMPSON)
+      {
+        CPPUNIT_ASSERT_EQUAL ( order, qrule1D->get_base_order() );
+        CPPUNIT_ASSERT_EQUAL ( order, qrule2D->get_base_order() );
+        CPPUNIT_ASSERT_EQUAL ( order, qrule3D->get_base_order() );
+      }
+
     CPPUNIT_ASSERT_EQUAL ( static_cast<unsigned int>(1) , qrule1D->get_dim() );
     CPPUNIT_ASSERT_EQUAL ( static_cast<unsigned int>(2) , qrule2D->get_dim() );
     CPPUNIT_ASSERT_EQUAL ( static_cast<unsigned int>(3) , qrule3D->get_dim() );

--- a/tests/quadrature/quadrature_test.C
+++ b/tests/quadrature/quadrature_test.C
@@ -512,7 +512,7 @@ public:
     CPPUNIT_ASSERT_EQUAL ( qtype, qrule2D->type() );
     CPPUNIT_ASSERT_EQUAL ( qtype, qrule3D->type() );
 
-    // Simpson's Rule is inherently second-order
+    // Simpson's Rule is inherently third-order
     if (qtype != QSIMPSON)
       {
         CPPUNIT_ASSERT_EQUAL ( order, qrule1D->get_base_order() );


### PR DESCRIPTION
Sometimes we want to compare multiple quadrature rules independently of
any p refinement level where they've been most recently used.