### PR TITLE
reset_memory -> restore_original_nonzero_pattern

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex17/miscellaneous_ex17.C
+++ b/examples/miscellaneous/miscellaneous_ex17/miscellaneous_ex17.C
@@ -160,8 +160,8 @@ int main (int argc, char ** argv)
   // MatResetHash added in PETSc version 3.23
 #if !PETSC_VERSION_LESS_THAN(3, 23, 0)
   // reset the memory
-  // sys_matrix.reset_memory(); # See https://gitlab.com/petsc/petsc/-/merge_requests/8063
-  pre_matrix.reset_memory();
+  // sys_matrix.restore_original_nonzero_pattern(); # See https://gitlab.com/petsc/petsc/-/merge_requests/8063
+  pre_matrix.restore_original_nonzero_pattern();
   // zero
   sys_matrix.zero();
   pre_matrix.zero();

--- a/include/numerics/diagonal_matrix.h
+++ b/include/numerics/diagonal_matrix.h
@@ -176,6 +176,9 @@ public:
 
   const NumericVector<T> & diagonal() const;
 
+  // Our nonzero pattern hasn't changed; it's always just the diagonal!
+  virtual void reset_memory() override {}
+
 protected:
   /// Underlying diagonal matrix storage
   std::unique_ptr<NumericVector<T>> _diagonal;

--- a/include/numerics/diagonal_matrix.h
+++ b/include/numerics/diagonal_matrix.h
@@ -177,7 +177,7 @@ public:
   const NumericVector<T> & diagonal() const;
 
   // Our nonzero pattern hasn't changed; it's always just the diagonal!
-  virtual void reset_memory() override {}
+  virtual void restore_original_nonzero_pattern() override {}
 
 protected:
   /// Underlying diagonal matrix storage

--- a/include/numerics/diagonal_matrix.h
+++ b/include/numerics/diagonal_matrix.h
@@ -177,7 +177,7 @@ public:
   const NumericVector<T> & diagonal() const;
 
   // Our nonzero pattern hasn't changed; it's always just the diagonal!
-  virtual bool reset_memory() override { return false; }
+  virtual void reset_memory() override {}
 
 protected:
   /// Underlying diagonal matrix storage

--- a/include/numerics/diagonal_matrix.h
+++ b/include/numerics/diagonal_matrix.h
@@ -177,7 +177,7 @@ public:
   const NumericVector<T> & diagonal() const;
 
   // Our nonzero pattern hasn't changed; it's always just the diagonal!
-  virtual void reset_memory() override {}
+  virtual bool reset_memory() override { return false; }
 
 protected:
   /// Underlying diagonal matrix storage

--- a/include/numerics/diagonal_matrix.h
+++ b/include/numerics/diagonal_matrix.h
@@ -176,8 +176,7 @@ public:
 
   const NumericVector<T> & diagonal() const;
 
-  // Our nonzero pattern hasn't changed; it's always just the diagonal!
-  virtual void restore_original_nonzero_pattern() override {}
+  virtual void restore_original_nonzero_pattern() override;
 
 protected:
   /// Underlying diagonal matrix storage

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -291,7 +291,7 @@ public:
 
   virtual bool supports_hash_table() const override;
 
-  virtual void reset_memory() override;
+  virtual void restore_original_nonzero_pattern() override;
 
 protected:
   /**

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -162,8 +162,10 @@ public:
 
   /**
    * Reset matrix to use the original nonzero pattern provided by users
+   * @returns Whether the memory was touched. Memory will be untouched if previous assemblies
+   * matched the preallocated sparsity pattern
    */
-  void reset_preallocation();
+  bool reset_preallocation();
 
   virtual void zero () override;
 
@@ -291,7 +293,7 @@ public:
 
   virtual bool supports_hash_table() const override;
 
-  virtual void reset_memory() override;
+  virtual bool reset_memory() override;
 
 protected:
   /**

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -162,10 +162,8 @@ public:
 
   /**
    * Reset matrix to use the original nonzero pattern provided by users
-   * @returns Whether the memory was touched. Memory will be untouched if previous assemblies
-   * matched the preallocated sparsity pattern
    */
-  bool reset_preallocation();
+  void reset_preallocation();
 
   virtual void zero () override;
 
@@ -293,7 +291,7 @@ public:
 
   virtual bool supports_hash_table() const override;
 
-  virtual bool reset_memory() override;
+  virtual void reset_memory() override;
 
 protected:
   /**

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -606,11 +606,12 @@ public:
   /**
    * Reset the memory storage of the matrix. Unlike \p clear(), this does not destroy the matrix but
    * rather will reset the matrix to use the original preallocation or when using hash table matrix
-   * assembly (see \p use_hash_table()) will reset (clear) the hash table used for assembly. An
-   * important note: if using preallocation based matrix memory and if the nonzero structure of the
-   * matrix has not changed from what was preallocated, then this will be a no-op!
+   * assembly (see \p use_hash_table()) will reset (clear) the hash table used for assembly. In the
+   * words of the \p MatResetPreallocation documentation in PETSc, 'current values in the matrix are
+   * lost in this call', so a user can expect to have back their original sparsity pattern in a
+   * zeroed state
    */
