### PR TITLE
Add missing header include

### DIFF
--- a/src/fe/fe_lagrange_shape_3D.C
+++ b/src/fe/fe_lagrange_shape_3D.C
@@ -22,6 +22,7 @@
 #include "libmesh/fe_lagrange_shape_1D.h"
 #include "libmesh/enum_to_string.h"
 #include "libmesh/cell_c0polyhedron.h"
+#include "libmesh/tensor_value.h"
 
 // Anonymous namespace for functions shared by LAGRANGE and
 // L2_LAGRANGE implementations. Implementations appear at the bottom


### PR DESCRIPTION
This is getting pulled in indirectly in most builds, but with configure --disable-second we're missing it, and it's better practice to directly include what we directly use in any case.

This fixes a regression in --disable-second builds for me; hopefully it will do the same in CI.