### PR TITLE
side_vertex_average_normal p-refinement compatibility fix

### DIFF
--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -3518,6 +3518,7 @@ Elem::side_vertex_average_normal(const unsigned int s) const
   const std::unique_ptr<const Elem> face = this->build_side_ptr(s);
   std::unique_ptr<libMesh::FEBase> fe(
       libMesh::FEBase::build(dim, libMesh::FEType(this->default_order())));
+  fe->add_p_level_in_reinit(false); // Yes, really use the default order
   const std::vector<Point> & normals = fe->get_normals();
   std::vector<Point> ref_side_vertex_average_v = {face->reference_elem()->vertex_average()};
   fe->reinit(this, s, TOLERANCE, &ref_side_vertex_average_v);

--- a/tests/geom/side_vertex_average_normal_test.C
+++ b/tests/geom/side_vertex_average_normal_test.C
@@ -31,12 +31,12 @@ public:
   LIBMESH_CPPUNIT_TEST_SUITE( SideVertexAverageNormalTest );
   CPPUNIT_TEST( testEdge2 );
   CPPUNIT_TEST( testEdge3 );
-  CPPUNIT_TEST( testTri3 );
-  CPPUNIT_TEST( testQuad4 );
-  CPPUNIT_TEST( testTet4 );
-  CPPUNIT_TEST( testPyramid5 );
-  CPPUNIT_TEST( testPrism6 );
-  CPPUNIT_TEST( testHex8 );
+  CPPUNIT_TEST( testTris );
+  CPPUNIT_TEST( testQuads );
+  CPPUNIT_TEST( testTets );
+  CPPUNIT_TEST( testPyramids );
+  CPPUNIT_TEST( testPrisms );
+  CPPUNIT_TEST( testHexes );
   CPPUNIT_TEST( testC0Polygon );
   CPPUNIT_TEST( testC0Polyhedron );
   CPPUNIT_TEST_SUITE_END();
@@ -108,20 +108,26 @@ public:
     }
   }
 
-  void testTri3()
+
+  void testTris()
   {
     LOG_UNIT_TEST;
 
-    {
-      // Reference
-      const Elem & tri3 = ReferenceElem::get(TRI3);
-      const Point n1 = tri3.side_vertex_average_normal(0);
-      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n1, TOLERANCE*TOLERANCE);
-      const Point n2 = tri3.side_vertex_average_normal(1);
-      LIBMESH_ASSERT_REALVEC_EQUAL((unit_x+unit_y).unit(), n2, TOLERANCE*TOLERANCE);
-      const Point n3 = tri3.side_vertex_average_normal(2);
-      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n3, TOLERANCE*TOLERANCE);
-    }
+    // Reference elements
+    const Elem * tris[] = {&ReferenceElem::get(TRI3),
+                           &ReferenceElem::get(TRI6),
+                           &ReferenceElem::get(TRI7)};
+
+    for (const Elem * tri : tris)
+      {
+        const Point n1 = tri->side_vertex_average_normal(0);
+        LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n1, TOLERANCE*TOLERANCE);
+        const Point n2 = tri->side_vertex_average_normal(1);
+        LIBMESH_ASSERT_REALVEC_EQUAL((unit_x+unit_y).unit(), n2, TOLERANCE*TOLERANCE);
+        const Point n3 = tri->side_vertex_average_normal(2);
+        LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n3, TOLERANCE*TOLERANCE);
+      }
+
     {
       // General shape
       std::vector<Point> pts = {Point(1, 0, 0), Point(1, 1, 0), Point(0, 3, 1)};
@@ -135,22 +141,26 @@ public:
     }
   }
 
-  void testQuad4()
+  void testQuads()
   {
     LOG_UNIT_TEST;
 
-    {
-      // Reference
-      const Elem & quad4 = ReferenceElem::get(QUAD4);
-      const Point n1 = quad4.side_vertex_average_normal(0);
-      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n1, TOLERANCE*TOLERANCE);
-      const Point n2 = quad4.side_vertex_average_normal(1);
-      LIBMESH_ASSERT_REALVEC_EQUAL(unit_x, n2, TOLERANCE*TOLERANCE);
-      const Point n3 = quad4.side_vertex_average_normal(2);
-      LIBMESH_ASSERT_REALVEC_EQUAL(unit_y, n3, TOLERANCE*TOLERANCE);
-      const Point n4 = quad4.side_vertex_average_normal(3);
-      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n4, TOLERANCE*TOLERANCE);
-    }
+    // Reference
+    const Elem * quads[] = {&ReferenceElem::get(QUAD4),
+                            &ReferenceElem::get(QUAD8),
+                            &ReferenceElem::get(QUAD9)};
+
+    for (const Elem * quad : quads)
+      {
+        const Point n1 = quad->side_vertex_average_normal(0);
+        LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n1, TOLERANCE*TOLERANCE);
+        const Point n2 = quad->side_vertex_average_normal(1);
+        LIBMESH_ASSERT_REALVEC_EQUAL(unit_x, n2, TOLERANCE*TOLERANCE);
+        const Point n3 = quad->side_vertex_average_normal(2);
+        LIBMESH_ASSERT_REALVEC_EQUAL(unit_y, n3, TOLERANCE*TOLERANCE);
+        const Point n4 = quad->side_vertex_average_normal(3);
+        LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n4, TOLERANCE*TOLERANCE);
+      }
 
     {
       // Planar, general shape
@@ -194,84 +204,102 @@ public:
   }
 
 
