### PR TITLE
Allow disconnected_clone() with invalid unique_id

### DIFF
--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -300,7 +300,8 @@ std::unique_ptr<Elem> Elem::disconnected_clone() const
 
   returnval->set_id() = this->id();
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
-  returnval->set_unique_id(this->unique_id());
+  if (this->valid_unique_id())
+    returnval->set_unique_id(this->unique_id());
 #endif
   returnval->subdomain_id() = this->subdomain_id();
   returnval->processor_id() = this->processor_id();


### PR DESCRIPTION
In the polyhedron branch we'd hit an assertion failure when trying to clone an element (a face of a polyhedron) with no unique_id set, but really as a general principle we should be able to copy an element that isn't directly owned by a mesh and thus doesn't currently have a valid unique_id.