### PR TITLE
Add runtime --enable-sigint option

### DIFF
--- a/include/base/libmesh_exceptions.h
+++ b/include/base/libmesh_exceptions.h
@@ -54,6 +54,11 @@ void enableFPE(bool on);
 void enableSEGV(bool on);
 
 /**
+ * Toggle libMesh handling of SIGINT (Ctrl+C) interrupts
+ */
+void enableSIGINT(bool on);
+
+/**
  * A class to represent the internal "this should never happen"
  * errors, to be thrown by "libmesh_error();"
  */

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -704,6 +704,9 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
   if (libMesh::on_command_line("--enable-segv"))
     libMesh::enableSEGV(true);
 
+  if (libMesh::on_command_line("--enable-sigint"))
+    libMesh::enableSIGINT(true);
+
 #if defined(LIBMESH_HAVE_HDF5) && !defined(_MSC_VER)
   // We may be running with ExodusII configured not to use HDF5 (in
   // which case user code which wants to lock files has to do flock()

--- a/src/base/libmesh_exceptions.C
+++ b/src/base/libmesh_exceptions.C
@@ -90,6 +90,12 @@ void libmesh_handleSEGV(int /*signo*/, siginfo_t * info, void * /*context*/)
                     << "  run ...\n"                                    \
                     << "  bt");
 }
+
+
+void libmesh_handleSIGINT(int /*signo*/, siginfo_t * /*info*/, void * /*context*/)
+{
+  libmesh_error_msg("Interrupt (Ctrl+C?) signaled!");
+}
 #endif
 } // anonymous namespace
 
@@ -249,6 +255,36 @@ void enableSEGV(bool on)
     {
       was_on = false;
       sigaction (SIGSEGV, &old_action, nullptr);
+    }
+#else
+  libmesh_error_msg("System call sigaction not supported.");
+#endif
+}
+
+
+// Enable handling of SIGINT (Ctrl+C) by libMesh
+void enableSIGINT(bool on)
+{
+#if LIBMESH_HAVE_DECL_SIGACTION
+  static struct sigaction old_action;
+  static bool was_on = false;
+
+  if (on)
+    {
+      struct sigaction new_action;
+      was_on = true;
+
+      // Set up the structure to specify the new action.
+      new_action.sa_sigaction = libmesh_handleSIGINT;
+      sigemptyset (&new_action.sa_mask);
+      new_action.sa_flags = SA_SIGINFO;
+
+      sigaction (SIGINT, &new_action, &old_action);
+    }
+  else if (was_on)
+    {
+      was_on = false;
+      sigaction (SIGINT, &old_action, nullptr);
     }
 #else
   libmesh_error_msg("System call sigaction not supported.");


### PR DESCRIPTION
It's useful to be able to still get a stack trace and PerfLog output after Ctrl+C.