### PR TITLE
Skip some operations in interior parents computation

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1359,6 +1359,13 @@ public:
   bool allow_find_neighbors() const { return !_skip_find_neighbors; }
 
   /**
+   * If \p false is passed then this mesh will no longer work to detect
+   * interior parents when being prepared for use
+   */
+  void allow_detect_interior_parents(bool allow) { _skip_detect_interior_parents = !allow; }
+  bool allow_detect_interior_parents() const { return !_skip_detect_interior_parents; }
+
+  /**
    * If false is passed in then this mesh will no longer have remote
    * elements deleted when being prepared for use; i.e. even a
    * DistributedMesh will remain (if it is already) serialized.
@@ -1555,7 +1562,8 @@ public:
   virtual void read  (const std::string & name,
                       void * mesh_data=nullptr,
                       bool skip_renumber_nodes_and_elements=false,
-                      bool skip_find_neighbors=false) = 0;
+                      bool skip_find_neighbors=false,
+                      bool skip_detect_interior_parents=false) = 0;
   virtual void write (const std::string & name) const = 0;
 
   /**
@@ -2203,6 +2211,11 @@ protected:
    * If this is \p true then we will skip \p find_neighbors in \p prepare_for_use
    */
   bool _skip_find_neighbors;
+
+  /**
+   * If this is \p true then we will skip \p detect_interior_parents in \p prepare_for_use
+   */
+  bool _skip_detect_interior_parents;
 
   /**
    * If this is false then even on DistributedMesh remote elements

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -206,8 +206,7 @@ public:
    * the preparation done in a call to \p prepare_for_use, \p false
    * otherwise.
    */
-  bool is_prepared () const
-  { return _preparation; }
+  bool is_prepared () const;
 
   /**
    * \returns the \p Preparation structure with details about in what
@@ -2022,53 +2021,37 @@ public:
    */
   struct Preparation
   {
-    bool is_partitioned = false,
-         has_synched_id_counts = false,
-         has_neighbor_ptrs = false,
-         has_cached_elem_data = false,
-         has_interior_parent_ptrs = false,
-         has_removed_remote_elements = false,
-         has_removed_orphaned_nodes = false,
-         has_boundary_id_sets = false,
-         has_reinit_ghosting_functors = false;
+    /**
+     * Constructor. Initializes all flags to false.
+     */
+    Preparation();
 
-    operator bool() const {
-      return is_partitioned &&
-             has_synched_id_counts &&
-             has_neighbor_ptrs &&
-             has_cached_elem_data &&
-             has_interior_parent_ptrs &&
-             has_removed_remote_elements &&
-             has_removed_orphaned_nodes &&
-             has_reinit_ghosting_functors &&
-             has_boundary_id_sets;
-    }
+    /**
+     * Returns true iff all the flags are true.
+     */
+    explicit operator bool() const;
 
-    Preparation & operator= (bool set_all) {
-      is_partitioned = set_all;
-      has_synched_id_counts = set_all;
-      has_neighbor_ptrs = set_all;
-      has_cached_elem_data = set_all;
-      has_interior_parent_ptrs = set_all;
-      has_removed_remote_elements = set_all;
-      has_removed_orphaned_nodes = set_all;
-      has_reinit_ghosting_functors = set_all;
-      has_boundary_id_sets = set_all;
+    /**
+     * Set all flags to the "set_all" value.
+     */
+    Preparation & operator= (bool set_all);
 
-      return *this;
-    }
+    /**
+     * Two Preparation objects are equivalent iff all the flags match,
+     * regardless of the true/false status of any given flag.
+     */
+    bool operator== (const Preparation & other) const;
+    bool operator!= (const Preparation & other) const;
 
-    bool operator== (const Preparation & other) {
-      return is_partitioned == other.is_partitioned &&
-             has_synched_id_counts == other.has_synched_id_counts &&
-             has_neighbor_ptrs == other.has_neighbor_ptrs &&
-             has_cached_elem_data == other.has_cached_elem_data &&
-             has_interior_parent_ptrs == other.has_interior_parent_ptrs &&
-             has_removed_remote_elements == other.has_removed_remote_elements &&
-             has_removed_orphaned_nodes == other.has_removed_orphaned_nodes &&
-             has_reinit_ghosting_functors == other.has_reinit_ghosting_functors &&
-             has_boundary_id_sets == other.has_boundary_id_sets;
-    }
+    bool is_partitioned;
+    bool has_synched_id_counts;
+    bool has_neighbor_ptrs;
+    bool has_cached_elem_data;
+    bool has_interior_parent_ptrs;
+    bool has_removed_remote_elements;
+    bool has_removed_orphaned_nodes;
+    bool has_boundary_id_sets;
+    bool has_reinit_ghosting_functors;
   };
 
 protected:

