### PR TITLE
Drop deprecated connect_families() function

### DIFF
--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -277,19 +277,6 @@ void connect_children(const MeshBase & mesh,
                       MeshBase::const_element_iterator elem_end,
                       connected_elem_set_type & connected_elements);
 
-// Take a set of elements and insert all elements' ancestors and
-// subactive descendants as well.  If a mesh is provided and has any
-// constraint rows, insert elements with the constraining nodes for
-// any constrained nodes in our set.
-//
-// \deprecated This method is now deprecated, because it does not
-// handle recursive dependencies.  Use the new
-// connect_element_dependencies method instead.
-#ifdef LIBMESH_ENABLE_DEPRECATED
-void connect_families(connected_elem_set_type & connected_elements,
-                      const MeshBase * mesh = nullptr);
-#endif // LIBMESH_ENABLE_DEPRECATED
-
 // Take a set of elements and create a set of connected nodes.
 void reconnect_nodes (connected_elem_set_type & connected_elements,
                       connected_node_set_type & connected_nodes);

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -349,24 +349,6 @@ void connect_children(const MeshBase & mesh,
 }
 
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-void connect_families(connected_elem_set_type & connected_elements,
-                      const MeshBase * mesh)
-{
-  // This old API won't be sufficient in cases (IGA meshes with
-  // non-NodeElem nodes acting as the unconstrained DoFs) that require
-  // recursion.
-  libmesh_deprecated();
-
-  // Just do everything in one fell swoop; this is adequate for most
-  // meshes.
-  connect_element_families(connected_elements, connected_elements,
-                           connected_elements, mesh);
-}
-#endif // LIBMESH_ENABLE_DEPRECATED
-
-
-
 void reconnect_nodes (connected_elem_set_type & connected_elements,
                       connected_node_set_type & connected_nodes)
 {


### PR DESCRIPTION
This function has been deprecated since 5f125d6f (May 2024), in the 1.8.x release series. I don't think it would really have been called in much user code prior to its deprecation anyway, so probably safe to get rid of completely now.