### PR TITLE
VariationalMeshSmoother cleanup

### DIFF
--- a/include/mesh/mesh_smoother_vsmoother.h
+++ b/include/mesh/mesh_smoother_vsmoother.h
@@ -122,14 +122,7 @@ public:
    * function in this class which takes an int, using
    * a default value of 1.
    */
-  virtual void smooth() override {this->smooth(1); }
-
-  /**
-   * The actual smoothing function, gets called whenever
-   * the user specifies an actual number of smoothing
-   * iterations.
-   */
-  void smooth(unsigned int n_iterations);
+  virtual void smooth() override;
 
   /**
    * Getter for the _system's _mesh_info attribute

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -135,7 +135,7 @@ void VariationalMeshSmoother::setup()
   _setup_called = true;
 }
 
-void VariationalMeshSmoother::smooth(unsigned int)
+void VariationalMeshSmoother::smooth()
 {
   if (!_setup_called)
     setup();


### PR DESCRIPTION
Removed unused smooth function that takes number of iterations as a parameter. Ref. #4082.