### PR TITLE
Make our Threads:: pthreads backend respect grainsize, make grainsize runtime-configurable

### DIFF
--- a/include/base/libmesh_base.h
+++ b/include/base/libmesh_base.h
@@ -41,6 +41,13 @@ processor_id_type global_processor_id();
 unsigned int n_threads();
 
 /**
+ * \returns The default grain size (work unit, chunk size), typically
+ * measured in nodes or elements or vector indices, below which work
+ * will not be split between additional threads.
+ */
+unsigned int default_grainsize();
+
+/**
  * Namespaces don't provide private data,
  * so let's take the data we would like
  * private and put it in an obnoxious
@@ -64,6 +71,12 @@ extern processor_id_type _processor_id;
  * Total number of threads possible.
  */
 extern int _n_threads;
+
+/**
+ * Minimum number of elements/nodes/indices per thread above which we
+ * can split work onto more threads.
+ */
+extern unsigned int _default_grainsize;
 }
 }
 
@@ -97,6 +110,15 @@ unsigned int libMesh::n_threads()
 {
   return static_cast<unsigned int>(libMeshPrivateData::_n_threads);
 }
+
+
+
+inline
+unsigned int libMesh::default_grainsize()
+{
+  return libMeshPrivateData::_default_grainsize;
+}
+
 
 
 // We now put everything we can into a separate libMesh namespace;

--- a/include/geom/stored_range.h
+++ b/include/geom/stored_range.h
@@ -66,7 +66,7 @@ public:
    * smallest chunk the range may be broken into for parallel
    * execution.
    */
-  StoredRange (const unsigned int new_grainsize = 1000) :
+  StoredRange (const unsigned int new_grainsize = libMesh::default_grainsize()) :
     _end(),
     _begin(),
     _last(),
@@ -83,7 +83,7 @@ public:
    */
   StoredRange (const iterator_type & first,
                const iterator_type & last,
-               const unsigned int new_grainsize = 1000) :
+               const unsigned int new_grainsize = libMesh::default_grainsize()) :
     _end(),
     _begin(),
     _last(),
@@ -105,7 +105,7 @@ public:
    * deleting this pointer.
    */
   StoredRange (vec_type * objs,
-               const unsigned int new_grainsize = 1000) :
+               const unsigned int new_grainsize = libMesh::default_grainsize()) :
     _end(objs->end()),
     _begin(objs->begin()),
     _last(objs->size()),

--- a/include/parallel/threads.h
+++ b/include/parallel/threads.h
@@ -175,7 +175,7 @@ public:
    * smallest chunk the range may be broken into for parallel
    * execution.
    */
-  explicit BlockedRange (const unsigned int new_grainsize = 1000) :
+  explicit BlockedRange (const unsigned int new_grainsize = libMesh::default_grainsize()) :
     _grainsize(new_grainsize)
   {}
 
@@ -187,7 +187,7 @@ public:
    */
   BlockedRange (const const_iterator first,
                 const const_iterator last,
-                const unsigned int new_grainsize = 1000) :
+                const unsigned int new_grainsize = libMesh::default_grainsize()) :
     _grainsize(new_grainsize)
   {
     this->reset(first, last);

--- a/include/parallel/threads_pthread.h
+++ b/include/parallel/threads_pthread.h
@@ -214,7 +214,7 @@ template <typename Range>
 unsigned int num_pthreads(const Range & range,
                           unsigned int requested = libMesh::n_threads())
 {
-  std::size_t mn = std::min((std::size_t)requested, range.size());
+  std::size_t mn = std::min((std::size_t)requested, range.size()/range.grainsize());
   return mn > 0 ? cast_int<unsigned int>(mn) : 1;
 }
 

--- a/include/utils/int_range.h
+++ b/include/utils/int_range.h
@@ -129,6 +129,9 @@ public:
   std::size_t size () const
   { return *_end - *_begin; }
 
+  // For thread splitting control
+  std::size_t grainsize () const { return libMesh::default_grainsize(); }
+
 private:
   iterator _begin, _end;
 };

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -425,6 +425,12 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
     task_scheduler = std::make_unique<Threads::task_scheduler_init>(libMesh::n_threads());
   }
 
+  // The optimal minimum chunk size for threading is probably fairly
+  // system-dependent.
+  libMesh::libMeshPrivateData::_default_grainsize =
+    libMesh::command_line_value("--default-grainsize",
+                                libMesh::libMeshPrivateData::_default_grainsize);
+
   // Construct singletons who may be at risk of the
   // "static initialization order fiasco"
   Singleton::setup();

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -301,6 +301,7 @@ processor_id_type libMesh::libMeshPrivateData::_n_processors = 1;
 processor_id_type libMesh::libMeshPrivateData::_processor_id = 0;
 #endif
 int           libMesh::libMeshPrivateData::_n_threads = 1; /* Threads::task_scheduler_init::automatic; */
+unsigned int  libMesh::libMeshPrivateData::_default_grainsize = 1000;
 bool          libMesh::libMeshPrivateData::_is_initialized = false;
 SolverPackage libMesh::libMeshPrivateData::_solver_package =
 #if   defined(LIBMESH_HAVE_PETSC)    // PETSc is the default

--- a/tests/parallel/parallel_test.C
+++ b/tests/parallel/parallel_test.C
@@ -887,7 +887,8 @@ public:
       (libMesh::n_threads() > 2) ? 2u : 1u;
     std::vector<unsigned int> values(3);
     std::iota(values.begin(), values.end(), 0u);
-    const TestRange range(values.cbegin(), values.cend());
+    const TestRange range(values.cbegin(), values.cend(),
+                          /* grainsize */ 1);
     VisitTracker tracker;
 
     Threads::parallel_for(range, ForBody(tracker), requested_threads);
@@ -909,7 +910,8 @@ public:
       (libMesh::n_threads() > 2) ? 2u : 1u;
     std::vector<unsigned int> values(3);
     std::iota(values.begin(), values.end(), 0u);
-    const TestRange range(values.cbegin(), values.cend());
+    const TestRange range(values.cbegin(), values.cend(),
+                          /* grainsize */ 1);
     auto tracker = std::make_shared<VisitTracker>();
     ReduceBody body(tracker);
 


### PR DESCRIPTION
This doesn't yet fix the MOOSE performance issues I was expecting it to, but I think it's either a step towards that or a worthwhile change on its own.