### PR TITLE
Iterate over GhostingFunctor* in vectors, not sets

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -308,6 +308,13 @@ public:
   void add_default_ghosting();
 
   /**
+   * Iterator type for coupling and algebraic ghosting functor ranges.
+   * This has changed in the past and may change again; code should
+   * use auto or the type here.
+   */
+  typedef std::vector<GhostingFunctor *>::const_iterator GhostingFunctorIterator;
+
+  /**
    * Adds a functor which can specify coupling requirements for
    * creation of sparse matrices.
    * Degree of freedom pairs which match the elements and variables
@@ -356,13 +363,13 @@ public:
   /**
    * Beginning of range of coupling functors
    */
-  std::vector<GhostingFunctor *>::const_iterator coupling_functors_begin() const
+  GhostingFunctorIterator coupling_functors_begin() const
   { return _coupling_functors.begin(); }
 
   /**
    * End of range of coupling functors
    */
-  std::vector<GhostingFunctor *>::const_iterator coupling_functors_end() const
+  GhostingFunctorIterator coupling_functors_end() const
   { return _coupling_functors.end(); }
 
   /**
@@ -418,13 +425,13 @@ public:
   /**
    * Beginning of range of algebraic ghosting functors
    */
-  std::vector<GhostingFunctor *>::const_iterator algebraic_ghosting_functors_begin() const
+  GhostingFunctorIterator algebraic_ghosting_functors_begin() const
   { return _algebraic_ghosting_functors.begin(); }
 
   /**
    * End of range of algebraic ghosting functors
    */
-  std::vector<GhostingFunctor *>::const_iterator algebraic_ghosting_functors_end() const
+  GhostingFunctorIterator algebraic_ghosting_functors_end() const
   { return _algebraic_ghosting_functors.end(); }
 
   /**
@@ -1849,8 +1856,8 @@ private:
   static void
   merge_ghost_functor_outputs (GhostingFunctor::map_type & elements_to_ghost,
                                CouplingMatricesSet & temporary_coupling_matrices,
-                               const std::vector<GhostingFunctor *>::const_iterator & gf_begin,
-                               const std::vector<GhostingFunctor *>::const_iterator & gf_end,
+                               const GhostingFunctorIterator & gf_begin,
+                               const GhostingFunctorIterator & gf_end,
                                const MeshBase::const_element_iterator & elems_begin,
                                const MeshBase::const_element_iterator & elems_end,
                                processor_id_type p);

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -356,13 +356,13 @@ public:
   /**
    * Beginning of range of coupling functors
    */
-  std::set<GhostingFunctor *>::const_iterator coupling_functors_begin() const
+  std::vector<GhostingFunctor *>::const_iterator coupling_functors_begin() const
   { return _coupling_functors.begin(); }
 
   /**
    * End of range of coupling functors
    */
-  std::set<GhostingFunctor *>::const_iterator coupling_functors_end() const
+  std::vector<GhostingFunctor *>::const_iterator coupling_functors_end() const
   { return _coupling_functors.end(); }
 
   /**
@@ -418,13 +418,13 @@ public:
   /**
    * Beginning of range of algebraic ghosting functors
    */
-  std::set<GhostingFunctor *>::const_iterator algebraic_ghosting_functors_begin() const
+  std::vector<GhostingFunctor *>::const_iterator algebraic_ghosting_functors_begin() const
   { return _algebraic_ghosting_functors.begin(); }
 
   /**
    * End of range of algebraic ghosting functors
    */
-  std::set<GhostingFunctor *>::const_iterator algebraic_ghosting_functors_end() const
+  std::vector<GhostingFunctor *>::const_iterator algebraic_ghosting_functors_end() const
   { return _algebraic_ghosting_functors.end(); }
 
   /**
@@ -1849,8 +1849,8 @@ private:
   static void
   merge_ghost_functor_outputs (GhostingFunctor::map_type & elements_to_ghost,
                                CouplingMatricesSet & temporary_coupling_matrices,
-                               const std::set<GhostingFunctor *>::iterator & gf_begin,
-                               const std::set<GhostingFunctor *>::iterator & gf_end,
+                               const std::vector<GhostingFunctor *>::const_iterator & gf_begin,
+                               const std::vector<GhostingFunctor *>::const_iterator & gf_end,
                                const MeshBase::const_element_iterator & elems_begin,
                                const MeshBase::const_element_iterator & elems_end,
                                processor_id_type p);
@@ -2040,11 +2040,14 @@ private:
    * The list of all GhostingFunctor objects to be used when
    * distributing ghosted vectors.
    *
-   * The library should automatically copy these functors to the
+   * The library should automatically refer these functors to the
    * MeshBase, too, so any algebraically ghosted dofs will live on
    * geometrically ghosted elements.
+   *
+   * Keep these in a vector so any parallel computation is done in the
+   * same order on all processors.
    */
