### PR TITLE
Remove error messages from lagrange shape computations in 1D to allow their inlining

### DIFF
--- a/include/fe/fe_lagrange_shape_1D.h
+++ b/include/fe/fe_lagrange_shape_1D.h
@@ -39,6 +39,7 @@ Real fe_lagrange_1D_linear_shape(const unsigned int i,
     case 0:
       return .5*(1. - xi);
 
+    // case 1
     default:
       return .5*(1. + xi);
     }
@@ -60,6 +61,7 @@ Real fe_lagrange_1D_quadratic_shape(const unsigned int i,
     case 1:
       return .5*xi*(xi + 1);
 
+    // case 2
     default:
       return (1. - xi*xi);
     }
@@ -84,6 +86,7 @@ Real fe_lagrange_1D_cubic_shape(const unsigned int i,
     case 2:
       return 27./16.*(1.-xi*xi)*(1./3.-xi);
 
+    // case 3
     default:
       return 27./16.*(1.-xi*xi)*(1./3.+xi);
     }
@@ -96,6 +99,8 @@ Real fe_lagrange_1D_shape(const Order order,
                           const unsigned int i,
                           const Real xi)
 {
+  libmesh_assert_less_equal(order, THIRD);
+
   switch (order)
     {
       // Lagrange linears
@@ -107,6 +112,7 @@ Real fe_lagrange_1D_shape(const Order order,
       return fe_lagrange_1D_quadratic_shape(i, xi);
 
       // Lagrange cubics
+      // case THIRD
     default:
       return fe_lagrange_1D_cubic_shape(i, xi);
     }
@@ -129,6 +135,7 @@ Real fe_lagrange_1D_linear_shape_deriv(const unsigned int i,
     case 0:
       return -.5;
 
+    // case 1
     default:
       return .5;
     }
@@ -153,6 +160,7 @@ Real fe_lagrange_1D_quadratic_shape_deriv(const unsigned int i,
     case 1:
       return xi+.5;
 
+    // case 2
     default:
       return -2.*xi;
     }
@@ -180,6 +188,7 @@ Real fe_lagrange_1D_cubic_shape_deriv(const unsigned int i,
     case 2:
       return 27./16.*(3.*xi*xi-2./3.*xi-1.);
 
+    // case 3
     default:
       return 27./16.*(-3.*xi*xi-2./3.*xi+1.);
     }
@@ -193,6 +202,8 @@ Real fe_lagrange_1D_shape_deriv(const Order order,
                                 const unsigned int j,
                                 const Real xi)
 {
+  libmesh_assert_less_equal(order, THIRD);
+
   switch (order)
     {
     case FIRST:
@@ -201,6 +212,7 @@ Real fe_lagrange_1D_shape_deriv(const Order order,
     case SECOND:
       return fe_lagrange_1D_quadratic_shape_deriv(i, j, xi);
 
+    // case THIRD
     default:
       return fe_lagrange_1D_cubic_shape_deriv(i, j, xi);
     }
@@ -220,6 +232,7 @@ Real fe_lagrange_1D_quadratic_shape_second_deriv(const unsigned int i,
   // Don't need to switch on j.  1D shape functions
   // depend on xi only!
   libmesh_assert_equal_to (j, 0);
+  libmesh_assert_less(i, 3);
 
   switch (i)
     {
@@ -229,6 +242,7 @@ Real fe_lagrange_1D_quadratic_shape_second_deriv(const unsigned int i,
     case 1:
       return 1.;
 
+    // case 2
     default:
       return -2.;
     }
@@ -243,6 +257,7 @@ Real fe_lagrange_1D_cubic_shape_second_deriv(const unsigned int i,
   // Don't need to switch on j.  1D shape functions
   // depend on xi only!
   libmesh_assert_equal_to (j, 0);
+  libmesh_assert_less(i, 4);
 
   switch (i)
     {
@@ -255,6 +270,7 @@ Real fe_lagrange_1D_cubic_shape_second_deriv(const unsigned int i,
     case 2:
       return 27./16.*(6*xi-2./3.);
 
+    // case 2
     default:
       return 27./16.*(-6*xi-2./3.);
     }
@@ -268,6 +284,8 @@ Real fe_lagrange_1D_shape_second_deriv(const Order order,
                                        const unsigned int j,
                                        const Real xi)
 {
+  libmesh_assert_less_equal(order, THIRD);
+
   switch (order)
     {
     // All second derivatives of linears are zero....
@@ -277,6 +295,7 @@ Real fe_lagrange_1D_shape_second_deriv(const Order order,
     case SECOND:
       return fe_lagrange_1D_quadratic_shape_second_deriv(i, j, xi);
 
+    // case THIRD
     default:
       return fe_lagrange_1D_cubic_shape_second_deriv(i, j, xi);
     } // end switch (order)


### PR DESCRIPTION
at least on M4 with clang (moose conda build of just petsc)

refs libmesh#4272

The differences are mild but perceptible I think
simple diffusion -r 6 ran 10 times
With optim
Average runtime: 10.021042 seconds
Standard deviation: .128654 seconds

Without optim
Average runtime: 10.429161 seconds
Standard deviation: .089638 seconds

simple diffusion -r 7 ran 20 times
With optim
Average runtime: 41.659667 seconds
Standard deviation: .197324 seconds

Without optiom
Average runtime: 42.970506 seconds
Standard deviation: .356495 seconds

The script
```
#!/bin/bash

# Path to the script you want to run
SCRIPT=".././../../moose_test-opt -i simple_diffusion.i Outputs/exodus=false"
OPTIONS="-r 7"

# Number of times to run the script
RUNS=20

# Arrays to store durations
durations=()

echo "Preventing page faults"
$SCRIPT "-r 1"

echo "Running $SCRIPT $RUNS times..."

for i in $(seq 1 $RUNS); do
    echo "Run #$i..."
    start_time=$(date +%s.%N)
    $SCRIPT $OPTIONS
    end_time=$(date +%s.%N)

    # Calculate duration
    duration=$(echo "$end_time - $start_time" | bc)
    durations+=($duration)
    echo "Duration: $duration seconds"
done

# Calculate average
total_time=0
for d in "${durations[@]}"; do
    total_time=$(echo "$total_time + $d" | bc)
done
average=$(echo "scale=6; $total_time / $RUNS" | bc)

# Calculate standard deviation
sum_sq_diff=0
for d in "${durations[@]}"; do
    diff=$(echo "$d - $average" | bc)
    sq_diff=$(echo "$diff * $diff" | bc)
    sum_sq_diff=$(echo "$sum_sq_diff + $sq_diff" | bc)
done
stddev=$(echo "scale=6; sqrt($sum_sq_diff / $RUNS)" | bc -l)

echo ""
echo "Average runtime: $average seconds"
echo "Standard deviation: $stddev seconds"
```
