### PR TITLE
Fix missing FE pre-request in VariationalSmootherSystem::compute_element_reference_volume()

### DIFF
--- a/src/systems/variational_smoother_system.C
+++ b/src/systems/variational_smoother_system.C
@@ -102,13 +102,16 @@ void VariationalSmootherSystem::compute_element_reference_volume()
 
   Real elem_averaged_det_J_sum = 0.;
 
+  // Must pre-request JxW before reinit() for efficiency in
+  // --enable-deprecated builds, and to avoid errors in
+  // --disable-deprecated builds.
+  const auto & fe_map = femcontext.get_element_fe(0)->get_fe_map();
+  const auto & JxW = fe_map.get_JxW();
+
   for (const auto * elem : mesh.active_local_element_ptr_range())
   {
     femcontext.pre_fe_reinit(*this, elem);
     femcontext.elem_fe_reinit();
-
-    const auto & fe_map = femcontext.get_element_fe(0)->get_fe_map();
-    const auto & JxW = fe_map.get_JxW();
 
     const auto elem_integrated_det_J = std::accumulate(JxW.begin(), JxW.end(), 0.);
     const auto ref_elem_vol = elem->reference_elem()->volume();


### PR DESCRIPTION
Otherwise, in --disable-deprecated builds, each of the MeshSmootherTest unit tests throws an error.

Refs #4191

Example of the error fixed by this PR:
```
1) test: MeshSmootherTest::testVariationalQuad (E) 
uncaught exception of type std::exception (or derived).
- 
Stack frames: 36
0: libMesh::print_trace(std::ostream&)
1: libMesh::MacroFunctions::report_error(char const*, int, char const*, char const*, std::ostream&)
2: libMesh::FEGenericBase<double>::determine_calculations()
3: libMesh::FE<2u, (libMesh::FEFamily)0>::reinit(libMesh::Elem const*, std::vector<libMesh::Point, std::allocator<libMesh::Point> > const*, std::vector<double, std::allocator<double> > const*)
4: libMesh::FEMContext::elem_fe_reinit(std::vector<libMesh::Point, std::allocator<libMesh::Point> > const*)
5: libMesh::VariationalSmootherSystem::compute_element_reference_volume()
6: libMesh::VariationalSmootherSystem::init_data()
7: libMesh::System::reinit_mesh()
8: libMesh::EquationSystems::reinit_mesh()
9: libMesh::EquationSystems::init()
10: libMesh::VariationalMeshSmoother::smooth(unsigned int)
11: libMesh::VariationalMeshSmoother::smooth()
```