### PR TITLE
VariationalMeshSmoother: Refactored element type check to use string comparison

### DIFF
--- a/src/systems/variational_smoother_system.C
+++ b/src/systems/variational_smoother_system.C
@@ -29,6 +29,7 @@
 #include "libmesh/quadrature.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/utility.h"
+#include "libmesh/enum_to_string.h"
 
 // C++ includes
 #include <functional> // std::reference_wrapper

--- a/tests/mesh/mesh_smoother_test.C
+++ b/tests/mesh/mesh_smoother_test.C
@@ -14,6 +14,7 @@
 #include <libmesh/system.h> // LIBMESH_HAVE_SOLVER define
 #include "libmesh/face_tri.h"
 #include "libmesh/utility.h"
+#include "libmesh/enum_to_string.h"
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"


### PR DESCRIPTION
as suggested in #4218.