### PR TITLE
More rigorous implementation and verification of mesh clone()

### DIFF
--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -117,7 +117,13 @@ public:
    * Virtual copy-constructor, creates a copy of this mesh
    */
   virtual std::unique_ptr<MeshBase> clone () const override
-  { return std::make_unique<DistributedMesh>(*this); }
+  {
+    auto returnval = std::make_unique<DistributedMesh>(*this);
+#ifdef DEBUG
+    libmesh_assert(*returnval == *this);
+#endif
+    return returnval;
+  }
 
   /**
    * Destructor.

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1818,6 +1818,12 @@ protected:
   void post_dofobject_moves(MeshBase && other_mesh);
 
   /**
+   * Helper class to copy cached data, to synchronize with a possibly
+   * unprepared \p other_mesh
+   */
+  void copy_cached_data (const MeshBase & other_mesh);
+
+  /**
    * Shim to allow operator == (&) to behave like a virtual function
    * without having to be one.
    */

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -123,6 +123,10 @@ public:
    * different Elem/Node addresses in memory) but not others (we do
    * not accept different subclass types, nor even different Elem/Node
    * ids).
+   *
+   * Though this method is non-virtual, its implementation calls the
+   * virtual function \p subclass_locally_equals() to test for
+   * equality of subclass-specific data as well.
    */
   bool operator== (const MeshBase & other_mesh) const;
 
@@ -138,9 +142,10 @@ public:
    */
   bool locally_equals (const MeshBase & other_mesh) const;
 
-
   /**
-   * Virtual "copy constructor"
+   * Virtual "copy constructor".  The copy will be of the same
+   * subclass as \p this, and will satisfy "copy == this" when it is
+   * created.
    */
   virtual std::unique_ptr<MeshBase> clone() const = 0;
 

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -103,7 +103,13 @@ public:
    * Virtual copy-constructor, creates a copy of this mesh
    */
   virtual std::unique_ptr<MeshBase> clone () const override
