### PR TITLE
Drop private: declaration wrapped in LIBMESH_ENABLE_DEPRECATED guards

### DIFF
--- a/include/base/sparsity_pattern.h
+++ b/include/base/sparsity_pattern.h
@@ -237,10 +237,6 @@ private:
                              std::vector<dof_id_type> & dofs_vi,
                              unsigned int vi);
 
-#ifndef LIBMESH_ENABLE_DEPRECATED
-private:
-#endif
-
   SparsityPattern::Graph sparsity_pattern;
 
   SparsityPattern::NonlocalGraph nonlocal_pattern;


### PR DESCRIPTION
This private section has been deprecated since 68bd377a (2020, 1.7.x series), but it's not clear to me that this was doing anything even when `LIBEMSH_ENABLE_DEPRECATED` was defined, since there is a private: declaration a few lines higher up in the class. So it should be totally safe to get rid of it.