### PR TITLE
Fix clang++ warnings in newer C++ standards

### DIFF
--- a/src/numerics/static_condensation_dof_map.C
+++ b/src/numerics/static_condensation_dof_map.C
@@ -93,7 +93,7 @@ void StaticCondensationDofMap::add_uncondensed_dof_plus_constraint_dofs(
                             uncondensed_local_dof_number,
                             constraint_dofs);
   if (is_constrained)
-    for (const auto [full_constraining_dof, weight] : it->second)
+    for (const auto & [full_constraining_dof, weight] : it->second)
       {
         libmesh_ignore(weight);
         // Our constraining dofs may themselves be constrained

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -919,7 +919,7 @@ namespace libMesh
     // geometric nodes. So can we loop over the nodes we cached in the node_map and
     // the DoFs for each field for that node. We need to give PETSc the local id
     // we built up in the node map.
-    for (const auto [global_node_id, local_node_id] : node_map )
+    for (const auto & [global_node_id, local_node_id] : node_map )
       {
         libmesh_assert( mesh.query_node_ptr(global_node_id) );
 
@@ -931,7 +931,7 @@ namespace libMesh
     // Some finite element types associate dofs with the element. So now we go through
     // any of those with the Elem as the point we add to the PetscSection with accompanying
     // dofs
-    for (const auto [global_elem_id, local_elem_id] : elem_map )
+    for (const auto & [global_elem_id, local_elem_id] : elem_map )
       {
         libmesh_assert( mesh.query_elem_ptr(global_elem_id) );
 
@@ -944,7 +944,7 @@ namespace libMesh
     // SCALAR dofs live on the "last" processor, so only work there if there are any
     if (system.processor_id() == (system.n_processors()-1))
       {
-        for (const auto [local_id, scalar_var] : scalar_map )
+        for (const auto & [local_id, scalar_var] : scalar_map )
           {
             // The number of SCALAR dofs comes from the variable order
             const int n_dofs = system.variable(scalar_var).type().order.get_order();


### PR DESCRIPTION
I'm not entirely sure why this is a warning (these are like 16 bytes each, tops; can't the copy fit in a couple registers?) or why it's only a warning when we bump up our C++ standard version, but it's breaking our --enable-werror test recipes.

Stripped out of #4469 