### PR TITLE
Assert that we don't PerfLog push/pop in threads

### DIFF
--- a/include/parallel/threads.h
+++ b/include/parallel/threads.h
@@ -50,16 +50,27 @@ extern bool in_threads;
  * We use a class to turn Threads::in_threads on and off, to be
  * exception-safe.
  */
-class BoolAcquire
+template <typename T, T new_x_default = T(), bool assert_change = false>
+class RAIIAcquire
 {
 public:
   explicit
-  BoolAcquire(bool & b) : _b(b) { libmesh_assert(!_b); _b = true; }
+  RAIIAcquire(T & x, T new_x = new_x_default) :
+    _x(x), _old_x(x), _new_x(new_x)
+  {
+    libmesh_assert(!assert_change || _x != _new_x);
+    _x = _new_x;
+  }
 
-  ~BoolAcquire() { libmesh_exceptionless_assert(_b); _b = false; }
+  ~RAIIAcquire() { libmesh_exceptionless_assert(_x == _new_x); _x = _old_x; }
 private:
-  bool & _b;
+  T & _x;
+  T _old_x;
+  T _new_x;
 };
+
+// We'll only acquire in_threads to turn it from false to true
+typedef RAIIAcquire<bool, true, true> BoolAcquire;
 
 /**
  * We use a class to turn perf logging off and on within threads, to

--- a/include/parallel/threads.h
+++ b/include/parallel/threads.h
@@ -40,15 +40,26 @@ namespace Threads
 {
 
 /**
+ * An integer which is set to the number of active threads when we are
+ * in a Threads:: parallel operation.
+ */
+extern int active_threads;
+
+/**
  * A boolean which is true iff we are in a Threads:: function
- * It may be useful to assert(!Threads::in_threads) in any code
- * which is known to not be thread-safe.
+ * It may be useful to assert(!Threads::in_threads), in any code which
+ * is known to not be thread-safe.  Code which is not thread-safe but
+ * which is specifically enabled only when multiple threads are active
+ * might test for (Threads::active_threads != 1) instead.
  */
 extern bool in_threads;
 
 /**
  * We use a class to turn Threads::in_threads on and off, to be
  * exception-safe.
+ *
+ * We'll use the same class to set Threads::active_threads, for the
+ * same reason, but it's a little more complicated for that.
  */
 template <typename T, T new_x_default = T(), bool assert_change = false>
 class RAIIAcquire

--- a/include/parallel/threads_none.h
+++ b/include/parallel/threads_none.h
@@ -76,7 +76,7 @@ void parallel_for (const Range & range, const Body & body,
   libmesh_error_msg_if(n_threads > libMesh::n_threads(),
                        "Requested n_threads (" << n_threads << ") exceeds the "
                        "global thread count (" << libMesh::n_threads() << ").");
-  BoolAcquire b(in_threads);
+  BoolAcquire set_in_threads(in_threads);
   body(range);
 }
 
@@ -94,7 +94,7 @@ void parallel_for (const Range & range, const Body & body, const Partitioner &,
   libmesh_error_msg_if(n_threads > libMesh::n_threads(),
                        "Requested n_threads (" << n_threads << ") exceeds the "
                        "global thread count (" << libMesh::n_threads() << ").");
-  BoolAcquire b(in_threads);
+  BoolAcquire set_in_threads(in_threads);
   body(range);
 }
 
@@ -112,7 +112,7 @@ void parallel_reduce (const Range & range, Body & body,
   libmesh_error_msg_if(n_threads > libMesh::n_threads(),
                        "Requested n_threads (" << n_threads << ") exceeds the "
                        "global thread count (" << libMesh::n_threads() << ").");
-  BoolAcquire b(in_threads);
+  BoolAcquire set_in_threads(in_threads);
   body(range);
 }
 
@@ -130,7 +130,7 @@ void parallel_reduce (const Range & range, Body & body, const Partitioner &,
   libmesh_error_msg_if(n_threads > libMesh::n_threads(),
                        "Requested n_threads (" << n_threads << ") exceeds the "
                        "global thread count (" << libMesh::n_threads() << ").");
-  BoolAcquire b(in_threads);
+  BoolAcquire set_in_threads(in_threads);
   body(range);
 }
 

