### PR TITLE
Use is_effectively_ghosted() in PetscVector

### DIFF
--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -169,6 +169,19 @@ public:
   { return (this->n_processors()==1) || (_type == SERIAL); }
 
   /**
+   * \returns Whether the vector is effectively ghosted, i.e. whether
+   * vector operations require handling of ghosted coefficients.
+   *
+   * This is true for GHOSTED vectors in parallel, but in serial
+   * subclasses may return false here for GHOSTED vectors since every
+   * ghosted vector is effectively serial and thus may be able to take
+   * advantage of serial-specific code paths.
+   */
+
+  bool is_effectively_ghosted() const
+  { return (this->n_processors()!=1) && (_type == GHOSTED); }
+
+  /**
    * \returns The type (SERIAL, PARALLEL, GHOSTED) of the vector.
    *
    * \deprecated because it is dangerous to change the ParallelType

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -916,7 +916,7 @@ void PetscVector<T>::close ()
 
   VecAssemblyBeginEnd(this->comm(), _vec);
 
-  if (this->type() == GHOSTED)
+  if (this->is_effectively_ghosted())
     VecGhostUpdateBeginEnd(this->comm(), _vec, INSERT_VALUES, SCATTER_FORWARD);
 
   this->_is_closed = true;
@@ -961,7 +961,7 @@ void PetscVector<T>::zero ()
 
   PetscScalar z=0.;
 
-  if (this->type() != GHOSTED)
+  if (!this->is_effectively_ghosted())
     LibmeshPetscCall(VecSet (_vec, z));
   else
     {
@@ -1145,10 +1145,8 @@ T PetscVector<T>::operator() (const numeric_index_type i) const
   const numeric_index_type local_index = this->map_global_to_local_index(i);
 
 #ifndef NDEBUG
-  if (this->type() == GHOSTED)
-    {
-      libmesh_assert_less (local_index, _local_size);
-    }
+  if (this->is_effectively_ghosted())
+    libmesh_assert_less (local_index, _local_size);
 #endif
 
   return static_cast<T>(_read_only_values[local_index]);
@@ -1169,10 +1167,8 @@ void PetscVector<T>::get(const std::vector<numeric_index_type> & index,
     {
       const numeric_index_type local_index = this->map_global_to_local_index(index[i]);
 #ifndef NDEBUG
-      if (this->type() == GHOSTED)
-        {
-          libmesh_assert_less (local_index, _local_size);
-        }
+      if (this->is_effectively_ghosted())
+        libmesh_assert_less (local_index, _local_size);
 #endif
       values[i] = static_cast<T>(_read_only_values[local_index]);
     }

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -338,7 +338,7 @@ void PetscVector<T>::add (const T a_in, const NumericVector<T> & v_in)
   libmesh_assert(this->comm().verify(
       static_cast<typename std::underlying_type<ParallelType>::type>(this->type())));
 
-  if (this->type() == GHOSTED)
+  if (this->is_effectively_ghosted())
     VecGhostUpdateBeginEnd(this->comm(), _vec, INSERT_VALUES, SCATTER_FORWARD);
 
   this->_is_closed = true;
@@ -379,7 +379,7 @@ void PetscVector<T>::scale (const T factor_in)
   libmesh_assert(this->comm().verify(
       static_cast<typename std::underlying_type<ParallelType>::type>(this->type())));
 
-  if (this->type() == GHOSTED)
+  if (this->is_effectively_ghosted())
     VecGhostUpdateBeginEnd(this->comm(), _vec, INSERT_VALUES, SCATTER_FORWARD);
 }
 
@@ -421,7 +421,7 @@ void PetscVector<T>::abs()
   libmesh_assert(this->comm().verify(
       static_cast<typename std::underlying_type<ParallelType>::type>(this->type())));
 
-  if (this->type() == GHOSTED)
+  if (this->is_effectively_ghosted())
     VecGhostUpdateBeginEnd(this->comm(), _vec, INSERT_VALUES, SCATTER_FORWARD);
 }
 
@@ -486,7 +486,7 @@ PetscVector<T>::operator = (const T s_in)
       libmesh_assert(this->comm().verify(
           static_cast<typename std::underlying_type<ParallelType>::type>(this->type())));
 
-      if (this->type() == GHOSTED)
+      if (this->is_effectively_ghosted())
         VecGhostUpdateBeginEnd(this->comm(), _vec, INSERT_VALUES, SCATTER_FORWARD);
     }
 
@@ -569,7 +569,7 @@ PetscVector<T>::operator = (const PetscVector<T> & v)
   libmesh_assert(this->comm().verify(
       static_cast<typename std::underlying_type<ParallelType>::type>(this->type())));
 
-  if (this->type() == GHOSTED)
+  if (this->is_effectively_ghosted())
     VecGhostUpdateBeginEnd(this->comm(), _vec, INSERT_VALUES, SCATTER_FORWARD);
 
   this->_is_closed = true;
@@ -610,7 +610,7 @@ PetscVector<T>::operator = (const std::vector<T> & v)
     }
 
   // Make sure ghost dofs are up to date
-  if (this->type() == GHOSTED)
+  if (this->is_effectively_ghosted())
     this->close();
 
   return *this;
@@ -969,7 +969,7 @@ void PetscVector<T>::pointwise_mult (const NumericVector<T> & vec1,
   libmesh_assert(this->comm().verify(
       static_cast<typename std::underlying_type<ParallelType>::type>(this->type())));
 
-  if (this->type() == GHOSTED)
+  if (this->is_effectively_ghosted())
     VecGhostUpdateBeginEnd(this->comm(), _vec, INSERT_VALUES, SCATTER_FORWARD);
 
   this->_is_closed = true;
@@ -993,7 +993,7 @@ void PetscVector<T>::pointwise_divide (const NumericVector<T> & vec1,
   libmesh_assert(this->comm().verify(
       static_cast<typename std::underlying_type<ParallelType>::type>(this->type())));
 
-  if (this->type() == GHOSTED)
+  if (this->is_effectively_ghosted())
     VecGhostUpdateBeginEnd(this->comm(), _vec, INSERT_VALUES, SCATTER_FORWARD);
 
   this->_is_closed = true;
@@ -1056,7 +1056,7 @@ void PetscVector<T>::create_subvector(NumericVector<T> & subvector,
   parallel_object_only();
 
   libmesh_error_msg_if(
-      subvector.type() == GHOSTED && !subvector.is_effectively_serial(),
+      subvector.is_effectively_ghosted(),
       "We do not support scattering parallel information to ghosts for subvectors");
 
   this->_restore_array();
@@ -1184,7 +1184,7 @@ void PetscVector<T>::_get_array(bool read_only) const
       std::scoped_lock lock(_petsc_get_restore_array_mutex);
       if (!_array_is_present.load(std::memory_order_relaxed))
         {
-                  if (this->type() != GHOSTED)
+          if (!this->is_effectively_ghosted())
             {
               if (read_only)
                 {
@@ -1243,7 +1243,7 @@ void PetscVector<T>::_restore_array() const
       std::scoped_lock lock(_petsc_get_restore_array_mutex);
       if (_array_is_present.load(std::memory_order_relaxed))
         {
-                  if (this->type() != GHOSTED)
+          if (!this->is_effectively_ghosted())
             {
               if (_values_read_only)
                 LibmeshPetscCall(VecRestoreArrayRead (_vec, &_read_only_values));
@@ -1307,7 +1307,7 @@ PetscVector<T>::restore_subvector(std::unique_ptr<NumericVector<T>> subvector,
   Vec subvec = petsc_subvector->vec();
   LibmeshPetscCall(VecRestoreSubVector(_vec, parent_is, &subvec));
 
-  if (this->type() == GHOSTED)
+  if (this->is_effectively_ghosted())
     VecGhostUpdateBeginEnd(this->comm(), _vec, INSERT_VALUES, SCATTER_FORWARD);
 
   this->_is_closed = true;


### PR DESCRIPTION
Now that we're storing general metadata for a constructed PetscVector in type() but sometimes doing something different with our specific Vec object for efficiency, we need to have our Vec operations match the Vec, not the metadata.

This fixes a MOOSE regression for me, thanks to @loganharbour for pointing out the CI failure.