### PR TITLE
Drop LOG_SCOPE calls from DofMap::dof_indices()

### DIFF
--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2192,7 +2192,12 @@ void DofMap::dof_indices (const Elem * const elem,
   // active)
   libmesh_assert(!elem || elem->active());
 
-  LOG_SCOPE("dof_indices()", "DofMap");
+  // dof_indices() is a relatively light-weight function that is
+  // called millions of times in normal codes. Therefore, it is not a
+  // good candidate for logging, since the cost of the logging code
+  // itself is roughly on par with the time required to call
+  // dof_indices().
+  // LOG_SCOPE("dof_indices()", "DofMap");
 
   // Clear the DOF indices vector
   di.clear();
@@ -2320,7 +2325,12 @@ void DofMap::dof_indices (const Node * const node,
   // We allow node==nullptr to request just SCALAR dofs
   // libmesh_assert(elem);
 
-  LOG_SCOPE("dof_indices(Node)", "DofMap");
+  // dof_indices() is a relatively light-weight function that is
+  // called millions of times in normal codes. Therefore, it is not a
+  // good candidate for logging, since the cost of the logging code
+  // itself is roughly on par with the time required to call
+  // dof_indices().
+  // LOG_SCOPE("dof_indices(Node)", "DofMap");
 
   // Clear the DOF indices vector
   di.clear();
@@ -2375,7 +2385,12 @@ void DofMap::dof_indices (const Node * const node,
   // We allow node==nullptr to request just SCALAR dofs
   // libmesh_assert(elem);
 
-  LOG_SCOPE("dof_indices(Node)", "DofMap");
+  // dof_indices() is a relatively light-weight function that is
+  // called millions of times in normal codes. Therefore, it is not a
+  // good candidate for logging, since the cost of the logging code
+  // itself is roughly on par with the time required to call
+  // dof_indices().
+  // LOG_SCOPE("dof_indices(Node)", "DofMap");
 
   // Clear the DOF indices vector
   di.clear();


### PR DESCRIPTION
I would like to propose that we drop the `LOG_SCOPE` calls from the various `DofMap::dof_indices()` functions, because it appears to be both adding overhead to the simulation time while also not providing particularly useful timing information. For example, we often see cases like the following:
```
 -------------------------------------------------------------------------------------------------------------------------------
| Event                                            nCalls     Total Time  Avg Time    Total Time  Avg Time    % of Active Time  |
|                                                             w/o Sub     w/o Sub     With Sub    With Sub    w/o S    With S   |
|-------------------------------------------------------------------------------------------------------------------------------|
|   dof_indices()                                  31640150   7.6276      0.000000    7.6276      0.000000    0.93     0.93     |
```
where the average time per call ends up being less than 1 microsecond. It is therefore not really possible to tell how much of the reported time is just the time taken by the logging code vs. the time taken by `dof_indices()` itself.