### PR TITLE
Added sliding boundary nodes to VariationalMeshSmoother

### DIFF
--- a/include/systems/variational_smoother_constraint.h
+++ b/include/systems/variational_smoother_constraint.h
@@ -87,6 +87,22 @@ private:
       const Elem & containing_elem,
       const BoundaryInfo & boundary_info);
 
+  static void filter_neighbors_for_subdomain_constraint(
+      const Node & node,
+      std::vector<const Node *> & neighbors,
+      const subdomain_id_type sub_id1,
+      const subdomain_id_type sub_id2,
+      std::unordered_map<dof_id_type, std::vector<const Elem *>> & nodes_to_elem_map
+    );
+
+  static void filter_neighbors_for_boundary_constraint(
+      const Node & node,
+      std::vector<const Node *> & neighbors,
+      std::unordered_map<dof_id_type, std::vector<const Elem *>> & nodes_to_elem_map,
+      const std::unordered_set<dof_id_type> & boundary_node_ids,
+      const BoundaryInfo & boundary_info
+    );
+
 public:
 
   /*

--- a/include/systems/variational_smoother_constraint.h
+++ b/include/systems/variational_smoother_constraint.h
@@ -41,10 +41,19 @@ private:
   const bool _preserve_subdomain_boundaries;
 
   /*
-   * Constrain (fix) a node to not move during mesh smoothing.
+   * Constrain (i.e., fix) a node to not move during mesh smoothing.
    * @param node Node to fix.
    */
   void fix_node(const Node & node);
+
+  /*
+   * Constrain a node to remain in the given plane during mesh smoothing.
+   * @param node Node to constrain
+   * @param ref_normal_vec Reference normal vector to the constraining plane.
+   * This, along with the coordinates of node, are used to define the
+   * constraining plane.
+   */
+  void constrain_node_to_plane(const Node & node, const Point & ref_normal_vec);
 
 public:
 

--- a/include/systems/variational_smoother_constraint.h
+++ b/include/systems/variational_smoother_constraint.h
@@ -55,6 +55,15 @@ private:
    */
   void constrain_node_to_plane(const Node & node, const Point & ref_normal_vec);
 
+  /*
+   * Constrain a node to remain on the given line during mesh smoothing.
+   * @param node Node to constrain
+   * @param line_vec vector parallel to the constraining line.
+   * This, along with the coordinates of node, are used to define the
+   * constraining line.
+   */
+  void constrain_node_to_line(const Node & node, const Point & line_vec);
+
 public:
 
   /*

--- a/include/systems/variational_smoother_constraint.h
+++ b/include/systems/variational_smoother_constraint.h
@@ -64,6 +64,20 @@ private:
    */
   void constrain_node_to_line(const Node & node, const Point & line_vec);
 
+  /*
+   * Determines whether two neighboring nodes share a common boundary id.
+   * @param boundary_node The first of the two prospective nodes.
+   * @param neighbor_node The second of the two prospective nodes.
+   * @param containing_elem The element containing node1 and node2.
+   * @param boundary_info The mesh's BoundaryInfo.
+   * @return nodes_share_bid Whether node1 and node2 share a common boundary id.
+   */
+  static bool nodes_share_boundary_id(
+      const Node & boundary_node,
+      const Node & neighbor_node,
+      const Elem & containing_elem,
+      const BoundaryInfo & boundary_info);
+
 public:
 
   /*

--- a/include/systems/variational_smoother_constraint.h
+++ b/include/systems/variational_smoother_constraint.h
@@ -41,6 +41,15 @@ private:
   const bool _preserve_subdomain_boundaries;
 
   /*
+   * Identifies and imposes the appropriate constraints on a node.
+   * @param node The node to constrain.
+   * @param neighbors Vector of neighbors to use to identify the constraint to
+   * impose.
+   */
+  void impose_constraints(const Node &node,
+                          const std::vector<const Node *> neighbors);
+
+  /*
    * Constrain (i.e., fix) a node to not move during mesh smoothing.
    * @param node Node to fix.
    */

--- a/include/systems/variational_smoother_constraint.h
+++ b/include/systems/variational_smoother_constraint.h
@@ -213,10 +213,8 @@ private:
   /// Get the relevant nodal neighbors for a subdomain constraint.
   /// @param mesh The mesh being smoothed.
   /// @param node The node (on the subdomain boundary) being constrained.
-  /// @param sub_id1 The subdomain id of the block on one side of the subdomain
+  /// @param sub_id The subdomain id of the block on one side of the subdomain
   /// boundary.
-  /// @param sub_id2 The subdomain id of the block on the other side of the
-  /// subdomain boundary.
   /// @param nodes_to_elem_map A mapping from node id to containing element ids.
   /// @return A set of node pointer sets containing nodal neighbors to 'node' on
   /// the sub_id1-sub_id2 boundary. The subsets are grouped by element faces
@@ -224,8 +222,7 @@ private:
   /// in this set.
   static std::set<std::set<const Node *>>
   get_neighbors_for_subdomain_constraint(
-      const MeshBase &mesh, const Node &node, const subdomain_id_type sub_id1,
-      const subdomain_id_type sub_id2,
+      const MeshBase &mesh, const Node &node, const subdomain_id_type sub_id,
       const std::unordered_map<dof_id_type, std::vector<const Elem *>>
           &nodes_to_elem_map);
 

--- a/include/systems/variational_smoother_system.h
+++ b/include/systems/variational_smoother_system.h
@@ -81,9 +81,12 @@ protected:
                                         libMesh::DiffContext & context) override;
 
   /* Computes the element reference volume used in the dilation metric
-   * The reference value is set to the averaged value of all elements' average |J|.
+   * The reference value is set to the averaged value of all elements' average
+   * |J|. Also computes any applicable target element inverse Jacobians. Target
+   * elements are relavant when the reference element does not minimize the
+   * distortion metric.
    */
-  void compute_element_reference_volume();
+  void prepare_for_smoothing();
 
   /// The small nonzero constant to prevent zero denominators (degenerate elements only)
   const Real _epsilon_squared;
