### PR TITLE
Backport netCDF fix for keyword clashes with C23

### DIFF
--- a/contrib/netcdf/netcdf-c-4.6.2/ncdump/utils.h
+++ b/contrib/netcdf/netcdf-c-4.6.2/ncdump/utils.h
@@ -18,7 +18,11 @@
 #define NC_GRP_DELIM '/'
 
 typedef int bool_t;
-enum {false=0, true=1};
+#ifndef false
+#define false 0
+#define true 1
+//enum {false=0, true=1};
+#endif
 
 struct safebuf_t;
 /* Buffer structure for implementing growable strings, used in


### PR DESCRIPTION
I copied the new fenced definitions verbatim from our v4.9.2 submodule.

-Nuno