### PR TITLE
Set PetscVector ParallelType in Vec constructor

### DIFF
--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -635,9 +635,11 @@ PetscVector<T>::PetscVector (Vec v,
           this->_type = GHOSTED;
           LibmeshPetscCall(ISRestoreIndices(ghostis, &indices));
         }
+      else
+        this->_type = PARALLEL;
     }
   else if (std::strcmp(ptype,VECSHARED) == 0)
-#else
+#else // PETSc < 3.21.0
   if ((std::strcmp(ptype,VECSHARED) == 0) || (std::strcmp(ptype,VECMPI) == 0))
 #endif
     {


### PR DESCRIPTION
This mimics the pre-3.21.0 behavior by setting the ParallelType to PARALLEL in the case where it does identify as "MPI" but is not GHOSTED.