-  std::set<GhostingFunctor *> _algebraic_ghosting_functors;
+  std::vector<GhostingFunctor *> _algebraic_ghosting_functors;
 
   /**
    * The list of all GhostingFunctor objects to be used when
@@ -2053,11 +2056,11 @@ private:
    * These objects will *also* be used as algebraic ghosting functors,
    * but not vice-versa.
    *
-   * The library should automatically copy these functors to the
+   * The library should automatically refer these functors to the
    * MeshBase, too, so any dofs coupled to local dofs will live on
    * geometrically ghosted elements.
    */
-  std::set<GhostingFunctor *> _coupling_functors;
+  std::vector<GhostingFunctor *> _coupling_functors;
 
   /**
    * Hang on to references to any GhostingFunctor objects we were

--- a/include/base/sparsity_pattern.h
+++ b/include/base/sparsity_pattern.h
@@ -105,7 +105,7 @@ class Build : public ParallelObject
 public:
   Build (const DofMap & dof_map_in,
          const CouplingMatrix * dof_coupling_in,
-         const std::set<GhostingFunctor *> & coupling_functors_in,
+         const std::vector<GhostingFunctor *> & coupling_functors_in,
          const bool implicit_neighbor_dofs_in,
          const bool need_full_sparsity_pattern_in,
          const bool calculate_constrained_in = false,
@@ -208,7 +208,7 @@ public:
 private:
   const DofMap & dof_map;
   const CouplingMatrix * dof_coupling;
-  const std::set<GhostingFunctor *> & coupling_functors;
+  const std::vector<GhostingFunctor *> & coupling_functors;
   const bool implicit_neighbor_dofs;
   const bool need_full_sparsity_pattern;
   const bool calculate_constrained;

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1264,8 +1264,7 @@ public:
    * this function; the GhostingFunctor lifetime is expected to extend
    * until either the functor is removed or the Mesh is destructed.
    */
-  void add_ghosting_functor(GhostingFunctor & ghosting_functor)
-  { _ghosting_functors.insert(&ghosting_functor); }
+  void add_ghosting_functor(GhostingFunctor & ghosting_functor);
 
   /**
    * Adds a functor which can specify ghosting requirements for use on
@@ -1288,13 +1287,13 @@ public:
   /**
    * Beginning of range of ghosting functors
    */
-  std::set<GhostingFunctor *>::const_iterator ghosting_functors_begin() const
+  std::vector<GhostingFunctor *>::const_iterator ghosting_functors_begin() const
   { return _ghosting_functors.begin(); }
 
   /**
    * End of range of ghosting functors
    */
-  std::set<GhostingFunctor *>::const_iterator ghosting_functors_end() const
+  std::vector<GhostingFunctor *>::const_iterator ghosting_functors_end() const
   { return _ghosting_functors.end(); }
 
   /**
@@ -2083,7 +2082,7 @@ protected:
    * Basically unused by ReplicatedMesh for now, but belongs to
    * MeshBase because the cost is trivial.
    */
-  std::set<GhostingFunctor *> _ghosting_functors;
+  std::vector<GhostingFunctor *> _ghosting_functors;
 
   /**
    * Hang on to references to any GhostingFunctor objects we were

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1285,15 +1285,22 @@ public:
   void remove_ghosting_functor(GhostingFunctor & ghosting_functor);
 
   /**
+   * Iterator type for ghosting functor ranges.  This has changed in
+   * the past and may change again; code should use auto or the type
+   * here.
+   */
+  typedef std::vector<GhostingFunctor *>::const_iterator GhostingFunctorIterator;
+
+  /**
    * Beginning of range of ghosting functors
    */
