### PR TITLE
Drop deprecated Elem::centroid() API

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -1012,19 +1012,6 @@ public:
    */
   virtual Order default_side_order () const { return default_order(); }
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  /**
-   * Calls Elem::vertex_average() for backwards compatibility.
-   *
-   * \deprecated This method has now been deprecated, so it will be
-   * removed at some point in the future.  Calls to Elem::centroid()
-   * in user code should be updated to either call
-   * Elem::vertex_average() or Elem::true_centroid() on a case by case
-   * basis.
-   */
-  virtual Point centroid () const;
-#endif // LIBMESH_ENABLE_DEPRECATED
-
   /**
    * \returns The "true" geometric centroid of the element, c=(cx, cy,
    * cz), where:

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -572,23 +572,6 @@ const Elem * Elem::reference_elem () const
 
 
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-Point Elem::centroid() const
-{
-  libmesh_do_once(libMesh::err
-                  << "Elem::centroid() has been deprecated. Replace with either "
-                  << "Elem::vertex_average() to maintain existing behavior, or "
-                  << "the more expensive Elem::true_centroid() "
-                  << "in cases where the true 'geometric' centroid is required."
-                  << std::endl);
-  libmesh_deprecated();
-
-  return Elem::vertex_average();
-}
-#endif // LIBMESH_ENABLE_DEPRECATED
-
-
-
 Point Elem::true_centroid() const
 {
   // The base class implementation builds a finite element of the correct


### PR DESCRIPTION
This has also been deprecated for a few releases now so it's time to remove it. Let's use the CI testing to see if any apps are still using the deprecated function.