### PR TITLE
Drop deprecated RBParametrized::get_parameter_names()

### DIFF
--- a/include/reduced_basis/rb_parametrized.h
+++ b/include/reduced_basis/rb_parametrized.h
@@ -99,18 +99,6 @@ public:
    */
   unsigned int get_n_discrete_params() const;
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  /**
-   * Get a set that stores the parameter names.
-   *
-   * \deprecated to avoid making it too easy to create copies that in
-   * most circumstances aren't needed.  If this functionality really
-   * is required, call get_parameters_min().get_parameters_map() and
-   * loop over the keys directly.
-   */
-  std::set<std::string> get_parameter_names() const;
-#endif // LIBMESH_ENABLE_DEPRECATED
-
   /**
    * Get the current parameters.
    */

--- a/src/reduced_basis/rb_parametrized.C
+++ b/src/reduced_basis/rb_parametrized.C
@@ -126,20 +126,6 @@ unsigned int RBParametrized::get_n_discrete_params() const
     (get_discrete_parameter_values().size());
 }
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-std::set<std::string> RBParametrized::get_parameter_names() const
-{
-  libmesh_deprecated();
-  libmesh_error_msg_if(!parameters_initialized, "Error: parameters not initialized in RBParametrized::get_parameter_names");
-
-  std::set<std::string> parameter_names;
-  for (const auto & pr : parameters_min)
-    parameter_names.insert(pr.first);
-
-  return parameter_names;
-}
-#endif // LIBMESH_ENABLE_DEPRECATED
-
 bool RBParametrized::set_parameters(const RBParameters & params)
 {
   libmesh_error_msg_if(!parameters_initialized, "Error: parameters not initialized in RBParametrized::set_parameters");


### PR DESCRIPTION
This has been deprecated since cbc851f4 (Sep 2020!), which includes the 1.6.x release series and everything since.  It is well past time for it to be removed completely.