### PR TITLE
Make libMesh::out and libMesh::err thread safe

### DIFF
--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -678,8 +678,8 @@ include_HEADERS = \
         error_estimation/hp_singular.h \
         error_estimation/jump_error_estimator.h \
         error_estimation/kelly_error_estimator.h \
-        error_estimation/smoothness_estimator.h \
         error_estimation/patch_recovery_error_estimator.h \
+        error_estimation/smoothness_estimator.h \
         error_estimation/uniform_refinement_estimator.h \
         error_estimation/weighted_patch_recovery_error_estimator.h \
         fe/fe.h \
@@ -1107,6 +1107,7 @@ include_HEADERS = \
         utils/simple_range.h \
         utils/statistics.h \
         utils/string_to_enum.h \
+        utils/thread_buffered_syncbuf.h \
         utils/timestamp.h \
         utils/topology_map.h \
         utils/tree.h \

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -77,8 +77,8 @@ include_HEADERS =  \
         error_estimation/hp_singular.h \
         error_estimation/jump_error_estimator.h \
         error_estimation/kelly_error_estimator.h \
-        error_estimation/smoothness_estimator.h \
         error_estimation/patch_recovery_error_estimator.h \
+        error_estimation/smoothness_estimator.h \
         error_estimation/uniform_refinement_estimator.h \
         error_estimation/weighted_patch_recovery_error_estimator.h \
         fe/fe.h \
@@ -506,6 +506,7 @@ include_HEADERS =  \
         utils/simple_range.h \
         utils/statistics.h \
         utils/string_to_enum.h \
+        utils/thread_buffered_syncbuf.h \
         utils/timestamp.h \
         utils/topology_map.h \
         utils/tree.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -67,8 +67,8 @@ BUILT_SOURCES = \
         hp_singular.h \
         jump_error_estimator.h \
         kelly_error_estimator.h \
-        smoothness_estimator.h \
         patch_recovery_error_estimator.h \
+        smoothness_estimator.h \
         uniform_refinement_estimator.h \
         weighted_patch_recovery_error_estimator.h \
         fe.h \
@@ -502,6 +502,7 @@ BUILT_SOURCES = \
         simple_range.h \
         statistics.h \
         string_to_enum.h \
+        thread_buffered_syncbuf.h \
         timestamp.h \
         topology_map.h \
         tree.h \
@@ -800,10 +801,10 @@ jump_error_estimator.h: $(top_srcdir)/include/error_estimation/jump_error_estima
 kelly_error_estimator.h: $(top_srcdir)/include/error_estimation/kelly_error_estimator.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
-smoothness_estimator.h: $(top_srcdir)/include/error_estimation/smoothness_estimator.h
+patch_recovery_error_estimator.h: $(top_srcdir)/include/error_estimation/patch_recovery_error_estimator.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
-patch_recovery_error_estimator.h: $(top_srcdir)/include/error_estimation/patch_recovery_error_estimator.h
+smoothness_estimator.h: $(top_srcdir)/include/error_estimation/smoothness_estimator.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 uniform_refinement_estimator.h: $(top_srcdir)/include/error_estimation/uniform_refinement_estimator.h
@@ -2103,6 +2104,9 @@ statistics.h: $(top_srcdir)/include/utils/statistics.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 string_to_enum.h: $(top_srcdir)/include/utils/string_to_enum.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+thread_buffered_syncbuf.h: $(top_srcdir)/include/utils/thread_buffered_syncbuf.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 timestamp.h: $(top_srcdir)/include/utils/timestamp.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -543,7 +543,7 @@ BUILT_SOURCES = auto_ptr.h dirichlet_boundaries.h dof_map.h \
 	error_estimator.h exact_error_estimator.h exact_solution.h \
 	fourth_error_estimators.h hp_coarsentest.h hp_selector.h \
 	hp_singular.h jump_error_estimator.h kelly_error_estimator.h \
-	smoothness_estimator.h patch_recovery_error_estimator.h \
+	patch_recovery_error_estimator.h smoothness_estimator.h \
 	uniform_refinement_estimator.h \
 	weighted_patch_recovery_error_estimator.h fe.h fe_abstract.h \
 	fe_base.h fe_compute_data.h fe_interface.h \
@@ -694,9 +694,9 @@ BUILT_SOURCES = auto_ptr.h dirichlet_boundaries.h dof_map.h \
 	point_locator_base.h point_locator_nanoflann.h \
 	point_locator_tree.h pointer_to_pointer_iter.h \
 	pool_allocator.h restore_warnings.h simple_range.h \
-	statistics.h string_to_enum.h timestamp.h topology_map.h \
-	tree.h tree_base.h tree_node.h utility.h vectormap.h \
-	win_gettimeofday.h xdr_cxx.h \
+	statistics.h string_to_enum.h thread_buffered_syncbuf.h \
+	timestamp.h topology_map.h tree.h tree_base.h tree_node.h \
+	utility.h vectormap.h win_gettimeofday.h xdr_cxx.h \
 	parallel_communicator_specializations $(am__append_1) \
 	$(am__append_3) $(am__append_5) $(am__append_7) \
 	$(am__append_9) $(am__append_11) $(am__append_13) \
