### PR TITLE
MeshTools::Modification::interpolate_boundary

### DIFF
--- a/include/mesh/mesh_modification.h
+++ b/include/mesh/mesh_modification.h
@@ -171,26 +171,26 @@ void smooth(MeshBase &, unsigned int, Real);
  * Move nodes in \p mesh to their closest points on the specified \p
  * surface.
  *
- * If \p boundary_nodes is true (the default), then \p ids is
+ * If \p use_boundary_nodes is true (the default), then \p ids is
  * interpreted as a set of boundary side ids, and nodes are moved iff
  * they are on element sides which have those boundary ids.  We
  * do not consider nodal boundary ids, which are for discrete points,
  * which cannot be continuously moved without moving a neighborhood
  * around them.
  *
- * If \p boundary_nodes is false, then \p ids is interpreted as a set
- * of subdomain ids, and nodes are moved iff they are on elements
+ * If \p use_boundary_nodes is false, then \p ids is interpreted as a
+ * set of subdomain ids, and nodes are moved iff they are on elements
  * which are on those subdomains.
  *
  * If \p ids is empty, then rather than "do nothing" we interpret that
- * as "do everything".  If \p boundary_nodes is true then we move all
- * nodes on domain boundary sides (where elements have null
+ * as "do everything".  If \p use_boundary_nodes is true then we move
+ * all nodes on domain boundary sides (where elements have null
  * neighbors), and if false then we move all nodes.
  */
-void interpolate_boundary (MeshBase & mesh,
-                           const Surface & surface,
-                           std::set<std::size_t> ids={},
-                           bool boundary_nodes=true);
+void interpolate_surface (MeshBase & mesh,
+                          const Surface & surface,
+                          std::set<std::size_t> ids={},
+                          bool use_boundary_nodes=true);
 
 #ifdef LIBMESH_ENABLE_AMR
 /**

--- a/include/mesh/mesh_modification.h
+++ b/include/mesh/mesh_modification.h
@@ -25,6 +25,9 @@
 #include "libmesh/id_types.h" // for boundary_id_type, subdomain_id_type
 #include "libmesh/tensor_value.h"
 
+// C++ Includes
+#include <set>
+
 namespace libMesh
 {
 

--- a/include/mesh/mesh_modification.h
+++ b/include/mesh/mesh_modification.h
@@ -31,6 +31,7 @@ namespace libMesh
 // forward declarations
 template <typename Output> class FunctionBase;
 class MeshBase;
+class Surface;
 
 
 // ------------------------------------------------------------
@@ -162,6 +163,31 @@ void all_rbb (MeshBase & mesh);
  * \date 2005
  */
 void smooth(MeshBase &, unsigned int, Real);
+
+/**
+ * Move nodes in \p mesh to their closest points on the specified \p
+ * surface.
+ *
+ * If \p boundary_nodes is true (the default), then \p ids is
+ * interpreted as a set of boundary side ids, and nodes are moved iff
+ * they are on element sides which have those boundary ids.  We
+ * do not consider nodal boundary ids, which are for discrete points,
+ * which cannot be continuously moved without moving a neighborhood
+ * around them.
+ *
+ * If \p boundary_nodes is false, then \p ids is interpreted as a set
+ * of subdomain ids, and nodes are moved iff they are on elements
+ * which are on those subdomains.
+ *
+ * If \p ids is empty, then rather than "do nothing" we interpret that
+ * as "do everything".  If \p boundary_nodes is true then we move all
+ * nodes on domain boundary sides (where elements have null
+ * neighbors), and if false then we move all nodes.
+ */
+void interpolate_boundary (MeshBase & mesh,
+                           const Surface & surface,
+                           std::set<std::size_t> ids={},
+                           bool boundary_nodes=true);
 
 #ifdef LIBMESH_ENABLE_AMR
 /**

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -2346,58 +2346,10 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
 
       mesh_refinement.uniformly_refine(1);
 
-      for (const auto & elem : mesh.active_element_ptr_range())
-        for (auto s : elem->side_index_range())
-          if (elem->neighbor_ptr(s) == nullptr || (mesh.mesh_dimension() == 2 && !flat))
-            {
-              elem->build_side_ptr(side, s);
-
-              // Pop each point to the sphere boundary.  Keep track of
-              // any points we don't own, so we can push their "moved"
-              // status to their owners.
-              for (auto n : side->node_index_range())
-                {
-                  Node & side_node = side->node_ref(n);
-                  side_node =
-                    sphere.closest_point(side->point(n));
-
-                  if (!is_replicated &&
-                      side_node.processor_id() != mesh.processor_id())
-                    moved_ghost_nodes.insert(side_node.id());
-                }
-            }
-
-      if (!is_replicated)
-        {
-          std::map<processor_id_type, std::vector<dof_id_type>> moved_nodes_map;
-          for (auto id : moved_ghost_nodes)
-            {
-              const Node & node = mesh.node_ref(id);
-              moved_nodes_map[node.processor_id()].push_back(node.id());
-            }
-
-          auto action_functor =
-            [& mesh, & sphere]
-            (processor_id_type /* pid */,
-             const std::vector<dof_id_type> & my_moved_nodes)
-            {
-              for (auto id : my_moved_nodes)
-                {
-                  Node & node = mesh.node_ref(id);
-                  node = sphere.closest_point(node);
-                }
-            };
-
-          // First get new node positions to their owners
-          Parallel::push_parallel_vector_data
-            (mesh.comm(), moved_nodes_map, action_functor);
-
-          // Then get node positions to anyone else with them ghosted
-          SyncNodalPositions sync_object(mesh);
-          Parallel::sync_dofobject_data_by_id
-            (mesh.comm(), mesh.nodes_begin(), mesh.nodes_end(),
-             sync_object);
-        }
+      const bool move_only_boundary_nodes =
+        mesh.mesh_dimension() != 2 || flat;
+      MeshTools::Modification::interpolate_boundary
+        (mesh, sphere, /*ids=*/{}, move_only_boundary_nodes);
     }
 
   // A DistributedMesh needs a little prep before flattening

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -2348,7 +2348,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
 
       const bool move_only_boundary_nodes =
         mesh.mesh_dimension() != 2 || flat;
