### PR TITLE
Move demangle into libmesh_common

### DIFF
--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -54,6 +54,7 @@
 #include <typeinfo> // std::bad_cast
 #include <type_traits> // std::decay
 #include <functional> // std::less, etc
+#include <string>
 
 // Include the MPI definition
 #ifdef LIBMESH_HAVE_MPI
@@ -528,6 +529,10 @@ void libmesh_merge_move(T & target, T & source)
 }
 #endif // LIBMESH_HAVE_CXX17_SPLICING
 
+/**
+ * Mostly system independent demangler
+ */
+ std::string demangle(const char * name);
 
 // cast_ref and cast_ptr do a dynamic cast and assert
 // the result, if we have RTTI enabled and we're in debug or
@@ -547,12 +552,12 @@ inline Tnew cast_ref(Told & oldvar)
     }
   catch (std::bad_cast &)
     {
-      libMesh::err << "Failed to convert " << typeid(Told).name()
-                   << " reference to " << typeid(Tnew).name()
+      libMesh::err << "Failed to convert " << demangle(typeid(Told).name())
+                   << " reference to " << demangle(typeid(Tnew).name())
                    << std::endl;
-      libMesh::err << "The " << typeid(Told).name()
+      libMesh::err << "The " << demangle(typeid(Told).name())
                    << " appears to be a "
-                   << typeid(*(&oldvar)).name() << std::endl;
+                   << demangle(typeid(*(&oldvar)).name()) << std::endl;
       libmesh_error();
     }
 #else
@@ -569,12 +574,12 @@ inline Tnew cast_ptr (Told * oldvar)
   Tnew newvar = dynamic_cast<Tnew>(oldvar);
   if (!newvar)
     {
-      libMesh::err << "Failed to convert " << typeid(Told).name()
-                   << " pointer to " << typeid(Tnew).name()
+      libMesh::err << "Failed to convert " << demangle(typeid(Told).name())
+                   << " pointer to " << demangle(typeid(Tnew).name())
                    << std::endl;
-      libMesh::err << "The " << typeid(Told).name()
+      libMesh::err << "The " << demangle(typeid(Told).name())
                    << " appears to be a "
-                   << typeid(*oldvar).name() << std::endl;
+                   << demangle(typeid(*oldvar).name()) << std::endl;
       libmesh_error();
     }
   return newvar;

--- a/include/base/print_trace.h
+++ b/include/base/print_trace.h
@@ -33,11 +33,6 @@ namespace libMesh
 void print_trace(std::ostream & out_stream = std::cerr);
 
 /**
- * Mostly system independent demangler
- */
-std::string demangle(const char * name);
-
-/**
  * Writes a stack trace to a uniquely named file if
  * --enable-tracefiles has been set by configure, otherwise does
  * nothing.

--- a/src/base/print_trace.C
+++ b/src/base/print_trace.C
@@ -68,10 +68,6 @@
 #include <execinfo.h>
 #endif
 
-#if defined(LIBMESH_HAVE_GCC_ABI_DEMANGLE)
-#include <cxxabi.h>
-#endif
-
 // Anonymous namespace for print_trace() helper functions
 namespace
 {
@@ -250,34 +246,5 @@ void write_traceout()
   libMesh::print_trace(traceout);
 #endif
 }
-
-
-
-// demangle() is used by the process_trace() helper function.  It is
-// also used by the Parameters class for demangling typeid's.  If
-// configure determined that your compiler does not support
-// demangling, it simply returns the input string.
-#if defined(LIBMESH_HAVE_GCC_ABI_DEMANGLE)
-std::string demangle(const char * name)
-{
-  int status = 0;
-  std::string ret = name;
-
-  // Actually do the demangling
-  char * demangled_name = abi::__cxa_demangle(name, 0, 0, &status);
-
-  // If demangling returns non-nullptr, save the result in a string.
-  if (demangled_name)
-    ret = demangled_name;
-
-  // According to cxxabi.h docs, the caller is responsible for
-  // deallocating memory.
-  std::free(demangled_name);
-
-  return ret;
-}
-#else
-std::string demangle(const char * name) { return std::string(name); }
-#endif
 
 } // namespace libMesh


### PR DESCRIPTION
Then we can use it in `cast_ref` and `cast_ptr`