### PR TITLE
copy_nodes_and_elements metadata setting fixes

### DIFF
--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -193,6 +193,11 @@ DistributedMesh::DistributedMesh (const MeshBase & other_mesh) :
 {
   this->copy_nodes_and_elements(other_mesh, true);
 
+  this->allow_find_neighbors(other_mesh.allow_find_neighbors());
+  this->allow_renumbering(other_mesh.allow_renumbering());
+  this->allow_remote_element_removal(other_mesh.allow_remote_element_removal());
+  this->skip_partitioning(other_mesh.skip_partitioning());
+
   // The prepare_for_use() in copy_nodes_and_elements() is going to be
   // tricky to remove without breaking backwards compatibility, but it
   // updates some things we want to just copy.

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -200,6 +200,8 @@ DistributedMesh::DistributedMesh (const MeshBase & other_mesh) :
 
   this->copy_constraint_rows(other_mesh);
 
+  this->_is_prepared = other_mesh.is_prepared();
+
   auto & this_boundary_info = this->get_boundary_info();
   const auto & other_boundary_info = other_mesh.get_boundary_info();
 

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -110,6 +110,8 @@ ReplicatedMesh::ReplicatedMesh (const MeshBase & other_mesh) :
 
   this->copy_constraint_rows(other_mesh);
 
+  this->_is_prepared = other_mesh.is_prepared();
+
   auto & this_boundary_info = this->get_boundary_info();
   const auto & other_boundary_info = other_mesh.get_boundary_info();
 

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -103,6 +103,11 @@ ReplicatedMesh::ReplicatedMesh (const MeshBase & other_mesh) :
 {
   this->copy_nodes_and_elements(other_mesh, true);
 
+  this->allow_find_neighbors(other_mesh.allow_find_neighbors());
+  this->allow_renumbering(other_mesh.allow_renumbering());
+  this->allow_remote_element_removal(other_mesh.allow_remote_element_removal());
+  this->skip_partitioning(other_mesh.skip_partitioning());
+
   // The prepare_for_use() in copy_nodes_and_elements() is going to be
   // tricky to remove without breaking backwards compatibility, but it
   // updates some things we want to just copy.

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -825,25 +825,32 @@ void UnstructuredMesh::copy_nodes_and_elements(const MeshBase & other_mesh,
   this->set_next_unique_id(other_mesh.parallel_max_unique_id() + unique_id_offset + 1);
 #endif
 
-  //Finally prepare the new Mesh for use.  Keep the same numbering and
-  //partitioning for now.
-  const bool was_prepared = this->is_prepared();
+  // Finally, partially prepare the new Mesh for use.
+  // This is for backwards compatibility, so we don't want to prepare
+  // everything.
+  //
+  // Keep the same numbering and partitioning and distribution status
+  // for now, but save our original policies to restore later.
+  const bool allowed_renumbering = this->allow_renumbering();
+  const bool allowed_find_neighbors = this->allow_find_neighbors();
+  const bool allowed_elem_removal = this->allow_remote_element_removal();
   this->allow_renumbering(false);
   this->allow_remote_element_removal(false);
   this->allow_find_neighbors(!skip_find_neighbors);
 
   // We should generally be able to skip *all* partitioning here
   // because we're only adding one already-consistent mesh to another.
+  const bool skipped_partitioning = this->skip_partitioning();
   this->skip_partitioning(true);
 
+  const bool was_prepared = this->is_prepared();
   this->prepare_for_use();
 
-  //But in the long term, use the same renumbering and partitioning
-  //policies as our source mesh.
-  this->allow_find_neighbors(other_mesh.allow_find_neighbors());
-  this->allow_renumbering(other_mesh.allow_renumbering());
-  this->allow_remote_element_removal(other_mesh.allow_remote_element_removal());
-  this->skip_partitioning(other_mesh.skip_partitioning());
+  //But in the long term, don't change our policies.
+  this->allow_find_neighbors(allowed_find_neighbors);
+  this->allow_renumbering(allowed_renumbering);
+  this->allow_remote_element_removal(allowed_elem_removal);
+  this->skip_partitioning(skipped_partitioning);
 
   // That prepare_for_use() call marked us as prepared, but we
   // specifically avoided some important preparation, so we might not

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -848,8 +848,8 @@ void UnstructuredMesh::copy_nodes_and_elements(const MeshBase & other_mesh,
   // That prepare_for_use() call marked us as prepared, but we
   // specifically avoided some important preparation, so we might not
   // actually be prepared now.
-  if (skip_find_neighbors &&
-      (!was_prepared || !other_mesh.is_prepared()))
+  if (skip_find_neighbors ||
+      !was_prepared || !other_mesh.is_prepared())
     this->set_isnt_prepared();
 }
 


### PR DESCRIPTION
We want to copy policies in our copy constructors, but *only* there, not in the method that specifically says it will not copy most "high level" data.

This fixes a bug in the MOOSE reactor module for me.

Unfortunately, this behavior is a 13 year old bug; hopefully other code hasn't come to depend on it.

While I was at it, I fixed a potential bug in the `set_isnt_prepared()` logic; that turned out to be a red herring for this case but better safe than sorry for the future.