### PR TITLE
NumericVector::print/read_matlab

### DIFF
--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -735,10 +735,20 @@ public:
    * format. Optionally prints the vector to the file named \p name.
    * If \p name is not specified it is dumped to the screen.
    */
-  virtual void print_matlab(const std::string & /*name*/ = "") const
-  {
-    libmesh_not_implemented();
-  }
+  virtual void print_matlab(const std::string & filename = "") const;
+
+  /**
+   * Read the contents of the vector from the Matlab-script format
+   * used by PETSc.
+   *
+   * If the size of the matrix in \p filename appears consistent with
+   * the existing partitioning of \p this then the existing parallel
+   * decomposition will be retained.
+   * If not, then \p this will be initialized with the size from
+   * the file, linearly partitioned onto the number of processors
+   * available.
+   */
+  virtual void read_matlab(const std::string & filename);
 
   /**
    * Fills in \p subvector from this vector using the indices in \p rows.

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -469,8 +469,8 @@ public:
   virtual void read(const std::string & filename);
 
   /**
-   * Read the contents of the matrix from Matlab's sparse matrix
-   * format.
+   * Read the contents of the matrix from the Matlab-script sparse
+   * matrix format used by PETSc.
    *
    * If the size and sparsity of the matrix in \p filename appears
    * consistent with the existing sparsity of \p this then the

--- a/src/numerics/distributed_vector.C
+++ b/src/numerics/distributed_vector.C
@@ -431,7 +431,7 @@ void DistributedVector<T>::close ()
       std::vector<numeric_index_type> last_local_indices;
       this->comm().allgather(_last_local_index, last_local_indices);
 
-      std::map<processor_id_type, std::vector<std::pair<numeric_index_type,T>>> 
+      std::map<processor_id_type, std::vector<std::pair<numeric_index_type,T>>>
         updates_to_send;
 
       processor_id_type p = 0;

--- a/src/numerics/distributed_vector.C
+++ b/src/numerics/distributed_vector.C
@@ -424,8 +424,11 @@ void DistributedVector<T>::close ()
       libmesh_assert_not_equal_to(someone_is_setting, someone_is_adding);
 #endif
 
-      // We want to traverse in order later
-      std::sort(_remote_values.begin(), _remote_values.end());
+      // We want to traverse in id order later, but we can't compare
+      // values with default < in the case where Number==complex.
+      std::sort(_remote_values.begin(), _remote_values.end(),
+                [](auto a, auto b)
+                { return a.first < b.first; });
 
       std::vector<numeric_index_type> last_local_indices;
       this->comm().allgather(_last_local_index, last_local_indices);

--- a/src/numerics/numeric_vector.C
+++ b/src/numerics/numeric_vector.C
@@ -28,12 +28,23 @@
 #include "libmesh/enum_solver_package.h"
 #include "libmesh/int_range.h"
 
+// gzstream for reading/writing compressed files as a stream
+#ifdef LIBMESH_HAVE_GZSTREAM
+# include "libmesh/ignore_warnings.h" // shadowing in gzstream.h
+# include "gzstream.h"
+# include "libmesh/restore_warnings.h"
+#endif
 
 // C++ includes
 #include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
 #include <cmath> // for std::abs
+#include <sstream>
 #include <limits>
 #include <memory>
+
+#ifdef LIBMESH_HAVE_CXX11_REGEX
+#include <regex>
+#endif
 
 
 namespace libMesh
@@ -227,6 +238,215 @@ int NumericVector<T>::global_relative_compare (const NumericVector<T> & other_ve
 
   return first_different_i;
 }
+
+
+
+template <typename T>
+void NumericVector<T>::print_matlab(const std::string & filename) const
+{
+  parallel_object_only();
+
+  libmesh_assert (this->initialized());
+
+  const numeric_index_type first_dof = this->first_local_index(),
+                           end_dof   = this->last_local_index();
+
+  // We'll print the vector from processor 0 to make sure
+  // it's serialized properly
+  if (this->processor_id() == 0)
+    {
+      std::unique_ptr<std::ofstream> file;
+
+      if (filename != "")
+        file = std::make_unique<std::ofstream>(filename.c_str());
+
+      std::ostream & os = (filename == "") ? libMesh::out : *file;
+
+      // Print a header similar to PETSC_VIEWER_ASCII_MATLAB
+      os << "%Vec Object: () " << this->n_processors() << " MPI processes\n"
+         << "%  type: " << (this->n_processors() > 1 ? "mpi" : "seq") << "\n"
+         << "Vec = [\n";
+
+      for (numeric_index_type i : make_range(end_dof))
+        os << (*this)(i) << '\n';
+
+      std::vector<T> cbuf;
+      for (auto p : IntRange<processor_id_type>(1, this->n_processors()))
+        {
+          this->comm().receive(p, cbuf);
+
+          for (auto c : cbuf)
+            os << c << '\n';
+        }
+
+      os << "];\n" << std::endl;
+    }
+  else
+    {
+      std::vector<T> cbuf(end_dof - first_dof);
+
+      for (numeric_index_type i : make_range(end_dof - first_dof))
+        cbuf[i] = (*this)(first_dof+i);
+      this->comm().send(0,cbuf);
+    }
+}
+
+
+
+template <typename T>
+void NumericVector<T>::read_matlab(const std::string & filename)
+{
+  LOG_SCOPE("read_matlab()", "NumericVector");
+
+#ifndef LIBMESH_HAVE_CXX11_REGEX
+  libmesh_not_implemented();  // What is your compiler?!?  Email us!
+  libmesh_ignore(filename);
+#else
+  parallel_object_only();
+
+  const bool gzipped_file = (filename.rfind(".gz") == filename.size() - 3);
+
+  // If we don't already have this size, we'll need to reinit, and
+  // determine which entries each processor is in charge of.
+  std::vector<numeric_index_type> first_entries, end_entries;
+
+  numeric_index_type first_entry = 0,
+                     end_entry = 0,
+                     n = 0;
+
+  // We'll use an istream here; it might be an ifstream if we're
+  // opening a raw ASCII file or a gzstream if we're opening a
+  // compressed one.
+  std::unique_ptr<std::istream> file;
+
+  // First read through the file, saving size and entry data
+  std::vector<T> entries;
+
+  {
+  // We'll read the vector on processor 0 rather than try to juggle
+  // parallel I/O.
+  if (this->processor_id() == 0)
+    {
+      // We'll be using regular expressions to make ourselves slightly
+      // more robust to formatting.
+      const std::regex start_regex // assignment like "Vec_0x84000002_1 = ["
+        ("\\s*\\w+\\s*=\\s*\\[");
+      const std::regex end_regex // end of assignment
+        ("^[^%]*\\]");
+
+      if (gzipped_file)
+        {
+#ifdef LIBMESH_HAVE_GZSTREAM
+          auto inf = std::make_unique<igzstream>();
+          libmesh_assert(inf);
+          inf->open(filename.c_str(), std::ios::in);
+          file = std::move(inf);
+#else
+          libmesh_error_msg("ERROR: need gzstream to handle .gz files!!!");
+#endif
+        }
+      else
+        {
+          auto inf = std::make_unique<std::ifstream>();
+          libmesh_assert(inf);
+
+          std::string new_name = Utility::unzip_file(filename);
+
+          inf->open(new_name.c_str(), std::ios::in);
+          file = std::move(inf);
+        }
+
+      const std::string whitespace = " \t";
+
+      bool have_started = false;
+      bool have_ended = false;
+
+      for (std::string line; std::getline(*file, line);)
+        {
+          std::smatch sm;
+
+          // First, try to match an entry.  This is the most common
+          // case so we won't rely on slow std::regex for it.
+          // stringstream is at least an improvement over that.
+          std::istringstream l(line);
+          T value;
+          l >> value;
+
+          if (!l.fail())
+            {
+              libmesh_error_msg_if
+                (!have_started, "Confused by premature entries in vector file " << filename);
+
+              entries.push_back(value);
+              ++n;
+            }
+
+          else if (std::regex_search(line, start_regex))
+            have_started = true;
+
+          else if (std::regex_search(line, end_regex))
+            {
+              have_ended = true;
+              break;
+            }
+        }
+
+      libmesh_error_msg_if
+        (!have_started, "Confused by missing assignment-beginning in vector file " << filename);
+
+      libmesh_error_msg_if
+        (!have_ended, "Confused by missing assignment-ending in vector file " << filename);
+    }
+
+  this->comm().broadcast(n);
+
+  if (this->initialized() &&
+      n == this->size())
+    {
+      first_entry = this->first_local_index(),
+      end_entry = this->last_local_index();
+    }
+  else
+    {
+      // Determine which rows/columns each processor will be in charge of
+      first_entry =     this->processor_id() * n / this->n_processors(),
+      end_entry   = (this->processor_id()+1) * n / this->n_processors();
+    }
+
+  this->comm().gather(0, first_entry, first_entries);
+  this->comm().gather(0, end_entry, end_entries);
+
+  } // Done reading entry data and broadcasting vector size
+
+  // If we're not already initialized compatibly with the file then
+  // we'll initialize here
+  bool need_init = !this->initialized() ||
+                   (this->size() != n) ||
+                   (this->local_size() != end_entry - first_entry);
+
+  this->comm().max(need_init);
+  
+  if (need_init)
+    this->init(n, end_entry - first_entry);
+
+  // Set the vector values last.  The iota call here is inefficient
+  // but it's probably better than calling a single virtual function
+  // per index.
+  if (this->processor_id() == 0)
+    for (auto p : make_range(this->n_processors()))
+      {
+        const numeric_index_type first_entry_p = first_entries[p];
+        const numeric_index_type n_local = end_entries[p] - first_entry_p;
+        std::vector<numeric_index_type> indices(n_local);
+        std::iota(indices.begin(), indices.end(), first_entry_p);
+        this->insert(entries.data() + first_entries[p],
+                     indices);
+      }
+
+  this->close();
+#endif
+}
+
 
 /*
 // Full specialization for float datatypes (DistributedVector wants this)

--- a/src/numerics/numeric_vector.C
+++ b/src/numerics/numeric_vector.C
@@ -425,7 +425,7 @@ void NumericVector<T>::read_matlab(const std::string & filename)
                    (this->local_size() != end_entry - first_entry);
 
   this->comm().max(need_init);
-  
+
   if (need_init)
     this->init(n, end_entry - first_entry);
 


### PR DESCRIPTION
This is easier than the SparseMatrix versions were, and it's useful for some utilities and debugging I'm working on.