--- a/include/mesh/unstructured_mesh.h
+++ b/include/mesh/unstructured_mesh.h
@@ -109,7 +109,8 @@ public:
   virtual void read (const std::string & name,
                      void * mesh_data=nullptr,
                      bool skip_renumber_nodes_and_elements=false,
-                     bool skip_find_neighbors=false) override;
+                     bool skip_find_neighbors=false,
+                     bool skip_detect_interior_parents=false) override;
   /**
    * Write the file specified by \p name.  Attempts to figure out the
    * proper method by the file extension.

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -195,6 +195,7 @@ DistributedMesh::DistributedMesh (const MeshBase & other_mesh) :
   this->copy_nodes_and_elements(other_mesh, true, 0, 0, 0, nullptr, true);
 
   this->allow_find_neighbors(other_mesh.allow_find_neighbors());
+  this->allow_detect_interior_parents(other_mesh.allow_detect_interior_parents());
   this->allow_renumbering(other_mesh.allow_renumbering());
   this->allow_remote_element_removal(other_mesh.allow_remote_element_removal());
   this->skip_partitioning(other_mesh.skip_partitioning());

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -1947,6 +1947,8 @@ void MeshBase::sync_subdomain_name_map()
 
 void MeshBase::detect_interior_parents()
 {
+  LOG_SCOPE("detect_interior_parents()", "MeshBase");
+
   // This requires an inspection on every processor
   parallel_object_only();
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -272,6 +272,8 @@ bool MeshBase::operator== (const MeshBase & other_mesh) const
 
 bool MeshBase::locally_equals (const MeshBase & other_mesh) const
 {
+  libmesh_here();
+
   // Check whether (almost) everything in the base is equal
   //
   // We don't check _next_unique_id here, because it's expected to
@@ -288,11 +290,19 @@ bool MeshBase::locally_equals (const MeshBase & other_mesh) const
     return false;
   if (_default_mapping_data != other_mesh._default_mapping_data)
     return false;
+
+  libmesh_here(); // we make it here
+
   if (_preparation != other_mesh._preparation)
     return false;
+
+  libmesh_here(); // we don't make it here
+
   if (_count_lower_dim_elems_in_point_locator !=
         other_mesh._count_lower_dim_elems_in_point_locator)
     return false;
+
+  libmesh_here(); // we don't make it here
 
   // We should either both have our own interior parents or both not;
   // but if we both don't then we can't really assert anything else
@@ -301,6 +311,8 @@ bool MeshBase::locally_equals (const MeshBase & other_mesh) const
   if ((_interior_mesh == this) !=
       (other_mesh._interior_mesh == &other_mesh))
     return false;
+
+  libmesh_here();
 
   if (_skip_noncritical_partitioning != other_mesh._skip_noncritical_partitioning)
     return false;
@@ -324,6 +336,9 @@ bool MeshBase::locally_equals (const MeshBase & other_mesh) const
     return false;
   if (_elem_dims != other_mesh._elem_dims)
     return false;
+
+  libmesh_here();
+
   if (_elem_default_orders != other_mesh._elem_default_orders)
     return false;
   if (_supported_nodal_order != other_mesh._supported_nodal_order)
@@ -346,6 +361,8 @@ bool MeshBase::locally_equals (const MeshBase & other_mesh) const
     return false;
   if (*boundary_info != *other_mesh.boundary_info)
     return false;
+
+  libmesh_here();
 
   // First check whether the "existence" of the two pointers differs (one present, one absent)
   if (static_cast<bool>(_disjoint_neighbor_boundary_pairs) !=
@@ -388,6 +405,8 @@ bool MeshBase::locally_equals (const MeshBase & other_mesh) const
         }
     }
 
+  libmesh_here();
+
   for (const auto & [elemset_code, elemset_ptr] : this->_elemset_codes)
     if (const auto it = other_mesh._elemset_codes.find(elemset_code);
         it == other_mesh._elemset_codes.end() || *elemset_ptr != *it->second)
@@ -404,6 +423,8 @@ bool MeshBase::locally_equals (const MeshBase & other_mesh) const
 
   // Same deal for partitioners.  We tested that we both have one or
   // both don't, but are they equivalent?  Let's guess "yes".
+
+  libmesh_here();
 
   // Now let the subclasses decide whether everything else is equal
   return this->subclass_locally_equals(other_mesh);
@@ -1030,6 +1051,10 @@ void MeshBase::clear ()
 }
 
 
+bool MeshBase::is_prepared() const
+{
+  return static_cast<bool>(_preparation);
+}
 
 void MeshBase::add_ghosting_functor(GhostingFunctor & ghosting_functor)
 {
@@ -2687,7 +2712,87 @@ std::string MeshBase::get_local_constraints(bool print_nonlocal) const
   return os.str();
 }
 
+MeshBase::Preparation::Preparation() :
+  is_partitioned(false),
+  has_synched_id_counts(false),
+  has_neighbor_ptrs(false),
+  has_cached_elem_data(false),
+  has_interior_parent_ptrs(false),
+  has_removed_remote_elements(false),
+  has_removed_orphaned_nodes(false),
+  has_boundary_id_sets(false),
+  has_reinit_ghosting_functors(false)
+{}
 
+MeshBase::Preparation::operator bool() const
+{
+  libmesh_here();
+
+  return is_partitioned &&
+         has_synched_id_counts &&
+         has_neighbor_ptrs &&
+         has_cached_elem_data &&
+         has_interior_parent_ptrs &&
+         has_removed_remote_elements &&
+         has_removed_orphaned_nodes &&
+         has_reinit_ghosting_functors &&
+         has_boundary_id_sets;
+}
+
+MeshBase::Preparation &
+MeshBase::Preparation::operator= (bool set_all)
+{
+  is_partitioned = set_all;
+  has_synched_id_counts = set_all;
+  has_neighbor_ptrs = set_all;
+  has_cached_elem_data = set_all;
+  has_interior_parent_ptrs = set_all;
+  has_removed_remote_elements = set_all;
+  has_removed_orphaned_nodes = set_all;
+  has_reinit_ghosting_functors = set_all;
+  has_boundary_id_sets = set_all;
+
+  return *this;
+}
+
+bool
+MeshBase::Preparation::operator== (const Preparation & other) const
+{
+  libmesh_here();
+
+  if (is_partitioned != other.is_partitioned)
+    return false;
+  if (has_synched_id_counts != other.has_synched_id_counts)
+    return false;
+  if (has_neighbor_ptrs != other.has_neighbor_ptrs)
+    return false;
+  if (has_cached_elem_data != other.has_cached_elem_data)
+    return false;
+
+  libmesh_here(); // we make it here
+
+  if (has_interior_parent_ptrs != other.has_interior_parent_ptrs)
+    return false;
+
+  libmesh_here(); // we don't make it here
+
+  if (has_removed_remote_elements != other.has_removed_remote_elements)
+    return false;
+  if (has_removed_orphaned_nodes != other.has_removed_orphaned_nodes)
+    return false;
+  if (has_reinit_ghosting_functors != other.has_reinit_ghosting_functors)
+    return false;
+  if (has_boundary_id_sets != other.has_boundary_id_sets)
+    return false;
+
+  return true;
+}
+
+bool
+MeshBase::Preparation::operator!= (const Preparation & other) const
+{
+  return !(*this == other);
+}
 
 
 // Explicit instantiations for our template function

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -2038,47 +2038,45 @@ void MeshBase::detect_interior_parents()
       if (skip_dimension_for_interior_parents[element->dim()] || element->interior_parent())
         continue;
 
-      // Start by generating a SET of elements that are dim+1 to the current
-      // element at each vertex of the current element, thus ignoring interior nodes.
-      // If one of the SET of elements is empty, then we will not have an interior parent
-      // since an interior parent must be connected to all vertices of the current element
+      // Start by generating sets of dim+1 dimensional elements that
+      // touch each vertex of the current element.  If we encounter a
+      // vertex not connected to _any_ dim+1 dimensional elements,
+      // then we can exit the loop without checking the remaining
+      // vertices since an interior parent (if it exists) will be
+      // connected to all vertices of the current element.
       std::vector<std::set<dof_id_type>> neighbors( element->n_vertices() );
 
-      bool found_interior_parents = false;
+      bool found_interior_parents = true;
 
       for (auto n : make_range(element->n_vertices()))
         {
           auto it = node_to_elem.find(element->node_id(n));
+
           // Check at first that this node is not isolated.
           if (it == node_to_elem.end())
             {
               found_interior_parents = false;
-              break;
+              break; // out of n-loop
             }
 
-          std::vector<dof_id_type> & element_ids = it->second;
-          for (const auto & eid : element_ids)
-            if (this->elem_ref(eid).dim() == element->dim()+1)
-              neighbors[n].insert(eid);
+          for (const auto & vertex_neighbor_id : it->second)
+            if (this->elem_ref(vertex_neighbor_id).dim() == element->dim()+1)
+              neighbors[n].insert(vertex_neighbor_id);
 
-          if (neighbors[n].size()>0)
+          if (neighbors[n].empty())
             {
-              found_interior_parents = true;
-            }
-          else
-            {
-              // We have found an empty set, no reason to continue
-              // Ensure we set this flag to false before the break since it could have
-              // been set to true for previous vertex
+              // We have found an empty set for one vertex, no reason
+              // to continue.
               found_interior_parents = false;
-              break;
+              break; // out of n-loop
             }
         }
 
-      // If we have successfully generated a set of elements for each vertex, we will compare
-      // the set for vertex 0 will the sets for the vertices until we find a id that exists in
-      // all sets.  If found, this is our an interior parent id.  The interior parent id found
-      // will be the lowest element id if there is potential for multiple interior parents.
+      // If we have generated a non-empty set of elements for each
+      // vertex, we will now look for a vertex_neighbor_id that
+      // appears in _all_ of those sets.  If found, this is our interior
+      // parent id.  If multiple such common ids are found, we will
+      // take the lowest such id to be the interior parent id.
       if (found_interior_parents)
         {
           std::set<dof_id_type> & neighbors_0 = neighbors[0];

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -1956,6 +1956,50 @@ void MeshBase::detect_interior_parents()
       return;
     }
 
+  // In this function we find only +1 dimensional interior parents,
+  // (so, for a given element el, the interior parent p must satisfy p.dim() == el.dim() + 1).
+  // Therefore, we can avoid checking the existence of interior parents
+  // for all those elements el such there there is no p with p.dim() == el.dim() + 1.
+  // We store whether to skip any given dimension in the construction of interior parents
+  // inside the vector in dimensions_to_skip_for_interior_parents.
+  std::vector<bool> skip_dimension_for_interior_parents(LIBMESH_DIM+1);  // all false by default
+  skip_dimension_for_interior_parents.back() = true;
+
+  // Moreover, in the following, we will build a node-to-elem map.
+  // It is among the elems of this map that we will look for interior parents.
+  // Therefore, we can skip all elems p such that there is no el with el.dim() == p.dim() - 1.
+  // We store whether to skip any given dimension in the construction of the node-to-elem map
+  // in the vector skip_dimensions_for_node_to_el_map.
+  std::vector<bool> skip_dimensions_for_node_to_el_map(LIBMESH_DIM+1);  // all false by default
+  skip_dimensions_for_node_to_el_map[*this->elem_dimensions().begin()] = true;
+
+  // We also create a flag to know if all dimensions should be skipped,
+  // and if we should therefore return early.
+  bool skip_all_dimensions = true;
+
+  // Fill dimensions_to_skip_for_interior_parents and dimensions_to_skip_for_node_to_el_map.
+    {
+      const std::set<unsigned char> & elem_dimensions = this->elem_dimensions();
+
+      auto it = elem_dimensions.begin();
+      auto next = std::next(it);
+
+      for (; next != elem_dimensions.end(); ++it, ++next)
+        {
+          if (*it + 1 != *next) // note: elem_dimensions is already sorted
+            {
+              skip_dimension_for_interior_parents[*it] = true;
+              skip_dimensions_for_node_to_el_map[*next] = true;
+            }
+          else if (!skip_dimension_for_interior_parents[*it])
+            skip_all_dimensions = false;
+        }
+    }
+
+  // There is nothing to do if all dimensions should be skipped.
+  if (skip_all_dimensions)
+    return;
+
   // Do we have interior parent pointers going to a different mesh?
   // If so then we'll still check to make sure that's the only place
   // they go, so we can libmesh_not_implemented() if not.
@@ -1966,6 +2010,10 @@ void MeshBase::detect_interior_parents()
 
   for (const auto & elem : this->element_ptr_range())
     {
+      // Ignore element if it cannot be interior parent of any other elem.
+      if (skip_dimensions_for_node_to_el_map[elem->dim()])
+        continue;
+
       // Populating the node_to_elem map, same as MeshTools::build_nodes_to_elem_map
       for (auto n : make_range(elem->n_vertices()))
         {
@@ -1978,8 +2026,9 @@ void MeshBase::detect_interior_parents()
   // Automatically set interior parents
   for (const auto & element : this->element_ptr_range())
     {
-      // Ignore an 3D element or an element that already has an interior parent
-      if (element->dim()>=LIBMESH_DIM || element->interior_parent())
+      // Ignore elements with dimensions to skip
+      // or elements that already have an interior parent.
+      if (skip_dimension_for_interior_parents[element->dim()] || element->interior_parent())
         continue;
 
       // Start by generating a SET of elements that are dim+1 to the current

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -272,8 +272,6 @@ bool MeshBase::operator== (const MeshBase & other_mesh) const
 
 bool MeshBase::locally_equals (const MeshBase & other_mesh) const
 {
-  libmesh_here();
-
   // Check whether (almost) everything in the base is equal
   //
   // We don't check _next_unique_id here, because it's expected to
@@ -290,19 +288,11 @@ bool MeshBase::locally_equals (const MeshBase & other_mesh) const
     return false;
   if (_default_mapping_data != other_mesh._default_mapping_data)
     return false;
-
-  libmesh_here(); // we make it here
-
   if (_preparation != other_mesh._preparation)
     return false;
-
-  libmesh_here(); // we don't make it here
-
   if (_count_lower_dim_elems_in_point_locator !=
         other_mesh._count_lower_dim_elems_in_point_locator)
     return false;
-
-  libmesh_here(); // we don't make it here
 
   // We should either both have our own interior parents or both not;
   // but if we both don't then we can't really assert anything else
@@ -311,8 +301,6 @@ bool MeshBase::locally_equals (const MeshBase & other_mesh) const
   if ((_interior_mesh == this) !=
       (other_mesh._interior_mesh == &other_mesh))
     return false;
-
-  libmesh_here();
 
   if (_skip_noncritical_partitioning != other_mesh._skip_noncritical_partitioning)
     return false;
@@ -336,9 +324,6 @@ bool MeshBase::locally_equals (const MeshBase & other_mesh) const
     return false;
   if (_elem_dims != other_mesh._elem_dims)
     return false;
-
-  libmesh_here();
-
   if (_elem_default_orders != other_mesh._elem_default_orders)
     return false;
   if (_supported_nodal_order != other_mesh._supported_nodal_order)
@@ -361,8 +346,6 @@ bool MeshBase::locally_equals (const MeshBase & other_mesh) const
     return false;
   if (*boundary_info != *other_mesh.boundary_info)
     return false;
-
-  libmesh_here();
 
   // First check whether the "existence" of the two pointers differs (one present, one absent)
   if (static_cast<bool>(_disjoint_neighbor_boundary_pairs) !=
@@ -405,8 +388,6 @@ bool MeshBase::locally_equals (const MeshBase & other_mesh) const
         }
     }
 
-  libmesh_here();
-
   for (const auto & [elemset_code, elemset_ptr] : this->_elemset_codes)
     if (const auto it = other_mesh._elemset_codes.find(elemset_code);
         it == other_mesh._elemset_codes.end() || *elemset_ptr != *it->second)
@@ -423,8 +404,6 @@ bool MeshBase::locally_equals (const MeshBase & other_mesh) const
 
   // Same deal for partitioners.  We tested that we both have one or
   // both don't, but are they equivalent?  Let's guess "yes".
-
-  libmesh_here();
 
   // Now let the subclasses decide whether everything else is equal
   return this->subclass_locally_equals(other_mesh);
@@ -1974,8 +1953,6 @@ void MeshBase::detect_interior_parents()
 {
   LOG_SCOPE("detect_interior_parents()", "MeshBase");
 
-  libmesh_here();
-
   // This requires an inspection on every processor
   parallel_object_only();
 
@@ -2029,9 +2006,6 @@ void MeshBase::detect_interior_parents()
             skip_all_dimensions = false;
         }
     }
-
-  libmesh_here();
-  libMesh::out << "skip_all_dimensions = " << skip_all_dimensions << std::endl;
 
   // There is nothing to do if all dimensions should be
   // skipped. Before returning, we must also set the flag that says
@@ -2740,8 +2714,6 @@ MeshBase::Preparation::Preparation() :
 
 MeshBase::Preparation::operator bool() const
 {
-  libmesh_here();
-
   return is_partitioned &&
          has_synched_id_counts &&
          has_neighbor_ptrs &&
@@ -2772,8 +2744,6 @@ MeshBase::Preparation::operator= (bool set_all)
 bool
 MeshBase::Preparation::operator== (const Preparation & other) const
 {
-  libmesh_here();
-
   if (is_partitioned != other.is_partitioned)
     return false;
   if (has_synched_id_counts != other.has_synched_id_counts)
@@ -2782,14 +2752,8 @@ MeshBase::Preparation::operator== (const Preparation & other) const
     return false;
   if (has_cached_elem_data != other.has_cached_elem_data)
     return false;
-
-  libmesh_here(); // we make it here
-
   if (has_interior_parent_ptrs != other.has_interior_parent_ptrs)
     return false;
-
-  libmesh_here(); // we don't make it here
-
   if (has_removed_remote_elements != other.has_removed_remote_elements)
     return false;
   if (has_removed_orphaned_nodes != other.has_removed_orphaned_nodes)

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -78,6 +78,7 @@ MeshBase::MeshBase (const Parallel::Communicator & comm_in,
   _skip_all_partitioning(libMesh::on_command_line("--skip-partitioning")),
   _skip_renumber_nodes_and_elements(false),
   _skip_find_neighbors(false),
+  _skip_detect_interior_parents(false),
   _allow_remote_element_removal(true),
   _allow_node_and_elem_unique_id_overlap(false),
   _spatial_dimension(d),
@@ -114,6 +115,7 @@ MeshBase::MeshBase (const MeshBase & other_mesh) :
   _skip_all_partitioning(other_mesh._skip_all_partitioning),
   _skip_renumber_nodes_and_elements(other_mesh._skip_renumber_nodes_and_elements),
   _skip_find_neighbors(other_mesh._skip_find_neighbors),
+  _skip_detect_interior_parents(other_mesh._skip_detect_interior_parents),
   _allow_remote_element_removal(other_mesh._allow_remote_element_removal),
   _allow_node_and_elem_unique_id_overlap(other_mesh._allow_node_and_elem_unique_id_overlap),
   _elem_dims(other_mesh._elem_dims),
@@ -202,6 +204,7 @@ MeshBase& MeshBase::operator= (MeshBase && other_mesh)
   _skip_all_partitioning = other_mesh.skip_partitioning();
   _skip_renumber_nodes_and_elements = !(other_mesh.allow_renumbering());
   _skip_find_neighbors = !(other_mesh.allow_find_neighbors());
+  _skip_detect_interior_parents = !(other_mesh.allow_detect_interior_parents());
   _allow_remote_element_removal = other_mesh.allow_remote_element_removal();
   _allow_node_and_elem_unique_id_overlap = other_mesh.allow_node_and_elem_unique_id_overlap();
   _block_id_to_name = std::move(other_mesh._block_id_to_name);
@@ -306,6 +309,8 @@ bool MeshBase::locally_equals (const MeshBase & other_mesh) const
   if (_skip_renumber_nodes_and_elements != other_mesh._skip_renumber_nodes_and_elements)
     return false;
   if (_skip_find_neighbors != other_mesh._skip_find_neighbors)
+    return false;
+  if (_skip_detect_interior_parents != other_mesh._skip_detect_interior_parents)
     return false;
   if (_allow_remote_element_removal != other_mesh._allow_remote_element_removal)
     return false;
@@ -921,7 +926,7 @@ void MeshBase::complete_preparation()
 
   // Search the mesh for elements that have a neighboring element
   // of dim+1 and set that element as the interior parent
-  if (!_preparation.has_interior_parent_ptrs)
+  if (!_preparation.has_interior_parent_ptrs && !_skip_detect_interior_parents)
     this->detect_interior_parents();
 
   // Fix up node unique ids in case mesh generation code didn't take

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -1974,6 +1974,8 @@ void MeshBase::detect_interior_parents()
 {
   LOG_SCOPE("detect_interior_parents()", "MeshBase");
 
+  libmesh_here();
+
   // This requires an inspection on every processor
   parallel_object_only();
 
@@ -2028,9 +2030,18 @@ void MeshBase::detect_interior_parents()
         }
     }
 
-  // There is nothing to do if all dimensions should be skipped.
+  libmesh_here();
+  libMesh::out << "skip_all_dimensions = " << skip_all_dimensions << std::endl;
+
+  // There is nothing to do if all dimensions should be
+  // skipped. Before returning, we must also set the flag that says
+  // "interior parent pointers have been set up" even though we
+  // determined there was no work to be done.
   if (skip_all_dimensions)
-    return;
+    {
+      _preparation.has_interior_parent_ptrs = true;
+      return;
+    }
 
   // Do we have interior parent pointers going to a different mesh?
   // If so then we'll still check to make sure that's the only place
@@ -2138,6 +2149,9 @@ void MeshBase::detect_interior_parents()
         }
     }
 
+  // This flag doesn't necessarily mean any Elems actually have
+  // interior parent pointers, just that we did all the work to
+  // determine whether or not they do.
   _preparation.has_interior_parent_ptrs = true;
 }
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -2041,7 +2041,15 @@ void MeshBase::detect_interior_parents()
 
       for (auto n : make_range(element->n_vertices()))
         {
-          std::vector<dof_id_type> & element_ids = node_to_elem[element->node_id(n)];
+          auto it = node_to_elem.find(element->node_id(n));
+          // Check at first that this node is not isolated.
+          if (it == node_to_elem.end())
+            {
+              found_interior_parents = false;
+              break;
+            }
+
+          std::vector<dof_id_type> & element_ids = it->second;
           for (const auto & eid : element_ids)
             if (this->elem_ref(eid).dim() == element->dim()+1)
               neighbors[n].insert(eid);

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -1959,13 +1959,16 @@ void MeshBase::detect_interior_parents()
   // This requires up-to-date mesh dimensions in cache
   libmesh_assert(_preparation.has_cached_elem_data);
 
-  // Check if the mesh contains mixed dimensions. If so, then we may
-  // have interior parents to set.  Otherwise return.
-  if (this->elem_dimensions().size() == 1)
+  // Early return if the mesh is empty or has elements of a single spatial dimension.
+  if (this->elem_dimensions().size() <= 1)
     {
       _preparation.has_interior_parent_ptrs = true;
       return;
     }
+
+  // Convenient elem_dimensions iterators
+  const auto dim_start = this->elem_dimensions().begin();
+  const auto dim_end = this->elem_dimensions().end();
 
   // In this function we find only +1 dimensional interior parents,
   // (so, for a given element el, the interior parent p must satisfy p.dim() == el.dim() + 1).
@@ -1973,7 +1976,7 @@ void MeshBase::detect_interior_parents()
   // for all those elements el such there there is no p with p.dim() == el.dim() + 1.
   // We store whether to skip any given dimension in the construction of interior parents
   // inside the vector in dimensions_to_skip_for_interior_parents.
-  std::vector<bool> skip_dimension_for_interior_parents(LIBMESH_DIM+1);  // all false by default
+  std::vector<bool> skip_dimension_for_interior_parents(/*count=*/LIBMESH_DIM+1, /*value=*/false);
   skip_dimension_for_interior_parents.back() = true;
 
   // Moreover, in the following, we will build a node-to-elem map.