@@ -93,6 +96,11 @@ protected:
 
   /// The relative weight to give the dilation metric. The distortion metric is given weight 1 - _dilation_weight.
   Real _dilation_weight;
+
+  /* Map to hold target qp-dependent element inverse reference-to-target mapping
+   * Jacobians, if any
+   */
+  std::map<ElemType, std::vector<RealTensor>> _target_inverse_jacobians;
 };
 
 } // namespace libMesh

--- a/src/systems/variational_smoother_constraint.C
+++ b/src/systems/variational_smoother_constraint.C
@@ -362,9 +362,19 @@ void VariationalSmootherConstraint::constrain()
       const auto &subdomain_constraint = it->second;
       // Combine current boundary constraint with previously determined
       // subdomain_constraint
-      const auto combined_constraint =
-          intersect_constraints(subdomain_constraint, boundary_constraint);
-      this->impose_constraint(node, combined_constraint);
+      try
+      {
+        const auto combined_constraint =
+            intersect_constraints(subdomain_constraint, boundary_constraint);
+        this->impose_constraint(node, combined_constraint);
+      }
+      catch (const std::exception & e)
+      {
+        // This will catch cases where constraints have no intersection
+        // Fall back to fixed node constraint
+        this->impose_constraint(node, PointConstraint(node));
+      }
+
     } else
       this->impose_constraint(node, boundary_constraint);
 
@@ -741,7 +751,19 @@ ConstraintVariant VariationalSmootherConstraint::determine_constraint(
   auto it = valid_planes.begin();
   ConstraintVariant current = *it++;
   for (; it != valid_planes.end(); ++it)
-    current = intersect_constraints(current, *it);
+  {
+    try
+    {
+      current = intersect_constraints(current, *it);
+    }
+    catch (const std::exception & e)
+    {
+      // This will catch cases where constraints have no intersection
+      // Fall back to fixed node constraint
+      current = PointConstraint(node);
+      break;
+    }
+  }
 
   return current;
 }

--- a/src/systems/variational_smoother_constraint.C
+++ b/src/systems/variational_smoother_constraint.C
@@ -33,7 +33,8 @@ VariationalSmootherConstraint::~VariationalSmootherConstraint() = default;
 
 void VariationalSmootherConstraint::constrain()
 {
-  auto & mesh = _sys.get_mesh();
+  const auto & mesh = _sys.get_mesh();
+  const auto dim = mesh.mesh_dimension();
 
   // Only compute the node to elem map once
   std::unordered_map<dof_id_type, std::vector<const Elem *>> nodes_to_elem_map;
@@ -58,8 +59,182 @@ void VariationalSmootherConstraint::constrain()
       neighbors.end()
     );
 
