### PR TITLE
Use get_order() in gauss quadrature code

### DIFF
--- a/src/quadrature/quadrature_gauss_2D.C
+++ b/src/quadrature/quadrature_gauss_2D.C
@@ -60,13 +60,7 @@ void QGauss::init_2D()
         // x^2    xy     y^2
         //    yx^2   xy^2
         //       x^2y^2
-        //
-        // Rather than construct a 1D quadrature rule (which inits it)
-        // and then reinit it with a potentially-elevated p-level, we
-        // add twice that p-level (as is our standard behavior,
-        // sensible for typical inner product integrals) to the order
-        // to get the desired p-elevated order.
-        QGauss q1D(1,_order + 2*_p_level);
+        QGauss q1D(1,get_order());
         tensor_product_quad( q1D );
         return;
       }

--- a/src/quadrature/quadrature_gauss_3D.C
+++ b/src/quadrature/quadrature_gauss_3D.C
@@ -42,13 +42,7 @@ void QGauss::init_3D()
       {
         // We compute the 3D quadrature rule as a tensor
         // product of the 1D quadrature rule.
-        //
-        // Rather than construct a 1D quadrature rule (which inits it)
-        // and then reinit it with a potentially-elevated p-level, we
-        // add twice that p-level (as is our standard behavior,
-        // sensible for typical inner product integrals) to the order
-        // to get the desired p-elevated order.
-        QGauss q1D(1, _order + 2*_p_level);
+        QGauss q1D(1, get_order());
         tensor_product_hex( q1D );
         return;
       }
@@ -517,12 +511,7 @@ void QGauss::init_3D()
         // product of the 1D quadrature rule and a 2D
         // triangle quadrature rule
 
-        // Rather than construct a 1D quadrature rule (which inits it)
-        // and then reinit it with a potentially-elevated p-level, we
-        // add twice that p-level (as is our standard behavior,
-        // sensible for typical inner product integrals) to the order
-        // to get the desired p-elevated order.
-        QGauss q1D(1,_order + 2*_p_level);
+        QGauss q1D(1,get_order());
         QGauss q2D(2,_order);
 
         // Initialize the 2D rule (1D is pre-initialized)

--- a/src/quadrature/quadrature_gauss_lobatto_2D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_2D.C
@@ -38,13 +38,7 @@ void QGaussLobatto::init_2D()
       {
         // We compute the 2D quadrature rule as a tensor
         // product of the 1D quadrature rule.
-        //
-        // Rather than construct a 1D quadrature rule (which inits it)
-        // and then reinit it with a potentially-elevated p-level, we
-        // add twice that p-level (as is our standard behavior,
-        // sensible for typical inner product integrals) to the order
-        // to get the desired p-elevated order.
-        QGaussLobatto q1D(1, _order + 2*_p_level);
+        QGaussLobatto q1D(1, get_order());
         tensor_product_quad(q1D);
         return;
       }

--- a/src/quadrature/quadrature_gauss_lobatto_3D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_3D.C
@@ -35,13 +35,7 @@ void QGaussLobatto::init_3D()
       {
         // We compute the 3D quadrature rule as a tensor
         // product of the 1D quadrature rule.
-        //
-        // Rather than construct a 1D quadrature rule (which inits it)
-        // and then reinit it with a potentially-elevated p-level, we
-        // add twice that p-level (as is our standard behavior,
-        // sensible for typical inner product integrals) to the order
-        // to get the desired p-elevated order.
-        QGaussLobatto q1D(1, _order + 2*_p_level);
+        QGaussLobatto q1D(1, get_order());
         tensor_product_hex(q1D);
         return;
       }


### PR DESCRIPTION
In case someday we ever want to change things in a centralized way? But also we should be consistent about using get_order where we can