### PR TITLE
Drop deprecated InfFE::n_dofs(), n_shape_functions() taking an ElemType

### DIFF
--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -890,28 +890,8 @@ private:
    * the calls to \p FE and \p InfFE.
    */
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  /**
-   * \deprecated Call the version of ifem_n_shape_functions() which
-   * takes a pointer-to-Elem instead.
-   */
-  static unsigned int ifem_n_shape_functions(const unsigned int dim,
-                                             const FEType & fe_t,
-                                             const ElemType t);
-#endif // LIBMESH_ENABLE_DEPRECATED
-
   static unsigned int ifem_n_shape_functions(const FEType & fe_t,
                                              const Elem * elem);
-
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  /**
-   * \deprecated Call the version of ifem_n_dofs() which takes a
-   * pointer-to-Elem instead.
-   */
-  static unsigned int ifem_n_dofs(const unsigned int dim,
-                                  const FEType & fe_t,
-                                  const ElemType t);
-#endif // LIBMESH_ENABLE_DEPRECATED
 
   static unsigned int ifem_n_dofs(const FEType & fe_t,
                                   const Elem * elem);

--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -382,23 +382,6 @@ public:
                                          const Elem * inf_elem)
   { return n_dofs(fet, inf_elem); }
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  /*
-   * \deprecated Call the version of this function that takes a
-   * pointer-to-Elem instead.
-   */
-  static unsigned int n_shape_functions (const FEType & fet,
-                                         const ElemType t)
-  { return n_dofs(fet, t); }
-
-  /**
-   * \deprecated Call the version of this function that takes an Elem*
-   * instead for consistency with other FEInterface::n_dofs() methods.
-   */
-  static unsigned int n_dofs(const FEType & fet,
-                             const ElemType inf_elem_type);
-#endif // LIBMESH_ENABLE_DEPRECATED
-
   /**
    * \returns The number of shape functions associated with this
    * infinite element.  Currently, we have \p o_radial+1 modes in

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -276,14 +276,12 @@ unsigned int FEInterface::n_shape_functions(const unsigned int dim,
   libmesh_deprecated();
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
-  /*
-   * Since the FEType, stored in DofMap/(some System child), has to
-   * be the _same_ for InfFE and FE, we have to catch calls
-   * to infinite elements through the element type.
-   */
 
+  // We no longer support calling this function with an infinite
+  // ElemType, you must call the FeInterface::n_shape_functions()
+  // taking an Elem* instead.
   if (is_InfFE_elem(t))
-    return ifem_n_shape_functions(dim, fe_t, t);
+    libmesh_not_implemented();
 
 #endif
 
