### PR TITLE
Avoid memory leak in unit test driver

### DIFF
--- a/tests/driver.C
+++ b/tests/driver.C
@@ -56,6 +56,9 @@ private:
   CppUnit::Test & _shimmed_test;
 };
 
+// "Magic number" for when we're not doing allow or deny regex
+static constexpr int added_whole_suite = -12345;
+
 // Add Tests to runner that match user-provided regex.
 int add_matching_tests_to_runner(CppUnit::Test * test,
                                  const std::string & allow_r_str,
@@ -72,7 +75,7 @@ int add_matching_tests_to_runner(CppUnit::Test * test,
   {
     libMesh::out << test->getName() << std::endl;
     runner.addTest(test);
-    return -12345;
+    return added_whole_suite;
   }
 
   if (test->getChildTestCount() == 0)
@@ -182,7 +185,7 @@ int main(int argc, char ** argv)
 
   // If we didn't add the whole suite to the runner, we need to clean
   // it up ourselves
-  if (n_tests_added != -12345)
+  if (n_tests_added != added_whole_suite)
     owned_suite.reset(suite);
 #else
   // If no C++11 <regex> just run all the tests.


### PR DESCRIPTION
If we add only a subset of tests to the runner (via --re or --deny_re options), we're careful to move the other tests to a "rejects" suite so they'll get deleted there, but the "supertest", the suite holding all the other tests, wasn't getting deleted in those cases.

This (on top of my earlier fixes, and using the MOOSE suppressions file for third-party library issues) gets selective valgrind runs of our unit tests clean for me.  (all-tests runs are clean either way)

This isn't urgent to merge; I still need to run through our examples to look for valgrind issues too.  This tiny leak is *only* a problem because it upsets valgrind, and until we're sure we're ready to make that be a big deal (add a `--error-exitcode=` option to our valgrind recipes), "do our unit tests upset valgrind" isn't a critical question.