### PR TITLE
New utilities fixing file suffix tests

### DIFF
--- a/include/mesh/namebased_io.h
+++ b/include/mesh/namebased_io.h
@@ -119,19 +119,6 @@ NameBasedIO::NameBasedIO (MeshBase & mesh) :
 {
 }
 
-inline
-bool
-NameBasedIO::is_parallel_file_format (std::string_view name)
-{
-  return ((name.rfind(".xda") < name.size()) ||
-          (name.rfind(".xdr") < name.size()) ||
-          (name.rfind(".nem") == name.size() - 4) ||
-          (name.rfind(".n") == name.size() - 2) ||
-          (name.rfind(".cp") < name.size())
-          );
-}
-
-
 } // namespace libMesh
 
 

--- a/include/utils/utility.h
+++ b/include/utils/utility.h
@@ -386,6 +386,20 @@ void deallocate (std::vector<T> & vec)
 std::string_view basename_of(const std::string & fullname);
 
 
+/**
+ * Look for a substring within a string.
+ */
+bool contains(std::string_view superstring,
+              std::string_view substring);
+
+
+/**
+ * Look for a substring at the very end of a string.
+ */
+bool ends_with(std::string_view superstring,
+               std::string_view suffix);
+
+
 // Utility functions useful when dealing with complex numbers.
 
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS

--- a/src/apps/projection.C
+++ b/src/apps/projection.C
@@ -35,6 +35,7 @@
 #include "libmesh/point.h"
 #include "libmesh/replicated_mesh.h"
 #include "libmesh/enum_xdr_mode.h"
+#include "libmesh/utility.h"
 
 
 using namespace libMesh;
@@ -151,9 +152,9 @@ int main(int argc, char ** argv)
 
   XdrMODE read_mode;
 
-  if (solnname.rfind(".xdr") < solnname.size())
+  if (Utility::contains(solnname, ".xdr"))
     read_mode = DECODE;
-  else if (solnname.rfind(".xda") < solnname.size())
+  else if (Utility::contains(solnname, ".xda"))
     read_mode = READ;
   else
     libmesh_error_msg("Unrecognized file extension on " << solnname);

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -233,7 +233,7 @@ void AbaqusIO::read (const std::string & fname)
   the_mesh.clear();
 
   // Open stream for reading