@@ -1981,30 +1984,24 @@ void MeshBase::detect_interior_parents()
   // Therefore, we can skip all elems p such that there is no el with el.dim() == p.dim() - 1.
   // We store whether to skip any given dimension in the construction of the node-to-elem map
   // in the vector skip_dimensions_for_node_to_el_map.
-  std::vector<bool> skip_dimensions_for_node_to_el_map(LIBMESH_DIM+1);  // all false by default
-  skip_dimensions_for_node_to_el_map[*this->elem_dimensions().begin()] = true;
+  std::vector<bool> skip_dimensions_for_node_to_el_map(/*count=*/LIBMESH_DIM+1, /*value=*/false);
+  skip_dimensions_for_node_to_el_map[*dim_start] = true;
 
   // We also create a flag to know if all dimensions should be skipped,
   // and if we should therefore return early.
   bool skip_all_dimensions = true;
 
   // Fill dimensions_to_skip_for_interior_parents and dimensions_to_skip_for_node_to_el_map.
+  for (auto [it, next] = std::make_tuple(dim_start, std::next(dim_start));
+       next != dim_end; ++it, ++next)
     {
-      const std::set<unsigned char> & elem_dimensions = this->elem_dimensions();
-
-      auto it = elem_dimensions.begin();
-      auto next = std::next(it);
-
-      for (; next != elem_dimensions.end(); ++it, ++next)
+      if (*it + 1 != *next) // if sequential dimensions differ by exactly 1
         {
-          if (*it + 1 != *next) // note: elem_dimensions is already sorted
-            {
-              skip_dimension_for_interior_parents[*it] = true;
-              skip_dimensions_for_node_to_el_map[*next] = true;
-            }
-          else if (!skip_dimension_for_interior_parents[*it])
-            skip_all_dimensions = false;
+          skip_dimension_for_interior_parents[*it] = true;
+          skip_dimensions_for_node_to_el_map[*next] = true;
         }
+      else if (!skip_dimension_for_interior_parents[*it])
+        skip_all_dimensions = false;
     }
 
   // There is nothing to do if all dimensions should be

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1247,9 +1247,9 @@ bool valid_is_prepared (const MeshBase & mesh)
   bool old_allow_remote_element_removal = mesh_clone->allow_remote_element_removal();
   mesh_clone->allow_remote_element_removal(false);
 