-  { return std::make_unique<ReplicatedMesh>(*this); }
+  {
+    auto returnval = std::make_unique<ReplicatedMesh>(*this);
+#ifdef DEBUG
+    libmesh_assert(*returnval == *this);
+#endif
+    return returnval;
+  }
 
   /**
    * Destructor.

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -192,6 +192,12 @@ DistributedMesh::DistributedMesh (const MeshBase & other_mesh) :
   _next_free_unpartitioned_elem_id(this->n_processors())
 {
   this->copy_nodes_and_elements(other_mesh, true);
+
+  // The prepare_for_use() in copy_nodes_and_elements() is going to be
+  // tricky to remove without breaking backwards compatibility, but it
+  // updates some things we want to just copy.
+  this->copy_cached_data(other_mesh);
+
   this->copy_constraint_rows(other_mesh);
 
   auto & this_boundary_info = this->get_boundary_info();

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -149,17 +149,12 @@ DistributedMesh::~DistributedMesh ()
 // make sure the compiler doesn't give us a default (non-deep) copy
 // constructor instead.
 DistributedMesh::DistributedMesh (const DistributedMesh & other_mesh) :
-  UnstructuredMesh (other_mesh), _is_serial(other_mesh._is_serial),
-  _is_serial_on_proc_0(other_mesh._is_serial_on_proc_0),
-  _deleted_coarse_elements(other_mesh._deleted_coarse_elements),
-  _n_nodes(0), _n_elem(0), _max_node_id(0), _max_elem_id(0),
-  _next_free_local_node_id(this->processor_id()),
-  _next_free_local_elem_id(this->processor_id()),
-  _next_free_unpartitioned_node_id(this->n_processors()),
-  _next_free_unpartitioned_elem_id(this->n_processors())
+  DistributedMesh(static_cast<const MeshBase &>(other_mesh))
 {
-  this->copy_nodes_and_elements(other_mesh, true);
-  this->copy_constraint_rows(other_mesh);
+  _is_serial = other_mesh._is_serial;
+  _is_serial_on_proc_0 = other_mesh._is_serial_on_proc_0;
+  _deleted_coarse_elements = other_mesh._deleted_coarse_elements;
+
   _n_nodes = other_mesh.n_nodes();
   _n_elem  = other_mesh.n_elem();
   _max_node_id = other_mesh.max_node_id();
@@ -178,13 +173,6 @@ DistributedMesh::DistributedMesh (const DistributedMesh & other_mesh) :
   _next_unpartitioned_unique_id =
     other_mesh._next_unpartitioned_unique_id;
 #endif
-
-  auto & this_boundary_info = this->get_boundary_info();
-  const auto & other_boundary_info = other_mesh.get_boundary_info();
-
-  this_boundary_info = other_boundary_info;
-
-  this->set_subdomain_name_map() = other_mesh.get_subdomain_name_map();
 
   // Need to copy extra_ghost_elems
   for (auto & elem : other_mesh._extra_ghost_elems)

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -1967,6 +1967,17 @@ MeshBase::post_dofobject_moves(MeshBase && other_mesh)
 }
 
 
+void
+MeshBase::copy_cached_data(const MeshBase & other_mesh)
+{
+  this->_spatial_dimension = other_mesh._spatial_dimension;
+  this->_elem_dims = other_mesh._elem_dims;
+  this->_elem_default_orders = other_mesh._elem_default_orders;
+  this->_supported_nodal_order = other_mesh._supported_nodal_order;
+  this->_mesh_subdomains = other_mesh._mesh_subdomains;
+}
+
+
 bool MeshBase::nodes_and_elements_equal(const MeshBase & other_mesh) const
 {
   for (const auto & other_node : other_mesh.node_ptr_range())

--- a/src/mesh/mesh_tet_interface.C
+++ b/src/mesh/mesh_tet_interface.C
@@ -28,6 +28,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/mesh_modification.h"
 #include "libmesh/mesh_serializer.h"
+#include "libmesh/mesh_tools.h"
 #include "libmesh/remote_elem.h"
 #include "libmesh/unstructured_mesh.h"
 
@@ -129,8 +130,10 @@ void MeshTetInterface::attach_hole_list
 
 BoundingBox MeshTetInterface::volume_to_surface_mesh(UnstructuredMesh & mesh)
 {
-  // If we've been handed an unprepared mesh then we need to fix that;
-  // we're relying on neighbor pointers here.
+  // If we've been handed an unprepared mesh then we need to be made
+  // aware of that and fix that; we're relying on neighbor pointers.
+  libmesh_assert(MeshTools::valid_is_prepared(mesh));
+
   if (!mesh.is_prepared())
     mesh.prepare_for_use();
 

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -102,6 +102,12 @@ ReplicatedMesh::ReplicatedMesh (const MeshBase & other_mesh) :
   _n_nodes(0), _n_elem(0) // copy_* will increment this
 {
   this->copy_nodes_and_elements(other_mesh, true);
+
+  // The prepare_for_use() in copy_nodes_and_elements() is going to be
+  // tricky to remove without breaking backwards compatibility, but it
+  // updates some things we want to just copy.
+  this->copy_cached_data(other_mesh);
+
   this->copy_constraint_rows(other_mesh);
 
   auto & this_boundary_info = this->get_boundary_info();

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -89,19 +89,8 @@ ReplicatedMesh::~ReplicatedMesh ()
 // make sure the compiler doesn't give us a default (non-deep) copy
 // constructor instead.
 ReplicatedMesh::ReplicatedMesh (const ReplicatedMesh & other_mesh) :
-  UnstructuredMesh (other_mesh),
-  _n_nodes(0), _n_elem(0) // copy_* will increment this
+  ReplicatedMesh(static_cast<const MeshBase&>(other_mesh))
 {
-  this->copy_nodes_and_elements(other_mesh, true);
-  this->copy_constraint_rows(other_mesh);
-
-  auto & this_boundary_info = this->get_boundary_info();
-  const auto & other_boundary_info = other_mesh.get_boundary_info();
-
-  this_boundary_info = other_boundary_info;
-
-  this->set_subdomain_name_map() = other_mesh.get_subdomain_name_map();
-
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
   this->_next_unique_id = other_mesh._next_unique_id;
 #endif

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -827,6 +827,7 @@ void UnstructuredMesh::copy_nodes_and_elements(const MeshBase & other_mesh,
 
   //Finally prepare the new Mesh for use.  Keep the same numbering and
   //partitioning for now.
+  const bool was_prepared = this->is_prepared();
   this->allow_renumbering(false);
   this->allow_remote_element_removal(false);
   this->allow_find_neighbors(!skip_find_neighbors);
@@ -843,6 +844,13 @@ void UnstructuredMesh::copy_nodes_and_elements(const MeshBase & other_mesh,
   this->allow_renumbering(other_mesh.allow_renumbering());
   this->allow_remote_element_removal(other_mesh.allow_remote_element_removal());
   this->skip_partitioning(other_mesh.skip_partitioning());
+
+  // That prepare_for_use() call marked us as prepared, but we
+  // specifically avoided some important preparation, so we might not
+  // actually be prepared now.
+  if (skip_find_neighbors &&
+      (!was_prepared || !other_mesh.is_prepared()))
+    this->set_isnt_prepared();
 }
 
 

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -1796,6 +1796,10 @@ UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
   MeshTools::libmesh_assert_valid_neighbors(*this);
 #endif
 
+  // We can't even afford any unset neighbor links here.
+  if (!this->is_prepared())
+    this->find_neighbors();
+
   // FIXME: make distributed mesh support efficient.
   // Yes, we currently suck.
   MeshSerializer serialize(*this);


### PR DESCRIPTION
The second commit here fixes the underlying problem uncovered in https://github.com/idaholab/moose/pull/30155#discussion_r2056875687

The first commit is a bit of refactoring for simplicity, the third gives us more rigorous clone() behavior, the fourth *checks* for rigorous clone() behavior, and the last checks that our fixes were sufficient in the tet meshing case that first triggered the problem.