--- a/include/parallel/threads_pthread.h
+++ b/include/parallel/threads_pthread.h
@@ -276,16 +276,16 @@ void parallel_for (const Range & range, const Body & body,
                        "global thread count (" << libMesh::n_threads() << ").");
   Threads::BoolAcquire b(Threads::in_threads);
 
+  unsigned int actual_threads = num_pthreads(range, n_threads);
+
   // If we're running in serial - just run!
-  if (n_threads == 1)
+  if (actual_threads == 1)
   {
     body(range);
     return;
   }
 
   DisablePerfLogInScope disable_perf;
-
-  unsigned int actual_threads = num_pthreads(range, n_threads);
 
   std::vector<std::unique_ptr<Range>> ranges(actual_threads);
   std::vector<RangeBody<const Range, const Body>> range_bodies(actual_threads);
@@ -371,16 +371,16 @@ void parallel_reduce (const Range & range, Body & body,
                        "global thread count (" << libMesh::n_threads() << ").");
   Threads::BoolAcquire b(Threads::in_threads);
 
+  unsigned int actual_threads = num_pthreads(range, n_threads);
+
   // If we're running in serial - just run!
-  if (n_threads == 1)
+  if (actual_threads == 1)
   {
     body(range);
     return;
   }
 
   DisablePerfLogInScope disable_perf;
-
-  unsigned int actual_threads = num_pthreads(range, n_threads);
 
   std::vector<std::unique_ptr<Range>> ranges(actual_threads);
   std::vector<std::unique_ptr<Body>> managed_bodies(actual_threads); // bodies we are responsible for

--- a/include/parallel/threads_pthread.h
+++ b/include/parallel/threads_pthread.h
@@ -285,6 +285,8 @@ void parallel_for (const Range & range, const Body & body,
     return;
   }
 
+  Threads::RAIIAcquire<int> a(Threads::active_threads, actual_threads);
+
   DisablePerfLogInScope disable_perf;
 
   std::vector<std::unique_ptr<Range>> ranges(actual_threads);
@@ -379,6 +381,8 @@ void parallel_reduce (const Range & range, Body & body,
     body(range);
     return;
   }
+
+  Threads::RAIIAcquire<int> a(Threads::active_threads, actual_threads);
 
   DisablePerfLogInScope disable_perf;
 