-  bool old_allow_detect_interior_parents = mesh_clone->allow_detect_interior_parents();
-  libMesh::out << "old_allow_detect_interior_parents = " << old_allow_detect_interior_parents << std::endl;
-  mesh_clone->allow_detect_interior_parents(false);
+  // bool old_allow_detect_interior_parents = mesh_clone->allow_detect_interior_parents();
+  // libMesh::out << "old_allow_detect_interior_parents = " << old_allow_detect_interior_parents << std::endl;
+  // mesh_clone->allow_detect_interior_parents(false);
 
   // Other debugging suggests these flags don't match on the clone vs. the original mesh.
   // Note: Calling MeshBase::preparation() returns a copy of the internal Preparation object, so it is logically const.
@@ -1263,7 +1263,7 @@ bool valid_is_prepared (const MeshBase & mesh)
   mesh_clone->allow_renumbering(old_allow_renumbering);
   mesh_clone->skip_partitioning(old_skip_partitioning);
   mesh_clone->allow_remote_element_removal(old_allow_remote_element_removal);
-  mesh_clone->allow_detect_interior_parents(old_allow_detect_interior_parents);
+  // mesh_clone->allow_detect_interior_parents(old_allow_detect_interior_parents);
 
   libmesh_here();
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1229,8 +1229,6 @@ bool valid_is_prepared (const MeshBase & mesh)
 {
   LOG_SCOPE("valid_is_prepared()", "MeshTools");
 
-  libmesh_here();
-
   if (!mesh.is_prepared())
     return true;
 
@@ -1247,15 +1245,6 @@ bool valid_is_prepared (const MeshBase & mesh)
   bool old_allow_remote_element_removal = mesh_clone->allow_remote_element_removal();
   mesh_clone->allow_remote_element_removal(false);
 
-  // bool old_allow_detect_interior_parents = mesh_clone->allow_detect_interior_parents();
-  // libMesh::out << "old_allow_detect_interior_parents = " << old_allow_detect_interior_parents << std::endl;
-  // mesh_clone->allow_detect_interior_parents(false);
-
-  // Other debugging suggests these flags don't match on the clone vs. the original mesh.
-  // Note: Calling MeshBase::preparation() returns a copy of the internal Preparation object, so it is logically const.
-  libMesh::out << "mesh.preparation().has_interior_parent_ptrs = " << mesh.preparation().has_interior_parent_ptrs << std::endl;
-  libMesh::out << "mesh_clone->preparation().has_interior_parent_ptrs = " << mesh_clone->preparation().has_interior_parent_ptrs << std::endl;
-
   // Call prepare_for_use() on the clone
   mesh_clone->prepare_for_use();
 
@@ -1263,13 +1252,6 @@ bool valid_is_prepared (const MeshBase & mesh)
   mesh_clone->allow_renumbering(old_allow_renumbering);
   mesh_clone->skip_partitioning(old_skip_partitioning);
   mesh_clone->allow_remote_element_removal(old_allow_remote_element_removal);
-  // mesh_clone->allow_detect_interior_parents(old_allow_detect_interior_parents);
-
-  libmesh_here();
-
-  libMesh::out << "After prepare_for_use():" << std::endl;
-  libMesh::out << "mesh.preparation().has_interior_parent_ptrs = " << mesh.preparation().has_interior_parent_ptrs << std::endl;
-  libMesh::out << "mesh_clone->preparation().has_interior_parent_ptrs = " << mesh_clone->preparation().has_interior_parent_ptrs << std::endl;
 
   // Check whether the original and clone compare equal
   return (mesh == *mesh_clone);

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1229,6 +1229,8 @@ bool valid_is_prepared (const MeshBase & mesh)
 {
   LOG_SCOPE("valid_is_prepared()", "MeshTools");
 
+  libmesh_here();
+
   if (!mesh.is_prepared())
     return true;
 
@@ -1238,16 +1240,38 @@ bool valid_is_prepared (const MeshBase & mesh)
   // avoid false assertion failures)
   bool old_allow_renumbering = mesh_clone->allow_renumbering();
   mesh_clone->allow_renumbering(false);
-  bool old_allow_remote_element_removal =
-    mesh_clone->allow_remote_element_removal();
+
   bool old_skip_partitioning = mesh_clone->skip_partitioning();
   mesh_clone->skip_partitioning(true);
-  mesh_clone->allow_remote_element_removal(false);
-  mesh_clone->prepare_for_use();
-  mesh_clone->allow_renumbering(old_allow_renumbering);
-  mesh_clone->allow_remote_element_removal(old_allow_remote_element_removal);
-  mesh_clone->skip_partitioning(old_skip_partitioning);
 
+  bool old_allow_remote_element_removal = mesh_clone->allow_remote_element_removal();
+  mesh_clone->allow_remote_element_removal(false);
+
+  bool old_allow_detect_interior_parents = mesh_clone->allow_detect_interior_parents();
+  libMesh::out << "old_allow_detect_interior_parents = " << old_allow_detect_interior_parents << std::endl;
+  mesh_clone->allow_detect_interior_parents(false);
+
+  // Other debugging suggests these flags don't match on the clone vs. the original mesh.
+  // Note: Calling MeshBase::preparation() returns a copy of the internal Preparation object, so it is logically const.
+  libMesh::out << "mesh.preparation().has_interior_parent_ptrs = " << mesh.preparation().has_interior_parent_ptrs << std::endl;
+  libMesh::out << "mesh_clone->preparation().has_interior_parent_ptrs = " << mesh_clone->preparation().has_interior_parent_ptrs << std::endl;
+
+  // Call prepare_for_use() on the clone
+  mesh_clone->prepare_for_use();
+
+  // Restore original flag values
+  mesh_clone->allow_renumbering(old_allow_renumbering);
+  mesh_clone->skip_partitioning(old_skip_partitioning);
+  mesh_clone->allow_remote_element_removal(old_allow_remote_element_removal);
+  mesh_clone->allow_detect_interior_parents(old_allow_detect_interior_parents);
+
+  libmesh_here();
+
+  libMesh::out << "After prepare_for_use():" << std::endl;
+  libMesh::out << "mesh.preparation().has_interior_parent_ptrs = " << mesh.preparation().has_interior_parent_ptrs << std::endl;
+  libMesh::out << "mesh_clone->preparation().has_interior_parent_ptrs = " << mesh_clone->preparation().has_interior_parent_ptrs << std::endl;
+
+  // Check whether the original and clone compare equal
   return (mesh == *mesh_clone);
 }
 

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -105,6 +105,7 @@ ReplicatedMesh::ReplicatedMesh (const MeshBase & other_mesh) :
   this->copy_nodes_and_elements(other_mesh, true, 0, 0, 0, nullptr, true);
 
   this->allow_find_neighbors(other_mesh.allow_find_neighbors());
+  this->allow_detect_interior_parents(other_mesh.allow_detect_interior_parents());
   this->allow_renumbering(other_mesh.allow_renumbering());
   this->allow_remote_element_removal(other_mesh.allow_remote_element_removal());
   this->skip_partitioning(other_mesh.skip_partitioning());

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -888,9 +888,11 @@ void UnstructuredMesh::copy_nodes_and_elements(const MeshBase & other_mesh,
       const bool allowed_renumbering = this->allow_renumbering();
       const bool allowed_find_neighbors = this->allow_find_neighbors();
       const bool allowed_elem_removal = this->allow_remote_element_removal();
+      const bool allowed_detect_detect_interior_parents = this->allow_detect_interior_parents();
       this->allow_renumbering(false);
       this->allow_remote_element_removal(false);
       this->allow_find_neighbors(!skip_find_neighbors);
+      this->allow_detect_interior_parents(other_mesh.allow_detect_interior_parents());
 
       // We should generally be able to skip *all* partitioning here
       // because we're only adding one already-consistent mesh to
@@ -906,6 +908,7 @@ void UnstructuredMesh::copy_nodes_and_elements(const MeshBase & other_mesh,
       this->allow_renumbering(allowed_renumbering);
       this->allow_remote_element_removal(allowed_elem_removal);
       this->skip_partitioning(skipped_partitioning);
+      this->allow_detect_interior_parents(allowed_detect_detect_interior_parents);
 
       // That prepare_for_use() call marked us as prepared, but we
       // specifically avoided some important preparation, so we might not
@@ -1346,7 +1349,8 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
 void UnstructuredMesh::read (const std::string & name,
                              void *,
                              bool skip_renumber_nodes_and_elements,
-                             bool skip_find_neighbors)
+                             bool skip_find_neighbors,
+                             bool skip_detect_interior_parents)
 {
   // Set the skip_renumber_nodes_and_elements flag on all processors
   // if necessary.
@@ -1368,9 +1372,15 @@ void UnstructuredMesh::read (const std::string & name,
 
   // Done reading the mesh.  Now prepare it for use.
   const bool old_allow_find_neighbors = this->allow_find_neighbors();
+  const bool old_allow_detect_interior_parents = this->allow_detect_interior_parents();
+
   this->allow_find_neighbors(!skip_find_neighbors);
+  this->allow_detect_interior_parents(!skip_detect_interior_parents);
+
   this->prepare_for_use();
+
   this->allow_find_neighbors(old_allow_find_neighbors);
+  this->allow_detect_interior_parents(old_allow_detect_interior_parents);
 }
 
 


### PR DESCRIPTION
Given that an interior parent `p` of an element `el` must satisfy `p.dim() == el.dim() + 1`, 
we can skip some computations in `MeshBase::detect_interior_parents()`:

1. do not check the interior parents of elements `el` such that there is no `p` with `p.dim() == el.dim() + 1`,
2. do not fill the node-to-elem map of candidate interior parents `p` if there is no `el` with `el.dim() == p.dim() - 1`.

In models with many elements, especially building the node-to-elem map can be a bottleneck,
so optimization 2 may help easing the computational effort.