-    // if 2D, determine if node and neighbors lie on the same line
-    // if 3D, determine if node and neighbors lie on the same plane
+    // Determine whether the current node is colinear (coplanar) with its boundary
+    // neighbors Start by computing the vectors from the current node to each boundary
+    // neighbor node
+    //std::cout << "Node " << node.id() << ":" << std::endl;
+    std::vector<Point> dist_vecs;
+    for (const auto & neighbor : neighbors)
+    {
+      dist_vecs.push_back((*neighbor) - node);
+      //std::cout << "  Neighbor " << neighbor->id() << ", dist_vec = " << dist_vecs.back() << std::endl;
+    }
+
+    // 2D: If the current node and all (two) boundary neighbor nodes lie on the same line,
+    // the magnitude of the dot product of the distance vectors will be equal
+    // to the product of the magnitudes of the vectors. This is because the distance
+    // vectors lie on the same line, so the cos(theta) term in the dot product
+    // evaluates to -1 or 1.
+    if (dim == 2)
+    {
+      // Physically, the boundary of a 2D mesh is a 1D curve. By the
+      // definition of a "neighbor", it is only possible for a node
+      // to have 2 neighbors on the boundary.
+      libmesh_assert_equal_to(dist_vecs.size(), dim);
+      const Real dot_product = dist_vecs[0] * dist_vecs[1];
+      const Real norm_product = dist_vecs[0].norm() * dist_vecs[1].norm();
+
+      // node is not colinear with its boundary neighbors and is thus immovable
+      if (!relative_fuzzy_equals(std::abs(dot_product), norm_product))
+      {
+        this->fix_node(node);
+        continue;
+      }
+
+      // else, determine equation of line: c_x * x + c_y * y + c = 0
+      Real c_x, c_y, c;
+      const auto & vec = dist_vecs[0];
+      if (vec(0) == 0) // vertical line
+      {
+        c_y = 0.;
+        c_x = 1.;
+        c = -node(0);
+      }
+      else // not a vertical line
+      {
+        c_y = 1.;
+        c_x = -vec(1) / vec(0); // c_x = -m from y = mx + b
+        c = -c_x * node(0) - node(1);
+      }
+
+      const std::vector<Real> xy_coefs{c_x, c_y};
+
+      // Constrain the dimension with the largest coefficient
+      const unsigned int constrained_dim = (std::abs(c_x) > std::abs(c_y)) ? 0 : 1;
+      const unsigned int free_dim = (std::abs(c_x) > std::abs(c_y)) ? 1 : 0;
+
+      const auto constrained_dof_index = node.dof_number(_sys.number(), constrained_dim, 0);
+      const auto free_dof_index = node.dof_number(_sys.number(), free_dim, 0);
+      DofConstraintRow constraint_row;
+      constraint_row[free_dof_index] =  -xy_coefs[free_dim] / xy_coefs[constrained_dim];
+      const auto constrained_value = -c / xy_coefs[constrained_dim];
+      _sys.get_dof_map().add_constraint_row( constrained_dof_index, constraint_row, constrained_value, true);
+    }
+
+    // 3D: If the current node and all boundary neighbor nodes lie on the same plane,
+    // all the distance vectors from the current node to the boundary nodes will be
+    // orthogonal to the plane normal. We can obtain a reference normal by normalizing
+    // the cross product between two of the distance vectors. If the normalized cross
+    // products of all other combinations (excluding self combinations) match this
+    // reference normal, then the current node is coplanar with all of its boundary nodes.
+    else if (dim == 3)
+    {
+      // We should have at least 2 distance vectors to compute a normal with in 3D
+      libmesh_assert_greater_equal(dist_vecs.size(), 2);
+
+      // Compute the reference normal by taking the cross product of two vectors in
+      // dist_vecs. We will use dist_vecs[0] as the first vector and the next available
+      // vector in dist_vecs that is not (anti)parallel to dist_vecs[0]. Without this
+      // check we may end up with a zero vector for the reference vector.
+      unsigned int vec_index;
+      const Point vec_0_normalized = dist_vecs[0] / dist_vecs[0].norm();
+      for (const auto ii : make_range(size_t(1), dist_vecs.size()))
+      {
+        // (anti)parallel check
+        const bool is_parallel =
+            vec_0_normalized.relative_fuzzy_equals(dist_vecs[ii] / dist_vecs[ii].norm());
+        const bool is_antiparallel =
+            vec_0_normalized.relative_fuzzy_equals(-dist_vecs[ii] / dist_vecs[ii].norm());
+        if (!(is_parallel || is_antiparallel))
+        {
+          vec_index = ii;
+          break;
+        }
+      }
+
+      const Point reference_cross_prod = dist_vecs[0].cross(dist_vecs[vec_index]);
+      const Point reference_normal = reference_cross_prod / reference_cross_prod.norm();
+      
+      bool node_is_coplanar = true;
+      for (const auto ii : index_range(dist_vecs))
+      {
+        const Point vec_ii_normalized = dist_vecs[ii] / dist_vecs[ii].norm();
+        for (const auto jj : make_range(ii + 1, dist_vecs.size()))
+        {
+          // No need to compute the cross product for this case, as it is by
+          // definition equal to the reference normal computed above.
+          // Also check for dist_vecs that are (anti)parallel, and skip,
+          // as their cross product will be zero.
+          const Point vec_jj_normalized = dist_vecs[jj] / dist_vecs[jj].norm();
+          const bool is_parallel =
+              vec_ii_normalized.relative_fuzzy_equals(vec_jj_normalized);
+          const bool is_antiparallel = vec_ii_normalized.relative_fuzzy_equals(
+              -vec_jj_normalized);
+
+          if ((ii == 0 and jj == vec_index) || (is_parallel || is_antiparallel))
+            continue;
+
+          const Point cross_prod = dist_vecs[ii].cross(dist_vecs[jj]);
+          const Point normal = cross_prod / cross_prod.norm();
+
+          // node is not coplanar with its boundary neighbors and is thus immovable
+          if (!(reference_normal.relative_fuzzy_equals(normal) ||
+                reference_normal.relative_fuzzy_equals(-normal)))
+          {
+            node_is_coplanar = false;
+            break;
+          }
+        }
+      }
+      
+      // TODO: Need to add check for sliding edge node
+
+      if (!node_is_coplanar)
+      {
+        this->fix_node(node);
+        continue;
+      }
+
+      // else, determine equation of plane: c_x * x + c_y * y + c_z * z + c = 0
+      const Real c_x = reference_normal(0);
+      const Real c_y = reference_normal(1);
+      const Real c_z = reference_normal(2);
+      const Real c = -(c_x * node(0) + c_y * node(1) + c_z * node(2));
+
+      const std::vector<Real> xyz_coefs{c_x, c_y, c_z};
+
+      // Find the dimension with the largest nonzero magnitude coefficient
+      auto it = std::max_element(xyz_coefs.begin(), xyz_coefs.end(),
+          [](double a, double b) {
+              return std::abs(a) < std::abs(b);
+          });
+      const unsigned int constrained_dim = std::distance(xyz_coefs.begin(), it);
+
+      //std::cout << "Node " << node.id() << " (" << node(0) << ", " << node(1) << ", " << node(2)
+      //          << ") lies on the plane " << std::endl
+      //          << c_x << " * x + " << c_y << " * y + " << c_z << " * z + " << c << " = 0" << std::endl;
+
+
+      //const std::vector<std::string> dim_names{"x", "y", "z"};
+      //std::cout << "Constraining " << dim_names[constrained_dim] << " = ";
+
+      DofConstraintRow constraint_row;
+      auto constrained_value = -c / xyz_coefs[constrained_dim];
+      for (const auto free_dim : index_range(xyz_coefs))
+      {
+        if (free_dim == constrained_dim)
+          continue;
+        const auto free_dof_index = node.dof_number(_sys.number(), free_dim, 0);
+        constraint_row[free_dof_index] =  -xyz_coefs[free_dim] / xyz_coefs[constrained_dim];
+        //std::cout << constraint_row[free_dof_index] << " * " << dim_names[free_dim] << " + ";
+      }
+
+      //std::cout << constrained_value << std::endl;
+      const auto constrained_dof_index = node.dof_number(_sys.number(), constrained_dim, 0);
+      _sys.get_dof_map().add_constraint_row( constrained_dof_index, constraint_row, constrained_value, true);
+
+    }
+
     // if not same line/plane, then node is either part of a curved surface or
     // it is the vertex where two boundary surfaces meet. In the first case,
     // we should just fix the node. For the latter case:
@@ -69,8 +244,9 @@ void VariationalSmootherConstraint::constrain()
     //   of 2 surfaces (i.e., the edge of a cube), constrain it to slide along
     //   this edge.
 
-    //   But for now, just fix all the boundary nodes to not move
-    this->fix_node(node);
+    //  1D
+    else
+      this->fix_node(node);
 
   }// end bid
 

--- a/src/systems/variational_smoother_constraint.C
+++ b/src/systems/variational_smoother_constraint.C
@@ -59,9 +59,9 @@ void VariationalSmootherConstraint::constrain()
       neighbors.end()
     );
 
-    // Determine whether the current node is colinear (coplanar) with its boundary
-    // neighbors Start by computing the vectors from the current node to each boundary
-    // neighbor node
+    // Determine whether the current node is colinear (2D) or coplanar 3D with
+    // its boundary neighbors. Start by computing the vectors from the current
+    // node to each boundary neighbor node
     std::vector<Point> dist_vecs;
     for (const auto & neighbor : neighbors)
     {
@@ -89,7 +89,17 @@ void VariationalSmootherConstraint::constrain()
         continue;
       }
 