-  const bool gzipped_file = (fname.rfind(".gz") == fname.size() - 3);
+  const bool gzipped_file = Utility::ends_with(fname, ".gz");
 
   if (gzipped_file)
     {

--- a/src/mesh/dyna_io.C
+++ b/src/mesh/dyna_io.C
@@ -138,10 +138,7 @@ DynaIO::DynaIO (MeshBase & mesh,
 
 void DynaIO::read (const std::string & name)
 {
-  const bool gzipped_file = (name.rfind(".gz") == name.size() - 3);
-  // These will be handled in unzip_file:
-  // const bool bzipped_file = (name.size() - name.rfind(".bz2") == 4);
-  // const bool xzipped_file = (name.size() - name.rfind(".xz") == 3);
+  const bool gzipped_file = Utility::ends_with(name, ".gz");
 
   std::unique_ptr<std::istream> in;
 

--- a/src/mesh/namebased_io.C
+++ b/src/mesh/namebased_io.C
@@ -72,14 +72,16 @@ void NameBasedIO::read (const std::string & name)
 
   const std::string_view basename = Utility::basename_of(name);
 
+  using Utility::ends_with;
+  using Utility::contains;
+
   // See if the file exists.  Perform this check on all processors
   // so that the code is terminated properly in the case that the
   // file does not exist.
 
   // For Nemesis files, the name we try to read will have suffixes
   // identifying processor rank
-  if (basename.rfind(".nem") == basename.size() - 4 ||
-      basename.rfind(".n") == basename.size() - 2)
+  if (ends_with(basename, ".nem") || ends_with(basename, ".n"))
     {
       std::ostringstream full_name;
 
@@ -98,7 +100,7 @@ void NameBasedIO::read (const std::string & name)
       std::ifstream in (full_name.str().c_str());
       libmesh_error_msg_if(!in.good(), "ERROR: cannot locate specified file:\n\t" << full_name.str());
     }
-  else if (basename.rfind(".cp")) {} // Do error checking in the reader
+  else if (contains(basename, ".cp")) {} // Do error checking in the reader
   else
     {
       std::ifstream in (name.c_str());
@@ -109,13 +111,13 @@ void NameBasedIO::read (const std::string & name)
   if (is_parallel_file_format(basename))
     {
       // no need to handle bz2 files here -- the Xdr class does that.
-      if ((basename.rfind(".xda") < basename.size()) ||
-          (basename.rfind(".xdr") < basename.size()))
+      if (contains(basename, ".xda") ||
+          contains(basename, ".xdr"))
         {
           XdrIO xdr_io(mymesh);
 
           // .xda* ==> bzip2/gzip/ASCII flavors
-          if (basename.rfind(".xda") < basename.size())
+          if (contains(basename, ".xda"))
             {
               xdr_io.binary() = false;
               xdr_io.read (name);
@@ -152,12 +154,12 @@ void NameBasedIO::read (const std::string & name)
           mymesh.allow_renumbering(false);
 #endif
         }
-      else if (basename.rfind(".nem") < basename.size() ||
-               basename.rfind(".n")   < basename.size())
+      else if (contains(basename, ".nem") ||
+               contains(basename, ".n"))
         Nemesis_IO(mymesh).read (name);
-      else if (basename.rfind(".cp") < basename.size())
+      else if (contains(basename, ".cp"))
         {
-          if (basename.rfind(".cpa") < basename.size())
+          if (contains(basename, ".cpa"))
             CheckpointIO(mymesh, false).read(name);
           else
             CheckpointIO(mymesh, true).read(name);
@@ -178,7 +180,7 @@ void NameBasedIO::read (const std::string & name)
           pid_suffix << '_' << getpid();
           // Nasty hack for reading/writing zipped files
           std::string new_name = name;
-          if (name.rfind(".bz2") == name.size() - 4)
+          if (ends_with(name, ".bz2"))
             {
 #ifdef LIBMESH_HAVE_BZIP
               new_name.erase(new_name.end() - 4, new_name.end());
@@ -192,7 +194,7 @@ void NameBasedIO::read (const std::string & name)
               libmesh_error_msg("ERROR: need bzip2/bunzip2 to open .bz2 file " << name);
 #endif
             }
-          else if (name.rfind(".xz") == name.size() - 3)
+          else if (ends_with(name, ".xz"))
             {
 #ifdef LIBMESH_HAVE_XZ
               new_name.erase(new_name.end() - 3, new_name.end());
@@ -207,49 +209,49 @@ void NameBasedIO::read (const std::string & name)
 #endif
             }
 
-          if (basename.rfind(".mat") < basename.size())
+          if (contains(basename, ".mat"))
             MatlabIO(mymesh).read(new_name);
 
-          else if (basename.rfind(".ucd") < basename.size())
+          else if (contains(basename, ".ucd"))
             UCDIO(mymesh).read (new_name);
 
-          else if ((basename.rfind(".off")  < basename.size()) ||
-                   (basename.rfind(".ogl")  < basename.size()) ||
-                   (basename.rfind(".oogl") < basename.size()))
+          else if (contains(basename, ".off") ||
+                   contains(basename, ".ogl") ||
+                   contains(basename, ".oogl"))
             OFFIO(mymesh).read (new_name);
 
-          else if (basename.rfind(".unv") < basename.size())
+          else if (contains(basename, ".unv"))
             UNVIO(mymesh).read (new_name);
 
-          else if ((basename.rfind(".node")  < basename.size()) ||
-                   (basename.rfind(".ele")   < basename.size()))
+          else if (contains(basename, ".node") ||
+                   contains(basename, ".ele"))
             TetGenIO(mymesh).read (new_name);
 
-          else if (basename.rfind(".exd") < basename.size() ||
-                   basename.rfind(".e") < basename.size())
+          else if (contains(basename, ".exd") ||
+                   contains(basename, ".e"))
             ExodusII_IO(mymesh).read (new_name);
 
-          else if (basename.rfind(".msh") < basename.size())
+          else if (contains(basename, ".msh"))
             GmshIO(mymesh).read (new_name);
 
-          else if (basename.rfind(".gmv") < basename.size())
+          else if (contains(basename, ".gmv"))
             GMVIO(mymesh).read (new_name);
 
-          else if (basename.rfind(".stl") < basename.size())
+          else if (contains(basename, ".stl"))
             STLIO(mymesh).read (new_name);
 
-          else if (basename.rfind(".pvtu") < basename.size() ||
-                   basename.rfind(".vtu") < basename.size())
+          else if (contains(basename, ".pvtu") ||
+                   contains(basename, ".vtu"))
             VTKIO(mymesh).read(new_name);
 
-          else if (basename.rfind(".inp") < basename.size())
+          else if (contains(basename, ".inp"))
             AbaqusIO(mymesh).read(new_name);
 
-          else if ((basename.rfind(".bext")  < basename.size()) ||
-                   (basename.rfind(".bxt")   < basename.size()))
+          else if (contains(basename, ".bext") ||
+                   contains(basename, ".bxt"))
             DynaIO(mymesh).read (new_name);
 
-          else if (basename.rfind(".bez")  < basename.size())
+          else if (contains(basename, ".bez"))
             DynaIO(mymesh, false).read (new_name);
 
           else
@@ -287,9 +289,9 @@ void NameBasedIO::read (const std::string & name)
 
           // If we temporarily decompressed a file, remove the
           // uncompressed version
-          if (name.rfind(".bz2") == name.size() - 4)
+          if (ends_with(basename, ".bz2"))
             std::remove(new_name.c_str());
-          if (name.rfind(".xz") == name.size() - 3)
+          if (ends_with(basename, ".xz"))
             std::remove(new_name.c_str());
         }
 
@@ -306,25 +308,28 @@ void NameBasedIO::write (const std::string & name)
 
   const std::string_view basename = Utility::basename_of(name);
 
+  using Utility::contains;
+  using Utility::ends_with;
+
   // parallel formats are special -- they may choose to write
   // separate files, let's not try to handle the zipping here.
   if (is_parallel_file_format(basename))
     {
       // no need to handle bz2 files here -- the Xdr class does that.
-      if (basename.rfind(".xda") < basename.size())
+      if (contains(basename, ".xda"))
         XdrIO(mymesh).write(name);
 
-      else if (basename.rfind(".xdr") < basename.size())
+      else if (contains(basename, ".xdr"))
         XdrIO(mymesh,true).write(name);
 
-      else if (basename.rfind(".nem") < basename.size() ||
-               basename.rfind(".n")   < basename.size())
+      else if (contains(basename, ".nem") ||
+               contains(basename, ".n"))
         Nemesis_IO(mymesh).write(name);
 
-      else if (basename.rfind(".cpa") < basename.size())
+      else if (contains(basename, ".cpa"))
         CheckpointIO(mymesh,false).write(name);
 
-      else if (basename.rfind(".cpr") < basename.size())
+      else if (contains(basename, ".cpr"))
         CheckpointIO(mymesh,true).write(name);
 
       else
@@ -343,12 +348,12 @@ void NameBasedIO::write (const std::string & name)
       std::ostringstream pid_suffix;
       pid_suffix << '_' << pid_0;
 
-      if (name.rfind(".bz2") == name.size() - 4)
+      if (ends_with(name, ".bz2"))
         {
           new_name.erase(new_name.end() - 4, new_name.end());
           new_name += pid_suffix.str();
         }
-      else if (name.rfind(".xz") == name.size() - 3)
+      else if (ends_with(name, ".xz"))
         {
           new_name.erase(new_name.end() - 3, new_name.end());
           new_name += pid_suffix.str();
@@ -357,16 +362,16 @@ void NameBasedIO::write (const std::string & name)
       // New scope so that io will close before we try to zip the file
       {
         // Write the file based on extension
-        if (basename.rfind(".dat") < basename.size())
+        if (contains(basename, ".dat"))
           TecplotIO(mymesh).write (new_name);
 
-        else if (basename.rfind(".plt") < basename.size())
+        else if (contains(basename, ".plt"))
           TecplotIO(mymesh,true).write (new_name);
 
-        else if (basename.rfind(".ucd") < basename.size())
+        else if (contains(basename, ".ucd"))
           UCDIO (mymesh).write (new_name);
 
-        else if (basename.rfind(".gmv") < basename.size())
+        else if (contains(basename, ".gmv"))
           if (mymesh.n_partitions() > 1)
             GMVIO(mymesh).write (new_name);
           else
@@ -376,29 +381,29 @@ void NameBasedIO::write (const std::string & name)
               io.write (new_name);
             }
 
-        else if (basename.rfind(".exd") < basename.size() ||
-                 basename.rfind(".e") < basename.size())
+        else if (contains(basename, ".exd") ||
+                 contains(basename, ".e"))
           ExodusII_IO(mymesh).write(new_name);
 
-        else if (basename.rfind(".unv") < basename.size())
+        else if (contains(basename, ".unv"))
           UNVIO(mymesh).write (new_name);
 
-        else if (basename.rfind(".mesh") < basename.size())
+        else if (contains(basename, ".mesh"))
           MEDITIO(mymesh).write (new_name);
 
-        else if (basename.rfind(".poly") < basename.size())
+        else if (contains(basename, ".poly"))
           TetGenIO(mymesh).write (new_name);
 
-        else if (basename.rfind(".msh") < basename.size())
+        else if (contains(basename, ".msh"))
           GmshIO(mymesh).write (new_name);
 
-        else if (basename.rfind(".fro") < basename.size())
+        else if (contains(basename, ".fro"))
           FroIO(mymesh).write (new_name);
 
-        else if (basename.rfind(".pvtu") < basename.size())
+        else if (contains(basename, ".pvtu"))
           VTKIO(mymesh).write (name);
 
-        else if (basename.rfind(".stl") < basename.size())
+        else if (contains(basename, ".stl"))
           STLIO(mymesh).write (new_name);
 
         else
@@ -431,7 +436,7 @@ void NameBasedIO::write (const std::string & name)
       }
 
       // Nasty hack for reading/writing zipped files
-      if (name.rfind(".bz2") == name.size() - 4)
+      if (ends_with(basename, ".bz2"))
         {
           LOG_SCOPE("system(bzip2)", "NameBasedIO");
           if (mymesh.processor_id() == 0)
@@ -444,7 +449,7 @@ void NameBasedIO::write (const std::string & name)
             }
           mymesh.comm().barrier();
         }
-      if (name.rfind(".xz") == name.size() - 3)
+      if (ends_with(basename, ".xz"))
         {
           LOG_SCOPE("system(xz)", "NameBasedIO");
           if (mymesh.processor_id() == 0)
@@ -467,15 +472,18 @@ void NameBasedIO::write_nodal_data (const std::string & name,
 {
   const MeshBase & mymesh = MeshOutput<MeshBase>::mesh();
 
+  using Utility::contains;
+  using Utility::ends_with;
+
   // Write the file based on extension
-  if (name.rfind(".dat") < name.size())
+  if (contains(name, ".dat"))
     TecplotIO(mymesh).write_nodal_data (name, v, vn);
 
-  else if (name.rfind(".exd") < name.size() ||
-           name.rfind(".e") < name.size())
+  else if (contains(name, ".exd") ||
+           contains(name, ".e"))
     ExodusII_IO(mymesh).write_nodal_data(name, v, vn);
 
-  else if (name.rfind(".gmv") < name.size())
+  else if (contains(name, ".gmv"))
     {
       if (mymesh.n_subdomains() > 1)
         GMVIO(mymesh).write_nodal_data (name, v, vn);
@@ -487,23 +495,23 @@ void NameBasedIO::write_nodal_data (const std::string & name,
         }
     }
 
-  else if (name.rfind(".mesh") < name.size())
+  else if (contains(name, ".mesh"))
     MEDITIO(mymesh).write_nodal_data (name, v, vn);
 
-  else if (name.rfind(".msh") < name.size())
+  else if (contains(name, ".msh"))
     GmshIO(mymesh).write_nodal_data (name, v, vn);
 
-  else if (name.rfind(".nem") < name.size() ||
-           name.rfind(".n")   < name.size())
+  else if (contains(name, ".nem") ||
+           contains(name, ".n"))
     Nemesis_IO(mymesh).write_nodal_data(name, v, vn);
 
-  else if (name.rfind(".plt") < name.size())
+  else if (contains(name, ".plt"))
     TecplotIO(mymesh,true).write_nodal_data (name, v, vn);
 
-  else if (name.rfind(".pvtu") < name.size())
+  else if (contains(name, ".pvtu"))
     VTKIO(mymesh).write_nodal_data (name, v, vn);
 
-  else if (name.rfind(".ucd") < name.size())
+  else if (contains(name, ".ucd"))
     UCDIO (mymesh).write_nodal_data (name, v, vn);
 
   else
@@ -538,14 +546,14 @@ void NameBasedIO::write_equation_systems (const std::string & filename,
       const std::string_view basename =
         Utility::basename_of(filename);
 
-      if (basename.rfind(".xda") < basename.size())
+      if (Utility::contains(basename, ".xda"))
         {
           es.write(filename,WRITE,
                    EquationSystems::WRITE_DATA |
                    EquationSystems::WRITE_ADDITIONAL_DATA);
           return;
         }
-      else if (basename.rfind(".xdr") < basename.size())
+      else if (Utility::contains(basename, ".xdr"))
         {
           es.write(filename,ENCODE,
                    EquationSystems::WRITE_DATA |
@@ -559,6 +567,15 @@ void NameBasedIO::write_equation_systems (const std::string & filename,
     (filename, es, system_names);
 }
 
+
+bool NameBasedIO::is_parallel_file_format(std::string_view name)
+{
+  using Utility::contains;
+  using Utility::ends_with;
+  return (contains(name, ".xda") || contains(name, ".xdr") ||
+          ends_with(name, ".nem") || ends_with(name, ".n") ||
+          contains(name, ".cp"));
+}
 
 
 } // namespace libMesh

--- a/src/mesh/stl_io.C
+++ b/src/mesh/stl_io.C
@@ -222,8 +222,7 @@ void STLIO::read (const std::string & filename)
 
 std::unique_ptr<std::istream> STLIO::open_file (const std::string & filename)
 {
-  std::string_view basename = Utility::basename_of(filename);
-  const bool gzipped_file = (basename.rfind(".gz") == basename.size() - 3);
+  const bool gzipped_file = Utility::ends_with(filename, ".gz");
 
   std::unique_ptr<std::istream> file;
 

--- a/src/mesh/tetgen_io.C
+++ b/src/mesh/tetgen_io.C
@@ -18,9 +18,11 @@
 
 // Local includes
 #include "libmesh/tetgen_io.h"
-#include "libmesh/mesh_base.h"
+
 #include "libmesh/cell_tet4.h"
 #include "libmesh/cell_tet10.h"
+#include "libmesh/mesh_base.h"
+#include "libmesh/utility.h"
 
 // C++ includes
 #include <array>
@@ -50,14 +52,14 @@ void TetGenIO::read (const std::string & name)
   // Check name for *.node or *.ele extension.
   // Set std::istream for node_stream and ele_stream.
   //
-  if (name.rfind(".node") < name.size())
+  if (Utility::contains(name, ".node"))
     {
       name_node            = name;
       dummy                = name;
       std::size_t position = dummy.rfind(".node");
       name_ele             = dummy.replace(position, 5, ".ele");
     }
-  else if (name.rfind(".ele") < name.size())
+  else if (Utility::contains(name, ".ele"))
     {
       name_ele = name;
       dummy    = name;
@@ -270,7 +272,7 @@ void TetGenIO::write (const std::string & fname)
   // libmesh_assert three dimensions (should be extended later)
   libmesh_assert_equal_to (MeshOutput<MeshBase>::mesh().mesh_dimension(), 3);
 
-  libmesh_error_msg_if(!(fname.rfind(".poly") < fname.size()),
+  libmesh_error_msg_if(!Utility::contains(fname, ".poly"),
                        "ERROR: Unrecognized file name: " << fname);
 
   // Open the output file stream

--- a/src/mesh/ucd_io.C
+++ b/src/mesh/ucd_io.C
@@ -81,7 +81,7 @@ std::map<std::string, ElemType> UCDIO::build_reading_element_map()
 
 void UCDIO::read (const std::string & file_name)
 {
-  if (file_name.rfind(".gz") < file_name.size())
+  if (Utility::contains(file_name, ".gz"))
     {
 #ifdef LIBMESH_HAVE_GZSTREAM
       igzstream in_stream (file_name.c_str());
@@ -102,7 +102,7 @@ void UCDIO::read (const std::string & file_name)
 
 void UCDIO::write (const std::string & file_name)
 {
-  if (file_name.rfind(".gz") < file_name.size())
+  if (Utility::contains(file_name, ".gz"))
     {
 #ifdef LIBMESH_HAVE_GZSTREAM
       ogzstream out_stream (file_name.c_str());

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -1237,7 +1237,7 @@ void UnstructuredMesh::read (const std::string & name,
   // during prepare_for_use() for certain types of mesh files.
   // This is required in cases where there is an associated solution
   // file which expects a certain ordering of the nodes.
-  if (name.rfind(".gmv") == name.size() - 4)
+  if (Utility::ends_with(name, ".gmv"))
     this->allow_renumbering(false);
 
   NameBasedIO(*this).read(name);

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -95,7 +95,7 @@ bool & UNVIO::verbose ()
 
 void UNVIO::read (const std::string & file_name)
 {
-  if (file_name.rfind(".gz") < file_name.size())
+  if (Utility::contains(file_name, ".gz"))
     {
 #ifdef LIBMESH_HAVE_GZSTREAM
 
@@ -256,7 +256,7 @@ void UNVIO::read_implementation (std::istream & in_stream)
 
 void UNVIO::write (const std::string & file_name)
 {
-  if (file_name.rfind(".gz") < file_name.size())
+  if (Utility::contains(file_name, ".gz"))
     {
 #ifdef LIBMESH_HAVE_GZSTREAM
 

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -26,6 +26,7 @@
 #include "libmesh/node.h"
 #include "libmesh/elem.h"
 #include "libmesh/enum_io_package.h"
+#include "libmesh/utility.h"
 
 #ifdef LIBMESH_HAVE_VTK
 
@@ -356,7 +357,7 @@ void VTKIO::write_nodal_data (const std::string & fname,
   // Warn that the .pvtu file extension should be used.  Paraview
   // recognizes this, and it works in both serial and parallel.  Only
   // warn about this once.
-  if (fname.substr(fname.rfind("."), fname.size()) != ".pvtu")
+  if (!Utility::ends_with(fname, ".pvtu"))
     libmesh_do_once(libMesh::err << "The .pvtu extension should be used when writing VTK files in libMesh.");
 
   // If there are variable names being written, the solution vector

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -28,6 +28,7 @@
 #include "libmesh/mesh_tools.h"
 #include "libmesh/node.h"
 #include "libmesh/partitioner.h"
+#include "libmesh/utility.h"
 #include "libmesh/xdr_cxx.h"
 
 // TIMPI includes

--- a/src/numerics/numeric_vector.C
+++ b/src/numerics/numeric_vector.C
@@ -304,7 +304,7 @@ void NumericVector<T>::read_matlab(const std::string & filename)
 #else
   parallel_object_only();
 
-  const bool gzipped_file = (filename.rfind(".gz") == filename.size() - 3);
+  const bool gzipped_file = Utility::ends_with(filename, ".gz");
 
   // If we don't already have this size, we'll need to reinit, and
   // determine which entries each processor is in charge of.

--- a/src/numerics/sparse_matrix.C
+++ b/src/numerics/sparse_matrix.C
@@ -519,15 +519,15 @@ void SparseMatrix<T>::read(const std::string & filename)
 
   std::string_view basename = Utility::basename_of(filename);
 
-  const bool gzipped_file = (basename.rfind(".gz") == basename.size() - 3);
+  const bool gzipped_file = Utility::ends_with(filename, ".gz");
 
   if (gzipped_file)
     basename.remove_suffix(3);
 
-  if (basename.rfind(".matlab") == basename.size() - 7 ||
-      basename.rfind(".m") == basename.size() - 2)
+  if (Utility::ends_with(basename, ".matlab") ||
+      Utility::ends_with(basename, ".m"))
     this->read_matlab(filename);
-  else if (basename.rfind(".petsc64") == basename.size() - 8)
+  else if (Utility::ends_with(basename, ".petsc64"))
     {
 #ifndef LIBMESH_HAVE_PETSC
       libmesh_error_msg("Cannot load PETSc matrix file " <<
@@ -539,7 +539,7 @@ void SparseMatrix<T>::read(const std::string & filename)
 #endif
       this->read_petsc_binary(filename);
     }
-  else if (basename.rfind(".petsc32") == basename.size() - 8)
+  else if (Utility::ends_with(basename, ".petsc32"))
     {
 #ifndef LIBMESH_HAVE_PETSC
       libmesh_error_msg("Cannot load PETSc matrix file " <<
@@ -574,7 +574,7 @@ void SparseMatrix<T>::read_matlab(const std::string & filename)
 #else
   parallel_object_only();
 
-  const bool gzipped_file = (filename.rfind(".gz") == filename.size() - 3);
+  const bool gzipped_file = Utility::ends_with(filename, ".gz");
 
   // The sizes we get from the file
   std::size_t m = 0,

--- a/src/systems/equation_systems_io.C
+++ b/src/systems/equation_systems_io.C
@@ -24,10 +24,11 @@
 #include "libmesh/libmesh_version.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/mesh_base.h"
+#include "libmesh/mesh_refinement.h"
 #include "libmesh/mesh_tools.h"
 #include "libmesh/parallel.h"
+#include "libmesh/utility.h"
 #include "libmesh/xdr_cxx.h"
-#include "libmesh/mesh_refinement.h"
 
 // C++ Includes
 #include <iomanip> // setfill
@@ -47,12 +48,12 @@ std::string local_file_name (const unsigned int processor_id,
   std::ostringstream returnval;
 
   std::string_view suffix;
-  if (basename.size() - basename.rfind(".bz2") == 4)
+  if (Utility::ends_with(basename, ".bz2"))
     {
       basename.remove_suffix(4);
       suffix = ".bz2";
     }
-  else if (basename.size() - basename.rfind(".gz") == 3)
+  else if (Utility::ends_with(basename, ".gz"))
     {
       basename.remove_suffix(3);
       suffix = ".gz";
@@ -217,14 +218,14 @@ void EquationSystems::read (Xdr & io,
         io.set_version(LIBMESH_VERSION_ID(ver_major, ver_minor, ver_patch));
 
 
-        read_parallel_files = (version.rfind(" parallel") < version.size());
+        read_parallel_files = Utility::contains(version, " parallel");
 
         // If requested that we try to read infinite element information,
         // and the string " with infinite elements" is not in the version,
         // then tack it on.  This is for compatibility reading ifem
         // files written prior to 11/10/2008 - BSK
         if (try_read_ifems)
-          if (!(version.rfind(" with infinite elements") < version.size()))
+          if (!Utility::contains(version, " with infinite elements"))
             version += " with infinite elements";
 
       }

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -140,7 +140,7 @@ void System::read_header (Xdr & io,
   // Figure out if we need to read infinite element information.
   // This will be true if the version string contains " with infinite elements"
   const bool read_ifem_info =
-    (version.rfind(" with infinite elements") < version.size()) ||
+    Utility::contains(version, " with infinite elements") ||
     libMesh::on_command_line ("--read-ifem-systems");
 
 

--- a/src/utils/error_vector.C
+++ b/src/utils/error_vector.C
@@ -268,19 +268,19 @@ void ErrorVector::plot_error(const std::string & filename,
       mesh.renumber_nodes_and_elements();
     }
 
-  if (filename.rfind(".gmv") < filename.size())
+  if (Utility::contains(filename, ".gmv"))
     {
       GMVIO(mesh).write_discontinuous_gmv(filename,
                                           temp_es, false);
     }
-  else if (filename.rfind(".plt") < filename.size())
+  else if (Utility::contains(filename, ".plt"))
     {
       TecplotIO (mesh).write_equation_systems
         (filename, temp_es);
     }
 #if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
-  else if ((filename.rfind(".nem") < filename.size()) ||
-           (filename.rfind(".n") < filename.size()))
+  else if (Utility::contains(filename, ".nem") ||
+           Utility::contains(filename, ".n"))
     {
       Nemesis_IO io(mesh);
       io.write(filename);
@@ -288,22 +288,22 @@ void ErrorVector::plot_error(const std::string & filename,
     }
 #endif
 #ifdef LIBMESH_HAVE_EXODUS_API
-  else if ((filename.rfind(".exo") < filename.size()) ||
-           (filename.rfind(".e") < filename.size()))
+  else if (Utility::contains(filename, ".exo") ||
+           Utility::contains(filename, ".e"))
     {
       ExodusII_IO io(mesh);
       io.write(filename);
       io.write_element_data(temp_es);
     }
 #endif
-  else if (filename.rfind(".xda") < filename.size())
+  else if (Utility::contains(filename, ".xda"))
     {
       XdrIO(mesh).write("mesh-"+filename);
       temp_es.write("soln-"+filename,WRITE,
                     EquationSystems::WRITE_DATA |
                     EquationSystems::WRITE_ADDITIONAL_DATA);
     }
-  else if (filename.rfind(".xdr") < filename.size())
+  else if (Utility::contains(filename, ".xdr"))
     {
       XdrIO(mesh,true).write("mesh-"+filename);
       temp_es.write("soln-"+filename,ENCODE,

--- a/src/utils/plt_loader_read.C
+++ b/src/utils/plt_loader_read.C
@@ -82,7 +82,7 @@ void PltLoader::read_header (std::istream & in)
 
   //----------------------------------------------------
   // Read plt files written by older versions of Tecplot
-  if (this->version().rfind("V7") < this->version().size())
+  if (Utility::contains(this->version(), "V7"))
     {
       if (this->verbose())
         libMesh::out << "Reading legacy .plt format (<= v9) ..."
@@ -281,7 +281,7 @@ void PltLoader::read_header (std::istream & in)
 
   //----------------------------------------------------
   // Read plt files written by newer versions of Tecplot
-  else if (this->version().rfind("V1") < this->version().size())
+  else if (Utility::contains(this->version(), "V1"))
     {
       if (this->verbose())
         libMesh::out << "Reading new .plt format (>= v10)..."
@@ -617,7 +617,7 @@ void PltLoader::read_data (std::istream & in)
 
       //----------------------------------------------------
       // Read plt files written by older versions of Tecplot
-      if (this->version().rfind("V7") < this->version().size())
+      if (Utility::contains(this->version(), "V7"))
         {
           float f = 0.;
 
@@ -717,7 +717,7 @@ void PltLoader::read_data (std::istream & in)
 
       //----------------------------------------------------
       // Read plt files written by newer versions of Tecplot
-      else if (this->version().rfind("V1") < this->version().size())
+      else if (Utility::contains(this->version(), "V1"))
         {
           float f = 0.;
 

--- a/src/utils/utility.C
+++ b/src/utils/utility.C
@@ -202,5 +202,27 @@ std::string Utility::unzip_file (std::string_view name)
 
 
 
+bool Utility::contains(std::string_view superstring, std::string_view substring)
+{
+  // This can just be C++23 contains() someday
+  return superstring.find(substring) != std::string::npos;
+}
+
+
+
+bool Utility::ends_with(std::string_view superstring,
+                        std::string_view suffix)
+{
+  // This can just be C++20 ends_with() someday
+  const auto sufsize = suffix.size();
+  const auto supsize = superstring.size();
+  if (sufsize > supsize)
+    return false;
+
+  return superstring.compare(supsize - sufsize, std::string::npos,
+                             suffix) == 0;
+}
+
+
 
 } // namespace libMesh

--- a/src/utils/utility.C
+++ b/src/utils/utility.C
@@ -167,7 +167,7 @@ std::string Utility::unzip_file (std::string_view name)
   pid_suffix << '_' << getpid();
 
   std::string new_name { name };
-  if (name.rfind(".bz2") == name.size() - 4)
+  if (Utility::ends_with(name, ".bz2"))
     {
 #ifdef LIBMESH_HAVE_BZIP
       new_name.erase(new_name.end() - 4, new_name.end());
@@ -182,7 +182,7 @@ std::string Utility::unzip_file (std::string_view name)
       libmesh_error_msg("ERROR: need bzip2/bunzip2 to open .bz2 file " << name);
 #endif
     }
-  else if (name.rfind(".xz") == name.size() - 3)
+  else if (Utility::ends_with(name, ".xz"))
     {
 #ifdef LIBMESH_HAVE_XZ
       new_name.erase(new_name.end() - 3, new_name.end());

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -80,13 +80,13 @@ void remove_unzipped_file (std::string_view name)
 
   // If we temporarily decompressed a file, remove the
   // uncompressed version
-  if (name.rfind(".bz2") == name.size() - 4)
+  if (libMesh::Utility::ends_with(name, ".bz2"))
     {
       std::string new_name(name.begin(), name.end()-4);
       new_name += pid_suffix.str();
       std::remove(new_name.c_str());
     }
-  if (name.rfind(".xz") == name.size() - 3)
+  if (libMesh::Utility::ends_with(name, ".xz"))
     {
       std::string new_name(name.begin(), name.end()-3);
       new_name += pid_suffix.str();
@@ -195,9 +195,9 @@ void Xdr::open (std::string name)
 
     case READ:
       {
-        gzipped_file = (file_name.rfind(".gz") == file_name.size() - 3);
-        bzipped_file = (file_name.rfind(".bz2") == file_name.size() - 4);
-        xzipped_file = (file_name.rfind(".xz") == file_name.size() - 3);
+        gzipped_file = Utility::ends_with(file_name, ".gz");
+        bzipped_file = Utility::ends_with(file_name, ".bz2");
+        xzipped_file = Utility::ends_with(file_name, ".xz");
 
         if (gzipped_file)
           {

--- a/tests/numerics/sparse_matrix_test.h
+++ b/tests/numerics/sparse_matrix_test.h
@@ -196,9 +196,12 @@ public:
 
     // If we're working with serial matrices then just print one of
     // them so they don't step on the others' toes.
+    //
+    // Use a very short filename, because we had a bug with that and
+    // we want to test it.
     if (matrix->n_processors() > 1 ||
         TestCommWorld->rank() == 0)
-      matrix->print_matlab(libmesh_suite_name+"_matrix.m");
+      matrix->print_matlab("M.m");
 
     matrix->clear();
 
@@ -213,7 +216,7 @@ public:
     return;
 #endif
 
-    matrix->read(libmesh_suite_name+"_matrix.m");
+    matrix->read("M.m");
 
     TestCommWorld->barrier();
 


### PR DESCRIPTION
@YaqiWang recently discovered that we couldn't `read_matlab("Acm")` with his matrix file named "Acm".  I then discovered that we couldn't read a matrix file with any three-letter (relative) filename.  Or a mesh file, for that matter.  And we've had this bug since I added the bzip2 support hack back in 2007.

It turns out that `std::string::npos` does the same "alias for -1" trick that all our `invalid_uint` type magic constants do, which means that `if (name.rfind(".bz2") == name.size() - 4)` does *not* do what you'd hope it will when `name.size() ==3`.

C++20 and C++23 added some new methods for people like me who ~~are too dumb to manipulate `std::string` ourselves~~ prefer semantically named utility functions, but we're not requiring those C++ versions yet, so I just put some C++17-compatible options into `libMesh::Utility` and made us use those everywhere.