-  void testTet4()
+  void testTets()
   {
     LOG_UNIT_TEST;
 
-    {
-      // Reference
-      const Elem & tet4 = ReferenceElem::get(TET4);
-      const Point n1 = tet4.side_vertex_average_normal(0);
-      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_z, n1, TOLERANCE*TOLERANCE);
-      const Point n2 = tet4.side_vertex_average_normal(1);
-      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n2, TOLERANCE*TOLERANCE);
-      const Point n3 = tet4.side_vertex_average_normal(2);
-      LIBMESH_ASSERT_REALVEC_EQUAL((unit_x+unit_y+unit_z).unit(), n3, TOLERANCE*TOLERANCE);
-      const Point n4 = tet4.side_vertex_average_normal(3);
-      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n4, TOLERANCE*TOLERANCE);
-    }
+    // Reference
+    const Elem * tets[] = {&ReferenceElem::get(TET4),
+                           &ReferenceElem::get(TET10),
+                           &ReferenceElem::get(TET14)};
+
+    for (const Elem * tet : tets)
+      {
+        const Point n1 = tet->side_vertex_average_normal(0);
+        LIBMESH_ASSERT_REALVEC_EQUAL(-unit_z, n1, TOLERANCE*TOLERANCE);
+        const Point n2 = tet->side_vertex_average_normal(1);
+        LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n2, TOLERANCE*TOLERANCE);
+        const Point n3 = tet->side_vertex_average_normal(2);
+        LIBMESH_ASSERT_REALVEC_EQUAL((unit_x+unit_y+unit_z).unit(), n3, TOLERANCE*TOLERANCE);
+        const Point n4 = tet->side_vertex_average_normal(3);
+        LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n4, TOLERANCE*TOLERANCE);
+      }
   }
 
-  void testPyramid5()
+  void testPyramids()
   {
     LOG_UNIT_TEST;
 
-    {
-      // Reference
-      const Elem & pyr5 = ReferenceElem::get(PYRAMID5);
-      const Point n1 = pyr5.side_vertex_average_normal(0);
-      LIBMESH_ASSERT_REALVEC_EQUAL((-unit_y+unit_z).unit(), n1, TOLERANCE*TOLERANCE);
-      const Point n2 = pyr5.side_vertex_average_normal(1);
-      LIBMESH_ASSERT_REALVEC_EQUAL((unit_x+unit_z).unit(), n2, TOLERANCE*TOLERANCE);
-      const Point n3 = pyr5.side_vertex_average_normal(2);
-      LIBMESH_ASSERT_REALVEC_EQUAL((unit_y+unit_z).unit(), n3, TOLERANCE*TOLERANCE);
-      const Point n4 = pyr5.side_vertex_average_normal(3);
-      LIBMESH_ASSERT_REALVEC_EQUAL((-unit_x+unit_z).unit(), n4, TOLERANCE*TOLERANCE);
-      const Point n5 = pyr5.side_vertex_average_normal(4);
-      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_z, n5, TOLERANCE*TOLERANCE);
-    }
+    // Reference
+    const Elem * pyrs[] = {&ReferenceElem::get(PYRAMID5),
+                           &ReferenceElem::get(PYRAMID13),
+                           &ReferenceElem::get(PYRAMID14),
+                           &ReferenceElem::get(PYRAMID18)};
+
+    for (const Elem * pyr : pyrs)
+      {
+        const Point n1 = pyr->side_vertex_average_normal(0);
+        LIBMESH_ASSERT_REALVEC_EQUAL((-unit_y+unit_z).unit(), n1, TOLERANCE*TOLERANCE);
+        const Point n2 = pyr->side_vertex_average_normal(1);
+        LIBMESH_ASSERT_REALVEC_EQUAL((unit_x+unit_z).unit(), n2, TOLERANCE*TOLERANCE);
+        const Point n3 = pyr->side_vertex_average_normal(2);
+        LIBMESH_ASSERT_REALVEC_EQUAL((unit_y+unit_z).unit(), n3, TOLERANCE*TOLERANCE);
+        const Point n4 = pyr->side_vertex_average_normal(3);
+        LIBMESH_ASSERT_REALVEC_EQUAL((-unit_x+unit_z).unit(), n4, TOLERANCE*TOLERANCE);
+        const Point n5 = pyr->side_vertex_average_normal(4);
+        LIBMESH_ASSERT_REALVEC_EQUAL(-unit_z, n5, TOLERANCE*TOLERANCE);
+      }
   }
 
