### PR TITLE
Drop deprecated EquationSystems::get_solution() API

### DIFF
--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -326,20 +326,6 @@ public:
   void get_vars_active_subdomains(const std::vector<std::string> & names,
                                   std::vector<std::set<subdomain_id_type>> & vars_active_subdomains) const;
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  /**
-   * Retrieve the solution data for CONSTANT MONOMIALs and/or components of
-   * CONSTANT MONOMIAL_VECs. If 'names' is populated, only the variables
-   * corresponding to those names will be retrieved. This can be used to
-   * filter which variables are retrieved.
-   *
-   * \deprecated Call the more appropriately-named build_elemental_solution_vector()
-   * instead.
-   */
-  void get_solution (std::vector<Number> & soln,
-                     std::vector<std::string> & names) const;
-#endif // LIBMESH_ENABLE_DEPRECATED
-
   /**
    * Retrieve the solution data for CONSTANT MONOMIALs and/or components of
    * CONSTANT MONOMIAL_VECs. If 'names' is populated, only the variables

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -1012,17 +1012,6 @@ void EquationSystems::get_vars_active_subdomains(const std::vector<std::string> 
 
 
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-void EquationSystems::get_solution (std::vector<Number> & soln,
-                                    std::vector<std::string> & names) const
-{
-  libmesh_deprecated();
-  this->build_elemental_solution_vector(soln, names);
-}
-#endif // LIBMESH_ENABLE_DEPRECATED
-
-
-
 void
 EquationSystems::build_elemental_solution_vector (std::vector<Number> & soln,
                                                   std::vector<std::string> & names) const


### PR DESCRIPTION
This has been deprecated since 1749f95d (Jun 2018), in the 1.4.x release series. It's definitely time that we remove it for good.