### PR TITLE
Use proxy neighbors everywhere in SimplexRefiner

### DIFF
--- a/src/mesh/simplex_refiner.C
+++ b/src/mesh/simplex_refiner.C
@@ -225,8 +225,8 @@ std::size_t SimplexRefiner::refine_via_edges(Elem & elem,
   // (which can't reconstruct them from scratch), and we need at least
   // placeholder neighbors to make sure we'll have good processor_id()
   // options for new nodes in future splits of the same edge.
-  subelem[0]->set_neighbor(1, subelem[1].get());
-  subelem[1]->set_neighbor(0, subelem[0].get());
+  subelem[0]->set_neighbor(1, proxy_elements[elem.processor_id()].get());
+  subelem[1]->set_neighbor(0, proxy_elements[elem.processor_id()].get());
 
   BoundaryInfo & boundary_info = _mesh.get_boundary_info();
   std::vector<boundary_id_type> bc_ids;


### PR DESCRIPTION
Even these subelems could get removed by later refinement, leaving dangling pointers that valgrind (6 months later!?) caught.

This isn't all of our recent Valgrind failures, but it's a start.  I wonder if our CI valgrind upgraded to a smarter version recently, or if new unit tests just finally managed to kick the heap into a state where some of this undefined behavior had its consequences changed from "dumb luck" to "obvious corruption".  I hope to fix the rest too, [before it gets any worse](http://www.catb.org/jargon/html/N/nasal-demons.html).