### PR TITLE
Always print ReferenceCounter info for leaks

### DIFF
--- a/include/base/reference_counter.h
+++ b/include/base/reference_counter.h
@@ -87,7 +87,7 @@ public:
 
   /**
    * Methods to enable/disable the reference counter output
-   * from print_info()
+   * from print_info().  Enabled by default.
    */
   static void enable_print_counter_info();
   static void disable_print_counter_info();

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -772,11 +772,18 @@ LibMeshInit::~LibMeshInit()
   // Ask the \p ReferenceCounter to print its reference count
   // information, if printing is enabled.  This allows us to find
   // memory leaks.
-  ReferenceCounter::print_info ();
+  //
+  // If we don't have any leaks, we'll print to cout, only if we've
+  // been told to.  If we do, we'll print to cerr, to make sure the
+  // user doesn't miss a leak that's only on a processor other than 0.
+  if (ReferenceCounter::n_objects() == 0)
+    ReferenceCounter::print_info ();
 
   // Scream specifically if we detect a memory leak
   if (ReferenceCounter::n_objects() != 0)
     {
+      ReferenceCounter::print_info (libMesh::err);
+
       libMesh::err << "Memory leak detected!"
                    << std::endl;
 

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -765,16 +765,16 @@ LibMeshInit::~LibMeshInit()
   // Clear the thread task manager we started
   task_scheduler.reset();
 
-  // Force the \p ReferenceCounter to print
-  // its reference count information.  This allows
-  // us to find memory leaks.  By default the
-  // \p ReferenceCounter only prints its information
-  // when the last created object has been destroyed.
-  // That does no good if we are leaking memory!
+  // If we have a memory leak, we want the details printed.
+  if (ReferenceCounter::n_objects() != 0)
+    ReferenceCounter::enable_print_counter_info();
+
+  // Ask the \p ReferenceCounter to print its reference count
+  // information, if printing is enabled.  This allows us to find
+  // memory leaks.
   ReferenceCounter::print_info ();
 
-
-  // Print an informative message if we detect a memory leak
+  // Scream specifically if we detect a memory leak
   if (ReferenceCounter::n_objects() != 0)
     {
       libMesh::err << "Memory leak detected!"
@@ -787,7 +787,6 @@ LibMeshInit::~LibMeshInit()
                    << "for more information"
                    << std::endl;
 #endif
-
     }
 
   //  print the perflog to individual processor's file.


### PR DESCRIPTION
This info is kind of trivial (and so tempting to suppress via the command-line option) when there's not a leak, but in the event there is a leak, we shouldn't be hiding any details.

See the discussion in idaholab/moose#32877