### PR TITLE
Prism::opposite_side()

### DIFF
--- a/include/geom/cell_hex.h
+++ b/include/geom/cell_hex.h
@@ -112,8 +112,7 @@ public:
                                const unsigned int s) const override final;
 
   /**
-   * \returns The side number opposite to \p s (for a tensor product
-   * element), or throws an error otherwise.
+   * \returns The side number opposite to \p s
    */
   virtual unsigned int opposite_side(const unsigned int s) const override final;
 

--- a/include/geom/cell_prism.h
+++ b/include/geom/cell_prism.h
@@ -118,6 +118,12 @@ public:
                                const unsigned int s) const override final;
 
   /**
+   * \returns The side number opposite to \p s (for the triangular
+   * sides) or \p invalid_uint (for the quad sides)
+   */
+  virtual unsigned int opposite_side(const unsigned int s) const override final;
+
+  /**
    * Don't hide Elem::key() defined in the base class.
    */
   using Elem::key;

--- a/src/geom/cell_prism.C
+++ b/src/geom/cell_prism.C
@@ -275,6 +275,17 @@ std::vector<unsigned int> Prism::sides_on_edge(const unsigned int e) const
 }
 
 
+
+unsigned int Prism::opposite_side(const unsigned int side_in) const
+{
+  libmesh_assert_less (side_in, 5);
+  static const unsigned int prism_opposites[5] =
+    {4, invalid_uint, invalid_uint, invalid_uint, 0};
+  return prism_opposites[side_in];
+}
+
+
+
 bool
 Prism::is_flipped() const
 {


### PR DESCRIPTION
This isn't well-defined on every side, but it is on two of them.

Thanks to @zachmprince for pointing out that we might be missing this.  The "march away from a boundary" code I've used on quad and hex meshes in the past would also be reasonable on the common "prism boundary layer extruded from triangular surface mesh" meshes.