### PR TITLE
Actually check hull integrity

### DIFF
--- a/include/mesh/mesh_tet_interface.h
+++ b/include/mesh/mesh_tet_interface.h
@@ -105,25 +105,28 @@ protected:
 
   /**
    * This function checks the integrity of the current set of
-   * elements in the Mesh to see if they comprise a hull,
-   * that is:
+   * elements in the Mesh to see if they comprise a topological
+   * manifold that (if it's also geometrically valid) would define
+   * valid hull for a tetrahedralized volume.
+   * That is:
    * - If they are all TRI3 elements
    * - They all have non-nullptr neighbors
    *
    * \returns
-   * - 0 if the mesh forms a valid hull
+   * - 0 if the mesh forms a topologically valid hull
    * - 1 if a non-TRI3 element is found
    * - 2 if an element with a nullptr-neighbor is found
+   * - 3 if the mesh is empty
    */
-  unsigned check_hull_integrity();
+  [[nodiscard]] unsigned int check_hull_integrity();
 
   /**
-   * This function prints an informative message and
-   * crashes based on the output of the check_hull_integrity()
-   * function.  It is a separate function so that you
-   * can check hull integrity without crashing if you desire.
+   * This function prints an informative message and throws an
+   * exception based on the output of the check_hull_integrity()
+   * function.  It is a separate function so that you can check hull
+   * integrity without exiting or catching an exception if desired.
    */
-  void process_hull_integrity_result(unsigned result);
+  void process_hull_integrity_result(unsigned int result);
 
   /**
    * Delete original convex hull elements from the Mesh

--- a/src/mesh/mesh_netgen_interface.C
+++ b/src/mesh/mesh_netgen_interface.C
@@ -127,7 +127,8 @@ void NetGenMeshInterface::triangulate ()
       return;
     }
 
-  this->check_hull_integrity();
+  auto integrity = this->check_hull_integrity();
+  this->process_hull_integrity_result(integrity);
 
   Ng_Meshing_Parameters params;
 

--- a/src/mesh/mesh_tet_interface.C
+++ b/src/mesh/mesh_tet_interface.C
@@ -335,7 +335,7 @@ BoundingBox MeshTetInterface::volume_to_surface_mesh(UnstructuredMesh & mesh)
 }
 
 
-unsigned MeshTetInterface::check_hull_integrity()
+unsigned int MeshTetInterface::check_hull_integrity()
 {
   // Check for easy return: if the Mesh is empty (i.e. if
   // somebody called triangulate_conformingDelaunayMesh on
@@ -371,17 +371,28 @@ unsigned MeshTetInterface::check_hull_integrity()
 
 void MeshTetInterface::process_hull_integrity_result(unsigned result)
 {
+  std::ostringstream err_msg;
+
   if (result != 0)
     {
-      libMesh::err << "Error! Conforming Delaunay mesh tetrahedralization requires a convex hull." << std::endl;
+      err_msg << "Error! Conforming Delaunay mesh tetrahedralization requires a convex hull." << std::endl;
 
       if (result==1)
         {
-          libMesh::err << "Non-TRI3 elements were found in the input Mesh.  ";
-          libMesh::err << "A constrained Delaunay triangulation requires a convex hull of TRI3 elements." << std::endl;
+          err_msg << "Non-TRI3 elements were found in the input Mesh.  ";
+          err_msg << "A constrained Delaunay tetrahedralization requires a convex hull of TRI3 elements." << std::endl;
         }
 
-      libmesh_error_msg("Consider calling TetGenMeshInterface::pointset_convexhull() followed by Mesh::find_neighbors() first.");
+      if (result==2)
+        {
+          err_msg << "At least one triangle without three neighbors was found in the input Mesh.  ";
+          err_msg << "A constrained Delaunay tetrahedralization must be a triangular manifold without boundary." << std::endl;
+        }
+
+      if (result==3)
+        err_msg << "The input Mesh was empty!" << std::endl;
+
+      libmesh_error_msg(err_msg.str());
     }
 }
 


### PR DESCRIPTION
This fixes a very embarrassing bug in our Netgen interface error checking, namely that we weren't actually doing it.