### PR TITLE
Drop deprecated MeshBase::insert_node() API

### DIFF
--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -312,15 +312,6 @@ public:
   virtual Node * add_node (Node * n) override final;
   virtual Node * add_node (std::unique_ptr<Node> n) override final;
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  /**
-   * These methods are deprecated. Please use \p add_node instead
-   * Calls add_node().
-   */
-  virtual Node * insert_node(Node * n) override final;
-  virtual Node * insert_node(std::unique_ptr<Node> n) override final;
-#endif
-
   /**
    * Takes ownership of node \p n on this partition of a distributed
    * mesh, by setting n.processor_id() to this->processor_id(), as

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -716,26 +716,6 @@ public:
    */
   virtual Node * add_node (std::unique_ptr<Node> n) = 0;
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  /**
-   * This method is deprecated. Please use \p add_node instead
-   * Insert \p Node \p n into the Mesh at a location consistent with
-   * n->id(), allocating extra storage if necessary.  Will error
-   * rather than overwriting an existing Node. Only use if you know what
-   * you are doing...
-   */
-  virtual Node * insert_node(Node * n) = 0;
-
-  /**
-   * This method is deprecated. Please use \p add_node instead
-   * Version of insert_node() taking a std::unique_ptr by value. This API is
-   * intended to indicate that ownership of the Node is transferred to the Mesh
-   * when this function is called, and it should play more nicely with the
-   * Node::build() API which has always returned a std::unique_ptr.
-   */
-  virtual Node * insert_node(std::unique_ptr<Node> n) = 0;
-#endif
-
   /**
    * Removes the Node n from the mesh.
    */

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -191,24 +191,6 @@ public:
                             const processor_id_type proc_id = DofObject::invalid_processor_id) override final;
   virtual Node * add_node (Node * n) override final;
   virtual Node * add_node (std::unique_ptr<Node> n) override final;
-
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  /**
-   * These methods are deprecated. Please use \p add_node instead
-   * Insert \p Node \p n into the Mesh at a location consistent with
-   * n->id(), allocating extra storage if necessary.  Throws an error if:
-   * .) n==nullptr
-   * .) n->id() == DofObject::invalid_id
-   * .) A node already exists in position n->id().
-   *
-   * This function differs from the ReplicatedMesh::add_node() function,
-   * which is only capable of appending nodes at the end of the nodes
-   * storage.
-   */
-  virtual Node * insert_node(Node * n) override final;
-  virtual Node * insert_node(std::unique_ptr<Node> n) override final;
-#endif
-
   virtual void delete_node (Node * n) override final;
   virtual void renumber_node (dof_id_type old_id, dof_id_type new_id) override final;
   virtual Elem * add_elem (Elem * e) override final;

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -912,22 +912,6 @@ Node * DistributedMesh::add_node (std::unique_ptr<Node> n)
   return add_node(n.release());
 }
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-
-Node * DistributedMesh::insert_node(Node * n)
-{
-  libmesh_deprecated();
-  return DistributedMesh::add_node(n);
-}
-
-Node * DistributedMesh::insert_node(std::unique_ptr<Node> n)
-{
-  libmesh_deprecated();
-  return insert_node(n.release());
-}
-
-#endif
-
 void DistributedMesh::delete_node(Node * n)
 {
   libmesh_assert(n);


### PR DESCRIPTION
This API has been deprecated since 712832e1 (May 2022) and was present in the 1.8.x and 1.9.x release series, so now is a good time to get rid of it completely.