@@ -360,8 +358,11 @@ unsigned int FEInterface::n_dofs(const unsigned int dim,
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
+  // We no longer support calling this function with an infinite
+  // ElemType, you must call the FeInterface::n_dofs() taking an Elem*
+  // instead.
   if (is_InfFE_elem(t))
-    return ifem_n_dofs(dim, fe_t, t);
+    libmesh_not_implemented();
 
 #endif
 

--- a/src/fe/fe_interface_inf_fe.C
+++ b/src/fe/fe_interface_inf_fe.C
@@ -36,40 +36,6 @@ namespace libMesh
 
 
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-unsigned int FEInterface::ifem_n_shape_functions(const unsigned int dim,
-                                                 const FEType & fe_t,
-                                                 const ElemType t)
-{
-  libmesh_deprecated();
-
-  switch (dim)
-    {
-      // 1D
-    case 1:
-      /*
-       * Since InfFE<Dim,T_radial,T_map>::n_shape_functions(...)
-       * is actually independent of T_radial and T_map, we can use
-       * just any T_radial and T_map
-       */
-      return InfFE<1,JACOBI_20_00,CARTESIAN>::n_shape_functions(fe_t, t);
-
-      // 2D
-    case 2:
-      return InfFE<2,JACOBI_20_00,CARTESIAN>::n_shape_functions(fe_t, t);
-
-      // 3D
-    case 3:
-      return InfFE<3,JACOBI_20_00,CARTESIAN>::n_shape_functions(fe_t, t);
-
-    default:
-      libmesh_error_msg("Unsupported dim = " << dim);
-    }
-}
-#endif // LIBMESH_ENABLE_DEPRECATED
-
-
-
 unsigned int FEInterface::ifem_n_shape_functions(const FEType & fe_t,
                                                  const Elem * elem)
 {
@@ -96,40 +62,6 @@ unsigned int FEInterface::ifem_n_shape_functions(const FEType & fe_t,
       libmesh_error_msg("Unsupported dim = " << elem->dim());
     }
 }
-
-
-
-#ifdef LIBMESH_ENABLE_DEPRECATED
-unsigned int FEInterface::ifem_n_dofs(const unsigned int dim,
-                                      const FEType & fe_t,
-                                      const ElemType t)
-{
-  libmesh_deprecated();
-
-  switch (dim)
-    {
-      // 1D
-    case 1:
-      /*
-       * Since InfFE<Dim,T_radial,T_map>::n_dofs(...)
-       * is actually independent of T_radial and T_map, we can use
-       * just any T_radial and T_map
-       */
-      return InfFE<1,JACOBI_20_00,CARTESIAN>::n_dofs(fe_t, t);
-
-      // 2D
-    case 2:
-      return InfFE<2,JACOBI_20_00,CARTESIAN>::n_dofs(fe_t, t);
-
-      // 3D
-    case 3:
-      return InfFE<3,JACOBI_20_00,CARTESIAN>::n_dofs(fe_t, t);
-
-    default:
-      libmesh_error_msg("Unsupported dim = " << dim);
-    }
-}
-#endif // LIBMESH_ENABLE_DEPRECATED
 
 
 

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -62,25 +62,6 @@ bool InfFE<Dim,T_radial,T_map>::_warned_for_dshape     = false;
 
 // ------------------------------------------------------------
 // InfFE static class members
-#ifdef LIBMESH_ENABLE_DEPRECATED
-template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
-unsigned int InfFE<Dim,T_radial,T_map>::n_dofs (const FEType & fet,
-                                                const ElemType inf_elem_type)
-{
-  libmesh_deprecated();
-
-  const ElemType base_et (InfFEBase::get_elem_type(inf_elem_type));
-
-  if (Dim > 1)
-    return FEInterface::n_dofs(Dim-1, fet, base_et) *
-      InfFERadial::n_dofs(fet.radial_order);
-  else
-    return InfFERadial::n_dofs(fet.radial_order);
-}
-#endif // LIBMESH_ENABLE_DEPRECATED
-
-
-
 template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
 unsigned int InfFE<Dim,T_radial,T_map>::n_dofs(const FEType & fet,
                                                const Elem * inf_elem)
@@ -1370,7 +1351,6 @@ void InfFE<Dim,T_radial,T_map>::compute_shape_indices (const FEType & fet,
 
     else                                                                         // range of i: 134..169
       {
-        libmesh_assert_less (i, n_dofs(fet, inf_elem_type));
         // belongs to the outer shell and is an element associated shape
         const unsigned int i_offset = i - (n_dof_at_all_vertices
                                            + n_dof_at_all_sides
@@ -1713,9 +1693,6 @@ void InfFE<Dim, T_radial, T_map>::inf_compute_constraints (DofConstraints & cons
 //#include "libmesh/inf_fe_instantiate_3D.h"
 
 #ifdef LIBMESH_ENABLE_DEPRECATED
-INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, unsigned int, n_dofs(const FEType &, const ElemType));
-INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, unsigned int, n_dofs(const FEType &, const ElemType));
-INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, unsigned int, n_dofs(const FEType &, const ElemType));
 INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, unsigned int, n_dofs_per_elem(const FEType &, const ElemType));
 INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, unsigned int, n_dofs_per_elem(const FEType &, const ElemType));
 INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, unsigned int, n_dofs_per_elem(const FEType &, const ElemType));


### PR DESCRIPTION
These functions have been marked libmesh_deprecated() since 1ec8fcd7 (Jun 2020), in release series 1.6.x and later.

This removal also triggers the removal of the FEInterface functions ifem_n_shape_functions() and ifem_n_dofs() since they called the version of InfFE::n_dofs() which is being removed. Technically, these FEInterface functions have not been marked libmesh_deprecated() for quite as long (a133c3d2, Feb 2025) but they have *effectively* been deprecated for just as long.

To avoid also dropping the deprecated FE APIs with the same names, we've simply placed libmesh_not_implemented() error messages in those deprecated functions for now to handle the infinite Elem case. This seems like a reasonable compromise to avoid dropping both the FE and InfFE deprecated functions at the same time.