-      MeshTools::Modification::interpolate_boundary
+      MeshTools::Modification::interpolate_surface
         (mesh, sphere, /*ids=*/{}, move_only_boundary_nodes);
     }
 

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1965,10 +1965,10 @@ void MeshTools::Modification::smooth (MeshBase & mesh,
 
 
 
-void MeshTools::Modification::interpolate_boundary (MeshBase & mesh,
-                                                    const Surface & surface,
-                                                    std::set<std::size_t> ids,
-                                                    bool boundary_nodes)
+void MeshTools::Modification::interpolate_surface (MeshBase & mesh,
+                                                   const Surface & surface,
+                                                   std::set<std::size_t> ids,
+                                                   bool use_boundary_nodes)
 {
   const bool is_serial = mesh.is_serial();
   const processor_id_type mesh_pid = mesh.processor_id();
@@ -1993,7 +1993,7 @@ void MeshTools::Modification::interpolate_boundary (MeshBase & mesh,
       if (elem->mapping_type() != LAGRANGE_MAP)
         libmesh_not_implemented();
 
-      if (boundary_nodes)
+      if (use_boundary_nodes)
         {
           for (auto s : elem->side_index_range())
             {

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -42,7 +42,9 @@
 #include "libmesh/mesh_modification.h"
 #include "libmesh/mesh_tools.h"
 #include "libmesh/parallel.h"
+#include "libmesh/parallel_ghost_sync.h"
 #include "libmesh/remote_elem.h"
+#include "libmesh/surface.h"
 #include "libmesh/enum_to_string.h"
 #include "libmesh/unstructured_mesh.h"
 #include "libmesh/elem_side_builder.h"
@@ -1955,6 +1957,105 @@ void MeshTools::Modification::smooth (MeshBase & mesh,
             }
         } // refinement_level loop
     } // end iteration
+
+  // We haven't changed any topology, but just changing geometry could
+  // have invalidated a point locator.
+  mesh.clear_point_locator();
+}
+
+
+
+void MeshTools::Modification::interpolate_boundary (MeshBase & mesh,
+                                                    const Surface & surface,
+                                                    std::set<std::size_t> ids,
+                                                    bool boundary_nodes)
+{
+  const bool is_serial = mesh.is_serial();
+  const processor_id_type mesh_pid = mesh.processor_id();
+
+  // We might have to move ghost nodes on a distributed mesh if their
+  // owners don't see a requisite element or boundary they're on.
+  std::unordered_set<dof_id_type> moved_ghost_nodes;
+
+  auto move_node = [& moved_ghost_nodes, & surface, is_serial, mesh_pid]
+                   (Node & node) {
+    node = surface.closest_point(node);
+
+    if (!is_serial && node.processor_id() != mesh_pid)
+      moved_ghost_nodes.insert(node.id());
+  };
+
+  const bool no_ids = ids.empty();
+  const BoundaryInfo & boundary_info = mesh.get_boundary_info();
+
+  for (const auto & elem : mesh.active_element_ptr_range())
+    {
+      if (elem->mapping_type() != LAGRANGE_MAP)
+        libmesh_not_implemented();
+
+      if (boundary_nodes)
+        {
+          for (auto s : elem->side_index_range())
+            {
+              if (no_ids)
+                {
+                  // If we're not using boundary ids, we're
+                  // interpolating all external and no internal
+                  // boundaries
+                  if (elem->neighbor_ptr(s))
+                    continue;
+                }
+              else
+                {
+                  if (std::none_of(ids.begin(), ids.end(),
+                                   [&boundary_info,elem,s](std::size_t bcid)
+                                   {return boundary_info.has_boundary_id(elem, s, bcid);}))
+                    continue;
+                }
+
+              for (auto n : elem->nodes_on_side(s))
+                move_node(elem->node_ref(n));
+            }
+        }
+      else
+        {
+          if (no_ids || ids.count(elem->subdomain_id()))
+            for (Node & node : elem->node_ref_range())
+              move_node(node);
+        }
+    }
+
+  if (!is_serial)
+    {
+      std::map<processor_id_type, std::vector<dof_id_type>> moved_nodes_map;
+      for (auto id : moved_ghost_nodes)
+        {
+          const Node & node = mesh.node_ref(id);
+          moved_nodes_map[node.processor_id()].push_back(node.id());
+        }
+
+      auto action_functor =
+        [& mesh, & surface]
+        (processor_id_type /* pid */,
+         const std::vector<dof_id_type> & my_moved_nodes)
+        {
+          for (auto id : my_moved_nodes)
+            {
+              Node & node = mesh.node_ref(id);
+              node = surface.closest_point(node);
+            }
+        };
+
+      // First get new node positions to their owners
+      Parallel::push_parallel_vector_data
+        (mesh.comm(), moved_nodes_map, action_functor);
+
+      // Then get node positions to anyone else with them ghosted
+      SyncNodalPositions sync_object(mesh);
+      Parallel::sync_dofobject_data_by_id
+        (mesh.comm(), mesh.nodes_begin(), mesh.nodes_end(),
+         sync_object);
+    }
 
   // We haven't changed any topology, but just changing geometry could
   // have invalidated a point locator.


### PR DESCRIPTION
After futzing with build_sphere() recently, talking to @GiudGiud about level set meshing has me thinking this code could be useful on its own too.

I probably should add more test coverage for various old and new options before we merge this, just wanted to get it up (and testing with CI configuration variants) before I forgot about it.