### PR TITLE
Drop CondensedEigenSystem deprecated public matrix members

### DIFF
--- a/include/systems/condensed_eigen_system.h
+++ b/include/systems/condensed_eigen_system.h
@@ -168,24 +168,6 @@ public:
    */
   void dont_create_submatrices_in_solve() { _create_submatrices_in_solve = false; }
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  /**
-   * The (condensed) system matrix for standard eigenvalue problems.
-   *
-   * Public access to this member variable will be deprecated in
-   * the future! Use get_condensed_matrix_A() instead.
-   */
-  SparseMatrix<Number> * condensed_matrix_A;
-
-  /**
-   * A second (condensed) system matrix for generalized eigenvalue problems.
-   *
-   * Public access to this member variable will be deprecated in
-   * the future! Use get_condensed_matrix_B() instead.
-   */
-  SparseMatrix<Number> * condensed_matrix_B;
-#endif
-
   /**
    * Vector storing the local dof indices that will not be condensed.
    * All dofs that are not in this vector will be eliminated from
@@ -212,10 +194,6 @@ protected:
 
 private:
   virtual bool condense_constrained_dofs() const override final { return true; }
-
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  void set_raw_pointers();
-#endif
 
   /**
    * A private flag to indicate whether the condensed dofs

--- a/src/systems/condensed_eigen_system.C
+++ b/src/systems/condensed_eigen_system.C
@@ -130,15 +130,6 @@ dof_id_type CondensedEigenSystem::n_global_non_condensed_dofs() const
     }
 }
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-void
-CondensedEigenSystem::set_raw_pointers()
-{
-  condensed_matrix_A = _condensed_matrix_A.get();
-  condensed_matrix_B = _condensed_matrix_B.get();
-}
-#endif
-
 void
 CondensedEigenSystem::clear()
 {
@@ -146,9 +137,6 @@ CondensedEigenSystem::clear()
   _condensed_matrix_A = nullptr;
   _condensed_matrix_B = nullptr;
   _condensed_precond_matrix = nullptr;
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  set_raw_pointers();
-#endif
 }
 
 void
@@ -171,10 +159,6 @@ CondensedEigenSystem::add_matrices()
     if (!_condensed_precond_matrix)
       _condensed_precond_matrix = SparseMatrix<Number>::build(this->comm());
   }
-
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  set_raw_pointers();
-#endif
 }
 
 void CondensedEigenSystem::solve()


### PR DESCRIPTION
This code has been deprecated since April 2024 (1.8.x series) so now is a good time to remove it completely.