### PR TITLE
Drop deprecated MeshFunction::init() taking an arg

### DIFF
--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -109,18 +109,6 @@ public:
    */
   virtual void init () override;
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  /**
-   * The actual initialization process.  Takes an optional argument which
-   * specifies the method to use when building a \p PointLocator
-   *
-   * \deprecated The input argument is not used (was it ever?) to
-   * control the PointLocator type which is built, so one should
-   * instead call the version of init() taking no args.
-   */
-  void init (const Trees::BuildType point_locator_build_type);
-#endif // LIBMESH_ENABLE_DEPRECATED
-
   /**
    * Clears the function.
    */

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -124,20 +124,6 @@ void MeshFunction::init ()
 
 
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-void MeshFunction::init (const Trees::BuildType /*point_locator_build_type*/)
-{
-  libmesh_deprecated();
-
-  // Call the init() taking no args instead. Note: this is backwards
-  // compatible because the argument was not used for anything
-  // previously anyway.
-  this->init();
-}
-#endif // LIBMESH_ENABLE_DEPRECATED
-
-
-
 void
 MeshFunction::clear ()
 {


### PR DESCRIPTION
This has been deprecated since 149a8e85 (Feb 2021), which is in the 1.7.x (and all later) release series.