### PR TITLE
Make some constants as constant expression

### DIFF
--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -479,18 +479,18 @@ public:
   /**
    * An invalid \p id to distinguish an uninitialized \p DofObject
    */
-  static const dof_id_type invalid_id = static_cast<dof_id_type>(-1);
+  static constexpr dof_id_type invalid_id = static_cast<dof_id_type>(-1);
 
   /**
    * An invalid \p unique_id to distinguish an uninitialized \p DofObject
    */
-  static const unique_id_type invalid_unique_id = static_cast<unique_id_type>(-1);
+  static constexpr unique_id_type invalid_unique_id = static_cast<unique_id_type>(-1);
 
   /**
    * An invalid \p processor_id to distinguish DoFs that have
    * not been assigned to a processor.
    */
-  static const processor_id_type invalid_processor_id = static_cast<processor_id_type>(-1);
+  static constexpr processor_id_type invalid_processor_id = static_cast<processor_id_type>(-1);
 
   /**
    * If we pack our indices into an buffer for communications, how

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -241,14 +241,9 @@ public:
    * \note We don't use the static_cast(-1) trick here since
    * \p subdomain_id_type is sometimes a *signed* integer for
    * compatibility reasons (see libmesh/id_types.h).
-   *
-   * \note Normally you can declare static const integral types
-   * directly in the header file (C++ standard, 9.4.2/4) but
-   * std::numeric_limits<T>::max() is not considered a "constant
-   * expression".  This one is therefore defined in elem.C.
-   * http://stackoverflow.com/questions/2738435/using-numeric-limitsmax-in-constant-expressions
    */
-  static const subdomain_id_type invalid_subdomain_id;
+  static constexpr subdomain_id_type invalid_subdomain_id
+    = std::numeric_limits<subdomain_id_type>::max();
 
   /**
    * \returns true iff this element type can vary in topology (e.g.

--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -23,14 +23,6 @@
 namespace libMesh
 {
 
-// ------------------------------------------------------------
-// DofObject class static member -now initialized in header
-const dof_id_type       DofObject::invalid_id;
-const unique_id_type    DofObject::invalid_unique_id;
-const processor_id_type DofObject::invalid_processor_id;
-
-
-
 // Copy Constructor
 DofObject::DofObject (const DofObject & dof_obj) :
   ReferenceCountedObject<DofObject>(),

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -97,8 +97,6 @@ namespace libMesh
 Threads::spin_mutex parent_indices_mutex;
 Threads::spin_mutex parent_bracketing_nodes_mutex;
 
-const subdomain_id_type Elem::invalid_subdomain_id = std::numeric_limits<subdomain_id_type>::max();
-
 // Initialize static member variables
 const unsigned int Elem::type_to_dim_map [] =
   {


### PR DESCRIPTION
`numeric_limits` seems to be constant expression now. With the current code, the invalid ID cannot be accessed on GPU because it is considered as a variable on CPU.