### PR TITLE
Make sure dof index containers sized even when not active on block

### DIFF
--- a/src/numerics/static_condensation_dof_map.C
+++ b/src/numerics/static_condensation_dof_map.C
@@ -215,13 +215,12 @@ void StaticCondensationDofMap::reinit()
       for (const auto vg : make_range(_dof_map.n_variable_groups()))
         {
           const auto & var_group = _dof_map.variable_group(vg);
-          if (!var_group.active_on_subdomain(sub_id))
-            continue;
-
           for (const auto v : make_range(var_group.n_variables()))
             {
               const auto var_num = var_group.number(v);
               dof_data.reduced_space_indices.resize(var_num + 1);
+              if (!var_group.active_on_subdomain(sub_id))
+                continue;
               elem_uncondensed_dofs.clear();
               _dof_map.dof_indices(elem,
                                    elem_dofs,


### PR DESCRIPTION
We need to make sure that we properly size dof index containers to be inclusive of variables that are not defined on the current subdomain ID. So for a given element we can index into the container at that variable number and then obviously the associated vector of indices will be of zero length since there are no dof indices

Refs @GiudGiud's investigation on https://github.com/idaholab/moose/pull/30357