### PR TITLE
Add the capability to specify subdomain IDs for boundary elements

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -182,10 +182,18 @@ public:
    * generates a mesh with elements of mixed dimension.
    *
    * Only boundary elements with the specified ids are created.
+   *
+   * If \p new_subdomain_ids is empty, newly created elements retain the
+   * default subdomain id.  If it contains a single entry, all new elements
+   * are assigned that subdomain id.  If its size equals
+   * \p requested_boundary_ids.size(), new elements are assigned subdomain
+   * ids in one-to-one correspondence with the boundary ids (iterated in
+   * sorted order).
    */
   void add_elements (const std::set<boundary_id_type> & requested_boundary_ids,
                      UnstructuredMesh & boundary_mesh,
-                     bool store_parent_side_ids = false);
+                     bool store_parent_side_ids = false,
+                     const std::vector<subdomain_id_type> & new_subdomain_ids = {});
 
   /**
    * Same as the add_elements() function above, but takes a set of
@@ -196,7 +204,8 @@ public:
   void add_elements(const std::set<boundary_id_type> & requested_boundary_ids,
                     UnstructuredMesh & boundary_mesh,
                     const std::set<subdomain_id_type> & subdomains_relative_to,
-                    bool store_parent_side_ids = false);
+                    bool store_parent_side_ids = false,
+                    const std::vector<subdomain_id_type> & new_subdomain_ids = {});
 
   /**
    * Add \p Node \p node with boundary id \p id to the boundary

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -181,7 +181,8 @@ public:
    * The \p boundary_mesh may be the *same* as the interior mesh; this
    * generates a mesh with elements of mixed dimension.
    *
-   * Only boundary elements with the specified ids are created.
+   * Only boundary element sides with boundary ids in the
+   * \p requested_boundary_ids set are considered for addition.
    *
    * If \p new_subdomain_ids is empty, newly created elements retain the
    * default subdomain id.  If it contains a single entry, all new elements

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -654,7 +654,8 @@ void BoundaryInfo::get_side_and_node_maps (UnstructuredMesh & boundary_mesh,
 
 void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_boundary_ids,
                                 UnstructuredMesh & boundary_mesh,
-                                bool store_parent_side_ids)
+                                bool store_parent_side_ids,
+                                const std::vector<subdomain_id_type> & new_subdomain_ids)
 {
   // Call the 3 argument version of this function with a dummy value for the third arg.
   std::set<subdomain_id_type> subdomains_relative_to;
@@ -663,7 +664,8 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
   this->add_elements(requested_boundary_ids,
                      boundary_mesh,
                      subdomains_relative_to,
-                     store_parent_side_ids);
+                     store_parent_side_ids,
+                     new_subdomain_ids);
 }
 
 
@@ -671,8 +673,12 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
 void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_boundary_ids,
                                 UnstructuredMesh & boundary_mesh,
                                 const std::set<subdomain_id_type> & subdomains_relative_to,
-                                bool store_parent_side_ids)
+                                bool store_parent_side_ids,
+                                const std::vector<subdomain_id_type> & new_subdomain_ids)
 {
+  libmesh_assert(new_subdomain_ids.empty() ||
+                 new_subdomain_ids.size() == 1 ||
+                 new_subdomain_ids.size() == requested_boundary_ids.size());
   LOG_SCOPE("add_elements()", "BoundaryInfo");
 
   // We're not prepared to mix serial and distributed meshes in this
@@ -704,7 +710,7 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
   // boundary_mesh and _mesh are the same then those additions can
   // invalidate our element iterators.  So we just use the element
   // loop to make a list of sides to add.
-  typedef std::vector<std::pair<dof_id_type, unsigned char>>
+  typedef std::vector<std::tuple<dof_id_type, unsigned char, boundary_id_type>>
     side_container;
   side_container sides_to_add;
 
@@ -723,6 +729,7 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
       for (auto s : elem->side_index_range())
         {
           bool add_this_side = false;
+          boundary_id_type triggering_bcid = invalid_id;
 
           // Find all the boundary side ids for this Elem side.
           std::vector<boundary_id_type> bcids;
@@ -734,6 +741,7 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
               if (requested_boundary_ids.count(bcid))
                 {
                   add_this_side = true;
+                  triggering_bcid = bcid;
                   break;
                 }
             }
@@ -749,7 +757,7 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
             add_this_side = true;
 
           if (add_this_side)
-            sides_to_add.emplace_back(elem->id(), s);
+            sides_to_add.emplace_back(elem->id(), s, triggering_bcid);
         }
     }
 
@@ -763,7 +771,7 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
   unsigned int parent_side_index_tag = store_parent_side_ids ?
     boundary_mesh.add_elem_integer("parent_side_index") : libMesh::invalid_uint;
 
-  for (const auto & [elem_id, s] : sides_to_add)
+  for (const auto & [elem_id, s, triggering_bcid] : sides_to_add)
     {
       Elem * elem = _mesh->elem_ptr(elem_id);
 
@@ -790,6 +798,17 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
       // side id "s" of the interior_parent it corresponds to.
       if (store_parent_side_ids)
         new_elem->set_extra_integer(parent_side_index_tag, s);
+
+      // Assign subdomain id if requested.
+      if (new_subdomain_ids.size() == 1)
+        new_elem->subdomain_id() = new_subdomain_ids[0];
+      else if (new_subdomain_ids.size() > 1)
+        {
+          auto it = requested_boundary_ids.find(triggering_bcid);
+          libmesh_assert(it != requested_boundary_ids.end());
+          new_elem->subdomain_id() =
+            new_subdomain_ids[std::distance(requested_boundary_ids.begin(), it)];
+        }
 
 #ifdef LIBMESH_ENABLE_AMR
       new_elem->set_refinement_flag(elem->refinement_flag());

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -30,6 +30,7 @@
 #include "libmesh/remote_elem.h"
 #include "libmesh/unstructured_mesh.h"
 #include "libmesh/elem_side_builder.h"
+#include "libmesh/utility.h"
 
 // TIMPI includes
 #include "timpi/parallel_sync.h"
@@ -771,6 +772,17 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
   unsigned int parent_side_index_tag = store_parent_side_ids ?
     boundary_mesh.add_elem_integer("parent_side_index") : libMesh::invalid_uint;
 
+  // When new elements are assigned subdomain ids in one-to-one
+  // correspondence with the requested boundary ids, we need to map a
+  // boundary id to its index in the (sorted) set. Copying the set into a
+  // contiguous vector lets us do that index lookup in O(1) (after an
+  // O(log N) Utility::binary_find()) rather than the O(N) std::distance()
+  // between std::set iterators.
+  std::vector<boundary_id_type> requested_boundary_ids_vec;
+  if (new_subdomain_ids.size() > 1)
+    requested_boundary_ids_vec.assign(requested_boundary_ids.begin(),
+                                      requested_boundary_ids.end());
+
   for (const auto & [elem_id, s, triggering_bcid] : sides_to_add)
     {
       Elem * elem = _mesh->elem_ptr(elem_id);
@@ -804,10 +816,12 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
         new_elem->subdomain_id() = new_subdomain_ids[0];
       else if (new_subdomain_ids.size() > 1)
         {
-          auto it = requested_boundary_ids.find(triggering_bcid);
-          libmesh_assert(it != requested_boundary_ids.end());
+          auto it = Utility::binary_find(requested_boundary_ids_vec.begin(),
+                                         requested_boundary_ids_vec.end(),
+                                         triggering_bcid);
+          libmesh_assert(it != requested_boundary_ids_vec.end());
           new_elem->subdomain_id() =
-            new_subdomain_ids[std::distance(requested_boundary_ids.begin(), it)];
+            new_subdomain_ids[std::distance(requested_boundary_ids_vec.begin(), it)];
         }
 
 #ifdef LIBMESH_ENABLE_AMR

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -952,6 +952,11 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
 
   // global containers are not synced
   boundary_mesh.unset_has_boundary_id_sets();
+
+  // New elements were added; mark the affected preparation flags invalid.
+  boundary_mesh.unset_has_neighbor_ptrs();
+  boundary_mesh.unset_has_cached_elem_data();
+  boundary_mesh.unset_has_reinit_ghosting_functors();
 }
 
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -949,6 +949,9 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
     parmesh->libmesh_assert_valid_parallel_ids();
 # endif
 #endif
+
+  // global containers are not synced
+  boundary_mesh.unset_has_boundary_id_sets();
 }
 
 

--- a/tests/mesh/boundary_mesh.C
+++ b/tests/mesh/boundary_mesh.C
@@ -6,6 +6,8 @@
 #include <libmesh/remote_elem.h>
 #include <libmesh/replicated_mesh.h>
 #include <libmesh/boundary_info.h>
+#include <libmesh/mesh_tools.h>
+#include <timpi/parallel_implementation.h>
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"
@@ -503,6 +505,128 @@ public:
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION( BoundaryMeshTest );
+
+
+class BoundaryMeshSubdomainTest : public CppUnit::TestCase {
+  /**
+   * Tests the new_subdomain_ids parameter of add_elements(), which assigns
+   * subdomain IDs to newly-created lower-D elements.  Three cases:
+   *   1. Empty (default) - elements retain subdomain 0.
+   *   2. Single ID       - all new elements get that ID.
+   *   3. Per-boundary    - one-to-one with requested_boundary_ids (sorted).
+   *
+   * Uses a 3x3 QUAD4 mesh.  build_square() assigns: bottom=0, right=1,
+   * top=2, left=3.
+   */
+public:
+  LIBMESH_CPPUNIT_TEST_SUITE( BoundaryMeshSubdomainTest );
+
+#if LIBMESH_DIM > 1
+  CPPUNIT_TEST( testDefaultSubdomain );
+  CPPUNIT_TEST( testSingleSubdomain );
+  CPPUNIT_TEST( testPerBoundarySubdomain );
+#endif
+
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void testDefaultSubdomain()
+  {
+    LOG_UNIT_TEST;
+
+    Mesh mesh(*TestCommWorld);
+    MeshTools::Generation::build_square(mesh, 3, 3, 0., 1., 0., 1., QUAD4);
+
+    const BoundaryInfo & bi = mesh.get_boundary_info();
+    const auto & side_boundary_ids = bi.get_side_boundary_ids();
+
+    mesh.get_boundary_info().add_elements(side_boundary_ids, mesh);
+    mesh.prepare_for_use();
+
+    for (const auto & elem : mesh.active_element_ptr_range())
+      if (elem->dim() < mesh.mesh_dimension())
+        CPPUNIT_ASSERT_EQUAL(static_cast<subdomain_id_type>(0), elem->subdomain_id());
+  }
+
+  void testSingleSubdomain()
+  {
+    LOG_UNIT_TEST;
+
+    Mesh mesh(*TestCommWorld);
+    MeshTools::Generation::build_square(mesh, 3, 3, 0., 1., 0., 1., QUAD4);
+
+    const BoundaryInfo & bi = mesh.get_boundary_info();
+    const auto & side_boundary_ids = bi.get_side_boundary_ids();
+
+    const subdomain_id_type sid = 42;
+    mesh.get_boundary_info().add_elements(side_boundary_ids, mesh, false, {sid});
+    mesh.prepare_for_use();
+
+    unsigned int n_lower = 0;
+    for (const auto & elem : mesh.active_element_ptr_range())
+      if (elem->dim() < mesh.mesh_dimension())
+        {
+          CPPUNIT_ASSERT_EQUAL(sid, elem->subdomain_id());
+          if (elem->processor_id() == mesh.processor_id())
+            ++n_lower;
+        }
+
+    // 3x3 quad mesh has 12 edges across its sides
+    mesh.comm().sum(n_lower);
+    CPPUNIT_ASSERT_EQUAL(12u, n_lower);
+  }
+
+  void testPerBoundarySubdomain()
+  {
+    LOG_UNIT_TEST;
+
+    Mesh mesh(*TestCommWorld);
+    MeshTools::Generation::build_square(mesh, 3, 3, 0., 1., 0., 1., QUAD4);
+
+    const BoundaryInfo & bi = mesh.get_boundary_info();
+    const boundary_id_type right_id = bi.get_id_by_name("right");
+    const boundary_id_type top_id   = bi.get_id_by_name("top");
+
+    // The set is iterated in sorted boundary_id order, so the subdomain_ids
+    // vector must be ordered accordingly.
+    const subdomain_id_type right_sid = 10;
+    const subdomain_id_type top_sid   = 20;
+    std::set<boundary_id_type> ids = {right_id, top_id};
+    std::vector<subdomain_id_type> sids;
+    for (const auto id : ids)
+      sids.push_back(id == right_id ? right_sid : top_sid);
+
+    mesh.get_boundary_info().add_elements(ids, mesh, false, sids);
+    mesh.prepare_for_use();
+
+    unsigned int n_right = 0, n_top = 0;
+    for (const auto & elem : mesh.active_element_ptr_range())
+      if (elem->dim() < mesh.mesh_dimension())
+        {
+          const Real cx = elem->vertex_average()(0);
+          if (cx > 0.9)
+            {
+              CPPUNIT_ASSERT_EQUAL(right_sid, elem->subdomain_id());
+              if (elem->processor_id() == mesh.processor_id())
+                ++n_right;
+            }
+          else
+            {
+              CPPUNIT_ASSERT_EQUAL(top_sid, elem->subdomain_id());
+              if (elem->processor_id() == mesh.processor_id())
+                ++n_top;
+            }
+        }
+
+    mesh.comm().sum(n_right);
+    mesh.comm().sum(n_top);
+    CPPUNIT_ASSERT_EQUAL(3u, n_right);
+    CPPUNIT_ASSERT_EQUAL(3u, n_top);
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( BoundaryMeshSubdomainTest );
+
 
 #ifdef LIBMESH_ENABLE_AMR
 

--- a/tests/mesh/boundary_mesh.C
+++ b/tests/mesh/boundary_mesh.C
@@ -541,7 +541,7 @@ public:
     const auto & side_boundary_ids = bi.get_side_boundary_ids();
 
     mesh.get_boundary_info().add_elements(side_boundary_ids, mesh);
-    mesh.prepare_for_use();
+    mesh.complete_preparation();
 
     for (const auto & elem : mesh.active_element_ptr_range())
       if (elem->dim() < mesh.mesh_dimension())
@@ -560,7 +560,7 @@ public:
 
     const subdomain_id_type sid = 42;
     mesh.get_boundary_info().add_elements(side_boundary_ids, mesh, false, {sid});
-    mesh.prepare_for_use();
+    mesh.complete_preparation();
 
     unsigned int n_lower = 0;
     for (const auto & elem : mesh.active_element_ptr_range())
@@ -597,7 +597,7 @@ public:
       sids.push_back(id == right_id ? right_sid : top_sid);
 
     mesh.get_boundary_info().add_elements(ids, mesh, false, sids);
-    mesh.prepare_for_use();
+    mesh.complete_preparation();
 
     unsigned int n_right = 0, n_top = 0;
     for (const auto & elem : mesh.active_element_ptr_range())


### PR DESCRIPTION
This will make it easier to make these APIs direct replacements for downstream lower-d block mesh generators