### PR TITLE
Just use DIFFERENT_NONZERO_PATTERN in PetscMatrix::operator= 

### DIFF
--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -806,6 +806,8 @@ void PetscMatrix<T>::_get_submatrix(SparseMatrix<T> & submatrix,
       const_cast<PetscMatrix<T> *>(this)->close();
     }
 
+  semiparallel_only();
+
   // Make sure the SparseMatrix passed in is really a PetscMatrix
   PetscMatrix<T> * petsc_submatrix = cast_ptr<PetscMatrix<T> *>(&submatrix);
 
@@ -1217,6 +1219,8 @@ void PetscMatrix<T>::get_row (numeric_index_type i_in,
 template <typename T>
 PetscMatrix<T> & PetscMatrix<T>::operator= (const PetscMatrix<T> & v)
 {
+  semiparallel_only();
+
   if (this->_mat)
     {
       PetscBool assembled;

--- a/src/systems/condensed_eigen_system.C
+++ b/src/systems/condensed_eigen_system.C
@@ -323,6 +323,8 @@ void
 CondensedEigenSystem::copy_super_to_sub(const SparseMatrix<Number> & super,
                                         SparseMatrix<Number> & sub)
 {
+  parallel_object_only();
+
   libmesh_assert_equal_to(sub.local_m(), local_non_condensed_dofs_vector.size());
   libmesh_assert_equal_to(sub.local_m() + this->get_dof_map().n_local_constrained_dofs(),
                           super.local_m());


### PR DESCRIPTION
Using MatGetInfo, particularly in the way it was being used, to
compare the nonzero pattern is brittle. There are several issues
- Likely the NONZERO_PATTERN is a function of zeroes used, not alloc'd
- Global nz comparison is obviously fraught
- Even comparing nz on process and doing a parallel min is fraught since
  you could have mismatches for different rows that balance out

With PETSc main, I was hitting a `PetscError` for a large process count for a MOOSE test. This change fixed that error