### PR TITLE
Fix an off-by-one error in HDF5 matrix reads

### DIFF
--- a/src/numerics/sparse_matrix.C
+++ b/src/numerics/sparse_matrix.C
@@ -755,7 +755,7 @@ void SparseMatrix<T>::read_coreform_hdf5(const std::string & filename,
               current_off_diagonal_nonzeros = 0;
             }
 
-          while (current_row >= (new_row_stops[current_proc]+1))
+          while (current_row >= new_row_stops[current_proc])
             ++current_proc;
 
           // 0-based indexing in file


### PR DESCRIPTION
I accidentally missed an edit when patterning this code for 0-based matrix files off the 1-based matlab matrix reader.