### PR TITLE
Refactor orientation-determining code

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -1098,10 +1098,11 @@ public:
   bool positive_edge_orientation(const unsigned int i) const;
 
   /**
-   * \returns \p true if face \p i is positively oriented. A face with N
-   * vertices is positively oriented iff its 3 lexicographically greatest
-   * vertices (i.e. 3 lexicographically greatest nodes amongst the N leading
-   * nodes) are an odd permutation relative to their lexicographic ordering.
+   * \returns \p true if face \p i is positively oriented. A face is
+   * positively oriented iff the triangle defined by the lexicographically
+   * least vertex and its two adjacent vertices on the same face is
+   * positively oriented. Said triangle is positively oriented iff its
+   * vertices are an odd permutation of their lexicographic ordering.
    */
   bool positive_face_orientation(const unsigned int i) const;
 

--- a/src/fe/fe_bernstein_shape_2D.C
+++ b/src/fe/fe_bernstein_shape_2D.C
@@ -208,9 +208,9 @@ Real FE<2,BERNSTEIN>::shape(const Elem * elem,
             unsigned int shape=i;
 
 
-            if ((i==3||i==4) && elem->point(0) > elem->point(1)) shape=7-i;
-            if ((i==5||i==6) && elem->point(1) > elem->point(2)) shape=11-i;
-            if ((i==7||i==8) && elem->point(0) > elem->point(2)) shape=15-i;
+            if ((i==3||i==4) &&  elem->positive_edge_orientation(0)) shape=7-i;
+            if ((i==5||i==6) &&  elem->positive_edge_orientation(1)) shape=11-i;
+            if ((i==7||i==8) && !elem->positive_edge_orientation(2)) shape=15-i;
 
             switch(shape)
               {
@@ -242,9 +242,9 @@ Real FE<2,BERNSTEIN>::shape(const Elem * elem,
 
             libmesh_assert_less (i, 15);
 
-            if ((i==3||i== 5) && elem->point(0) > elem->point(1)) shape=8-i;
-            if ((i==6||i== 8) && elem->point(1) > elem->point(2)) shape=14-i;
-            if ((i==9||i==11) && elem->point(0) > elem->point(2)) shape=20-i;
+            if ((i==3||i== 5) &&  elem->positive_edge_orientation(0)) shape=8-i;
+            if ((i==6||i== 8) &&  elem->positive_edge_orientation(1)) shape=14-i;
+            if ((i==9||i==11) && !elem->positive_edge_orientation(2)) shape=20-i;
 
 
             switch(shape)
@@ -285,9 +285,9 @@ Real FE<2,BERNSTEIN>::shape(const Elem * elem,
 
             libmesh_assert_less (i, 21);
 
-            if ((i>= 3&&i<= 6) && elem->point(0) > elem->point(1)) shape=9-i;
-            if ((i>= 7&&i<=10) && elem->point(1) > elem->point(2)) shape=17-i;
-            if ((i>=11&&i<=14) && elem->point(0) > elem->point(2)) shape=25-i;
+            if ((i>= 3&&i<= 6) &&  elem->positive_edge_orientation(0)) shape=9-i;
+            if ((i>= 7&&i<=10) &&  elem->positive_edge_orientation(1)) shape=17-i;
+            if ((i>=11&&i<=14) && !elem->positive_edge_orientation(2)) shape=25-i;
 
             switch(shape)
               {
@@ -333,9 +333,9 @@ Real FE<2,BERNSTEIN>::shape(const Elem * elem,
 
             libmesh_assert_less (i, 28);
 
-            if ((i>= 3&&i<= 7) && elem->point(0) > elem->point(1)) shape=10-i;
-            if ((i>= 8&&i<=12) && elem->point(1) > elem->point(2)) shape=20-i;
-            if ((i>=13&&i<=17) && elem->point(0) > elem->point(2)) shape=30-i;
+            if ((i>= 3&&i<= 7) &&  elem->positive_edge_orientation(0)) shape=10-i;
+            if ((i>= 8&&i<=12) &&  elem->positive_edge_orientation(1)) shape=20-i;
+            if ((i>=13&&i<=17) && !elem->positive_edge_orientation(2)) shape=30-i;
 
             switch(shape)
               {

--- a/src/fe/fe_bernstein_shape_3D.C
+++ b/src/fe/fe_bernstein_shape_3D.C
@@ -184,7 +184,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
           const Point min_point = get_min_point(elem, 1, 2, 0, 3);
 
           if (elem->point(0) == min_point)
-            if (elem->point(1) == std::min(elem->point(1), elem->point(3)))
+            if (elem->positive_face_orientation(0))
               {
                 // case 1
                 xi_mapped  = xi;
@@ -198,7 +198,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
               }
 
           else if (elem->point(3) == min_point)
-            if (elem->point(0) == std::min(elem->point(0), elem->point(2)))
+            if (elem->positive_face_orientation(0))
               {
                 // case 3
                 xi_mapped  = -eta;
@@ -212,7 +212,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
               }
 
           else if (elem->point(2) == min_point)
-            if (elem->point(3) == std::min(elem->point(3), elem->point(1)))
+            if (elem->positive_face_orientation(0))
               {
                 // case 5
                 xi_mapped  = -xi;
@@ -227,7 +227,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
 
           else if (elem->point(1) == min_point)
             {
-              if (elem->point(2) == std::min(elem->point(2), elem->point(0)))
+              if (elem->positive_face_orientation(0))
                 {
                   // case 7
                   xi_mapped  = eta;
@@ -249,7 +249,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
           const Point min_point = get_min_point(elem, 0, 1, 5, 4);
 
           if (elem->point(0) == min_point)
-            if (elem->point(1) == std::min(elem->point(1), elem->point(4)))
+            if (!elem->positive_face_orientation(1))
               {
                 // Case 1
                 xi_mapped   = xi;
@@ -263,7 +263,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
               }
 
           else if (elem->point(1) == min_point)
-            if (elem->point(5) == std::min(elem->point(5), elem->point(0)))
+            if (!elem->positive_face_orientation(1))
               {
                 // Case 3
                 xi_mapped   = zeta;
@@ -277,7 +277,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
               }
 
           else if (elem->point(5) == min_point)
-            if (elem->point(4) == std::min(elem->point(4), elem->point(1)))
+            if (!elem->positive_face_orientation(1))
               {
                 // Case 5
                 xi_mapped   = -xi;
@@ -292,7 +292,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
 
           else if (elem->point(4) == min_point)
             {
-              if (elem->point(0) == std::min(elem->point(0), elem->point(5)))
+              if (!elem->positive_face_orientation(1))
                 {
                   // Case 7
                   xi_mapped   = -xi;
@@ -314,7 +314,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
           const Point min_point = get_min_point(elem, 1, 2, 6, 5);
 
           if (elem->point(1) == min_point)
-            if (elem->point(2) == std::min(elem->point(2), elem->point(5)))
+            if (!elem->positive_face_orientation(2))
               {
                 // Case 1
                 eta_mapped  = eta;
@@ -328,7 +328,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
               }
 
           else if (elem->point(2) == min_point)
-            if (elem->point(6) == std::min(elem->point(6), elem->point(1)))
+            if (!elem->positive_face_orientation(2))
               {
                 // Case 3
                 eta_mapped  = zeta;
@@ -342,7 +342,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
               }
 
           else if (elem->point(6) == min_point)
-            if (elem->point(5) == std::min(elem->point(5), elem->point(2)))
+            if (!elem->positive_face_orientation(2))
               {
                 // Case 5
                 eta_mapped  = -eta;
@@ -357,7 +357,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
 
           else if (elem->point(5) == min_point)
             {
-              if (elem->point(1) == std::min(elem->point(1), elem->point(6)))
+              if (!elem->positive_face_orientation(2))
                 {
                   // Case 7
                   eta_mapped  = -zeta;
@@ -379,7 +379,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
           const Point min_point = get_min_point(elem, 2, 3, 7, 6);
 
           if (elem->point(3) == min_point)
-            if (elem->point(2) == std::min(elem->point(2), elem->point(7)))
+            if (elem->positive_face_orientation(3))
               {
                 // Case 1
                 xi_mapped   = xi;
@@ -393,7 +393,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
               }
 
           else if (elem->point(7) == min_point)
-            if (elem->point(3) == std::min(elem->point(3), elem->point(6)))
+            if (elem->positive_face_orientation(3))
               {
                 // Case 3
                 xi_mapped   = -zeta;
@@ -407,7 +407,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
               }
 
           else if (elem->point(6) == min_point)
-            if (elem->point(7) == std::min(elem->point(7), elem->point(2)))
+            if (elem->positive_face_orientation(3))
               {
                 // Case 5
                 xi_mapped   = -xi;
@@ -422,7 +422,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
 
           else if (elem->point(2) == min_point)
             {
-              if (elem->point(6) == std::min(elem->point(3), elem->point(6)))
+              if (elem->positive_face_orientation(3))
                 {
                   // Case 7
                   xi_mapped   = zeta;
@@ -444,21 +444,21 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
           const Point min_point = get_min_point(elem, 3, 0, 4, 7);
 
           if (elem->point(0) == min_point)
-            if (elem->point(3) == std::min(elem->point(3), elem->point(4)))
+            if (elem->positive_face_orientation(4))
               {
                 // Case 1
                 eta_mapped  = eta;
                 zeta_mapped = zeta;
               }
             else
-                        {
+              {
                 // Case 2
                 eta_mapped  = zeta;
                 zeta_mapped = eta;
               }
 
           else if (elem->point(4) == min_point)
-            if (elem->point(0) == std::min(elem->point(0), elem->point(7)))
+            if (elem->positive_face_orientation(4))
               {
                 // Case 3
                 eta_mapped  = -zeta;
@@ -472,7 +472,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
               }
 
           else if (elem->point(7) == min_point)
-            if (elem->point(4) == std::min(elem->point(4), elem->point(3)))
+            if (elem->positive_face_orientation(4))
               {
                 // Case 5
                 eta_mapped  = -eta;
@@ -487,7 +487,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
 
           else if (elem->point(3) == min_point)
             {
-              if (elem->point(7) == std::min(elem->point(7), elem->point(0)))
+              if (elem->positive_face_orientation(4))
                 {
                   // Case 7
                   eta_mapped   = zeta;
@@ -509,8 +509,8 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
           const Point min_point = get_min_point(elem, 4, 5, 6, 7);
 
           if (elem->point(4) == min_point)
-            if (elem->point(5) == std::min(elem->point(5), elem->point(7)))
-                        {
+            if (!elem->positive_face_orientation(5))
+              {
                 // Case 1
                 xi_mapped  = xi;
                 eta_mapped = eta;
@@ -523,7 +523,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
               }
 
           else if (elem->point(5) == min_point)
-            if (elem->point(6) == std::min(elem->point(6), elem->point(4)))
+            if (!elem->positive_face_orientation(5))
               {
                 // Case 3
                 xi_mapped  = eta;
@@ -531,13 +531,13 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
               }
             else
               {
-                          // Case 4
+                // Case 4
                 xi_mapped  = -xi;
                 eta_mapped = eta;
               }
 
           else if (elem->point(6) == min_point)
-            if (elem->point(7) == std::min(elem->point(7), elem->point(5)))
+            if (!elem->positive_face_orientation(5))
               {
                 // Case 5
                 xi_mapped  = -xi;
@@ -552,7 +552,7 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
 
           else if (elem->point(7) == min_point)
             {
-                        if (elem->point(4) == std::min(elem->point(4), elem->point(6)))
+              if (!elem->positive_face_orientation(5))
                 {
                   // Case 7
                   xi_mapped  = -eta;

--- a/src/fe/fe_bernstein_shape_3D.C
+++ b/src/fe/fe_bernstein_shape_3D.C
@@ -52,6 +52,13 @@ namespace {
   static const Real hex20_scal25[] =     {0,     0,     0,     0,     -0.25, -0.25, -0.25, -0.25, 0,     0,     0,     0,     0,     0,     0,     0,     0.5,   0.5,   0.5,   0.5};
   static const Real hex20_scal26[] =     {-0.25, -0.25, -0.25, -0.25, -0.25, -0.25, -0.25, -0.25, 0.25,  0.25,  0.25,  0.25,  0.25,  0.25,  0.25,  0.25,  0.25,  0.25,  0.25,  0.25};
 
+  Point get_min_point(const Elem * elem,
+                      unsigned int a, unsigned int b,
+                      unsigned int c, unsigned int d)
+  {
+    return std::min(std::min(elem->point(a),elem->point(b)),
+                    std::min(elem->point(c),elem->point(d)));
+  }
 } // anonymous namespace
 
 
@@ -174,10 +181,8 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
       // face 0
       if ((hex_i2[i] == 0) && (hex_i0[i] >= 2) && (hex_i1[i] >= 2))
         {
-          const Point min_point = std::min(elem->point(1),
-                                           std::min(elem->point(2),
-                                                    std::min(elem->point(0),
-                                                             elem->point(3))));
+          const Point min_point = get_min_point(elem, 1, 2, 0, 3);
+
           if (elem->point(0) == min_point)
             if (elem->point(1) == std::min(elem->point(1), elem->point(3)))
               {
@@ -241,10 +246,8 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
       // Face 1
       else if ((hex_i1[i] == 0) && (hex_i0[i] >= 2) && (hex_i2[i] >= 2))
         {
-          const Point min_point = std::min(elem->point(0),
-                                           std::min(elem->point(1),
-                                                    std::min(elem->point(5),
-                                                             elem->point(4))));
+          const Point min_point = get_min_point(elem, 0, 1, 5, 4);
+
           if (elem->point(0) == min_point)
             if (elem->point(1) == std::min(elem->point(1), elem->point(4)))
               {
@@ -308,10 +311,8 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
       // Face 2
       else if ((hex_i0[i] == 1) && (hex_i1[i] >= 2) && (hex_i2[i] >= 2))
         {
-          const Point min_point = std::min(elem->point(1),
-                                           std::min(elem->point(2),
-                                                    std::min(elem->point(6),
-                                                             elem->point(5))));
+          const Point min_point = get_min_point(elem, 1, 2, 6, 5);
+
           if (elem->point(1) == min_point)
             if (elem->point(2) == std::min(elem->point(2), elem->point(5)))
               {
@@ -375,10 +376,8 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
       // Face 3
       else if ((hex_i1[i] == 1) && (hex_i0[i] >= 2) && (hex_i2[i] >= 2))
         {
-          const Point min_point = std::min(elem->point(2),
-                                           std::min(elem->point(3),
-                                                    std::min(elem->point(7),
-                                                             elem->point(6))));
+          const Point min_point = get_min_point(elem, 2, 3, 7, 6);
+
           if (elem->point(3) == min_point)
             if (elem->point(2) == std::min(elem->point(2), elem->point(7)))
               {
@@ -442,10 +441,8 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
       // Face 4
       else if ((hex_i0[i] == 0) && (hex_i1[i] >= 2) && (hex_i2[i] >= 2))
         {
-          const Point min_point = std::min(elem->point(3),
-                                           std::min(elem->point(0),
-                                                    std::min(elem->point(4),
-                                                             elem->point(7))));
+          const Point min_point = get_min_point(elem, 3, 0, 4, 7);
+
           if (elem->point(0) == min_point)
             if (elem->point(3) == std::min(elem->point(3), elem->point(4)))
               {
@@ -509,10 +506,8 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
       // Face 5
       else if ((hex_i2[i] == 1) && (hex_i0[i] >= 2) && (hex_i1[i] >= 2))
         {
-          const Point min_point = std::min(elem->point(4),
-                                           std::min(elem->point(5),
-                                                    std::min(elem->point(6),
-                                                             elem->point(7))));
+          const Point min_point = get_min_point(elem, 4, 5, 6, 7);
+
           if (elem->point(4) == min_point)
             if (elem->point(5) == std::min(elem->point(5), elem->point(7)))
                         {

--- a/src/fe/fe_bernstein_shape_3D.C
+++ b/src/fe/fe_bernstein_shape_3D.C
@@ -97,73 +97,73 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
       // Edge 0
       if ((hex_i0[i] >= 2) && (hex_i1[i] == 0) && (hex_i2[i] == 0))
         {
-          if (elem->point(0) != std::min(elem->point(0), elem->point(1)))
+          if (elem->positive_edge_orientation(0))
             xi_mapped = -xi;
         }
       // Edge 1
       else if ((hex_i0[i] == 1) && (hex_i1[i] >= 2) && (hex_i2[i] == 0))
         {
-          if (elem->point(1) != std::min(elem->point(1), elem->point(2)))
+          if (elem->positive_edge_orientation(1))
             eta_mapped = -eta;
         }
       // edge 2
       else if ((hex_i0[i] >= 2) && (hex_i1[i] == 1) && (hex_i2[i] == 0))
         {
-          if (elem->point(3) != std::min(elem->point(3), elem->point(2)))
+          if (!elem->positive_edge_orientation(2))
             xi_mapped = -xi;
         }
       // edge 3
       else if ((hex_i0[i] == 0) && (hex_i1[i] >= 2) && (hex_i2[i] == 0))
         {
-          if (elem->point(0) != std::min(elem->point(0), elem->point(3)))
+          if (elem->positive_edge_orientation(3))
             eta_mapped = -eta;
         }
       // edge 4
       else if ((hex_i0[i] == 0) && (hex_i1[i] == 0) && (hex_i2[i] >=2 ))
         {
-          if (elem->point(0) != std::min(elem->point(0), elem->point(4)))
+          if (elem->positive_edge_orientation(4))
             zeta_mapped = -zeta;
         }
       // edge 5
       else if ((hex_i0[i] == 1) && (hex_i1[i] == 0) && (hex_i2[i] >=2 ))
         {
-          if (elem->point(1) != std::min(elem->point(1), elem->point(5)))
+          if (elem->positive_edge_orientation(5))
             zeta_mapped = -zeta;
         }
       // edge 6
       else if ((hex_i0[i] == 1) && (hex_i1[i] == 1) && (hex_i2[i] >=2 ))
         {
-          if (elem->point(2) != std::min(elem->point(2), elem->point(6)))
+          if (elem->positive_edge_orientation(6))
             zeta_mapped = -zeta;
         }
       // edge 7
       else if ((hex_i0[i] == 0) && (hex_i1[i] == 1) && (hex_i2[i] >=2 ))
         {
-          if (elem->point(3) != std::min(elem->point(3), elem->point(7)))
+          if (elem->positive_edge_orientation(7))
             zeta_mapped = -zeta;
         }
       // edge 8
       else if ((hex_i0[i] >=2 ) && (hex_i1[i] == 0) && (hex_i2[i] == 1))
         {
-          if (elem->point(4) != std::min(elem->point(4), elem->point(5)))
+          if (elem->positive_edge_orientation(8))
             xi_mapped = -xi;
         }
       // edge 9
       else if ((hex_i0[i] == 1) && (hex_i1[i] >=2 ) && (hex_i2[i] == 1))
         {
-          if (elem->point(5) != std::min(elem->point(5), elem->point(6)))
+          if (elem->positive_edge_orientation(9))
             eta_mapped = -eta;
         }
       // edge 10
       else if ((hex_i0[i] >=2 ) && (hex_i1[i] == 1) && (hex_i2[i] == 1))
         {
-          if (elem->point(7) != std::min(elem->point(7), elem->point(6)))
+          if (!elem->positive_edge_orientation(10))
             xi_mapped = -xi;
         }
       // edge 11
       else if ((hex_i0[i] == 0) && (hex_i1[i] >=2 ) && (hex_i2[i] == 1))
         {
-          if (elem->point(4) != std::min(elem->point(4), elem->point(7)))
+          if (elem->positive_edge_orientation(11))
             eta_mapped = -eta;
         }
     }

--- a/src/fe/fe_hierarchic_shape_2D.C
+++ b/src/fe/fe_hierarchic_shape_2D.C
@@ -109,13 +109,13 @@ quad_indices(const Elem * elem,
   Real f = 1.;
 
   if ((i0%2) && (i0 > 2) && (i1 == 0))
-    f = (elem->point(0) > elem->point(1))?-1.:1.;
+    f =  elem->positive_edge_orientation(0)?-1.:1.;
   else if ((i0%2) && (i0>2) && (i1 == 1))
-    f = (elem->point(3) > elem->point(2))?-1.:1.;
+    f = !elem->positive_edge_orientation(2)?-1.:1.;
   else if ((i0 == 0) && (i1%2) && (i1>2))
-    f = (elem->point(0) > elem->point(3))?-1.:1.;
+    f = !elem->positive_edge_orientation(3)?-1.:1.;
   else if ((i0 == 1) && (i1%2) && (i1>2))
-    f = (elem->point(1) > elem->point(2))?-1.:1.;
+    f =  elem->positive_edge_orientation(1)?-1.:1.;
 
   return {i0, i1, f};
 }
@@ -254,7 +254,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape(const Elem * elem,
               return 1;
 
             if ((i < 2 || i % 2) &&
-                elem->point(0) > elem->point(1))
+                elem->positive_edge_orientation(0))
               f = -1;
 
             return FE<1,HIERARCHIC>::shape(EDGE3, totalorder, i, f*(zeta1-zeta0));
@@ -271,7 +271,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape(const Elem * elem,
             const unsigned int side_i = i - dofs_per_side;
 
             if ((side_i < 2 || side_i % 2) &&
-                elem->point(1) > elem->point(2))
+                elem->positive_edge_orientation(1))
               f = -1;
 
             return FE<1,HIERARCHIC>::shape(EDGE3, totalorder, side_i, f*(zeta2-zeta1));
@@ -289,7 +289,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape(const Elem * elem,
             const unsigned int side_i = i - 2*dofs_per_side;
 
             if ((side_i < 2 || side_i % 2) &&
-                elem->point(2) > elem->point(0))
+                elem->positive_edge_orientation(2))
               f = -1;
 
             return FE<1,HIERARCHIC>::shape(EDGE3, totalorder, side_i, f*(zeta0-zeta2));
@@ -320,7 +320,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape(const Elem * elem,
                   return 1;
 
                 if ((i < 2 || i % 2) &&
-                    elem->point(0) > elem->point(1))
+                    elem->positive_edge_orientation(0))
                   f = -1;
 
                 return FE<1,HIERARCHIC>::shape(EDGE3, totalorder, i, f*xi);
@@ -337,7 +337,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape(const Elem * elem,
                 const unsigned int side_i = i - dofs_per_side;
 
                 if ((side_i < 2 || side_i % 2) &&
-                    elem->point(1) > elem->point(2))
+                    elem->positive_edge_orientation(1))
                   f = -1;
 
                 return FE<1,HIERARCHIC>::shape(EDGE3, totalorder, side_i, f*eta);
@@ -357,7 +357,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape(const Elem * elem,
                 const unsigned int side_i = i - 2*dofs_per_side;
 
                 if ((side_i < 2 || side_i % 2) &&
-                    elem->point(3) > elem->point(2))
+                    !elem->positive_edge_orientation(2))
                   f = -1;
 
                 return FE<1,HIERARCHIC>::shape(EDGE3, totalorder, side_i, f*xi);
@@ -373,7 +373,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape(const Elem * elem,
                 const unsigned int side_i = i - 3*dofs_per_side;
 
                 if ((side_i < 2 || side_i % 2) &&
-                    elem->point(0) > elem->point(3))
+                    !elem->positive_edge_orientation(3))
                   f = -1;
 
                 return FE<1,HIERARCHIC>::shape(EDGE3, totalorder, side_i, f*eta);
@@ -541,7 +541,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape_deriv(const Elem * elem,
               return 0;
 
             if ((i < 2 || i % 2) &&
-                elem->point(0) > elem->point(1))
+                elem->positive_edge_orientation(0))
               f = -1;
 
             return f*FE<1,HIERARCHIC>::shape_deriv(EDGE3, totalorder, i, 0, f*(zeta1-zeta0));
@@ -558,7 +558,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape_deriv(const Elem * elem,
             const unsigned int side_i = i - dofs_per_side;
 
             if ((side_i < 2 || side_i % 2) &&
-                elem->point(1) > elem->point(2))
+                elem->positive_edge_orientation(1))
               f = -1;
 
             Real g = 1;
@@ -583,7 +583,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape_deriv(const Elem * elem,
             const unsigned int side_i = i - 2*dofs_per_side;
 
             if ((side_i < 2 || side_i % 2) &&
-                elem->point(2) > elem->point(0))
+                elem->positive_edge_orientation(2))
               f = -1;
 
             return -f*FE<1,HIERARCHIC>::shape_deriv(EDGE3, totalorder, side_i, 0, f*(zeta0-zeta2));
@@ -613,7 +613,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape_deriv(const Elem * elem,
                 if (j != 0)
                   return 0;
                 if ((i < 2 || i % 2) &&
-                    elem->point(0) > elem->point(1))
+                    elem->positive_edge_orientation(0))
                   f = -1;
 
                 return f*FE<1,HIERARCHIC>::shape_deriv(EDGE3, totalorder, i, 0, f*xi);
@@ -629,7 +629,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape_deriv(const Elem * elem,
                 const unsigned int side_i = i - dofs_per_side;
 
                 if ((side_i < 2 || side_i % 2) &&
-                    elem->point(1) > elem->point(2))
+                    elem->positive_edge_orientation(1))
                   f = -1;
 
                 return f*FE<1,HIERARCHIC>::shape_deriv(EDGE3, totalorder, side_i, 0, f*eta);
@@ -648,7 +648,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape_deriv(const Elem * elem,
                 const unsigned int side_i = i - 2*dofs_per_side;
 
                 if ((side_i < 2 || side_i % 2) &&
-                    elem->point(3) > elem->point(2))
+                    !elem->positive_edge_orientation(2))
                   f = -1;
 
                 return f*FE<1,HIERARCHIC>::shape_deriv(EDGE3, totalorder, side_i, 0, f*xi);
@@ -663,7 +663,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape_deriv(const Elem * elem,
                 const unsigned int side_i = i - 3*dofs_per_side;
 
                 if ((side_i < 2 || side_i % 2) &&
-                    elem->point(0) > elem->point(3))
+                    !elem->positive_edge_orientation(3))
                   f = -1;
 
                 return f*FE<1,HIERARCHIC>::shape_deriv(EDGE3, totalorder, side_i, 0, f*eta);
@@ -827,7 +827,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape_second_deriv(const Elem * elem,
                 if (j != 0)
                   return 0;
                 if ((i < 2 || i % 2) &&
-                    elem->point(0) > elem->point(1))
+                    elem->positive_edge_orientation(0))
                   f = -1;
 
                 return FE<1,HIERARCHIC>::shape_second_deriv(EDGE3, totalorder, i, 0, f*xi);
@@ -843,7 +843,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape_second_deriv(const Elem * elem,
                 const unsigned int side_i = i - dofs_per_side;
 
                 if ((side_i < 2 || side_i % 2) &&
-                    elem->point(1) > elem->point(2))
+                    elem->positive_edge_orientation(1))
                   f = -1;
 
                 return FE<1,HIERARCHIC>::shape_second_deriv(EDGE3, totalorder, side_i, 0, f*eta);
@@ -862,7 +862,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape_second_deriv(const Elem * elem,
                 const unsigned int side_i = i - 2*dofs_per_side;
 
                 if ((side_i < 2 || side_i % 2) &&
-                    elem->point(3) > elem->point(2))
+                    !elem->positive_edge_orientation(2))
                   f = -1;
 
                 return FE<1,HIERARCHIC>::shape_second_deriv(EDGE3, totalorder, side_i, 0, f*xi);
@@ -877,7 +877,7 @@ Real FE<2,SIDE_HIERARCHIC>::shape_second_deriv(const Elem * elem,
                 const unsigned int side_i = i - 3*dofs_per_side;
 
                 if ((side_i < 2 || side_i % 2) &&
-                    elem->point(0) > elem->point(3))
+                    !elem->positive_edge_orientation(3))
                   f = -1;
 
                 return FE<1,HIERARCHIC>::shape_second_deriv(EDGE3, totalorder, side_i, 0, f*eta);

--- a/src/fe/fe_hierarchic_shape_3D.C
+++ b/src/fe/fe_hierarchic_shape_3D.C
@@ -245,7 +245,7 @@ void cube_indices(const Elem * elem,
       i0 = i - 6;
       i1 = 0;
       i2 = 0;
-      if (elem->point(0) > elem->point(1))
+      if (elem->positive_edge_orientation(0))
         xi = -xi_saved;
     }
   // Edge 1
@@ -254,7 +254,7 @@ void cube_indices(const Elem * elem,
       i0 = 1;
       i1 = i - e - 6;
       i2 = 0;
-      if (elem->point(1) > elem->point(2))
+      if (elem->positive_edge_orientation(1))
         eta = -eta_saved;
     }
   // Edge 2
@@ -263,7 +263,7 @@ void cube_indices(const Elem * elem,
       i0 = i - 2*e - 6;
       i1 = 1;
       i2 = 0;
-      if (elem->point(3) > elem->point(2))
+      if (!elem->positive_edge_orientation(2))
         xi = -xi_saved;
     }
   // Edge 3
@@ -272,7 +272,7 @@ void cube_indices(const Elem * elem,
       i0 = 0;
       i1 = i - 3*e - 6;
       i2 = 0;
-      if (elem->point(0) > elem->point(3))
+      if (elem->positive_edge_orientation(3))
         eta = -eta_saved;
     }
   // Edge 4
@@ -281,7 +281,7 @@ void cube_indices(const Elem * elem,
       i0 = 0;
       i1 = 0;
       i2 = i - 4*e - 6;
-      if (elem->point(0) > elem->point(4))
+      if (elem->positive_edge_orientation(4))
         zeta = -zeta_saved;
     }
   // Edge 5
@@ -290,7 +290,7 @@ void cube_indices(const Elem * elem,
       i0 = 1;
       i1 = 0;
       i2 = i - 5*e - 6;
-      if (elem->point(1) > elem->point(5))
+      if (elem->positive_edge_orientation(5))
         zeta = -zeta_saved;
     }
   // Edge 6
@@ -299,7 +299,7 @@ void cube_indices(const Elem * elem,
       i0 = 1;
       i1 = 1;
       i2 = i - 6*e - 6;
-      if (elem->point(2) > elem->point(6))
+      if (elem->positive_edge_orientation(6))
         zeta = -zeta_saved;
     }
   // Edge 7
@@ -308,7 +308,7 @@ void cube_indices(const Elem * elem,
       i0 = 0;
       i1 = 1;
       i2 = i - 7*e - 6;
-      if (elem->point(3) > elem->point(7))
+      if (elem->positive_edge_orientation(7))
         zeta = -zeta_saved;
     }
   // Edge 8
@@ -317,7 +317,7 @@ void cube_indices(const Elem * elem,
       i0 = i - 8*e - 6;
       i1 = 0;
       i2 = 1;
-      if (elem->point(4) > elem->point(5))
+      if (elem->positive_edge_orientation(8))
         xi = -xi_saved;
     }
   // Edge 9
@@ -326,7 +326,7 @@ void cube_indices(const Elem * elem,
       i0 = 1;
       i1 = i - 9*e - 6;
       i2 = 1;
-      if (elem->point(5) > elem->point(6))
+      if (elem->positive_edge_orientation(9))
         eta = -eta_saved;
     }
   // Edge 10
@@ -335,7 +335,7 @@ void cube_indices(const Elem * elem,
       i0 = i - 10*e - 6;
       i1 = 1;
       i2 = 1;
-      if (elem->point(7) > elem->point(6))
+      if (!elem->positive_edge_orientation(10))
         xi = -xi_saved;
     }
   // Edge 11
@@ -344,7 +344,7 @@ void cube_indices(const Elem * elem,
       i0 = 0;
       i1 = i - 11*e - 6;
       i2 = 1;
-      if (elem->point(4) > elem->point(7))
+      if (elem->positive_edge_orientation(11))
         eta = -eta_saved;
     }
   // Face 0
@@ -820,7 +820,7 @@ void prism_indices(const Elem * elem,
       i01 = (i - 6 - 3*e)/e; // which tri DoF are we?
       i2 = (i - 6 - 3*e)%e+2; // edge DoF? +2 to skip endpoints
       // EDGE evaluations don't flip, so handle that here
-      if (elem->point(i01) > elem->point(i01+3))
+      if (elem->positive_edge_orientation(i01+3))
         zeta = -zeta;
     }
   // Edge 6,7,8 (vertices 12,13,14)
@@ -2387,8 +2387,7 @@ Real fe_hierarchic_3D_shape(const Elem * elem,
             // Get factors to account for edge-flipping
             Real flip = 1;
             if (basisorder%2 &&
-                (elem->point(edgevertex0) >
-                 elem->point(edgevertex1)))
+                elem->positive_edge_orientation(edge_num))
               flip = -1;
 
             const Real crossval = zeta[edgevertex0] + zeta[edgevertex1];

--- a/src/fe/fe_hierarchic_shape_3D.C
+++ b/src/fe/fe_hierarchic_shape_3D.C
@@ -357,7 +357,7 @@ void cube_indices(const Elem * elem,
       const Point min_point = get_min_point(elem, 1, 2, 0, 3);
 
       if (elem->point(0) == min_point)
-        if (elem->point(1) == std::min(elem->point(1), elem->point(3)))
+        if (elem->positive_face_orientation(0))
           {
             // Case 1
             xi  = xi_saved;
@@ -371,7 +371,7 @@ void cube_indices(const Elem * elem,
           }
 
       else if (elem->point(3) == min_point)
-        if (elem->point(0) == std::min(elem->point(0), elem->point(2)))
+        if (elem->positive_face_orientation(0))
           {
             // Case 3
             xi  = -eta_saved;
@@ -385,7 +385,7 @@ void cube_indices(const Elem * elem,
           }
 
       else if (elem->point(2) == min_point)
-        if (elem->point(3) == std::min(elem->point(3), elem->point(1)))
+        if (elem->positive_face_orientation(0))
           {
             // Case 5
             xi  = -xi_saved;
@@ -400,7 +400,7 @@ void cube_indices(const Elem * elem,
 
       else if (elem->point(1) == min_point)
         {
-          if (elem->point(2) == std::min(elem->point(2), elem->point(0)))
+          if (elem->positive_face_orientation(0))
             {
               // Case 7
               xi  = eta_saved;
@@ -424,7 +424,7 @@ void cube_indices(const Elem * elem,
       const Point min_point = get_min_point(elem, 0, 1, 5, 4);
 
       if (elem->point(0) == min_point)
-        if (elem->point(1) == std::min(elem->point(1), elem->point(4)))
+        if (!elem->positive_face_orientation(1))
           {
             // Case 1
             xi   = xi_saved;
@@ -438,7 +438,7 @@ void cube_indices(const Elem * elem,
           }
 
       else if (elem->point(1) == min_point)
-        if (elem->point(5) == std::min(elem->point(5), elem->point(0)))
+        if (!elem->positive_face_orientation(1))
           {
             // Case 3
             xi   = zeta_saved;
@@ -452,7 +452,7 @@ void cube_indices(const Elem * elem,
           }
 
       else if (elem->point(5) == min_point)
-        if (elem->point(4) == std::min(elem->point(4), elem->point(1)))
+        if (!elem->positive_face_orientation(1))
           {
             // Case 5
             xi   = -xi_saved;
@@ -467,7 +467,7 @@ void cube_indices(const Elem * elem,
 
       else if (elem->point(4) == min_point)
         {
-          if (elem->point(0) == std::min(elem->point(0), elem->point(5)))
+          if (!elem->positive_face_orientation(1))
             {
               // Case 7
               xi   = -xi_saved;
@@ -491,7 +491,7 @@ void cube_indices(const Elem * elem,
       const Point min_point = get_min_point(elem, 1, 2, 6, 5);
 
       if (elem->point(1) == min_point)
-        if (elem->point(2) == std::min(elem->point(2), elem->point(5)))
+        if (!elem->positive_face_orientation(2))
           {
             // Case 1
             eta  = eta_saved;
@@ -505,7 +505,7 @@ void cube_indices(const Elem * elem,
           }
 
       else if (elem->point(2) == min_point)
-        if (elem->point(6) == std::min(elem->point(6), elem->point(1)))
+        if (!elem->positive_face_orientation(2))
           {
             // Case 3
             eta  = zeta_saved;
@@ -519,7 +519,7 @@ void cube_indices(const Elem * elem,
           }
 
       else if (elem->point(6) == min_point)
-        if (elem->point(5) == std::min(elem->point(5), elem->point(2)))
+        if (!elem->positive_face_orientation(2))
           {
             // Case 5
             eta  = -eta_saved;
@@ -534,7 +534,7 @@ void cube_indices(const Elem * elem,
 
       else if (elem->point(5) == min_point)
         {
-          if (elem->point(1) == std::min(elem->point(1), elem->point(6)))
+          if (!elem->positive_face_orientation(2))
             {
               // Case 7
               eta  = -zeta_saved;
@@ -558,7 +558,7 @@ void cube_indices(const Elem * elem,
       const Point min_point = get_min_point(elem, 2, 3, 7, 6);
 
       if (elem->point(3) == min_point)
-        if (elem->point(2) == std::min(elem->point(2), elem->point(7)))
+        if (elem->positive_face_orientation(3))
           {
             // Case 1
             xi   = xi_saved;
@@ -572,7 +572,7 @@ void cube_indices(const Elem * elem,
           }
 
       else if (elem->point(7) == min_point)
-        if (elem->point(3) == std::min(elem->point(3), elem->point(6)))
+        if (elem->positive_face_orientation(3))
           {
             // Case 3
             xi   = -zeta_saved;
@@ -586,7 +586,7 @@ void cube_indices(const Elem * elem,
           }
 
       else if (elem->point(6) == min_point)
-        if (elem->point(7) == std::min(elem->point(7), elem->point(2)))
+        if (elem->positive_face_orientation(3))
           {
             // Case 5
             xi   = -xi_saved;
@@ -601,7 +601,7 @@ void cube_indices(const Elem * elem,
 
       else if (elem->point(2) == min_point)
         {
-          if (elem->point(6) == std::min(elem->point(3), elem->point(6)))
+          if (elem->positive_face_orientation(3))
             {
               // Case 7
               xi   = zeta_saved;
@@ -625,7 +625,7 @@ void cube_indices(const Elem * elem,
       const Point min_point = get_min_point(elem, 3, 0, 4, 7);
 
       if (elem->point(0) == min_point)
-        if (elem->point(3) == std::min(elem->point(3), elem->point(4)))
+        if (elem->positive_face_orientation(4))
           {
             // Case 1
             eta  = eta_saved;
@@ -639,7 +639,7 @@ void cube_indices(const Elem * elem,
           }
 
       else if (elem->point(4) == min_point)
-        if (elem->point(0) == std::min(elem->point(0), elem->point(7)))
+        if (elem->positive_face_orientation(4))
           {
             // Case 3
             eta  = -zeta_saved;
@@ -653,7 +653,7 @@ void cube_indices(const Elem * elem,
           }
 
       else if (elem->point(7) == min_point)
-        if (elem->point(4) == std::min(elem->point(4), elem->point(3)))
+        if (elem->positive_face_orientation(4))
           {
             // Case 5
             eta  = -eta_saved;
@@ -668,7 +668,7 @@ void cube_indices(const Elem * elem,
 
       else if (elem->point(3) == min_point)
         {
-          if (elem->point(7) == std::min(elem->point(7), elem->point(0)))
+          if (elem->positive_face_orientation(4))
             {
               // Case 7
               eta   = zeta_saved;
@@ -692,7 +692,7 @@ void cube_indices(const Elem * elem,
       const Point min_point = get_min_point(elem, 4, 5, 6, 7);
 
       if (elem->point(4) == min_point)
-        if (elem->point(5) == std::min(elem->point(5), elem->point(7)))
+        if (!elem->positive_face_orientation(5))
           {
             // Case 1
             xi  = xi_saved;
@@ -706,7 +706,7 @@ void cube_indices(const Elem * elem,
           }
 
       else if (elem->point(5) == min_point)
-        if (elem->point(6) == std::min(elem->point(6), elem->point(4)))
+        if (!elem->positive_face_orientation(5))
           {
             // Case 3
             xi  = eta_saved;
@@ -720,7 +720,7 @@ void cube_indices(const Elem * elem,
           }
 
       else if (elem->point(6) == min_point)
-        if (elem->point(7) == std::min(elem->point(7), elem->point(5)))
+        if (!elem->positive_face_orientation(5))
           {
             // Case 5
             xi  = -xi_saved;
@@ -735,7 +735,7 @@ void cube_indices(const Elem * elem,
 
       else if (elem->point(7) == min_point)
         {
-          if (elem->point(4) == std::min(elem->point(4), elem->point(6)))
+          if (!elem->positive_face_orientation(5))
             {
               // Case 7
               xi  = -eta_saved;
@@ -850,7 +850,7 @@ void prism_indices(const Elem * elem,
 
       if (elem->point(0) == min_point)
         {
-          if (elem->point(1) == std::min(elem->point(1), elem->point(3)))
+          if (!elem->positive_face_orientation(1))
             {
               // Case 1: no flips needed
               i01 = s0+1; // edge to triangle side 0 numbering
@@ -867,7 +867,7 @@ void prism_indices(const Elem * elem,
         }
       else if (elem->point(3) == min_point)
         {
-          if (elem->point(0) == std::min(elem->point(0), elem->point(4)))
+          if (!elem->positive_face_orientation(1))
             {
               // Case 3: 0->3->4->1->0 rotation
               i01 = s1+1;
@@ -883,10 +883,9 @@ void prism_indices(const Elem * elem,
               zeta = -zeta_saved;
             }
         }
-
       else if (elem->point(1) == min_point)
         {
-          if (elem->point(4) == std::min(elem->point(4), elem->point(0)))
+          if (!elem->positive_face_orientation(1))
             {
               // Case 5: 0->1->4->3->0 rotation
               i01 = s1+1;
@@ -904,7 +903,7 @@ void prism_indices(const Elem * elem,
         }
       else if (elem->point(4) == min_point)
         {
-          if (elem->point(3) == std::min(elem->point(3), elem->point(1)))
+          if (!elem->positive_face_orientation(1))
             {
               // Case 7: 180 degree rotation
               i01 = s0+1;
@@ -942,7 +941,7 @@ void prism_indices(const Elem * elem,
 
       if (elem->point(1) == min_point)
         {
-          if (elem->point(2) == std::min(elem->point(2), elem->point(4)))
+          if (!elem->positive_face_orientation(2))
             {
               // Case 1: no flips needed
               i01 = s0+1+3; // edge to triangle side 1 numbering
@@ -961,7 +960,7 @@ void prism_indices(const Elem * elem,
         }
       else if (elem->point(4) == min_point)
         {
-          if (elem->point(1) == std::min(elem->point(1), elem->point(5)))
+          if (!elem->positive_face_orientation(2))
             {
               // Case 3: 1->4->5->2->1 rotation
               i01 = s1+1+e;
@@ -979,10 +978,9 @@ void prism_indices(const Elem * elem,
               zeta = -zeta_saved;
             }
         }
-
       else if (elem->point(2) == min_point)
         {
-          if (elem->point(5) == std::min(elem->point(5), elem->point(1)))
+          if (!elem->positive_face_orientation(2))
             {
               // Case 5: 1->2->5->4->1 rotation
               i01 = s1+1+e;
@@ -1004,7 +1002,7 @@ void prism_indices(const Elem * elem,
         }
       else if (elem->point(5) == min_point)
         {
-          if (elem->point(4) == std::min(elem->point(4), elem->point(2)))
+          if (!elem->positive_face_orientation(2))
             {
               // Case 7: 180 degree rotation
               i01 = s0+1+e;
@@ -1046,7 +1044,7 @@ void prism_indices(const Elem * elem,
 
       if (elem->point(2) == min_point)
         {
-          if (elem->point(0) == std::min(elem->point(0), elem->point(5)))
+          if (!elem->positive_face_orientation(3))
             {
               // Case 1: no flips needed
               i01 = s0+1+2*e; // edge to triangle side 2 numbering
@@ -1064,7 +1062,7 @@ void prism_indices(const Elem * elem,
         }
       else if (elem->point(5) == min_point)
         {
-          if (elem->point(2) == std::min(elem->point(2), elem->point(3)))
+          if (!elem->positive_face_orientation(3))
             {
               // Case 3: 2->5->3->0->2 rotation
               i01 = s1+1+2*e;
@@ -1083,7 +1081,7 @@ void prism_indices(const Elem * elem,
         }
       else if (elem->point(0) == min_point)
         {
-          if (elem->point(3) == std::min(elem->point(3), elem->point(2)))
+          if (!elem->positive_face_orientation(3))
             {
               // Case 5: 2->0->3->5->2 rotation
               i01 = s1+1+2*e;
@@ -1103,7 +1101,7 @@ void prism_indices(const Elem * elem,
         }
       else if (elem->point(3) == min_point)
         {
-          if (elem->point(5) == std::min(elem->point(5), elem->point(0)))
+          if (!elem->positive_face_orientation(3))
             {
               // Case 7: 180 degree rotation
               i01 = s0+1+2*e;

--- a/src/fe/fe_szabab_shape_2D.C
+++ b/src/fe/fe_szabab_shape_2D.C
@@ -59,14 +59,12 @@ Real quad_flip(const Elem * elem,
   libmesh_assert_less(edge, 4);
   libmesh_assert_greater_equal(edge, 0);
 
-  const int edge_end = (edge+1)%4;
-
   const int edge_i = i - 4 - edge*(totalorder-1);
 
   // The "natural" orientation is p1>p0 on edge 0,
   // p2>p1 on e1, p2>p3 on e2, p3>p0 on e3
   if (edge_i%2 &&
-      ((elem->point(edge) > elem->point(edge_end)) ==
+      (elem->positive_edge_orientation(edge) ==
        (edge < 2)))
     return -1;
 
@@ -181,9 +179,9 @@ Real FE<2,SZABAB>::shape(const Elem * elem,
               libmesh_assert_less (i, 10);
 
 
-              if (i==4 && (elem->point(0) > elem->point(1)))f=-1;
-              if (i==6 && (elem->point(1) > elem->point(2)))f=-1;
-              if (i==8 && (elem->point(2) > elem->point(0)))f=-1;
+              if (i==4 && elem->positive_edge_orientation(0))f=-1;
+              if (i==6 && elem->positive_edge_orientation(1))f=-1;
+              if (i==8 && elem->positive_edge_orientation(2))f=-1;
 
 
               switch (i)
@@ -258,9 +256,9 @@ Real FE<2,SZABAB>::shape(const Elem * elem,
               libmesh_assert_less (i, 15);
 
 
-              if (i== 4 && (elem->point(0) > elem->point(1)))f=-1;
-              if (i== 7 && (elem->point(1) > elem->point(2)))f=-1;
-              if (i==10 && (elem->point(2) > elem->point(0)))f=-1;
+              if (i== 4 && elem->positive_edge_orientation(0))f=-1;
+              if (i== 7 && elem->positive_edge_orientation(1))f=-1;
+              if (i==10 && elem->positive_edge_orientation(2))f=-1;
 
 
               switch (i)
@@ -344,9 +342,9 @@ Real FE<2,SZABAB>::shape(const Elem * elem,
               libmesh_assert_less (i, 21);
 
 
-              if ((i== 4||i== 6) && (elem->point(0) > elem->point(1)))f=-1;
-              if ((i== 8||i==10) && (elem->point(1) > elem->point(2)))f=-1;
-              if ((i==12||i==14) && (elem->point(2) > elem->point(0)))f=-1;
+              if ((i== 4||i== 6) && elem->positive_edge_orientation(0))f=-1;
+              if ((i== 8||i==10) && elem->positive_edge_orientation(1))f=-1;
+              if ((i==12||i==14) && elem->positive_edge_orientation(2))f=-1;
 
 
               switch (i)
@@ -436,9 +434,9 @@ Real FE<2,SZABAB>::shape(const Elem * elem,
               libmesh_assert_less (i, 28);
 
 
-              if ((i== 4||i== 6) && (elem->point(0) > elem->point(1)))f=-1;
-              if ((i== 9||i==11) && (elem->point(1) > elem->point(2)))f=-1;
-              if ((i==14||i==16) && (elem->point(2) > elem->point(0)))f=-1;
+              if ((i== 4||i== 6) && elem->positive_edge_orientation(0))f=-1;
+              if ((i== 9||i==11) && elem->positive_edge_orientation(1))f=-1;
+              if ((i==14||i==16) && elem->positive_edge_orientation(2))f=-1;
 
 
               switch (i)
@@ -540,9 +538,9 @@ Real FE<2,SZABAB>::shape(const Elem * elem,
               libmesh_assert_less (i, 36);
 
 
-              if ((i>= 4&&i<= 8) && (elem->point(0) > elem->point(1)))f=-1;
-              if ((i>=10&&i<=14) && (elem->point(1) > elem->point(2)))f=-1;
-              if ((i>=16&&i<=20) && (elem->point(2) > elem->point(0)))f=-1;
+              if ((i>= 4&&i<= 8) && elem->positive_edge_orientation(0))f=-1;
+              if ((i>=10&&i<=14) && elem->positive_edge_orientation(1))f=-1;
+              if ((i>=16&&i<=20) && elem->positive_edge_orientation(2))f=-1;
 
 
               switch (i)

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -3428,22 +3428,14 @@ Elem::positive_face_orientation(const unsigned int i) const
   const unsigned int N = Elem::type_to_n_sides_map[this->side_type(i)];
 
   const std::vector<unsigned int> nodes = this->nodes_on_side(i);
-  std::vector<Point> vertices(N);
-  std::transform(nodes.begin(), nodes.begin() + N, vertices.begin(),
-                 [&](unsigned int n) { return this->point(n); });
 
-  for (unsigned int j = 0; j < N - 3; j++)
-    std::rotate(vertices.begin() + j,
-                std::min_element(vertices.begin() + j, vertices.end()),
-                vertices.end());
+  auto cmp = [&](const unsigned int & m, const unsigned int & n) -> bool
+             { return this->point(m) < this->point(n); };
 
-  unsigned int cnt = 0;
-  for (unsigned int j = N - 3; j < N; j++)
-    for (unsigned int k = j + 1; k < N; k++)
-      if (vertices[j] > vertices[k])
-        cnt++;
+  const unsigned int V = std::distance(nodes.begin(),
+                         std::min_element(nodes.begin(), nodes.begin() + N, cmp));
 
-  return cnt % 2;
+  return cmp(nodes[(V + N - 1) % N], nodes[(V + 1) % N]);
 }
 
 } // namespace libMesh


### PR DESCRIPTION
Hi,

Though this keeps lexicographic ordering on the point coordinates as the orientation-determining factor, there is now both a single place where we determine edge orientations, `Elem::positive_edge_orientation()`, and a single place where we determine face orientations, `Elem::positive_face_orientation()`, for the entire codebase. This should make things easier if and when we decide to switch to comparing ids instead.

Cheers,
Nuno