### PR TITLE
Add orientation-dependent caching checks and option to disable caching

### DIFF
--- a/doc/html/examples/vector_fe_ex3.html
+++ b/doc/html/examples/vector_fe_ex3.html
@@ -297,6 +297,69 @@ HCurl-Error is: 0.813116
 ***************************************************************
 ***************************************************************
 * Running Example vector_fe_ex3:
+*   ./example-opt element_type=QUAD9 grid_size=5 refine=2 -pc_type lu
+***************************************************************
+
+ Mesh Information:
+  elem_dimensions()={2}
+  elem_default_orders()={SECOND}
+  supported_nodal_order()=2
+  spatial_dimension()=2
+  n_nodes()=1681
+    n_local_nodes()=1681
+  n_elem()=525
+    n_local_elem()=525
+    n_active_elem()=400
+  n_subdomains()=1
+  n_elemsets()=0
+  n_partitions()=1
+  n_processors()=1
+  n_threads()=1
+  processor_id()=0
+  is_prepared()=true
+  is_replicated()=true
+
+ EquationSystems
+  n_systems()=1
+   System #0, "CurlCurl"
+    Type "Implicit"
+    Variables="u"
+    Finite Element Types="NEDELEC_ONE"
+    Approximation Orders="FIRST"
+    n_dofs()=840
+    n_local_dofs()=840
+    max(n_local_dofs())=840
+    n_constrained_dofs()=0
+    n_local_constrained_dofs()=0
+    max(local unconstrained dofs)=840
+    n_vectors()=1
+    n_matrices()=1
+    DofMap Sparsity
+      Average  On-Processor Bandwidth <= 6.71429
+      Average Off-Processor Bandwidth <= 0
+      Maximum  On-Processor Bandwidth <= 7
+      Maximum Off-Processor Bandwidth <= 0
+    DofMap Constraints
+      Number of DoF Constraints = 0
+
+Assembling the System
+Nonlinear Residual: 28.9779
+Linear solve starting, tolerance 1e-12
+Linear solve finished, step 1, residual 4.3648e-14
+Trying full Newton step
+  Current Residual: 6.73932e-14
+  Nonlinear solver converged, step 0, residual reduction 2.32568e-15 < 1e-06
+  Nonlinear solver relative step size 1 > 1e-06
+L2-Error is: 0.12862
+HCurl semi-norm error is: 0.802879
+HCurl-Error is: 0.813116
+
+***************************************************************
+* Done Running Example vector_fe_ex3:
+*   ./example-opt element_type=QUAD9 grid_size=5 refine=2 -pc_type lu
+***************************************************************
+***************************************************************
+* Running Example vector_fe_ex3:
 *   ./example-opt order=2 element_type=TRI6 -pc_type lu
 ***************************************************************
 

--- a/examples/vector_fe/vector_fe_ex3/run.sh
+++ b/examples/vector_fe/vector_fe_ex3/run.sh
@@ -21,6 +21,9 @@ run_example_no_extra_options "$example_name" "$options"
 options="element_type=QUAD9 -pc_type lu"
 run_example_no_extra_options "$example_name" "$options"
 
+options="element_type=QUAD9 grid_size=5 refine=2 -pc_type lu"
+run_example_no_extra_options "$example_name" "$options"
+
 options="order=2 element_type=TRI6 -pc_type lu"
 run_example_no_extra_options "$example_name" "$options"
 

--- a/examples/vector_fe/vector_fe_ex3/vector_fe_ex3.C
+++ b/examples/vector_fe/vector_fe_ex3/vector_fe_ex3.C
@@ -31,6 +31,7 @@
 #include "libmesh/mesh.h"
 #include "libmesh/mesh_generation.h"
 #include "libmesh/mesh_modification.h"
+#include "libmesh/mesh_refinement.h"
 #include "libmesh/exact_solution.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/enum_solver_package.h"
@@ -92,6 +93,10 @@ int main (int argc, char ** argv)
 
   // Make sure the code is robust against nodal reorderings.
   MeshTools::Modification::permute_elements(mesh);
+
+  // Make sure the code is robust against mesh refinements.
+  MeshRefinement mesh_refinement(mesh);
+  mesh_refinement.uniformly_refine(infile("refine", 0));
 
   // Make sure the code is robust against solves on 2d meshes rotated out of
   // the xy plane. By default, all Euler angles are zero, the rotation matrix

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -806,7 +806,7 @@ protected:
    * Check if the node locations, edge and face orientations
    * held in the element cache match those of element \p elem.
    */
