### PR TITLE
Pass along flip_tris parameter

### DIFF
--- a/tests/mesh/mesh_tet_test.C
+++ b/tests/mesh/mesh_tet_test.C
@@ -26,7 +26,7 @@ Real build_octahedron (UnstructuredMesh & mesh, bool flip_tris,
                        Real zmin, Real zmax)
 {
   MeshTools::Generation::surface_octahedron
-    (mesh, xmin, xmax, ymin, ymax, zmin, zmax);
+    (mesh, xmin, xmax, ymin, ymax, zmin, zmax, flip_tris);
 
   // Octahedron volume
   return (xmax-xmin)*(ymax-ymin)*(zmax-zmin)/6;


### PR DESCRIPTION
I have no idea why neither g++ nor clang++ were giving me an unused parameter warning here, but thanks to nvc++ for catching it; we haven't been properly testing both orientations of manifolds in our tetrahedralization code!