### PR TITLE
VariationalMeshSmoother: Support for higher order elements

### DIFF
--- a/include/systems/variational_smoother_constraint.h
+++ b/include/systems/variational_smoother_constraint.h
@@ -422,6 +422,19 @@ private:
   void constrain_node_to_line(const Node & node, const Point & line_vec);
 
   /**
+   * Given a mesh and a node in the mesh, the vector will be filled with
+   * every node directly attached to the given one. IF NO neighbors are found,
+   * all nodes on the containing side are treated as neighbors. This is useful
+   * when the node does not lie on an edge, such as the central face node in
+   * HEX27 elements.
+   */
+  static void find_nodal_or_face_neighbors(
+      const MeshBase &mesh, const Node &node,
+      const std::unordered_map<dof_id_type, std::vector<const Elem *>>
+          &nodes_to_elem_map,
+      std::vector<const Node *> &neighbors);
+
+  /**
    * Determines whether two neighboring nodes share a common boundary id.
    * @param boundary_node The first of the two prospective nodes.
    * @param neighbor_node The second of the two prospective nodes.

--- a/include/systems/variational_smoother_constraint.h
+++ b/include/systems/variational_smoother_constraint.h
@@ -57,7 +57,7 @@ public:
    * @param point The point defining the constraint.
    * @param tol The tolerance to use for numerical comparisons.
    */
