### PR TITLE
Remove warnings guards around gzstream.h

### DIFF
--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -25,9 +25,7 @@
 
 // gzstream for reading compressed files as a stream
 #ifdef LIBMESH_HAVE_GZSTREAM
-# include "libmesh/ignore_warnings.h" // shadowing in gzstream.h
 # include "gzstream.h"
-# include "libmesh/restore_warnings.h"
 #endif
 
 // C++ includes

--- a/src/mesh/dyna_io.C
+++ b/src/mesh/dyna_io.C
@@ -31,9 +31,7 @@
 
 // gzstream for reading compressed files as a stream
 #ifdef LIBMESH_HAVE_GZSTREAM
-# include "libmesh/ignore_warnings.h" // shadowing in gzstream.h
 # include "gzstream.h"
-# include "libmesh/restore_warnings.h"
 #endif
 
 // C++ includes

--- a/src/mesh/stl_io.C
+++ b/src/mesh/stl_io.C
@@ -29,9 +29,7 @@
 
 // gzstream for reading compressed files as a stream
 #ifdef LIBMESH_HAVE_GZSTREAM
-# include "libmesh/ignore_warnings.h" // shadowing in gzstream.h
 # include "gzstream.h"
-# include "libmesh/restore_warnings.h"
 #endif
 
 // C++ includes

--- a/src/mesh/ucd_io.C
+++ b/src/mesh/ucd_io.C
@@ -31,9 +31,7 @@
 #include "libmesh/utility.h"
 
 #ifdef LIBMESH_HAVE_GZSTREAM
-# include "libmesh/ignore_warnings.h" // shadowing in gzstream.h
 # include "gzstream.h" // For reading/writing compressed streams
-# include "libmesh/restore_warnings.h"
 #endif
 
 // C++ includes

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -46,9 +46,7 @@
 #include <unordered_map>
 
 #ifdef LIBMESH_HAVE_GZSTREAM
-# include "libmesh/ignore_warnings.h" // shadowing in gzstream.h
 # include "gzstream.h" // For reading/writing compressed streams
-# include "libmesh/restore_warnings.h"
 #endif
 
 

--- a/src/numerics/numeric_vector.C
+++ b/src/numerics/numeric_vector.C
@@ -30,9 +30,7 @@
 
 // gzstream for reading/writing compressed files as a stream
 #ifdef LIBMESH_HAVE_GZSTREAM
-# include "libmesh/ignore_warnings.h" // shadowing in gzstream.h
 # include "gzstream.h"
-# include "libmesh/restore_warnings.h"
 #endif
 
 // C++ includes

--- a/src/numerics/sparse_matrix.C
+++ b/src/numerics/sparse_matrix.C
@@ -36,9 +36,7 @@
 
 // gzstream for reading compressed files as a stream
 #ifdef LIBMESH_HAVE_GZSTREAM
-# include "libmesh/ignore_warnings.h" // shadowing in gzstream.h
 # include "gzstream.h"
-# include "libmesh/restore_warnings.h"
 #endif
 
 // C++ includes

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -28,9 +28,7 @@
 #include "libmesh/xdr_cxx.h"
 #include "libmesh/libmesh_logging.h"
 #ifdef LIBMESH_HAVE_GZSTREAM
-# include "libmesh/ignore_warnings.h" // shadowing in gzstream.h
 # include "gzstream.h" // For reading/writing compressed streams
-# include "libmesh/restore_warnings.h"
 #endif
 #include "libmesh/utility.h" // unzip_file
 


### PR DESCRIPTION
The shadowing warnings we used to get were a gcc 8 bug, and should be fixed by now.

I say "should be", of course, which does not imply "were".  gcc 9.5 works fine for me, and hopefully 8.x is fine now too, but if our "Min gcc" CI recipes aren't happy then we'll just let this branch languish a while.