### PR TITLE
Drop deprecated Parallel::Utils::is_sorted()

### DIFF
--- a/include/parallel/parallel_conversion_utils.h
+++ b/include/parallel/parallel_conversion_utils.h
@@ -41,22 +41,6 @@ namespace Parallel {
 namespace Utils {
 
 /**
- * \returns \p true if the vector \p v is sorted, \p false otherwise.
- *
- * This was implemented because std::is_sorted() was an STL extension
- * at the time.
- */
-#ifdef LIBMESH_ENABLE_DEPRECATED
-template <typename KeyType>
-inline
-bool is_sorted (const std::vector<KeyType> & v)
-{
-  libmesh_deprecated();
-  return std::is_sorted(v.begin(), v.end());
-}
-#endif // LIBMESH_ENABLE_DEPRECATED
-
-/**
  * A utility function which converts whatever \p KeyType is to
  * a \p double for the histogram bounds
  */


### PR DESCRIPTION
This has been deprecated since 752d12ea31 (Apr 2022), in the 1.8.x release series and later.