-  PointConstraint(const Point &point, const Real &tol = TOLERANCE);
+  PointConstraint(const Point &point, const Real &tol = TOLERANCE * TOLERANCE);
 
   /**
    * Comparison operator for ordering PointConstraint objects.
@@ -132,7 +132,7 @@ public:
    * @param tol The tolerance to use for numerical comparisons.
    */
   LineConstraint(const Point &point, const Point &direction,
-                 const Real &tol = TOLERANCE);
+                 const Real &tol = TOLERANCE * TOLERANCE);
 
   /**
    * Comparison operator for ordering LineConstraint objects.
@@ -232,7 +232,7 @@ public:
    * @param tol The tolerance to use for numerical comparisons.
    */
   PlaneConstraint(const Point &point, const Point &normal,
-                  const Real &tol = TOLERANCE);
+                  const Real &tol = TOLERANCE * TOLERANCE);
 
   /**
    * Comparison operator for ordering PlaneConstraint objects.

--- a/include/systems/variational_smoother_constraint.h
+++ b/include/systems/variational_smoother_constraint.h
@@ -429,10 +429,10 @@ private:
    * HEX27 elements.
    */
   static void find_nodal_or_face_neighbors(
-      const MeshBase &mesh, const Node &node,
-      const std::unordered_map<dof_id_type, std::vector<const Elem *>>
-          &nodes_to_elem_map,
-      std::vector<const Node *> &neighbors);
+      const MeshBase & mesh,
+      const Node & node,
+      const std::unordered_map<dof_id_type, std::vector<const Elem *>> & nodes_to_elem_map,
+      std::vector<const Node *> & neighbors);
 
   /**
    * Determines whether two neighboring nodes share a common boundary id.

--- a/src/systems/variational_smoother_constraint.C
+++ b/src/systems/variational_smoother_constraint.C
@@ -536,10 +536,6 @@ void VariationalSmootherConstraint::find_nodal_or_face_neighbors(
   if (!neighbors.size())
     {
       // Grab the element containing node
-      // It doesn't make sense for a node having no edge neighbors to belong to
-      // multiple elements, right? Otherwise, we will figure out those cases as
-      // they occur.
-      libmesh_assert(nodes_to_elem_map.at(node.id()).size() == 1);
       const auto *elem = nodes_to_elem_map.at(node.id()).front();
       // Find the element side containing node
       for (const auto &side : elem->side_index_range())

--- a/src/systems/variational_smoother_constraint.C
+++ b/src/systems/variational_smoother_constraint.C
@@ -521,6 +521,51 @@ void VariationalSmootherConstraint::constrain_node_to_line(const Node & node,
     }
 }
 
+void VariationalSmootherConstraint::find_nodal_or_face_neighbors(
+    const MeshBase &mesh, const Node &node,
+    const std::unordered_map<dof_id_type, std::vector<const Elem *>>
+        &nodes_to_elem_map,
+    std::vector<const Node *> &neighbors)
+{
+  // Find all the nodal neighbors... that is the nodes directly connected
+  // to this node through one edge.
+  MeshTools::find_nodal_neighbors(mesh, node, nodes_to_elem_map, neighbors);
+
+  // If no neighbors are found, use all nodes on the containing side as
+  // neighbors.
+  if (!neighbors.size())
+    {
+      // Grab the element containing node
+      // It doesn't make sense for a node having no edge neighbors to belong to
+      // multiple elements, right? Otherwise, we will figure out those cases as
+      // they occur.
+      libmesh_assert(nodes_to_elem_map.at(node.id()).size() == 1);
+      const auto *elem = nodes_to_elem_map.at(node.id()).front();
+      // Find the element side containing node
+      for (const auto &side : elem->side_index_range())
+        {
+          bool found_node = false;
+          const auto &nodes_on_side = elem->nodes_on_side(side);
+          for (const auto &local_node_id : nodes_on_side)
+            if (elem->node_id(local_node_id) == node.id())
+            {
+              found_node = true;
+              break;
+            }
+          if (found_node)
+            {
+              for (const auto &local_node_id : nodes_on_side)
+                // No need to add node itself as a neighbor
+                if (const auto *node_ptr = elem->node_ptr(local_node_id);
+                    *node_ptr != node)
+                  neighbors.push_back(node_ptr);
+              break;
+            }
+        }
+    }
+  libmesh_assert(neighbors.size());
+}
+
 // Utility function to determine whether two nodes share a boundary ID.
 // The motivation for this is that a sliding boundary node on a triangular
 // element can have a neighbor boundary node in the same element that is not
@@ -588,9 +633,11 @@ VariationalSmootherConstraint::get_neighbors_for_subdomain_constraint(
 {
 
   // Find all the nodal neighbors... that is the nodes directly connected
-  // to this node through one edge
+  // to this node through one edge, or if none exists, use other nodes on the
+  // containing face
   std::vector<const Node *> neighbors;
-  MeshTools::find_nodal_neighbors(mesh, node, nodes_to_elem_map, neighbors);
+  VariationalSmootherConstraint::find_nodal_or_face_neighbors(
+      mesh, node, nodes_to_elem_map, neighbors);
 
   // Each constituent set corresponds to neighbors sharing a face on the
   // subdomain boundary
@@ -672,9 +719,11 @@ VariationalSmootherConstraint::get_neighbors_for_boundary_constraint(
 {
 
   // Find all the nodal neighbors... that is the nodes directly connected
-  // to this node through one edge
+  // to this node through one edge, or if none exists, use other nodes on the
+  // containing face
   std::vector<const Node *> neighbors;
-  MeshTools::find_nodal_neighbors(mesh, node, nodes_to_elem_map, neighbors);
+  VariationalSmootherConstraint::find_nodal_or_face_neighbors(
+      mesh, node, nodes_to_elem_map, neighbors);
 
   // Each constituent set corresponds to neighbors sharing a face on the
   // boundary

--- a/src/systems/variational_smoother_constraint.C
+++ b/src/systems/variational_smoother_constraint.C
@@ -522,10 +522,10 @@ void VariationalSmootherConstraint::constrain_node_to_line(const Node & node,
 }
 
 void VariationalSmootherConstraint::find_nodal_or_face_neighbors(
-    const MeshBase &mesh, const Node &node,
-    const std::unordered_map<dof_id_type, std::vector<const Elem *>>
-        &nodes_to_elem_map,
-    std::vector<const Node *> &neighbors)
+    const MeshBase & mesh,
+    const Node & node,
+    const std::unordered_map<dof_id_type, std::vector<const Elem *>> & nodes_to_elem_map,
+    std::vector<const Node *> & neighbors)
 {
   // Find all the nodal neighbors... that is the nodes directly connected
   // to this node through one edge.
@@ -536,19 +536,17 @@ void VariationalSmootherConstraint::find_nodal_or_face_neighbors(
   if (!neighbors.size())
     {
       // Grab the element containing node
-      const auto *elem = nodes_to_elem_map.at(node.id()).front();
+      const auto * elem = libmesh_map_find(nodes_to_elem_map, node.id()).front();
       // Find the element side containing node
       for (const auto &side : elem->side_index_range())
         {
-          bool found_node = false;
           const auto &nodes_on_side = elem->nodes_on_side(side);
-          for (const auto &local_node_id : nodes_on_side)
-            if (elem->node_id(local_node_id) == node.id())
-            {
-              found_node = true;
-              break;
-            }
-          if (found_node)
+          const auto it =
+              std::find_if(nodes_on_side.begin(), nodes_on_side.end(), [&](auto local_node_id) {
+                return elem->node_id(local_node_id) == node.id();
+              });
+
+          if (it != nodes_on_side.end())
             {
               for (const auto &local_node_id : nodes_on_side)
                 // No need to add node itself as a neighbor
@@ -643,8 +641,8 @@ VariationalSmootherConstraint::get_neighbors_for_subdomain_constraint(
     {
       // Determine whether the neighbor is on the subdomain boundary
       // First, find the common elements that both node and neigh belong to
-      const auto & elems_containing_node = nodes_to_elem_map.at(node.id());
-      const auto & elems_containing_neigh = nodes_to_elem_map.at(neigh->id());
+      const auto & elems_containing_node = libmesh_map_find(nodes_to_elem_map, node.id());
+      const auto & elems_containing_neigh = libmesh_map_find(nodes_to_elem_map, neigh->id());
       const Elem * common_elem = nullptr;
       for (const auto * neigh_elem : elems_containing_neigh)
         {
@@ -734,8 +732,8 @@ VariationalSmootherConstraint::get_neighbors_for_boundary_constraint(
 
       // Determine whether nodes share a common boundary id
       // First, find the common element that both node and neigh belong to
-      const auto & elems_containing_node = nodes_to_elem_map.at(node.id());
-      const auto & elems_containing_neigh = nodes_to_elem_map.at(neigh->id());
+      const auto & elems_containing_node = libmesh_map_find(nodes_to_elem_map, node.id());
+      const auto & elems_containing_neigh = libmesh_map_find(nodes_to_elem_map, neigh->id());
       const Elem * common_elem = nullptr;
       for (const auto * neigh_elem : elems_containing_neigh)
         {

--- a/src/systems/variational_smoother_system.C
+++ b/src/systems/variational_smoother_system.C
@@ -155,15 +155,11 @@ void VariationalSmootherSystem::prepare_for_smoothing()
                 Point(0.5, 0.5 * sqrt_3)
               };
 
-              // Area of the reference element
-              Real ref_area;
-
               // Target element
               const auto target_elem = Elem::build(elem->type());
 
-              // equilateral triangle side length that preserves area of reference
-              // element
-              ref_area = target_elem->reference_elem()->volume();
+              // Area of the reference element
+              const auto ref_area = target_elem->reference_elem()->volume();
 
               switch (elem->type())
                 {

--- a/src/systems/variational_smoother_system.C
+++ b/src/systems/variational_smoother_system.C
@@ -427,7 +427,7 @@ bool VariationalSmootherSystem::element_time_derivative (bool request_jacobian,
       const Real chi_prime = 0.5 * (1. + det / sqrt_term);
       const Real chi_prime_sq = chi_prime * chi_prime;
       // d2chi(x) / dx2
-      const Real chi_2prime = 0.5 * (1. / sqrt_term - det_sq / std::pow(sqrt_term, 3));
+      const Real chi_2prime = 0.5 * (1. / sqrt_term - det_sq / Utility::pow<3>(sqrt_term));
 
       // Distortion metric (beta)
       //const Real beta = trace_powers[0] / chi;

--- a/src/systems/variational_smoother_system.C
+++ b/src/systems/variational_smoother_system.C
@@ -159,29 +159,22 @@ void VariationalSmootherSystem::prepare_for_smoothing()
               Real ref_area;
 
               // Target element
-              std::unique_ptr<Tri> target_elem;
+              const auto target_elem = Elem::build(elem->type());
+
+              // equilateral triangle side length that preserves area of reference
+              // element
+              ref_area = target_elem->reference_elem()->volume();
 
               switch (elem->type())
                 {
                 case TRI3:
                   {
-                    target_elem = std::make_unique<Tri3>();
-
-                    // equilateral triangle side length that preserves area of reference
-                    // element
-                    ref_area = target_elem->reference_elem()->volume();
-
+                    // Nothing to do here, vertices already defined in equilateral_points
                     break;
                   }
 
                 case TRI6:
                   {
-                    target_elem = std::make_unique<Tri6>();
-
-                    // equilateral triangle side length that preserves area of reference
-                    // element
-                    ref_area = target_elem->reference_elem()->volume();
-
                     // Define the midpoint nodes of the equilateral triangle
                     equilateral_points.emplace_back(0.50, 0.          );
                     equilateral_points.emplace_back(0.75, 0.25 * sqrt_3);

--- a/src/systems/variational_smoother_system.C
+++ b/src/systems/variational_smoother_system.C
@@ -195,7 +195,7 @@ void VariationalSmootherSystem::prepare_for_smoothing()
                   // Scale the nodal positions to conserve area
                   auto node_ptr = std::make_unique<Node>(
                       equilateral_points[node_id] * side_length, node_id);
-                  target_elem->set_node(node_id) = node_ptr.get();
+                  target_elem->set_node(node_id, node_ptr.get());
 
                   // Store the pointer so it stays alive
                   owned_nodes.push_back(std::move(node_ptr));

--- a/src/systems/variational_smoother_system.C
+++ b/src/systems/variational_smoother_system.C
@@ -140,7 +140,7 @@ void VariationalSmootherSystem::prepare_for_smoothing()
               std::vector<Real>(nq_points, 1.0);
 
           // Elems deriving from Tri
-          if (dynamic_cast<const Tri*>(elem))
+          if (elem->type() == TRI3 || elem->type() == TRI6)
             {
 
               // The target element will be an equilateral triangle with area equal to

--- a/src/systems/variational_smoother_system.C
+++ b/src/systems/variational_smoother_system.C
@@ -143,7 +143,7 @@ void VariationalSmootherSystem::prepare_for_smoothing()
           if (dynamic_cast<const Tri*>(elem))
             {
 
-              // The target element will be an equilateral triangle with area equal to 
+              // The target element will be an equilateral triangle with area equal to
               // the area of the reference element.
 
               // First, let's define the nodal locations of the vertices

--- a/src/systems/variational_smoother_system.C
+++ b/src/systems/variational_smoother_system.C
@@ -192,13 +192,10 @@ void VariationalSmootherSystem::prepare_for_smoothing()
               // Set nodes of target element to form an equilateral triangle
               for (const dof_id_type node_id : index_range(equilateral_points))
                 {
-                  // Scale the nodal positions to conserve area
-                  auto node_ptr = std::make_unique<Node>(
-                      equilateral_points[node_id] * side_length, node_id);
-                  target_elem->set_node(node_id, node_ptr.get());
-
-                  // Store the pointer so it stays alive
-                  owned_nodes.push_back(std::move(node_ptr));
+                  // Scale the nodal positions to conserve area, store the pointer to keep it alive
+                  owned_nodes.emplace_back(
+                      Node::build(equilateral_points[node_id] * side_length, node_id));
+                  target_elem->set_node(node_id, owned_nodes.back().get());
                 }
 
               // build map
@@ -224,7 +221,7 @@ void VariationalSmootherSystem::prepare_for_smoothing()
         }// if find == end()
 
       // Reference volume computation
-      Real elem_integrated_det_J(0.);
+      Real elem_integrated_det_J = 0.;
       for (const auto qp : index_range(JxW))
         elem_integrated_det_J +=
             JxW[qp] * target_elem_inverse_jacobian_dets[elem->type()][qp];

--- a/tests/mesh/mesh_smoother_test.C
+++ b/tests/mesh/mesh_smoother_test.C
@@ -193,7 +193,8 @@ public:
 
   CPPUNIT_TEST(testVariationalHex8);
   CPPUNIT_TEST(testVariationalHex20);
-  CPPUNIT_TEST(testVariationalHex20MultipleSubdomains);
+  CPPUNIT_TEST(testVariationalHex27);
+  CPPUNIT_TEST(testVariationalHex27MultipleSubdomains);
 #endif // LIBMESH_ENABLE_VSMOOTHER
 #endif
 
@@ -570,12 +571,20 @@ public:
     testVariationalSmoother(mesh, variational, HEX20);
   }
 
-  void testVariationalHex20MultipleSubdomains()
+  void testVariationalHex27()
   {
     ReplicatedMesh mesh(*TestCommWorld);
     VariationalMeshSmoother variational(mesh);
 
-    testVariationalSmoother(mesh, variational, HEX20, true);
+    testVariationalSmoother(mesh, variational, HEX27);
+  }
+
+  void testVariationalHex27MultipleSubdomains()
+  {
+    ReplicatedMesh mesh(*TestCommWorld);
+    VariationalMeshSmoother variational(mesh);
+
+    testVariationalSmoother(mesh, variational, HEX27, true);
   }
 #endif // LIBMESH_ENABLE_VSMOOTHER
 };

--- a/tests/mesh/mesh_smoother_test.C
+++ b/tests/mesh/mesh_smoother_test.C
@@ -13,6 +13,7 @@
 #include <libmesh/replicated_mesh.h>
 #include <libmesh/system.h> // LIBMESH_HAVE_SOLVER define
 #include "libmesh/face_tri.h"
+#include "libmesh/utility.h"
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"
@@ -20,6 +21,7 @@
 namespace
 {
 using namespace libMesh;
+using Utility::pow;
 
 // Distortion function that doesn't distort boundary nodes
 // 2D only, use for LaplaceMeshSmoother
@@ -41,8 +43,8 @@ class DistortSquare : public FunctionBase<Real>
     output.resize(3);
     const Real eta = 2 * p(0) - 1;
     const Real zeta = 2 * p(1) - 1;
-    output(0) = p(0) + (std::pow(eta, 3) - eta) * p(1) * (1 - p(1));
-    output(1) = p(1) + (std::pow(zeta, 3) - zeta) * p(0) * (1 - p(0));
+    output(0) = p(0) + (pow<3>(eta) - eta) * p(1) * (1 - p(1));
+    output(1) = p(1) + (pow<3>(zeta) - zeta) * p(0) * (1 - p(0));
     output(2) = 0;
   }
 };
@@ -103,7 +105,7 @@ private:
                     modulation *= (pj - 0.5) * (pj - 0.5) * 4.; // quadratic bump centered at 0.5
                   }
               }
-            const auto delta = (std::pow(xi, 3) - xi) * modulation;
+            const auto delta = (pow<3>(xi) - xi) * modulation;
             // Check for delta = 0 to make sure we perturb every point
             output(i) = (delta > TOLERANCE) ? p(i) + delta : 1.05 * p(i);
           }

--- a/tests/mesh/mesh_smoother_test.C
+++ b/tests/mesh/mesh_smoother_test.C
@@ -186,8 +186,10 @@ public:
 
   CPPUNIT_TEST(testVariationalQuad);
   CPPUNIT_TEST(testVariationalQuadMultipleSubdomains);
-  CPPUNIT_TEST(testVariationalTri);
-  CPPUNIT_TEST(testVariationalTriMultipleSubdomains);
+
+  CPPUNIT_TEST(testVariationalTri3);
+  CPPUNIT_TEST(testVariationalTri6);
+  CPPUNIT_TEST(testVariationalTri6MultipleSubdomains);
 
   CPPUNIT_TEST(testVariationalHex8);
   CPPUNIT_TEST(testVariationalHex20);
@@ -528,7 +530,7 @@ public:
     testVariationalSmoother(mesh, variational, QUAD4, true);
   }
 
-  void testVariationalTri()
+  void testVariationalTri3()
   {
     ReplicatedMesh mesh(*TestCommWorld);
     VariationalMeshSmoother variational(mesh);
@@ -536,7 +538,15 @@ public:
     testVariationalSmoother(mesh, variational, TRI3);
   }
 
-  void testVariationalTriMultipleSubdomains()
+  void testVariationalTri6()
+  {
+    ReplicatedMesh mesh(*TestCommWorld);
+    VariationalMeshSmoother variational(mesh);
+
+    testVariationalSmoother(mesh, variational, TRI6);
+  }
+
+  void testVariationalTri6MultipleSubdomains()
   {
     ReplicatedMesh mesh(*TestCommWorld);
     VariationalMeshSmoother variational(mesh);

--- a/tests/mesh/mesh_smoother_test.C
+++ b/tests/mesh/mesh_smoother_test.C
@@ -12,6 +12,7 @@
 #include <libmesh/reference_elem.h>
 #include <libmesh/replicated_mesh.h>
 #include <libmesh/system.h> // LIBMESH_HAVE_SOLVER define
+#include "libmesh/face_tri.h"
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"
@@ -179,14 +180,18 @@ public:
   CPPUNIT_TEST(testLaplaceQuad);
   CPPUNIT_TEST(testLaplaceTri);
 #if defined(LIBMESH_ENABLE_VSMOOTHER) && defined(LIBMESH_HAVE_SOLVER)
-  CPPUNIT_TEST(testVariationalEdge);
-  CPPUNIT_TEST(testVariationalEdgeMultipleSubdomains);
+  CPPUNIT_TEST(testVariationalEdge2);
+  CPPUNIT_TEST(testVariationalEdge3);
+  CPPUNIT_TEST(testVariationalEdge3MultipleSubdomains);
+
   CPPUNIT_TEST(testVariationalQuad);
   CPPUNIT_TEST(testVariationalQuadMultipleSubdomains);
   CPPUNIT_TEST(testVariationalTri);
   CPPUNIT_TEST(testVariationalTriMultipleSubdomains);
-  CPPUNIT_TEST(testVariationalHex);
-  CPPUNIT_TEST(testVariationalHexMultipleSubdomains);
+
+  CPPUNIT_TEST(testVariationalHex8);
+  CPPUNIT_TEST(testVariationalHex20);
+  CPPUNIT_TEST(testVariationalHex20MultipleSubdomains);
 #endif // LIBMESH_ENABLE_VSMOOTHER
 #endif
 
@@ -270,7 +275,10 @@ public:
   {
     LOG_UNIT_TEST;
 
-    const auto dim = ReferenceElem::get(type).dim();
+    // Get mesh dimension, determine whether type is triangular
+    const auto * ref_elem = &(ReferenceElem::get(type));
+    const auto dim = ref_elem->dim();
+    const bool type_is_tri = dynamic_cast<const Tri*>(ref_elem);
 
     unsigned int n_elems_per_side = 5;
 
@@ -352,59 +360,69 @@ public:
             }
       }
 
-    // Function to assert the distortion is as expected
-    const auto & boundary_info = mesh.get_boundary_info();
-    auto distortion_is = [&n_elems_per_side, &dim, &boundary_info](
-                             const Node & node, bool distortion, Real distortion_tol = TOLERANCE) {
-      // Get boundary ids associated with the node
-      std::vector<boundary_id_type> boundary_ids;
-      boundary_info.boundary_ids(&node, boundary_ids);
 
-      // This tells us what type of node we are: internal, sliding, or fixed
-      const auto num_dofs = dim - boundary_ids.size();
-      /*
-       * The following cases of num_dofs are possible, ASSUMING all boundaries
-       * are non-overlapping
-       * 3D: 3-0,     3-1,     3-2,     3-3
-       *   = 3        2        1        0
-       *     internal sliding, sliding, fixed
-       * 2D: 2-0,     2-1,     2-2
-       *   = 2        1        0
-       *     internal sliding, fixed
-       * 1D: 1-0,     1-1
-       *   = 1        0
-       *     internal fixed
-       *
-       * We expect that R is an integer in [0, n_elems_per_side] for
-       * num_dofs of the node's cooridinantes, while the remaining coordinates
-       * are fixed to the boundary with value 0 or 1. In other words, at LEAST
-       * dim - num_dofs coordinantes should be 0 or 1.
-       */
+      // Get the mesh order
+      const auto &elem_orders = mesh.elem_default_orders();
+      libmesh_error_msg_if(
+          elem_orders.size() != 1,
+          "The variational smoother cannot be used for mixed-order meshes!");
+      const auto fe_order = *elem_orders.begin();
 
