### PR TITLE
Don't double-create a PetscViewer

### DIFF
--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -521,14 +521,12 @@ void PetscMatrix<T>::print_matlab (const std::string & name) const
       const_cast<PetscMatrix<T> *>(this)->close();
     }
 
-  WrappedPetsc<PetscViewer> petsc_viewer;
-  LibmeshPetscCall(PetscViewerCreate (this->comm().get(),
-                                      petsc_viewer.get()));
-
   // Create an ASCII file containing the matrix
   // if a filename was provided.
   if (name != "")
     {
+      WrappedPetsc<PetscViewer> petsc_viewer;
+
       LibmeshPetscCall(PetscViewerASCIIOpen( this->comm().get(),
                                              name.c_str(),
                                              petsc_viewer.get()));

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -1039,14 +1039,12 @@ void PetscVector<T>::print_matlab (const std::string & name) const
   this->_restore_array();
   libmesh_assert (this->closed());
 
-
-  WrappedPetsc<PetscViewer> petsc_viewer;
-  LibmeshPetscCall(PetscViewerCreate (this->comm().get(), petsc_viewer.get()));
-
   // Create an ASCII file containing the matrix
   // if a filename was provided.
   if (name != "")
     {
+      WrappedPetsc<PetscViewer> petsc_viewer;
+
       LibmeshPetscCall(PetscViewerASCIIOpen(this->comm().get(),
                                             name.c_str(),
                                             petsc_viewer.get()));


### PR DESCRIPTION
The docs for PetscViewerASCIIOpen say that it does the PetscViewerCreate, and gdb agrees, and doing a redundant PetscViewerCreate makes valgrind yell at us about a memory leak.