-      // TODO: what if z is not the inactive dimension in 2D!?!?
+      // TODO: what if z is not the inactive dimension in 2D?
+      // Would this even happen!?!?
+      //
+      // Yes, yes, we are using a function called "constrain_node_to_plane" to
+      // constrain a node to a line in a 2D mesh. However, the line
+      // c_x * x + c_y * y + c = 0 is equivalent to the plane
+      // c_x * x + c_y * y + 0 * z + c = 0, so the same logic applies here.
+      // Since all dist_vecs reside in the xy plane, and are parallel to the line
+      // we are constraining to, crossing one of the dist_vecs with the unit
+      // vector in the z direction should give us a vector normal to the
+      // constraining line. This reference normal vector also resides in the xy plane.
       const auto reference_normal = dist_vecs[0].cross(Point(0., 0., 1.));
       this->constrain_node_to_plane(node, reference_normal);
     }

--- a/src/systems/variational_smoother_constraint.C
+++ b/src/systems/variational_smoother_constraint.C
@@ -46,6 +46,7 @@ void VariationalSmootherConstraint::constrain()
   for (const auto & bid : boundary_node_ids)
   {
     const auto & node = mesh.node_ref(bid);
+
     // Find all the nodal neighbors... that is the nodes directly connected
     // to this node through one edge
     std::vector<const Node *> neighbors;
@@ -112,82 +113,81 @@ void VariationalSmootherConstraint::constrain()
           if (
               std::find(already_constrained_node_ids.begin(),
                         already_constrained_node_ids.end(),
-                        node.id()) == already_constrained_node_ids.end()
+                        node.id()) != already_constrained_node_ids.end()
           )
+            continue;
+
+          // Find all the nodal neighbors... that is the nodes directly connected
+          // to this node through one edge
+          std::vector<const Node *> neighbors;
+          MeshTools::find_nodal_neighbors(mesh, node, nodes_to_elem_map, neighbors);
+
+          // Remove any neighbors that are not on the subdomain boundary
+          auto remove_neighbor = [&node, &nodes_to_elem_map, &sub_id1, &sub_id2]
+            (const Node * neigh) -> bool
           {
-
-            // Find all the nodal neighbors... that is the nodes directly connected
-            // to this node through one edge
-            std::vector<const Node *> neighbors;
-            MeshTools::find_nodal_neighbors(mesh, node, nodes_to_elem_map, neighbors);
-
-            // Remove any neighbors that are not on the subdomain boundary
-            auto remove_neighbor = [&node, &nodes_to_elem_map, &sub_id1, &sub_id2]
-              (const Node * neigh) -> bool
+            // Determine whether the neighbor is on the subdomain boundary
+            // First, find the common element that both node and neigh belong to
+            const auto & elems_containing_node = nodes_to_elem_map[node.id()];
+            const auto & elems_containing_neigh = nodes_to_elem_map[neigh->id()];
+            const Elem * common_elem = nullptr;
+            for (const auto * neigh_elem : elems_containing_neigh)
             {
-              // Determine whether the neighbor is on the subdomain boundary
-              // First, find the common element that both node and neigh belong to
-              const auto & elems_containing_node = nodes_to_elem_map[node.id()];
-              const auto & elems_containing_neigh = nodes_to_elem_map[neigh->id()];
-              const Elem * common_elem = nullptr;
-              for (const auto * neigh_elem : elems_containing_neigh)
+              if (std::find(elems_containing_node.begin(), elems_containing_node.end(), neigh_elem) != elems_containing_node.end())
               {
-                if (std::find(elems_containing_node.begin(), elems_containing_node.end(), neigh_elem) != elems_containing_node.end())
-                {
-                  common_elem = neigh_elem;
-                  break;
-                }
+                common_elem = neigh_elem;
+                break;
+              }
+            }
+
+            libmesh_assert(common_elem != nullptr);
+            const auto common_sub_id = common_elem->subdomain_id();
+            libmesh_assert(common_sub_id == sub_id1 || common_sub_id == sub_id2);
+
+            // Define this allias for convenience
+            const auto & other_sub_id = (common_sub_id == sub_id1) ? sub_id2: sub_id1;
+
+            // Now, determine whether node and neigh are on a side coincident
+            // with the interval boundary
+            for (const auto common_side : common_elem->side_index_range())
+            {
+              bool node_found_on_side = false;
+              bool neigh_found_on_side = false;
+              for (const auto local_node_id : common_elem->nodes_on_side(common_side))
+              {
+                if (common_elem->node_id(local_node_id) == node.id())
+                  node_found_on_side = true;
+                else if (common_elem->node_id(local_node_id) == neigh->id())
+                  neigh_found_on_side = true;
               }
 
-              libmesh_assert(common_elem != nullptr);
-              const auto common_sub_id = common_elem->subdomain_id();
-              libmesh_assert(common_sub_id == sub_id1 || common_sub_id == sub_id2);
-
-              // Define this allias for convenience
-              const auto & other_sub_id = (common_sub_id == sub_id1) ? sub_id2: sub_id1;
-
-              // Now, determine whether node and neigh are on a side coincident
-              // with the interval boundary
-              for (const auto common_side : common_elem->side_index_range())
+              if (node_found_on_side && neigh_found_on_side)
               {
-                bool node_found_on_side = false;
-                bool neigh_found_on_side = false;
-                for (const auto local_node_id : common_elem->nodes_on_side(common_side))
-                {
-                  if (common_elem->node_id(local_node_id) == node.id())
-                    node_found_on_side = true;
-                  else if (common_elem->node_id(local_node_id) == neigh->id())
-                    neigh_found_on_side = true;
-                }
-
-                if (node_found_on_side && neigh_found_on_side)
-                {
-                  const auto matched_side = common_side;
-                  // There could be multiple matched sides, so keep this next part
-                  // inside the loop
-                  //
-                  // Does matched_side, containing both node and neigh, lie on the
-                  // subdomain boundary between sub_id1 (= common_sub_id or other_sub_id)
-                  // and sub_id2 (= other sub_id or common_sub_id)?
-                  const auto matched_neighbor_sub_id = common_elem->neighbor_ptr(matched_side)->subdomain_id();
-                  const bool is_matched_side_on_subdomain_boundary = matched_neighbor_sub_id == other_sub_id;
-                  if (is_matched_side_on_subdomain_boundary)
-                    return false; // Don't remove the neighbor node
-                }
+                const auto matched_side = common_side;
+                // There could be multiple matched sides, so keep this next part
+                // inside the loop
+                //
+                // Does matched_side, containing both node and neigh, lie on the
+                // subdomain boundary between sub_id1 (= common_sub_id or other_sub_id)
+                // and sub_id2 (= other sub_id or common_sub_id)?
+                const auto matched_neighbor_sub_id = common_elem->neighbor_ptr(matched_side)->subdomain_id();
+                const bool is_matched_side_on_subdomain_boundary = matched_neighbor_sub_id == other_sub_id;
+                if (is_matched_side_on_subdomain_boundary)
+                  return false; // Don't remove the neighbor node
               }
+            }
 
-              return true; // Remove the neighbor node
-            };
+            return true; // Remove the neighbor node
+          };
 