-  void testPrism6()
+  void testPrisms()
   {
     LOG_UNIT_TEST;
 
-    {
-      // Reference
-      const Elem & pri6 = ReferenceElem::get(PRISM6);
-      const Point n1 = pri6.side_vertex_average_normal(0);
-      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_z, n1, TOLERANCE*TOLERANCE);
-      const Point n2 = pri6.side_vertex_average_normal(1);
-      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n2, TOLERANCE*TOLERANCE);
-      const Point n3 = pri6.side_vertex_average_normal(2);
-      LIBMESH_ASSERT_REALVEC_EQUAL((unit_x+unit_y).unit(), n3, TOLERANCE*TOLERANCE);
-      const Point n4 = pri6.side_vertex_average_normal(3);
-      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n4, TOLERANCE*TOLERANCE);
-      const Point n5 = pri6.side_vertex_average_normal(4);
-      LIBMESH_ASSERT_REALVEC_EQUAL(unit_z, n5, TOLERANCE*TOLERANCE);
-    }
+    // Reference
+    const Elem * pris[] = {&ReferenceElem::get(PRISM6),
+                           &ReferenceElem::get(PRISM15),
+                           &ReferenceElem::get(PRISM18),
+                           &ReferenceElem::get(PRISM20),
+                           &ReferenceElem::get(PRISM21)};
+
+    for (const Elem * pri : pris)
+      {
+        const Point n1 = pri->side_vertex_average_normal(0);
+        LIBMESH_ASSERT_REALVEC_EQUAL(-unit_z, n1, TOLERANCE*TOLERANCE);
+        const Point n2 = pri->side_vertex_average_normal(1);
+        LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n2, TOLERANCE*TOLERANCE);
+        const Point n3 = pri->side_vertex_average_normal(2);
+        LIBMESH_ASSERT_REALVEC_EQUAL((unit_x+unit_y).unit(), n3, TOLERANCE*TOLERANCE);
+        const Point n4 = pri->side_vertex_average_normal(3);
+        LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n4, TOLERANCE*TOLERANCE);
+        const Point n5 = pri->side_vertex_average_normal(4);
+        LIBMESH_ASSERT_REALVEC_EQUAL(unit_z, n5, TOLERANCE*TOLERANCE);
+      }
   }
 
