### PR TITLE
Drop deprecated DynaIO::clear_spline_nodes() function

### DIFF
--- a/include/mesh/dyna_io.h
+++ b/include/mesh/dyna_io.h
@@ -99,17 +99,6 @@ public:
                               unsigned int sys_num,
                               unsigned int var_num);
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  /**
-   * Removes any spline nodes (both NodeElem and Node), leaving only
-   * the FE mesh generated from those splines.  Also removes node
-   * constraints to the now-missing nodes.
-   *
-   * \p deprecated - use MeshTools::clear_spline_nodes(mesh) instead.
-   */
-  void clear_spline_nodes();
-#endif // LIBMESH_ENABLE_DEPRECATED
-
   /**
    * The integer type DYNA uses
    */

--- a/src/mesh/dyna_io.C
+++ b/src/mesh/dyna_io.C
@@ -737,17 +737,6 @@ void DynaIO::add_spline_constraints(DofMap &,
 }
 
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-void DynaIO::clear_spline_nodes()
-{
-  libmesh_deprecated();
-
-  MeshTools::clear_spline_nodes(MeshInput<MeshBase>::mesh());
-}
-#endif // LIBMESH_ENABLE_DEPRECATED
-
-
-
 const DynaIO::ElementDefinition &
 DynaIO::find_elem_definition(dyna_int_type dyna_elem,
                              int dim, int p)


### PR DESCRIPTION
This function has been deprecated since b68b48aaae (v1.8.x release series) so now is a good time to get rid of it for good.