### PR TITLE
Drop deprecated libmesh_make_unique macro

### DIFF
--- a/include/base/auto_ptr.h
+++ b/include/base/auto_ptr.h
@@ -24,14 +24,4 @@
 // C++ includes
 #include <memory>
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-
-// Set up the libmesh_make_unique macro, for backwards compatibility.
-// We require C++17 now; users should just use std::make_unique
-// directly.
-
-#define libmesh_make_unique std::make_unique
-
-#endif // LIBMESH_ENABLE_DEPRECATED
-
 #endif // LIBMESH_AUTO_PTR_H


### PR DESCRIPTION
This was originally a workaround for compilers that did not support std::make_unique, but it should not be getting used by anything now.

Using this macro was deprecated in 55813c4b (2022), which appeared in the 1.8.x release series, so now is a good time to get rid of it.