-  void testHex8()
+  void testHexes()
   {
     LOG_UNIT_TEST;
 
-    {
-      // Reference
-      const Elem & hex8 = ReferenceElem::get(HEX8);
-      const Point n1 = hex8.side_vertex_average_normal(0);
-      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_z, n1, TOLERANCE*TOLERANCE);
-      const Point n2 = hex8.side_vertex_average_normal(1);
-      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n2, TOLERANCE*TOLERANCE);
-      const Point n3 = hex8.side_vertex_average_normal(2);
-      LIBMESH_ASSERT_REALVEC_EQUAL(unit_x, n3, TOLERANCE*TOLERANCE);
-      const Point n4 = hex8.side_vertex_average_normal(3);
-      LIBMESH_ASSERT_REALVEC_EQUAL(unit_y, n4, TOLERANCE*TOLERANCE);
-      const Point n5 = hex8.side_vertex_average_normal(4);
-      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n5, TOLERANCE*TOLERANCE);
-      const Point n6 = hex8.side_vertex_average_normal(5);
-      LIBMESH_ASSERT_REALVEC_EQUAL(unit_z, n6, TOLERANCE*TOLERANCE);
-    }
+    const Elem * hexes[] = {&ReferenceElem::get(HEX8),
+                            &ReferenceElem::get(HEX20),
+                            &ReferenceElem::get(HEX27)};
+
+    for (const Elem * hex : hexes)
+      {
+        const Point n1 = hex->side_vertex_average_normal(0);
+        LIBMESH_ASSERT_REALVEC_EQUAL(-unit_z, n1, TOLERANCE*TOLERANCE);
+        const Point n2 = hex->side_vertex_average_normal(1);
+        LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n2, TOLERANCE*TOLERANCE);
+        const Point n3 = hex->side_vertex_average_normal(2);
+        LIBMESH_ASSERT_REALVEC_EQUAL(unit_x, n3, TOLERANCE*TOLERANCE);
+        const Point n4 = hex->side_vertex_average_normal(3);
+        LIBMESH_ASSERT_REALVEC_EQUAL(unit_y, n4, TOLERANCE*TOLERANCE);
+        const Point n5 = hex->side_vertex_average_normal(4);
+        LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n5, TOLERANCE*TOLERANCE);
+        const Point n6 = hex->side_vertex_average_normal(5);
+        LIBMESH_ASSERT_REALVEC_EQUAL(unit_z, n6, TOLERANCE*TOLERANCE);
+      }
 
     {
       // Non-planar quad faces

--- a/tests/geom/side_vertex_average_normal_test.C
+++ b/tests/geom/side_vertex_average_normal_test.C
@@ -42,6 +42,10 @@ public:
   CPPUNIT_TEST_SUITE_END();
 
 public:
+  const RealVectorValue unit_x{1};
+  const RealVectorValue unit_y{0,1};
+  const RealVectorValue unit_z{0,0,1};
+
   void setUp()
   {
   }
@@ -58,26 +62,18 @@ public:
       // Reference
       const Elem & edge2 = ReferenceElem::get(EDGE2);
       const Point n1 = edge2.side_vertex_average_normal(0);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n1(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n1, TOLERANCE*TOLERANCE);
       const Point n2 = edge2.side_vertex_average_normal(1);
-      LIBMESH_ASSERT_FP_EQUAL(1, n2(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_x, n2, TOLERANCE*TOLERANCE);
     }
     {
       // Oriented
       std::vector<Point> pts = {Point(1, 0, 0), Point(1, 3, 0)};
       auto [edge2, nodes] = this->construct_elem(pts, EDGE2);
       const Point n1 = edge2->side_vertex_average_normal(0);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n1(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n1, TOLERANCE*TOLERANCE);
       const Point n2 = edge2->side_vertex_average_normal(1);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(1, n2(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_y, n2, TOLERANCE*TOLERANCE);
     }
   }
 
@@ -89,13 +85,9 @@ public:
       // Reference
       const Elem & edge3 = ReferenceElem::get(EDGE3);
       const Point n1 = edge3.side_vertex_average_normal(0);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n1(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n1, TOLERANCE*TOLERANCE);
       const Point n2 = edge3.side_vertex_average_normal(1);
-      LIBMESH_ASSERT_FP_EQUAL(1, n2(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_x, n2, TOLERANCE*TOLERANCE);
     }
 
     {
@@ -111,9 +103,7 @@ public:
         fe->attach_quadrature_rule(&qface);
         fe->reinit(edge3.get(), s, TOLERANCE);
         const Point n1 = edge3->side_vertex_average_normal(s);
-        LIBMESH_ASSERT_FP_EQUAL(normals[0](0), n1(0), TOLERANCE*TOLERANCE);
-        LIBMESH_ASSERT_FP_EQUAL(normals[0](1), n1(1), TOLERANCE*TOLERANCE);
-        LIBMESH_ASSERT_FP_EQUAL(normals[0](2), n1(2), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_REALVEC_EQUAL(normals[0], n1, TOLERANCE*TOLERANCE);
       }
     }
   }
@@ -126,34 +116,22 @@ public:
       // Reference
       const Elem & tri3 = ReferenceElem::get(TRI3);
       const Point n1 = tri3.side_vertex_average_normal(0);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n1(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n1, TOLERANCE*TOLERANCE);
       const Point n2 = tri3.side_vertex_average_normal(1);
