### PR TITLE
More exhaustive boundary sync tests, fixes

### DIFF
--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -848,8 +848,9 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
     }
 
   // We haven't been bothering to keep unique ids consistent on ghost
-  // elements
-  if (!boundary_mesh.is_serial())
+  // elements or nodes, unless we're doing everything the same on
+  // every processor.
+  if (!boundary_mesh.is_replicated())
     MeshCommunication().make_node_unique_ids_parallel_consistent(boundary_mesh);
 
   // Make sure we didn't add ids inconsistently

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -101,8 +101,8 @@ MeshBase::MeshBase (const MeshBase & other_mesh) :
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
   _next_unique_id(other_mesh._next_unique_id),
 #endif
-  _skip_noncritical_partitioning(false),
-  _skip_all_partitioning(libMesh::on_command_line("--skip-partitioning")),
+  _skip_noncritical_partitioning(other_mesh._skip_noncritical_partitioning),
+  _skip_all_partitioning(other_mesh._skip_all_partitioning),
   _skip_renumber_nodes_and_elements(other_mesh._skip_renumber_nodes_and_elements),
   _skip_find_neighbors(other_mesh._skip_find_neighbors),
   _allow_remote_element_removal(other_mesh._allow_remote_element_removal),

--- a/tests/mesh/boundary_mesh.C
+++ b/tests/mesh/boundary_mesh.C
@@ -1,3 +1,4 @@
+#include <libmesh/distributed_mesh.h>
 #include <libmesh/mesh.h>
 #include <libmesh/mesh_generation.h>
 #include <libmesh/mesh_refinement.h>
@@ -28,17 +29,23 @@ public:
 
 protected:
 
-  std::unique_ptr<Mesh> _mesh;
-  std::unique_ptr<Mesh> _all_boundary_mesh;
-  std::unique_ptr<Mesh> _left_boundary_mesh;
-  std::unique_ptr<Mesh> _internal_boundary_mesh;
+  std::unique_ptr<UnstructuredMesh> _mesh;
+  std::unique_ptr<UnstructuredMesh> _all_boundary_mesh;
+  std::unique_ptr<UnstructuredMesh> _left_boundary_mesh;
+  std::unique_ptr<UnstructuredMesh> _internal_boundary_mesh;
 
   void build_mesh()
   {
     _mesh = std::make_unique<Mesh>(*TestCommWorld);
     _all_boundary_mesh = std::make_unique<Mesh>(*TestCommWorld);
-    _left_boundary_mesh = std::make_unique<Mesh>(*TestCommWorld);
-    _internal_boundary_mesh = std::make_unique<Mesh>(*TestCommWorld);
+
+    // We want to test Distributed->Replicated sync; this does that in
+    // some builds
+    _left_boundary_mesh = std::make_unique<ReplicatedMesh>(*TestCommWorld);
+
+    // We want to test Replicated->Distributed sync; this does that in
+    // other builds
+    _internal_boundary_mesh = std::make_unique<DistributedMesh>(*TestCommWorld);
 
     MeshTools::Generation::build_square(*_mesh, 3, 5,
                                         0.2, 0.8, 0.2, 0.7, QUAD9);


### PR DESCRIPTION
@YaqiWang hit a couple bugs in BoundaryInfo::sync() combinations that I anticipated well enough to support but apparently didn't anticipate well enough to properly test.  This PR adds bug fixes, better test coverage, and bug fixes for bugs revealed when they were triggered by the first bug fixes.  This was all reordered via rebase so the intermediate commits here shouldn't be any *more* broken than their predecessors.