### PR TITLE
Print all failed assertion expressions

### DIFF
--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -308,7 +308,7 @@ extern bool warned_about_auto_ptr;
 #define libmesh_assert_msg(asserted, msg)                               \
   do {                                                                  \
     if (!(asserted)) {                                                  \
-      libmesh_error_msg(msg);                                           \
+      libmesh_error_msg("Assertion `" #asserted "' failed.\n" << msg);                                           \
     } } while (0)
 
 #define libmesh_exceptionless_assert_msg(asserted, msg)                 \

--- a/src/base/libmesh_common.C
+++ b/src/base/libmesh_common.C
@@ -91,12 +91,13 @@ void report_error(const char * file, int line, const char * date, const char * t
     }
   reporting_error = true;
 
+  libMesh::MacroFunctions::here(file, line, date, time, os);
+
   if (libMesh::global_n_processors() == 1 ||
       libMesh::on_command_line("--print-trace"))
     libMesh::print_trace(os);
   else
     libMesh::write_traceout();
-  libMesh::MacroFunctions::here(file, line, date, time, os);
 
   reporting_error = false;
 }


### PR DESCRIPTION
We print all the specialized assertions' expressions, but in the general case we've apparently just been relying on file/line output, which is less friendly.