-  std::vector<GhostingFunctor *>::const_iterator ghosting_functors_begin() const
+  GhostingFunctorIterator ghosting_functors_begin() const
   { return _ghosting_functors.begin(); }
 
   /**
    * End of range of ghosting functors
    */
-  std::vector<GhostingFunctor *>::const_iterator ghosting_functors_end() const
+  GhostingFunctorIterator ghosting_functors_end() const
   { return _ghosting_functors.end(); }
 
   /**

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1613,8 +1613,8 @@ void
 DofMap::
 merge_ghost_functor_outputs(GhostingFunctor::map_type & elements_to_ghost,
                             CouplingMatricesSet & temporary_coupling_matrices,
-                            const std::vector<GhostingFunctor *>::const_iterator & gf_begin,
-                            const std::vector<GhostingFunctor *>::const_iterator & gf_end,
+                            const GhostingFunctorIterator & gf_begin,
+                            const GhostingFunctorIterator & gf_end,
                             const MeshBase::const_element_iterator & elems_begin,
                             const MeshBase::const_element_iterator & elems_end,
                             processor_id_type p)

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1613,8 +1613,8 @@ void
 DofMap::
 merge_ghost_functor_outputs(GhostingFunctor::map_type & elements_to_ghost,
                             CouplingMatricesSet & temporary_coupling_matrices,
-                            const std::set<GhostingFunctor *>::iterator & gf_begin,
-                            const std::set<GhostingFunctor *>::iterator & gf_end,
+                            const std::vector<GhostingFunctor *>::const_iterator & gf_begin,
+                            const std::vector<GhostingFunctor *>::const_iterator & gf_end,
                             const MeshBase::const_element_iterator & elems_begin,
                             const MeshBase::const_element_iterator & elems_end,
                             processor_id_type p)
@@ -2033,7 +2033,13 @@ void
 DofMap::add_coupling_functor(GhostingFunctor & coupling_functor,
                              bool to_mesh)
 {
-  _coupling_functors.insert(&coupling_functor);
+  // We shouldn't have two copies of the same functor
+  libmesh_assert(std::find(_coupling_functors.begin(),
+                           _coupling_functors.end(),
+                           &coupling_functor) ==
+                 _coupling_functors.end());
+
+  _coupling_functors.push_back(&coupling_functor);
   coupling_functor.set_mesh(&_mesh);
   if (to_mesh)
     _mesh.add_ghosting_functor(coupling_functor);
@@ -2044,7 +2050,17 @@ DofMap::add_coupling_functor(GhostingFunctor & coupling_functor,
 void
 DofMap::remove_coupling_functor(GhostingFunctor & coupling_functor)
 {
-  _coupling_functors.erase(&coupling_functor);
+  auto raw_it = std::find(_coupling_functors.begin(),
+                          _coupling_functors.end(), &coupling_functor);
+  libmesh_assert(raw_it != _coupling_functors.end());
+  _coupling_functors.erase(raw_it);
+
+  // We shouldn't have had two copies of the same functor
+  libmesh_assert(std::find(_coupling_functors.begin(),
+                           _coupling_functors.end(),
+                           &coupling_functor) ==
+                 _coupling_functors.end());
+
   _mesh.remove_ghosting_functor(coupling_functor);
 
   if (const auto it = _shared_functors.find(&coupling_functor);
@@ -2058,7 +2074,13 @@ void
 DofMap::add_algebraic_ghosting_functor(GhostingFunctor & evaluable_functor,
                                        bool to_mesh)
 {
-  _algebraic_ghosting_functors.insert(&evaluable_functor);
+  // We shouldn't have two copies of the same functor
+  libmesh_assert(std::find(_algebraic_ghosting_functors.begin(),
+                           _algebraic_ghosting_functors.end(),
+                           &evaluable_functor) ==
+                 _algebraic_ghosting_functors.end());
+
+  _algebraic_ghosting_functors.push_back(&evaluable_functor);
   evaluable_functor.set_mesh(&_mesh);
   if (to_mesh)
     _mesh.add_ghosting_functor(evaluable_functor);
@@ -2069,7 +2091,18 @@ DofMap::add_algebraic_ghosting_functor(GhostingFunctor & evaluable_functor,
 void
 DofMap::remove_algebraic_ghosting_functor(GhostingFunctor & evaluable_functor)
 {
-  _algebraic_ghosting_functors.erase(&evaluable_functor);
+  auto raw_it = std::find(_algebraic_ghosting_functors.begin(),
+                          _algebraic_ghosting_functors.end(),
+                          &evaluable_functor);
+  libmesh_assert(raw_it != _algebraic_ghosting_functors.end());
+  _algebraic_ghosting_functors.erase(raw_it);
+
+  // We shouldn't have had two copies of the same functor
+  libmesh_assert(std::find(_algebraic_ghosting_functors.begin(),
+                           _algebraic_ghosting_functors.end(),
+                           &evaluable_functor) ==
+                 _algebraic_ghosting_functors.end());
+
   _mesh.remove_ghosting_functor(evaluable_functor);
 
   if (const auto it = _shared_functors.find(&evaluable_functor);

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2033,6 +2033,15 @@ void
 DofMap::add_coupling_functor(GhostingFunctor & coupling_functor,
                              bool to_mesh)
 {
+  // We used to implicitly support duplicate inserts to std::set
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  _coupling_functors.erase
+    (std::remove(_coupling_functors.begin(),
+                 _coupling_functors.end(),
+                 &coupling_functor),
+     _coupling_functors.end());
+#endif
+
   // We shouldn't have two copies of the same functor
   libmesh_assert(std::find(_coupling_functors.begin(),
                            _coupling_functors.end(),
@@ -2074,6 +2083,15 @@ void
 DofMap::add_algebraic_ghosting_functor(GhostingFunctor & evaluable_functor,
                                        bool to_mesh)
 {
+  // We used to implicitly support duplicate inserts to std::set
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  _algebraic_ghosting_functors.erase
+    (std::remove(_algebraic_ghosting_functors.begin(),
+                 _algebraic_ghosting_functors.end(),
+                 &evaluable_functor),
+     _algebraic_ghosting_functors.end());
+#endif
+
   // We shouldn't have two copies of the same functor
   libmesh_assert(std::find(_algebraic_ghosting_functors.begin(),
                            _algebraic_ghosting_functors.end(),

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2061,8 +2061,15 @@ DofMap::remove_coupling_functor(GhostingFunctor & coupling_functor)
 {
   auto raw_it = std::find(_coupling_functors.begin(),
                           _coupling_functors.end(), &coupling_functor);
+
+#ifndef LIBMESH_ENABLE_DEPRECATED
+  // We shouldn't be trying to remove a functor that isn't there
   libmesh_assert(raw_it != _coupling_functors.end());
-  _coupling_functors.erase(raw_it);
+#else
+  // Our old API supported trying to remove a functor that isn't there
+  if (raw_it != _coupling_functors.end())
+#endif
+    _coupling_functors.erase(raw_it);
 
   // We shouldn't have had two copies of the same functor
   libmesh_assert(std::find(_coupling_functors.begin(),
@@ -2112,8 +2119,15 @@ DofMap::remove_algebraic_ghosting_functor(GhostingFunctor & evaluable_functor)
   auto raw_it = std::find(_algebraic_ghosting_functors.begin(),
                           _algebraic_ghosting_functors.end(),
                           &evaluable_functor);
+
+#ifndef LIBMESH_ENABLE_DEPRECATED
+  // We shouldn't be trying to remove a functor that isn't there
   libmesh_assert(raw_it != _algebraic_ghosting_functors.end());
-  _algebraic_ghosting_functors.erase(raw_it);
+#else
+  // Our old API supported trying to remove a functor that isn't there
+  if (raw_it != _algebraic_ghosting_functors.end())
+#endif
+    _algebraic_ghosting_functors.erase(raw_it);
 
   // We shouldn't have had two copies of the same functor
   libmesh_assert(std::find(_algebraic_ghosting_functors.begin(),

--- a/src/base/sparsity_pattern.C
+++ b/src/base/sparsity_pattern.C
@@ -46,7 +46,7 @@ namespace SparsityPattern
 // a full DofMap definition is available.
 Build::Build (const DofMap & dof_map_in,
               const CouplingMatrix * dof_coupling_in,
-              const std::set<GhostingFunctor *> & coupling_functors_in,
+              const std::vector<GhostingFunctor *> & coupling_functors_in,
               const bool implicit_neighbor_dofs_in,
               const bool need_full_sparsity_pattern_in,
               const bool calculate_constrained_in,

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -81,7 +81,7 @@ MeshBase::MeshBase (const Parallel::Communicator & comm_in,
   _point_locator_close_to_point_tol(0.)
 {
   _elem_dims.insert(d);
-  _ghosting_functors.insert(_default_ghosting.get());
+  _ghosting_functors.push_back(_default_ghosting.get());
   libmesh_assert_less_equal (LIBMESH_DIM, 3);
   libmesh_assert_greater_equal (LIBMESH_DIM, d);
   libmesh_assert (libMesh::initialized());
@@ -128,7 +128,7 @@ MeshBase::MeshBase (const MeshBase & other_mesh) :
       // default ghosting
       if (gf == other_default_ghosting)
         {
-          _ghosting_functors.insert(_default_ghosting.get());
+          _ghosting_functors.push_back(_default_ghosting.get());
           continue;
         }
 
@@ -344,7 +344,7 @@ bool MeshBase::locally_equals (const MeshBase & other_mesh) const
       return false;
 
   // FIXME: we have no good way to compare ghosting functors, since
-  // they're in a set sorted by pointer, and we have no way *at all*
+  // they're in a vector of pointers, and we have no way *at all*
   // to compare ghosting functors, since they don't have operator==
   // defined and we encourage users to subclass them.  We can check if
   // we have the same number, is all.
@@ -945,9 +945,37 @@ void MeshBase::clear ()
 
 
 
+void MeshBase::add_ghosting_functor(GhostingFunctor & ghosting_functor)
+{
+  // We shouldn't have two copies of the same functor
+  libmesh_assert(std::find(_ghosting_functors.begin(),
+                           _ghosting_functors.end(),
+                           &ghosting_functor) ==
+                 _ghosting_functors.end());
+
+  _ghosting_functors.push_back(&ghosting_functor);
+}
+
+
+
 void MeshBase::remove_ghosting_functor(GhostingFunctor & ghosting_functor)
 {
-  _ghosting_functors.erase(&ghosting_functor);
+  auto raw_it = std::find(_ghosting_functors.begin(),
+                          _ghosting_functors.end(), &ghosting_functor);
+
+  // The DofMap has a "to_mesh" parameter that tells it to avoid
+  // registering a new functor with the mesh, but it doesn't keep
+  // track of which functors weren't added, so we'll support "remove a
+  // functor that isn't there" just like we did with set::erase
+  // before.
+  if (raw_it != _ghosting_functors.end())
+    _ghosting_functors.erase(raw_it);
+
+  // We shouldn't have had two copies of the same functor
+  libmesh_assert(std::find(_ghosting_functors.begin(),
+                           _ghosting_functors.end(),
+                           &ghosting_functor) ==
+                 _ghosting_functors.end());
 
   if (const auto it = _shared_functors.find(&ghosting_functor);
       it != _shared_functors.end())

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -947,6 +947,15 @@ void MeshBase::clear ()
 
 void MeshBase::add_ghosting_functor(GhostingFunctor & ghosting_functor)
 {
+  // We used to implicitly support duplicate inserts to std::set
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  _ghosting_functors.erase
+    (std::remove(_ghosting_functors.begin(),
+                 _ghosting_functors.end(),
+                 &ghosting_functor),
+     _ghosting_functors.end());
+#endif
+
   // We shouldn't have two copies of the same functor
   libmesh_assert(std::find(_ghosting_functors.begin(),
                            _ghosting_functors.end(),


### PR DESCRIPTION
It's entirely fair for GhostingFunctor subclasses to want to do parallel operations in e.g. mesh_reinit(), but we can't do that if they're not executed in the same order on all processors, and a set of pointers is definitely not guaranteed to be in the same order on all processors.

I think I may have actually fixed this bug before anyone got bitten by it (while investigating other issues, though).

This is technically an API change, but hopefully everybody uses "auto" for any ugly iterators that they have to declare, in which case this won't be an API change that breaks anyone's compile.