### PR TITLE
Refactor --enable-complex unit testing

### DIFF
--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -184,10 +184,14 @@ typedef std::complex<Real> COMPLEX;
 // Helper functions for complex/real numbers
 // to clean up #ifdef LIBMESH_USE_COMPLEX_NUMBERS elsewhere
 template<typename T> inline T libmesh_real(T a) { return a; }
+template<typename T> inline T libmesh_imag(T /*a*/) { return 0; }
 template<typename T> inline T libmesh_conj(T a) { return a; }
 
 template<typename T>
 inline T libmesh_real(std::complex<T> a) { return std::real(a); }
+
+template<typename T>
+inline T libmesh_imag(std::complex<T> a) { return std::imag(a); }
 
 template<typename T>
 inline std::complex<T> libmesh_conj(std::complex<T> a) { return std::conj(a); }

--- a/tests/base/default_coupling_test.C
+++ b/tests/base/default_coupling_test.C
@@ -130,9 +130,9 @@ public:
 
                     Point p = n3->vertex_average();
 
-                    LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(0,p,n3)),
-                                            libmesh_real(cubic_default_coupling_test(p,es.parameters,"","")),
-                                            TOLERANCE*TOLERANCE);
+                    LIBMESH_ASSERT_NUMBERS_EQUAL(sys.point_value(0,p,n3),
+                                                cubic_default_coupling_test(p,es.parameters,"",""),
+                                                TOLERANCE*TOLERANCE);
                   }
               }
           }

--- a/tests/base/point_neighbor_coupling_test.C
+++ b/tests/base/point_neighbor_coupling_test.C
@@ -132,9 +132,9 @@ public:
 
                   Point p = n3->vertex_average();
 
-                  LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(0,p,n3)),
-                                          libmesh_real(cubic_point_neighbor_coupling_test(p,es.parameters,"","")),
-                                          TOLERANCE*TOLERANCE);
+                  LIBMESH_ASSERT_NUMBERS_EQUAL(sys.point_value(0,p,n3),
+                                              cubic_point_neighbor_coupling_test(p,es.parameters,"",""),
+                                              TOLERANCE*TOLERANCE);
                 }
             }
         }

--- a/tests/fe/fe_side_test.C
+++ b/tests/fe/fe_side_test.C
@@ -155,31 +155,22 @@ public:
                z = LIBMESH_DIM > 2 ? p(2) : 0;
 
           if (family == RATIONAL_BERNSTEIN && order > 1)
-            LIBMESH_ASSERT_FP_EQUAL
-              (libmesh_real(rational_test(p, dummy, "", "")),
-               libmesh_real(u),
-               this->_value_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (rational_test(p, dummy, "", ""), u, this->_value_tol);
           else if (order > 3)
-            LIBMESH_ASSERT_FP_EQUAL
-              (libmesh_real(fe_quartic_test(p, dummy, "", "")),
-               libmesh_real(u),
-               this->_value_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (fe_quartic_test(p, dummy, "", ""), u, this->_value_tol);
           else if (order > 2)
-            LIBMESH_ASSERT_FP_EQUAL
-              (libmesh_real(fe_cubic_test(p, dummy, "", "")),
-               libmesh_real(u),
-               this->_value_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (fe_cubic_test(p, dummy, "", ""), u, this->_value_tol);
           else if (order > 1)
-            LIBMESH_ASSERT_FP_EQUAL
-              (libmesh_real(x*x + 0.5*y*y + 0.25*z*z + 0.125*x*y +
-                            0.0625*x*z + 0.03125*y*z),
-               libmesh_real(u),
-               this->_value_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (x*x + 0.5*y*y + 0.25*z*z + 0.125*x*y +
+                            0.0625*x*z + 0.03125*y*z,
+               u, this->_value_tol);
           else
-            LIBMESH_ASSERT_FP_EQUAL
-              (libmesh_real(x + 0.25*y + 0.0625*z),
-               libmesh_real(u),
-               this->_value_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL (x + 0.25*y + 0.0625*z, u,
+                                         this->_value_tol);
         }
     };
 
@@ -248,17 +239,17 @@ public:
 
           const Gradient true_tangential_grad = true_grad - ((true_grad * n) * n);
 
-          LIBMESH_ASSERT_FP_EQUAL(libmesh_real(tangential_grad_u(0)),
-                                  libmesh_real(true_tangential_grad(0)),
-                                  this->_grad_tol);
+          LIBMESH_ASSERT_NUMBERS_EQUAL(tangential_grad_u(0),
+                                      true_tangential_grad(0),
+                                      this->_grad_tol);
           if (this->_dim > 1)
-            LIBMESH_ASSERT_FP_EQUAL(libmesh_real(tangential_grad_u(1)),
-                                    libmesh_real(true_tangential_grad(1)),
-                                    this->_grad_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL(tangential_grad_u(1),
+                                        true_tangential_grad(1),
+                                        this->_grad_tol);
           if (this->_dim > 2)
-            LIBMESH_ASSERT_FP_EQUAL(libmesh_real(tangential_grad_u(2)),
-                                    libmesh_real(true_tangential_grad(2)),
-                                    this->_grad_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL(tangential_grad_u(2),
+                                        true_tangential_grad(2),
+                                        this->_grad_tol);
         }
     };
 
@@ -332,17 +323,17 @@ public:
 
           const Gradient true_tangential_grad = true_grad - ((true_grad * n) * n);
 
-          LIBMESH_ASSERT_FP_EQUAL(libmesh_real(tangential_grad_u(0)),
-                                  libmesh_real(true_tangential_grad(0)),
-                                  this->_grad_tol);
+          LIBMESH_ASSERT_NUMBERS_EQUAL(tangential_grad_u(0),
+                                      true_tangential_grad(0),
+                                      this->_grad_tol);
           if (this->_dim > 1)
-            LIBMESH_ASSERT_FP_EQUAL(libmesh_real(tangential_grad_u(1)),
-                                    libmesh_real(true_tangential_grad(1)),
+            LIBMESH_ASSERT_NUMBERS_EQUAL(tangential_grad_u(1),
+                                    true_tangential_grad(1),
                                     this->_grad_tol);
           if (this->_dim > 2)
-            LIBMESH_ASSERT_FP_EQUAL(libmesh_real(tangential_grad_u(2)),
-                                    libmesh_real(true_tangential_grad(2)),
-                                    this->_grad_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL(tangential_grad_u(2),
+                                        true_tangential_grad(2),
+                                        this->_grad_tol);
         }
     };
 
@@ -403,29 +394,29 @@ public:
           // Subtract off values only relevant in normal directions
           RealTensor tangential_hess = tangential_hessian(true_hess, n);
 
-          LIBMESH_ASSERT_FP_EQUAL(tangential_hess(0,0), libmesh_real(hess_u(0,0)),
-                                  this->_hess_tol);
+          LIBMESH_ASSERT_NUMBERS_EQUAL(tangential_hess(0,0),
+                                      hess_u(0,0), this->_hess_tol);
           if (this->_dim > 1)
             {
-              LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(0,1)), libmesh_real(hess_u(1,0)),
-                                      this->_hess_tol);
-              LIBMESH_ASSERT_FP_EQUAL(tangential_hess(0,1), libmesh_real(hess_u(0,1)),
-                                      this->_hess_tol);
-              LIBMESH_ASSERT_FP_EQUAL(tangential_hess(1,1), libmesh_real(hess_u(1,1)),
-                                      this->_hess_tol);
+              LIBMESH_ASSERT_NUMBERS_EQUAL
+                (hess_u(0,1), hess_u(1,0), this->_hess_tol);
+              LIBMESH_ASSERT_NUMBERS_EQUAL
+                (tangential_hess(0,1), hess_u(0,1), this->_hess_tol);
+              LIBMESH_ASSERT_NUMBERS_EQUAL
+                (tangential_hess(1,1), hess_u(1,1), this->_hess_tol);
             }
           if (this->_dim > 2)
             {
-              LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(0,2)), libmesh_real(hess_u(2,0)),
-                                      this->_hess_tol);
-              LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(1,2)), libmesh_real(hess_u(2,1)),
-                                      this->_hess_tol);
-              LIBMESH_ASSERT_FP_EQUAL(tangential_hess(0,2), libmesh_real(hess_u(0,2)),
-                                      this->_hess_tol);
-              LIBMESH_ASSERT_FP_EQUAL(tangential_hess(1,2), libmesh_real(hess_u(1,2)),
-                                      this->_hess_tol);
-              LIBMESH_ASSERT_FP_EQUAL(tangential_hess(2,2), libmesh_real(hess_u(2,2)),
-                                      this->_hess_tol);
+              LIBMESH_ASSERT_NUMBERS_EQUAL
+                (hess_u(0,2), hess_u(2,0), this->_hess_tol);
+              LIBMESH_ASSERT_NUMBERS_EQUAL
+                (hess_u(1,2), hess_u(2,1), this->_hess_tol);
+              LIBMESH_ASSERT_NUMBERS_EQUAL
+                (tangential_hess(0,2), hess_u(0,2), this->_hess_tol);
+              LIBMESH_ASSERT_NUMBERS_EQUAL
+                (tangential_hess(1,2), hess_u(1,2), this->_hess_tol);
+              LIBMESH_ASSERT_NUMBERS_EQUAL
+                (tangential_hess(2,2), hess_u(2,2), this->_hess_tol);
             }
         }
     };
