### PR TITLE
Avoid AnalyticFunction segfaults in debug mode by asserting valid pointers

### DIFF
--- a/include/numerics/analytic_function.h
+++ b/include/numerics/analytic_function.h
@@ -111,7 +111,8 @@ inline
 Output AnalyticFunction<Output>::operator() (const Point & p,
                                              const Real time)
 {
-  libmesh_assert (this->initialized());
+  libmesh_assert(this->initialized());
+  libmesh_assert(_number_fptr);
   return (this->_number_fptr(p, time));
 }
 
@@ -123,7 +124,8 @@ void AnalyticFunction<Output>::operator() (const Point & p,
                                            const Real time,
                                            DenseVector<Output> & output)
 {
-  libmesh_assert (this->initialized());
+  libmesh_assert(this->initialized());
+  libmesh_assert(_vector_fptr);
   this->_vector_fptr(output, p, time);
   return;
 }

--- a/include/numerics/analytic_function.h
+++ b/include/numerics/analytic_function.h
@@ -112,7 +112,9 @@ Output AnalyticFunction<Output>::operator() (const Point & p,
                                              const Real time)
 {
   libmesh_assert(this->initialized());
-  libmesh_assert(_number_fptr);
+  libmesh_assert_msg(_number_fptr,
+                     "You must construct AnalyticFunction with a scalar-valued "
+                     "function in order to use this operator() override.");
   return (this->_number_fptr(p, time));
 }
 
@@ -125,7 +127,9 @@ void AnalyticFunction<Output>::operator() (const Point & p,
                                            DenseVector<Output> & output)
 {
   libmesh_assert(this->initialized());
-  libmesh_assert(_vector_fptr);
+  libmesh_assert_msg(_vector_fptr,
+                     "You must construct AnalyticFunction with a vector-valued "
+                     "function in order to use this operator() override.");
   this->_vector_fptr(output, p, time);
   return;
 }


### PR DESCRIPTION
There are two ways of constructing an `AnalyticFunction` (either with a scalar-valued or a vector-valued function), but `System::reinit_constraints()` expects to be able to use the latter. Previously, it was a segfault even in debug mode when you attempted to use a scalar-valued `AnalyticFunction`. With this patch, at least in debug mode, we now get an assert with a more informative error message.