### PR TITLE
Check for our current blessed autotools version

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -34,11 +34,11 @@ function check_autotool_prerequisites ()
 {
     # prerequisite versions
     automake_major=1
-    automake_minor=16
-    automake_subminor=5
+    automake_minor=18
+    automake_subminor=1
 
     autoconf_major=2
-    autoconf_minor=71
+    autoconf_minor=72
 
     build_autotools=0
 


### PR DESCRIPTION
Users of older-but-compatible autotools can run autoreconf manually if they really don't want to upgrade.

After 2023, this marks twice in a row I've inadvertently sabotaged Alex's autotools verification.  Fingers crossed for 2027!