@@ -517,23 +508,23 @@ public:
           // Subtract off values only relevant in normal directions
           RealTensor tangential_hess = tangential_hessian(true_hess, n);
 
-          LIBMESH_ASSERT_FP_EQUAL(tangential_hess(0,0), libmesh_real(hess_u(0,0)),
-                                  this->_hess_tol);
+          LIBMESH_ASSERT_NUMBERS_EQUAL
+            (tangential_hess(0,0), hess_u(0,0), this->_hess_tol);
           if (this->_dim > 1)
             {
-              LIBMESH_ASSERT_FP_EQUAL(tangential_hess(0,1), libmesh_real(hess_u(0,1)),
-                                      this->_hess_tol);
-              LIBMESH_ASSERT_FP_EQUAL(tangential_hess(1,1), libmesh_real(hess_u(1,1)),
-                                      this->_hess_tol);
+              LIBMESH_ASSERT_NUMBERS_EQUAL
+                (tangential_hess(0,1), hess_u(0,1), this->_hess_tol);
+              LIBMESH_ASSERT_NUMBERS_EQUAL
+                (tangential_hess(1,1), hess_u(1,1), this->_hess_tol);
             }
           if (this->_dim > 2)
             {
-              LIBMESH_ASSERT_FP_EQUAL( tangential_hess(0,2), libmesh_real(hess_u(0,2)),
-                                       this->_hess_tol);
-              LIBMESH_ASSERT_FP_EQUAL( tangential_hess(1,2), libmesh_real(hess_u(1,2)),
-                                       this->_hess_tol);
-              LIBMESH_ASSERT_FP_EQUAL( tangential_hess(2,2), libmesh_real(hess_u(2,2)),
-                                       this->_hess_tol);
+              LIBMESH_ASSERT_NUMBERS_EQUAL
+                (tangential_hess(0,2), hess_u(0,2), this->_hess_tol);
+              LIBMESH_ASSERT_NUMBERS_EQUAL
+                (tangential_hess(1,2), hess_u(1,2), this->_hess_tol);
+              LIBMESH_ASSERT_NUMBERS_EQUAL
+                (tangential_hess(2,2), hess_u(2,2), this->_hess_tol);
             }
         }
     };

--- a/tests/fe/fe_test.h
+++ b/tests/fe/fe_test.h
@@ -750,8 +750,7 @@ public:
         else
           true_u = p(0) + 0.25*p(1) + 0.0625*p(2);
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(true_u), libmesh_real(u), this->_value_tol);
+        LIBMESH_ASSERT_NUMBERS_EQUAL (true_u, u, this->_value_tol);
       };
 
     testLoop(f);
@@ -787,14 +786,14 @@ public:
 
         RealGradient true_grad = this->true_gradient(p);
 
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(grad_u(0)),
-                                true_grad(0), this->_grad_tol);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (grad_u(0), true_grad(0), this->_grad_tol);
         if (this->_dim > 1)
-          LIBMESH_ASSERT_FP_EQUAL(libmesh_real(grad_u(1)),
-                                  true_grad(1), this->_grad_tol);
+          LIBMESH_ASSERT_NUMBERS_EQUAL
+           (grad_u(1), true_grad(1), this->_grad_tol);
         if (this->_dim > 2)
-          LIBMESH_ASSERT_FP_EQUAL(libmesh_real(grad_u(2)),
-                                  true_grad(2), this->_grad_tol);
+          LIBMESH_ASSERT_NUMBERS_EQUAL
+           (grad_u(2), true_grad(2), this->_grad_tol);
       };
 
     testLoop(f);
@@ -822,14 +821,14 @@ public:
 
         RealGradient true_grad = this->true_gradient(p);
 
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(grad_u_x),
+        LIBMESH_ASSERT_NUMBERS_EQUAL(grad_u_x,
                                 true_grad(0), this->_grad_tol);
         if (this->_dim > 1)
-          LIBMESH_ASSERT_FP_EQUAL(libmesh_real(grad_u_y),
-                                  true_grad(1), this->_grad_tol);
+          LIBMESH_ASSERT_NUMBERS_EQUAL
+            (grad_u_y, true_grad(1), this->_grad_tol);
         if (this->_dim > 2)
-          LIBMESH_ASSERT_FP_EQUAL(libmesh_real(grad_u_z),
-                                  true_grad(2), this->_grad_tol);
+          LIBMESH_ASSERT_NUMBERS_EQUAL
+            (grad_u_z, true_grad(2), this->_grad_tol);
       };
 
     testLoop(f);
@@ -857,29 +856,29 @@ public:
 
         RealTensor true_hess = this->true_hessian(p);
 
