### PR TITLE
Drop deprecated ImplicitSystem::release_linear_solver()

### DIFF
--- a/include/systems/implicit_system.h
+++ b/include/systems/implicit_system.h
@@ -141,17 +141,6 @@ public:
   virtual std::pair<unsigned int, Real>
   get_linear_solve_parameters() const;
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  /**
-   * Currently a no-op.
-   *
-   * \deprecated This function no longer needs to be called, since
-   * get_linear_solver() no longer returns a heap-allocated dumb
-   * pointer.
-   */
-  virtual void release_linear_solver(LinearSolver<Number> *) const;
-#endif // LIBMESH_ENABLE_DEPRECATED
-
   /**
    * Assembles a residual in \p rhs and/or a jacobian in \p matrix,
    * as requested.

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -1244,20 +1244,6 @@ std::pair<unsigned int, Real> ImplicitSystem::get_linear_solve_parameters() cons
 
 
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-void ImplicitSystem::release_linear_solver(LinearSolver<Number> *) const
-{
-  // This function was originally paired with get_linear_solver()
-  // calls when that returned a dumb pointer which needed to be
-  // cleaned up. Since get_linear_solver() now just returns a pointer
-  // to a LinearSolver object managed by this class, this function no
-  // longer needs to do any cleanup.
-  libmesh_deprecated();
-}
-#endif // LIBMESH_ENABLE_DEPRECATED
-
-
-
 const SparseMatrix<Number> & ImplicitSystem::get_system_matrix() const
 {
   libmesh_assert(matrix);


### PR DESCRIPTION
This function has been deprecated since 82e3be93 (Oct 2016!), which was in every release series since 1.2.x.  It's well past time that we get rid of it completely.