-  virtual void reset_memory() { libmesh_not_implemented(); }
+  virtual void restore_original_nonzero_pattern() { libmesh_not_implemented(); }
 
 protected:
   /**

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -609,9 +609,8 @@ public:
    * assembly (see \p use_hash_table()) will reset (clear) the hash table used for assembly. An
    * important note: if using preallocation based matrix memory and if the nonzero structure of the
    * matrix has not changed from what was preallocated, then this will be a no-op!
-   * @returns Whether memory has changed
    */
-  virtual bool reset_memory() { libmesh_not_implemented(); }
+  virtual void reset_memory() { libmesh_not_implemented(); }
 
 protected:
   /**

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -609,8 +609,9 @@ public:
    * assembly (see \p use_hash_table()) will reset (clear) the hash table used for assembly. An
    * important note: if using preallocation based matrix memory and if the nonzero structure of the
    * matrix has not changed from what was preallocated, then this will be a no-op!
+   * @returns Whether memory has changed
    */
-  virtual void reset_memory() { libmesh_not_implemented(); }
+  virtual bool reset_memory() { libmesh_not_implemented(); }
 
 protected:
   /**

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -606,7 +606,9 @@ public:
   /**
    * Reset the memory storage of the matrix. Unlike \p clear(), this does not destroy the matrix but
    * rather will reset the matrix to use the original preallocation or when using hash table matrix
-   * assembly (see \p use_hash_table()) will reset (clear) the hash table used for assembly
+   * assembly (see \p use_hash_table()) will reset (clear) the hash table used for assembly. An
+   * important note: if using preallocation based matrix memory and if the nonzero structure of the
+   * matrix has not changed from what was preallocated, then this will be a no-op!
    */
   virtual void reset_memory() { libmesh_not_implemented(); }
 

--- a/src/numerics/diagonal_matrix.C
+++ b/src/numerics/diagonal_matrix.C
@@ -331,5 +331,12 @@ DiagonalMatrix<T>::diagonal() const
   return *_diagonal;
 }
 
+template <typename T>
+void
+DiagonalMatrix<T>::restore_original_nonzero_pattern()
+{
+  _diagonal->zero();
+}
+
 template class LIBMESH_EXPORT DiagonalMatrix<Number>;
 }

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -380,13 +380,17 @@ void PetscMatrix<T>::update_preallocation_and_zero ()
 }
 
 template <typename T>
-bool PetscMatrix<T>::reset_preallocation()
+void PetscMatrix<T>::reset_preallocation()
 {
+#if !PETSC_VERSION_LESS_THAN(3,9,0)
   libmesh_assert (this->initialized());
 
-  PetscBool memoryreset;
-  LibmeshPetscCall(MatResetPreallocation(this->_mat, &memoryreset));
-  return memoryreset;
+  LibmeshPetscCall(MatResetPreallocation(this->_mat));
+#else
+  libmesh_warning("Your version of PETSc doesn't support resetting of "
+                  "preallocation, so we will use your most recent sparsity "
+                  "pattern. This may result in a degradation of performance\n");
+#endif
 }
 
 template <typename T>
@@ -1281,23 +1285,18 @@ PetscMatrix<T>::copy_from_hash ()
 #endif
 
 template <typename T>
-bool
+void
 PetscMatrix<T>::reset_memory()
 {
-  semiparallel_only();
-
   if (this->_use_hash_table)
 #if PETSC_RELEASE_GREATER_EQUALS(3, 23, 0)
-    {
     // This performs MatReset plus re-establishes the hash table
     LibmeshPetscCall(MatResetHash(this->_mat));
-    return true;
-    }
 #else
     libmesh_error_msg("Resetting hash tables not supported until PETSc version 3.23");
 #endif
   else
-    return this->reset_preallocation();
+    this->reset_preallocation();
 }
 
 //------------------------------------------------------------------

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -1288,7 +1288,7 @@ PetscMatrix<T>::copy_from_hash ()
 
 template <typename T>
 void
-PetscMatrix<T>::reset_memory()
+PetscMatrix<T>::restore_original_nonzero_pattern()
 {
   semiparallel_only();
 

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -382,6 +382,8 @@ void PetscMatrix<T>::update_preallocation_and_zero ()
 template <typename T>
 void PetscMatrix<T>::reset_preallocation()
 {
+  semiparallel_only();
+
 #if !PETSC_VERSION_LESS_THAN(3,9,0)
   libmesh_assert (this->initialized());
 
@@ -1288,6 +1290,8 @@ template <typename T>
 void
 PetscMatrix<T>::reset_memory()
 {
+  semiparallel_only();
+
   if (this->_use_hash_table)
 #if PETSC_RELEASE_GREATER_EQUALS(3, 23, 0)
     // This performs MatReset plus re-establishes the hash table


### PR DESCRIPTION
I also added a pretty important comment to the doxygen string. This reflects what happens in the PETSc implementation. I now have some concern about the method name ... a name like `reset_memory` makes me think that there's no way something like a no-op could happen. Perhaps a name like `restore_(original_)nonzero_pattern` would be better? Would this still conceptually allow its use for hash table based memory allocation? I think so since resetting/clearing the hash table restores the original sparsity pattern ... that pattern being whatever you want it to be