### PR TITLE
Disable more tests with --disable-amr

### DIFF
--- a/tests/base/overlapping_coupling_test.C
+++ b/tests/base/overlapping_coupling_test.C
@@ -515,7 +515,9 @@ public:
 
   CPPUNIT_TEST( testGhostingCouplingMatrix );
   CPPUNIT_TEST( testGhostingNullCouplingMatrix );
+#ifdef LIBMESH_ENABLE_AMR
   CPPUNIT_TEST( testGhostingNullCouplingMatrixUnifRef );
+#endif
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -635,7 +637,9 @@ public:
 
   CPPUNIT_TEST( testSparsityCouplingMatrix );
   CPPUNIT_TEST( testSparsityNullCouplingMatrix );
+#ifdef LIBMESH_ENABLE_AMR
   CPPUNIT_TEST( testSparsityNullCouplingMatrixUnifRef );
+#endif
 
   CPPUNIT_TEST_SUITE_END();
 


### PR DESCRIPTION
This should fix that devel->master recipe; I added an assert to catch bad tests, and disabled some, but was in a configuration that was already disabling other tests for other reasons.