-        LIBMESH_ASSERT_FP_EQUAL(true_hess(0,0), libmesh_real(hess_u(0,0)),
-                                this->_hess_tol);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (true_hess(0,0), hess_u(0,0), this->_hess_tol);
         if (this->_dim > 1)
           {
-            LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(0,1)), libmesh_real(hess_u(1,0)),
-                                    this->_hess_tol);
-            LIBMESH_ASSERT_FP_EQUAL(true_hess(0,1), libmesh_real(hess_u(0,1)),
-                                    this->_hess_tol);
-            LIBMESH_ASSERT_FP_EQUAL(true_hess(1,1), libmesh_real(hess_u(1,1)),
-                                    this->_hess_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (hess_u(0,1), hess_u(1,0), this->_hess_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (true_hess(0,1), hess_u(0,1), this->_hess_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (true_hess(1,1), hess_u(1,1), this->_hess_tol);
           }
         if (this->_dim > 2)
           {
-            LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(0,2)), libmesh_real(hess_u(2,0)),
-                                    this->_hess_tol);
-            LIBMESH_ASSERT_FP_EQUAL(libmesh_real(hess_u(1,2)), libmesh_real(hess_u(2,1)),
-                                    this->_hess_tol);
-            LIBMESH_ASSERT_FP_EQUAL(true_hess(0,2), libmesh_real(hess_u(0,2)),
-                                    this->_hess_tol);
-            LIBMESH_ASSERT_FP_EQUAL(true_hess(1,2), libmesh_real(hess_u(1,2)),
-                                    this->_hess_tol);
-            LIBMESH_ASSERT_FP_EQUAL(true_hess(2,2), libmesh_real(hess_u(2,2)),
-                                    this->_hess_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (hess_u(0,2), hess_u(2,0), this->_hess_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (hess_u(1,2), hess_u(2,1), this->_hess_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (true_hess(0,2), hess_u(0,2), this->_hess_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (true_hess(1,2), hess_u(1,2), this->_hess_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (true_hess(2,2), hess_u(2,2), this->_hess_tol);
           }
       };
 
@@ -920,23 +919,23 @@ public:
 
         RealTensor true_hess = this->true_hessian(p);
 
-        LIBMESH_ASSERT_FP_EQUAL(true_hess(0,0), libmesh_real(hess_u_xx),
-                                this->_hess_tol);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (true_hess(0,0), hess_u_xx, this->_hess_tol);
         if (this->_dim > 1)
           {
-            LIBMESH_ASSERT_FP_EQUAL(true_hess(0,1), libmesh_real(hess_u_xy),
-                                    this->_hess_tol);
-            LIBMESH_ASSERT_FP_EQUAL(true_hess(1,1), libmesh_real(hess_u_yy),
-                                    this->_hess_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (true_hess(0,1), hess_u_xy, this->_hess_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (true_hess(1,1), hess_u_yy, this->_hess_tol);
           }
         if (this->_dim > 2)
           {
-            LIBMESH_ASSERT_FP_EQUAL(true_hess(0,2), libmesh_real(hess_u_xz),
-                                    this->_hess_tol);
-            LIBMESH_ASSERT_FP_EQUAL(true_hess(1,2), libmesh_real(hess_u_yz),
-                                    this->_hess_tol);
-            LIBMESH_ASSERT_FP_EQUAL(true_hess(2,2), libmesh_real(hess_u_zz),
-                                    this->_hess_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (true_hess(0,2), hess_u_xz, this->_hess_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (true_hess(1,2), hess_u_yz, this->_hess_tol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (true_hess(2,2), hess_u_zz, this->_hess_tol);
           }
       };
 

--- a/tests/libmesh_cppunit.h
+++ b/tests/libmesh_cppunit.h
@@ -19,6 +19,17 @@
          CPPUNIT_ASSERT_DOUBLES_EQUAL(expected,actual,tolerance)
 #endif
 
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+# define LIBMESH_ASSERT_NUMBERS_EQUAL(expected,actual,tolerance) \
+  do { \
+    LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(expected),libMesh::libmesh_real(actual),tolerance); \
+    LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_imag(expected),libMesh::libmesh_imag(actual),tolerance); \
+  } while (0)
+#else
+# define LIBMESH_ASSERT_NUMBERS_EQUAL(expected,actual,tolerance) \
+         LIBMESH_ASSERT_FP_EQUAL(expected,actual,tolerance)
+#endif
+
 // THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
 // std::auto_ptr, which in turn produces -Wdeprecated-declarations
 // warnings.  These can be ignored in GCC as long as we wrap the

--- a/tests/mesh/mesh_function.C
+++ b/tests/mesh/mesh_function.C
@@ -123,22 +123,22 @@ public:
             mesh_function(c, 0, vec_values, nullptr);
             const Number retval3 = vec_values.empty() ? -12345 : vec_values(0);
 
-            LIBMESH_ASSERT_FP_EQUAL(libmesh_real(retval3), expected_value,
-                                    TOLERANCE * TOLERANCE);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (retval3, expected_value, TOLERANCE * TOLERANCE);
 
             if (sbdids1.count(elem->subdomain_id()))
               {
                 CPPUNIT_ASSERT(!sbdids2.count(elem->subdomain_id()));
-                LIBMESH_ASSERT_FP_EQUAL(libmesh_real(retval1), expected_value,
-                                        TOLERANCE * TOLERANCE);
+                LIBMESH_ASSERT_NUMBERS_EQUAL
+                  (retval1, expected_value, TOLERANCE * TOLERANCE);
 
                 mesh_function(c, 0, vec_values, &sbdids2);
                 CPPUNIT_ASSERT(vec_values.empty());
               }
             else
               {
-                LIBMESH_ASSERT_FP_EQUAL(libmesh_real(retval2), expected_value,
-                                        TOLERANCE * TOLERANCE);
+                LIBMESH_ASSERT_NUMBERS_EQUAL
+                  (retval2, expected_value, TOLERANCE * TOLERANCE);
 
                 mesh_function(c, 0, vec_values, &sbdids1);
                 CPPUNIT_ASSERT(vec_values.empty());
@@ -215,10 +215,8 @@ public:
                               dummy,
                               dummy);
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (libmesh_real(vec_values(0)),
-           libmesh_real(mesh_function_value),
-           TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (vec_values(0), mesh_function_value, TOLERANCE*TOLERANCE);
       }
   }
 #endif // LIBMESH_ENABLE_AMR

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -565,9 +565,8 @@ public:
         for (Real y = 0; y < 1 + TOLERANCE; y += Real(1.L/3.L))
           {
             Point p(x,y);
-            LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(0,p)),
-                                    libmesh_real(6*x+60*y),
-                                    exotol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (sys.point_value(0,p), 6*x+60*y, exotol);
           }
     }
   }
@@ -655,9 +654,8 @@ public:
         for (Real y = Real(1.L/6.L); y < 1; y += Real(1.L/3.L))
           {
             Point p(x,y);
-            LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(0,p)),
-                                    libmesh_real(6*x+60*y),
-                                    exotol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (sys.point_value(0,p), 6*x+60*y, exotol);
           }
     }
   }
@@ -834,12 +832,10 @@ public:
         for (Real y = Real(1.L/6.L); y < 1; y += Real(1.L/3.L))
           {
             Point p(x,y);
-            LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(0,p)),
-                                    libmesh_real(6*x+60*y),
-                                    exotol);
-            LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(1,p)),
-                                    libmesh_real(sin(x)+cos(y)),
-                                    exotol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (sys.point_value(0,p), 6*x+60*y, exotol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (sys.point_value(1,p), sin(x)+cos(y), exotol);
           }
     }
   }
@@ -1710,7 +1706,7 @@ public:
       {
         if (elem->type() == NODEELEM)
           continue;
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(0.04), elem->volume(), TOLERANCE);
+        LIBMESH_ASSERT_FP_EQUAL(Real(0.04), elem->volume(), TOLERANCE);
 
         for (unsigned int n=0; n != 9; ++n)
           CPPUNIT_ASSERT_EQUAL

--- a/tests/mesh/slit_mesh_test.C
+++ b/tests/mesh/slit_mesh_test.C
@@ -371,9 +371,8 @@ public:
 
             const Number discrete_val = context.interior_value(0, qp);
 
-            LIBMESH_ASSERT_FP_EQUAL(libmesh_real(exact_val),
-                                    libmesh_real(discrete_val),
-                                    TOLERANCE*TOLERANCE);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (exact_val, discrete_val, TOLERANCE*TOLERANCE);
           }
       }
 
@@ -457,9 +456,8 @@ public:
 
             const Number discrete_val = context.interior_value(0, qp);
 
-            LIBMESH_ASSERT_FP_EQUAL(libmesh_real(exact_val),
-                                    libmesh_real(discrete_val),
-                                    TOLERANCE*TOLERANCE);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (exact_val, discrete_val, TOLERANCE*TOLERANCE);
           }
       }
   }

--- a/tests/mesh/write_vec_and_scalar.C
+++ b/tests/mesh/write_vec_and_scalar.C
@@ -124,27 +124,27 @@ public:
         const dof_id_type gold_i_v  = gold_i_uy + 1;
         CPPUNIT_ASSERT_LESS(gold_vector.size(), std::size_t(gold_i_v));
 
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,0,0))),
-                                gold_vector[gold_i_ux], tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,v2,0))),
-                                gold_vector[gold_i_uy], tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,2*v2,0))),
-                                gold_vector[gold_i_v], tol);
+        LIBMESH_ASSERT_NUMBERS_EQUAL(sys2_soln(node->dof_number(0,0,0)),
+                                    gold_vector[gold_i_ux], tol);
+        LIBMESH_ASSERT_NUMBERS_EQUAL(sys2_soln(node->dof_number(0,v2,0)),
+                                    gold_vector[gold_i_uy], tol);
+        LIBMESH_ASSERT_NUMBERS_EQUAL(sys2_soln(node->dof_number(0,2*v2,0)),
+                                    gold_vector[gold_i_v], tol);
 
         // Let's check imaginary parts and magnitude for good measure
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,1,0))),
-                                0.0, tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,2,0))),
-                                std::abs(gold_vector[gold_i_ux]), tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,4,0))),
-                                0.0, tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,5,0))),
-                                std::abs(gold_vector[gold_i_uy]), tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,7,0))),
-                                0.0, tol);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,8,0))),
-                                std::abs(gold_vector[gold_i_v]), tol);
+        LIBMESH_ASSERT_NUMBERS_EQUAL(sys2_soln(node->dof_number(0,1,0)),
+                                    0.0, tol);
+        LIBMESH_ASSERT_NUMBERS_EQUAL(sys2_soln(node->dof_number(0,2,0)),
+                                    std::abs(gold_vector[gold_i_ux]), tol);
+        LIBMESH_ASSERT_NUMBERS_EQUAL(sys2_soln(node->dof_number(0,4,0)),
+                                    0.0, tol);
+        LIBMESH_ASSERT_NUMBERS_EQUAL(sys2_soln(node->dof_number(0,5,0)),
+                                    std::abs(gold_vector[gold_i_uy]), tol);
+        LIBMESH_ASSERT_NUMBERS_EQUAL(sys2_soln(node->dof_number(0,7,0)),
+                                    0.0, tol);
+        LIBMESH_ASSERT_NUMBERS_EQUAL(sys2_soln(node->dof_number(0,8,0)),
+                                    std::abs(gold_vector[gold_i_v]), tol);
 #endif
       }
   }

--- a/tests/numerics/dense_matrix_test.C
+++ b/tests/numerics/dense_matrix_test.C
@@ -48,7 +48,8 @@ private:
 
     for (unsigned int i = 0; i < a.size(); ++i)
       for (unsigned int j = 0; j < b.size(); ++j)
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(a_times_b(i,j)), libmesh_real(a_times_b_correct(i,j)), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (a_times_b(i,j), a_times_b_correct(i,j), TOLERANCE*TOLERANCE);
   }
 
   void testSVD()
@@ -81,11 +82,11 @@ private:
 
     for (unsigned i=0; i<U.m(); ++i)
       for (unsigned j=0; j<U.n(); ++j)
