### PR TITLE
Try to fix "incomplete type" in Test No Optional

### DIFF
--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -42,6 +42,7 @@
 
 // C++ includes
 #include <algorithm> // std::all_of
+#include <atomic>
 #include <fstream>
 #include <iomanip>
 #include <map>


### PR DESCRIPTION
I can't actually seem to reproduce this, but my best guess is that our regular builds are getting <atomic> indirectly from other libMesh headers, my own builds are getting <atomic> indirectly from other system headers, but our Test No Optional recipe actually needs to directly include <atomic> if it wants to use std::atomic.