### PR TITLE
verify() doesn't actually do assert() by itself.

### DIFF
--- a/include/parallel/parallel_algebra.h
+++ b/include/parallel/parallel_algebra.h
@@ -144,11 +144,11 @@ struct TypeVectorAttributes
   static const bool has_min_max = true;
   static void set_lowest(V & x) {
     for (int d=0; d != LIBMESH_DIM; ++d)
-      TIMPI::Attributes<decltype(x(d))>::set_lowest(x(d));
+      TIMPI::Attributes<typename std::remove_reference<decltype(x(d))>::type>::set_lowest(x(d));
   }
   static void set_highest(V & x) {
     for (int d=0; d != LIBMESH_DIM; ++d)
-      TIMPI::Attributes<decltype(x(d))>::set_highest(x(d));
+      TIMPI::Attributes<typename std::remove_reference<decltype(x(d))>::type>::set_highest(x(d));
   }
 };
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1607,7 +1607,7 @@ void libmesh_assert_equal_points (const MeshBase & mesh)
     {
       const Point * p = mesh.query_node_ptr(i);
 
-      mesh.comm().semiverify(p);
+      libmesh_assert(mesh.comm().semiverify(p));
     }
 }
 
@@ -1628,7 +1628,7 @@ void libmesh_assert_equal_connectivity (const MeshBase & mesh)
         for (auto n : e->node_index_range())
           nodes.push_back(e->node_id(n));
 
-      mesh.comm().semiverify(e ? &nodes : nullptr);
+      libmesh_assert(mesh.comm().semiverify(e ? &nodes : nullptr));
     }
 }
 

--- a/src/numerics/static_condensation.C
+++ b/src/numerics/static_condensation.C
@@ -363,9 +363,7 @@ StaticCondensation::close()
   if (!_have_cached_values)
     {
       const bool closed = _reduced_sys_mat->closed();
-#ifndef NDEBUG
-      _communicator.verify(closed);
-#endif
+      libmesh_assert(_communicator.verify(closed));
       if (!closed)
         _reduced_sys_mat->close();
       return;

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -393,7 +393,7 @@ void RBConstructionBase<Base>::load_training_set(const std::map<std::string, std
   // Check that (new_training_set.size() == get_n_params()) is the same on all processes so that
   // we go into the same branch of the "if" statement below on all processes.
   const bool size_matches = (new_training_set.size() == n_params);
-  this->comm().verify(size_matches);
+  libmesh_assert(this->comm().verify(size_matches));
 
   if (size_matches)
     {

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -1108,7 +1108,7 @@ write_out_interior_basis_functions(const std::string & directory_name,
   // Quick return if there is no work to do. Note: make sure all procs
   // agree there is no work to do.
   bool is_empty = _local_eim_basis_functions.empty();
-  this->comm().verify(is_empty);
+  libmesh_assert(this->comm().verify(is_empty));
 
   if (is_empty)
     return;
@@ -1279,7 +1279,7 @@ get_interior_basis_functions_as_vecs()
   // Quick return if there is no work to do. Note: make sure all procs
   // agree there is no work to do.
   bool is_empty = _local_eim_basis_functions.empty();
-  this->comm().verify(is_empty);
+  libmesh_assert(this->comm().verify(is_empty));
 
   if (is_empty)
     return interior_basis_functions;
@@ -1315,7 +1315,7 @@ write_out_side_basis_functions(const std::string & directory_name,
   // Quick return if there is no work to do. Note: make sure all procs
   // agree there is no work to do.
   bool is_empty = _local_side_eim_basis_functions.empty();
-  this->comm().verify(is_empty);
+  libmesh_assert(this->comm().verify(is_empty));
 
   if (is_empty)
     return;
@@ -1431,7 +1431,7 @@ write_out_node_basis_functions(const std::string & directory_name,
   // Quick return if there is no work to do. Note: make sure all procs
   // agree there is no work to do.
   bool is_empty = _local_node_eim_basis_functions.empty();
-  this->comm().verify(is_empty);
+  libmesh_assert(this->comm().verify(is_empty));
 
   if (is_empty)
     return;
@@ -1899,7 +1899,7 @@ void RBEIMEvaluation::gather_bfs()
   // each processor is the same, the only thing that differs is the number
   // of elements, so make sure that is the case now.
   auto n_bf = _local_eim_basis_functions.size();
-  this->comm().verify(n_bf);
+  libmesh_assert(this->comm().verify(n_bf));
 
   // This function should never be called if there are no basis
   // functions, so if it was, something went wrong.
@@ -2047,7 +2047,7 @@ void RBEIMEvaluation::side_gather_bfs()
   // each processor is the same, the only thing that differs is the number
   // of elements, so make sure that is the case now.
   auto n_bf = _local_side_eim_basis_functions.size();
-  this->comm().verify(n_bf);
+  libmesh_assert(this->comm().verify(n_bf));
 
   // This function should never be called if there are no basis
   // functions, so if it was, something went wrong.
@@ -2195,7 +2195,7 @@ void RBEIMEvaluation::node_gather_bfs()
   // each processor is the same, the only thing that differs is the number
   // of elements, so make sure that is the case now.
   auto n_bf = _local_node_eim_basis_functions.size();
-  this->comm().verify(n_bf);
+  libmesh_assert(this->comm().verify(n_bf));
 
   // This function should never be called if there are no basis
   // functions, so if it was, something went wrong.


### PR DESCRIPTION
I was going to make fun of @lindsayad for making this mistake, but it turns out it's a popular mistake to make.

Pinging @jwpeterson to run the RB code through their tests.

I'll add some distributed sweeps here just in case those accidentally-do-nothing distributed consistency tests actually were missing inconsistencies.