-            neighbors.erase(
-              std::remove_if(neighbors.begin(), neighbors.end(), remove_neighbor),
-              neighbors.end()
-            );
+          neighbors.erase(
+            std::remove_if(neighbors.begin(), neighbors.end(), remove_neighbor),
+            neighbors.end()
+          );
 
+          this->impose_constraints(node, neighbors);
+          already_constrained_node_ids.insert(node.id());
 
-            this->impose_constraints(node, neighbors);
-            already_constrained_node_ids.insert(node.id());
-          }
         }//for local_node_id
 
       }// for side

--- a/src/systems/variational_smoother_constraint.C
+++ b/src/systems/variational_smoother_constraint.C
@@ -327,10 +327,12 @@ void VariationalSmootherConstraint::constrain()
           if (boundary_node_ids.find(node.id()) == boundary_node_ids.end())
             this->impose_constraint(node, subdomain_constraint);
 
-          // This subdomain boundary node lies on an external boundary, save it
-          // for later to combine with the external boundary constraint
-          else
-            subdomain_boundary_map[node.id()] = subdomain_constraint;
+          // This subdomain boundary node could lie on an external boundary, save it
+          // for later to combine with the external boundary constraint.
+          // We also save constraints for non-boundary nodes so we don't try to
+          // re-constrain the node when accessed from the neighboring elem.
+          // See subdomain_boundary_map.count call above.
+          subdomain_boundary_map[node.id()] = subdomain_constraint;
 
         }//for local_node_id
 

--- a/tests/mesh/mesh_smoother_test.C
+++ b/tests/mesh/mesh_smoother_test.C
@@ -142,9 +142,14 @@ public:
   CPPUNIT_TEST( testLaplaceQuad );
   CPPUNIT_TEST( testLaplaceTri );
 #if defined(LIBMESH_ENABLE_VSMOOTHER) && defined(LIBMESH_HAVE_SOLVER)
-  CPPUNIT_TEST( testVariationalQuad );
-  CPPUNIT_TEST( testVariationalTri );
+  CPPUNIT_TEST(testVariationalEdge);
+  CPPUNIT_TEST(testVariationalEdgeMultipleSubdomains);
+  CPPUNIT_TEST(testVariationalQuad);
   CPPUNIT_TEST( testVariationalQuadMultipleSubdomains );
+  CPPUNIT_TEST(testVariationalTri);
+  CPPUNIT_TEST(testVariationalTriMultipleSubdomains);
+  CPPUNIT_TEST(testVariationalHex);
+  CPPUNIT_TEST(testVariationalHexMultipleSubdomains);
 #  endif // LIBMESH_ENABLE_VSMOOTHER
 #endif
 
@@ -170,8 +175,24 @@ public:
     libmesh_error_msg_if(n_elems_per_side % 2 != 1,
                          "n_elems_per_side should be odd.");
 
-    MeshTools::Generation::build_square(mesh, n_elems_per_side, n_elems_per_side,
-                                        0.,1.,0.,1., type);
+    switch (dim) {
+    case 1:
+      MeshTools::Generation::build_line(mesh, n_elems_per_side, 0., 1., type);
+      break;
+    case 2:
+      MeshTools::Generation::build_square(
+          mesh, n_elems_per_side, n_elems_per_side, 0., 1., 0., 1., type);
+      break;
+
+    case 3:
+      MeshTools::Generation::build_cube(mesh, n_elems_per_side,
+                                        n_elems_per_side, n_elems_per_side, 0.,
+                                        1., 0., 1., 0., 1., type);
+      break;
+
+    default:
+      libmesh_error_msg("Unsupported dimension " << dim);
+    }
 
     // Move it around so we have something that needs smoothing
     DistortHyperCube dh(dim);
@@ -340,6 +361,20 @@ public:
 
 
 #ifdef LIBMESH_ENABLE_VSMOOTHER
+  void testVariationalEdge() {
+    ReplicatedMesh mesh(*TestCommWorld);
+    VariationalMeshSmoother variational(mesh);
+
+    testSmoother(mesh, variational, EDGE2);
+  }
+
+  void testVariationalEdgeMultipleSubdomains() {
+    ReplicatedMesh mesh(*TestCommWorld);
+    VariationalMeshSmoother variational(mesh);
+
+    testSmoother(mesh, variational, EDGE2, true);
+  }
+
   void testVariationalQuad()
   {
     ReplicatedMesh mesh(*TestCommWorld);
@@ -348,6 +383,12 @@ public:
     testSmoother(mesh, variational, QUAD4);
   }
 
