### PR TITLE
Tell FESubdivision to calculate phi, dphi, d2phi

### DIFF
--- a/src/fe/fe_subdivision_2D.C
+++ b/src/fe/fe_subdivision_2D.C
@@ -686,6 +686,9 @@ void FESubdivision::reinit(const Elem * elem,
   libmesh_assert_equal_to(sd_elem->get_ordered_valence(2), 6);
 
   // We're calculating now!  Time to determine what.
+  this->calculate_phi = true;
+  this->calculate_dphi = true;
+  this->calculate_d2phi = true;
   this->determine_calculations();
 
   // no custom quadrature support


### PR DESCRIPTION
Avoid deprecation warning in FEGenericBase::determine_calculations() by telling FESubdivision to calculate phi, dphi, and d2phi. See https://github.com/libMesh/libmesh/discussions/4259