### PR TITLE
RB Update: Enable error indicator in the Online stage when using POD training

### DIFF
--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -1536,6 +1536,14 @@ void RBConstruction::train_reduced_basis_with_POD()
 
   this->delta_N = get_rb_evaluation().get_n_basis_functions();
   update_system();
+
+  // We now compute all terms required to evaluate the RB error indicator.
+  // Unlike in the case of the RB Greedy algorithm, for the POD approach
+  // we do not need this data in order to compute the basis. However, we
+  // do need this data in order to evaluate error indicator quantities in
+  // the Online stage, so we compute it now so that it can be saved in
+  // the training data.
+  recompute_all_residual_terms();
 }
 
 bool RBConstruction::greedy_termination_test(Real abs_greedy_error,


### PR DESCRIPTION
Call recompute_all_residual_terms() in RBConstruction::train_reduced_basis_with_POD().

This enables us to evaluate the error indicator in the Online stage. We already do this in the case of Greedy, but it was missing the POD case.