### PR TITLE
Retain build_side_ptr proxy option, deprecated

### DIFF
--- a/include/geom/cell_hex20.h
+++ b/include/geom/cell_hex20.h
@@ -168,6 +168,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * Builds a \p EDGE3 built coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -183,6 +183,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * Builds a \p EDGE3 built coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.

--- a/include/geom/cell_hex8.h
+++ b/include/geom/cell_hex8.h
@@ -141,6 +141,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * Builds a EDGE2 built coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.

--- a/include/geom/cell_inf_hex16.h
+++ b/include/geom/cell_inf_hex16.h
@@ -150,6 +150,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * \returns An \p EDGE3 built coincident with edges 0 to 3, or \p
    * INFEDGE2 built coincident with edges 4 to 11.

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -138,6 +138,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * \returns An \p EDGE3 built coincident with edges 0-3, or an \p INFEDGE2
    * built coincident with edges 4 to 11.

--- a/include/geom/cell_inf_hex8.h
+++ b/include/geom/cell_inf_hex8.h
@@ -123,6 +123,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * \returns An \p EDGE2 built coincident with edges 0 to 3, or an \p INFEDGE2
    * built coincident with edges 4 to 7.

--- a/include/geom/cell_inf_prism12.h
+++ b/include/geom/cell_inf_prism12.h
@@ -141,6 +141,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * \returns An \p EDGE3 built coincident with edges 0 to 2, or an \p INFEDGE2
    * built coincident with edges 3 to 5.

--- a/include/geom/cell_inf_prism6.h
+++ b/include/geom/cell_inf_prism6.h
@@ -125,6 +125,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * \returns An \p EDGE2 built coincident with edges 0 to 2, an \p INFEDGE2
    * built coincident with edges 3 to 5.

--- a/include/geom/cell_polyhedron.h
+++ b/include/geom/cell_polyhedron.h
@@ -191,6 +191,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * \returns An element coincident with edge \p i wrapped in a smart pointer.
    */

--- a/include/geom/cell_prism15.h
+++ b/include/geom/cell_prism15.h
@@ -173,6 +173,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * Builds a \p EDGE3 or \p INFEDGE2 coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -188,6 +188,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * Builds a \p EDGE3 or \p INFEDGE2 built coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.

--- a/include/geom/cell_prism20.h
+++ b/include/geom/cell_prism20.h
@@ -192,6 +192,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * Builds a \p EDGE3 or \p INFEDGE2 built coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.

--- a/include/geom/cell_prism21.h
+++ b/include/geom/cell_prism21.h
@@ -195,6 +195,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * Builds a \p EDGE3 or \p INFEDGE2 built coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.

--- a/include/geom/cell_prism6.h
+++ b/include/geom/cell_prism6.h
@@ -139,6 +139,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * Builds a \p EDGE2 or \p INFEDGE2 built coincident with face i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.

--- a/include/geom/cell_pyramid13.h
+++ b/include/geom/cell_pyramid13.h
@@ -172,6 +172,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * Builds a \p EDGE3 coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -190,6 +190,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * Builds a \p EDGE3 coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.

--- a/include/geom/cell_pyramid18.h
+++ b/include/geom/cell_pyramid18.h
@@ -196,6 +196,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * Builds a \p EDGE3 coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.

--- a/include/geom/cell_pyramid5.h
+++ b/include/geom/cell_pyramid5.h
@@ -138,6 +138,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * Builds a \p EDGE2 built coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.

--- a/include/geom/cell_tet10.h
+++ b/include/geom/cell_tet10.h
@@ -169,6 +169,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * Builds a \p EDGE3 built coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.

--- a/include/geom/cell_tet14.h
+++ b/include/geom/cell_tet14.h
@@ -175,6 +175,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * Builds a \p EDGE3 built coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.

--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -163,6 +163,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * Builds a \p EDGE2 built coincident with face i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -184,6 +184,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override final;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * The \p Elem::build_edge_ptr() member makes no sense for edges.
    */

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -920,6 +920,17 @@ public:
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i) = 0;
   std::unique_ptr<const Elem> build_side_ptr (const unsigned int i) const;
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  /*
+   * Older versions of libMesh supported a "proxy" option here.
+   */
+  virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i, bool proxy)
+  { if (proxy) libmesh_error(); libmesh_deprecated(); return this->build_side_ptr(i); }
+
+  std::unique_ptr<const Elem> build_side_ptr (const unsigned int i, bool proxy) const
+  { if (proxy) libmesh_error(); libmesh_deprecated(); return this->build_side_ptr(i); }
+#endif
+
   /**
    * Resets the loose element \p side, which may currently point to a
    * different side than \p i or even a different element than \p

--- a/include/geom/face_c0polygon.h
+++ b/include/geom/face_c0polygon.h
@@ -154,6 +154,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/face_inf_quad.h
+++ b/include/geom/face_inf_quad.h
@@ -211,6 +211,9 @@ public:
   virtual void build_edge_ptr (std::unique_ptr<Elem> & edge, const unsigned int i) override final
   { build_side_ptr(edge, i); }
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * is_edge_on_side is trivial in 2D.
    */

--- a/include/geom/face_inf_quad4.h
+++ b/include/geom/face_inf_quad4.h
@@ -117,6 +117,8 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
 
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,

--- a/include/geom/face_inf_quad6.h
+++ b/include/geom/face_inf_quad6.h
@@ -138,6 +138,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -135,6 +135,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/face_quad8.h
+++ b/include/geom/face_quad8.h
@@ -154,6 +154,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/face_quad9.h
+++ b/include/geom/face_quad9.h
@@ -162,6 +162,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -149,6 +149,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/face_tri6.h
+++ b/include/geom/face_tri6.h
@@ -164,6 +164,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/face_tri7.h
+++ b/include/geom/face_tri7.h
@@ -169,6 +169,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
                                const unsigned int i) override;
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -159,6 +159,9 @@ public:
   virtual void build_side_ptr (std::unique_ptr<Elem> &, const unsigned int) override
   { libmesh_not_implemented(); }
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   /**
    * The \p Elem::build_edge_ptr() member makes no sense for nodes.
    */

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -211,6 +211,9 @@ public:
                                const unsigned int) override
   { remote_elem_error("build_side_ptr"); }
 
+  // Avoid hiding deprecated version with different signature
+  using Elem::build_side_ptr;
+
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int) override
   { remote_elem_error("build_edge_ptr"); return std::unique_ptr<Elem>(); }
 


### PR DESCRIPTION
We've deprecated calls with proxy=true for years, but proxy=false never tripped any deprecation warnings, so we should provide a smoother upgrade path here.

This is prompted by a long delay fixing some downstream MOOSE apps, but coincidentally it's also the right thing to do.