### PR TITLE
Default to sync c++ streams

### DIFF
--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -599,7 +599,7 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
   // The amount of benefit which occurs is probably implementation
   // defined, and may be nothing.  On the other hand, I have seen
   // some IO tests where IO performance improves by a factor of two.
-  if (!libMesh::on_command_line ("--sync-with-stdio"))
+  if (libMesh::on_command_line ("--dont-sync-with-stdio"))
     std::ios::sync_with_stdio(false);
 
   // Honor the --separate-libmeshout command-line option.


### PR DESCRIPTION
This may be slower but @roystgnr and I think it makes more sense for the default to be safety rather than speed. Safety here means that we guarantee no data races to the stream. You can still have interleaved bytes (for which we are planning a new thread safe ostream proxy) but at least each byte write will be atomic