### PR TITLE
Cached elem ranges

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -234,8 +234,7 @@ public:
    * consider ourself prepared.  This is a very coarse setting; it is
    * generally more efficient to mark finer-grained settings instead.
    */
-  void unset_is_prepared()
-  { _preparation = false; }
+  void unset_is_prepared();
 
   /**
    * Tells this we have done some operation creating unpartitioned

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -59,6 +59,8 @@ enum ElemMappingType : unsigned char;
 template <class MT>
 class MeshInput;
 
+template <typename iterator_type, typename object_type>
+class StoredRange;
 
 /**
  * This is the \p MeshBase class. This class provides all the data necessary
@@ -1856,6 +1858,36 @@ public:
   // solution can be evaluated for all variables of all given DoF maps
   ABSTRACT_NODE_ITERATORS(multi_evaluable_,std::vector<const DofMap *> dof_maps)
 
+  // Technically these define libMesh::MeshBase::*ElemRange, but since
+  // those don't conflict with libMesh::*ElemRange they're as good as
+  // a real forward declaration, which we can't do here.
+  typedef StoredRange<MeshBase::element_iterator,             Elem *>      ElemRange;
+  typedef StoredRange<MeshBase::const_element_iterator, const Elem *> ConstElemRange;
+
+  /**
+   * \returns A reference to a cached vector copy of a range of
+   * pointers to all semilocal elements, suitable for threading.
+   *
+   * Iterating over all semilocal elements is most useful for
+   * modifying the mesh, so we only have a non-const version for now.
+   */
+  const ElemRange & element_stored_range();
+
+  /**
+   * \returns A reference to a cached vector copy of a range of
+   * pointers to all active local elements, suitable for threading.
+   *
+   * Iterating over only local elements is most useful for computing
+   * on the mesh, so we only have a non-const version for now.
+   */
+  const ConstElemRange & active_local_element_stored_range() const;
+
+  /**
+   * Clears stored ranges, to indicate that the mesh has changed and
+   * they should be regenerated when next needed.
+   */
+  void clear_stored_ranges();
+
   /**
    * \returns A writable reference to the whole subdomain name map
    */
@@ -2128,6 +2160,27 @@ protected:
    * Flags indicating in what ways \p this mesh has been prepared.
    */
   Preparation _preparation;
+
+  /**
+   * A cached \p ElemRange for threaded mutation of all semilocal
+   * elements of this mesh.
+   *
+   * This will not actually be built unless needed. Further, since we
+   * want our \p elem_stored_range() method to be \p const (yet do the
+   * dynamic allocating) this needs to be mutable.
+   */
+  mutable std::unique_ptr<ElemRange> _element_stored_range;
+
+  /**
+   * A cached \p ConstElemRange for threaded calculation on all
+   * local elements of this mesh.
+   *
+   * This will not actually be built unless needed. Further, since we
+   * want our \p elem_stored_range() method to be \p const (yet do the
+   * dynamic allocating) this needs to be mutable.
+   */
+  mutable std::unique_ptr<ConstElemRange>
+    _const_active_local_element_stored_range;
 
   /**
    * A \p PointLocator class for this mesh.

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1319,10 +1319,11 @@ public:
   virtual void redistribute ();
 
   /**
-   * Recalculate any cached data after elements and nodes have been
+   * Recalculate any cached data (or invalidate any caches that are
+   * computed on the fly) after elements and nodes have been
    * repartitioned.
    */
