### PR TITLE
Run ./bootstrap after new CLEANFILES were added in #4307

### DIFF
--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -2437,7 +2437,7 @@ EXTRA_DIST = $(data)
 CLEANFILES = cube_mesh.xda slit_mesh.xda slit_solution.xda out.e \
 	mesh_with_soln.e elemental_from_nodal.e write_elemset_data.e \
 	write_sideset_data.e write_nodeset_data.e write_edgeset_data.e \
-	read_header_test.e output.dat periodic.e M.m \
+	read_header_test.e output.dat periodic.e M.m Mzipped.m.gz M.h5 \
 	mesh.out.memory.moved.xda mesh.out.file.moved.xda \
 	repl_with_nodal_soln.nem.1.0 dist_with_elem_soln.e dist.e \
 	dist_with_nodal_soln.e dist_with_nodal_soln.nem.1.0 \


### PR DESCRIPTION
I noticed this while working on something else. It looks like ./bootstrap wasn't run after the unit test Makefile.am's `CLEANFILES` target was updated recently.