### PR TITLE
Initialize epsilon_squared_assembly

### DIFF
--- a/include/systems/variational_smoother_system.h
+++ b/include/systems/variational_smoother_system.h
@@ -90,6 +90,7 @@ public:
                             const unsigned int number)
     : libMesh::FEMSystem(es, name, number),
       _epsilon_squared(TOLERANCE),
+      _epsilon_squared_assembly(0.),
       _ref_vol(0.),
       _dilation_weight(0.5),
       _untangling_solve(false)


### PR DESCRIPTION
Otherwise it doesn't get initialized until the first time we test whether the mesh is tangled, but since we do that test at the same time as we calculate mesh info including element-wise residual contributions, those calculations use uninitialized data.

IMHO what we need here is to separate out a tangling test from the rest of the mesh info calculations, but I'll leave that for Patrick to consider and just fix valgrind's screaming for now.