### PR TITLE
Add missing headers

### DIFF
--- a/src/numerics/numeric_vector.C
+++ b/src/numerics/numeric_vector.C
@@ -36,6 +36,8 @@
 // C++ includes
 #include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
 #include <cmath> // for std::abs
+#include <fstream>
+#include <iostream>
 #include <sstream>
 #include <limits>
 #include <memory>


### PR DESCRIPTION
This fixes compilation failures with --disable-optional for me; hopefully it will fix it for the Civet devel->master testing too.