-      LIBMESH_ASSERT_FP_EQUAL(sqrt(2) / 2, n2(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(sqrt(2) / 2, n2(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL((unit_x+unit_y).unit(), n2, TOLERANCE*TOLERANCE);
       const Point n3 = tri3.side_vertex_average_normal(2);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n3(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n3(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n3(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n3, TOLERANCE*TOLERANCE);
     }
     {
       // General shape
       std::vector<Point> pts = {Point(1, 0, 0), Point(1, 1, 0), Point(0, 3, 1)};
       auto [tri3, nodes] = this->construct_elem(pts, TRI3);
       const Point n1 = tri3->side_vertex_average_normal(0);
-      LIBMESH_ASSERT_FP_EQUAL(sqrt(2) / 2, n1(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-sqrt(2) / 2, n1(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL((unit_x-unit_z).unit(), n1, TOLERANCE*TOLERANCE);
       const Point n2 = tri3->side_vertex_average_normal(1);
-      LIBMESH_ASSERT_FP_EQUAL(1. / sqrt(3), n2(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(1. / sqrt(3), n2(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1. / sqrt(3), n2(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL((unit_x+unit_y-unit_z).unit(), n2, TOLERANCE*TOLERANCE);
       const Point n3 = tri3->side_vertex_average_normal(2);
-      LIBMESH_ASSERT_FP_EQUAL(-3. / sqrt(22), n3(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-2. / sqrt(22), n3(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(3. / sqrt(22), n3(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL((-3*unit_x-2*unit_y+3*unit_z).unit(), n3, TOLERANCE*TOLERANCE);
     }
   }
 
@@ -165,21 +143,13 @@ public:
       // Reference
       const Elem & quad4 = ReferenceElem::get(QUAD4);
       const Point n1 = quad4.side_vertex_average_normal(0);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n1(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n1, TOLERANCE*TOLERANCE);
       const Point n2 = quad4.side_vertex_average_normal(1);
-      LIBMESH_ASSERT_FP_EQUAL(1, n2(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_x, n2, TOLERANCE*TOLERANCE);
       const Point n3 = quad4.side_vertex_average_normal(2);
-      LIBMESH_ASSERT_FP_EQUAL(0, n3(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(1, n3(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n3(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_y, n3, TOLERANCE*TOLERANCE);
       const Point n4 = quad4.side_vertex_average_normal(3);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n4(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n4(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n4(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n4, TOLERANCE*TOLERANCE);
     }
 
     {
@@ -187,21 +157,13 @@ public:
       std::vector<Point> pts = {Point(1, 0, 0), Point(1, 3, 0), Point(-1, -1, 0), Point(0, -1, 0)};
       auto [quad4, nodes] = this->construct_elem(pts, QUAD4);
       const Point n1 = quad4->side_vertex_average_normal(0);
-      LIBMESH_ASSERT_FP_EQUAL(1, n1(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_x, n1, TOLERANCE*TOLERANCE);
       const Point n2 = quad4->side_vertex_average_normal(1);
-      LIBMESH_ASSERT_FP_EQUAL(-2 / sqrt(5), n2(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(1 / sqrt(5), n2(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL((-2*unit_x+unit_y).unit(), n2, TOLERANCE*TOLERANCE);
       const Point n3 = quad4->side_vertex_average_normal(2);
-      LIBMESH_ASSERT_FP_EQUAL(0, n3(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n3(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n3(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n3, TOLERANCE*TOLERANCE);
       const Point n4 = quad4->side_vertex_average_normal(3);
-      LIBMESH_ASSERT_FP_EQUAL(1 / sqrt(2), n4(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1 / sqrt(2), n4(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n4(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL((unit_x-unit_y).unit(), n4, TOLERANCE*TOLERANCE);
     }
 
     {
@@ -209,21 +171,13 @@ public:
       std::vector<Point> pts = {Point(0, 0, 0), Point(1, 0, 1), Point(1, 1, 0), Point(0, 1, 1)};
       auto [quad4, nodes] = this->construct_elem(pts, QUAD4);
       const Point n1 = quad4->side_vertex_average_normal(0);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n1(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n1, TOLERANCE*TOLERANCE);
       const Point n2 = quad4->side_vertex_average_normal(1);
-      LIBMESH_ASSERT_FP_EQUAL(1, n2(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_x, n2, TOLERANCE*TOLERANCE);
       const Point n3 = quad4->side_vertex_average_normal(2);
-      LIBMESH_ASSERT_FP_EQUAL(0, n3(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(1, n3(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n3(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_y, n3, TOLERANCE*TOLERANCE);
       const Point n4 = quad4->side_vertex_average_normal(3);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n4(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n4(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n4(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n4, TOLERANCE*TOLERANCE);
     }
 
     {
@@ -234,9 +188,7 @@ public:
       {
         const Point n1 = quad4->side_vertex_average_normal(s);
         const Point normal = quad4->Elem::side_vertex_average_normal(s);
-        LIBMESH_ASSERT_FP_EQUAL(normal(0), n1(0), TOLERANCE*TOLERANCE);
-        LIBMESH_ASSERT_FP_EQUAL(normal(1), n1(1), TOLERANCE*TOLERANCE);
-        LIBMESH_ASSERT_FP_EQUAL(normal(2), n1(2), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_REALVEC_EQUAL(normal, n1, TOLERANCE*TOLERANCE);
       }
     }
   }
@@ -250,21 +202,13 @@ public:
       // Reference
       const Elem & tet4 = ReferenceElem::get(TET4);
       const Point n1 = tet4.side_vertex_average_normal(0);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n1(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_z, n1, TOLERANCE*TOLERANCE);
       const Point n2 = tet4.side_vertex_average_normal(1);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n2(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n2, TOLERANCE*TOLERANCE);
       const Point n3 = tet4.side_vertex_average_normal(2);
-      LIBMESH_ASSERT_FP_EQUAL(1./sqrt(3), n3(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(1./sqrt(3), n3(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(1./sqrt(3), n3(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL((unit_x+unit_y+unit_z).unit(), n3, TOLERANCE*TOLERANCE);
       const Point n4 = tet4.side_vertex_average_normal(3);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n4(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n4(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n4(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n4, TOLERANCE*TOLERANCE);
     }
   }
 
@@ -276,25 +220,15 @@ public:
       // Reference
       const Elem & pyr5 = ReferenceElem::get(PYRAMID5);
       const Point n1 = pyr5.side_vertex_average_normal(0);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-sqrt(2) / 2, n1(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(sqrt(2) / 2, n1(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL((-unit_y+unit_z).unit(), n1, TOLERANCE*TOLERANCE);
       const Point n2 = pyr5.side_vertex_average_normal(1);
-      LIBMESH_ASSERT_FP_EQUAL(sqrt(2) / 2, n2(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(sqrt(2) / 2, n2(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL((unit_x+unit_z).unit(), n2, TOLERANCE*TOLERANCE);
       const Point n3 = pyr5.side_vertex_average_normal(2);
-      LIBMESH_ASSERT_FP_EQUAL(0, n3(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(sqrt(2) / 2, n3(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(sqrt(2) / 2, n3(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL((unit_y+unit_z).unit(), n3, TOLERANCE*TOLERANCE);
       const Point n4 = pyr5.side_vertex_average_normal(3);
-      LIBMESH_ASSERT_FP_EQUAL(-sqrt(2) / 2, n4(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n4(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(sqrt(2) / 2, n4(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL((-unit_x+unit_z).unit(), n4, TOLERANCE*TOLERANCE);
       const Point n5 = pyr5.side_vertex_average_normal(4);
-      LIBMESH_ASSERT_FP_EQUAL(0, n5(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n5(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n5(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_z, n5, TOLERANCE*TOLERANCE);
     }
   }
 
@@ -306,25 +240,15 @@ public:
       // Reference
       const Elem & pri6 = ReferenceElem::get(PRISM6);
       const Point n1 = pri6.side_vertex_average_normal(0);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n1(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_z, n1, TOLERANCE*TOLERANCE);
       const Point n2 = pri6.side_vertex_average_normal(1);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n2(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n2, TOLERANCE*TOLERANCE);
       const Point n3 = pri6.side_vertex_average_normal(2);
-      LIBMESH_ASSERT_FP_EQUAL(sqrt(2) / 2, n3(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(sqrt(2) / 2, n3(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n3(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL((unit_x+unit_y).unit(), n3, TOLERANCE*TOLERANCE);
       const Point n4 = pri6.side_vertex_average_normal(3);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n4(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n4(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n4(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n4, TOLERANCE*TOLERANCE);
       const Point n5 = pri6.side_vertex_average_normal(4);
-      LIBMESH_ASSERT_FP_EQUAL(0, n5(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n5(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(1, n5(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_z, n5, TOLERANCE*TOLERANCE);
     }
   }
 
@@ -336,29 +260,17 @@ public:
       // Reference
       const Elem & hex8 = ReferenceElem::get(HEX8);
       const Point n1 = hex8.side_vertex_average_normal(0);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n1(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_z, n1, TOLERANCE*TOLERANCE);
       const Point n2 = hex8.side_vertex_average_normal(1);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n2(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n2, TOLERANCE*TOLERANCE);
       const Point n3 = hex8.side_vertex_average_normal(2);
-      LIBMESH_ASSERT_FP_EQUAL(1, n3(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n3(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n3(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_x, n3, TOLERANCE*TOLERANCE);
       const Point n4 = hex8.side_vertex_average_normal(3);
-      LIBMESH_ASSERT_FP_EQUAL(0, n4(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(1, n4(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n4(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_y, n4, TOLERANCE*TOLERANCE);
       const Point n5 = hex8.side_vertex_average_normal(4);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n5(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n5(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n5(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n5, TOLERANCE*TOLERANCE);
       const Point n6 = hex8.side_vertex_average_normal(5);
-      LIBMESH_ASSERT_FP_EQUAL(0, n6(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n6(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(1, n6(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_z, n6, TOLERANCE*TOLERANCE);
     }
 
     {
@@ -375,9 +287,7 @@ public:
         fe->attach_quadrature_rule(&qface);
         fe->reinit(hex8.get(), s, TOLERANCE);
         const Point n1 = hex8->side_vertex_average_normal(s);
-        LIBMESH_ASSERT_FP_EQUAL(normals[0](0), n1(0), TOLERANCE*TOLERANCE);
-        LIBMESH_ASSERT_FP_EQUAL(normals[0](1), n1(1), TOLERANCE*TOLERANCE);
-        LIBMESH_ASSERT_FP_EQUAL(normals[0](2), n1(2), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_REALVEC_EQUAL(normals[0], n1, TOLERANCE*TOLERANCE);
       }
     }
   }
@@ -390,50 +300,30 @@ public:
       std::vector<Point> pts = {Point(0, 0, 0), Point(1, 0, 0), Point(1, 1, 0), Point(0, 1, 0)};
       auto [square, nodes] = this->construct_elem(pts, C0POLYGON);
       const Point n1 = square->side_vertex_average_normal(0);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n1(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n1, TOLERANCE*TOLERANCE);
       const Point n2 = square->side_vertex_average_normal(1);
-      LIBMESH_ASSERT_FP_EQUAL(1, n2(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_x, n2, TOLERANCE*TOLERANCE);
       const Point n3 = square->side_vertex_average_normal(2);
-      LIBMESH_ASSERT_FP_EQUAL(0, n3(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(1, n3(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n3(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_y, n3, TOLERANCE*TOLERANCE);
       const Point n4 = square->side_vertex_average_normal(3);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n4(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n4(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n4(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n4, TOLERANCE*TOLERANCE);
     }
     {
       // Hexagon (not the ref one but an easy one to draw)
       std::vector<Point> pts = {Point(0, 0, 0), Point(1, 0, 0), Point(1.5, 1, 0), Point(1, 2, 0), Point(0, 2, 0) , Point(-0.5, 1, 0)};
       auto [hexagon, nodes] = this->construct_elem(pts, C0POLYGON);
       const Point n1 = hexagon->side_vertex_average_normal(0);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n1(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n1, TOLERANCE*TOLERANCE);
       const Point n2 = hexagon->side_vertex_average_normal(1);
-      LIBMESH_ASSERT_FP_EQUAL(2 / sqrt(5), n2(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1 / sqrt(5), n2(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL((2*unit_x-unit_y).unit(), n2, TOLERANCE*TOLERANCE);
       const Point n3 = hexagon->side_vertex_average_normal(2);
-      LIBMESH_ASSERT_FP_EQUAL(2 / sqrt(5), n3(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(1 / sqrt(5), n3(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n3(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL((2*unit_x+unit_y).unit(), n3, TOLERANCE*TOLERANCE);
       const Point n4 = hexagon->side_vertex_average_normal(3);
-      LIBMESH_ASSERT_FP_EQUAL(0, n4(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(1, n4(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n4(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_y, n4, TOLERANCE*TOLERANCE);
       const Point n5 = hexagon->side_vertex_average_normal(4);
-      LIBMESH_ASSERT_FP_EQUAL(-2 / sqrt(5), n5(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(1 / sqrt(5), n5(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n5(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL((-2*unit_x+unit_y).unit(), n5, TOLERANCE*TOLERANCE);
       const Point n6 = hexagon->side_vertex_average_normal(5);
-      LIBMESH_ASSERT_FP_EQUAL(-2 / sqrt(5), n6(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1 / sqrt(5), n6(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n6(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL((-2*unit_x-unit_y).unit(), n6, TOLERANCE*TOLERANCE);
     }
     {
       // Non-planar quad (see quad unit test)
@@ -453,9 +343,7 @@ public:
         fe->attach_quadrature_rule(&qface);
         fe->reinit(quad4.get(), s, TOLERANCE);
         const Point n1 = quad4->side_vertex_average_normal(s);
-        LIBMESH_ASSERT_FP_EQUAL(normals[0](0), n1(0), TOLERANCE*TOLERANCE);
-        LIBMESH_ASSERT_FP_EQUAL(normals[0](1), n1(1), TOLERANCE*TOLERANCE);
-        LIBMESH_ASSERT_FP_EQUAL(normals[0](2), n1(2), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_REALVEC_EQUAL(normals[0], n1, TOLERANCE*TOLERANCE);
       }
     }
   }
@@ -498,29 +386,17 @@ public:
       std::unique_ptr<libMesh::Node> mid_elem_node;
       std::unique_ptr<Elem> polyhedron = std::make_unique<C0Polyhedron>(sides, mid_elem_node);
       const Point n1 = polyhedron->side_vertex_average_normal(0);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n1(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n1(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_z, n1, TOLERANCE*TOLERANCE);
       const Point n2 = polyhedron->side_vertex_average_normal(1);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n2(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n2(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n2, TOLERANCE*TOLERANCE);
       const Point n3 = polyhedron->side_vertex_average_normal(2);
-      LIBMESH_ASSERT_FP_EQUAL(1, n3(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n3(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n3(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_x, n3, TOLERANCE*TOLERANCE);
       const Point n4 = polyhedron->side_vertex_average_normal(3);
-      LIBMESH_ASSERT_FP_EQUAL(0, n4(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(1, n4(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n4(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_y, n4, TOLERANCE*TOLERANCE);
       const Point n5 = polyhedron->side_vertex_average_normal(4);
-      LIBMESH_ASSERT_FP_EQUAL(-1, n5(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n5(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n5(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_x, n5, TOLERANCE*TOLERANCE);
       const Point n6 = polyhedron->side_vertex_average_normal(5);
-      LIBMESH_ASSERT_FP_EQUAL(0, n6(0), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(0, n6(1), TOLERANCE*TOLERANCE);
-      LIBMESH_ASSERT_FP_EQUAL(1, n6(2), TOLERANCE*TOLERANCE);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_z, n6, TOLERANCE*TOLERANCE);
     }
 
     {
@@ -562,9 +438,7 @@ public:
       {
         const Point n1 = polyhedron->side_vertex_average_normal(s);
         const Point normal = hex8->Elem::side_vertex_average_normal(s);
-        LIBMESH_ASSERT_FP_EQUAL(normal(0), n1(0), TOLERANCE*TOLERANCE);
-        LIBMESH_ASSERT_FP_EQUAL(normal(1), n1(1), TOLERANCE*TOLERANCE);
-        LIBMESH_ASSERT_FP_EQUAL(normal(2), n1(2), TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_REALVEC_EQUAL(normal, n1, TOLERANCE*TOLERANCE);
       }
     }
   }

--- a/tests/geom/side_vertex_average_normal_test.C
+++ b/tests/geom/side_vertex_average_normal_test.C
@@ -39,6 +39,9 @@ public:
   CPPUNIT_TEST( testHexes );
   CPPUNIT_TEST( testC0Polygon );
   CPPUNIT_TEST( testC0Polyhedron );
+#ifdef LIBMESH_ENABLE_AMR
+  CPPUNIT_TEST( testEdge3PRefine );
+#endif // LIBMESH_ENABLE_AMR
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -107,6 +110,25 @@ public:
       }
     }
   }
+
+
+#ifdef LIBMESH_ENABLE_AMR
+  void testEdge3PRefine()
+  {
+    LOG_UNIT_TEST;
+
+    {
+      // Constructed so we can tweak the p level
+      std::vector<Point> pts = {Point(0, 1, 0), Point(0, 2, 0), Point(0, 1.5, 0)};
+      auto [edge3, nodes] = this->construct_elem(pts, EDGE3);
+      edge3->set_p_level(1);
+      const Point n1 = edge3->side_vertex_average_normal(0);
+      LIBMESH_ASSERT_REALVEC_EQUAL(-unit_y, n1, TOLERANCE*TOLERANCE);
+      const Point n2 = edge3->side_vertex_average_normal(1);
+      LIBMESH_ASSERT_REALVEC_EQUAL(unit_y, n2, TOLERANCE*TOLERANCE);
+    }
+  }
+#endif // LIBMESH_ENABLE_AMR
 
 
   void testTris()

--- a/tests/libmesh_cppunit.h
+++ b/tests/libmesh_cppunit.h
@@ -36,7 +36,7 @@
     VectorValue<Real> expected_vec{expected}; \
     VectorValue<Real> actual_vec{actual}; \
   for (int realvec_d=0; realvec_d != LIBMESH_DIM; ++realvec_d) \
-    LIBMESH_ASSERT_FP_EQUAL(expected(realvec_d), actual(realvec_d), tolerance); \
+    LIBMESH_ASSERT_FP_EQUAL(expected_vec(realvec_d), actual_vec(realvec_d), tolerance); \
   } while(0)
 
 // THE CPPUNIT_TEST_SUITE_END macro expands to code that involves

--- a/tests/libmesh_cppunit.h
+++ b/tests/libmesh_cppunit.h
@@ -30,6 +30,15 @@
          LIBMESH_ASSERT_FP_EQUAL(expected,actual,tolerance)
 #endif
 
+
+#define LIBMESH_ASSERT_REALVEC_EQUAL(expected,actual,tolerance) \
+  do { \
+    VectorValue<Real> expected_vec{expected}; \
+    VectorValue<Real> actual_vec{actual}; \
+  for (int realvec_d=0; realvec_d != LIBMESH_DIM; ++realvec_d) \
+    LIBMESH_ASSERT_FP_EQUAL(expected(realvec_d), actual(realvec_d), tolerance); \
+  } while(0)
+
 // THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
 // std::auto_ptr, which in turn produces -Wdeprecated-declarations
 // warnings.  These can be ignored in GCC as long as we wrap the


### PR DESCRIPTION
Also a bunch of unit test refactoring and expanded unit test feature coverage for that method, but really the core here is the one-line fix in elem.C.