--- a/include/parallel/threads_pthread.h
+++ b/include/parallel/threads_pthread.h
@@ -274,7 +274,7 @@ void parallel_for (const Range & range, const Body & body,
   libmesh_error_msg_if(n_threads > libMesh::n_threads(),
                        "Requested n_threads (" << n_threads << ") exceeds the "
                        "global thread count (" << libMesh::n_threads() << ").");
-  Threads::BoolAcquire b(Threads::in_threads);
+  Threads::BoolAcquire set_in_threads(Threads::in_threads);
 
   unsigned int actual_threads = num_pthreads(range, n_threads);
 
@@ -285,7 +285,7 @@ void parallel_for (const Range & range, const Body & body,
     return;
   }
 
-  Threads::RAIIAcquire<int> a(Threads::active_threads, actual_threads);
+  Threads::RAIIAcquire<int> set_active_threads(Threads::active_threads, actual_threads);
 
   DisablePerfLogInScope disable_perf;
 
@@ -371,7 +371,7 @@ void parallel_reduce (const Range & range, Body & body,
   libmesh_error_msg_if(n_threads > libMesh::n_threads(),
                        "Requested n_threads (" << n_threads << ") exceeds the "
                        "global thread count (" << libMesh::n_threads() << ").");
-  Threads::BoolAcquire b(Threads::in_threads);
+  Threads::BoolAcquire set_in_threads(Threads::in_threads);
 
   unsigned int actual_threads = num_pthreads(range, n_threads);
 
@@ -382,7 +382,7 @@ void parallel_reduce (const Range & range, Body & body,
     return;
   }
 
-  Threads::RAIIAcquire<int> a(Threads::active_threads, actual_threads);
+  Threads::RAIIAcquire<int> set_active_threads(Threads::active_threads, actual_threads);
 
   DisablePerfLogInScope disable_perf;
 

--- a/include/parallel/threads_tbb.h
+++ b/include/parallel/threads_tbb.h
@@ -147,11 +147,11 @@ void parallel_for (const Range & range, const Body & body,
   libmesh_error_msg_if(n_threads > libMesh::n_threads(),
                        "Requested n_threads (" << n_threads << ") exceeds the "
                        "global thread count (" << libMesh::n_threads() << ").");
-  BoolAcquire b(in_threads);
+  BoolAcquire set_in_threads(in_threads);
 
   if (n_threads > 1)
     {
-      Threads::RAIIAcquire<int> a(Threads::active_threads, n_threads);
+      Threads::RAIIAcquire<int> set_active_threads(Threads::active_threads, n_threads);
 
       DisablePerfLogInScope disable_perf;
       if (n_threads == libMesh::n_threads())
@@ -180,11 +180,11 @@ void parallel_for (const Range & range, const Body & body, const Partitioner & p
   libmesh_error_msg_if(n_threads > libMesh::n_threads(),
                        "Requested n_threads (" << n_threads << ") exceeds the "
                        "global thread count (" << libMesh::n_threads() << ").");
-  BoolAcquire b(in_threads);
+  BoolAcquire set_in_threads(in_threads);
 
   if (n_threads > 1)
     {
-      Threads::RAIIAcquire<int> a(Threads::active_threads, n_threads);
+      Threads::RAIIAcquire<int> set_active_threads(Threads::active_threads, n_threads);
 
       DisablePerfLogInScope disable_perf;
       if (n_threads == libMesh::n_threads())
@@ -213,11 +213,11 @@ void parallel_reduce (const Range & range, Body & body,
   libmesh_error_msg_if(n_threads > libMesh::n_threads(),
                        "Requested n_threads (" << n_threads << ") exceeds the "
                        "global thread count (" << libMesh::n_threads() << ").");
-  BoolAcquire b(in_threads);
+  BoolAcquire set_in_threads(in_threads);
 
   if (n_threads > 1)
     {
-      Threads::RAIIAcquire<int> a(Threads::active_threads, n_threads);
+      Threads::RAIIAcquire<int> set_active_threads(Threads::active_threads, n_threads);
 
       DisablePerfLogInScope disable_perf;
       if (n_threads == libMesh::n_threads())
@@ -246,11 +246,11 @@ void parallel_reduce (const Range & range, Body & body, const Partitioner & part
   libmesh_error_msg_if(n_threads > libMesh::n_threads(),
                        "Requested n_threads (" << n_threads << ") exceeds the "
                        "global thread count (" << libMesh::n_threads() << ").");
-  BoolAcquire b(in_threads);
+  BoolAcquire set_in_threads(in_threads);
 
   if (n_threads > 1)
     {
-      Threads::RAIIAcquire<int> a(Threads::active_threads, n_threads);
+      Threads::RAIIAcquire<int> set_active_threads(Threads::active_threads, n_threads);
 
       DisablePerfLogInScope disable_perf;
       if (n_threads == libMesh::n_threads())

--- a/include/parallel/threads_tbb.h
+++ b/include/parallel/threads_tbb.h
@@ -151,6 +151,8 @@ void parallel_for (const Range & range, const Body & body,
 
   if (n_threads > 1)
     {
+      Threads::RAIIAcquire<int> a(Threads::active_threads, n_threads);
+
       DisablePerfLogInScope disable_perf;
       if (n_threads == libMesh::n_threads())
         tbb::parallel_for (range, body, tbb::auto_partitioner());
@@ -182,6 +184,8 @@ void parallel_for (const Range & range, const Body & body, const Partitioner & p
 
   if (n_threads > 1)
     {
+      Threads::RAIIAcquire<int> a(Threads::active_threads, n_threads);
+
       DisablePerfLogInScope disable_perf;
       if (n_threads == libMesh::n_threads())
         tbb::parallel_for (range, body, partitioner);
@@ -213,6 +217,8 @@ void parallel_reduce (const Range & range, Body & body,
 
   if (n_threads > 1)
     {
+      Threads::RAIIAcquire<int> a(Threads::active_threads, n_threads);
+
       DisablePerfLogInScope disable_perf;
       if (n_threads == libMesh::n_threads())
         tbb::parallel_reduce (range, body, tbb::auto_partitioner());
@@ -244,6 +250,8 @@ void parallel_reduce (const Range & range, Body & body, const Partitioner & part
 
   if (n_threads > 1)
     {
+      Threads::RAIIAcquire<int> a(Threads::active_threads, n_threads);
+
       DisablePerfLogInScope disable_perf;
       if (n_threads == libMesh::n_threads())
         tbb::parallel_reduce (range, body, partitioner);

--- a/include/utils/perf_log.h
+++ b/include/utils/perf_log.h
@@ -505,12 +505,12 @@ void PerfLog::fast_push (const char * label,
   if (this->log_events)
     {
       // The global perflog stack may not be thread-safe, but if we're
-      // in threads we should have disabled it already
-      libmesh_assert(!Threads::in_threads);
+      // creating threads we should have disabled it already
+      libmesh_assert_equal_to(Threads::active_threads, 1);
 #ifdef LIBMESH_HAVE_OPENMP
       // Users might be doing their own non-libMesh threading.  We
       // can't catch every case of that but we can catch OpenMP
-      libmesh_assert(!omp_in_parallel());
+      libmesh_assert_equal_to(omp_get_num_threads(), 1);
 #endif
 
       // Get a reference to the event data to avoid
@@ -542,12 +542,12 @@ void PerfLog::fast_pop(const char * libmesh_dbg_var(label),
   if (this->log_events)
     {
       // The global perflog stack may not be thread-safe, but if we're
-      // in threads we should have disabled it already
-      libmesh_exceptionless_assert(!Threads::in_threads);
+      // creating threads we should have disabled it already
+      libmesh_exceptionless_assert(Threads::active_threads == 1);
 #ifdef LIBMESH_HAVE_OPENMP
       // Users might be doing their own non-libMesh threading.  We
-      // can't catch every case of that but we can catch OpenMP
-      libmesh_exceptionless_assert(!omp_in_parallel());
+      // can't catch every case of that but we can catch OpenMP.
+      libmesh_exceptionless_assert(omp_get_num_threads() == 1);
 #endif
 
 #ifdef LIBMESH_HAVE_NVTX_API

--- a/include/utils/perf_log.h
+++ b/include/utils/perf_log.h
@@ -24,6 +24,8 @@
 // Local includes
 #include "libmesh/libmesh_common.h"
 
+#include "libmesh/threads.h"
+
 // C++ includes
 #include <cstddef>
 #include <map>
@@ -40,6 +42,9 @@
 #endif
 #ifdef LIBMESH_HAVE_NVTX_API
 #include <nvtx3/nvtx3.hpp>
+#endif
+#ifdef LIBMESH_HAVE_OPENMP
+#include <omp.h>
 #endif
 
 namespace libMesh
@@ -499,6 +504,15 @@ void PerfLog::fast_push (const char * label,
 {
   if (this->log_events)
     {
+      // The global perflog stack may not be thread-safe, but if we're
+      // in threads we should have disabled it already
+      libmesh_assert(!Threads::in_threads);
+#ifdef LIBMESH_HAVE_OPENMP
+      // Users might be doing their own non-libMesh threading.  We
+      // can't catch every case of that but we can catch OpenMP
+      libmesh_assert(!omp_in_parallel());
+#endif
+
       // Get a reference to the event data to avoid
       // repeated map lookups
       PerfData * perf_data = &(log[std::make_pair(header,label)]);
@@ -527,6 +541,15 @@ void PerfLog::fast_pop(const char * libmesh_dbg_var(label),
 {
   if (this->log_events)
     {
+      // The global perflog stack may not be thread-safe, but if we're
+      // in threads we should have disabled it already
+      libmesh_exceptionless_assert(!Threads::in_threads);
+#ifdef LIBMESH_HAVE_OPENMP
+      // Users might be doing their own non-libMesh threading.  We
+      // can't catch every case of that but we can catch OpenMP
+      libmesh_exceptionless_assert(!omp_in_parallel());
+#endif
+
 #ifdef LIBMESH_HAVE_NVTX_API
       nvtxRangePop();
 #endif

--- a/src/parallel/threads.C
+++ b/src/parallel/threads.C
@@ -29,6 +29,7 @@ namespace Threads
 // object instantiation
 spin_mutex spin_mtx;
 recursive_mutex recursive_mtx;
+int active_threads = 1;
 bool in_threads = false;
 
 void lock_singleton_spin_mutex() { spin_mtx.lock(); }

--- a/src/utils/perf_log.C
+++ b/src/utils/perf_log.C
@@ -102,13 +102,13 @@ void PerfLog::clear()
 void PerfLog::push (const std::string & label,
                     const std::string & header)
 {
-  // The global perflog stack may not be thread-safe, but if we're in
-  // threads we should have disabled it already
-  libmesh_assert(!Threads::in_threads);
+  // The global perflog stack may not be thread-safe, but if we're
+  // creating threads we should have disabled it already
+  libmesh_assert_equal_to(Threads::active_threads, 1);
 #ifdef LIBMESH_HAVE_OPENMP
   // Users might be doing their own non-libMesh threading.  We can't
-  // catch every case of that but we can catch OpenMP
-  libmesh_assert(!omp_in_parallel());
+  // catch every case of that but we can catch OpenMP.
+  libmesh_assert_equal_to(omp_get_num_threads(), 1);
 #endif
 
   const char * label_c_str;
@@ -157,13 +157,13 @@ void PerfLog::push (const char * label,
 void PerfLog::pop (const std::string & label,
                    const std::string & header)
 {
-  // The global perflog stack may not be thread-safe, but if we're in
-  // threads we should have disabled it already
-  libmesh_assert(!Threads::in_threads);
+  // The global perflog stack may not be thread-safe, but if we're
+  // creating threads we should have disabled it already
+  libmesh_assert_equal_to(Threads::active_threads, 1);
 #ifdef LIBMESH_HAVE_OPENMP
   // Users might be doing their own non-libMesh threading.  We can't
-  // catch every case of that but we can catch OpenMP
-  libmesh_assert(!omp_in_parallel());
+  // catch every case of that but we can catch OpenMP.
+  libmesh_exceptionless_assert(omp_get_num_threads() == 1);
 #endif
 
   const char * label_c_str = non_temporary_strings[label].get();

--- a/src/utils/perf_log.C
+++ b/src/utils/perf_log.C
@@ -102,6 +102,15 @@ void PerfLog::clear()
 void PerfLog::push (const std::string & label,
                     const std::string & header)
 {
+  // The global perflog stack may not be thread-safe, but if we're in
+  // threads we should have disabled it already
+  libmesh_assert(!Threads::in_threads);
+#ifdef LIBMESH_HAVE_OPENMP
+  // Users might be doing their own non-libMesh threading.  We can't
+  // catch every case of that but we can catch OpenMP
+  libmesh_assert(!omp_in_parallel());
+#endif
+
   const char * label_c_str;
   const char * header_c_str;
 
@@ -148,6 +157,14 @@ void PerfLog::push (const char * label,
 void PerfLog::pop (const std::string & label,
                    const std::string & header)
 {
+  // The global perflog stack may not be thread-safe, but if we're in
+  // threads we should have disabled it already
+  libmesh_assert(!Threads::in_threads);
+#ifdef LIBMESH_HAVE_OPENMP
+  // Users might be doing their own non-libMesh threading.  We can't
+  // catch every case of that but we can catch OpenMP
+  libmesh_assert(!omp_in_parallel());
+#endif
 
   const char * label_c_str = non_temporary_strings[label].get();
   const char * header_c_str = non_temporary_strings[header].get();


### PR DESCRIPTION
Our stacks here aren't thread-safe, we don't want to add expensive locks to make them thread-safe, but we also don't want people crashing with corrupted stacks.

With libMesh Threads:: this was already solved by temporarily disabling perf logging in threads, but we might as well assert that that's working.

Users are writing custom OpenMP code, and we already have detection for whether OpenMP's enabled, so it's cheap enough in dbg/devel to see if we're in a non-libMesh OpenMP thread section.