### PR TITLE
Drop deprecated Elem::which_node_am_i() API

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -462,14 +462,6 @@ public:
   virtual unsigned int local_edge_node(unsigned int edge,
                                        unsigned int edge_node) const = 0;
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  /**
-   * This function is deprecated, call local_side_node(side, side_node) instead.
-   */
-  unsigned int which_node_am_i(unsigned int side,
-                               unsigned int side_node) const;
-#endif // LIBMESH_ENABLE_DEPRECATED
-
   /**
    * \returns \p true if a vertex of \p e is contained
    * in this element.  If \p mesh_connection is true, looks

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -901,17 +901,6 @@ unsigned int Elem::which_side_am_i (const Elem * e) const
 
 
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-unsigned int Elem::which_node_am_i(unsigned int side,
-                                   unsigned int side_node) const
-{
-  libmesh_deprecated();
-  return local_side_node(side, side_node);
-}
-#endif // LIBMESH_ENABLE_DEPRECATED
-
-
-
 bool Elem::contains_vertex_of(const Elem * e, bool mesh_connection) const
 {
   // Our vertices are the first numbered nodes


### PR DESCRIPTION
This has been officially deprecated since Feb 2025 (4154046815) when a bunch of APIs were deprecated. If nothing important is still using it, it's a good time to get rid of it.