### PR TITLE
Mesh stitching: Consider boundary NodeElem separation distances when computing h_min

### DIFF
--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -1989,7 +1989,7 @@ UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
 #endif
         }
 
-      if (this_boundary_node_ids.size())
+      if (!this_boundary_node_ids.empty())
       {
         if (use_binary_search)
         {
@@ -1999,12 +1999,12 @@ UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
 
           // Create the dataset needed to build the kd tree with nanoflann
           std::vector<std::pair<Point, dof_id_type>> this_mesh_nodes(this_boundary_node_ids.size());
-          std::set<dof_id_type>::iterator current_node = this_boundary_node_ids.begin(),
-                                          node_ids_end = this_boundary_node_ids.end();
-          for (unsigned int ctr = 0; current_node != node_ids_end; ++current_node, ++ctr)
+
+          for (auto [it, ctr] = std::make_tuple(this_boundary_node_ids.begin(), 0u);
+               it != this_boundary_node_ids.end(); ++it, ++ctr)
           {
-            this_mesh_nodes[ctr].first = this->point(*current_node);
-            this_mesh_nodes[ctr].second = *current_node;
+            this_mesh_nodes[ctr].first = this->point(*it);
+            this_mesh_nodes[ctr].second = *it;
           }
 
           VectorOfNodesAdaptor vec_nodes_adaptor(this_mesh_nodes);

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -2017,20 +2017,22 @@ UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
           Real ret_dist_sqr;
 
           // Loop over other mesh. For each node, find its nearest neighbor in this mesh, and fill in the maps.
-          for (auto node : other_boundary_node_ids)
+          for (const auto & node_id : other_boundary_node_ids)
           {
-            const Real query_pt[] = {other_mesh->point(node)(0), other_mesh->point(node)(1), other_mesh->point(node)(2)};
+            const auto & p = other_mesh->point(node_id);
+            const Real query_pt[] = {p(0), p(1), p(2)};
             this_kd_tree.knnSearch(&query_pt[0], 1, &ret_index, &ret_dist_sqr);
             if (ret_dist_sqr < TOLERANCE*TOLERANCE)
             {
-              node_to_node_map[this_mesh_nodes[ret_index].second] = node;
-              other_to_this_node_map[node] = this_mesh_nodes[ret_index].second;
+              node_to_node_map[this_mesh_nodes[ret_index].second] = node_id;
+              other_to_this_node_map[node_id] = this_mesh_nodes[ret_index].second;
             }
           }
 
-          // If the 2 maps don't have the same size, it means we have overwritten a value in node_to_node_map
-          // It means one node in this mesh is the nearest neighbor of several nodes in other mesh.
-          // Not possible !
+          // If the two maps don't have the same size, it means one
+          // node in this mesh is the nearest neighbor of several
+          // nodes in other mesh. Since the stitching is ambiguous in
+          // this case, we throw an error.
           libmesh_error_msg_if(node_to_node_map.size() != other_to_this_node_map.size(),
                                "Error: Found multiple matching nodes in stitch_meshes");
 #endif


### PR DESCRIPTION
Previously, we used the `Elem::hmin()` values for boundary elem sides and edges to determine `h_min`, a value used in conjunction with the user-provided `tol` to do tolerance checks during mesh stitching. This doesn't handle the case where an entire boundary nodeset is made up of Nodes attached only to NodeElems, though, since NodeElems don't have sides or edges. To fix that, this branch introduces the idea of computing the "minimum separation distance" between all NodeElems in the boundary set, and allowing that number to (potentially) be used as `h_min`. 

This fixes an actual test case we ran into where a mesh with a mix of very long 1D "beam" elements and NodeElems was using a large value (based on the beams) for `h_min` when it should have instead been using an `h_min` value based on the distance between the NodeElems. 

In the case where a boundary set being stitched contains only a single `NodeElem`, we will still fall back to using an absolute tolerance for the checks, as was done previously.