### PR TITLE
Remove superfluous semicolon

### DIFF
--- a/src/numerics/sparse_matrix.C
+++ b/src/numerics/sparse_matrix.C
@@ -70,7 +70,7 @@ namespace
   {
     if (hdf5val < 0)
       libmesh_error_msg("HDF5 error from " + objname + " in " + filename);
-  };
+  }
 #endif
 }
 


### PR DESCRIPTION
Not sure why we don't have more recipes screaming about this, but at least a few of the devel->master recipe compilers caught it.