### PR TITLE
Add an assert to prevent returning true when asking if invalid_uint is the id of a vertex of a 1st order element

### DIFF
--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -179,7 +179,8 @@ public:
   /**
    * \returns \p true if the specified (local) node number is a vertex.
    */
-  virtual bool is_vertex(const unsigned int) const override { return true; }
+  virtual bool is_vertex(const unsigned int n) const override
+  { libmesh_ignore(n); libmesh_assert_not_equal_to (n, invalid_uint); return true; }
 
   /**
    * NodeElem objects don't have faces or sides.

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -179,8 +179,8 @@ public:
   /**
    * \returns \p true if the specified (local) node number is a vertex.
    */
-  virtual bool is_vertex(const unsigned int n) const override
-  { libmesh_ignore(n); libmesh_assert_not_equal_to (n, invalid_uint); return true; }
+  virtual bool is_vertex(const unsigned int libmesh_dbg_var(n)) const override
+  { libmesh_assert_not_equal_to (n, invalid_uint); return true; }
 
   /**
    * NodeElem objects don't have faces or sides.

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -69,8 +69,10 @@ const unsigned int Hex8::edge_nodes_map[Hex8::num_edges][Hex8::nodes_per_edge] =
 // ------------------------------------------------------------
 // Hex8 class member functions
 
-bool Hex8::is_vertex(const unsigned int) const
+bool Hex8::is_vertex(const unsigned int n) const
 {
+  libmesh_ignore(n);
+  libmesh_assert_not_equal_to (n, invalid_uint);
   return true;
 }
 

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -69,9 +69,8 @@ const unsigned int Hex8::edge_nodes_map[Hex8::num_edges][Hex8::nodes_per_edge] =
 // ------------------------------------------------------------
 // Hex8 class member functions
 
-bool Hex8::is_vertex(const unsigned int n) const
+bool Hex8::is_vertex(const unsigned int libmesh_dbg_var(n)) const
 {
-  libmesh_ignore(n);
   libmesh_assert_not_equal_to (n, invalid_uint);
   return true;
 }

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -145,8 +145,10 @@ const unsigned int Prism6::edge_nodes_map[Prism6::num_edges][Prism6::nodes_per_e
 // ------------------------------------------------------------
 // Prism6 class member functions
 
-bool Prism6::is_vertex(const unsigned int) const
+bool Prism6::is_vertex(const unsigned int n) const
 {
+  libmesh_ignore(n);
+  libmesh_assert_not_equal_to (n, invalid_uint);
   return true;
 }
 
@@ -154,6 +156,7 @@ bool Prism6::is_edge(const unsigned int) const
 {
   return false;
 }
+
 
 bool Prism6::is_face(const unsigned int) const
 {

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -145,9 +145,8 @@ const unsigned int Prism6::edge_nodes_map[Prism6::num_edges][Prism6::nodes_per_e
 // ------------------------------------------------------------
 // Prism6 class member functions
 
-bool Prism6::is_vertex(const unsigned int n) const
+bool Prism6::is_vertex(const unsigned int libmesh_dbg_var(n)) const
 {
-  libmesh_ignore(n);
   libmesh_assert_not_equal_to (n, invalid_uint);
   return true;
 }

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -62,8 +62,10 @@ const unsigned int Pyramid5::edge_nodes_map[Pyramid5::num_edges][Pyramid5::nodes
 // ------------------------------------------------------------
 // Pyramid5 class member functions
 
-bool Pyramid5::is_vertex(const unsigned int) const
+bool Pyramid5::is_vertex(const unsigned int n) const
 {
+  libmesh_ignore(n);
+  libmesh_assert_not_equal_to (n, invalid_uint);
   return true;
 }
 

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -62,9 +62,8 @@ const unsigned int Pyramid5::edge_nodes_map[Pyramid5::num_edges][Pyramid5::nodes
 // ------------------------------------------------------------
 // Pyramid5 class member functions
 
-bool Pyramid5::is_vertex(const unsigned int n) const
+bool Pyramid5::is_vertex(const unsigned int libmesh_dbg_var(n)) const
 {
-  libmesh_ignore(n);
   libmesh_assert_not_equal_to (n, invalid_uint);
   return true;
 }

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -57,8 +57,10 @@ const unsigned int Tet4::edge_nodes_map[Tet4::num_edges][Tet4::nodes_per_edge] =
 // ------------------------------------------------------------
 // Tet4 class member functions
 
-bool Tet4::is_vertex(const unsigned int) const
+bool Tet4::is_vertex(const unsigned int n) const
 {
+  libmesh_ignore(n);
+  libmesh_assert_not_equal_to (n, invalid_uint);
   return true;
 }
 

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -57,9 +57,8 @@ const unsigned int Tet4::edge_nodes_map[Tet4::num_edges][Tet4::nodes_per_edge] =
 // ------------------------------------------------------------
 // Tet4 class member functions
 
-bool Tet4::is_vertex(const unsigned int n) const
+bool Tet4::is_vertex(const unsigned int libmesh_dbg_var(n)) const
 {
-  libmesh_ignore(n);
   libmesh_assert_not_equal_to (n, invalid_uint);
   return true;
 }

--- a/src/geom/edge_edge2.C
+++ b/src/geom/edge_edge2.C
@@ -51,8 +51,10 @@ const Real Edge2::_embedding_matrix[Edge2::num_children][Edge2::num_nodes][Edge2
 
 #endif
 
-bool Edge2::is_vertex(const unsigned int) const
+bool Edge2::is_vertex(const unsigned int n) const
 {
+  libmesh_ignore(n);
+  libmesh_assert_not_equal_to (n, invalid_uint);
   return true;
 }
 

--- a/src/geom/edge_edge2.C
+++ b/src/geom/edge_edge2.C
@@ -51,9 +51,8 @@ const Real Edge2::_embedding_matrix[Edge2::num_children][Edge2::num_nodes][Edge2
 
 #endif
 
-bool Edge2::is_vertex(const unsigned int n) const
+bool Edge2::is_vertex(const unsigned int libmesh_dbg_var(n)) const
 {
-  libmesh_ignore(n);
   libmesh_assert_not_equal_to (n, invalid_uint);
   return true;
 }

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -91,8 +91,10 @@ const Real Quad4::_embedding_matrix[Quad4::num_children][Quad4::num_nodes][Quad4
 // ------------------------------------------------------------
 // Quad4 class member functions
 
-bool Quad4::is_vertex(const unsigned int) const
+bool Quad4::is_vertex(const unsigned int n) const
 {
+  libmesh_ignore(n);
+  libmesh_assert_not_equal_to (n, invalid_uint);
   return true;
 }
 

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -91,9 +91,8 @@ const Real Quad4::_embedding_matrix[Quad4::num_children][Quad4::num_nodes][Quad4
 // ------------------------------------------------------------
 // Quad4 class member functions
 
-bool Quad4::is_vertex(const unsigned int n) const
+bool Quad4::is_vertex(const unsigned int libmesh_dbg_var(n)) const
 {
-  libmesh_ignore(n);
   libmesh_assert_not_equal_to (n, invalid_uint);
   return true;
 }

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -83,9 +83,8 @@ const Real Tri3::_embedding_matrix[Tri3::num_children][Tri3::num_nodes][Tri3::nu
 // ------------------------------------------------------------
 // Tri3 class member functions
 
-bool Tri3::is_vertex(const unsigned int n) const
+bool Tri3::is_vertex(const unsigned int libmesh_dbg_var(n)) const
 {
-  libmesh_ignore(n);
   libmesh_assert_not_equal_to (n, invalid_uint);
   return true;
 }

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -83,8 +83,10 @@ const Real Tri3::_embedding_matrix[Tri3::num_children][Tri3::num_nodes][Tri3::nu
 // ------------------------------------------------------------
 // Tri3 class member functions
 
-bool Tri3::is_vertex(const unsigned int) const
+bool Tri3::is_vertex(const unsigned int n) const
 {
+  libmesh_ignore(n);
+  libmesh_assert_not_equal_to (n, invalid_uint);
   return true;
 }
 


### PR DESCRIPTION
refs #4122

we could also do 
```
  libmesh_assert_less (n, n_nodes());
``` 
instead. Seems like it would be just as invalid to me