### PR TITLE
Assorted fixes for uncommon configurations

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
+++ b/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
@@ -438,7 +438,8 @@ void assemble_wave(EquationSystems & es,
           // points, the number of shape functions may also be obtained
           // in a different manner.  This offers the great advantage
           // of being valid for both finite and infinite elements.
-          const unsigned int n_sf = cfe->n_shape_functions();
+          const unsigned int n_sf =
+            FEInterface::n_dofs(cfe->get_fe_type(), elem);
 
           // Now we will build the element matrices.  Since the infinite
           // elements are based on a Petrov-Galerkin scheme, the

--- a/examples/miscellaneous/miscellaneous_ex14/miscellaneous_ex14.C
+++ b/examples/miscellaneous/miscellaneous_ex14/miscellaneous_ex14.C
@@ -465,7 +465,8 @@ void assemble_SchroedingerEquation(EquationSystems &es, const std::string &syste
           Number potval=-1./(q_point[qp]).norm();
 
           // Now, get number of shape functions that are nonzero at this point::
-          unsigned int n_sf = cfe->n_shape_functions();
+          const unsigned int n_sf =
+            FEInterface::n_dofs(cfe->get_fe_type(), elem);
           // loop over them:
           for (unsigned int i=0; i<n_sf; i++)
             {
@@ -539,7 +540,8 @@ void assemble_SchroedingerEquation(EquationSystems &es, const std::string &syste
          // the base side always has number 0
          const unsigned int side=0;
          face_fe->reinit (elem, side);
-         unsigned int n_sf = face_fe->n_shape_functions();
+         const unsigned int n_sf =
+           FEInterface::n_dofs(face_fe->get_fe_type(), elem);
 
          H.resize (dof_indices.size(), dof_indices.size());
 
@@ -639,7 +641,8 @@ void assemble_SchroedingerEquation(EquationSystems &es, const std::string &syste
             //out<<"neighbor id: "<<relevant_neighbor->id();
             //out<<"  this id: "<<elem->id()<<std::endl;
             face_fe->reinit (elem, side);
-            unsigned int n_sf = face_fe->n_shape_functions();
+            const unsigned int n_sf =
+              FEInterface::n_dofs(face_fe->get_fe_type(), elem);
 
             H.resize (dof_indices.size(), dof_indices.size());
 

--- a/examples/miscellaneous/miscellaneous_ex15/miscellaneous_ex15.C
+++ b/examples/miscellaneous/miscellaneous_ex15/miscellaneous_ex15.C
@@ -123,7 +123,8 @@ void assemble_func(EquationSystems & es, const std::string & system_name)
       const unsigned int max_qp = cfe->n_quadrature_points();
       for (unsigned int qp=0; qp<max_qp; ++qp)
         {
-          const unsigned int n_sf = cfe->n_shape_functions();
+          const unsigned int n_sf =
+            FEInterface::n_dofs(cfe->get_fe_type(), elem);
           for (unsigned int i=0; i<n_sf; ++i)
             {
               if (rho > 0)

--- a/examples/miscellaneous/miscellaneous_ex15/miscellaneous_ex15.C
+++ b/examples/miscellaneous/miscellaneous_ex15/miscellaneous_ex15.C
@@ -170,17 +170,6 @@ int main (int argc, char** argv)
   libmesh_example_requires(false, "--enable-ifem");
 #else
 
-#ifdef LIBMESH_ENABLE_NODE_CONSTRAINTS
-  // Node constraints are not yet implemented for infinite elements.
-  libmesh_example_requires(false, "--disable-node-constraints");
-#endif
-
-#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
-  // UniformRefinement uses second derivatives if they are enabled,
-  // but for infinite elements they are not implemented.
-  libmesh_example_requires(false, "--disable-second");
-#endif
-
   // Skip this example if libMesh was compiled with <3 dimensions.
   // INFINITE ELEMENTS ARE IMPLEMENTED ONLY FOR 3 DIMENSIONS AT THE MOMENT.
   libmesh_example_requires(3 <= LIBMESH_DIM, "3D support");

--- a/tests/numerics/petsc_matrix_test.C
+++ b/tests/numerics/petsc_matrix_test.C
@@ -23,7 +23,11 @@ public:
 
   SPARSEMATRIXTEST
 
+  // Our repo's test files use PetscScalar==double
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
   CPPUNIT_TEST(testPetscBinaryRead);
+#endif
+
   CPPUNIT_TEST(testPetscBinaryWrite);
 #if PETSC_RELEASE_GREATER_EQUALS(3, 23, 0)
   CPPUNIT_TEST(testPetscCopyFromHash);

--- a/tests/numerics/petsc_matrix_test.C
+++ b/tests/numerics/petsc_matrix_test.C
@@ -24,8 +24,10 @@ public:
   SPARSEMATRIXTEST
 
   // Our repo's test files use PetscScalar==double
-#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+#ifndef LIBMESH_USE_COMPLEX_NUMBERS
+#ifdef LIBMESH_DEFAULT_DOUBLE_PRECISION
   CPPUNIT_TEST(testPetscBinaryRead);
+#endif
 #endif
 
   CPPUNIT_TEST(testPetscBinaryWrite);


### PR DESCRIPTION
Some of our examples only run in configurations I hadn't been testing with `--disable-deprecated` before, and while trying to hunt down those I discovered that one of our recently-added unit tests is also only appropriate for our standard settings.