@@ -1129,10 +1129,10 @@ jump_error_estimator.h: $(top_srcdir)/include/error_estimation/jump_error_estima
 kelly_error_estimator.h: $(top_srcdir)/include/error_estimation/kelly_error_estimator.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
-smoothness_estimator.h: $(top_srcdir)/include/error_estimation/smoothness_estimator.h
+patch_recovery_error_estimator.h: $(top_srcdir)/include/error_estimation/patch_recovery_error_estimator.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
-patch_recovery_error_estimator.h: $(top_srcdir)/include/error_estimation/patch_recovery_error_estimator.h
+smoothness_estimator.h: $(top_srcdir)/include/error_estimation/smoothness_estimator.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 uniform_refinement_estimator.h: $(top_srcdir)/include/error_estimation/uniform_refinement_estimator.h
@@ -2432,6 +2432,9 @@ statistics.h: $(top_srcdir)/include/utils/statistics.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 string_to_enum.h: $(top_srcdir)/include/utils/string_to_enum.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+thread_buffered_syncbuf.h: $(top_srcdir)/include/utils/thread_buffered_syncbuf.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 timestamp.h: $(top_srcdir)/include/utils/timestamp.h

--- a/include/utils/thread_buffered_syncbuf.h
+++ b/include/utils/thread_buffered_syncbuf.h
@@ -1,0 +1,95 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2025 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#ifndef LIBMESH_THREAD_BUFFERED_SYNCBUF_H
+#define LIBMESH_THREAD_BUFFERED_SYNCBUF_H
+
+#include <streambuf>
+#include <string>
+#include <memory>
+
+namespace libMesh
+{
+namespace Threads
+{
+class spin_mutex;
+}
+
+class ThreadBufferedSyncbuf : public std::streambuf
+{
+public:
+  explicit ThreadBufferedSyncbuf(std::streambuf & sink, bool flush_on_newline = true);
+
+  /**
+   * Defaulted destructor defined in implementation so we don't need to include threads.h
+   */
+  ~ThreadBufferedSyncbuf();
+
+protected:
+  // Single-char path
+  int_type overflow(int_type ch) override;
+
+  // Bulk write path
+  std::streamsize xsputn(const char * s, std::streamsize n) override;
+
+  // Flush path (std::flush / std::endl / ostream::flush)
+  int sync() override;
+
+private:
+  /**
+   * A class that wraps a thread-local string. We make sure when we're destructing and our buffer is
+   * non-empty to write to our main output sink
+   */
+  class ThreadLocalBuffer
+  {
+  public:
+    explicit ThreadLocalBuffer(ThreadBufferedSyncbuf & owner) : _owner(owner) {}
+
+    /**
+     * Ensures we write to our sink upon destruction if our buf is non-empty
+     */
+    ~ThreadLocalBuffer();
+
+    /// per-thread buffer
+    std::string buf;
+
+  private:
+    /// owning syncing stream buffer
+    ThreadBufferedSyncbuf & _owner;
+  };
+
+  /**
+   * One ThreadLocalBuffer instance per thread, constructed on first use with *this.
+   */
+  ThreadLocalBuffer & thread_local_buffer();
+
+  /**
+   * Emit from the thread local buffer to our wrapped \p _sink
+   */
+  void emit_from_thread_local_buffer(std::string & b, bool force_flush);
+
+  /// Wrapped output sink
+  std::streambuf & _sink;
+  /// Whether to flush our sink to terminal/file on terminating new-line characters (\n)
+  const bool _flush_on_newline;
+
+  /// Serialization for commits to the shared sink
+  std::unique_ptr<Threads::spin_mutex> _mu;
+};
+
+}
+#endif // LIBMESH_THREAD_BUFFERED_SYNCBUF_H

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -736,7 +736,8 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
       libMesh::err.rdbuf (nullptr);
 
   // Now that we've finished setting our stream buffers, let's wrap them (if they're non-null) in our thread-safe wrapper
-  install_thread_buffered_sync();
+  if (!libMesh::on_command_line ("--disable-thread-safe-output"))
+    install_thread_buffered_sync();
 
   // Check command line to override printing
   // of reference count information.
@@ -849,7 +850,8 @@ LibMeshInit::~LibMeshInit()
   libMeshPrivateData::_is_initialized = false;
 
   // Before resetting the stream buffers, let's remove our thread wrappers
