### PR TITLE
Fix for OSX clang++ warning

### DIFF
--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -235,7 +235,7 @@ public:
 
   virtual Real l1_norm () const override;
 
-  virtual Real frobenius_norm () const;
+  Real frobenius_norm () const;
 
   virtual Real linfty_norm () const override;
 


### PR DESCRIPTION
The compiler noticed (at least in my personal `--paranoid-warnings` builds) that we have a method marked `virtual` despite being in a class marked `final` from which we can never override it.  It kinda has a point.