### PR TITLE
Drop deprecated public Mesh::boundary_info member

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1820,6 +1820,7 @@ public:
   const std::set<subdomain_id_type> & get_mesh_subdomains() const
   { libmesh_assert(this->is_prepared()); return _mesh_subdomains; }
 
+protected:
 
   /**
    * This class holds the boundary information.  It can store nodes, edges,
@@ -1830,13 +1831,8 @@ public:
    * be removed in future libMesh versions.  Use the \p get_boundary_info()
    * accessor instead.
    */
-#ifndef LIBMESH_ENABLE_DEPRECATED
-protected:
-#endif
   std::unique_ptr<BoundaryInfo> boundary_info;
 
-
-protected:
   /**
    * Moves any superclass data (e.g. GhostingFunctors that might rely
    * on element and nodal data (which is managed by subclasses!)


### PR DESCRIPTION
The public BoundaryInfo member has apparently been deprecated since 2020 (see cd00ce5c) so it's well past the time for the deprecation to be removed. This is as good a time as any since we recently started a 1.9.x release branch.