### PR TITLE
Fix for overwriting nodesets

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -387,6 +387,17 @@ public:
   void renumber_id (boundary_id_type old_id, boundary_id_type new_id);
 
   /**
+   * Returns nodeset id to be used when converting a sideset to a nodeset
+   */
+  boundary_id_type check_renumber_nodeset (boundary_id_type bc_id);
+
+  /**
+   * Checks for existing nodeset that matches with this sideset
+   */
+
+  bool has_equivalent_nodeset(const Elem * side, boundary_id_type bc_id);
+
+  /**
    * \returns The number of user-specified boundary ids on the
    * semilocal part of the mesh.
    *
@@ -1043,6 +1054,11 @@ private:
    * This only contains information related to this process's local and ghosted elements
    */
   std::set<boundary_id_type> _node_boundary_ids;
+
+  /**
+   * Map from sideset id to nodeset id for when a sideset is converted to a nodeset
+   */
+  std::map<boundary_id_type, boundary_id_type> _sideset_to_nodeset_conversion;
 
   /**
    * Set of user-specified boundary IDs for shellfaces *only*.


### PR DESCRIPTION
- When creating sidesets from nodesets if the sideset shares an id with a nodeset they are combined
- This checks first that the two are actually the same (same id and same nodes)
- If they are not the same the instead of overwriting a new id is assigned to the new nodeset
- If this is to be merged some tests in MOOSE would have to be re-golded

refs idaholab/moose#30085