### PR TITLE
Netgen interface performance logging

### DIFF
--- a/include/mesh/mesh_netgen_interface.h
+++ b/include/mesh/mesh_netgen_interface.h
@@ -26,11 +26,6 @@
 // Local includes
 #include "libmesh/mesh_serializer.h"
 #include "libmesh/mesh_tet_interface.h"
-#include "libmesh/point.h" // used for specifying holes
-
-namespace nglib {
-#include "netgen/nglib/nglib.h"
-}
 
 // C++ includes
 #include <cstddef>

--- a/src/mesh/mesh_netgen_interface.C
+++ b/src/mesh/mesh_netgen_interface.C
@@ -32,6 +32,10 @@
 #include "libmesh/unstructured_mesh.h"
 #include "libmesh/utility.h" // libmesh_map_find
 
+namespace nglib {
+#include "netgen/nglib/nglib.h"
+}
+
 namespace {
 
 // RAII for exception safety

--- a/src/mesh/mesh_netgen_interface.C
+++ b/src/mesh/mesh_netgen_interface.C
@@ -28,6 +28,7 @@
 #include "libmesh/boundary_info.h"
 #include "libmesh/cell_tet4.h"
 #include "libmesh/face_tri3.h"
+#include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_communication.h"
 #include "libmesh/unstructured_mesh.h"
 #include "libmesh/utility.h" // libmesh_map_find
@@ -81,6 +82,8 @@ NetGenMeshInterface::NetGenMeshInterface (UnstructuredMesh & mesh) :
 void NetGenMeshInterface::triangulate ()
 {
   using namespace nglib;
+
+  LOG_SCOPE("triangulate()", "NetGenMeshInterface");
 
   // We're hoping to do volume_to_surface_mesh in parallel at least,
   // but then we'll need to serialize any hole meshes to rank 0 so it
@@ -211,6 +214,8 @@ void NetGenMeshInterface::triangulate ()
       (UnstructuredMesh & srcmesh, bool hole_mesh,
        boundary_id_type bcid)
     {
+      LOG_SCOPE("create_surface_component()", "NetGenMeshInterface");
+
       // Keep track of what nodes we've already added to the Netgen
       // mesh vs what nodes we need to add.  We'll keep track by id,
       // not by point location.  I don't know if Netgen can handle
@@ -309,8 +314,12 @@ void NetGenMeshInterface::triangulate ()
         create_surface_component(*h, true, ++bcid);
   }
 
-  auto result = Ng_GenerateVolumeMesh(ngmesh, &params);
-  handle_ng_result(result);
+  {
+    LOG_SCOPE("Ng_GenerateVolumeMesh()", "NetGenMeshInterface");
+
+    auto result = Ng_GenerateVolumeMesh(ngmesh, &params);
+    handle_ng_result(result);
+  }
 
   const int n_elem = Ng_GetNE(ngmesh);
 


### PR DESCRIPTION
I was hoping to get some improvements (in the valgrind case) out of this, and I couldn't, but the logging alone is still better included than omitted.