+  void testVariationalQuadMultipleSubdomains() {
+    ReplicatedMesh mesh(*TestCommWorld);
+    VariationalMeshSmoother variational(mesh);
+
+    testSmoother(mesh, variational, QUAD4, true);
+  }
 
   void testVariationalTri()
   {
@@ -357,12 +398,25 @@ public:
     testSmoother(mesh, variational, TRI3);
   }
 
-  void testVariationalQuadMultipleSubdomains()
-  {
+  void testVariationalTriMultipleSubdomains() {
     ReplicatedMesh mesh(*TestCommWorld);
     VariationalMeshSmoother variational(mesh);
 
-    testSmoother(mesh, variational, QUAD4, true);
+    testSmoother(mesh, variational, TRI3, true);
+  }
+
+  void testVariationalHex() {
+    ReplicatedMesh mesh(*TestCommWorld);
+    VariationalMeshSmoother variational(mesh);
+
+    testSmoother(mesh, variational, HEX8);
+  }
+
+  void testVariationalHexMultipleSubdomains() {
+    ReplicatedMesh mesh(*TestCommWorld);
+    VariationalMeshSmoother variational(mesh);
+
+    testSmoother(mesh, variational, HEX8, true);
   }
 #endif // LIBMESH_ENABLE_VSMOOTHER
 };