-      std::size_t num_zero_or_one = 0;
+      // Function to assert the distortion is as expected
+      const auto &boundary_info = mesh.get_boundary_info();
+      auto distortion_is = [
+        &n_elems_per_side, &dim, &boundary_info, &fe_order
+      ](const Node &node, bool distortion, Real distortion_tol = TOLERANCE)
+      {
+        // Get boundary ids associated with the node
+        std::vector<boundary_id_type> boundary_ids;
+        boundary_info.boundary_ids(&node, boundary_ids);
 
-      bool distorted = false;
-      for (const auto d : make_range(dim))
-        {
-          const Real r = node(d);
-          const Real R = r * n_elems_per_side;
-          CPPUNIT_ASSERT_GREATER(-distortion_tol * distortion_tol, r);
-          CPPUNIT_ASSERT_GREATER(-distortion_tol * distortion_tol, 1 - r);
+        // This tells us what type of node we are: internal, sliding, or fixed
+        const auto num_dofs = dim - boundary_ids.size();
+        /*
+         * The following cases of num_dofs are possible, ASSUMING all boundaries
+         * are non-overlapping
+         * 3D: 3-0,     3-1,     3-2,     3-3
+         *   = 3        2        1        0
+         *     internal sliding, sliding, fixed
+         * 2D: 2-0,     2-1,     2-2
+         *   = 2        1        0
+         *     internal sliding, fixed
+         * 1D: 1-0,     1-1
+         *   = 1        0
+         *     internal fixed
+         *
+         * We expect that R is an integer in [0, n_elems_per_side] for
+         * num_dofs of the node's cooridinantes, while the remaining coordinates
+         * are fixed to the boundary with value 0 or 1. In other words, at LEAST
+         * dim - num_dofs coordinantes should be 0 or 1.
+         */
 
-          const bool d_distorted = std::abs(R - std::round(R)) > distortion_tol;
-          distorted |= d_distorted;
-          num_zero_or_one +=
-              (absolute_fuzzy_equals(r, 0.) || absolute_fuzzy_equals(r, 1.));
-        }
+        std::size_t num_zero_or_one = 0;
 
-      CPPUNIT_ASSERT_GREATEREQUAL(dim - num_dofs, num_zero_or_one);
+        bool distorted = false;
+        for (const auto d : make_range(dim))
+          {
+            const Real r = node(d);
+            const Real R = r * n_elems_per_side * fe_order;
+            CPPUNIT_ASSERT_GREATER(-distortion_tol * distortion_tol, r);
+            CPPUNIT_ASSERT_GREATER(-distortion_tol * distortion_tol, 1 - r);
 
-      // We can never expect a fixed node to be distorted
-      if (num_dofs == 0)
-        // if (num_dofs < dim)
-        return true;
-      return distorted == distortion;
-    };
+            const bool d_distorted = std::abs(R - std::round(R)) > distortion_tol;
+            distorted |= d_distorted;
+            num_zero_or_one +=
+                (absolute_fuzzy_equals(r, 0.) || absolute_fuzzy_equals(r, 1.));
+          }
+
+        CPPUNIT_ASSERT_GREATEREQUAL(dim - num_dofs, num_zero_or_one);
+
+        // We can never expect a fixed node to be distorted
+        if (num_dofs == 0)
+          // if (num_dofs < dim)
+          return true;
+        return distorted == distortion;
+      };
 
     // Function to check if a given node has changed based on previous mapping
     auto is_subdomain_boundary_node_the_same = [&subdomain_boundary_node_id_to_point](
@@ -424,7 +442,7 @@ public:
     // Transform the square mesh of triangles to a parallelogram mesh of
     // triangles. This will allow the Variational Smoother to smooth the mesh
     // to the optimal case of equilateral triangles
-    if (type == TRI3)
+    if (type_is_tri)
       {
         SquareToParallelogram stp;
         MeshTools::Modification::redistribute(mesh, stp);
@@ -436,7 +454,7 @@ public:
     // the Variational Smoother, equilateral triangular elements will be
     // transformed into right triangular elements that align with the original
     // undistorted mesh.
-    if (type == TRI3)
+    if (type_is_tri)
       {
         ParallelogramToSquare pts;
         MeshTools::Modification::redistribute(mesh, pts);
@@ -470,7 +488,7 @@ public:
   }
 
 #ifdef LIBMESH_ENABLE_VSMOOTHER
-  void testVariationalEdge()
+  void testVariationalEdge2()
   {
     ReplicatedMesh mesh(*TestCommWorld);
     VariationalMeshSmoother variational(mesh);
@@ -478,12 +496,20 @@ public:
     testVariationalSmoother(mesh, variational, EDGE2);
   }
 
-  void testVariationalEdgeMultipleSubdomains()
+  void testVariationalEdge3()
   {
     ReplicatedMesh mesh(*TestCommWorld);
     VariationalMeshSmoother variational(mesh);
 
-    testVariationalSmoother(mesh, variational, EDGE2, true);
+    testVariationalSmoother(mesh, variational, EDGE3);
+  }
+
+  void testVariationalEdge3MultipleSubdomains()
+  {
+    ReplicatedMesh mesh(*TestCommWorld);
+    VariationalMeshSmoother variational(mesh);
+
+    testVariationalSmoother(mesh, variational, EDGE3, true);
   }
 
   void testVariationalQuad()
@@ -518,7 +544,7 @@ public:
     testVariationalSmoother(mesh, variational, TRI3, true);
   }
 
-  void testVariationalHex()
+  void testVariationalHex8()
   {
     ReplicatedMesh mesh(*TestCommWorld);
     VariationalMeshSmoother variational(mesh);
@@ -526,12 +552,20 @@ public:
     testVariationalSmoother(mesh, variational, HEX8);
   }
 
-  void testVariationalHexMultipleSubdomains()
+  void testVariationalHex20()
   {
     ReplicatedMesh mesh(*TestCommWorld);
     VariationalMeshSmoother variational(mesh);
 
-    testVariationalSmoother(mesh, variational, HEX8, true);
+    testVariationalSmoother(mesh, variational, HEX20);
+  }
+
+  void testVariationalHex20MultipleSubdomains()
+  {
+    ReplicatedMesh mesh(*TestCommWorld);
+    VariationalMeshSmoother variational(mesh);
+
+    testVariationalSmoother(mesh, variational, HEX20, true);
   }
 #endif // LIBMESH_ENABLE_VSMOOTHER
 };


### PR DESCRIPTION
This pull request extends the `VariationalMeshSmoother` to handle higher-order elements, as part of the work on issue #4082.

- **Improved Test Coverage**:

  - Updated the `VariationalMeshSmoother` tester to better handle symmetric configurations. Nodes previously unaffected by the `DistortHypercube` due to lying on planes of symmetry now receive a 5% forced distortion.
  - The above forced distortion removed the need to skip distortion checks on nodes with coordinate value 0.5, simplifying the `distortion_is` logic.

- **Extended Element Support**:

  - **EDGE3 and HEX20**: Added tests verifying smoother functionality on these higher-order elements. Minor adjustments to `distortion_is` were made to correctly map midpoint nodes to integer values using `fe_order`.
  - **TRI6**: Introduced a target equilateral quadratic triangle to support smoothing for TRI6 elements, along with corresponding tests.
  - **HEX27**: Implemented logic to determine face neighbors for face-center nodes when no nodal neighbors are available, enabling full support and test coverage for HEX27 elements.

Ref #4082.