-  uninstall_thread_buffered_sync();
+  if (!libMesh::on_command_line ("--disable-thread-safe-output"))
+    uninstall_thread_buffered_sync();
 
   if (libMesh::on_command_line ("--redirect-stdout") ||
       libMesh::on_command_line ("--redirect-output"))

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -230,9 +230,17 @@ std::streambuf * _err_prewrap_buf = nullptr;
 // Install after redirection/drop decisions
 void install_thread_buffered_sync()
 {
+  auto check_stored_buffer = [](const auto * const libmesh_dbg_var(stored_buffer)) {
+    libmesh_assert_msg(!stored_buffer,
+                       "Oops, we've already stored a prewrapped buffer. We must be calling this "
+                       "function a second time in which case we're going to lose the already "
+                       "stored prewrapped buffer forever");
+  };
+
   // libMesh::out
   if (auto * ob = libMesh::out.rdbuf(); ob)
     {
+      check_stored_buffer(_out_prewrap_buf);
       _out_prewrap_buf = ob;
       _out_syncd_thread_buffer =
           std::make_unique<ThreadBufferedSyncbuf>(*ob, /*flush_on_newline=*/true);
@@ -242,6 +250,7 @@ void install_thread_buffered_sync()
   // libMesh::err
   if (auto * eb = libMesh::err.rdbuf(); eb)
     {
+      check_stored_buffer(_err_prewrap_buf);
       _err_prewrap_buf = eb;
       _err_syncd_thread_buffer =
           std::make_unique<ThreadBufferedSyncbuf>(*eb, /*flush_on_newline=*/true);

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -30,8 +30,8 @@ libmesh_SOURCES =  \
         src/error_estimation/hp_singular.C \
         src/error_estimation/jump_error_estimator.C \
         src/error_estimation/kelly_error_estimator.C \
-        src/error_estimation/smoothness_estimator.C \
         src/error_estimation/patch_recovery_error_estimator.C \
+        src/error_estimation/smoothness_estimator.C \
         src/error_estimation/uniform_refinement_estimator.C \
         src/error_estimation/weighted_patch_recovery_error_estimator.C \
         src/fe/fe.C \
@@ -469,9 +469,10 @@ libmesh_SOURCES =  \
         src/utils/point_locator_tree.C \
         src/utils/statistics.C \
         src/utils/string_to_enum.C \
+        src/utils/thread_buffered_syncbuf.C \
         src/utils/timestamp.C \
         src/utils/topology_map.C \
         src/utils/tree.C \
         src/utils/tree_node.C \
         src/utils/utility.C \
-        src/utils/xdr_cxx.C
+        src/utils/xdr_cxx.C 

--- a/src/utils/thread_buffered_syncbuf.C
+++ b/src/utils/thread_buffered_syncbuf.C
@@ -1,0 +1,95 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2025 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#include "libmesh/thread_buffered_syncbuf.h"
+#include "libmesh/threads.h"
+
+namespace libMesh
+{
+ThreadBufferedSyncbuf::ThreadBufferedSyncbuf(std::streambuf & sink, bool flush_on_newline)
+  : _sink(sink), _flush_on_newline(flush_on_newline), _mu(std::make_unique<Threads::spin_mutex>())
+{
+}
+
+ThreadBufferedSyncbuf::~ThreadBufferedSyncbuf() = default;
+
+ThreadBufferedSyncbuf::int_type ThreadBufferedSyncbuf::overflow(int_type ch)
+{
+  if (traits_type::eq_int_type(ch, traits_type::eof()))
+    return traits_type::not_eof(ch);
+
+  auto & t = this->thread_local_buffer();
+  t.buf.push_back(traits_type::to_char_type(ch));
+
+  if (_flush_on_newline && ch == '\n')
+    this->emit_from_thread_local_buffer(t.buf, /*force_flush=*/false);
+
+  return ch;
+}
+
+std::streamsize ThreadBufferedSyncbuf::xsputn(const char * s, std::streamsize n)
+{
+  auto & t = this->thread_local_buffer();
+  t.buf.append(s, static_cast<size_t>(n));
+
+  if (_flush_on_newline && !t.buf.empty() && t.buf.back() == '\n')
+    this->emit_from_thread_local_buffer(t.buf, /*force_flush=*/false);
+
+  return n;
+}
+
+int ThreadBufferedSyncbuf::sync()
+{
+  this->emit_from_thread_local_buffer(this->thread_local_buffer().buf, /*force_flush=*/true);
+  return 0;
+}
+
+ThreadBufferedSyncbuf::ThreadLocalBuffer & ThreadBufferedSyncbuf::thread_local_buffer()
+{
+  static thread_local ThreadLocalBuffer t(*this);
+  return t;
+}
+
+void ThreadBufferedSyncbuf::emit_from_thread_local_buffer(std::string & b, bool force_flush)
+{
+  if (b.empty())
+    {
+      if (force_flush)
+        {
+          Threads::spin_mutex::scoped_lock lk(*_mu);
+          _sink.pubsync();
+        }
+      return;
+    }
+
+  {
+    Threads::spin_mutex::scoped_lock lk(*_mu);
+    _sink.sputn(b.data(), static_cast<std::streamsize>(b.size()));
+    if (force_flush)
+      _sink.pubsync();
+  }
+  b.clear();
+}
+
+ThreadBufferedSyncbuf::ThreadLocalBuffer::~ThreadLocalBuffer()
+{
+  // Runs at thread exit: commit any leftovers for this thread.
+  if (!buf.empty())
+    _owner.emit_from_thread_local_buffer(buf, /*force_flush=*/false);
+}
+
+}


### PR DESCRIPTION
This is based on @roystgnr's idea to make thread local buffers that we send to the wrapped output sink whenever we receive a flush indicator, at which time we lock while writing the the thread local buffer to the shared sink. This also defaults to flushing if the end of an operation is `\n`