### PR TITLE
Fix FE::n_quadrature_points() when not using the qrule

### DIFF
--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -634,13 +634,6 @@ public:
    */
   virtual void attach_quadrature_rule (QBase * q) override;
 
-  /**
-   * \returns The total number of quadrature points.  Call this
-   * to get an upper bound for the \p for loop in your simulation
-   * for matrix assembly of the current element.
-   */
-  virtual unsigned int n_quadrature_points () const override;
-
 #ifdef LIBMESH_ENABLE_AMR
   /**
    * Computes the constraint matrix contributions (for

--- a/include/fe/fe_abstract.h
+++ b/include/fe/fe_abstract.h
@@ -483,10 +483,10 @@ public:
   virtual unsigned int n_shape_functions () const = 0;
 
   /**
-   * \returns The total number of quadrature points.  Useful
-   * during matrix assembly.  Implement this in derived classes.
+   * \returns The total number of quadrature points with which this
+   * was last reinitialized.  Useful during matrix assembly.
    */
-  virtual unsigned int n_quadrature_points () const = 0;
+  virtual unsigned int n_quadrature_points () const;
 
   /**
    * \returns The element that the current shape functions have been
@@ -766,6 +766,12 @@ protected:
    * correspond to quadrature rule points
    */
   bool shapes_on_quadrature;
+
+  /**
+   * The total number of quadrature points
+   * for the current configuration
+   */
+  unsigned int _n_total_qp;
 
   /**
    * \returns \p true when the shape functions (for

--- a/include/fe/fe_macro.h
+++ b/include/fe/fe_macro.h
@@ -45,7 +45,6 @@
   template LIBMESH_EXPORT FE<2,SUBDIVISION>::FE(const FEType & fet); \
   template LIBMESH_EXPORT unsigned int FE<2,SUBDIVISION>::n_shape_functions () const;  \
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::attach_quadrature_rule (QBase *); \
-  template LIBMESH_EXPORT unsigned int FE<2,SUBDIVISION>::n_quadrature_points () const; \
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::reinit(const Elem *,const std::vector<Point> * const,const std::vector<Real> * const); \
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::init_base_shape_functions(const std::vector<Point> &, const Elem *); \
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::init_shape_functions(const std::vector<Point> &, const Elem *); \
@@ -59,7 +58,6 @@
   template LIBMESH_EXPORT FE<2,SUBDIVISION>::FE(const FEType & fet);                     \
   template LIBMESH_EXPORT unsigned int FE<2,SUBDIVISION>::n_shape_functions () const;  \
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::attach_quadrature_rule (QBase *); \
-  template LIBMESH_EXPORT unsigned int FE<2,SUBDIVISION>::n_quadrature_points () const; \
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::reinit(const Elem *,const std::vector<Point> * const,const std::vector<Real> * const); \
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::init_shape_functions(const std::vector<Point> &, const Elem *); \
   template LIBMESH_EXPORT void         FE<2,SUBDIVISION>::init_dual_shape_functions(unsigned int, unsigned int); \

--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -575,8 +575,7 @@ public:
    * for matrix assembly of the current element.
    */
   virtual unsigned int n_quadrature_points () const override
-  { libmesh_assert(radial_qrule); return _n_total_qp; }
-
+  { libmesh_assert(radial_qrule); return this->_n_total_qp; }
 
   /**
    * \returns the \p xyz spatial locations of the quadrature
@@ -1189,12 +1188,6 @@ protected:
    * the current configuration
    */
   unsigned int _n_total_approx_sf;
-
-  /**
-   * The total number of quadrature points
-   * for the current configuration
-   */
-  unsigned int _n_total_qp;
 
   /**
    * this vector contains the combined integration weights, so

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -82,14 +82,6 @@ void FE<Dim,T>::attach_quadrature_rule (QBase * q)
 
 
 template <unsigned int Dim, FEFamily T>
-unsigned int FE<Dim,T>::n_quadrature_points () const
-{
-  libmesh_assert(this->qrule);
-  return this->qrule->n_points();
-}
-
-
-template <unsigned int Dim, FEFamily T>
 void FE<Dim,T>::dofs_on_side(const Elem * const elem,
                              const Order o,
                              unsigned int s,
@@ -412,6 +404,7 @@ void FE<Dim,T>::init_shape_functions(const std::vector<Point> & qp,
 
   // The number of quadrature points.
   const unsigned int n_qp = cast_int<unsigned int>(qp.size());
+  this->_n_total_qp = n_qp;
 
   // Number of shape functions in the finite element approximation
   // space.

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -66,6 +66,7 @@ FEAbstract::FEAbstract(const unsigned int d,
   _p_level(0),
   qrule(nullptr),
   shapes_on_quadrature(false),
+  _n_total_qp(0),
   _add_p_level_in_reinit(true)
 {
 }
@@ -1274,5 +1275,16 @@ void FEAbstract::compute_periodic_node_constraints (NodeConstraints & constraint
 
 #endif // LIBMESH_ENABLE_PERIODIC
 
+
+unsigned int FEAbstract::n_quadrature_points () const
+{
+  if (this->shapes_on_quadrature)
+    {
+      libmesh_assert(this->qrule);
+      libmesh_assert_equal_to(this->qrule->n_points(),
+                              this->_n_total_qp);
+    }
+  return this->_n_total_qp;
+}
 
 } // namespace libMesh

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -49,7 +49,6 @@ InfFE<Dim,T_radial,T_map>::InfFE (const FEType & fet) :
   calculate_xyz(false),
   calculate_jxw(false),
   _n_total_approx_sf (0),
-  _n_total_qp        (0),
 
   // initialize the current_fe_type to all the same
   // values as \p fet (since the FE families and coordinate

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -320,6 +320,7 @@ void FEMContext::some_value(unsigned int var, unsigned int qp, OutputType & u) c
 
   // Get current local coefficients
   const DenseSubVector<Number> & coef = (this->*subsolution_getter)(var);
+  libmesh_assert_equal_to(coef.size(), n_dofs);
 
   // Get finite element object
   typename FENeeded<OutputType>::value_base * fe = nullptr;
@@ -328,12 +329,16 @@ void FEMContext::some_value(unsigned int var, unsigned int qp, OutputType & u) c
   // Get shape function values at quadrature point
   const std::vector<std::vector
                     <typename FENeeded<OutputType>::value_shape>> & phi = fe->get_phi();
+  libmesh_assert_equal_to(phi.size(), n_dofs);
 
   // Accumulate solution value
   u = 0.;
 
   for (unsigned int l=0; l != n_dofs; l++)
-    u += phi[l][qp] * coef(l);
+    {
+      libmesh_assert_less(qp, phi[l].size());
+      u += phi[l][qp] * coef(l);
+    }
 }
 
 


### PR DESCRIPTION
We weren't doing anything to track quadrature point counts in cases where we supplied a vector of points rather than relied on the qrule, and this was causing n_quadrature_points() to return potentially-erroneous values.

This was causing errors in JumpErrorEstimator subclasses, including a valgrind failure in one of our slit mesh unit tests.

This change fixes the OOB; hopefully CI doesn't find anything it regresses.  I'm worried about the possibility of fixed calculation errors in the indicators us exodiffs on MOOSE adaptivity tests.