### PR TITLE
Drop deprecated RBEvaluation::eval_output_dual_norm()

### DIFF
--- a/include/reduced_basis/rb_evaluation.h
+++ b/include/reduced_basis/rb_evaluation.h
@@ -150,20 +150,6 @@ public:
    */
   virtual Real residual_scaling_denom(Real alpha_LB);
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  /**
-   * Evaluate the dual norm of output \p n for the current parameters.
-   *
-   * This function is \deprecated, since you should either evaluate
-   * the output dual norm using a vector of pre-evaluated thetas, or
-   * by using the RBParameters object returned by calling
-   * get_parameters() on this class. Instead call the version of this
-   * function that takes an option pointer to a vector of evalauted
-   * theta values.
-   */
-  Real eval_output_dual_norm(unsigned int n, const RBParameters & mu);
-#endif // LIBMESH_ENABLE_DEPRECATED
-
   /**
    * Evaluate the dual norm of output \p n for the current parameters,
    * or using the pre-evaluted theta values provided in the "evaluated_thetas"

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -471,16 +471,6 @@ Real RBEvaluation::residual_scaling_denom(Real alpha_LB)
   return alpha_LB;
 }
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-Real RBEvaluation::eval_output_dual_norm(unsigned int n, const RBParameters & /*mu*/)
-{
-  libmesh_deprecated();
-
-  // Call non-deprecated version of this function, ignoring input mu
-  return this->eval_output_dual_norm(n, nullptr);
-}
-#endif // LIBMESH_ENABLE_DEPRECATED
-
 Real RBEvaluation::eval_output_dual_norm(unsigned int n,
                                          const std::vector<Number> * evaluated_thetas)
 {


### PR DESCRIPTION
This function has been deprecated since a353dcc0 (May 2023). That commit appeared in the 1.8.x release series, so now is a good time to get rid of it completely.