### PR TITLE
ExodusII_IO: if the mesh is renumbered then don't load solution vector data.

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -212,6 +212,11 @@ public:
   /**
    * If we read in a nodal solution while reading in a mesh, we can attempt
    * to copy that nodal solution into an EquationSystems object.
+   *
+   * \note This function cannot be used with renumbering. For more information,
+   * see MeshBase::allow_renumbering(). If you need both renumbering and nodal
+   * solution vectors, then disable renumbering, load the solution vectors, and
+   * then reenable renumbering.
    */
   void copy_nodal_solution(System & system,
                            std::string system_var_name,
@@ -221,6 +226,11 @@ public:
   /**
    * If we read in a elemental solution while reading in a mesh, we can attempt
    * to copy that elemental solution into an EquationSystems object.
+   *
+   * \note This function cannot be used with renumbering. For more
+   * information, see MeshBase::allow_renumbering(). If you need both
+   * renumbering and nodal solution vectors, then disable renumbering, load the
+   * solution vectors, and then reenable renumbering.
    */
   void copy_elemental_solution(System & system,
                                std::string system_var_name,

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1061,6 +1061,9 @@ void ExodusII_IO::copy_nodal_solution(System & system,
 
   const MeshBase & mesh = MeshInput<MeshBase>::mesh();
 
+  libmesh_error_msg_if(mesh.allow_renumbering(),
+                       "ERROR, nodal data cannot be loaded if the mesh may be renumbered!");
+
   // With Exodus files we only open them on processor 0, so that's the
   // where we have to do the data read too.
   if (system.comm().rank() == 0)
@@ -1172,6 +1175,9 @@ void ExodusII_IO::copy_elemental_solution(System & system,
 
   const MeshBase & mesh = MeshInput<MeshBase>::mesh();
   const DofMap & dof_map = system.get_dof_map();
+
+  libmesh_error_msg_if(mesh.allow_renumbering(),
+                       "ERROR, elemental data cannot be loaded if the mesh may be renumbered!");
 
   // Map from element ID to elemental variable value.  We need to use
   // a map here rather than a vector (e.g. elem_var_values) since the

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -653,12 +653,12 @@ public:
 
     {
       MeshType mesh(*TestCommWorld);
+      mesh.allow_renumbering(false);
       IOType meshinput(mesh);
 
       // Avoid getting Nemesis solution values mixed up
       if (meshinput.is_parallel_format())
         {
-          mesh.allow_renumbering(false);
           mesh.skip_noncritical_partitioning(true);
         }
 
@@ -742,12 +742,12 @@ public:
 
     {
       MeshType mesh(*TestCommWorld);
+      mesh.allow_renumbering(false);
       IOType meshinput(mesh);
 
       // Avoid getting Nemesis solution values mixed up
       if (meshinput.is_parallel_format())
         {
-          mesh.allow_renumbering(false);
           mesh.skip_noncritical_partitioning(true);
         }
 
@@ -831,6 +831,7 @@ public:
     // file(s) were written properly.
     {
       MeshType mesh(*TestCommWorld);
+      mesh.allow_renumbering(false);
       EquationSystems es(mesh);
       auto & sys = es.add_system<System>("SimpleSystem");
       sys.add_variable("teste", CONSTANT, MONOMIAL);
@@ -921,12 +922,12 @@ public:
 
     {
       MeshType mesh(*TestCommWorld);
+      mesh.allow_renumbering(false);
       IOType meshinput(mesh);
 
       // Avoid getting Nemesis solution values mixed up
       if (meshinput.is_parallel_format())
         {
-          mesh.allow_renumbering(false);
           mesh.skip_noncritical_partitioning(true);
         }
 
@@ -1034,6 +1035,7 @@ public:
 
       // copy_elemental_solution currently requires ReplicatedMesh
       ReplicatedMesh mesh(*TestCommWorld);
+      mesh.allow_renumbering(false);
 
       EquationSystems es(mesh);
       System & sys = es.add_system<System> ("SimpleSystem");
@@ -1183,7 +1185,6 @@ public:
     {
       Mesh mesh(*TestCommWorld);
       mesh.allow_renumbering(false);
-
       ExodusII_IO exii(mesh);
 
       if (mesh.processor_id() == 0)

--- a/tests/mesh/write_vec_and_scalar.C
+++ b/tests/mesh/write_vec_and_scalar.C
@@ -170,6 +170,7 @@ public:
 
     // Now read it back in
     MeshType read_mesh(*TestCommWorld);
+    read_mesh.allow_renumbering(false);
     ExodusII_IO exio(read_mesh);
     exio.read(filename);
 
@@ -215,6 +216,7 @@ public:
 
     // Now read it back in
     MeshType read_mesh(*TestCommWorld);
+    read_mesh.allow_renumbering(false);
     Nemesis_IO nemio(read_mesh);
     nemio.read(filename);
 


### PR DESCRIPTION
Follow-up to #4340 - as a user, I'd rather set an additional flag then unknowingly load wrong nodal data.