-  bool match(const Elem * elem);
+  bool matches_cache(const Elem * elem);
 
   /**
    * The last side and last edge we did a reinit on

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -790,10 +790,23 @@ protected:
                                       const unsigned vdim = 1);
 
   /**
-   * An array of the node locations on the last
-   * element we computed on
+   * Vectors holding the node locations, edge and
+   * face orientations of the last element we cached.
    */
   std::vector<Point> cached_nodes;
+  std::vector<bool> cached_edges, cached_faces;
+
+  /**
+   * Repopulate the element cache with the node locations,
+   * edge and face orientations of the element \p elem.
+   */
+  void cache(const Elem * elem);
+
+  /**
+   * Check if the node locations, edge and face orientations
+   * held in the element cache match those of element \p elem.
+   */
+  bool match(const Elem * elem);
 
   /**
    * The last side and last edge we did a reinit on

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -846,6 +846,11 @@ public:
   static FEFieldType field_type (const FEFamily & fe_family);
 
   /**
+   * \returns Whether the element's shape functions are orientation-dependent.
+   */
+  static bool orientation_dependent (const FEFamily & fe_family);
+
+  /**
    * \returns The number of components of a vector-valued element.
    * Scalar-valued elements return 1.
    */

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -749,6 +749,12 @@ public:
   virtual unsigned int n_faces () const = 0;
 
   /**
+   * \returns An integer range from 0 up to (but not including)
+   * the number of faces this element has.
+   */
+  IntRange<unsigned short> face_index_range () const;
+
+  /**
    * \returns The number of children the element that has been derived
    * from this class may have.
    */
@@ -2661,6 +2667,15 @@ IntRange<unsigned short>
 Elem::edge_index_range() const
 {
   return {0, cast_int<unsigned short>(this->n_edges())};
+}
+
+
+
+inline
+IntRange<unsigned short>
+Elem::face_index_range() const
+{
+  return {0, cast_int<unsigned short>(this->n_faces())};
 }
 
 

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -171,7 +171,7 @@ void FE<Dim,T>::cache(const Elem * elem)
 
 
 template <unsigned int Dim, FEFamily T>
-bool FE<Dim,T>::match(const Elem * elem)
+bool FE<Dim,T>::matches_cache(const Elem * elem)
 {
   bool m = cached_nodes.size() == elem->n_nodes();
   for (unsigned n = 1; m && n < elem->n_nodes(); n++)
@@ -271,7 +271,7 @@ void FE<Dim,T>::reinit(const Elem * elem,
               this->_elem = elem;
 
               // Check if cached element's nodes, edge and face orientations still fit
-              cached_elem_still_fits = this->match(elem);
+              cached_elem_still_fits = this->matches_cache(elem);
 
               // Initialize the shape functions if needed
               if (this->shapes_need_reinit() && !cached_elem_still_fits)

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -2655,6 +2655,25 @@ FEFieldType FEInterface::field_type (const FEFamily & fe_family)
     }
 }
 
+bool FEInterface::orientation_dependent (const FEFamily & fe_family)
+{
+  switch (fe_family)
+    {
+    case HIERARCHIC:
+    case L2_HIERARCHIC:
+    case HIERARCHIC_VEC:
+    case L2_HIERARCHIC_VEC:
+    case BERNSTEIN:
+    case RATIONAL_BERNSTEIN:
+    case SZABAB:
+    case NEDELEC_ONE:
+    case RAVIART_THOMAS:
+      return true;
+    default:
+      return false;
+    }
+}
+
 unsigned int FEInterface::n_vec_dim (const MeshBase & mesh,
                                      const FEType & fe_type)
 {


### PR DESCRIPTION
Hi,

It turns out the problem I initially thought was to do with tetrahedral refinement is not specifically related to our refinement procedures, it is just more likely to happen when we refine.

There are cases in which two consecutive elements are sufficiently similar to trigger and reuse cached shape functions when, in fact, the orientation of the second element doesn't match that of the first. For example, two parallel edges aligned with the y-axis on neighbouring elements might not have the same orientation because the second has got a O(1e-16) difference in the x-coordinates of its two vertices for example. This is bound to happen when we refine and the resulting coordinates can't be exactly represented numerically (in base 2).

I've added a case to Vector FE Ex. 3: you expect `grid_size=5 refine=2` to be the same as `grid_size=20` (our default), but unless we disable caching, that isn't the case.

Of course an alternative to this would be, just like we do for caching, to do fuzzy comparisons for orientations as well. Opinions?

Cheers,
Nuno