### PR TITLE
Netgen reconfigure fix

### DIFF
--- a/configure
+++ b/configure
@@ -55270,7 +55270,8 @@ then :
 
                               my_top_builddir="$(pwd)"
 
-                              rm -rf contrib/netgen/build
+                                                  rm -f contrib/netgen/.buildstamp
+          rm -rf contrib/netgen/build
           mkdir -p contrib/netgen/build
 
                                         mkdir -p contrib/netgen/install

--- a/m4/netgen.m4
+++ b/m4/netgen.m4
@@ -46,8 +46,11 @@ AC_DEFUN([CONFIGURE_NETGEN],
           dnl apparently not?
           my_top_builddir="$(pwd)"
 
-          dnl Wipe the old build directory, because it can corrupt a
-          dnl "fresh" cmake, because cmake sucks
+          dnl Wipe the old build directory (along with our .buildstamp
+          dnl that lets us know a build is complete there), because an
+          dnl old build can corrupt a "fresh" cmake, because cmake
+          dnl sucks
+          rm -f contrib/netgen/.buildstamp
           rm -rf contrib/netgen/build
           mkdir -p contrib/netgen/build
 


### PR DESCRIPTION
Previously, if you re-ran configure (or had it re-run for you after a build system change) in a build directory where you had built Netgen and where your new configuration included Netgen, your subsequent make would fail at link time, because we were cleaning up the build directory without cleaning up the build stamp file.