-        LIBMESH_ASSERT_FP_EQUAL( libmesh_real(U(i,j)), libmesh_real(true_U(i,j)), tol);
+        LIBMESH_ASSERT_NUMBERS_EQUAL( U(i,j), true_U(i,j), tol);
 
     for (unsigned i=0; i<VT.m(); ++i)
       for (unsigned j=0; j<VT.n(); ++j)
-        LIBMESH_ASSERT_FP_EQUAL( libmesh_real(VT(i,j)), libmesh_real(true_VT(i,j)), tol);
+        LIBMESH_ASSERT_NUMBERS_EQUAL( VT(i,j), true_VT(i,j), tol);
 
     for (unsigned i=0; i<sigma.size(); ++i)
       LIBMESH_ASSERT_FP_EQUAL(sigma(i), true_sigma(i), tol);

--- a/tests/numerics/diagonal_matrix_test.C
+++ b/tests/numerics/diagonal_matrix_test.C
@@ -86,8 +86,8 @@ public:
     _matrix->set(beginning_index + 1, beginning_index, 1);
 
     // Test that off-diagonal elements are always zero
-    LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real((*_matrix)(beginning_index, beginning_index + 1)), _tolerance);
-    LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real((*_matrix)(beginning_index + 1, beginning_index)), _tolerance);
+    LIBMESH_ASSERT_NUMBERS_EQUAL(0, (*_matrix)(beginning_index, beginning_index + 1), _tolerance);
+    LIBMESH_ASSERT_NUMBERS_EQUAL(0, (*_matrix)(beginning_index + 1, beginning_index), _tolerance);
 
     // Test add
     {
@@ -105,9 +105,9 @@ public:
       for (numeric_index_type i = beginning_index; i < end_index; ++i)
       {
         if (i)
-          LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, i)), i, _tolerance);
+          LIBMESH_ASSERT_NUMBERS_EQUAL((*_matrix)(i, i), i, _tolerance);
         else
-          LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, i)), _comm->size(), _tolerance);
+          LIBMESH_ASSERT_NUMBERS_EQUAL((*_matrix)(i, i), _comm->size(), _tolerance);
       }
     }
 
@@ -128,9 +128,9 @@ public:
       for (numeric_index_type i = beginning_index; i < end_index; ++i)
       {
         if (i != _global_size - 1)
-          LIBMESH_ASSERT_FP_EQUAL(i, libmesh_real((*_matrix)(i, i)), _tolerance);
+          LIBMESH_ASSERT_NUMBERS_EQUAL(i, (*_matrix)(i, i), _tolerance);
         else
-          LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real((*_matrix)(i, i)), _tolerance);
+          LIBMESH_ASSERT_NUMBERS_EQUAL(0, (*_matrix)(i, i), _tolerance);
       }
     }
 
@@ -156,7 +156,7 @@ public:
       _matrix->close();
 
       for (numeric_index_type i = beginning_index; i < end_index; ++i)
-        LIBMESH_ASSERT_FP_EQUAL(i, libmesh_real((*_matrix)(i, i)), _tolerance);
+        LIBMESH_ASSERT_NUMBERS_EQUAL(i, (*_matrix)(i, i), _tolerance);
 
       // Build
       auto diagonal = NumericVector<Number>::build(*_comm);
@@ -177,18 +177,18 @@ public:
       _matrix->close();
 
       for (numeric_index_type i = beginning_index; i < end_index; ++i)
-        LIBMESH_ASSERT_FP_EQUAL(2 * i, libmesh_real((*_matrix)(i, i)), _tolerance);
+        LIBMESH_ASSERT_NUMBERS_EQUAL(2 * i, (*_matrix)(i, i), _tolerance);
 
       // SparseMatrix add
       _matrix->add(-1, copy);
 
       for (numeric_index_type i = beginning_index; i < end_index; ++i)
-        LIBMESH_ASSERT_FP_EQUAL(i, libmesh_real((*_matrix)(i, i)), _tolerance);
+        LIBMESH_ASSERT_NUMBERS_EQUAL(i, (*_matrix)(i, i), _tolerance);
 
       _matrix->get_transpose(copy);
 
       for (numeric_index_type i = beginning_index; i < end_index; ++i)
-        LIBMESH_ASSERT_FP_EQUAL(i, libmesh_real(copy(i, i)), _tolerance);
+        LIBMESH_ASSERT_NUMBERS_EQUAL(i, copy(i, i), _tolerance);
     }
 
     // Test norms
@@ -204,9 +204,9 @@ public:
         for (numeric_index_type j = beginning_index; j < end_index; ++j)
         {
           if (i == j)
-            LIBMESH_ASSERT_FP_EQUAL(1, libmesh_real((*_matrix)(i, j)), _tolerance);
+            LIBMESH_ASSERT_NUMBERS_EQUAL(1, (*_matrix)(i, j), _tolerance);
           else
-            LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real((*_matrix)(i, j)), _tolerance);
+            LIBMESH_ASSERT_NUMBERS_EQUAL(0, (*_matrix)(i, j), _tolerance);
         }
     }
   }

--- a/tests/numerics/lumped_mass_matrix_test.C
+++ b/tests/numerics/lumped_mass_matrix_test.C
@@ -72,9 +72,9 @@ public:
       for (const auto j : make_range(beginning_index, end_index))
       {
         if (i != j)
-          LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real((*_matrix)(i, j)), _tolerance);
+          LIBMESH_ASSERT_NUMBERS_EQUAL(0, (*_matrix)(i, j), _tolerance);
         else
-          LIBMESH_ASSERT_FP_EQUAL(gold_values[i - beginning_index], libmesh_real((*_matrix)(i, i)), _tolerance);
+          LIBMESH_ASSERT_NUMBERS_EQUAL(gold_values[i - beginning_index], (*_matrix)(i, i), _tolerance);
       }
 
     // Test set
@@ -87,7 +87,7 @@ public:
     _matrix->close();
 
     for (const auto i : make_range(beginning_index, end_index))
-      LIBMESH_ASSERT_FP_EQUAL(gold_values[i - beginning_index], libmesh_real((*_matrix)(i, i)), _tolerance);
+      LIBMESH_ASSERT_NUMBERS_EQUAL(gold_values[i - beginning_index], (*_matrix)(i, i), _tolerance);
 
     // Test clone
     auto copy = _matrix->clone();
@@ -100,7 +100,7 @@ public:
 
     for (const auto i : make_range(beginning_index, end_index))
       for (const auto j : make_range(beginning_index, end_index))
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, j)), libmesh_real((*copy)(i, j)), _tolerance);
+        LIBMESH_ASSERT_NUMBERS_EQUAL((*_matrix)(i, j), (*copy)(i, j), _tolerance);
 
     // Test zero clone
     auto zero_copy = _matrix->zero_clone();
@@ -113,7 +113,7 @@ public:
 
     for (const auto i : make_range(beginning_index, end_index))
       for (const auto j : make_range(beginning_index, end_index))
-        LIBMESH_ASSERT_FP_EQUAL(0, libmesh_real((*zero_copy)(i, j)), _tolerance);
+        LIBMESH_ASSERT_NUMBERS_EQUAL(0, (*zero_copy)(i, j), _tolerance);
   }
 
 private:

--- a/tests/numerics/numeric_vector_test.h
+++ b/tests/numerics/numeric_vector_test.h
@@ -82,70 +82,70 @@ public:
     CPPUNIT_ASSERT(!relative_fuzzy_equals(v, vorig));
 
     for (libMesh::dof_id_type n=first; n != last; n++)
-      LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(v(n)),
-                              libMesh::Real(2*n+2),
-                              libMesh::TOLERANCE*libMesh::TOLERANCE);
+      LIBMESH_ASSERT_NUMBERS_EQUAL
+        (v(n), libMesh::Real(2*n+2),
+         libMesh::TOLERANCE*libMesh::TOLERANCE);
 
     v *= v;
 
     for (libMesh::dof_id_type n=first; n != last; n++)
-      LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(v(n)),
-                              libMesh::Real(4*n*n+8*n+4),
-                              libMesh::TOLERANCE*libMesh::TOLERANCE);
+      LIBMESH_ASSERT_NUMBERS_EQUAL
+        (v(n), libMesh::Real(4*n*n+8*n+4),
+         libMesh::TOLERANCE*libMesh::TOLERANCE);
 
     v -= vorig;
 
     for (libMesh::dof_id_type n=first; n != last; n++)
-      LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(v(n)),
-                              libMesh::Real(4*n*n+7*n+3),
-                              libMesh::TOLERANCE*libMesh::TOLERANCE);
+      LIBMESH_ASSERT_NUMBERS_EQUAL
+        (v(n), libMesh::Real(4*n*n+7*n+3),
+         libMesh::TOLERANCE*libMesh::TOLERANCE);
 
     v /= vorig;
 
     for (libMesh::dof_id_type n=first; n != last; n++)