--- a/tests/mesh/mesh_smoother_test.C
+++ b/tests/mesh/mesh_smoother_test.C
@@ -181,10 +181,14 @@ public:
     std::unordered_map<dof_id_type, Point> subdomain_boundary_node_id_to_point;
     if (multiple_subdomains)
     {
-      // Increment the subdomain id on the right half by 1
-      for (auto *elem : mesh.active_element_ptr_range())
-        if (elem->vertex_average()(0) > 0.5)
-          ++elem->subdomain_id();
+      // Modify the subdomain ids in an interesting way
+      for (auto *elem : mesh.active_element_ptr_range()) {
+        unsigned int subdomain_id = 0;
+        for (const auto d : make_range(dim))
+          if (elem->vertex_average()(d) > 0.5)
+            ++subdomain_id;
+        elem->subdomain_id() += subdomain_id;
+      }
 
       // This loop should NOT be combined with the one above because we need to
       // finish checking and updating subdomain ids for all elements before

--- a/tests/mesh/mesh_smoother_test.C
+++ b/tests/mesh/mesh_smoother_test.C
@@ -221,7 +221,8 @@ public:
       (const Node & node) {
       auto it = subdomain_boundary_node_id_to_point.find(node.id());
       if (it != subdomain_boundary_node_id_to_point.end())
-        return (Point(node) == subdomain_boundary_node_id_to_point[node.id()]);
+        return (relative_fuzzy_equals(
+            Point(node), subdomain_boundary_node_id_to_point[node.id()]));
       else
         // node is not an internal subdomain boundary node, just return true
         return true;

--- a/tests/mesh/mesh_smoother_test.C
+++ b/tests/mesh/mesh_smoother_test.C
@@ -1,15 +1,16 @@
-#include <libmesh/libmesh.h>
+#include <libmesh/boundary_info.h>
+#include <libmesh/elem.h>
 #include <libmesh/enum_elem_type.h>
 #include <libmesh/function_base.h>
+#include <libmesh/libmesh.h>
 #include <libmesh/mesh_generation.h>
 #include <libmesh/mesh_modification.h>
 #include <libmesh/mesh_smoother_laplace.h>
 #include <libmesh/mesh_smoother_vsmoother.h>
 #include <libmesh/mesh_tools.h>
 #include <libmesh/node.h>
-#include <libmesh/elem.h>
+#include <libmesh/reference_elem.h>
 #include <libmesh/replicated_mesh.h>
-#include <libmesh/boundary_info.h>
 #include <libmesh/system.h> // LIBMESH_HAVE_SOLVER define
 
 #include "test_comm.h"
@@ -18,27 +19,64 @@
 namespace {
 using namespace libMesh;
 
-class DistortSquare : public FunctionBase<Real>
-{
-  std::unique_ptr<FunctionBase<Real>> clone () const override
-  { return std::make_unique<DistortSquare>(); }
+// Distortion function supporting 1D, 2D, and 3D
+class DistortHyperCube : public FunctionBase<Real> {
+public:
+  DistortHyperCube(const unsigned int dim) : _dim(dim) {}
 
-  Real operator() (const Point &,
-                   const Real = 0.) override
-  { libmesh_not_implemented(); } // scalar-only API
-
-  // Skew inward based on a cubic function
-  void operator() (const Point & p,
-                   const Real,
-                   DenseVector<Real> & output)
-  {
-    output.resize(3);
-    const Real eta = 2*p(0)-1;
-    const Real zeta = 2*p(1)-1;
-    output(0) = p(0) + (std::pow(eta,3)-eta)*p(1)*(1-p(1));
-    output(1) = p(1) + (std::pow(zeta,3)-zeta)*p(0)*(1-p(0));
-    output(2) = 0;
+private:
+  std::unique_ptr<FunctionBase<Real>> clone() const override {
+    return std::make_unique<DistortHyperCube>(_dim);
   }
+
+  Real operator()(const Point &, const Real = 0.) override {
+    libmesh_not_implemented();
+  }
+
+  void operator()(const Point &p, const Real,
+                  DenseVector<Real> &output) override {
+    output.resize(3);
+    output.zero();
+
+    // Count how many coordinates are exactly on the boundary (0 or 1)
+    unsigned int boundary_dims = 0;
+    std::array<bool, 3> is_on_boundary = {false, false, false};
+    for (unsigned int i = 0; i < _dim; ++i) {
+      if (std::abs(p(i)) < TOLERANCE || std::abs(p(i) - 1.) < TOLERANCE) {
+        ++boundary_dims;
+        is_on_boundary[i] = true;
+      }
+    }
+
+    // If all coordinates are on the boundary, treat as vertex — leave unchanged
+    if (boundary_dims == _dim) {
+      for (unsigned int i = 0; i < _dim; ++i)
+        output(i) = p(i);
+      return;
+    }
+
+    // Distort only those directions not fixed on the boundary
+    for (unsigned int i = 0; i < _dim; ++i) {
+      if (!is_on_boundary[i]) // only distort free dimensions
+      {
+        Real xi = 2. * p(i) - 1.;
+        Real modulation =
+            0.3; // This value constrols the strength of the distortion
+        for (unsigned int j = 0; j < _dim; ++j) {
+          if (j != i) {
+            Real pj = std::clamp(p(j), 0., 1.); // ensure numeric safety
+            modulation *=
+                (pj - 0.5) * (pj - 0.5) * 4.; // quadratic bump centered at 0.5
+          }
+        }
+        output(i) = p(i) + (std::pow(xi, 3) - xi) * modulation;
+      } else {
+        output(i) = p(i); // dimension on boundary remains unchanged
+      }
+    }
+  }
+
+  const unsigned int _dim;
 };
 
 class SquareToParallelogram : public FunctionBase<Real>
@@ -121,20 +159,30 @@ public:
   {
     LOG_UNIT_TEST;
 
-    unsigned int n_elems_per_side = 4;
+    const auto dim = ReferenceElem::get(type).dim();
+
+    unsigned int n_elems_per_side = 5;
+
+    // If n_elems_per_side is even, then some sliding boundary nodes will have a
+    // coordinante with value 0.5, which is already the optimal position,
+    // causing distortion_is(node, true) to return false when evaluating the
+    // distorted mesh. To avoid this, we require n_elems_per_side to be odd.
+    libmesh_error_msg_if(n_elems_per_side % 2 != 1,
+                         "n_elems_per_side should be odd.");
 
     MeshTools::Generation::build_square(mesh, n_elems_per_side, n_elems_per_side,
                                         0.,1.,0.,1., type);
 
     // Move it around so we have something that needs smoothing
-    DistortSquare ds;
-    MeshTools::Modification::redistribute(mesh, ds);
+    DistortHyperCube dh(dim);
+    MeshTools::Modification::redistribute(mesh, dh);
 
+    // Add multiple subdomains if requested
     std::unordered_map<dof_id_type, Point> subdomain_boundary_node_id_to_point;
     if (multiple_subdomains)
     {
       // Increment the subdomain id on the right half by 1
-      for (auto * elem : mesh.active_element_ptr_range())
+      for (auto *elem : mesh.active_element_ptr_range())
         if (elem->vertex_average()(0) > 0.5)
           ++elem->subdomain_id();
 
@@ -156,94 +204,91 @@ public:
         }
       }
 
-    const auto & boundary_info = mesh.get_boundary_info();
-
     // Function to assert the distortion is as expected
-    auto center_distortion_is = [&boundary_info, n_elems_per_side]
-      (const Node & node, int d, bool distortion,
-       Real distortion_tol=TOLERANCE) {
-      const Real r = node(d);
-      const Real R = r * n_elems_per_side;
-      CPPUNIT_ASSERT_GREATER(-distortion_tol*distortion_tol, r);
-      CPPUNIT_ASSERT_GREATER(-distortion_tol*distortion_tol, 1-r);
+      const auto &boundary_info = mesh.get_boundary_info();
+      auto distortion_is = [&n_elems_per_side, &dim,
+                            &boundary_info](const Node &node, bool distortion,
+                                            Real distortion_tol = TOLERANCE) {
+        // Get boundary ids associated with the node
+        std::vector<boundary_id_type> boundary_ids;
+        boundary_info.boundary_ids(&node, boundary_ids);
 
-      // If we're at the center we're fine
-      if (std::abs(r-0.5) < distortion_tol*distortion_tol)
-        return true;
+        // This tells us what type of node we are: internal, sliding, or fixed
+        const auto num_dofs = dim - boundary_ids.size();
+        /*
+         * The following cases of num_dofs are possible, ASSUMING all boundaries
+         * are non-overlapping
+         * 3D: 3-0,     3-1,     3-2,     3-3
+         *   = 3        2        1        0
+         *     internal sliding, sliding, fixed
+         * 2D: 2-0,     2-1,     2-2
+         *   = 2        1        0
+         *     internal sliding, fixed
+         * 1D: 1-0,     1-1
+         *   = 1        0
+         *     internal fixed
+         *
+         * We expect that R is an integer in [0, n_elems_per_side] for
+         * num_dofs of the node's cooridinantes, while the remaining coordinates
+         * are fixed to the boundary with value 0 or 1. In other words, at LEAST
+         * dim - num_dofs coordinantes should be 0 or 1.
+         */
 
-      // Boundary nodes are allowed to slide along the boundary.
-      // However, nodes that are part of more than one boundary (i.e., corners) should remain fixed.
+        size_t num_zero_or_one = 0;
 
-      // Get boundary ids associated with the node
-      std::vector<boundary_id_type> boundary_ids;
-      boundary_info.boundary_ids(&node, boundary_ids);
+        bool distorted = false;
+        for (const auto d : make_range(dim)) {
+          const Real r = node(d);
+          const Real R = r * n_elems_per_side;
+          CPPUNIT_ASSERT_GREATER(-distortion_tol * distortion_tol, r);
+          CPPUNIT_ASSERT_GREATER(-distortion_tol * distortion_tol, 1 - r);
 
-      switch (boundary_ids.size())
-      {
-        // Internal node
-        case 0:
-          return ((std::abs(R-std::round(R)) > distortion_tol) == distortion);
-          break;
-        // Sliding boundary node
-        case 1:
-          // Since sliding boundary nodes may or may not already be in the optimal
-          // position, they may or may not be different from the originally distorted
-          // mesh. Return true here to avoid issues.
+          // Due to the type of distortion used, nodes on the x, y, or z plane
+          // of symmetry do not have their respective x, y, or z node adjusted.
+          // Just continue to the next dimension.
+          if (std::abs(r - 0.5) < distortion_tol * distortion_tol)
+            continue;
+
+          const bool d_distorted = std::abs(R - std::round(R)) > distortion_tol;
+          distorted |= d_distorted;
+          num_zero_or_one +=
+              (absolute_fuzzy_equals(r, 0.) || absolute_fuzzy_equals(r, 1.));
+        }
+
+        CPPUNIT_ASSERT_GREATEREQUAL(dim - num_dofs, num_zero_or_one);
+
+        // We can never expect a fixed node to be distorted
+        if (num_dofs == 0)
+          // if (num_dofs < dim)
           return true;
-          break;
-        // Fixed boundary node, should not have moved
-        case 2:
-          if (std::abs(node(0)) < distortion_tol*distortion_tol ||
-              std::abs(node(0)-1) < distortion_tol*distortion_tol)
-            {
-              const Real R1 = node(1) * n_elems_per_side;
-              CPPUNIT_ASSERT_LESS(distortion_tol*distortion_tol, std::abs(R1-std::round(R1)));
+        return distorted == distortion;
+      };
+
+      // Function to check if a given node has changed based on previous mapping
+      auto is_subdomain_boundary_node_the_same =
+          [&subdomain_boundary_node_id_to_point](const Node &node) {
+            auto it = subdomain_boundary_node_id_to_point.find(node.id());
+            if (it != subdomain_boundary_node_id_to_point.end())
+              return (relative_fuzzy_equals(
+                  Point(node), subdomain_boundary_node_id_to_point[node.id()]));
+            else
+              // node is not a subdomain boundary node, just return true
               return true;
-            }
+          };
 
-          if (std::abs(node(1)) < distortion_tol*distortion_tol ||
-              std::abs(node(1)-1) < distortion_tol*distortion_tol)
-            {
-              const Real R0 = node(0) * n_elems_per_side;
-              CPPUNIT_ASSERT_LESS(distortion_tol*distortion_tol, std::abs(R0-std::round(R0)));
+      // Make sure our DistortSquare transformation has distorted the mesh
+      for (auto node : mesh.node_ptr_range())
+        CPPUNIT_ASSERT(distortion_is(*node, true));
 
-              return true;
-            }
-            return false;
-          break;
-          default:
-            libmesh_error_msg("Node has unsupported number of boundary ids = " << boundary_ids.size());
+      // Transform the square mesh of triangles to a parallelogram mesh of
+      // triangles. This will allow the Variational Smoother to smooth the mesh
+      // to the optimal case of equilateral triangles
+      const bool is_variational_smoother_type =
+          (dynamic_cast<VariationalMeshSmoother *>(&smoother) != nullptr);
+      if (type == TRI3 && is_variational_smoother_type) {
+        SquareToParallelogram stp;
+        MeshTools::Modification::redistribute(mesh, stp);
       }
-    };
-
-    // Function to check if a given node has changed based on previous mapping
-    auto is_internal_subdomain_boundary_node_the_same = [&subdomain_boundary_node_id_to_point]
-      (const Node & node) {
-      auto it = subdomain_boundary_node_id_to_point.find(node.id());
-      if (it != subdomain_boundary_node_id_to_point.end())
-        return (relative_fuzzy_equals(
-            Point(node), subdomain_boundary_node_id_to_point[node.id()]));
-      else
-        // node is not an internal subdomain boundary node, just return true
-        return true;
-    };
-
-    // Make sure our DistortSquare transformation has distorted the mesh
-    for (auto node : mesh.node_ptr_range())
-      {
-        CPPUNIT_ASSERT(center_distortion_is(*node, 0, true));
-        CPPUNIT_ASSERT(center_distortion_is(*node, 1, true));
-      }
-
-    // Transform the square mesh of triangles to a parallelogram mesh of triangles.
-    // This will allow the Variational Smoother to smooth the mesh to the optimal case
-    // of equilateral triangles
-   const bool is_variational_smoother_type = (dynamic_cast<VariationalMeshSmoother*>(&smoother) != nullptr);
-   if (type == TRI3 && is_variational_smoother_type)
-    {
-      SquareToParallelogram stp;
-      MeshTools::Modification::redistribute(mesh, stp);
-    }
 
     // Enough iterations to mostly fix us up.  Laplace seems to be at 1e-3
     // tolerance by iteration 6, so hopefully everything is there on any
@@ -265,14 +310,9 @@ public:
     for (auto node : mesh.node_ptr_range())
       {
         if (multiple_subdomains)
-        {
-          CPPUNIT_ASSERT(is_internal_subdomain_boundary_node_the_same(*node));
-        }
+          CPPUNIT_ASSERT(is_subdomain_boundary_node_the_same(*node));
         else
-        {
-          CPPUNIT_ASSERT(center_distortion_is(*node, 0, false, 1e-3));
-          CPPUNIT_ASSERT(center_distortion_is(*node, 1, false, 1e-3));
-        }
+          CPPUNIT_ASSERT(distortion_is(*node, false, 1e-3));
       }
   }
 


### PR DESCRIPTION
### Pull Request: Sliding Boundary Constraint Refinement and Dimensional Generalization

#### Summary
This pull request implements sliding external and subdomain boundary node constraints in the `VariationalMeshSmoother`
In addition to expanding test coverage to test sliding boundary nodes, 1D and 3D test cases were added to the unit test suite.

#### Highlights
- **Constraint Framework Refactor**
  - Introduced `PointConstraint`, `LineConstraint`, and `PlaneConstraint` structs to represent fixed nodes, nodes constrained to a line, and nodes constrained to a plane
  - Implemented a unified `intersect()` interface for combining constraints using `std::variant`
  - Added robust geometric logic for line-line, plane-line, and plane-plane intersections
  - Fallback to `PointConstraint` if constraints fail to intersect cleanly

- **Sliding Boundary Enhancements**
  - Implemented sliding boundary node constraints: previously, boundary and subdomain boundary nodes were fully fixed and not allowed to slide
  - Nodes on external boundaries internal subdomain boundaries now slide along planes and lines unless constrained by geometry

- **Expanded Tests and Validation**
  - Added new smoother test cases in 1D and 3D
  - Replaced `DistortSquare` with `DistortHypercube`, supporting 1D, 2D, and 3D skewing
  - Boundary nodes are now distorted within the faces and edges they belong to (while preserving corner vertices)
  - Increased complexity of subdomain boundary test to cover more complex cases such a an element having neighbors of multiply different subdomain ids


#### References
- Related to #4082