-  virtual void update_post_partitioning () {}
+  virtual void update_post_partitioning ();
 
   /**
    * If false is passed in then this mesh will no longer be renumbered

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -38,24 +38,17 @@
 
 #include "libmesh/vector_value.h"
 
-// periodic boundary condition support
-// Use forward declarations inside the libMesh namespace
 namespace libMesh
 {
-  class PeriodicBoundary;
-  class PeriodicBoundaries;
-}
-
-namespace libMesh
-{
-
-// forward declarations
+// Forward declarations
+class BoundaryInfo;
 class Elem;
 class GhostingFunctor;
 class Node;
 class Point;
 class Partitioner;
-class BoundaryInfo;
+class PeriodicBoundary;
+class PeriodicBoundaries;
 
 template <typename T>
 class SparseMatrix;

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -523,12 +523,16 @@ void DofMap::reinit
       libmesh_assert (!node->get_old_dof_object());
     }
 
-  for (auto & elem : mesh.element_ptr_range())
-    {
-      elem->clear_old_dof_object();
-      libmesh_assert (!elem->get_old_dof_object());
-    }
-
+  Threads::parallel_for
+    (mesh.element_stored_range(),
+     [](const ElemRange & range)
+     {
+       for (Elem * elem : range)
+         {
+           elem->clear_old_dof_object();
+           libmesh_assert (!elem->get_old_dof_object());
+         }
+     });
 
   //------------------------------------------------------------
   // Set the old_dof_objects for the elements that
@@ -564,8 +568,13 @@ void DofMap::reinit
     node->set_n_vars_per_group(sys_num, n_vars_per_group);
 
   // All the elements
-  for (auto & elem : mesh.element_ptr_range())
-    elem->set_n_vars_per_group(sys_num, n_vars_per_group);
+  Threads::parallel_for
+    (mesh.element_stored_range(),
+     [sys_num, n_vars_per_group](const ElemRange & range)
+     {
+       for (Elem * elem : range)
+         elem->set_n_vars_per_group(sys_num, n_vars_per_group);
+     });
 
   // Zero _n_SCALAR_dofs, it will be updated below.
   this->_n_SCALAR_dofs = 0;

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -587,6 +587,11 @@ Elem * DistributedMesh::add_elem (Elem * e)
 
   _elements[e->id()] = e;
 
+  // We actually added a new element.  Some of our caches might still
+  // be valid, but we should clear the ones which definitely are not.
+  this->clear_point_locator();
+  this->clear_stored_ranges();
+
   // Try to make the cached elem data more accurate
   if (elem_procid == this->processor_id() ||
       elem_procid == DofObject::invalid_processor_id)
@@ -688,6 +693,11 @@ Elem * DistributedMesh::insert_elem (Elem * e)
 
   _elements[e->id()] = e;
 
+  // We actually added a new element.  Some of our caches might still
+  // be valid, but we should clear the ones which definitely are not.
+  this->clear_point_locator();
+  this->clear_stored_ranges();
+
   // Make sure any new element is given space for any extra integers
   // we've requested
   e->add_extra_integers(_elem_integer_names.size(),
@@ -740,6 +750,11 @@ void DistributedMesh::delete_elem(Elem * e)
 
   // delete the element
   delete e;
+
+  // Some of our caches might still be valid, but we should clear the
+  // ones which definitely are not.
+  this->clear_point_locator();
+  this->clear_stored_ranges();
 }
 
 
@@ -759,6 +774,12 @@ void DistributedMesh::renumber_elem(const dof_id_type old_id,
   libmesh_assert (!_elements[new_id]);
   _elements[new_id] = el;
   _elements.erase(old_id);
+
+  // Should we delete any caches here?  Our point locator indexes by
+  // element pointer and should be fine with an id change.  Our stored
+  // ranges are no longer sorted, which is *probably* fine, but let's
+  // just be safe.
+  this->clear_stored_ranges();
 }
 
 

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -1063,6 +1063,11 @@ void DistributedMesh::update_post_partitioning ()
 {
   // this->recalculate_n_partitions();
 
+  // Let's do the base class cache clearing first, just in case our
+  // later computations are ever changed to make use of a local
+  // elements range cache
+  this->MeshBase::update_post_partitioning();
+
   // Partitioning changes our numbers of unpartitioned objects
   this->update_parallel_id_counts();
 }

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -1054,6 +1054,15 @@ bool MeshBase::is_prepared() const
   return static_cast<bool>(_preparation);
 }
 
+
+void MeshBase::unset_is_prepared()
+{
+  _preparation = false;
+  this->clear_point_locator();
+  this->clear_stored_ranges();
+}
+
+
 void MeshBase::add_ghosting_functor(GhostingFunctor & ghosting_functor)
 {
   // We used to implicitly support duplicate inserts to std::set

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -2311,8 +2311,14 @@ Real MeshBase::get_point_locator_close_to_point_tol() const
 void MeshBase::size_elem_extra_integers()
 {
   const std::size_t new_size = _elem_integer_names.size();
-  for (auto elem : this->element_ptr_range())
-    elem->add_extra_integers(new_size, _elem_integer_default_values);
+
+  Threads::parallel_for
+    (this->element_stored_range(),
+     [new_size, this](const ElemRange & range)
+     {
+       for (Elem * elem : range)
+         elem->add_extra_integers(new_size, this->_elem_integer_default_values);
+     });
 }
 
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -41,6 +41,8 @@
 #include "libmesh/enum_to_string.h"
 #include "libmesh/point_locator_nanoflann.h"
 #include "libmesh/elem_side_builder.h"
+#include "libmesh/elem_range.h"
+#include "libmesh/node_range.h"
 
 // C++ includes
 #include <algorithm> // for std::min
@@ -67,6 +69,8 @@ MeshBase::MeshBase (const Parallel::Communicator & comm_in,
   _default_mapping_type(LAGRANGE_MAP),
   _default_mapping_data(0),
   _preparation (),
+  _element_stored_range (),
+  _const_active_local_element_stored_range (),
   _point_locator (),
   _count_lower_dim_elems_in_point_locator(true),
   _partitioner   (),
@@ -101,6 +105,8 @@ MeshBase::MeshBase (const MeshBase & other_mesh) :
   _default_mapping_type(other_mesh._default_mapping_type),
   _default_mapping_data(other_mesh._default_mapping_data),
   _preparation (other_mesh._preparation),
+  _element_stored_range (),
+  _const_active_local_element_stored_range (),
   _point_locator (),
   _count_lower_dim_elems_in_point_locator(other_mesh._count_lower_dim_elems_in_point_locator),
   _partitioner   (),
@@ -191,6 +197,8 @@ MeshBase& MeshBase::operator= (MeshBase && other_mesh)
   _default_mapping_type = other_mesh.default_mapping_type();
   _default_mapping_data = other_mesh.default_mapping_data();
   _preparation = other_mesh._preparation;
+  _element_stored_range = std::move(other_mesh._element_stored_range);
+  _const_active_local_element_stored_range = std::move(other_mesh._const_active_local_element_stored_range);
   _point_locator = std::move(other_mesh._point_locator);
   _count_lower_dim_elems_in_point_locator = other_mesh.get_count_lower_dim_elems_in_point_locator();
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
@@ -849,6 +857,7 @@ void MeshBase::prepare_for_use ()
   // Mark everything as unprepared, except for those things we've been
   // told we don't need to prepare, for backwards compatibility
   this->clear_point_locator();
+  this->clear_stored_ranges();
   _preparation = false;
   _preparation.has_neighbor_ptrs = _skip_find_neighbors;
   _preparation.has_removed_remote_elements = !_allow_remote_element_removal;
@@ -1036,6 +1045,7 @@ void MeshBase::clear ()
 
   // Clear our point locator.
   this->clear_point_locator();
+  this->clear_stored_ranges();
 }
 
 
@@ -1858,6 +1868,44 @@ subdomain_id_type MeshBase::get_id_by_name(std::string_view name) const
   // with the requested name, so return Elem::invalid_subdomain_id.
   return Elem::invalid_subdomain_id;
 }
+
+
+const ElemRange & MeshBase::element_stored_range()
+{
+  if (!_element_stored_range)
+  {
+    // Range construction may not be safe within threads
+    libmesh_assert(!Threads::in_threads);
+
+    _element_stored_range =
+      std::make_unique<ElemRange>(this->elements_begin(),
+                                  this->elements_end());
+  }
+
+  return *_element_stored_range;
+}
+
+const ConstElemRange & MeshBase::active_local_element_stored_range() const
+{
+  if (!_const_active_local_element_stored_range)
+  {
+    // Range construction may not be safe within threads
+    libmesh_assert(!Threads::in_threads);
+
+    _const_active_local_element_stored_range =
+      std::make_unique<ConstElemRange>(this->active_local_elements_begin(),
+                                  this->active_local_elements_end());
+  }
+
+  return *_const_active_local_element_stored_range;
+}
+
+void MeshBase::clear_stored_ranges()
+{
+  _element_stored_range.reset(nullptr);
+  _const_active_local_element_stored_range.reset(nullptr);
+}
+
 
 #ifdef LIBMESH_ENABLE_DEPRECATED
 void MeshBase::cache_elem_dims()

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -1170,6 +1170,16 @@ void MeshBase::redistribute()
 
 
 
+void MeshBase::update_post_partitioning()
+{
+  // A range over all elements might still be fine here, but any range
+  // over local elements is obsolete if our partitioner changed the
+  // definition of "local".
+  _const_active_local_element_stored_range.reset(nullptr);
+}
+
+
+
 subdomain_id_type MeshBase::n_subdomains() const
 {
   // This requires an inspection on every processor

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -547,14 +547,19 @@ void MeshBase::change_elemset_code(dof_id_type old_code, dof_id_type new_code)
   unsigned int elemset_index = this->get_elem_integer_index("elemset_code");
 
   // Loop over all elems and update code
-  for (auto & elem : this->element_ptr_range())
-    {
-      dof_id_type elemset_code =
-        elem->get_extra_integer(elemset_index);
+  Threads::parallel_for
+    (this->element_stored_range(),
+     [elemset_index, old_code, new_code](const ElemRange & range)
+     {
+       for (Elem * elem : range)
+         {
+           dof_id_type elemset_code =
+             elem->get_extra_integer(elemset_index);
 
-      if (elemset_code == old_code)
-        elem->set_extra_integer(elemset_index, new_code);
-    }
+           if (elemset_code == old_code)
+             elem->set_extra_integer(elemset_index, new_code);
+         }
+     });
 }
 
 void MeshBase::change_elemset_id(elemset_id_type old_id, elemset_id_type new_id)

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -1122,10 +1122,26 @@ void MeshBase::subdomain_ids (std::set<subdomain_id_type> & ids, const bool glob
   if (global)
     parallel_object_only();
 
-  ids.clear();
+  struct SBDInserter {
+    std::set<subdomain_id_type> my_ids;
 
-  for (const auto & elem : this->active_local_element_ptr_range())
-    ids.insert(elem->subdomain_id());
+    SBDInserter () {}
+    SBDInserter (SBDInserter &, Threads::split) {}
+
+    void operator()(const ConstElemRange & range) {
+      for (const Elem * elem : range)
+        my_ids.insert(elem->subdomain_id());
+    }
+
+    void join(SBDInserter & other) {
+      my_ids.merge(other.my_ids);
+    }
+  };
+
+  SBDInserter inserter;
+  Threads::parallel_reduce(this->active_local_element_stored_range(), inserter);
+
+  ids.swap(inserter.my_ids);
 
   if (global)
     {

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -30,6 +30,7 @@
 #include "libmesh/function_base.h"
 #include "libmesh/cell_tet4.h"
 #include "libmesh/cell_tet10.h"
+#include "libmesh/elem_range.h"
 #include "libmesh/face_tri3.h"
 #include "libmesh/face_tri6.h"
 #include "libmesh/libmesh_logging.h"
@@ -1758,11 +1759,14 @@ void MeshTools::Modification::change_subdomain_id (MeshBase & mesh,
       return;
     }
 
-  for (auto & elem : mesh.element_ptr_range())
-    {
-      if (elem->subdomain_id() == old_id)
-        elem->subdomain_id() = new_id;
-    }
+  Threads::parallel_for
+    (mesh.element_stored_range(),
+     [old_id, new_id](const ElemRange & range)
+     {
+       for (Elem * elem : range)
+         if (elem->subdomain_id() == old_id)
+           elem->subdomain_id() = new_id;
+     });
 
   // We just invalidated mesh.get_subdomain_ids(), but it might not be
   // efficient to fix that here.

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -722,20 +722,25 @@ bool MeshRefinement::refine_elements ()
 
   // Possibly clean up the refinement flags from
   // a previous step
-  for (auto & elem : _mesh.element_ptr_range())
-    {
-      // Set refinement flag to INACTIVE if the
-      // element isn't active
-      if (!elem->active())
-        {
-          elem->set_refinement_flag(Elem::INACTIVE);
-          elem->set_p_refinement_flag(Elem::INACTIVE);
-        }
+  Threads::parallel_for
+    (_mesh.element_stored_range(),
+     [](const ElemRange & range)
+     {
+       for (Elem * elem : range)
+         {
+           // Set refinement flag to INACTIVE if the
+           // element isn't active
+           if (!elem->active())
+             {
+               elem->set_refinement_flag(Elem::INACTIVE);
+               elem->set_p_refinement_flag(Elem::INACTIVE);
+             }
 
-      // This might be left over from the last step
-      if (elem->refinement_flag() == Elem::JUST_REFINED)
-        elem->set_refinement_flag(Elem::DO_NOTHING);
-    }
+           // This might be left over from the last step
+           if (elem->refinement_flag() == Elem::JUST_REFINED)
+             elem->set_refinement_flag(Elem::DO_NOTHING);
+         }
+     });
 
   // Parallel consistency has to come first, or coarsening
   // along processor boundaries might occasionally be falsely

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -491,42 +491,48 @@ bool MeshRefinement::refine_and_coarsen_elements ()
   // Possibly clean up the refinement flags from
   // a previous step.  While we're at it, see if this method should be
   // a no-op.
-  bool elements_flagged = false;
+  std::atomic<bool> elements_flagged{false};
 
-  for (auto & elem : _mesh.element_ptr_range())
-    {
-      // This might be left over from the last step
-      const Elem::RefinementState flag = elem->refinement_flag();
+  Threads::parallel_for
+    (_mesh.element_stored_range(),
+     [&elements_flagged](const ElemRange & range)
+     {
+       for (Elem * elem : range)
+         {
+           // This might be left over from the last step
+           const Elem::RefinementState flag = elem->refinement_flag();
 
-      // Set refinement flag to INACTIVE if the
-      // element isn't active
-      if ( !elem->active())
-        {
-          elem->set_refinement_flag(Elem::INACTIVE);
-          elem->set_p_refinement_flag(Elem::INACTIVE);
-        }
-      else if (flag == Elem::JUST_REFINED)
-        elem->set_refinement_flag(Elem::DO_NOTHING);
-      else if (!elements_flagged)
-        {
-          if (flag == Elem::REFINE || flag == Elem::COARSEN)
-            elements_flagged = true;
-          else
-            {
-              const Elem::RefinementState pflag =
-                elem->p_refinement_flag();
-              if (pflag == Elem::REFINE || pflag == Elem::COARSEN)
-                elements_flagged = true;
-            }
-        }
-    }
+           // Set refinement flag to INACTIVE if the
+           // element isn't active
+           if (!elem->active())
+             {
+               elem->set_refinement_flag(Elem::INACTIVE);
+               elem->set_p_refinement_flag(Elem::INACTIVE);
+             }
+           else if (flag == Elem::JUST_REFINED)
+             elem->set_refinement_flag(Elem::DO_NOTHING);
+           else if (!elements_flagged)
+             {
+               if (flag == Elem::REFINE || flag == Elem::COARSEN)
+                 elements_flagged = true;
+               else
+                 {
+                   const Elem::RefinementState pflag =
+                     elem->p_refinement_flag();
+                   if (pflag == Elem::REFINE || pflag == Elem::COARSEN)
+                     elements_flagged = true;
+                 }
+             }
+         }
+     });
 
   // Did *any* processor find elements flagged for AMR/C?
-  _mesh.comm().max(elements_flagged);
+  bool any_elements_flagged = elements_flagged;
+  _mesh.comm().max(any_elements_flagged);
 
   // If we have nothing to do, let's not bother verifying that nothing
   // is compatible with nothing.
-  if (!elements_flagged)
+  if (!any_elements_flagged)
     return false;
 
   // Parallel consistency has to come first, or coarsening

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -16,11 +16,6 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-#include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
-#include <cmath> // for isnan(), when it's defined
-#include <limits>
-
 // Local includes
 #include "libmesh/libmesh_config.h"
 
@@ -28,6 +23,7 @@
 #ifdef LIBMESH_ENABLE_AMR
 
 #include "libmesh/boundary_info.h"
+#include "libmesh/elem_range.h"
 #include "libmesh/error_vector.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_base.h"
@@ -49,6 +45,11 @@
 #include "libmesh/periodic_boundaries.h"
 #endif
 
+// C++ includes
+#include <atomic>
+#include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
+#include <cmath> // for isnan(), when it's defined
+#include <limits>
 
 
 // Anonymous namespace for helper functions
@@ -283,24 +284,29 @@ void MeshRefinement::create_parent_error_vector(const ErrorVector & error_per_ce
   // calculate local contributions to the parents' errors squared
   // first, then sum across processors and take the square roots
   // second.
-  for (auto & elem : _mesh.active_local_element_ptr_range())
-    {
-      Elem * parent = elem->parent();
+  Threads::parallel_for
+    (_mesh.active_local_element_stored_range(),
+     [&error_per_cell, &error_per_parent](const ConstElemRange & range)
+     {
+       for (const Elem * elem : range)
+         {
+           const Elem * parent = elem->parent();
 
-      // Calculate each contribution to parent cells
-      if (parent)
-        {
-          const dof_id_type parentid  = parent->id();
-          libmesh_assert_less (parentid, error_per_parent.size());
+           // Calculate each contribution to parent cells
+           if (parent)
+             {
+               const dof_id_type parentid  = parent->id();
+               libmesh_assert_less (parentid, error_per_parent.size());
 
-          // If the parent has grandchildren we won't be able to
-          // coarsen it, so forget it.  Otherwise, add this child's
-          // contribution to the sum of the squared child errors
-          if (error_per_parent[parentid] != -1.0)
-            error_per_parent[parentid] += (error_per_cell[elem->id()] *
-                                           error_per_cell[elem->id()]);
-        }
-    }
+               // If the parent has grandchildren we won't be able to
+               // coarsen it, so forget it.  Otherwise, add this child's
+               // contribution to the sum of the squared child errors
+               if (error_per_parent[parentid] != -1.0)
+                 error_per_parent[parentid] += (error_per_cell[elem->id()] *
+                                                error_per_cell[elem->id()]);
+             }
+         }
+     });
 
   // Sum the vector across all processors
   this->comm().sum(static_cast<std::vector<ErrorVectorReal> &>(error_per_parent));

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -628,20 +628,25 @@ bool MeshRefinement::coarsen_elements ()
 
   // Possibly clean up the refinement flags from
   // a previous step
-  for (auto & elem : _mesh.element_ptr_range())
-    {
-      // Set refinement flag to INACTIVE if the
-      // element isn't active
-      if (!elem->active())
-        {
-          elem->set_refinement_flag(Elem::INACTIVE);
-          elem->set_p_refinement_flag(Elem::INACTIVE);
-        }
+  Threads::parallel_for
+    (_mesh.element_stored_range(),
+     [](const ElemRange & range)
+     {
+       for (Elem * elem : range)
+         {
+           // Set refinement flag to INACTIVE if the
+           // element isn't active
+           if (!elem->active())
+             {
+               elem->set_refinement_flag(Elem::INACTIVE);
+               elem->set_p_refinement_flag(Elem::INACTIVE);
+             }
 
-      // This might be left over from the last step
-      if (elem->refinement_flag() == Elem::JUST_REFINED)
-        elem->set_refinement_flag(Elem::DO_NOTHING);
-    }
+           // This might be left over from the last step
+           if (elem->refinement_flag() == Elem::JUST_REFINED)
+             elem->set_refinement_flag(Elem::DO_NOTHING);
+         }
+     });
 
   // Parallel consistency has to come first, or coarsening
   // along processor boundaries might occasionally be falsely

--- a/src/mesh/mesh_tet_interface.C
+++ b/src/mesh/mesh_tet_interface.C
@@ -26,6 +26,7 @@
 
 #include "libmesh/boundary_info.h"
 #include "libmesh/elem.h"
+#include "libmesh/elem_range.h"
 #include "libmesh/mesh_modification.h"
 #include "libmesh/mesh_serializer.h"
 #include "libmesh/mesh_tools.h"
@@ -359,85 +360,111 @@ std::set<MeshTetInterface::SurfaceIntegrity> MeshTetInterface::check_hull_integr
                         std::abs(extents(0) * extents(2)) +
                         std::abs(extents(1) * extents(2));
 
-  for (auto & elem : this->_mesh.element_ptr_range())
-    {
-      // Check for proper element type
-      if (elem->type() != TRI3)
+  struct TriChecker {
+    std::set<MeshTetInterface::SurfaceIntegrity> my_returnval;
+    const Real my_ref_area;
+    const unsigned int my_verbosity;
+
+    TriChecker (Real ref_area, unsigned int verbosity) :
+      my_returnval(), my_ref_area(ref_area),
+      my_verbosity(verbosity) {}
+    TriChecker (TriChecker & other, Threads::split) :
+      my_returnval(), my_ref_area(other.my_ref_area),
+      my_verbosity(other.my_verbosity) {}
+
+    void operator()(const ConstElemRange & range) {
+
+      for (const Elem * elem : range)
         {
-          if (this->_verbosity >= 50)
-            std::cerr << "Non-Tri3: " << elem->get_info() << std::endl;
-          returnval.insert(NON_TRI3);
-        }
-
-      // Make sure it's a decent element.
-      if (elem->volume() < ref_area * TOLERANCE * TOLERANCE)
-        {
-          if (this->_verbosity >= 50)
-            std::cerr << "Degenerate element: " << elem->get_info() << std::endl;
-          returnval.insert(DEGENERATE_ELEMENT);
-        }
-
-      for (auto s : elem->side_index_range())
-        {
-          const Elem * const neigh = elem->neighbor_ptr(s);
-
-          if (neigh == nullptr)
+          // Check for proper element type
+          if (elem->type() != TRI3)
             {
-              if (this->_verbosity >= 50)
-                std::cerr << "Element missing neighbor " << s << ": " << elem->get_info() << std::endl;
-              returnval.insert(MISSING_NEIGHBOR);
-              continue;
+              if (my_verbosity >= 50)
+                std::cerr << "Non-Tri3: " << elem->get_info() << std::endl;
+              my_returnval.insert(NON_TRI3);
             }
 
-          // Make sure our neighbor points back to us
-          const unsigned int nn = neigh->which_neighbor_am_i(elem);
-
-          if (nn >= 3)
+          // Make sure it's a decent element.
+          if (elem->volume() < my_ref_area * TOLERANCE * TOLERANCE)
             {
-              if (this->_verbosity >= 50)
-                std::cerr << "Element missing backlink " << s << ": " << elem->get_info() << std::endl;
-              returnval.insert(MISSING_BACKLINK);
-              continue;
+              if (my_verbosity >= 50)
+                std::cerr << "Degenerate element: " << elem->get_info() << std::endl;
+              my_returnval.insert(DEGENERATE_ELEMENT);
             }
 
-          // Our neighbor should have the same the edge nodes we do on
-          // the neighboring edgei
-          const Node * const n1 = elem->node_ptr(s);
-          const Node * const n2 = elem->node_ptr((s+1)%3);
-
-          const unsigned int i1 = neigh->local_node(n1->id());
-          const unsigned int i2 = neigh->local_node(n2->id());
-          if (i1 >= 3 || i2 >= 3)
+          for (auto s : elem->side_index_range())
             {
-              if (this->_verbosity >= 50)
-                std::cerr << "Element with bad neighbor " << s << " nodes: " << elem->get_info() << std::endl;
-              returnval.insert(BAD_NEIGHBOR_NODES);
-              continue;
-            }
+              const Elem * const neigh = elem->neighbor_ptr(s);
 
-          // It should have those edge nodes in the opposite order
-          // (because they have the same orientation we do)
-          if ((i2 + 1)%3 != i1)
-            {
-              if (this->_verbosity >= 50)
-                std::cerr << "Element orientation mismatch with neighbor " << s << ": " << elem->get_info() << std::endl;
-              returnval.insert(NON_ORIENTED);
-              continue;
-            }
+              if (neigh == nullptr)
+                {
+                  if (my_verbosity >= 50)
+                    std::cerr << "Element missing neighbor " << s << ": " << elem->get_info() << std::endl;
+                  my_returnval.insert(MISSING_NEIGHBOR);
+                  continue;
+                }
 
-          // And it should have those edge nodes in the expected
-          // places relative to its neighbor link
-          if (i2 != nn)
-            {
-              if (this->_verbosity >= 50)
-                std::cerr << "Element with bad links on neighbor " << s << ": " << elem->get_info() << std::endl;
-              returnval.insert(BAD_NEIGHBOR_LINKS);
-              continue;
+              // Make sure our neighbor points back to us
+              const unsigned int nn = neigh->which_neighbor_am_i(elem);
+
+              if (nn >= 3)
+                {
+                  if (my_verbosity >= 50)
+                    std::cerr << "Element missing backlink " << s << ": " << elem->get_info() << std::endl;
+                  my_returnval.insert(MISSING_BACKLINK);
+                  continue;
+                }
+
+              // Our neighbor should have the same the edge nodes we do on
+              // the neighboring edgei
+              const Node * const n1 = elem->node_ptr(s);
+              const Node * const n2 = elem->node_ptr((s+1)%3);
+
+              const unsigned int i1 = neigh->local_node(n1->id());
+              const unsigned int i2 = neigh->local_node(n2->id());
+              if (i1 >= 3 || i2 >= 3)
+                {
+                  if (my_verbosity >= 50)
+                    std::cerr << "Element with bad neighbor " << s << " nodes: " << elem->get_info() << std::endl;
+                  my_returnval.insert(BAD_NEIGHBOR_NODES);
+                  continue;
+                }
+
+              // It should have those edge nodes in the opposite order
+              // (because they have the same orientation we do)
+              if ((i2 + 1)%3 != i1)
+                {
+                  if (my_verbosity >= 50)
+                    std::cerr << "Element orientation mismatch with neighbor " << s << ": " << elem->get_info() << std::endl;
+                  my_returnval.insert(NON_ORIENTED);
+                  continue;
+                }
+
+              // And it should have those edge nodes in the expected
+              // places relative to its neighbor link
+              if (i2 != nn)
+                {
+                  if (my_verbosity >= 50)
+                    std::cerr << "Element with bad links on neighbor " << s << ": " << elem->get_info() << std::endl;
+                  my_returnval.insert(BAD_NEIGHBOR_LINKS);
+                  continue;
+                }
             }
         }
     }
 
+    void join(TriChecker & other) {
+      my_returnval.merge(other.my_returnval);
+    }
+  };
+
+  TriChecker checker (ref_area, this->_verbosity);
+
+  Threads::parallel_reduce
+    (this->_mesh.active_local_element_stored_range(), checker);
+
   // Return anything and everything we found
+  returnval.merge(checker.my_returnval);
   return returnval;
 }
 

--- a/src/mesh/mesh_tet_interface.C
+++ b/src/mesh/mesh_tet_interface.C
@@ -33,6 +33,8 @@
 #include "libmesh/remote_elem.h"
 #include "libmesh/unstructured_mesh.h"
 
+#include "timpi/parallel_implementation.h"
+
 namespace {
   using namespace libMesh;
 
@@ -463,8 +465,21 @@ std::set<MeshTetInterface::SurfaceIntegrity> MeshTetInterface::check_hull_integr
   Threads::parallel_reduce
     (this->_mesh.active_local_element_stored_range(), checker);
 
-  // Return anything and everything we found
+  // Join problems found in threaded loop
   returnval.merge(checker.my_returnval);
+
+  // Join problems found on other ranks
+  std::set<char> int_set;
+  std::transform
+    (returnval.begin(), returnval.end(),
+     std::inserter<std::set<char>>(int_set, int_set.end()),
+     [](SurfaceIntegrity i){return int(i);});
+  _mesh.comm().set_union(int_set);
+  std::transform
+    (int_set.begin(), int_set.end(),
+     std::inserter<std::set<SurfaceIntegrity>>(returnval, returnval.end()),
+     [](int i){return SurfaceIntegrity(i);});
+
   return returnval;
 }
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -766,12 +766,29 @@ dof_id_type n_non_subactive_elem_of_type_at_level(const MeshBase & mesh,
 
 unsigned int n_active_local_levels(const MeshBase & mesh)
 {
-  unsigned int nl = 0;
+  struct LevelCounter {
+    unsigned int nl;
 
-  for (auto & elem : mesh.active_local_element_ptr_range())
-    nl = std::max(elem->level() + 1, nl);
+    LevelCounter () : nl(0) {}
 
-  return nl;
+    LevelCounter (LevelCounter &, Threads::split) :
+      nl(0) {}
+
+    void operator()(const ConstElemRange & range) {
+      for (const Elem * elem : range)
+        nl = std::max(elem->level() + 1, nl);
+    }
+
+    void join(const LevelCounter & other) {
+      nl = std::max(nl, other.nl);
+    }
+  };
+
+  LevelCounter counter;
+
+  Threads::parallel_reduce(mesh.active_local_element_stored_range(), counter);
+
+  return counter.nl;
 }
 
 

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -312,6 +312,11 @@ Elem * ReplicatedMesh::add_elem (Elem * e)
   ++_n_elem;
   _elements[id] = e;
 
+  // We actually added a new element.  Some of our caches might still
+  // be valid, but we should clear the ones which definitely are not.
+  this->clear_point_locator();
+  this->clear_stored_ranges();
+
   // Make sure any new element is given space for any extra integers
   // we've requested
   e->add_extra_integers(_elem_integer_names.size(),
@@ -355,6 +360,11 @@ Elem * ReplicatedMesh::insert_elem (Elem * e)
 
   ++_n_elem;
   _elements[eid] = e;
+
+  // We actually added a new element.  Some of our caches might still
+  // be valid, but we should clear the ones which definitely are not.
+  this->clear_point_locator();
+  this->clear_stored_ranges();
 
   // Make sure any new element is given space for any extra integers
   // we've requested
@@ -417,6 +427,11 @@ void ReplicatedMesh::delete_elem(Elem * e)
 
   // explicitly zero the pointer
   *pos = nullptr;
+
+  // Some of our caches might still be valid, but we should clear the
+  // ones which definitely are not.
+  this->clear_point_locator();
+  this->clear_stored_ranges();
 }
 
 
@@ -439,6 +454,12 @@ void ReplicatedMesh::renumber_elem(const dof_id_type old_id,
   libmesh_assert (!_elements[new_id]);
   _elements[new_id] = el;
   _elements[old_id] = nullptr;
+
+  // Should we delete any caches here?  Our point locator indexes by
+  // element pointer and should be fine with an id change.  Our stored
+  // ranges are no longer sorted, which is *probably* fine, but let's
+  // just be safe.
+  this->clear_stored_ranges();
 }
 
 

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -24,6 +24,7 @@
 #include "libmesh/unstructured_mesh.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/elem.h"
+#include "libmesh/elem_range.h"
 #include "libmesh/mesh_tools.h" // For n_levels
 #include "libmesh/parallel.h"
 #include "libmesh/remote_elem.h"
@@ -812,13 +813,19 @@ void UnstructuredMesh::copy_nodes_and_elements(const MeshBase & other_mesh,
     // that aren't to that same third mesh.
     if (!ip_map.empty())
       {
-        bool existing_interior_parents = false;
-        for (const auto & elem : this->element_ptr_range())
-          if (elem->interior_parent())
-            {
-              existing_interior_parents = true;
-              break;
-            }
+        std::atomic<bool> existing_interior_parents{false};
+
+        Threads::parallel_for
+          (this->element_stored_range(),
+           [&existing_interior_parents](const ElemRange & range)
+           {
+             for (Elem * elem : range)
+               if (elem->interior_parent())
+                 {
+                   existing_interior_parents = true;
+                   break;
+                 }
+           });
 
         MeshBase * other_interior_mesh =
           const_cast<MeshBase *>(&other_mesh.interior_mesh());

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -967,10 +967,15 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
 
   //TODO:[BSK] This should be removed later?!
   if (reset_current_list)
-    for (const auto & e : this->element_ptr_range())
-      for (auto s : e->side_index_range())
-        if (e->neighbor_ptr(s) != remote_elem || reset_remote_elements)
-          e->set_neighbor(s, nullptr);
+    Threads::parallel_for
+      (this->element_stored_range(),
+       [reset_remote_elements](const ElemRange & range)
+       {
+         for (Elem * e : range)
+           for (auto s : e->side_index_range())
+             if (e->neighbor_ptr(s) != remote_elem || reset_remote_elements)
+               e->set_neighbor(s, nullptr);
+       });
 
   // Find neighboring elements by first finding elements
   // with identical side keys and then check to see if they

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -392,6 +392,9 @@ void ParmetisPartitioner::initialize (const MeshBase & mesh,
              libmesh_assert_less (local_index, n_active_local_elem);
              libmesh_assert_less (local_index, _pmetis->vwgt.size());
 
+             libmesh_ignore(n_active_elem); // unused outside dbg/devel
+             libmesh_ignore(n_active_local_elem); // unused outside dbg/devel
+
              // Spline nodes are a special case (storing all the
              // unconstrained DoFs in an IGA simulation), but in general
              // we'll try to distribute work by expecting it to be roughly

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -23,6 +23,7 @@
 // libMesh includes
 #include "libmesh/libmesh_config.h"
 #include "libmesh/elem.h"
+#include "libmesh/elem_range.h"
 #include "libmesh/enum_partitioner_type.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_base.h"
@@ -32,6 +33,7 @@
 #include "libmesh/metis_partitioner.h"
 #include "libmesh/parallel_only.h"
 #include "libmesh/parmetis_helper.h"
+#include "libmesh/utility.h"
 
 // TIMPI includes
 #include "timpi/communicator.h"    // also includes mpi.h
@@ -373,48 +375,52 @@ void ParmetisPartitioner::initialize (const MeshBase & mesh,
 
     libmesh_assert_equal_to (subdomain_bounds.back(), n_active_elem);
 
-    for (const auto & elem : mesh.active_local_element_ptr_range())
-      {
-        libmesh_assert (_global_index_by_pid_map.count(elem->id()));
-        const dof_id_type global_index_by_pid =
-          _global_index_by_pid_map[elem->id()];
-        libmesh_assert_less (global_index_by_pid, n_active_elem);
+    Threads::parallel_for
+      (mesh.active_local_element_stored_range(),
+       [first_local_elem, n_active_elem, n_active_local_elem, this,
+        &global_index_map, &subdomain_bounds](const ConstElemRange & range)
+       {
+         for (const Elem * elem : range)
+           {
+             const dof_id_type global_index_by_pid =
+               libmesh_map_find(_global_index_by_pid_map, elem->id());
+             libmesh_assert_less (global_index_by_pid, n_active_elem);
 
-        const dof_id_type local_index =
-          global_index_by_pid - first_local_elem;
+             const dof_id_type local_index =
+               global_index_by_pid - first_local_elem;
 
-        libmesh_assert_less (local_index, n_active_local_elem);
-        libmesh_assert_less (local_index, _pmetis->vwgt.size());
+             libmesh_assert_less (local_index, n_active_local_elem);
+             libmesh_assert_less (local_index, _pmetis->vwgt.size());
 
-        // Spline nodes are a special case (storing all the
-        // unconstrained DoFs in an IGA simulation), but in general
-        // we'll try to distribute work by expecting it to be roughly
-        // proportional to DoFs, which are roughly proportional to
-        // nodes.
-        if (elem->type() == NODEELEM &&
-            elem->mapping_type() == RATIONAL_BERNSTEIN_MAP)
-          _pmetis->vwgt[local_index] = 50;
-        else
-          _pmetis->vwgt[local_index] = elem->n_nodes();
+             // Spline nodes are a special case (storing all the
+             // unconstrained DoFs in an IGA simulation), but in general
+             // we'll try to distribute work by expecting it to be roughly
+             // proportional to DoFs, which are roughly proportional to
+             // nodes.
+             if (elem->type() == NODEELEM &&
+                 elem->mapping_type() == RATIONAL_BERNSTEIN_MAP)
+               _pmetis->vwgt[local_index] = 50;
+             else
+               _pmetis->vwgt[local_index] = elem->n_nodes();
 
-        // find the subdomain this element belongs in
-        libmesh_assert (global_index_map.count(elem->id()));
-        const dof_id_type global_index =
-          global_index_map[elem->id()];
+             // find the subdomain this element belongs in
+             const dof_id_type global_index =
+               libmesh_map_find(global_index_map, elem->id());
 
-        libmesh_assert_less (global_index, subdomain_bounds.back());
+             libmesh_assert_less (global_index, subdomain_bounds.back());
 
-        const unsigned int subdomain_id =
-          cast_int<unsigned int>
-          (std::distance(subdomain_bounds.begin(),
-                         std::lower_bound(subdomain_bounds.begin(),
-                                          subdomain_bounds.end(),
-                                          global_index)));
-        libmesh_assert_less (subdomain_id, _pmetis->nparts);
-        libmesh_assert_less (local_index, _pmetis->part.size());
+             const unsigned int subdomain_id =
+               cast_int<unsigned int>
+               (std::distance(subdomain_bounds.begin(),
+                              std::lower_bound(subdomain_bounds.begin(),
+                                               subdomain_bounds.end(),
+                                               global_index)));
+             libmesh_assert_less (subdomain_id, _pmetis->nparts);
+             libmesh_assert_less (local_index, _pmetis->part.size());
 
-        _pmetis->part[local_index] = subdomain_id;
-      }
+             _pmetis->part[local_index] = subdomain_id;
+           }
+       });
   }
 }
 

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -110,8 +110,13 @@ void EquationSystems::reinit_mesh ()
   for (auto & node : _mesh.node_ptr_range())
     node->set_n_systems(n_sys);
 
-  for (auto & elem : _mesh.element_ptr_range())
-    elem->set_n_systems(n_sys);
+  Threads::parallel_for
+    (_mesh.element_stored_range(),
+     [n_sys](const ElemRange & range)
+     {
+       for (Elem * elem : range)
+         elem->set_n_systems(n_sys);
+     });
 
   //for (auto i : make_range(this->n_systems()))
     //this->get_system(i).init();

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -1764,8 +1764,13 @@ void EquationSystems::_add_system_to_nodes_and_elems()
     node->add_system();
 
   // All the elements
-  for (auto & elem : _mesh.element_ptr_range())
-    elem->add_system();
+  Threads::parallel_for
+    (_mesh.element_stored_range(),
+     [](const ElemRange & range)
+     {
+       for (Elem * elem : range)
+         elem->add_system();
+     });
 }
 
 void EquationSystems::_remove_default_ghosting(unsigned int sys_num)

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -158,8 +158,13 @@ bool EquationSystems::reinit_solutions ()
       node->set_n_systems(n_sys);
 
     // All the elements
-    for (auto & elem : _mesh.element_ptr_range())
-      elem->set_n_systems(n_sys);
+    Threads::parallel_for
+      (_mesh.element_stored_range(),
+       [n_sys](const ElemRange & range)
+       {
+         for (Elem * elem : range)
+           elem->set_n_systems(n_sys);
+       });
   }
 
   // Localize each system's vectors

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -1215,9 +1215,6 @@ EquationSystems::build_parallel_elemental_solution_vector (std::vector<std::stri
 
       NumericVector<Number> & sys_soln(*system.current_local_solution);
 
-      // The DOF indices for the finite element
-      std::vector<dof_id_type> dof_indices;
-
       const unsigned int var = var_num.second;
 
       const Variable & variable = system.variable(var);
@@ -1231,18 +1228,29 @@ EquationSystems::build_parallel_elemental_solution_vector (std::vector<std::stri
         (system.variable_type(var) == type[1]) ? _mesh.spatial_dimension() : 1;
 
       // Loop over all elements in the mesh and index all components of the variable if it's active
-      for (const auto & elem : _mesh.active_local_element_ptr_range())
-        if (variable.active_on_subdomain(elem->subdomain_id()))
-          {
-            dof_map.dof_indices(elem, dof_indices, var);
+      Threads::parallel_for
+        (_mesh.active_local_element_stored_range(),
+         [&dof_map, &variable, ne, var, var_ctr, n_comps,
+         &parallel_soln, &sys_soln](const ConstElemRange & range)
+         {
+           // The DOF indices for the finite element
+           std::vector<dof_id_type> dof_indices;
 
-            // The number of DOF components needs to be equal to the expected number so that we know
-            // where to store data to correctly correspond to variable names.
-            libmesh_assert_equal_to(dof_indices.size(), n_comps);
+           for (const Elem * elem : range)
+             {
+               if (variable.active_on_subdomain(elem->subdomain_id()))
+                 {
+                   dof_map.dof_indices(elem, dof_indices, var);
 
-            for (unsigned int comp = 0; comp < n_comps; comp++)
-              parallel_soln.set(ne * (var_ctr + comp) + elem->id(), sys_soln(dof_indices[comp]));
-          }
+                   // The number of DOF components needs to be equal to the expected number so that we know
+                   // where to store data to correctly correspond to variable names.
+                   libmesh_assert_equal_to(dof_indices.size(), n_comps);
+
+                   for (unsigned int comp = 0; comp < n_comps; comp++)
+                     parallel_soln.set(ne * (var_ctr + comp) + elem->id(), sys_soln(dof_indices[comp]));
+                 }
+             }
+         });
 
       var_ctr += n_comps;
     } // end loop over var_nums

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -290,8 +290,13 @@ void EquationSystems::allgather ()
   for (auto & node : _mesh.node_ptr_range())
     node->set_n_systems(n_sys);
 
-  for (auto & elem : _mesh.element_ptr_range())
-    elem->set_n_systems(n_sys);
+  Threads::parallel_for
+    (_mesh.element_stored_range(),
+     [n_sys](const ElemRange & range)
+     {
+       for (Elem * elem : range)
+         elem->set_n_systems(n_sys);
+     });
 
   // And distribute each system's dofs
   for (auto i : make_range(this->n_systems()))

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -37,11 +37,6 @@
 namespace {
 using namespace libMesh;
 
-// give this guy some scope since there
-// is underlying vector allocation upon
-// creation/deletion
-ConstElemRange elem_range;
-
 typedef Threads::spin_mutex femsystem_mutex;
 femsystem_mutex assembly_mutex;
 
@@ -943,8 +938,7 @@ void FEMSystem::assembly (bool get_residual, bool get_jacobian,
   // Build the residual and jacobian contributions on every active
   // mesh element on this processor
   Threads::parallel_for
-    (elem_range.reset(mesh.active_local_elements_begin(),
-                      mesh.active_local_elements_end()),
+    (mesh.active_local_element_stored_range(),
      AssemblyContributions(*this, get_residual, get_jacobian,
                            apply_heterogeneous_constraints,
                            apply_no_constraints));
@@ -1137,8 +1131,7 @@ void FEMSystem::postprocess ()
   this->get_time_solver().set_is_adjoint(false);
 
   // Loop over every active mesh element on this processor
-  Threads::parallel_for (elem_range.reset(mesh.active_local_elements_begin(),
-                                          mesh.active_local_elements_end()),
+  Threads::parallel_for (mesh.active_local_element_stored_range(),
                          PostprocessContributions(*this));
 }
 
@@ -1165,8 +1158,7 @@ void FEMSystem::assemble_qoi (const QoISet & qoi_indices)
   QoIContributions qoi_contributions(*this, *(this->get_qoi()), qoi_indices);
 
   // Loop over every active mesh element on this processor
-  Threads::parallel_reduce(elem_range.reset(mesh.active_local_elements_begin(),
-                                            mesh.active_local_elements_end()),
+  Threads::parallel_reduce(mesh.active_local_element_stored_range(),
                            qoi_contributions);
 
   std::vector<Number> global_qoi = this->get_qoi_values();
@@ -1193,8 +1185,7 @@ void FEMSystem::assemble_qoi_derivative (const QoISet & qoi_indices,
       this->add_adjoint_rhs(i).zero();
 
   // Loop over every active mesh element on this processor
-  Threads::parallel_for (elem_range.reset(mesh.active_local_elements_begin(),
-                                          mesh.active_local_elements_end()),
+  Threads::parallel_for (mesh.active_local_element_stored_range(),
                          QoIDerivativeContributions(*this, qoi_indices,
                                                     *(this->get_qoi()),
                                                     include_liftfunc,

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1471,15 +1471,20 @@ void System::zero_variable (NumericVector<Number> & v,
     }
 
   // Loop over elements.
-  for (const auto & elem : mesh.active_local_element_ptr_range())
-    {
-      unsigned int n_comp = elem->n_comp(sys_num,var_num);
-      for (unsigned int i=0; i<n_comp; i++)
-        {
-          const dof_id_type index = elem->dof_number(sys_num,var_num,i);
-          v.set(index,0.0);
-        }
-    }
+  Threads::parallel_for
+    (mesh.active_local_element_stored_range(),
+     [sys_num, var_num, &v](const ConstElemRange & range)
+     {
+       for (const Elem * elem : range)
+         {
+           unsigned int n_comp = elem->n_comp(sys_num,var_num);
+           for (unsigned int i=0; i<n_comp; i++)
+             {
+               const dof_id_type index = elem->dof_number(sys_num,var_num,i);
+               v.set(index,0.0);
+             }
+         }
+     });
 }
 
 


### PR DESCRIPTION
These make it much easier for us to do threading, by simplifying the developer code, and much easier for the CPU to do threading, by amortizing the range creation over more than just a single thread block.

For applications which use ElemRange and can switch to the cached ranges (FEMSystem, hopefully MOOSE soon) this ought to be free, but I could be persuaded that we shouldn't merge this until after eliminating the overhead for other applications in the single-thread-per-rank case.

I'm pretty happy with the simplicity of `parallel_for` code combined with lambda functions here, but `parallel_reduce` is still a bit more hassle than I'd like.

I've tested this with 16-threads each on 4 ranks, with pthreads, but I could be talked into not merging until I build and try it out on TBB too.