### PR TITLE
Drop deprecated DifferentiableQoI::init_qoi()

### DIFF
--- a/include/physics/diff_qoi.h
+++ b/include/physics/diff_qoi.h
@@ -64,20 +64,6 @@ public:
    */
   virtual ~DifferentiableQoI () = default;
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  /**
-   * Initialize system qoi.  This version of the function required
-   * direct vector access, and is now deprecated.
-   */
-  virtual void init_qoi( std::vector<Number> & /*sys_qoi*/){}
-#else
-  /**
-   * Non-virtual, to try to help deprecated user code catch this
-   * change at compile time (if they specified override)
-   */
-  void init_qoi( std::vector<Number> & /*sys_qoi*/){}
-#endif
-
   /**
    * Initialize system qoi.  Often this will just call
    * sys.init_qois(some_desired_number_of_qois)

--- a/src/systems/diff_system.C
+++ b/src/systems/diff_system.C
@@ -282,25 +282,7 @@ void DifferentiableSystem::attach_qoi( DifferentiableQoI * qoi_in )
   this->_diff_qoi.push(qoi_in->clone());
 
   auto & dq = this->_diff_qoi.top();
-  // User needs to resize qoi system qoi accordingly
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  // Call the old API for backwards compatibility
-  dq->init_qoi( this->qoi );
-
-  // Then the new API for forwards compatibility
   dq->init_qoi_count( *this );
-#else
-#ifndef NDEBUG
-  // Make sure the user has updated their QoI subclass - call the old
-  // API and make sure it does nothing
-  std::vector<Number> deprecated_vector;
-  dq->init_qoi( deprecated_vector );
-  libmesh_assert(deprecated_vector.empty());
-#endif
-
-  // Then the new API
-  dq->init_qoi_count( *this );
-#endif
 }
 
 unsigned int DifferentiableSystem::get_second_order_dot_var( unsigned int var ) const


### PR DESCRIPTION
This virtual keyword on this function was deprecated in 6fbd01f6 (2022), so it has been deprecated since the 1.8.x release series. The non-deprecated, non-virtual version of the function was made into a no-op. Therefore, there may be code which still calls this function, but it would just be doing nothing, so let's try removing it to see whether everything still compiles.