-      LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(v(n)),
-                              libMesh::Real(4*n+3),
-                              libMesh::TOLERANCE*libMesh::TOLERANCE);
+      LIBMESH_ASSERT_NUMBERS_EQUAL
+        (v(n), libMesh::Real(4*n+3),
+         libMesh::TOLERANCE*libMesh::TOLERANCE);
 
     v.add(1);
     for (libMesh::dof_id_type n=first; n != last; n++)
-      LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(v(n)),
-                              libMesh::Real(4*n+4),
-                              libMesh::TOLERANCE*libMesh::TOLERANCE);
+      LIBMESH_ASSERT_NUMBERS_EQUAL
+        (v(n), libMesh::Real(4*n+4),
+         libMesh::TOLERANCE*libMesh::TOLERANCE);
 
     v.add(2, vorig);
     for (libMesh::dof_id_type n=first; n != last; n++)
-      LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(v(n)),
-                              libMesh::Real(6*n+6),
-                              libMesh::TOLERANCE*libMesh::TOLERANCE);
+      LIBMESH_ASSERT_NUMBERS_EQUAL
+        (v(n), libMesh::Real(6*n+6),
+         libMesh::TOLERANCE*libMesh::TOLERANCE);
 
     v.scale(1/libMesh::Real(3));
     for (libMesh::dof_id_type n=first; n != last; n++)
-      LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(v(n)),
-                              libMesh::Real(2*n+2),
-                              libMesh::TOLERANCE*libMesh::TOLERANCE);
+      LIBMESH_ASSERT_NUMBERS_EQUAL
+        (v(n), libMesh::Real(2*n+2),
+         libMesh::TOLERANCE*libMesh::TOLERANCE);
 
     v = 4;
     for (libMesh::dof_id_type n=first; n != last; n++)
-      LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(v(n)),
-                              libMesh::Real(4),
-                              libMesh::TOLERANCE*libMesh::TOLERANCE);
+      LIBMESH_ASSERT_NUMBERS_EQUAL
+        (v(n), libMesh::Real(4),
+         libMesh::TOLERANCE*libMesh::TOLERANCE);
 
     v = vorig;
     for (libMesh::dof_id_type n=first; n != last; n++)
-      LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(v(n)),
-                              libMesh::Real(n+1),
-                              libMesh::TOLERANCE*libMesh::TOLERANCE);
+      LIBMESH_ASSERT_NUMBERS_EQUAL
+        (v(n), libMesh::Real(n+1),
+         libMesh::TOLERANCE*libMesh::TOLERANCE);
 
     v.reciprocal();
     for (libMesh::dof_id_type n=first; n != last; n++)
-      LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(v(n)),
-                              1/libMesh::Real(n+1),
-                              libMesh::TOLERANCE*libMesh::TOLERANCE);
+      LIBMESH_ASSERT_NUMBERS_EQUAL
+        (v(n), 1/libMesh::Real(n+1),
+         libMesh::TOLERANCE*libMesh::TOLERANCE);
 
-    LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(v.dot(vorig)),
-                            libMesh::Real(global_size),
-                            libMesh::TOLERANCE*libMesh::TOLERANCE);
+    LIBMESH_ASSERT_NUMBERS_EQUAL
+      (v.dot(vorig), libMesh::Real(global_size),
+       libMesh::TOLERANCE*libMesh::TOLERANCE);
   }
 
   template <class Base, class Derived>
@@ -171,7 +171,7 @@ public:
       std::sqrt(libMesh::Real(global_size-1) *
                 (2*global_size) *
                 (2*global_size-1) / 3);
-    LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(v.sum()), -exact_l1,
+    LIBMESH_ASSERT_NUMBERS_EQUAL(v.sum(), -exact_l1,
                             libMesh::TOLERANCE*libMesh::TOLERANCE);
     LIBMESH_ASSERT_FP_EQUAL(v.l1_norm(), exact_l1,
                             libMesh::TOLERANCE*libMesh::TOLERANCE);
@@ -231,9 +231,8 @@ public:
       if (!to_one || my_comm->rank() == root_pid)
         // Yes I really mean v.size()
         for (libMesh::dof_id_type i=0; i<v.size(); i++)
-          LIBMESH_ASSERT_FP_EQUAL(2.*libMesh::libmesh_real(i),
-                                  libMesh::libmesh_real(l[i]),
-                                  libMesh::TOLERANCE*libMesh::TOLERANCE);
+          LIBMESH_ASSERT_NUMBERS_EQUAL
+            (2.*i, l[i], libMesh::TOLERANCE*libMesh::TOLERANCE);
 
       for (libMesh::dof_id_type n=first; n != last; n++)
       {
@@ -250,9 +249,8 @@ public:
       if (!to_one || my_comm->rank() == root_pid)
         // Yes I really mean v.size()
         for (libMesh::dof_id_type i=0; i<v.size(); i++)
-          LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(i),
-                                  libMesh::libmesh_real(l[i]),
-                                  libMesh::TOLERANCE*libMesh::TOLERANCE);
+          LIBMESH_ASSERT_NUMBERS_EQUAL
+            (libMesh::Real(i), l[i], libMesh::TOLERANCE*libMesh::TOLERANCE);
     }
   }
 
@@ -292,9 +290,9 @@ public:
         {
           end_index += block_size + p;
           for (unsigned int j = 0; j != block_size; ++j)
-            LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(values[p*block_size+j]),
-                                    libMesh::libmesh_real(end_index-j-1),
-                                    libMesh::TOLERANCE*libMesh::TOLERANCE);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (values[p*block_size+j], libMesh::Real(end_index-j-1),
+               libMesh::TOLERANCE*libMesh::TOLERANCE);
         }
     }
   }

--- a/tests/numerics/parsed_fem_function_test.C
+++ b/tests/numerics/parsed_fem_function_test.C
@@ -154,12 +154,12 @@ private:
 
           pfvec.push_back(xy8_stolen);
 
-          LIBMESH_ASSERT_FP_EQUAL
-            (2.0, libmesh_real(xy8_stolen(*c,Point(0.5,0.5,0.5))), TOLERANCE*TOLERANCE);
+          LIBMESH_ASSERT_NUMBERS_EQUAL
+            (2.0, xy8_stolen(*c,Point(0.5,0.5,0.5)), TOLERANCE*TOLERANCE);
         }
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (2.0, libmesh_real(pfvec[0](*c,Point(0.5,0.5,0.5))), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (2.0, pfvec[0](*c,Point(0.5,0.5,0.5)), TOLERANCE*TOLERANCE);
       }
   }
 
