### PR TITLE
Make l1_norm_diff multithreaded too

### DIFF
--- a/src/numerics/numeric_vector.C
+++ b/src/numerics/numeric_vector.C
@@ -654,13 +654,34 @@ Real NumericVector<T>::l1_norm_diff (const NumericVector<T> & v) const
 {
   libmesh_assert(this->compatible(v));
 
-  Real norm = 0;
-  for (const auto i : make_range(this->first_local_index(), this->last_local_index()))
-    norm += libMesh::l1_norm_diff((*this)(i), v(i));
+  struct L1Differ {
+    const NumericVector<T> & v1, & v2;
+    Real norm;
 
-  this->comm().sum(norm);
+    L1Differ (const NumericVector<T> & v1in,
+              const NumericVector<T> & v2in) :
+      v1(v1in), v2(v2in), norm(0) {}
 
-  return norm;
+    L1Differ (L1Differ & other, Threads::split) :
+      v1(other.v1), v2(other.v2), norm(0) {}
+
+    void operator()(const IntRange<numeric_index_type> & index_range) {
+      for (const auto i : index_range)
+        norm += libMesh::l1_norm_diff(v1(i), v2(i));
+    }
+
+    void join(const L1Differ & other) {
+      norm += other.norm;
+    }
+  };
+
+  L1Differ differ(*this, v);
+
+  Threads::parallel_reduce(make_range(this->first_local_index(), this->last_local_index()), differ);
+
+  this->comm().sum(differ.norm);
+
+  return differ.norm;
 }
 
 

--- a/src/numerics/numeric_vector.C
+++ b/src/numerics/numeric_vector.C
@@ -617,15 +617,15 @@ Real NumericVector<T>::l2_norm_diff (const NumericVector<T> & v) const
 {
   libmesh_assert(this->compatible(v));
 
-  struct Differ {
+  struct L2Differ {
     const NumericVector<T> & v1, & v2;
     Real norm_sq;
 
-    Differ (const NumericVector<T> & v1in,
-            const NumericVector<T> & v2in) :
+    L2Differ (const NumericVector<T> & v1in,
+              const NumericVector<T> & v2in) :
       v1(v1in), v2(v2in), norm_sq(0) {}
 
-    Differ (Differ & other, Threads::split) :
+    L2Differ (L2Differ & other, Threads::split) :
       v1(other.v1), v2(other.v2), norm_sq(0) {}
 
     void operator()(const IntRange<numeric_index_type> & index_range) {
@@ -633,12 +633,12 @@ Real NumericVector<T>::l2_norm_diff (const NumericVector<T> & v) const
         norm_sq += TensorTools::norm_sq(v1(i) - v2(i));
     }
 
-    void join(const Differ & other) {
+    void join(const L2Differ & other) {
       norm_sq += other.norm_sq;
     }
   };
 
-  Differ differ(*this, v);
+  L2Differ differ(*this, v);
 
   Threads::parallel_reduce(make_range(this->first_local_index(), this->last_local_index()), differ);
 


### PR DESCRIPTION
Easy enough, while we're at it.

Sadly, though, there just don't seem to be many *other* cases inside the library itself where the new Threads:: compatible IntRange buys us anything!  All our big non-linear-algebra workloads are over node ranges or elem ranges, and all our other big linear-algebra workloads are handled internal to the solver package!