### PR TITLE
Fix PETSc 3.24 deprecated warnings

### DIFF
--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -773,8 +773,13 @@ LinearConvergenceReason PetscLinearSolver<T>::get_converged_reason() const
 
   switch(reason)
     {
+#if PETSC_VERSION_LESS_THAN(3,24,0)
     case KSP_CONVERGED_RTOL_NORMAL     : return CONVERGED_RTOL_NORMAL;
     case KSP_CONVERGED_ATOL_NORMAL     : return CONVERGED_ATOL_NORMAL;
+#else
+    case KSP_CONVERGED_RTOL_NORMAL_EQUATIONS : return CONVERGED_RTOL_NORMAL;
+    case KSP_CONVERGED_ATOL_NORMAL_EQUATIONS : return CONVERGED_ATOL_NORMAL;
+#endif
     case KSP_CONVERGED_RTOL            : return CONVERGED_RTOL;
     case KSP_CONVERGED_ATOL            : return CONVERGED_ATOL;
     case KSP_CONVERGED_ITS             : return CONVERGED_ITS;


### PR DESCRIPTION
I don't have PETSc 3.24 installed, so this is going to be coding via CI...