@@ -179,18 +179,18 @@ private:
         // ParsedFEMFunction<Number> c2_assigned(*sys, "grad_y_xyz");
         // c2_assigned = c2;
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (2.0, libmesh_real(c2(*c,Point(0.35,0.45,0.55))), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (2.0, c2(*c,Point(0.35,0.45,0.55)), TOLERANCE*TOLERANCE);
 
         ParsedFEMFunction<Number> xz(*sys, "grad_y_xyz");
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (0.1875, libmesh_real(xz(*c,Point(0.25,0.35,0.75))), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (0.1875, xz(*c,Point(0.25,0.35,0.75)), TOLERANCE*TOLERANCE);
 
         ParsedFEMFunction<Number> xyz(*sys, "grad_y_xyz*grad_x_xy");
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (0.09375, libmesh_real(xyz(*c,Point(0.25,0.5,0.75))), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (0.09375, xyz(*c,Point(0.25,0.5,0.75)), TOLERANCE*TOLERANCE);
       }
   }
 
@@ -204,18 +204,18 @@ private:
       {
         ParsedFEMFunction<Number> c1(*sys, "hess_xy_xy");
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (1.0, libmesh_real(c1(*c,Point(0.35,0.45,0.55))), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (1.0, c1(*c,Point(0.35,0.45,0.55)), TOLERANCE*TOLERANCE);
 
         ParsedFEMFunction<Number> x(*sys, "hess_yz_xyz");
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (0.25, libmesh_real(x(*c,Point(0.25,0.35,0.55))), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (0.25, x(*c,Point(0.25,0.35,0.55)), TOLERANCE*TOLERANCE);
 
         ParsedFEMFunction<Number> xz(*sys, "hess_yz_xyz*grad_y_yz");
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (0.1875, libmesh_real(xz(*c,Point(0.25,0.4,0.75))), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (0.1875, xz(*c,Point(0.25,0.4,0.75)), TOLERANCE*TOLERANCE);
       }
   }
 
@@ -228,23 +228,23 @@ private:
       {
         ParsedFEMFunction<Number> ax2(*sys, "a:=4.5;a*x2");
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (2.25, libmesh_real(ax2(*c,Point(0.25,0.25,0.25))), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (2.25, ax2(*c,Point(0.25,0.25,0.25)), TOLERANCE*TOLERANCE);
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (4.5, libmesh_real(ax2.get_inline_value("a")), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (4.5, ax2.get_inline_value("a"), TOLERANCE*TOLERANCE);
 
         ParsedFEMFunction<Number> cxy8
           (*sys, "a := 4 ; b := a/2+1; c:=b-a+3.5; c*x2*y4");
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (5.0, libmesh_real(cxy8(*c,Point(0.5,0.5,0.5))), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (5.0, cxy8(*c,Point(0.5,0.5,0.5)), TOLERANCE*TOLERANCE);
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (3.0, libmesh_real(cxy8.get_inline_value("b")), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (3.0, cxy8.get_inline_value("b"), TOLERANCE*TOLERANCE);
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (2.5, libmesh_real(cxy8.get_inline_value("c")), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (2.5, cxy8.get_inline_value("c"), TOLERANCE*TOLERANCE);
       }
   }
 
@@ -258,25 +258,25 @@ private:
         ParsedFEMFunction<Number> ax2(*sys, "a:=4.5;a*x2");
         ax2.set_inline_value("a", 2.5);
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (1.25, libmesh_real(ax2(*c,Point(0.25,0.25,0.25))), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (1.25, ax2(*c,Point(0.25,0.25,0.25)), TOLERANCE*TOLERANCE);
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (2.5, libmesh_real(ax2.get_inline_value("a")), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (2.5, ax2.get_inline_value("a"), TOLERANCE*TOLERANCE);
 
         ParsedFEMFunction<Number> cxy8
           (*sys, "a := 4 ; b := a/2+1; c:=b-a+3.5; c*x2*y4");
 
         cxy8.set_inline_value("a", 2);
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (7.0, libmesh_real(cxy8(*c,Point(0.5,0.5,0.5))), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (7.0, cxy8(*c,Point(0.5,0.5,0.5)), TOLERANCE*TOLERANCE);
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (2.0, libmesh_real(cxy8.get_inline_value("b")), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (2.0, cxy8.get_inline_value("b"), TOLERANCE*TOLERANCE);
 
-        LIBMESH_ASSERT_FP_EQUAL
-          (3.5, libmesh_real(cxy8.get_inline_value("c")), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (3.5, cxy8.get_inline_value("c"), TOLERANCE*TOLERANCE);
 
       }
   }
@@ -299,12 +299,12 @@ private:
         // On side 3 of a hex the normal direction is +y
         for (std::size_t qp=0; qp != xyz.size(); ++qp)
           {
-            LIBMESH_ASSERT_FP_EQUAL
-              (0.0, libmesh_real(nx(*s,xyz[qp])), TOLERANCE*TOLERANCE);
-            LIBMESH_ASSERT_FP_EQUAL
-              (1.0, libmesh_real(ny(*s,xyz[qp])), TOLERANCE*TOLERANCE);
-            LIBMESH_ASSERT_FP_EQUAL
-              (0.0, libmesh_real(nz(*s,xyz[qp])), TOLERANCE*TOLERANCE);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (0.0, nx(*s,xyz[qp]), TOLERANCE*TOLERANCE);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (1.0, ny(*s,xyz[qp]), TOLERANCE*TOLERANCE);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (0.0, nz(*s,xyz[qp]), TOLERANCE*TOLERANCE);
           }
       }
   }

--- a/tests/numerics/parsed_function_test.C
+++ b/tests/numerics/parsed_function_test.C
@@ -52,11 +52,11 @@ private:
 
       pfvec.push_back(xy8_stolen);
 
-      LIBMESH_ASSERT_FP_EQUAL
-        (6.0, libmesh_real(xy8_stolen(Point(0.5,1.5,2.5))), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_NUMBERS_EQUAL
+        (6.0, xy8_stolen(Point(0.5,1.5,2.5)), TOLERANCE*TOLERANCE);
     }
-    LIBMESH_ASSERT_FP_EQUAL
-      (6.0, libmesh_real(pfvec[0](Point(0.5,1.5,2.5))), TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_NUMBERS_EQUAL
+      (6.0, pfvec[0](Point(0.5,1.5,2.5)), TOLERANCE*TOLERANCE);
   }
 
   void testInlineGetter()
@@ -69,23 +69,23 @@ private:
     ParsedFunction<Number> ax2_stolen("x");
     ax2_stolen = std::move(ax2);
 
-    LIBMESH_ASSERT_FP_EQUAL
-      (2.25, libmesh_real(ax2_stolen(Point(0.25,0.25,0.25))), TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_NUMBERS_EQUAL
+      (2.25, ax2_stolen(Point(0.25,0.25,0.25)), TOLERANCE*TOLERANCE);
 
-    LIBMESH_ASSERT_FP_EQUAL
-      (4.5, libmesh_real(ax2_stolen.get_inline_value("a")), TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_NUMBERS_EQUAL
+      (4.5, ax2_stolen.get_inline_value("a"), TOLERANCE*TOLERANCE);
 
     ParsedFunction<Number> cxy8
       ("a := 4 ; b := a/2+1; c:=b-a+3.5; c*x*2*y*4");
 
-    LIBMESH_ASSERT_FP_EQUAL
-      (5.0, libmesh_real(cxy8(Point(0.5,0.5,0.5))), TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_NUMBERS_EQUAL
+      (5.0, cxy8(Point(0.5,0.5,0.5)), TOLERANCE*TOLERANCE);
 
-    LIBMESH_ASSERT_FP_EQUAL
-      (3.0, libmesh_real(cxy8.get_inline_value("b")), TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_NUMBERS_EQUAL
+      (3.0, cxy8.get_inline_value("b"), TOLERANCE*TOLERANCE);
 
-    LIBMESH_ASSERT_FP_EQUAL
-      (2.5, libmesh_real(cxy8.get_inline_value("c")), TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_NUMBERS_EQUAL
+      (2.5, cxy8.get_inline_value("c"), TOLERANCE*TOLERANCE);
   }
 
   void testInlineSetter()
@@ -95,24 +95,24 @@ private:
     ParsedFunction<Number> ax2("a:=4.5;a*x*2");
     ax2.set_inline_value("a", 2.5);
 
-    LIBMESH_ASSERT_FP_EQUAL
-      (1.25, libmesh_real(ax2(Point(0.25,0.25,0.25))), TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_NUMBERS_EQUAL
+      (1.25, ax2(Point(0.25,0.25,0.25)), TOLERANCE*TOLERANCE);
 
-    LIBMESH_ASSERT_FP_EQUAL
-      (2.5, libmesh_real(ax2.get_inline_value("a")), TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_NUMBERS_EQUAL
+      (2.5, ax2.get_inline_value("a"), TOLERANCE*TOLERANCE);
 
     ParsedFunction<Number> cxy8
       ("a := 4 ; b := a/2+1; c:=b-a+3.5; c*x*2*y*4");
     cxy8.set_inline_value("a", 2);
 
-    LIBMESH_ASSERT_FP_EQUAL
-      (7.0, libmesh_real(cxy8(Point(0.5,0.5,0.5))), TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_NUMBERS_EQUAL
+      (7.0, cxy8(Point(0.5,0.5,0.5)), TOLERANCE*TOLERANCE);
 
-    LIBMESH_ASSERT_FP_EQUAL
-      (2.0, libmesh_real(cxy8.get_inline_value("b")), TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_NUMBERS_EQUAL
+      (2.0, cxy8.get_inline_value("b"), TOLERANCE*TOLERANCE);
 
-    LIBMESH_ASSERT_FP_EQUAL
-      (3.5, libmesh_real(cxy8.get_inline_value("c")), TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_NUMBERS_EQUAL
+      (3.5, cxy8.get_inline_value("c"), TOLERANCE*TOLERANCE);
   }
 
   void testTimeDependence()

--- a/tests/numerics/petsc_vector_test.C
+++ b/tests/numerics/petsc_vector_test.C
@@ -117,16 +117,16 @@ public:
     v_working.pointwise_mult(v1, *v2);
 
     for (libMesh::dof_id_type n=first; n != last; n++)
-      LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(v_working(n)),
-                              libMesh::Real((n+1)*2*(n+1)),
-                              libMesh::TOLERANCE*libMesh::TOLERANCE);
+      LIBMESH_ASSERT_NUMBERS_EQUAL
+        (v_working(n), libMesh::Real((n+1)*2*(n+1)),
+         libMesh::TOLERANCE*libMesh::TOLERANCE);
 
     v_working.pointwise_divide(v1, *v2);
 
     for (libMesh::dof_id_type n=first; n != last; n++)
-      LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(v_working(n)),
-                              libMesh::Real(0.5),
-                              libMesh::TOLERANCE*libMesh::TOLERANCE);
+      LIBMESH_ASSERT_NUMBERS_EQUAL
+        (v_working(n), libMesh::Real(0.5),
+         libMesh::TOLERANCE*libMesh::TOLERANCE);
   }
 
 };

--- a/tests/numerics/sparse_matrix_test.h
+++ b/tests/numerics/sparse_matrix_test.h
@@ -111,9 +111,9 @@ public:
                libMesh::index_range(cols_to_get))
             {
               CPPUNIT_ASSERT_EQUAL(cols_to_get[col_j], col_start + col_j);
-              LIBMESH_ASSERT_FP_EQUAL
+              LIBMESH_ASSERT_NUMBERS_EQUAL
                 ((i - matrix->row_start() + 1) * (col_j + 1) * (my_comm->rank() + 1),
-                 libMesh::libmesh_real(values[col_j]), _tolerance);
+                 values[col_j], _tolerance);
             }
         }
     };

--- a/tests/numerics/type_vector_test.h
+++ b/tests/numerics/type_vector_test.h
@@ -176,12 +176,12 @@ public:
 
     DerivedClass avector = 0;
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_FP_EQUAL( 0.0 , libmesh_real(avector(i)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , avector(i) , TOLERANCE*TOLERANCE );
 
     DerivedClass bvector = 2.0;
-    LIBMESH_ASSERT_FP_EQUAL( 2.0 , libmesh_real(bvector(0)) , TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , bvector(0) , TOLERANCE*TOLERANCE );
     for (int i = 1; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_FP_EQUAL( 0.0 , libmesh_real(bvector(i)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , bvector(i) , TOLERANCE*TOLERANCE );
   }
 
   void testScalarMult()
@@ -190,9 +190,9 @@ public:
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
     {
-      LIBMESH_ASSERT_FP_EQUAL( 5.0 , libmesh_real(((*m_1_1_1)*5.0)(i)) , TOLERANCE*TOLERANCE );
-      LIBMESH_ASSERT_FP_EQUAL( 5.0 , libmesh_real(outer_product(*m_1_1_1,5.0)(i)) , TOLERANCE*TOLERANCE );
-      LIBMESH_ASSERT_FP_EQUAL( 5.0 , libmesh_real(outer_product(5.0,*m_1_1_1)(i)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 5.0 , ((*m_1_1_1)*5.0)(i) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 5.0 , outer_product(*m_1_1_1,5.0)(i) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 5.0 , outer_product(5.0,*m_1_1_1)(i) , TOLERANCE*TOLERANCE );
     }
   }
 
@@ -201,7 +201,7 @@ public:
     LOG_UNIT_TEST;
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_FP_EQUAL( 1/Real(5) , libmesh_real(((*m_1_1_1)/5.0)(i)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 1/Real(5) , ((*m_1_1_1)/5.0)(i) , TOLERANCE*TOLERANCE );
   }
 
   void testScalarMultAssign()
@@ -212,7 +212,7 @@ public:
     avector*=5.0;
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_FP_EQUAL( 5.0 , libmesh_real(avector(i)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 5.0 , avector(i) , TOLERANCE*TOLERANCE );
   }
 
   void testScalarDivAssign()
@@ -223,18 +223,18 @@ public:
     avector/=5.0;
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_FP_EQUAL( 1/Real(5) , libmesh_real(avector(i)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 1/Real(5) , avector(i) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorAdd()
   {
     LOG_UNIT_TEST;
 
-    LIBMESH_ASSERT_FP_EQUAL( 0.0 , libmesh_real(((*m_1_1_1)+(*m_n1_1_n1))(0)) , TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , ((*m_1_1_1)+(*m_n1_1_n1))(0) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 1)
-      LIBMESH_ASSERT_FP_EQUAL( 2.0 , libmesh_real(((*m_1_1_1)+(*m_n1_1_n1))(1)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , ((*m_1_1_1)+(*m_n1_1_n1))(1) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 2)
-      LIBMESH_ASSERT_FP_EQUAL( 0.0 , libmesh_real(((*m_1_1_1)+(*m_n1_1_n1))(2)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , ((*m_1_1_1)+(*m_n1_1_n1))(2) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorAddScaled()
@@ -245,18 +245,18 @@ public:
     avector.add_scaled((*m_1_1_1),0.5);
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_FP_EQUAL( 1.5 , libmesh_real(avector(i)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 1.5 , avector(i) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorSub()
   {
     LOG_UNIT_TEST;
 
-    LIBMESH_ASSERT_FP_EQUAL( 2.0 , libmesh_real(((*m_1_1_1)-(*m_n1_1_n1))(0)) , TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , ((*m_1_1_1)-(*m_n1_1_n1))(0) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 1)
-      LIBMESH_ASSERT_FP_EQUAL( 0.0 , libmesh_real(((*m_1_1_1)-(*m_n1_1_n1))(1)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , ((*m_1_1_1)-(*m_n1_1_n1))(1) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 2)
-      LIBMESH_ASSERT_FP_EQUAL( 2.0 , libmesh_real(((*m_1_1_1)-(*m_n1_1_n1))(2)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , ((*m_1_1_1)-(*m_n1_1_n1))(2) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorMult()
@@ -264,9 +264,9 @@ public:
     LOG_UNIT_TEST;
 
     if (LIBMESH_DIM == 2)
-      LIBMESH_ASSERT_FP_EQUAL( 0.0 , libmesh_real((*m_1_1_1)*(*m_n1_1_n1)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , (*m_1_1_1)*(*m_n1_1_n1) , TOLERANCE*TOLERANCE );
     else
-      LIBMESH_ASSERT_FP_EQUAL( -1.0 , libmesh_real((*m_1_1_1)*(*m_n1_1_n1)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( -1.0 , (*m_1_1_1)*(*m_n1_1_n1) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorAddAssign()
@@ -277,7 +277,7 @@ public:
     avector+=(*m_1_1_1);
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_FP_EQUAL( 2.0 , libmesh_real(avector(i)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , avector(i) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorSubAssign()
@@ -287,11 +287,11 @@ public:
     DerivedClass avector {*basem_1_1_1};
     avector-=(*m_n1_1_n1);
 
-    LIBMESH_ASSERT_FP_EQUAL( 2.0 , libmesh_real(avector(0)) , TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , avector(0) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 1)
-      LIBMESH_ASSERT_FP_EQUAL( 0.0 , libmesh_real(avector(1)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , avector(1) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 2)
-      LIBMESH_ASSERT_FP_EQUAL( 2.0 , libmesh_real(avector(2)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , avector(2) , TOLERANCE*TOLERANCE );
   }
 
   void testValueBase()
@@ -392,7 +392,7 @@ public:
     LOG_UNIT_TEST;
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_FP_EQUAL( 5.0 , libmesh_real(((*basem_1_1_1)*5.0)(i)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 5.0 , ((*basem_1_1_1)*5.0)(i) , TOLERANCE*TOLERANCE );
   }
 
   void testScalarDivBase()
@@ -400,7 +400,7 @@ public:
     LOG_UNIT_TEST;
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_FP_EQUAL( 1/Real(5) , libmesh_real(((*basem_1_1_1)/5.0)(i)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 1/Real(5) , ((*basem_1_1_1)/5.0)(i) , TOLERANCE*TOLERANCE );
   }
 
   void testScalarMultAssignBase()
@@ -411,7 +411,7 @@ public:
     avector*=5.0;
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_FP_EQUAL( 5.0 , libmesh_real(avector(i)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 5.0 , avector(i) , TOLERANCE*TOLERANCE );
   }
 
   void testScalarDivAssignBase()
@@ -422,18 +422,18 @@ public:
     avector/=5.0;
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_FP_EQUAL( 1/Real(5) , libmesh_real(avector(i)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 1/Real(5) , avector(i) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorAddBase()
   {
     LOG_UNIT_TEST;
 
-    LIBMESH_ASSERT_FP_EQUAL( 0.0 , libmesh_real(((*basem_1_1_1)+(*basem_n1_1_n1))(0)) , TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , ((*basem_1_1_1)+(*basem_n1_1_n1))(0) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 1)
-      LIBMESH_ASSERT_FP_EQUAL( 2.0 , libmesh_real(((*basem_1_1_1)+(*basem_n1_1_n1))(1)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , ((*basem_1_1_1)+(*basem_n1_1_n1))(1) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 2)
-      LIBMESH_ASSERT_FP_EQUAL( 0.0 , libmesh_real(((*basem_1_1_1)+(*basem_n1_1_n1))(2)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , ((*basem_1_1_1)+(*basem_n1_1_n1))(2) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorAddScaledBase()
@@ -444,18 +444,18 @@ public:
     avector.add_scaled((*basem_1_1_1),0.5);
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_FP_EQUAL( 1.5 , libmesh_real(avector(i)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 1.5 , avector(i) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorSubBase()
   {
     LOG_UNIT_TEST;
 
-    LIBMESH_ASSERT_FP_EQUAL( 2.0 , libmesh_real(((*basem_1_1_1)-(*basem_n1_1_n1))(0)) , TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , ((*basem_1_1_1)-(*basem_n1_1_n1))(0) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 1)
-      LIBMESH_ASSERT_FP_EQUAL( 0.0 , libmesh_real(((*basem_1_1_1)-(*basem_n1_1_n1))(1)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , ((*basem_1_1_1)-(*basem_n1_1_n1))(1) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 2)
-      LIBMESH_ASSERT_FP_EQUAL( 2.0 , libmesh_real(((*basem_1_1_1)-(*basem_n1_1_n1))(2)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , ((*basem_1_1_1)-(*basem_n1_1_n1))(2) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorMultBase()
@@ -463,9 +463,9 @@ public:
     LOG_UNIT_TEST;
 
     if (LIBMESH_DIM == 2)
-      LIBMESH_ASSERT_FP_EQUAL(  0.0 , libmesh_real((*basem_1_1_1)*(*basem_n1_1_n1)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL(  0.0 , (*basem_1_1_1)*(*basem_n1_1_n1) , TOLERANCE*TOLERANCE );
     else
-      LIBMESH_ASSERT_FP_EQUAL( -1.0 , libmesh_real((*basem_1_1_1)*(*basem_n1_1_n1)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( -1.0 , (*basem_1_1_1)*(*basem_n1_1_n1) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorAddAssignBase()
@@ -476,7 +476,7 @@ public:
     avector+=(*basem_1_1_1);
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_FP_EQUAL( 2.0 , libmesh_real(avector(i)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , avector(i) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorSubAssignBase()
@@ -486,11 +486,11 @@ public:
     TypeVector<T> avector(*m_1_1_1);
     avector-=(*basem_n1_1_n1);
 
-    LIBMESH_ASSERT_FP_EQUAL( 2.0 , libmesh_real(avector(0)) , TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , avector(0) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 1)
-      LIBMESH_ASSERT_FP_EQUAL( 0.0 , libmesh_real(avector(1)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , avector(1) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 2)
-      LIBMESH_ASSERT_FP_EQUAL( 2.0 , libmesh_real(avector(2)) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , avector(2) , TOLERANCE*TOLERANCE );
   }
 
   void testReplaceAlgebraicType()

--- a/tests/systems/equation_systems_test.C
+++ b/tests/systems/equation_systems_test.C
@@ -299,9 +299,10 @@ public:
       for (Real y = 0.1; y < 1; y += 0.2)
         {
           Point p(x,y);
-          LIBMESH_ASSERT_FP_EQUAL(libmesh_real(sys.point_value(0,p)),
-                                  libmesh_real(bilinear_test(p,es.parameters,"","")),
-                                  TOLERANCE*TOLERANCE);
+          LIBMESH_ASSERT_NUMBERS_EQUAL
+            (sys.point_value(0,p),
+             bilinear_test(p,es.parameters,"",""),
+             TOLERANCE*TOLERANCE);
         }
   }
 

--- a/tests/systems/periodic_bc_test.C
+++ b/tests/systems/periodic_bc_test.C
@@ -243,9 +243,8 @@ private:
           Point p{x,y};
           const Number exact = quadratic_solution(p,params,"","");
           const Number approx = sys.point_value(0,p);
-          LIBMESH_ASSERT_FP_EQUAL(libmesh_real(exact),
-                                  libmesh_real(approx),
-                                  TOLERANCE*TOLERANCE*20);
+          LIBMESH_ASSERT_NUMBERS_EQUAL(exact, approx,
+                                      TOLERANCE*TOLERANCE*20);
         }
   }
 

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -511,39 +511,45 @@ private:
 
     if (u_subdomains.count(sbd_id))
       {
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(cubic_test(p,param,"","")),
-                                libmesh_real(sys.point_value(0,p)),
+        LIBMESH_ASSERT_NUMBERS_EQUAL(cubic_test(p,param,"",""),
+                                sys.point_value(0,p),
                                 TOLERANCE*TOLERANCE*10);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(cubic_test(p,param,"","") + Number(10)),
-                                libmesh_real(sys.point_value(0,p,sys.old_local_solution)),
-                                TOLERANCE*TOLERANCE*100);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(cubic_test(p,param,"","") + Number(20)),
-                                libmesh_real(sys.point_value(0,p,sys.older_local_solution)),
-                                TOLERANCE*TOLERANCE*100);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (cubic_test(p,param,"","") + Number(10),
+           sys.point_value(0,p,sys.old_local_solution),
+           TOLERANCE*TOLERANCE*100);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (cubic_test(p,param,"","") + Number(20),
+           sys.point_value(0,p,sys.older_local_solution),
+           TOLERANCE*TOLERANCE*100);
       }
     if (v_subdomains.count(sbd_id))
       {
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(new_linear_test(p,param,"","")),
-                                libmesh_real(sys.point_value(1,p)),
-                                TOLERANCE*TOLERANCE*10);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(new_linear_test(p,param,"","") + Number(10)),
-                                libmesh_real(sys.point_value(1,p,sys.old_local_solution)),
-                                TOLERANCE*TOLERANCE*100);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(new_linear_test(p,param,"","") + Number(20)),
-                                libmesh_real(sys.point_value(1,p,sys.older_local_solution)),
-                                TOLERANCE*TOLERANCE*100);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (new_linear_test(p,param,"",""), sys.point_value(1,p),
+           TOLERANCE*TOLERANCE*10);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (new_linear_test(p,param,"","") + Number(10),
+           sys.point_value(1,p,sys.old_local_solution),
+           TOLERANCE*TOLERANCE*100);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (new_linear_test(p,param,"","") + Number(20),
+           sys.point_value(1,p,sys.older_local_solution),
+           TOLERANCE*TOLERANCE*100);
       }
     if (w_subdomains.count(sbd_id))
       {
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(disc_thirds_test(p,param,"","")),
-                                libmesh_real(sys.point_value(2,p)),
-                                TOLERANCE*TOLERANCE*10);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(disc_thirds_test(p,param,"","") + Number(10)),
-                                libmesh_real(sys.point_value(2,p,sys.old_local_solution)),
-                                TOLERANCE*TOLERANCE*100);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(disc_thirds_test(p,param,"","") + Number(20)),
-                                libmesh_real(sys.point_value(2,p,sys.older_local_solution)),
-                                TOLERANCE*TOLERANCE*100);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (disc_thirds_test(p,param,"",""), sys.point_value(2,p),
+           TOLERANCE*TOLERANCE*10);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (disc_thirds_test(p,param,"","") + Number(10),
+           sys.point_value(2,p,sys.old_local_solution),
+           TOLERANCE*TOLERANCE*100);
+        LIBMESH_ASSERT_NUMBERS_EQUAL
+          (disc_thirds_test(p,param,"","") + Number(20),
+           sys.point_value(2,p,sys.older_local_solution),
+           TOLERANCE*TOLERANCE*100);
       }
   }
 
@@ -810,7 +816,7 @@ public:
       {
         auto dof_index = node->dof_number(sys.number(), u_var, i);
         auto value = (*sys.solution)(dof_index);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(value), (*node)(i), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL(value, (*node)(i), TOLERANCE*TOLERANCE);
       }
     }
   }
@@ -861,7 +867,7 @@ public:
       {
         auto dof_index = node->dof_number(sys.number(), u_var, i);
         auto value = (*sys.solution)(dof_index);
-        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(value), (*node)(i), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_NUMBERS_EQUAL(value, (*node)(i), TOLERANCE*TOLERANCE);
       }
     }
   }
@@ -1035,9 +1041,9 @@ public:
         for (Real z = 0.1; z < 1; z += 0.2)
           {
             Point p(x,y,z);
-            LIBMESH_ASSERT_FP_EQUAL(libmesh_real(cubic_test(p,es.parameters,"","")),
-                                    libmesh_real(proj_sys.point_value(0,p)),
-                                    TOLERANCE*TOLERANCE);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (cubic_test(p,es.parameters,"",""),
+               proj_sys.point_value(0,p), TOLERANCE*TOLERANCE);
           }
   }
 


### PR DESCRIPTION
`LIBMESH_ASSERT_NUMBERS_EQUAL` is a little less finicky and a little cleaner to use than casting things to `libmesh_real()`, and it also asserts when comparing real to complex numbers that the latter has an empty imaginary part.

This PR pulls out an independent chunk of #4150, that being the point where I got fed up with wrapping `libmesh_real()` around everything that might be stored as complex without actually being complex.