### PR TITLE
VariationalMeshSmoother improved error message

### DIFF
--- a/include/base/libmesh_exceptions.h
+++ b/include/base/libmesh_exceptions.h
@@ -77,7 +77,7 @@ public:
 class ConvergenceFailure : public std::runtime_error
 {
 public:
-  ConvergenceFailure() : std::runtime_error( "Unrecoverable failure to converge" ) {}
+  ConvergenceFailure(const std::string & err_msg="Unrecoverable failure to converge") : std::runtime_error( err_msg ) {}
 };
 
 

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -140,7 +140,15 @@ void VariationalMeshSmoother::smooth(unsigned int)
   if (!_setup_called)
     setup();
 
-  system()->solve();
+  try
+    {
+      system()->solve();
+    }
+
+  catch (std::runtime_error& e)
+    {
+      throw std::runtime_error(std::string("VariationalMeshSmoother: issue encountered during solve:\n") + e.what());
+    }
 
   // Update _mesh from _mesh_copy
   for (auto * node_copy : _mesh_copy->local_node_ptr_range())

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -145,10 +145,10 @@ void VariationalMeshSmoother::smooth(unsigned int)
       system()->solve();
     }
 
-  libmesh_catch (std::runtime_error& e)
+  libmesh_catch (ConvergenceFailure& e)
     {
 #ifdef LIBMESH_ENABLE_EXCEPTIONS
-      throw std::runtime_error(std::string("VariationalMeshSmoother: issue encountered during solve:\n") + e.what());
+      throw ConvergenceFailure("The VariationalMeshSmoother solve failed to converge.");
 #endif
     }
 

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -140,12 +140,12 @@ void VariationalMeshSmoother::smooth(unsigned int)
   if (!_setup_called)
     setup();
 
-  try
+  libmesh_try
     {
       system()->solve();
     }
 
-  catch (std::runtime_error& e)
+  libmesh_catch (std::runtime_error& e)
     {
       throw std::runtime_error(std::string("VariationalMeshSmoother: issue encountered during solve:\n") + e.what());
     }

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -145,9 +145,11 @@ void VariationalMeshSmoother::smooth(unsigned int)
       system()->solve();
     }
 
-  libmesh_catch(std::runtime_error& e)
+  libmesh_catch (std::runtime_error& e)
     {
+#ifdef LIBMESH_ENABLE_EXCEPTIONS
       throw std::runtime_error(std::string("VariationalMeshSmoother: issue encountered during solve:\n") + e.what());
+#endif
     }
 
   // Update _mesh from _mesh_copy

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -145,7 +145,7 @@ void VariationalMeshSmoother::smooth(unsigned int)
       system()->solve();
     }
 
-  libmesh_catch (std::runtime_error& e)
+  libmesh_catch(std::runtime_error& e)
     {
       throw std::runtime_error(std::string("VariationalMeshSmoother: issue encountered during solve:\n") + e.what());
     }


### PR DESCRIPTION
Added VariationalMeshSmoother-specific error message to any caught runtime_errors when the smoother solve fails.
This is useful for informing moose users what part of their input is crashing.

Ref. #4082.