### PR TITLE
Add Polygon/Polyhedron NSIDED/NFACED ExodusII output

### DIFF
--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -226,6 +226,11 @@ public:
   void read_elem_in_block(int block);
 
   /**
+   * Reads NSIDED face blocks used by NFACED element blocks.
+   */
+  void read_face_blocks();
+
+  /**
    * Read in edge blocks, storing information in the BoundaryInfo object.
    */
   void read_edge_blocks(MeshBase & mesh);
@@ -754,6 +759,15 @@ public:
 
   // Vector of nodes in an element
   std::vector<int> connect;
+
+  // For NSIDED element blocks, the number of nodes in each element
+  std::vector<int> elem_node_counts;
+
+  // For NFACED element blocks, the number of faces in each element
+  std::vector<int> elem_face_counts;
+
+  // For NFACED element blocks, the nodes in each Exodus face
+  std::vector<std::vector<int>> c0polyhedron_face_connect;
 
   // Vector of the sideset IDs
   std::vector<int> ss_ids;

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -703,6 +703,13 @@ public:
   // each block must equal num_edge.
   int & num_edge_blk;
 
+  // Total number of faces
+  int & num_face;
+
+  // Total number of face blocks. The sum of the number of faces in
+  // each block must equal num_face.
+  int & num_face_blk;
+
   // Total number of node sets
   int & num_node_sets;
 

--- a/include/mesh/exodus_header_info.h
+++ b/include/mesh/exodus_header_info.h
@@ -57,7 +57,8 @@ public:
     // Pack individual integers into vector
     std::vector<int> buffer =
       {num_dim, num_elem, num_elem_blk, num_node_sets,
-       num_side_sets, num_elem_sets, num_edge_blk, num_edge};
+       num_side_sets, num_elem_sets, num_edge_blk, num_edge,
+       num_face_blk, num_face};
 
     // broadcast integers
     comm.broadcast(buffer);
@@ -72,6 +73,8 @@ public:
     num_elem_sets = buffer[ctr++];
     num_edge_blk  = buffer[ctr++];
     num_edge      = buffer[ctr++];
+    num_face_blk  = buffer[ctr++];
+    num_face      = buffer[ctr++];
   }
 
   std::vector<char> title;
@@ -84,6 +87,8 @@ public:
   int num_elem_sets;
   int num_edge_blk;
   int num_edge;
+  int num_face_blk;
+  int num_face;
 };
 
 } // namespace libMesh

--- a/src/geom/cell_c0polyhedron.C
+++ b/src/geom/cell_c0polyhedron.C
@@ -18,6 +18,7 @@
 // Local includes
 #include "libmesh/cell_c0polyhedron.h"
 
+#include "libmesh/enum_io_package.h"
 #include "libmesh/enum_order.h"
 #include "libmesh/face_polygon.h"
 #include "libmesh/mesh_tools.h"
@@ -188,11 +189,44 @@ C0Polyhedron::edges_adjacent_to_node(const unsigned int n) const
 
 
 
-void C0Polyhedron::connectivity(const unsigned int /*sf*/,
-                                const IOPackage /*iop*/,
-                                std::vector<dof_id_type> & /*conn*/) const
+void C0Polyhedron::connectivity(const unsigned int sf,
+                                const IOPackage iop,
+                                std::vector<dof_id_type> & conn) const
 {
-  libmesh_not_implemented();
+  libmesh_assert_less (sf, this->n_sub_elem());
+  libmesh_assert_not_equal_to (iop, INVALID_IO_PACKAGE);
+
+  const auto & subtet = this->_triangulation[sf];
+
+  switch (iop)
+    {
+    case TECPLOT:
+      {
+        conn.resize(8);
+        conn[0] = this->node_id(subtet[0])+1;
+        conn[1] = this->node_id(subtet[1])+1;
+        conn[2] = this->node_id(subtet[2])+1;
+        conn[3] = this->node_id(subtet[2])+1;
+        conn[4] = this->node_id(subtet[3])+1;
+        conn[5] = this->node_id(subtet[3])+1;
+        conn[6] = this->node_id(subtet[3])+1;
+        conn[7] = this->node_id(subtet[3])+1;
+        return;
+      }
+
+    case VTK:
+      {
+        conn.resize(4);
+        conn[0] = this->node_id(subtet[0]);
+        conn[1] = this->node_id(subtet[1]);
+        conn[2] = this->node_id(subtet[2]);
+        conn[3] = this->node_id(subtet[3]);
+        return;
+      }
+
+    default:
+      libmesh_error_msg("Unsupported IO package " << iop);
+    }
 }
 
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -468,13 +468,13 @@ void ExodusII_IO::read (const std::string & fname)
 
           if (is_c0polygon)
             {
-              const int n_nodes = exio_helper->elem_node_counts[elem_num];
-              libmesh_error_msg_if(n_nodes < 3,
+              const int n_elem_nodes = exio_helper->elem_node_counts[elem_num];
+              libmesh_error_msg_if(n_elem_nodes < 3,
                                    "Error: Exodus NSIDED block element "
                                    << elem_num
-                                   << " has only " << n_nodes << " nodes.");
+                                   << " has only " << n_elem_nodes << " nodes.");
 
-              uelem = std::make_unique<C0Polygon>(cast_int<unsigned int>(n_nodes));
+              uelem = std::make_unique<C0Polygon>(cast_int<unsigned int>(n_elem_nodes));
             }
           else if (is_c0polyhedron)
             {

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -20,6 +20,7 @@
 #include "libmesh/exodusII_io.h"
 
 #include "libmesh/boundary_info.h"
+#include "libmesh/cell_c0polyhedron.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/dyna_io.h"  // ElementDefinition for BEX
 #include "libmesh/enum_elem_type.h"
@@ -27,6 +28,7 @@
 #include "libmesh/enum_to_string.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/exodusII_io_helper.h"
+#include "libmesh/face_c0polygon.h"
 #include "libmesh/fpe_disabler.h"
 #include "libmesh/int_range.h"
 #include "libmesh/libmesh_logging.h"
@@ -452,20 +454,89 @@ void ExodusII_IO::read (const std::string & fname)
       // Set any relevant node/edge maps for this element
       const std::string type_str (exio_helper->get_elem_type());
       const auto & conv = exio_helper->get_conversion(type_str);
+      const bool is_c0polygon = (conv.libmesh_elem_type() == C0POLYGON);
+      const bool is_c0polyhedron = (conv.libmesh_elem_type() == C0POLYHEDRON);
+      std::size_t c0polygon_connect_offset = 0;
+      std::size_t c0polyhedron_connect_offset = 0;
 
       // Loop over all the faces in this block
       int jmax = nelem_last_block+exio_helper->num_elem_this_blk;
       for (int j=nelem_last_block; j<jmax; j++)
         {
-          auto uelem = Elem::build(conv.libmesh_elem_type());
-
           const int elem_num = j - nelem_last_block;
+          std::unique_ptr<Elem> uelem;
+
+          if (is_c0polygon)
+            {
+              const int n_nodes = exio_helper->elem_node_counts[elem_num];
+              libmesh_error_msg_if(n_nodes < 3,
+                                   "Error: Exodus NSIDED block element "
+                                   << elem_num
+                                   << " has only " << n_nodes << " nodes.");
+
+              uelem = std::make_unique<C0Polygon>(cast_int<unsigned int>(n_nodes));
+            }
+          else if (is_c0polyhedron)
+            {
+              const int n_faces = exio_helper->elem_face_counts[elem_num];
+              libmesh_error_msg_if(n_faces < 4,
+                                   "Error: Exodus NFACED block element "
+                                   << elem_num
+                                   << " has only " << n_faces << " faces.");
+
+              std::vector<std::shared_ptr<Polygon>>
+                sides(cast_int<std::size_t>(n_faces));
+
+              for (auto s : index_range(sides))
+                {
+                  libmesh_assert_less(c0polyhedron_connect_offset,
+                                      exio_helper->connect.size());
+                  const int exodus_face_id =
+                    exio_helper->connect[c0polyhedron_connect_offset++];
+
+                  libmesh_error_msg_if
+                    (exodus_face_id <= 0 ||
+                     exodus_face_id >
+                     cast_int<int>(exio_helper->c0polyhedron_face_connect.size()),
+                     "Error: Exodus NFACED block element "
+                     << elem_num
+                     << " references face ID " << exodus_face_id
+                     << ", but the file contains "
+                     << exio_helper->c0polyhedron_face_connect.size()
+                     << " faces.");
+
+                  const auto & face_nodes =
+                    exio_helper->c0polyhedron_face_connect[exodus_face_id - 1];
+                  auto side = std::make_shared<C0Polygon>
+                    (cast_int<unsigned int>(face_nodes.size()));
+
+                  for (auto n : index_range(face_nodes))
+                    {
+                      const auto libmesh_node_id =
+                        exio_helper->get_libmesh_node_id(face_nodes[n]);
+                      side->set_node(n, mesh.node_ptr(libmesh_node_id));
+                    }
+
+                  sides[s] = std::move(side);
+                }
+
+              std::unique_ptr<Node> mid_elem_node;
+              uelem = std::make_unique<C0Polyhedron>(sides, mid_elem_node);
+              if (mid_elem_node)
+                {
+                  Node * added_node = mesh.add_node(std::move(mid_elem_node));
+                  if (added_node->id() >= n_nodes)
+                    n_nodes = added_node->id() + 1;
+                }
+            }
+          else
+            uelem = Elem::build(conv.libmesh_elem_type());
 
           // Make sure that Exodus's number of nodes per Elem matches
           // the number of Nodes for this type of Elem. We only check
           // this for the first Elem in each block, since these values
           // are the same for every Elem in the block.
-          if (!elem_num)
+          if (!is_c0polygon && !is_c0polyhedron && !elem_num)
             libmesh_error_msg_if(exio_helper->num_nodes_per_elem != static_cast<int>(uelem->n_nodes()),
                                  "Error: Exodus file says "
                                  << exio_helper->num_nodes_per_elem
@@ -549,12 +620,26 @@ void ExodusII_IO::read (const std::string & fname)
           // If we don't have any Bezier extraction operators, this
           // is easy: we've already built all our nodes and just need
           // to link to them.
-          if (exio_helper->bex_cv_conn.empty())
+          if (is_c0polyhedron)
             {
-              for (int k=0; k<exio_helper->num_nodes_per_elem; k++)
+              // Node pointers were already assigned while constructing
+              // the polygonal sides above.
+            }
+          else if (exio_helper->bex_cv_conn.empty())
+            {
+              const int n_nodes_this_elem =
+                is_c0polygon ?
+                exio_helper->elem_node_counts[elem_num] :
+                exio_helper->num_nodes_per_elem;
+
+              for (int k=0; k<n_nodes_this_elem; k++)
                 {
                   // Get index into this block's connectivity array
-                  int gi = elem_num * exio_helper->num_nodes_per_elem + conv.get_node_map(k);
+                  std::size_t gi =
+                    is_c0polygon ?
+                    c0polygon_connect_offset++ :
+                    elem_num * exio_helper->num_nodes_per_elem + conv.get_node_map(k);
+                  libmesh_assert_less(gi, exio_helper->connect.size());
 
                   // Get the 1-based Exodus node id from the "connect" array
                   auto exodus_node_id = exio_helper->connect[gi];
@@ -688,6 +773,11 @@ void ExodusII_IO::read (const std::string & fname)
                 }
             }
         }
+
+      libmesh_assert(!is_c0polygon ||
+                     c0polygon_connect_offset == exio_helper->connect.size());
+      libmesh_assert(!is_c0polyhedron ||
+                     c0polyhedron_connect_offset == exio_helper->connect.size());
 
       // running sum of # of elements per block,
       // (should equal total number of elements in the end)

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1344,9 +1344,18 @@ void ExodusII_IO_Helper::read_elem_in_block(int block)
   EX_CHECK_ERR(ex_err, "Error getting block info.");
   message("Info retrieved successfully for block: ", block);
 
-  const auto & conv = get_conversion(std::string(elem_type.data()));
-  const bool is_c0polygon = (conv.libmesh_elem_type() == C0POLYGON);
-  const bool is_c0polyhedron = (conv.libmesh_elem_type() == C0POLYHEDRON);
+  // Nemesis uses "Empty" as the element type for blocks with no
+  // elements on the current processor.  There is no element conversion
+  // for that sentinel type, nor is one needed for an empty block.
+  const bool is_bezier = is_bezier_elem(elem_type.data());
+  const Conversion * conversion = nullptr;
+  if (num_elem_this_blk || is_bezier)
+    conversion = &get_conversion(std::string(elem_type.data()));
+
+  const bool is_c0polygon =
+    conversion && conversion->libmesh_elem_type() == C0POLYGON;
+  const bool is_c0polyhedron =
+    conversion && conversion->libmesh_elem_type() == C0POLYHEDRON;
 
   // Warn or error when we don't currently support reading blocks with extended info.
   // Note: the docs say -1 will be returned for this but I found that it was
@@ -1362,9 +1371,11 @@ void ExodusII_IO_Helper::read_elem_in_block(int block)
   // If we have a Bezier element here, then we've packed constraint
   // vector connectivity at the end of the nodal connectivity, and
   // num_nodes_per_elem reflected both.
-  const bool is_bezier = is_bezier_elem(elem_type.data());
   if (is_bezier)
-    num_nodes_per_elem = conv.n_nodes;
+    {
+      libmesh_assert(conversion);
+      num_nodes_per_elem = conversion->n_nodes;
+    }
   else if (is_c0polygon)
     {
       elem_node_counts.resize(num_elem_this_blk);
@@ -1504,9 +1515,8 @@ void ExodusII_IO_Helper::read_elem_in_block(int block)
               // for p>2 and aren't useful for p<2, and we don't
               // support anisotropic p...
 #ifndef NDEBUG
-              const auto & conv = get_conversion(std::string(elem_type.data()));
-
-              for (auto d : IntRange<int>(0, conv.dim))
+              libmesh_assert(conversion);
+              for (auto d : IntRange<int>(0, conversion->dim))
                 libmesh_assert_equal_to(bex_elem_degrees[d], 2);
 #endif
             }

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -723,6 +723,9 @@ void ExodusII_IO_Helper::open(const char * filename, bool read_only)
   if (read_only)
   {
     opened_for_reading = true;
+    elem_node_counts.clear();
+    elem_face_counts.clear();
+    c0polyhedron_face_connect.clear();
 
     // ExodusII reads truncate to 32-char strings by default; we'd
     // like to support whatever's in the file, so as early as possible
@@ -1190,6 +1193,124 @@ std::string ExodusII_IO_Helper::get_node_set_name(int index)
 }
 
 
+void ExodusII_IO_Helper::read_face_blocks()
+{
+  LOG_SCOPE("read_face_blocks()", "ExodusII_IO_Helper");
+
+  if (!c0polyhedron_face_connect.empty())
+    return;
+
+  libmesh_error_msg_if(num_face_blk == 0,
+                       "Error: Exodus NFACED element block found, "
+                       "but the file has no face blocks.");
+
+  std::vector<int> face_block_ids(num_face_blk);
+  ex_err = exII::ex_get_ids(ex_id,
+                            exII::EX_FACE_BLOCK,
+                            face_block_ids.data());
+  EX_CHECK_ERR(ex_err, "Error getting face block IDs.");
+
+  c0polyhedron_face_connect.clear();
+  c0polyhedron_face_connect.reserve(num_face);
+
+  for (auto block : index_range(face_block_ids))
+    {
+      std::vector<char> face_type(libmesh_max_str_length+1);
+      int num_face_this_blk = 0;
+      int num_node_data_this_blk = 0;
+      int num_edges_per_face = 0;
+      int num_faces_per_face = 0;
+      int num_attr_face = 0;
+
+      ex_err = exII::ex_get_block(ex_id,
+                                  exII::EX_FACE_BLOCK,
+                                  face_block_ids[block],
+                                  face_type.data(),
+                                  &num_face_this_blk,
+                                  &num_node_data_this_blk,
+                                  &num_edges_per_face,
+                                  &num_faces_per_face,
+                                  &num_attr_face);
+      EX_CHECK_ERR(ex_err, "Error getting face block info.");
+
+      const auto & conv = get_conversion(std::string(face_type.data()));
+      libmesh_error_msg_if(conv.libmesh_elem_type() != C0POLYGON,
+                           "Error: NFACED polyhedron input currently expects "
+                           "NSIDED face blocks, but face block "
+                           << face_block_ids[block] << " has Exodus type "
+                           << face_type.data() << ".");
+
+      libmesh_error_msg_if
+        (!(num_edges_per_face == 0) && !(num_edges_per_face == -1),
+         "Error: Exodus NSIDED face block "
+         << face_block_ids[block]
+         << " has edge connectivity, which NFACED polyhedron input "
+         << "does not currently support.");
+      libmesh_error_msg_if
+        (!(num_faces_per_face == 0) && !(num_faces_per_face == -1),
+         "Error: Exodus NSIDED face block "
+         << face_block_ids[block]
+         << " has face-in-face connectivity, which NFACED polyhedron "
+         << "input does not currently support.");
+
+      std::vector<int> face_node_counts(num_face_this_blk);
+      if (!face_node_counts.empty())
+        {
+          ex_err = exII::ex_get_entity_count_per_polyhedra
+            (ex_id,
+             exII::EX_FACE_BLOCK,
+             face_block_ids[block],
+             face_node_counts.data());
+          EX_CHECK_ERR(ex_err, "Error reading polyhedron face node counts");
+        }
+
+      int counted_nodes = 0;
+      for (const auto count : face_node_counts)
+        counted_nodes += count;
+
+      libmesh_error_msg_if(counted_nodes != num_node_data_this_blk,
+                           "Error: Exodus NSIDED face block "
+                           << face_block_ids[block]
+                           << " says it has " << num_node_data_this_blk
+                           << " total node entries, but its per-face "
+                           << "node counts sum to " << counted_nodes << ".");
+
+      std::vector<int> face_connect(num_node_data_this_blk);
+      if (!face_connect.empty())
+        {
+          ex_err = exII::ex_get_conn(ex_id,
+                                     exII::EX_FACE_BLOCK,
+                                     face_block_ids[block],
+                                     face_connect.data(),
+                                     nullptr,
+                                     nullptr);
+          EX_CHECK_ERR(ex_err, "Error reading polyhedron face connectivity.");
+        }
+
+      std::size_t offset = 0;
+      for (const auto count : face_node_counts)
+        {
+          libmesh_error_msg_if(count < 3,
+                               "Error: Exodus NSIDED face block "
+                               << face_block_ids[block]
+                               << " has a face with only "
+                               << count << " nodes.");
+
+          c0polyhedron_face_connect.emplace_back
+            (face_connect.begin() + offset,
+             face_connect.begin() + offset + count);
+          offset += count;
+        }
+    }
+
+  libmesh_error_msg_if(c0polyhedron_face_connect.size() !=
+                       cast_int<std::size_t>(num_face),
+                       "Error: Exodus file says it has "
+                       << num_face << " faces, but its face blocks contain "
+                       << c0polyhedron_face_connect.size() << " faces.");
+}
+
+
 
 
 void ExodusII_IO_Helper::read_elem_in_block(int block)
@@ -1197,6 +1318,8 @@ void ExodusII_IO_Helper::read_elem_in_block(int block)
   LOG_SCOPE("read_elem_in_block()", "ExodusII_IO_Helper");
 
   libmesh_assert_less (block, block_ids.size());
+  elem_node_counts.clear();
+  elem_face_counts.clear();
 
   // Unlike the other "extended" APIs, this one does not use a parameter struct.
   int num_edges_per_elem = 0;
@@ -1215,12 +1338,19 @@ void ExodusII_IO_Helper::read_elem_in_block(int block)
   EX_CHECK_ERR(ex_err, "Error getting block info.");
   message("Info retrieved successfully for block: ", block);
 
-  // Warn that we don't currently support reading blocks with extended info.
+  const auto & conv = get_conversion(std::string(elem_type.data()));
+  const bool is_c0polygon = (conv.libmesh_elem_type() == C0POLYGON);
+  const bool is_c0polyhedron = (conv.libmesh_elem_type() == C0POLYHEDRON);
+
+  // Warn or error when we don't currently support reading blocks with extended info.
   // Note: the docs say -1 will be returned for this but I found that it was
   // actually 0, so not sure which it will be in general.
-  if (!(num_edges_per_elem == 0) && !(num_edges_per_elem == -1))
+  if (is_c0polyhedron && !(num_edges_per_elem == 0) && !(num_edges_per_elem == -1))
+    libmesh_error_msg("Error: Exodus NFACED element blocks with edge "
+                      "connectivity are not currently supported.");
+  else if (!(num_edges_per_elem == 0) && !(num_edges_per_elem == -1))
     libmesh_warning("Exodus files with extended edge connectivity not currently supported.");
-  if (!(num_faces_per_elem == 0) && !(num_faces_per_elem == -1))
+  if (!is_c0polyhedron && !(num_faces_per_elem == 0) && !(num_faces_per_elem == -1))
     libmesh_warning("Exodus files with extended face connectivity not currently supported.");
 
   // If we have a Bezier element here, then we've packed constraint
@@ -1228,32 +1358,100 @@ void ExodusII_IO_Helper::read_elem_in_block(int block)
   // num_nodes_per_elem reflected both.
   const bool is_bezier = is_bezier_elem(elem_type.data());
   if (is_bezier)
+    num_nodes_per_elem = conv.n_nodes;
+  else if (is_c0polygon)
     {
-      const auto & conv = get_conversion(std::string(elem_type.data()));
-      num_nodes_per_elem = conv.n_nodes;
+      elem_node_counts.resize(num_elem_this_blk);
+
+      if (!elem_node_counts.empty())
+        {
+          ex_err = exII::ex_get_entity_count_per_polyhedra
+            (ex_id,
+             exII::EX_ELEM_BLOCK,
+             block_ids[block],
+             elem_node_counts.data());
+          EX_CHECK_ERR(ex_err, "Error reading polygon node counts");
+        }
+
+      int counted_nodes = 0;
+      for (const auto count : elem_node_counts)
+        counted_nodes += count;
+
+      libmesh_error_msg_if(counted_nodes != num_node_data_per_elem,
+                           "Error: Exodus NSIDED block "
+                           << block_ids[block]
+                           << " says it has " << num_node_data_per_elem
+                           << " total node entries, but its per-element "
+                           << "node counts sum to " << counted_nodes << ".");
+
+      num_nodes_per_elem = 0;
+    }
+  else if (is_c0polyhedron)
+    {
+      if (c0polyhedron_face_connect.empty())
+        this->read_face_blocks();
+
+      elem_face_counts.resize(num_elem_this_blk);
+
+      if (!elem_face_counts.empty())
+        {
+          ex_err = exII::ex_get_entity_count_per_polyhedra
+            (ex_id,
+             exII::EX_ELEM_BLOCK,
+             block_ids[block],
+             elem_face_counts.data());
+          EX_CHECK_ERR(ex_err, "Error reading polyhedron face counts");
+        }
+
+      int counted_faces = 0;
+      for (const auto count : elem_face_counts)
+        counted_faces += count;
+
+      libmesh_error_msg_if(counted_faces != num_faces_per_elem,
+                           "Error: Exodus NFACED block "
+                           << block_ids[block]
+                           << " says it has " << num_faces_per_elem
+                           << " total face entries, but its per-element "
+                           << "face counts sum to " << counted_faces << ".");
+
+      num_nodes_per_elem = 0;
     }
   else
     num_nodes_per_elem = num_node_data_per_elem;
 
   if (verbose)
-    libMesh::out << "Read a block of " << num_elem_this_blk
-                 << " " << elem_type.data() << "(s)"
-                 << " having " << num_nodes_per_elem
-                 << " nodes per element." << std::endl;
+    {
+      libMesh::out << "Read a block of " << num_elem_this_blk
+                   << " " << elem_type.data() << "(s)";
+      if (is_c0polygon)
+        libMesh::out << " having " << num_node_data_per_elem
+                     << " total node entries.";
+      else if (is_c0polyhedron)
+        libMesh::out << " having " << num_faces_per_elem
+                     << " total face entries.";
+      else
+        libMesh::out << " having " << num_nodes_per_elem
+                     << " nodes per element.";
+      libMesh::out << std::endl;
+    }
 
   // Read in the connectivity of the elements of this block,
   // watching out for the case where we actually have no
   // elements in this block (possible with parallel files)
-  connect.resize(num_node_data_per_elem*num_elem_this_blk);
+  connect.resize(is_c0polygon ?
+                 num_node_data_per_elem :
+                 is_c0polyhedron ?
+                 num_faces_per_elem :
+                 num_node_data_per_elem*num_elem_this_blk);
 
   if (!connect.empty())
     {
       ex_err = exII::ex_get_conn(ex_id,
                                  exII::EX_ELEM_BLOCK,
                                  block_ids[block],
-                                 connect.data(), // node_conn
-                                 nullptr,        // elem_edge_conn (unused)
-                                 nullptr);       // elem_face_conn (unused)
+                                 is_c0polyhedron ? nullptr : connect.data(),
+                                 nullptr, // elem_edge_conn (unused)
+                                 is_c0polyhedron ? connect.data() : nullptr);
 
       EX_CHECK_ERR(ex_err, "Error reading block connectivity.");
       message("Connectivity retrieved successfully for block: ", block);

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -3367,9 +3367,9 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
     next_fake_id = mesh.next_unique_id();
 #endif
 
-  std::vector<int> c0polyhedron_face_connect;
+  std::vector<int> face_connect;
   std::vector<int> c0polyhedron_face_node_counts;
-  c0polyhedron_face_connect.reserve(c0polyhedron_total_face_nodes);
+  face_connect.reserve(c0polyhedron_total_face_nodes);
   c0polyhedron_face_node_counts.reserve(c0polyhedron_total_faces);
   int next_c0polyhedron_face_id = 1;
 
@@ -3451,7 +3451,7 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
             c0polyhedron_face_node_counts.push_back(cast_int<int>(side_nodes.size()));
 
             for (const auto elem_node_index : side_nodes)
-            c0polyhedron_face_connect.push_back(
+            face_connect.push_back(
               get_exodus_node_id(elem, elem_id, elem_node_index));
           }
         };
@@ -3600,9 +3600,9 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
         (ex_id,
          exII::EX_FACE_BLOCK,
          c0polyhedron_face_block_id,
-         c0polyhedron_face_connect.data(), // node_conn
-         nullptr,                          // elem_edge_conn (unused)
-         nullptr);                         // elem_face_conn (unused)
+         face_connect.data(), // node_conn
+         nullptr,             // elem_edge_conn (unused)
+         nullptr);            // elem_face_conn (unused)
       EX_CHECK_ERR(ex_err, "Error writing polyhedron face connectivities");
 
       ex_err = exII::ex_put_entity_count_per_polyhedra

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -67,8 +67,6 @@ static constexpr int libmesh_max_str_length = MAX_LINE_LENGTH;
 
 using namespace libMesh;
 
-constexpr int c0polyhedron_face_block_id = 1;
-
 // File scope constant node/edge/face mapping arrays.
 // 2D inverse face map definitions.
 // These take a libMesh ID and turn it into an Exodus ID
@@ -203,7 +201,10 @@ const std::vector<int> prism_inverse_face_map = {4, 1, 2, 3, 5};
 
 
   std::map<subdomain_id_type, std::vector<unsigned int>>
-  build_subdomain_map(const MeshBase & mesh, bool add_sides, subdomain_id_type & subdomain_id_end)
+  build_subdomain_map(const MeshBase & mesh,
+                      bool add_sides,
+                      subdomain_id_type & subdomain_id_end,
+                      int & next_block_id)
   {
     std::map<subdomain_id_type, std::vector<unsigned int>> subdomain_map;
 
@@ -249,6 +250,11 @@ const std::vector<int> prism_inverse_face_map = {4, 1, 2, 3, 5};
 
     if (!add_sides && !subdomain_map.empty())
       subdomain_id_end = subdomain_map.rbegin()->first + 1;
+
+    // Allocate optional block IDs after both mesh subdomains and any blocks
+    // synthesized for visualization sides.
+    if (!subdomain_map.empty())
+      next_block_id = cast_int<int>(subdomain_map.rbegin()->first) + 1;
 
     return subdomain_map;
   }
@@ -2574,7 +2580,11 @@ void ExodusII_IO_Helper::initialize(std::string str_title, const MeshBase & mesh
 
   // We need to know about all processors' subdomains
   subdomain_id_type subdomain_id_end = 0;
-  auto subdomain_map = build_subdomain_map(mesh, _add_sides, subdomain_id_end);
+  int c0polyhedron_face_block_id = -1;
+  auto subdomain_map = build_subdomain_map(mesh,
+                                           _add_sides,
+                                           subdomain_id_end,
+                                           c0polyhedron_face_block_id);
 
   num_elem = n_active_elem;
   num_nodes = 0;
@@ -2943,7 +2953,11 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
   // Map from block ID to a vector of element IDs in that block.  Element
   // IDs are now of type dof_id_type, subdomain IDs are of type subdomain_id_type.
   subdomain_id_type subdomain_id_end = 0;
-  auto subdomain_map = build_subdomain_map(mesh, _add_sides, subdomain_id_end);
+  int c0polyhedron_face_block_id = -1;
+  auto subdomain_map = build_subdomain_map(mesh,
+                                           _add_sides,
+                                           subdomain_id_end,
+                                           c0polyhedron_face_block_id);
 
   if ((_run_only_on_proc0) && (this->processor_id() != 0))
     return;

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -53,6 +53,7 @@ extern "C" {
 #include <cfenv> // workaround for HDF5 bug
 #include <cstdlib> // std::strtol
 #include <sstream>
+#include <string>
 #include <unordered_map>
 
 // Anonymous namespace for file local data and helper functions
@@ -65,6 +66,8 @@ namespace
 static constexpr int libmesh_max_str_length = MAX_LINE_LENGTH;
 
 using namespace libMesh;
+
+constexpr int c0polyhedron_face_block_id = 1;
 
 // File scope constant node/edge/face mapping arrays.
 // 2D inverse face map definitions.
@@ -274,6 +277,8 @@ ExodusII_IO_Helper::ExodusII_IO_Helper(const ParallelObject & parent,
   num_elem_blk(header_info.num_elem_blk),
   num_edge(header_info.num_edge),
   num_edge_blk(header_info.num_edge_blk),
+  num_face(header_info.num_face),
+  num_face_blk(header_info.num_face_blk),
   num_node_sets(header_info.num_node_sets),
   num_side_sets(header_info.num_side_sets),
   num_elem_sets(header_info.num_elem_sets),
@@ -361,6 +366,14 @@ void ExodusII_IO_Helper::init_conversion_map()
   convert_type(QUAD4, "QUAD4");
   convert_type(QUAD8, "QUAD8");
   convert_type(QUAD9, "QUAD9");
+  convert_type(C0POLYGON, "NSIDED");
+  {
+    auto & conv = conversion_map[3][C0POLYHEDRON];
+    conv.libmesh_type = C0POLYHEDRON;
+    conv.exodus_type = "NFACED";
+    conv.dim = 3;
+    conv.n_nodes = 0;
+  }
   convert_type(QUADSHELL4, "SHELL4", nullptr, nullptr, nullptr,
                /* inverse_side_map = */ &quadshell4_inverse_edge_map,
                nullptr, nullptr, /* shellface_index_offset = */ 2);
@@ -476,6 +489,10 @@ void ExodusII_IO_Helper::init_element_equivalence_map()
 
   // QUADSHELL9 equivalences
   element_equivalence_map["SHELL9"] = QUADSHELL9;
+
+  // Runtime-topology polytope equivalences
+  element_equivalence_map["NSIDED"] = C0POLYGON;
+  element_equivalence_map["NFACED"] = C0POLYHEDRON;
 
   // TRI3 equivalences
   element_equivalence_map["TRI"]       = TRI3;
@@ -756,6 +773,8 @@ ExodusII_IO_Helper::read_header() const
   h.num_elem_sets = params.num_elem_sets;
   h.num_edge_blk = params.num_edge_blk;
   h.num_edge = params.num_edge;
+  h.num_face_blk = params.num_face_blk;
+  h.num_face = params.num_face;
 
   // And return it
   return h;
@@ -2361,6 +2380,25 @@ void ExodusII_IO_Helper::initialize(std::string str_title, const MeshBase & mesh
 
   num_elem = n_active_elem;
   num_nodes = 0;
+  num_face = 0;
+  num_face_blk = 0;
+
+  dof_id_type local_num_c0polyhedron_faces = 0;
+  int has_c0polyhedron = 0;
+  for (const auto & elem : mesh.active_local_element_ptr_range())
+    if (elem->type() == C0POLYHEDRON)
+      {
+        has_c0polyhedron = 1;
+        local_num_c0polyhedron_faces += elem->n_sides();
+      }
+
+  mesh.comm().sum(local_num_c0polyhedron_faces);
+  mesh.comm().max(has_c0polyhedron);
+  if (has_c0polyhedron)
+    {
+      num_face = cast_int<int>(local_num_c0polyhedron_faces);
+      num_face_blk = 1;
+    }
 
   // If we're adding face elements they'll need copies of their nodes.
   // We also have to count of how many nodes (and gaps between nodes!)
@@ -2534,6 +2572,8 @@ void ExodusII_IO_Helper::initialize(std::string str_title, const MeshBase & mesh
   params.num_elem_sets = num_elem_sets;
   params.num_edge_blk = num_edge_blk;
   params.num_edge = num_edge;
+  params.num_face_blk = num_face_blk;
+  params.num_face = num_face;
 
   ex_err = exII::ex_put_init_ext(ex_id, &params);
   EX_CHECK_ERR(ex_err, "Error initializing new Exodus file.");
@@ -2729,6 +2769,10 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
   NamesData names_table(num_elem_blk, _max_name_length);
 
   num_elem = 0;
+  bool has_c0polygon_blocks = false;
+  bool has_c0polyhedron_blocks = false;
+  int c0polyhedron_total_faces = 0;
+  int c0polyhedron_total_face_nodes = 0;
 
   // counter indexes into the block_ids vector
   unsigned int counter = 0;
@@ -2754,8 +2798,13 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
           libmesh_assert(!element_id_vec.empty());
           num_elem_this_blk_vec.push_back
             (cast_int<int>(element_id_vec.size()));
-          names_table.push_back_entry
-            (mesh.subdomain_name(subdomain_id));
+
+          std::string block_name = mesh.subdomain_name(subdomain_id);
+          if (block_name.empty() && elem_t == C0POLYGON)
+            block_name = "NSIDED_" + std::to_string(counter + 1);
+          if (block_name.empty() && elem_t == C0POLYHEDRON)
+            block_name = "NFACED_" + std::to_string(counter + 1);
+          names_table.push_back_entry(block_name);
         }
 
       num_elem += num_elem_this_blk_vec.back();
@@ -2764,17 +2813,77 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
       // Note that Exodus assumes all elements in a block are of the same type!
       // We are using that same assumption here!
       const auto & conv = get_conversion(elem_t);
-      num_nodes_per_elem = Elem::type_to_n_nodes_map[elem_t];
-      if (Elem::type_to_n_nodes_map[elem_t] == invalid_uint)
-        libmesh_not_implemented_msg("Support for Polygons/Polyhedra not yet implemented");
+      int num_edges_per_elem = 0;
+      int num_faces_per_elem = 0;
+      if (elem_t == C0POLYGON)
+        {
+          if (subdomain_id >= subdomain_id_end)
+            libmesh_not_implemented_msg("Support for C0POLYGON side blocks not yet implemented");
+
+          has_c0polygon_blocks = true;
+          num_nodes_per_elem = 0;
+
+          for (auto elem_id : element_id_vec)
+            {
+              const Elem & elem = mesh.elem_ref(elem_id);
+
+              libmesh_error_msg_if(elem.type() != C0POLYGON,
+                                   "Error: Exodus requires all elements with a given subdomain ID "
+                                   "to be the same type.\n"
+                                   << "Can't write both "
+                                   << Utility::enum_to_string(elem.type())
+                                   << " and C0POLYGON in the same block!");
+
+              num_nodes_per_elem += cast_int<int>(elem.n_nodes());
+            }
+        }
+      else if (elem_t == C0POLYHEDRON)
+        {
+          if (subdomain_id >= subdomain_id_end)
+            libmesh_not_implemented_msg("Support for C0POLYHEDRON side blocks not yet implemented");
+
+          has_c0polyhedron_blocks = true;
+          num_nodes_per_elem = 0;
+
+          for (auto elem_id : element_id_vec)
+            {
+              const Elem & elem = mesh.elem_ref(elem_id);
+
+              libmesh_error_msg_if(elem.type() != C0POLYHEDRON,
+                                   "Error: Exodus requires all elements with a given subdomain ID "
+                                   "to be the same type.\n"
+                                   << "Can't write both "
+                                   << Utility::enum_to_string(elem.type())
+                                   << " and C0POLYHEDRON in the same block!");
+
+              const int elem_n_sides = cast_int<int>(elem.n_sides());
+              num_faces_per_elem += elem_n_sides;
+              c0polyhedron_total_faces += elem_n_sides;
+
+              for (auto s : elem.side_index_range())
+                c0polyhedron_total_face_nodes += cast_int<int>(elem.nodes_on_side(s).size());
+            }
+        }
+      else
+        {
+          num_nodes_per_elem = Elem::type_to_n_nodes_map[elem_t];
+          if (Elem::type_to_n_nodes_map[elem_t] == invalid_uint)
+            libmesh_not_implemented_msg("Support for Polygons/Polyhedra not yet implemented");
+        }
 
       elem_blk_id.push_back(subdomain_id);
       elem_type_table.push_back_entry(conv.exodus_elem_type().c_str());
       num_nodes_per_elem_vec.push_back(num_nodes_per_elem);
       num_attr_vec.push_back(0); // we don't currently use elem block attributes.
-      num_edges_per_elem_vec.push_back(0); // We don't currently store any edge blocks
-      num_faces_per_elem_vec.push_back(0); // We don't currently store any face blocks
+      num_edges_per_elem_vec.push_back(num_edges_per_elem); // We don't currently store any edge blocks
+      num_faces_per_elem_vec.push_back(num_faces_per_elem);
       ++counter;
+    }
+
+  if (has_c0polyhedron_blocks)
+    {
+      libmesh_assert_equal_to(num_face_blk, 1);
+      libmesh_assert_equal_to(num_face, c0polyhedron_total_faces);
     }
 
   // Here we reserve() space so that we can push_back() onto the
@@ -2915,6 +3024,9 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
   // We also build a data structure of edge block names which can
   // later be passed to exII::ex_put_names().
   NamesData edge_block_names_table(num_edge_blk, _max_name_length);
+  NamesData face_block_names_table(num_face_blk, _max_name_length);
+  if (has_c0polyhedron_blocks)
+    face_block_names_table.push_back_entry("NSIDED_FACES");
 
   // Note: We are going to use the edge **boundary** ids as **block** ids.
   for (const auto & pr : edge_id_to_conn)
@@ -2940,41 +3052,91 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
       edge_block_names_table.push_back_entry(bi.get_edgeset_name(id));
     }
 
-  // Zero-initialize and then fill in an exII::ex_block_params struct
-  // with the data we have collected. This new API replaces the old
-  // exII::ex_put_concat_elem_block() API, and will eventually allow
-  // us to also allocate space for edge/face blocks if desired.
-  //
-  // TODO: It seems like we should be able to take advantage of the
-  // optimization where you set define_maps==1, but when I tried this
-  // I got the error: "failed to find node map size". I think the
-  // problem is that we need to first specify a nonzero number of
-  // node/elem maps during the call to ex_put_init_ext() in order for
-  // this to work correctly.
-  exII::ex_block_params params = {};
-
-  // Set pointers for information about elem blocks.
-  params.elem_blk_id = elem_blk_id.data();
-  params.elem_type = elem_type_table.get_char_star_star();
-  params.num_elem_this_blk = num_elem_this_blk_vec.data();
-  params.num_nodes_per_elem = num_nodes_per_elem_vec.data();
-  params.num_edges_per_elem = num_edges_per_elem_vec.data();
-  params.num_faces_per_elem = num_faces_per_elem_vec.data();
-  params.num_attr_elem = num_attr_vec.data();
-  params.define_maps = 0;
-
-  // Set pointers to edge block information only if we actually have some.
-  if (num_edge_blk)
+  if (has_c0polygon_blocks || has_c0polyhedron_blocks)
     {
-      params.edge_blk_id = edge_blk_id.data();
-      params.edge_type = edge_type_table.get_char_star_star();
-      params.num_edge_this_blk = num_edge_this_blk_vec.data();
-      params.num_nodes_per_edge = num_nodes_per_edge_vec.data();
-      params.num_attr_edge = num_attr_edge_vec.data();
-    }
+      // ex_put_concat_all_blocks() does not define the per-polytope
+      // entity count arrays required by NSIDED/NFACED blocks in all supported
+      // Exodus versions. Define blocks individually through ex_put_block().
+      if (has_c0polyhedron_blocks)
+        {
+          ex_err = exII::ex_put_block(ex_id,
+                                      exII::EX_FACE_BLOCK,
+                                      c0polyhedron_face_block_id,
+                                      "NSIDED",
+                                      c0polyhedron_total_faces,
+                                      c0polyhedron_total_face_nodes,
+                                      0,
+                                      0,
+                                      0);
+          EX_CHECK_ERR(ex_err, "Error writing polyhedron face block.");
+        }
 
-  ex_err = exII::ex_put_concat_all_blocks(ex_id, &params);
-  EX_CHECK_ERR(ex_err, "Error writing element blocks.");
+      for (auto i : index_range(elem_blk_id))
+        {
+          ex_err = exII::ex_put_block(ex_id,
+                                      exII::EX_ELEM_BLOCK,
+                                      elem_blk_id[i],
+                                      elem_type_table.get_char_star(cast_int<int>(i)),
+                                      num_elem_this_blk_vec[i],
+                                      num_nodes_per_elem_vec[i],
+                                      num_edges_per_elem_vec[i],
+                                      num_faces_per_elem_vec[i],
+                                      num_attr_vec[i]);
+          EX_CHECK_ERR(ex_err, "Error writing element block.");
+        }
+
+      for (auto i : index_range(edge_blk_id))
+        {
+          ex_err = exII::ex_put_block(ex_id,
+                                      exII::EX_EDGE_BLOCK,
+                                      edge_blk_id[i],
+                                      edge_type_table.get_char_star(cast_int<int>(i)),
+                                      num_edge_this_blk_vec[i],
+                                      num_nodes_per_edge_vec[i],
+                                      0,
+                                      0,
+                                      num_attr_edge_vec[i]);
+          EX_CHECK_ERR(ex_err, "Error writing edge block.");
+        }
+    }
+  else
+    {
+      // Zero-initialize and then fill in an exII::ex_block_params struct
+      // with the data we have collected. This new API replaces the old
+      // exII::ex_put_concat_elem_block() API, and will eventually allow
+      // us to also allocate space for edge/face blocks if desired.
+      //
+      // TODO: It seems like we should be able to take advantage of the
+      // optimization where you set define_maps==1, but when I tried this
+      // I got the error: "failed to find node map size". I think the
+      // problem is that we need to first specify a nonzero number of
+      // node/elem maps during the call to ex_put_init_ext() in order for
+      // this to work correctly.
+      exII::ex_block_params params = {};
+
+      // Set pointers for information about elem blocks.
+      params.elem_blk_id = elem_blk_id.data();
+      params.elem_type = elem_type_table.get_char_star_star();
+      params.num_elem_this_blk = num_elem_this_blk_vec.data();
+      params.num_nodes_per_elem = num_nodes_per_elem_vec.data();
+      params.num_edges_per_elem = num_edges_per_elem_vec.data();
+      params.num_faces_per_elem = num_faces_per_elem_vec.data();
+      params.num_attr_elem = num_attr_vec.data();
+      params.define_maps = 0;
+
+      // Set pointers to edge block information only if we actually have some.
+      if (num_edge_blk)
+        {
+          params.edge_blk_id = edge_blk_id.data();
+          params.edge_type = edge_type_table.get_char_star_star();
+          params.num_edge_this_blk = num_edge_this_blk_vec.data();
+          params.num_nodes_per_edge = num_nodes_per_edge_vec.data();
+          params.num_attr_edge = num_attr_edge_vec.data();
+        }
+
+      ex_err = exII::ex_put_concat_all_blocks(ex_id, &params);
+      EX_CHECK_ERR(ex_err, "Error writing element blocks.");
+    }
 
   // This counter is used to fill up the libmesh_elem_num_to_exodus map in the loop below.
   unsigned libmesh_elem_num_to_exodus_counter = 0;
@@ -2993,6 +3155,12 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
     next_fake_id = mesh.next_unique_id();
 #endif
 
+  std::vector<int> c0polyhedron_face_connect;
+  std::vector<int> c0polyhedron_face_node_counts;
+  c0polyhedron_face_connect.reserve(c0polyhedron_total_face_nodes);
+  c0polyhedron_face_node_counts.reserve(c0polyhedron_total_faces);
+  int next_c0polyhedron_face_id = 1;
+
   for (auto & [subdomain_id, element_id_vec] : subdomain_map)
     {
       // Use the first element in the block to get representative
@@ -3004,15 +3172,39 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
         mesh.elem_ref(element_id_vec[0]).type();
 
       const auto & conv = get_conversion(elem_t);
-      num_nodes_per_elem = Elem::type_to_n_nodes_map[elem_t];
-      if (Elem::type_to_n_nodes_map[elem_t] == invalid_uint)
-        libmesh_not_implemented_msg("Support for Polygons/Polyhedra not yet implemented");
+      const bool is_c0polygon_block = (elem_t == C0POLYGON);
+      const bool is_c0polyhedron_block = (elem_t == C0POLYHEDRON);
+      std::vector<int> c0polygon_node_counts;
+      std::vector<int> c0polyhedron_face_counts;
+
+      if (is_c0polygon_block && subdomain_id >= subdomain_id_end)
+        libmesh_not_implemented_msg("Support for C0POLYGON side blocks not yet implemented");
+      if (is_c0polyhedron_block && subdomain_id >= subdomain_id_end)
+        libmesh_not_implemented_msg("Support for C0POLYHEDRON side blocks not yet implemented");
+
+      if (!is_c0polygon_block && !is_c0polyhedron_block)
+        {
+          num_nodes_per_elem = Elem::type_to_n_nodes_map[elem_t];
+          if (Elem::type_to_n_nodes_map[elem_t] == invalid_uint)
+            libmesh_not_implemented_msg("Support for Polygons/Polyhedra not yet implemented");
+        }
 
       // If this is a *real* block, we just loop over vectors of
       // element ids to add.
       if (subdomain_id < subdomain_id_end)
       {
-        connect.resize(element_id_vec.size()*num_nodes_per_elem);
+        if (is_c0polygon_block)
+          {
+            connect.clear();
+            c0polygon_node_counts.reserve(element_id_vec.size());
+          }
+        else if (is_c0polyhedron_block)
+          {
+            connect.clear();
+            c0polyhedron_face_counts.reserve(element_id_vec.size());
+          }
+        else
+          connect.resize(element_id_vec.size()*num_nodes_per_elem);
 
         for (auto i : index_range(element_id_vec))
         {
@@ -3039,30 +3231,92 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
                                << Utility::enum_to_string(conv.libmesh_elem_type())
                                << " in the same block!");
 
-          for (unsigned int j=0; j<static_cast<unsigned int>(num_nodes_per_elem); ++j)
+          if (is_c0polygon_block)
             {
-              unsigned int connect_index   = cast_int<unsigned int>((i*num_nodes_per_elem)+j);
-              unsigned elem_node_index = conv.get_inverse_node_map(j); // inverse node map is for writing.
-              if (!use_discontinuous)
-                {
-                  // The global id for the current node in libmesh.
-                  dof_id_type libmesh_node_id = elem.node_id(elem_node_index);
+              c0polygon_node_counts.push_back(cast_int<int>(elem.n_nodes()));
 
-                  // Write the Exodus global node id associated with
-                  // this libmesh node number to the connectivity
-                  // array, or throw an error if it's not found.
-                  connect[connect_index] =
-                    libmesh_map_find(libmesh_node_num_to_exodus,
-                                     cast_int<int>(libmesh_node_id));
-                }
-              else
+              for (auto elem_node_index : elem.node_index_range())
                 {
-                  // Look up the (elem_id, elem_node_index) pair in the map.
-                  connect[connect_index] =
-                    libmesh_map_find(discontinuous_node_indices,
-                                     std::make_pair(elem_id, elem_node_index));
+                  if (!use_discontinuous)
+                    {
+                      // The global id for the current node in libmesh.
+                      dof_id_type libmesh_node_id = elem.node_id(elem_node_index);
+
+                      // Write the Exodus global node id associated with
+                      // this libmesh node number to the connectivity
+                      // array, or throw an error if it's not found.
+                      connect.push_back
+                        (libmesh_map_find(libmesh_node_num_to_exodus,
+                                          cast_int<int>(libmesh_node_id)));
+                    }
+                  else
+                    {
+                      // Look up the (elem_id, elem_node_index) pair in the map.
+                      connect.push_back
+                        (libmesh_map_find(discontinuous_node_indices,
+                                          std::make_pair(elem_id, elem_node_index)));
+                    }
                 }
-            } // end for(j)
+            }
+          else if (is_c0polyhedron_block)
+            {
+              c0polyhedron_face_counts.push_back(cast_int<int>(elem.n_sides()));
+
+              for (auto s : elem.side_index_range())
+                {
+                  connect.push_back(next_c0polyhedron_face_id++);
+
+                  const std::vector<unsigned int> side_nodes =
+                    elem.nodes_on_side(s);
+                  c0polyhedron_face_node_counts.push_back
+                    (cast_int<int>(side_nodes.size()));
+
+                  for (const auto elem_node_index : side_nodes)
+                    {
+                      if (!use_discontinuous)
+                        {
+                          const dof_id_type libmesh_node_id =
+                            elem.node_id(elem_node_index);
+                          c0polyhedron_face_connect.push_back
+                            (libmesh_map_find(libmesh_node_num_to_exodus,
+                                              cast_int<int>(libmesh_node_id)));
+                        }
+                      else
+                        {
+                          c0polyhedron_face_connect.push_back
+                            (libmesh_map_find(discontinuous_node_indices,
+                                              std::make_pair(elem_id, elem_node_index)));
+                        }
+                    }
+                }
+            }
+          else
+            {
+              for (unsigned int j=0; j<static_cast<unsigned int>(num_nodes_per_elem); ++j)
+                {
+                  unsigned int connect_index   = cast_int<unsigned int>((i*num_nodes_per_elem)+j);
+                  unsigned elem_node_index = conv.get_inverse_node_map(j); // inverse node map is for writing.
+                  if (!use_discontinuous)
+                    {
+                      // The global id for the current node in libmesh.
+                      dof_id_type libmesh_node_id = elem.node_id(elem_node_index);
+
+                      // Write the Exodus global node id associated with
+                      // this libmesh node number to the connectivity
+                      // array, or throw an error if it's not found.
+                      connect[connect_index] =
+                        libmesh_map_find(libmesh_node_num_to_exodus,
+                                         cast_int<int>(libmesh_node_id));
+                    }
+                  else
+                    {
+                      // Look up the (elem_id, elem_node_index) pair in the map.
+                      connect[connect_index] =
+                        libmesh_map_find(discontinuous_node_indices,
+                                         std::make_pair(elem_id, elem_node_index));
+                    }
+                } // end for(j)
+            }
 
           // push_back() either elem_id+1 or the current Elem's
           // unique_id+1 into the elem_num_map, depending on the value
@@ -3126,11 +3380,53 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
         (ex_id,
          exII::EX_ELEM_BLOCK,
          subdomain_id,
-         connect.data(), // node_conn
-         nullptr,        // elem_edge_conn (unused)
-         nullptr);       // elem_face_conn (unused)
+         is_c0polyhedron_block ? nullptr : connect.data(), // node_conn
+         nullptr,                                          // elem_edge_conn (unused)
+         is_c0polyhedron_block ? connect.data() : nullptr);
       EX_CHECK_ERR(ex_err, "Error writing element connectivities");
+
+      if (is_c0polygon_block)
+        {
+          ex_err = exII::ex_put_entity_count_per_polyhedra
+            (ex_id,
+             exII::EX_ELEM_BLOCK,
+             subdomain_id,
+             c0polygon_node_counts.data());
+          EX_CHECK_ERR(ex_err, "Error writing polygon node counts");
+        }
+      if (is_c0polyhedron_block)
+        {
+          ex_err = exII::ex_put_entity_count_per_polyhedra
+            (ex_id,
+             exII::EX_ELEM_BLOCK,
+             subdomain_id,
+             c0polyhedron_face_counts.data());
+          EX_CHECK_ERR(ex_err, "Error writing polyhedron face counts");
+        }
     } // end for (auto & [subdomain_id, element_id_vec] : subdomain_map)
+
+  if (has_c0polyhedron_blocks)
+    {
+      libmesh_assert_equal_to(c0polyhedron_face_node_counts.size(),
+                              cast_int<std::size_t>(num_face));
+      libmesh_assert_equal_to(next_c0polyhedron_face_id, num_face + 1);
+
+      ex_err = exII::ex_put_conn
+        (ex_id,
+         exII::EX_FACE_BLOCK,
+         c0polyhedron_face_block_id,
+         c0polyhedron_face_connect.data(), // node_conn
+         nullptr,                          // elem_edge_conn (unused)
+         nullptr);                         // elem_face_conn (unused)
+      EX_CHECK_ERR(ex_err, "Error writing polyhedron face connectivities");
+
+      ex_err = exII::ex_put_entity_count_per_polyhedra
+        (ex_id,
+         exII::EX_FACE_BLOCK,
+         c0polyhedron_face_block_id,
+         c0polyhedron_face_node_counts.data());
+      EX_CHECK_ERR(ex_err, "Error writing polyhedron face node counts");
+    }
 
   // write out the element number map that we created
   ex_err = exII::ex_put_elem_num_map(ex_id, elem_num_map.data());
@@ -3141,6 +3437,15 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
     {
       ex_err = exII::ex_put_names(ex_id, exII::EX_ELEM_BLOCK, names_table.get_char_star_star());
       EX_CHECK_ERR(ex_err, "Error writing element block names");
+    }
+
+  if (num_face_blk > 0)
+    {
+      ex_err = exII::ex_put_names
+        (ex_id,
+         exII::EX_FACE_BLOCK,
+         face_block_names_table.get_char_star_star());
+      EX_CHECK_ERR(ex_err, "Error writing face block names");
     }
 
   // Write out edge blocks if we have any

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -3373,6 +3373,19 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
   c0polyhedron_face_node_counts.reserve(c0polyhedron_total_faces);
   int next_c0polyhedron_face_id = 1;
 
+  const auto get_exodus_node_id = [&](const Elem &elem,
+                                  dof_id_type elem_id,
+                                  unsigned int elem_node_index)
+                                   -> int
+  {
+    if (!use_discontinuous)
+    return libmesh_map_find(libmesh_node_num_to_exodus,
+                            cast_int<int>(elem.node_id(elem_node_index)));
+
+    return cast_int<int>(libmesh_map_find(discontinuous_node_indices,
+                                          std::make_pair(elem_id, elem_node_index)));
+  };
+
   for (auto & [subdomain_id, element_id_vec] : subdomain_map)
     {
       // Use the first element in the block to get representative
@@ -3386,15 +3399,17 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
       const auto & conv = get_conversion(elem_t);
       const bool is_c0polygon_block = (elem_t == C0POLYGON);
       const bool is_c0polyhedron_block = (elem_t == C0POLYHEDRON);
+      const bool is_variable_connectivity_block =
+        is_c0polygon_block || is_c0polyhedron_block;
       std::vector<int> c0polygon_node_counts;
       std::vector<int> c0polyhedron_face_counts;
 
-      if (is_c0polygon_block && subdomain_id >= subdomain_id_end)
-        libmesh_not_implemented_msg("Support for C0POLYGON side blocks not yet implemented");
-      if (is_c0polyhedron_block && subdomain_id >= subdomain_id_end)
-        libmesh_not_implemented_msg("Support for C0POLYHEDRON side blocks not yet implemented");
+      if (is_variable_connectivity_block && subdomain_id >= subdomain_id_end)
+        libmesh_not_implemented_msg("Support for " <<
+                                    Utility::enum_to_string(elem_t) <<
+                                    " side blocks not yet implemented");
 
-      if (!is_c0polygon_block && !is_c0polyhedron_block)
+      if (!is_variable_connectivity_block)
         {
           num_nodes_per_elem = Elem::type_to_n_nodes_map[elem_t];
           if (Elem::type_to_n_nodes_map[elem_t] == invalid_uint)
@@ -3405,18 +3420,56 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
       // element ids to add.
       if (subdomain_id < subdomain_id_end)
       {
+        if (is_variable_connectivity_block)
+            connect.clear();
         if (is_c0polygon_block)
-          {
-            connect.clear();
             c0polygon_node_counts.reserve(element_id_vec.size());
-          }
         else if (is_c0polyhedron_block)
-          {
-            connect.clear();
             c0polyhedron_face_counts.reserve(element_id_vec.size());
-          }
         else
           connect.resize(element_id_vec.size()*num_nodes_per_elem);
+
+        const auto add_c0polygon_connectivity =
+            [&](const Elem &elem, dof_id_type elem_id)
+        {
+          c0polygon_node_counts.push_back(cast_int<int>(elem.n_nodes()));
+          for (auto elem_node_index : elem.node_index_range())
+            connect.push_back(get_exodus_node_id(elem, elem_id, elem_node_index));
+
+        };
+
+        const auto add_c0polyhedron_connectivity =
+            [&](const Elem &elem, dof_id_type elem_id)
+        {
+          c0polyhedron_face_counts.push_back(cast_int<int>(elem.n_sides()));
+
+          for (auto s: elem.side_index_range())
+          {
+            connect.push_back(next_c0polyhedron_face_id++);
+
+            const std::vector<unsigned int> side_nodes = elem.nodes_on_side(s);
+            c0polyhedron_face_node_counts.push_back(cast_int<int>(side_nodes.size()));
+
+            for (const auto elem_node_index : side_nodes)
+            c0polyhedron_face_connect.push_back(
+              get_exodus_node_id(elem, elem_id, elem_node_index));
+          }
+        };
+
+        const auto add_fixed_connectivity =
+          [&](const Elem &elem, dof_id_type elem_id, std::size_t elem_index)
+        {
+          for (unsigned int j = 0;
+              j < static_cast<unsigned int>(num_nodes_per_elem);
+              ++j)
+          {
+            const auto connect_index =
+              cast_int<unsigned int>((elem_index * num_nodes_per_elem) + j);
+            const auto elem_node_index = conv.get_inverse_node_map(j);
+            connect[connect_index] =
+              get_exodus_node_id(elem, elem_id, elem_node_index);
+          }
+        };
 
         for (auto i : index_range(element_id_vec))
         {
@@ -3444,91 +3497,11 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
                                << " in the same block!");
 
           if (is_c0polygon_block)
-            {
-              c0polygon_node_counts.push_back(cast_int<int>(elem.n_nodes()));
-
-              for (auto elem_node_index : elem.node_index_range())
-                {
-                  if (!use_discontinuous)
-                    {
-                      // The global id for the current node in libmesh.
-                      dof_id_type libmesh_node_id = elem.node_id(elem_node_index);
-
-                      // Write the Exodus global node id associated with
-                      // this libmesh node number to the connectivity
-                      // array, or throw an error if it's not found.
-                      connect.push_back
-                        (libmesh_map_find(libmesh_node_num_to_exodus,
-                                          cast_int<int>(libmesh_node_id)));
-                    }
-                  else
-                    {
-                      // Look up the (elem_id, elem_node_index) pair in the map.
-                      connect.push_back
-                        (libmesh_map_find(discontinuous_node_indices,
-                                          std::make_pair(elem_id, elem_node_index)));
-                    }
-                }
-            }
+            add_c0polygon_connectivity(elem, elem_id);
           else if (is_c0polyhedron_block)
-            {
-              c0polyhedron_face_counts.push_back(cast_int<int>(elem.n_sides()));
-
-              for (auto s : elem.side_index_range())
-                {
-                  connect.push_back(next_c0polyhedron_face_id++);
-
-                  const std::vector<unsigned int> side_nodes =
-                    elem.nodes_on_side(s);
-                  c0polyhedron_face_node_counts.push_back
-                    (cast_int<int>(side_nodes.size()));
-
-                  for (const auto elem_node_index : side_nodes)
-                    {
-                      if (!use_discontinuous)
-                        {
-                          const dof_id_type libmesh_node_id =
-                            elem.node_id(elem_node_index);
-                          c0polyhedron_face_connect.push_back
-                            (libmesh_map_find(libmesh_node_num_to_exodus,
-                                              cast_int<int>(libmesh_node_id)));
-                        }
-                      else
-                        {
-                          c0polyhedron_face_connect.push_back
-                            (libmesh_map_find(discontinuous_node_indices,
-                                              std::make_pair(elem_id, elem_node_index)));
-                        }
-                    }
-                }
-            }
+            add_c0polyhedron_connectivity(elem, elem_id);
           else
-            {
-              for (unsigned int j=0; j<static_cast<unsigned int>(num_nodes_per_elem); ++j)
-                {
-                  unsigned int connect_index   = cast_int<unsigned int>((i*num_nodes_per_elem)+j);
-                  unsigned elem_node_index = conv.get_inverse_node_map(j); // inverse node map is for writing.
-                  if (!use_discontinuous)
-                    {
-                      // The global id for the current node in libmesh.
-                      dof_id_type libmesh_node_id = elem.node_id(elem_node_index);
-
-                      // Write the Exodus global node id associated with
-                      // this libmesh node number to the connectivity
-                      // array, or throw an error if it's not found.
-                      connect[connect_index] =
-                        libmesh_map_find(libmesh_node_num_to_exodus,
-                                         cast_int<int>(libmesh_node_id));
-                    }
-                  else
-                    {
-                      // Look up the (elem_id, elem_node_index) pair in the map.
-                      connect[connect_index] =
-                        libmesh_map_find(discontinuous_node_indices,
-                                         std::make_pair(elem_id, elem_node_index));
-                    }
-                } // end for(j)
-            }
+            add_fixed_connectivity(elem, elem_id, i);
 
           // push_back() either elem_id+1 or the current Elem's
           // unique_id+1 into the elem_num_map, depending on the value

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -2592,11 +2592,11 @@ void ExodusII_IO_Helper::initialize(std::string str_title, const MeshBase & mesh
   num_face_blk = 0;
 
   dof_id_type local_num_c0polyhedron_faces = 0;
-  int has_c0polyhedron = 0;
+  bool has_c0polyhedron = false;
   for (const auto & elem : mesh.active_local_element_ptr_range())
     if (elem->type() == C0POLYHEDRON)
       {
-        has_c0polyhedron = 1;
+        has_c0polyhedron = true;
         local_num_c0polyhedron_faces += elem->n_sides();
       }
 

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -1217,10 +1217,15 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
             {
               const dof_id_type grid_nodes =
                 cast_int<dof_id_type>((nx+1)*(ny+1)*(nz+1));
-              mesh.reserve_nodes(grid_nodes +
-                                 (type == C0POLYHEDRON ?
-                                  cast_int<dof_id_type>(nx*ny*nz) :
-                                  0));
+
+              // Reserve one interior node per polyhedron for the robust
+              // fallback tetrahedralization used when the preferred
+              // tetrahedralization cannot be constructed.
+              const dof_id_type mid_polyhedron_nodes =
+                (type == C0POLYHEDRON) ?
+                cast_int<dof_id_type>(nx*ny*nz) : 0;
+
+              mesh.reserve_nodes(grid_nodes + mid_polyhedron_nodes);
               break;
             }
 

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -31,6 +31,7 @@
 #include "libmesh/face_quad8.h"
 #include "libmesh/face_quad9.h"
 #include "libmesh/face_c0polygon.h"
+#include "libmesh/cell_c0polyhedron.h"
 #include "libmesh/cell_hex8.h"
 #include "libmesh/cell_hex20.h"
 #include "libmesh/cell_hex27.h"
@@ -57,6 +58,7 @@
 #include "libmesh/enum_to_string.h"
 
 // C++ includes
+#include <array>
 #include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
 #include <cmath> // for std::sqrt
 #include <unordered_set>
@@ -125,6 +127,7 @@ unsigned int idx(const ElemType type,
     case INVALID_ELEM:
     case HEX8:
     case PRISM6:
+    case C0POLYHEDRON:
       {
         return i + (nx+1)*(j + k*(ny+1));
       }
@@ -921,8 +924,8 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
             std::vector<Node *> node_list;
 
             // Start with a layer of triangles on the boundary
-            const auto dx_tri = (xmax - xmin) / (nx);
-            const auto dy_tri = (ymax - ymin) / (ny + 1);
+            const auto dx_tri = Real(1) / nx;
+            const auto dy_tri = Real(1) / (ny + 1);
             std::unique_ptr<Elem> new_elem;
             for (const auto i : make_range(nx + 1))
             {
@@ -973,7 +976,9 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
 
             // Build layers of hexagons
             const auto hex_side =
-                (ymax - ymin - (ny == 1 ? dy_tri : (1. + (ny - 1) / 2.) * dy_tri)) / ny;
+                (Real(1) - (ny == 1 ?
+                             dy_tri :
+                             (Real(1) + (ny - 1) / 2.) * dy_tri)) / ny;
             for (const auto j : make_range(ny))
             {
               for (const auto i : make_range(nx + (j % 2)))
@@ -1066,7 +1071,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
               Node *node0, *node1, *node2;
               if (i == 0 && ny_odd)
               {
-                node0 = mesh.add_point(Point(0., ymax, 0.));
+                node0 = mesh.add_point(Point(0., 1., 0.));
                 node1 = node_list[running_index++];
                 node2 = node_list[running_index];
               }
@@ -1081,7 +1086,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
               {
                 node0 = node_list[running_index++];
                 node1 = node_list[running_index];
-                node2 = mesh.add_point(Point(xmax, ymax, 0.));
+                node2 = mesh.add_point(Point(1., 1., 0.));
               }
 
               new_elem = std::make_unique<C0Polygon>(3);
@@ -1171,6 +1176,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
           case HEX8:
           case HEX20:
           case HEX27:
+          case C0POLYHEDRON:
           case TET4:  // TET4's are created from an initial HEX27 discretization
           case TET10: // TET10's are created from an initial HEX27 discretization
           case TET14: // TET14's are created from an initial HEX27 discretization
@@ -1207,8 +1213,14 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
           case INVALID_ELEM:
           case HEX8:
           case PRISM6:
+          case C0POLYHEDRON:
             {
-              mesh.reserve_nodes( (nx+1)*(ny+1)*(nz+1) );
+              const dof_id_type grid_nodes =
+                cast_int<dof_id_type>((nx+1)*(ny+1)*(nz+1));
+              mesh.reserve_nodes(grid_nodes +
+                                 (type == C0POLYHEDRON ?
+                                  cast_int<dof_id_type>(nx*ny*nz) :
+                                  0));
               break;
             }
 
@@ -1267,6 +1279,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
           case INVALID_ELEM:
           case HEX8:
           case PRISM6:
+          case C0POLYHEDRON:
             {
               for (unsigned int k=0; k<=nz; k++)
                 for (unsigned int j=0; j<=ny; j++)
@@ -1392,6 +1405,69 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                       elem->set_node(5, mesh.node_ptr(idx(type,nx,ny,i+1,j,k+1)  ));
                       elem->set_node(6, mesh.node_ptr(idx(type,nx,ny,i+1,j+1,k+1)));
                       elem->set_node(7, mesh.node_ptr(idx(type,nx,ny,i,j+1,k+1)  ));
+
+                      if (k == 0)
+                        boundary_info.add_side(elem, 0, 0);
+
+                      if (k == (nz-1))
+                        boundary_info.add_side(elem, 5, 5);
+
+                      if (j == 0)
+                        boundary_info.add_side(elem, 1, 1);
+
+                      if (j == (ny-1))
+                        boundary_info.add_side(elem, 3, 3);
+
+                      if (i == 0)
+                        boundary_info.add_side(elem, 4, 4);
+
+                      if (i == (nx-1))
+                        boundary_info.add_side(elem, 2, 2);
+                    }
+              break;
+            }
+
+
+          case C0POLYHEDRON:
+            {
+              const std::array<std::array<unsigned int, 4>, 6> side_nodes =
+                {{{0, 1, 2, 3},   // min z
+                  {0, 1, 5, 4},   // min y
+                  {2, 6, 5, 1},   // max x
+                  {2, 3, 7, 6},   // max y
+                  {0, 4, 7, 3},   // min x
+                  {5, 6, 7, 4}}}; // max z
+
+              for (unsigned int k=0; k<nz; k++)
+                for (unsigned int j=0; j<ny; j++)
+                  for (unsigned int i=0; i<nx; i++)
+                    {
+                      std::array<Node *, 8> elem_nodes =
+                        {{mesh.node_ptr(idx(type,nx,ny,i,j,k)      ),
+                          mesh.node_ptr(idx(type,nx,ny,i+1,j,k)    ),
+                          mesh.node_ptr(idx(type,nx,ny,i+1,j+1,k)  ),
+                          mesh.node_ptr(idx(type,nx,ny,i,j+1,k)    ),
+                          mesh.node_ptr(idx(type,nx,ny,i,j,k+1)    ),
+                          mesh.node_ptr(idx(type,nx,ny,i+1,j,k+1)  ),
+                          mesh.node_ptr(idx(type,nx,ny,i+1,j+1,k+1)),
+                          mesh.node_ptr(idx(type,nx,ny,i,j+1,k+1)  )}};
+
+                      std::vector<std::shared_ptr<Polygon>> sides(side_nodes.size());
+                      for (auto s : index_range(side_nodes))
+                        {
+                          sides[s] = std::make_shared<C0Polygon>(side_nodes[s].size());
+                          for (auto n : index_range(side_nodes[s]))
+                            sides[s]->set_node(n, elem_nodes[side_nodes[s][n]]);
+                        }
+
+                      std::unique_ptr<Node> mid_elem_node;
+                      std::unique_ptr<Elem> new_elem =
+                        std::make_unique<C0Polyhedron>(sides, mid_elem_node);
+                      if (mid_elem_node)
+                        mesh.add_node(std::move(mid_elem_node));
+
+                      new_elem->set_id() = elem_id++;
+                      Elem * elem = mesh.add_elem(std::move(new_elem));
 
                       if (k == 0)
                         boundary_info.add_side(elem, 0, 0);

--- a/src/parallel/parallel_elem.C
+++ b/src/parallel/parallel_elem.C
@@ -21,8 +21,12 @@
 
 // Local includes
 #include "libmesh/boundary_info.h"
+#include "libmesh/cell_c0polyhedron.h"
 #include "libmesh/distributed_mesh.h"
 #include "libmesh/elem.h"
+#include "libmesh/enum_to_string.h"
+#include "libmesh/face_c0polygon.h"
+#include "libmesh/int_range.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/parallel_elem.h"
 #include "libmesh/parallel_mesh.h"
@@ -73,20 +77,38 @@ Packing<const Elem *>::packed_size (std::vector<largest_id_type>::const_iterator
   const ElemType type =
     cast_int<ElemType>(typeint);
 
-  const unsigned int n_nodes =
-    Elem::type_to_n_nodes_map[type];
+  unsigned int n_nodes = Elem::type_to_n_nodes_map[type];
+  unsigned int n_sides = Elem::type_to_n_sides_map[type];
+  unsigned int n_edges = Elem::type_to_n_edges_map[type];
+  unsigned int variable_topology_size = 0;
 
   if (n_nodes == invalid_uint)
-    libmesh_not_implemented_msg("Support for Polygons/Polyhedra not yet implemented");
+    {
+      libmesh_error_msg_if(type != C0POLYGON && type != C0POLYHEDRON,
+                           "Unsupported variable-topology element "
+                           << Utility::enum_to_string(type));
 
-  const unsigned int n_sides =
-    Elem::type_to_n_sides_map[type];
+      auto topology_in = in + header_size;
+      n_nodes = cast_int<unsigned int>(*topology_in++);
+      n_sides = cast_int<unsigned int>(*topology_in++);
+      n_edges = cast_int<unsigned int>(*topology_in++);
+      variable_topology_size = 3;
 
-  const unsigned int n_edges =
-    Elem::type_to_n_edges_map[type];
+      if (type == C0POLYHEDRON)
+        {
+          topology_in += n_nodes;
+          for (unsigned int s = 0; s != n_sides; ++s)
+            {
+              const unsigned int n_side_nodes =
+                cast_int<unsigned int>(*topology_in++);
+              topology_in += n_side_nodes;
+              variable_topology_size += n_side_nodes + 1;
+            }
+        }
+    }
 
   const unsigned int pre_indexing_size =
-    header_size + n_nodes + n_sides*2;
+    header_size + variable_topology_size + n_nodes + n_sides*2;
 
   const unsigned int indexing_size =
     DofObject::unpackable_indexing_size(in+pre_indexing_size);
@@ -159,9 +181,23 @@ unsigned int
 Packing<const Elem *>::packable_size (const Elem * const & elem,
                                       const MeshBase * mesh)
 {
+  unsigned int variable_topology_size = 0;
+  if (elem->type() == C0POLYGON || elem->type() == C0POLYHEDRON)
+    {
+      // Store the dynamic node, side, and edge counts.
+      variable_topology_size = 3;
+
+      // A polygon's node ordering fully specifies its topology.  A
+      // polyhedron additionally needs each side's local node indices.
+      if (elem->type() == C0POLYHEDRON)
+        for (auto s : elem->side_index_range())
+          variable_topology_size +=
+            1 + cast_int<unsigned int>(elem->nodes_on_side(s).size());
+    }
+
   // We always communicate if we are on a boundary or not
   unsigned int total_packed_bcs = 1;
-  const unsigned short n_sides = elem->n_sides();
+  const unsigned int n_sides = elem->n_sides();
 
   largest_id_type on_boundary = 0;
   for (auto s : elem->side_index_range())
@@ -180,7 +216,7 @@ Packing<const Elem *>::packable_size (const Elem * const & elem,
     if (elem->level() == 0 || mesh->get_boundary_info().is_children_on_boundary_side())
     {
       total_packed_bcs += n_sides;
-      for (unsigned short s = 0; s != n_sides; ++s)
+      for (unsigned int s = 0; s != n_sides; ++s)
         total_packed_bcs +=
           mesh->get_boundary_info().n_raw_boundary_ids(elem,s);
     }
@@ -188,9 +224,9 @@ Packing<const Elem *>::packable_size (const Elem * const & elem,
 
   if (elem->level() == 0)
     {
-      const unsigned short n_edges = elem->n_edges();
+      const unsigned int n_edges = elem->n_edges();
       total_packed_bcs += n_edges;
-      for (unsigned short e = 0; e != n_edges; ++e)
+      for (unsigned int e = 0; e != n_edges; ++e)
         total_packed_bcs +=
           mesh->get_boundary_info().n_edge_boundary_ids(elem,e);
 
@@ -204,7 +240,7 @@ Packing<const Elem *>::packable_size (const Elem * const & elem,
 #ifndef NDEBUG
     1 + // add an int for the magic header when testing
 #endif
-    header_size + elem->n_nodes() + n_sides*2 +
+    header_size + variable_topology_size + elem->n_nodes() + n_sides*2 +
     elem->packed_indexing_size() + total_packed_bcs;
 }
 
@@ -300,8 +336,27 @@ Packing<const Elem *>::pack (const Elem * const & elem,
   else
     *data_out++ =(DofObject::invalid_id);
 
+  const bool has_variable_topology =
+    elem->type() == C0POLYGON || elem->type() == C0POLYHEDRON;
+  if (has_variable_topology)
+    {
+      *data_out++ = elem->n_nodes();
+      *data_out++ = elem->n_sides();
+      *data_out++ = elem->n_edges();
+    }
+
   for (const Node & node : elem->node_ref_range())
     *data_out++ = node.id();
+
+  if (elem->type() == C0POLYHEDRON)
+    for (auto s : elem->side_index_range())
+      {
+        const std::vector<unsigned int> side_nodes =
+          elem->nodes_on_side(s);
+        *data_out++ = side_nodes.size();
+        for (const auto node : side_nodes)
+          *data_out++ = node;
+      }
 
   // Add the id of and the side for any return link from each neighbor
   for (auto neigh : elem->neighbor_ptr_range())
@@ -461,8 +516,9 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
   const ElemType type =
     cast_int<ElemType>(typeint);
 
-  const unsigned int n_nodes =
-    Elem::type_to_n_nodes_map[type];
+  unsigned int n_nodes = Elem::type_to_n_nodes_map[type];
+  unsigned int n_sides = Elem::type_to_n_sides_map[type];
+  unsigned int n_edges = Elem::type_to_n_edges_map[type];
 
   // int 5: processor id
   const processor_id_type processor_id =
@@ -516,6 +572,73 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
   // plus the real data header
   libmesh_assert_equal_to (in - original_in, header_size + 1);
 
+  if (n_nodes == invalid_uint)
+    {
+      libmesh_error_msg_if(type != C0POLYGON && type != C0POLYHEDRON,
+                           "Unsupported variable-topology element "
+                           << Utility::enum_to_string(type));
+
+      n_nodes = cast_int<unsigned int>(*in++);
+      n_sides = cast_int<unsigned int>(*in++);
+      n_edges = cast_int<unsigned int>(*in++);
+
+      if (type == C0POLYGON)
+        libmesh_error_msg_if
+          (n_nodes < 3 || n_sides != n_nodes || n_edges != n_nodes,
+           "Invalid packed C0POLYGON topology with "
+           << n_nodes << " nodes, " << n_sides << " sides, and "
+           << n_edges << " edges");
+      else
+        libmesh_error_msg_if
+          (n_nodes < 4 || n_sides < 4,
+           "Invalid packed C0POLYHEDRON topology with "
+           << n_nodes << " nodes and " << n_sides << " sides");
+    }
+
+  const auto node_ids_in = in;
+  in += n_nodes;
+
+  std::vector<std::vector<unsigned int>> polyhedron_side_nodes;
+  if (type == C0POLYHEDRON)
+    {
+      polyhedron_side_nodes.resize(n_sides);
+      std::vector<bool> node_seen(n_nodes, false);
+      unsigned int next_new_node = 0;
+      for (auto & side_nodes : polyhedron_side_nodes)
+        {
+          const unsigned int n_side_nodes =
+            cast_int<unsigned int>(*in++);
+          libmesh_error_msg_if(n_side_nodes < 3,
+                               "Cannot unpack a C0POLYHEDRON side with only "
+                               << n_side_nodes << " nodes");
+          side_nodes.resize(n_side_nodes);
+          for (auto & node : side_nodes)
+            {
+              node = cast_int<unsigned int>(*in++);
+              libmesh_error_msg_if(node >= n_nodes,
+                                   "Invalid local node " << node
+                                   << " in packed C0POLYHEDRON side");
+
+              if (!node_seen[node])
+                {
+                  libmesh_error_msg_if
+                    (node != next_new_node,
+                     "Packed C0POLYHEDRON side connectivity first encounters "
+                     "local node " << node << " where local node "
+                     << next_new_node << " was expected");
+                  node_seen[node] = true;
+                  ++next_new_node;
+                }
+            }
+        }
+
+      libmesh_error_msg_if
+        (next_new_node != n_nodes && next_new_node + 1 != n_nodes,
+         "Packed C0POLYHEDRON sides reference " << next_new_node
+         << " vertices, but the element has " << n_nodes
+         << " nodes; at most one unreferenced midpoint node is permitted");
+    }
+
   Elem * elem = mesh->query_elem_ptr(id);
 
   // if we already have this element, make sure its
@@ -531,15 +654,42 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
       libmesh_assert_equal_to (elem->processor_id(), processor_id);
       libmesh_assert_equal_to (elem->subdomain_id(), subdomain_id);
       libmesh_assert_equal_to (elem->type(), type);
+
+      if (type == C0POLYGON || type == C0POLYHEDRON)
+        {
+          libmesh_error_msg_if
+            (elem->type() != type ||
+             elem->n_nodes() != n_nodes ||
+             elem->n_sides() != n_sides ||
+             elem->n_edges() != n_edges,
+             "Existing " << Utility::enum_to_string(type)
+             << " topology does not match its packed topology");
+
+          for (unsigned int n = 0; n != n_nodes; ++n)
+            libmesh_error_msg_if
+              (elem->node_id(n) !=
+               cast_int<dof_id_type>(*(node_ids_in + n)),
+               "Existing " << Utility::enum_to_string(type)
+               << " local node " << n
+               << " does not match its packed node");
+
+          if (type == C0POLYHEDRON)
+            for (auto s : elem->side_index_range())
+              libmesh_error_msg_if
+                (elem->nodes_on_side(s) != polyhedron_side_nodes[s],
+                 "Existing C0POLYHEDRON side " << s
+                 << " does not match its packed topology");
+        }
+
       libmesh_assert_equal_to (elem->n_nodes(), n_nodes);
+      libmesh_assert_equal_to (elem->n_sides(), n_sides);
+      libmesh_assert_equal_to (elem->n_edges(), n_edges);
 
 #ifndef NDEBUG
       // All our nodes should be correct
       for (unsigned int i=0; i != n_nodes; ++i)
         libmesh_assert(elem->node_id(i) ==
-                       cast_int<dof_id_type>(*in++));
-#else
-      in += n_nodes;
+                       cast_int<dof_id_type>(*(node_ids_in + i)));
 #endif
 
 #ifdef LIBMESH_ENABLE_AMR
@@ -730,7 +880,48 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
       libmesh_assert_equal_to (level, 0);
 #endif
 
-      elem = Elem::build(type,parent).release();
+      if (type == C0POLYGON)
+        elem = std::make_unique<C0Polygon>(n_nodes, parent).release();
+      else if (type == C0POLYHEDRON)
+        {
+          std::vector<std::shared_ptr<Polygon>> sides(n_sides);
+          for (auto s : index_range(sides))
+            {
+              const auto & side_nodes = polyhedron_side_nodes[s];
+              auto side = std::make_shared<C0Polygon>
+                (cast_int<unsigned int>(side_nodes.size()));
+              for (auto n : index_range(side_nodes))
+                {
+                  const dof_id_type node_id =
+                    cast_int<dof_id_type>
+                    (*(node_ids_in + side_nodes[n]));
+                  side->set_node(n, mesh->node_ptr(node_id));
+                }
+              sides[s] = std::move(side);
+            }
+
+          std::unique_ptr<Node> generated_mid_node;
+          auto polyhedron = std::make_unique<C0Polyhedron>
+            (sides, generated_mid_node, parent);
+
+          libmesh_error_msg_if
+            (polyhedron->n_nodes() != n_nodes,
+             "Packed C0POLYHEDRON has " << n_nodes
+             << " nodes, but reconstructing its topology produced "
+             << polyhedron->n_nodes() << " nodes");
+
+          if (generated_mid_node)
+            {
+              const dof_id_type mid_node_id =
+                cast_int<dof_id_type>(*(node_ids_in + n_nodes - 1));
+              polyhedron->set_node(n_nodes - 1,
+                                   mesh->node_ptr(mid_node_id));
+            }
+
+          elem = polyhedron.release();
+        }
+      else
+        elem = Elem::build(type,parent).release();
       libmesh_assert (elem);
 
 #ifdef LIBMESH_ENABLE_AMR
@@ -772,9 +963,28 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
       // Assign the connectivity
       libmesh_assert_equal_to (elem->n_nodes(), n_nodes);
 
-      for (unsigned int n=0; n != n_nodes; n++)
-        elem->set_node (n, mesh->node_ptr
-                        (cast_int<dof_id_type>(*in++)));
+      if (type == C0POLYHEDRON)
+        {
+          libmesh_error_msg_if(elem->n_sides() != n_sides,
+                               "Packed C0POLYHEDRON has " << n_sides
+                               << " sides, but reconstructing its topology produced "
+                               << elem->n_sides() << " sides");
+          libmesh_error_msg_if(elem->n_edges() != n_edges,
+                               "Packed C0POLYHEDRON has " << n_edges
+                               << " edges, but reconstructing its topology produced "
+                               << elem->n_edges() << " edges");
+
+          for (unsigned int n = 0; n != n_nodes; ++n)
+            libmesh_error_msg_if
+              (elem->node_id(n) !=
+               cast_int<dof_id_type>(*(node_ids_in + n)),
+               "Packed C0POLYHEDRON local node ordering was not preserved");
+        }
+      else
+        for (unsigned int n=0; n != n_nodes; n++)
+          elem->set_node
+            (n, mesh->node_ptr
+             (cast_int<dof_id_type>(*(node_ids_in + n))));
 
       // Set interior_parent if found
       {

--- a/src/parallel/parallel_elem.C
+++ b/src/parallel/parallel_elem.C
@@ -24,7 +24,6 @@
 #include "libmesh/cell_c0polyhedron.h"
 #include "libmesh/distributed_mesh.h"
 #include "libmesh/elem.h"
-#include "libmesh/enum_to_string.h"
 #include "libmesh/face_c0polygon.h"
 #include "libmesh/int_range.h"
 #include "libmesh/mesh_base.h"
@@ -81,20 +80,19 @@ Packing<const Elem *>::packed_size (std::vector<largest_id_type>::const_iterator
   unsigned int n_sides = Elem::type_to_n_sides_map[type];
   unsigned int n_edges = Elem::type_to_n_edges_map[type];
   unsigned int variable_topology_size = 0;
+  // No Elem exists yet, so use the static-count sentinel corresponding
+  // to Elem::runtime_topology() in type_to_n_nodes_map.
+  const bool has_runtime_topology = (n_nodes == invalid_uint);
 
-  if (n_nodes == invalid_uint)
+  if (has_runtime_topology)
     {
-      libmesh_error_msg_if(type != C0POLYGON && type != C0POLYHEDRON,
-                           "Unsupported variable-topology element "
-                           << Utility::enum_to_string(type));
-
       auto topology_in = in + header_size;
       n_nodes = cast_int<unsigned int>(*topology_in++);
       n_sides = cast_int<unsigned int>(*topology_in++);
       n_edges = cast_int<unsigned int>(*topology_in++);
       variable_topology_size = 3;
 
-      if (type == C0POLYHEDRON)
+      if (Elem::type_to_dim_map[type] == 3)
         {
           topology_in += n_nodes;
           for (unsigned int s = 0; s != n_sides; ++s)
@@ -182,14 +180,14 @@ Packing<const Elem *>::packable_size (const Elem * const & elem,
                                       const MeshBase * mesh)
 {
   unsigned int variable_topology_size = 0;
-  if (elem->type() == C0POLYGON || elem->type() == C0POLYHEDRON)
+  if (elem->runtime_topology())
     {
       // Store the dynamic node, side, and edge counts.
       variable_topology_size = 3;
 
       // A polygon's node ordering fully specifies its topology.  A
       // polyhedron additionally needs each side's local node indices.
-      if (elem->type() == C0POLYHEDRON)
+      if (elem->dim() == 3)
         for (auto s : elem->side_index_range())
           variable_topology_size +=
             1 + cast_int<unsigned int>(elem->nodes_on_side(s).size());
@@ -336,8 +334,7 @@ Packing<const Elem *>::pack (const Elem * const & elem,
   else
     *data_out++ =(DofObject::invalid_id);
 
-  const bool has_variable_topology =
-    elem->type() == C0POLYGON || elem->type() == C0POLYHEDRON;
+  const bool has_variable_topology = elem->runtime_topology();
   if (has_variable_topology)
     {
       *data_out++ = elem->n_nodes();
@@ -348,7 +345,7 @@ Packing<const Elem *>::pack (const Elem * const & elem,
   for (const Node & node : elem->node_ref_range())
     *data_out++ = node.id();
 
-  if (elem->type() == C0POLYHEDRON)
+  if (has_variable_topology && elem->dim() == 3) // AKA, is c0polyhedron
     for (auto s : elem->side_index_range())
       {
         const std::vector<unsigned int> side_nodes =
@@ -519,6 +516,9 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
   unsigned int n_nodes = Elem::type_to_n_nodes_map[type];
   unsigned int n_sides = Elem::type_to_n_sides_map[type];
   unsigned int n_edges = Elem::type_to_n_edges_map[type];
+  // No Elem exists yet, so use the static-count sentinel corresponding
+  // to Elem::runtime_topology().
+  const bool has_runtime_topology = (n_nodes == invalid_uint);
 
   // int 5: processor id
   const processor_id_type processor_id =
@@ -572,71 +572,64 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
   // plus the real data header
   libmesh_assert_equal_to (in - original_in, header_size + 1);
 
-  if (n_nodes == invalid_uint)
+  if (has_runtime_topology)
     {
-      libmesh_error_msg_if(type != C0POLYGON && type != C0POLYHEDRON,
-                           "Unsupported variable-topology element "
-                           << Utility::enum_to_string(type));
-
       n_nodes = cast_int<unsigned int>(*in++);
       n_sides = cast_int<unsigned int>(*in++);
       n_edges = cast_int<unsigned int>(*in++);
 
-      if (type == C0POLYGON)
-        libmesh_error_msg_if
-          (n_nodes < 3 || n_sides != n_nodes || n_edges != n_nodes,
-           "Invalid packed C0POLYGON topology with "
-           << n_nodes << " nodes, " << n_sides << " sides, and "
-           << n_edges << " edges");
-      else
-        libmesh_error_msg_if
-          (n_nodes < 4 || n_sides < 4,
-           "Invalid packed C0POLYHEDRON topology with "
-           << n_nodes << " nodes and " << n_sides << " sides");
+      if (Elem::type_to_dim_map[type] == 2)
+        {
+          libmesh_assert_less (2, n_sides);
+          libmesh_assert_equal_to (n_nodes % n_sides, 0);
+          libmesh_assert_equal_to (n_edges, n_sides);
+        }
+      else if (Elem::type_to_dim_map[type] == 3)
+        {
+          libmesh_assert_less (3, n_nodes);
+          libmesh_assert_less (3, n_sides);
+        }
     }
+  libmesh_ignore(n_edges); // unused outside dbg/devel
 
   const auto node_ids_in = in;
   in += n_nodes;
 
   std::vector<std::vector<unsigned int>> polyhedron_side_nodes;
-  if (type == C0POLYHEDRON)
+  if (has_runtime_topology && Elem::type_to_dim_map[type] == 3)
     {
       polyhedron_side_nodes.resize(n_sides);
+#ifndef NDEBUG
       std::vector<bool> node_seen(n_nodes, false);
       unsigned int next_new_node = 0;
+#endif
       for (auto & side_nodes : polyhedron_side_nodes)
         {
           const unsigned int n_side_nodes =
             cast_int<unsigned int>(*in++);
-          libmesh_error_msg_if(n_side_nodes < 3,
-                               "Cannot unpack a C0POLYHEDRON side with only "
-                               << n_side_nodes << " nodes");
+          libmesh_assert_less (2, n_side_nodes);
           side_nodes.resize(n_side_nodes);
           for (auto & node : side_nodes)
             {
               node = cast_int<unsigned int>(*in++);
-              libmesh_error_msg_if(node >= n_nodes,
-                                   "Invalid local node " << node
-                                   << " in packed C0POLYHEDRON side");
+              libmesh_assert_less (node, n_nodes);
 
-              if (!node_seen[node])
+#ifndef NDEBUG
+              if (type == C0POLYHEDRON && !node_seen[node])
                 {
-                  libmesh_error_msg_if
-                    (node != next_new_node,
-                     "Packed C0POLYHEDRON side connectivity first encounters "
-                     "local node " << node << " where local node "
-                     << next_new_node << " was expected");
+                  libmesh_assert_equal_to (node, next_new_node);
                   node_seen[node] = true;
                   ++next_new_node;
                 }
+#endif
             }
         }
 
-      libmesh_error_msg_if
-        (next_new_node != n_nodes && next_new_node + 1 != n_nodes,
-         "Packed C0POLYHEDRON sides reference " << next_new_node
-         << " vertices, but the element has " << n_nodes
-         << " nodes; at most one unreferenced midpoint node is permitted");
+#ifndef NDEBUG
+      if (type == C0POLYHEDRON)
+        libmesh_assert (next_new_node == n_nodes ||
+                        next_new_node + 1 == n_nodes);
+#endif
     }
 
   Elem * elem = mesh->query_elem_ptr(id);
@@ -654,42 +647,23 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
       libmesh_assert_equal_to (elem->processor_id(), processor_id);
       libmesh_assert_equal_to (elem->subdomain_id(), subdomain_id);
       libmesh_assert_equal_to (elem->type(), type);
-
-      if (type == C0POLYGON || type == C0POLYHEDRON)
-        {
-          libmesh_error_msg_if
-            (elem->type() != type ||
-             elem->n_nodes() != n_nodes ||
-             elem->n_sides() != n_sides ||
-             elem->n_edges() != n_edges,
-             "Existing " << Utility::enum_to_string(type)
-             << " topology does not match its packed topology");
-
-          for (unsigned int n = 0; n != n_nodes; ++n)
-            libmesh_error_msg_if
-              (elem->node_id(n) !=
-               cast_int<dof_id_type>(*(node_ids_in + n)),
-               "Existing " << Utility::enum_to_string(type)
-               << " local node " << n
-               << " does not match its packed node");
-
-          if (type == C0POLYHEDRON)
-            for (auto s : elem->side_index_range())
-              libmesh_error_msg_if
-                (elem->nodes_on_side(s) != polyhedron_side_nodes[s],
-                 "Existing C0POLYHEDRON side " << s
-                 << " does not match its packed topology");
-        }
-
       libmesh_assert_equal_to (elem->n_nodes(), n_nodes);
       libmesh_assert_equal_to (elem->n_sides(), n_sides);
       libmesh_assert_equal_to (elem->n_edges(), n_edges);
 
 #ifndef NDEBUG
+      if (elem->runtime_topology() && elem->dim() == 3)
+        for (auto s : elem->side_index_range())
+          libmesh_assert(elem->nodes_on_side(s) ==
+                         polyhedron_side_nodes[s]);
+#endif
+
+#ifndef NDEBUG
       // All our nodes should be correct
       for (unsigned int i=0; i != n_nodes; ++i)
-        libmesh_assert(elem->node_id(i) ==
-                       cast_int<dof_id_type>(*(node_ids_in + i)));
+        libmesh_assert_equal_to
+          (elem->node_id(i),
+           cast_int<dof_id_type>(*(node_ids_in + i)));
 #endif
 
 #ifdef LIBMESH_ENABLE_AMR
@@ -904,11 +878,7 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
           auto polyhedron = std::make_unique<C0Polyhedron>
             (sides, generated_mid_node, parent);
 
-          libmesh_error_msg_if
-            (polyhedron->n_nodes() != n_nodes,
-             "Packed C0POLYHEDRON has " << n_nodes
-             << " nodes, but reconstructing its topology produced "
-             << polyhedron->n_nodes() << " nodes");
+          libmesh_assert_equal_to (polyhedron->n_nodes(), n_nodes);
 
           if (generated_mid_node)
             {
@@ -962,29 +932,21 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
 
       // Assign the connectivity
       libmesh_assert_equal_to (elem->n_nodes(), n_nodes);
+      libmesh_assert_equal_to (elem->n_sides(), n_sides);
+      libmesh_assert_equal_to (elem->n_edges(), n_edges);
 
-      if (type == C0POLYHEDRON)
-        {
-          libmesh_error_msg_if(elem->n_sides() != n_sides,
-                               "Packed C0POLYHEDRON has " << n_sides
-                               << " sides, but reconstructing its topology produced "
-                               << elem->n_sides() << " sides");
-          libmesh_error_msg_if(elem->n_edges() != n_edges,
-                               "Packed C0POLYHEDRON has " << n_edges
-                               << " edges, but reconstructing its topology produced "
-                               << elem->n_edges() << " edges");
-
-          for (unsigned int n = 0; n != n_nodes; ++n)
-            libmesh_error_msg_if
-              (elem->node_id(n) !=
-               cast_int<dof_id_type>(*(node_ids_in + n)),
-               "Packed C0POLYHEDRON local node ordering was not preserved");
-        }
-      else
+      if (!elem->runtime_topology() || elem->dim() != 3)
         for (unsigned int n=0; n != n_nodes; n++)
           elem->set_node
             (n, mesh->node_ptr
              (cast_int<dof_id_type>(*(node_ids_in + n))));
+
+#ifndef NDEBUG
+      for (unsigned int n = 0; n != n_nodes; ++n)
+        libmesh_assert_equal_to
+          (elem->node_id(n),
+           cast_int<dof_id_type>(*(node_ids_in + n)));
+#endif
 
       // Set interior_parent if found
       {

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -59,6 +59,7 @@ extern "C" {
 
 // C++ includes
 #include <unordered_map>
+#include <unordered_set>
 
 
 namespace libMesh
@@ -440,30 +441,44 @@ void ParmetisPartitioner::build_graph (const MeshBase & mesh)
 
   Partitioner::build_graph(mesh);
 
-  dof_id_type graph_size=0;
+  dof_id_type graph_size_upper_bound = 0;
 
   for (auto & row: _dual_graph)
-   graph_size += cast_int<dof_id_type>(row.size());
+    graph_size_upper_bound += cast_int<dof_id_type>(row.size());
 
   // Reserve space in the adjacency array
   _pmetis->xadj.clear();
   _pmetis->xadj.reserve (n_active_local_elem + 1);
   _pmetis->adjncy.clear();
-  _pmetis->adjncy.reserve (graph_size);
+  _pmetis->adjncy.reserve (graph_size_upper_bound);
 
-  for (auto & graph_row : _dual_graph)
+  const dof_id_type first_local_elem =
+    _pmetis->vtxdist[mesh.processor_id()];
+  std::unordered_set<dof_id_type> unique_neighbors;
+
+  // ParMETIS requires a simple graph.  Preserve first-occurrence order
+  // while filtering so valid graph rows remain otherwise unchanged.
+  for (auto i : index_range(_dual_graph))
     {
       _pmetis->xadj.push_back(cast_int<int>(_pmetis->adjncy.size()));
-      _pmetis->adjncy.insert(_pmetis->adjncy.end(),
-                             graph_row.begin(),
-                             graph_row.end());
+
+      const dof_id_type global_index =
+        first_local_elem + cast_int<dof_id_type>(i);
+      const auto & graph_row = _dual_graph[i];
+      unique_neighbors.clear();
+
+      for (const auto neighbor : graph_row)
+        if (neighbor != global_index &&
+            unique_neighbors.insert(neighbor).second)
+          _pmetis->adjncy.push_back(neighbor);
     }
 
   // The end of the adjacency array for the last elem
   _pmetis->xadj.push_back(cast_int<int>(_pmetis->adjncy.size()));
 
   libmesh_assert_equal_to (_pmetis->xadj.size(), n_active_local_elem+1);
-  libmesh_assert_equal_to (_pmetis->adjncy.size(), graph_size);
+  libmesh_assert_less_equal (_pmetis->adjncy.size(),
+                             graph_size_upper_bound);
 }
 
 #endif // #ifdef LIBMESH_HAVE_PARMETIS

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -1380,6 +1380,25 @@ void Partitioner::build_graph (const MeshBase & mesh)
                                       connections_to_push,
                                       symmetrize_entries);
 
+  // Constraint-based connections can duplicate existing neighbor
+  // connections, or connect an element to itself.  Partitioners expect
+  // a simple graph, so remove self-edges and repeated entries.
+  for (auto i : index_range(_dual_graph))
+    {
+      auto & graph_row = _dual_graph[i];
+      const dof_id_type global_index =
+        first_local_elem + cast_int<dof_id_type>(i);
+
+      graph_row.erase(std::remove(graph_row.begin(),
+                                  graph_row.end(),
+                                  global_index),
+                      graph_row.end());
+
+      std::sort(graph_row.begin(), graph_row.end());
+      graph_row.erase(std::unique(graph_row.begin(), graph_row.end()),
+                      graph_row.end());
+    }
+
   // *Now* we should have a symmetric adjacency matrix.  Let's check
   // that, so any failures get caught before they e.g. confuse
   // Parmetis in hard-to-debug ways.  That's a global communication so

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -1380,25 +1380,6 @@ void Partitioner::build_graph (const MeshBase & mesh)
                                       connections_to_push,
                                       symmetrize_entries);
 
-  // Constraint-based connections can duplicate existing neighbor
-  // connections, or connect an element to itself.  Partitioners expect
-  // a simple graph, so remove self-edges and repeated entries.
-  for (auto i : index_range(_dual_graph))
-    {
-      auto & graph_row = _dual_graph[i];
-      const dof_id_type global_index =
-        first_local_elem + cast_int<dof_id_type>(i);
-
-      graph_row.erase(std::remove(graph_row.begin(),
-                                  graph_row.end(),
-                                  global_index),
-                      graph_row.end());
-
-      std::sort(graph_row.begin(), graph_row.end());
-      graph_row.erase(std::unique(graph_row.begin(), graph_row.end()),
-                      graph_row.end());
-    }
-
   // *Now* we should have a symmetric adjacency matrix.  Let's check
   // that, so any failures get caught before they e.g. confuse
   // Parmetis in hard-to-debug ways.  That's a global communication so

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -415,6 +415,10 @@ CLEANFILES = cube_mesh.xda \
              side_discontinuous_QUAD9_disc.e \
              side_discontinuous_TRI6.e \
              side_discontinuous_TRI6_disc.e \
+             write_exodus_C0POLYGON.e \
+             write_exodus_C0POLYHEDRON.e \
+             write_exodus_C0POLYHEDRON_HEXPRISM.e \
+             write_exodus_C0POLYHEDRON_HEXPRISM_READ.e \
              write_exodus_EDGE2.e \
              write_exodus_EDGE3.e \
              write_exodus_EDGE4.e \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -2521,9 +2521,11 @@ CLEANFILES = cube_mesh.xda slit_mesh.xda slit_solution.xda out.e \
 	side_discontinuous_EDGE3_disc.e side_discontinuous_HEX27.e \
 	side_discontinuous_HEX27_disc.e side_discontinuous_QUAD9.e \
 	side_discontinuous_QUAD9_disc.e side_discontinuous_TRI6.e \
-	side_discontinuous_TRI6_disc.e write_exodus_EDGE2.e \
-	write_exodus_EDGE3.e write_exodus_EDGE4.e write_exodus_HEX20.e \
-	write_exodus_HEX27.e write_exodus_HEX8.e \
+	side_discontinuous_TRI6_disc.e write_exodus_C0POLYGON.e \
+	write_exodus_C0POLYHEDRON.e write_exodus_C0POLYHEDRON_HEXPRISM.e \
+	write_exodus_C0POLYHEDRON_HEXPRISM_READ.e \
+	write_exodus_EDGE2.e write_exodus_EDGE3.e write_exodus_EDGE4.e \
+	write_exodus_HEX20.e write_exodus_HEX27.e write_exodus_HEX8.e \
 	write_exodus_PRISM15.e write_exodus_PRISM18.e \
 	write_exodus_PRISM20.e write_exodus_PRISM21.e \
 	write_exodus_PRISM6.e write_exodus_PYRAMID13.e \

--- a/tests/mesh/exodus_test.C
+++ b/tests/mesh/exodus_test.C
@@ -316,6 +316,16 @@ public:
 
     this->build_c0polyhedron(mesh, points, nodes_on_side);
 
+    std::vector<std::vector<dof_id_type>> expected_nodes_on_side;
+    const Elem & output_elem = mesh.elem_ref(0);
+    expected_nodes_on_side.reserve(output_elem.n_sides());
+    for (auto s : output_elem.side_index_range())
+      {
+        expected_nodes_on_side.emplace_back();
+        for (const auto n : output_elem.nodes_on_side(s))
+          expected_nodes_on_side.back().push_back(output_elem.node_id(n));
+      }
+
     {
       ExodusII_IO exii(mesh);
       exii.write("write_exodus_C0POLYHEDRON_HEXPRISM_READ.e");
@@ -337,12 +347,12 @@ public:
     CPPUNIT_ASSERT_EQUAL(12u, elem->n_vertices());
     CPPUNIT_ASSERT_EQUAL(8u, elem->n_sides());
 
-    for (auto s : index_range(nodes_on_side))
+    for (auto s : index_range(expected_nodes_on_side))
       {
         const auto side_nodes = elem->nodes_on_side(s);
-        CPPUNIT_ASSERT_EQUAL(nodes_on_side[s].size(), side_nodes.size());
-        for (auto n : index_range(nodes_on_side[s]))
-          CPPUNIT_ASSERT_EQUAL(cast_int<dof_id_type>(nodes_on_side[s][n]),
+        CPPUNIT_ASSERT_EQUAL(expected_nodes_on_side[s].size(), side_nodes.size());
+        for (auto n : index_range(expected_nodes_on_side[s]))
+          CPPUNIT_ASSERT_EQUAL(expected_nodes_on_side[s][n],
                                elem->node_id(side_nodes[n]));
       }
   }

--- a/tests/mesh/exodus_test.C
+++ b/tests/mesh/exodus_test.C
@@ -110,6 +110,68 @@ INSTANTIATE_EXODUSTEST(QUAD8);
 INSTANTIATE_EXODUSTEST(QUADSHELL8);
 INSTANTIATE_EXODUSTEST(QUAD9);
 INSTANTIATE_EXODUSTEST(QUADSHELL9);
+
+class ExodusC0PolygonTest : public CppUnit::TestCase
+{
+public:
+  LIBMESH_CPPUNIT_TEST_SUITE(ExodusC0PolygonTest);
+
+  CPPUNIT_TEST(test_write_and_read_pentagon);
+
+  CPPUNIT_TEST_SUITE_END();
+
+  void build_pentagon(Mesh &mesh)
+  {
+    const std::vector<Point> points =
+      { {0, 0}, {1, 0}, {1.5, 0.5}, {1, 1}, {0, 1} };
+
+    for (auto p : index_range(points))
+      mesh.add_point(points[p], /*id=*/p);
+
+    std::unique_ptr<Elem> polygon =
+        std::make_unique<C0Polygon>(cast_int<unsigned int>(points.size()));
+    for (auto i : index_range(points))
+      polygon->set_node(i, mesh.node_ptr(i));
+
+    polygon->set_id() = 0;
+    Elem *elem = mesh.add_elem(std::move(polygon));
+    elem->subdomain_id() = 1;
+    mesh.prepare_for_use();
+  }
+
+  void test_write_and_read_pentagon()
+  {
+    LOG_UNIT_TEST;
+
+    Mesh mesh(*TestCommWorld);
+    this->build_pentagon(mesh);
+
+    {
+      ExodusII_IO exii(mesh);
+      exii.write("write_exodus_C0POLYGON.e");
+    }
+
+    Mesh input_mesh(*TestCommWorld);
+    ExodusII_IO exii_input(input_mesh);
+    if (input_mesh.processor_id() == 0)
+      exii_input.read("write_exodus_C0POLYGON.e");
+
+    MeshCommunication().broadcast(input_mesh);
+    input_mesh.prepare_for_use();
+
+    CPPUNIT_ASSERT_EQUAL(cast_int<dof_id_type>(1), input_mesh.n_elem());
+
+    const Elem *elem = input_mesh.elem_ptr(0);
+    CPPUNIT_ASSERT(elem);
+    CPPUNIT_ASSERT_EQUAL(C0POLYGON, elem->type());
+    CPPUNIT_ASSERT_EQUAL(5u, elem->n_nodes());
+
+    for (auto i : make_range(5))
+      CPPUNIT_ASSERT_EQUAL(cast_int<dof_id_type>(i), elem->node_id(i));
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(ExodusC0PolygonTest);
 #endif // LIBMESH_DIM > 1
 
 #if LIBMESH_DIM > 2
@@ -120,6 +182,7 @@ public:
 
   CPPUNIT_TEST(test_write_cube_header);
   CPPUNIT_TEST(test_write_hexagonal_prism_header);
+  CPPUNIT_TEST(test_write_and_read_hexagonal_prism);
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -228,6 +291,60 @@ public:
     CPPUNIT_ASSERT_EQUAL(header_info.num_face_blk, 1);
     CPPUNIT_ASSERT_EQUAL(header_info.num_node_sets, 0);
     CPPUNIT_ASSERT_EQUAL(header_info.num_side_sets, 0);
+  }
+
+  void test_write_and_read_hexagonal_prism()
+  {
+    LOG_UNIT_TEST;
+
+    Mesh mesh(*TestCommWorld);
+    const std::vector<Point> points =
+      { { 0, -2, 0}, {-1, -1, 0}, {-1, 1, 0},
+        { 0,  2, 0}, { 1,  1, 0}, { 1, -1, 0},
+        { 0, -2, 1}, {-1, -1, 1}, {-1, 1, 1},
+        { 0,  2, 1}, { 1,  1, 1}, { 1, -1, 1} };
+
+    const std::vector<std::vector<unsigned int>> nodes_on_side =
+      { {0, 1, 2, 3, 4, 5},
+        {0, 1,  7,  6},
+        {1, 2,  8,  7},
+        {2, 3,  9,  8},
+        {3, 4, 10,  9},
+        {4, 5, 11, 10},
+        {5, 0,  6, 11},
+        {6, 7,  8,  9, 10, 11} };
+
+    this->build_c0polyhedron(mesh, points, nodes_on_side);
+
+    {
+      ExodusII_IO exii(mesh);
+      exii.write("write_exodus_C0POLYHEDRON_HEXPRISM_READ.e");
+    }
+
+    Mesh input_mesh(*TestCommWorld);
+    ExodusII_IO exii_input(input_mesh);
+    if (input_mesh.processor_id() == 0)
+      exii_input.read("write_exodus_C0POLYHEDRON_HEXPRISM_READ.e");
+
+    MeshCommunication().broadcast(input_mesh);
+    input_mesh.prepare_for_use();
+
+    CPPUNIT_ASSERT_EQUAL(cast_int<dof_id_type>(1), input_mesh.n_elem());
+
+    const Elem *elem = input_mesh.elem_ptr(0);
+    CPPUNIT_ASSERT(elem);
+    CPPUNIT_ASSERT_EQUAL(C0POLYHEDRON, elem->type());
+    CPPUNIT_ASSERT_EQUAL(12u, elem->n_vertices());
+    CPPUNIT_ASSERT_EQUAL(8u, elem->n_sides());
+
+    for (auto s : index_range(nodes_on_side))
+      {
+        const auto side_nodes = elem->nodes_on_side(s);
+        CPPUNIT_ASSERT_EQUAL(nodes_on_side[s].size(), side_nodes.size());
+        for (auto n : index_range(nodes_on_side[s]))
+          CPPUNIT_ASSERT_EQUAL(cast_int<dof_id_type>(nodes_on_side[s][n]),
+                               elem->node_id(side_nodes[n]));
+      }
   }
 };
 

--- a/tests/mesh/exodus_test.C
+++ b/tests/mesh/exodus_test.C
@@ -2,10 +2,19 @@
 
 #ifdef LIBMESH_HAVE_EXODUS_API
 
+#include "libmesh/cell_c0polyhedron.h"
 #include "libmesh/enum_to_string.h"
 #include "libmesh/exodusII_io.h"
+#include "libmesh/face_c0polygon.h"
+#include "libmesh/int_range.h"
 #include "libmesh/mesh_communication.h"
+#include "libmesh/mesh_generation.h"
 #include "libmesh/mesh_serializer.h"
+#include "libmesh/node.h"
+
+#include <memory>
+#include <string>
+#include <vector>
 
 using namespace libMesh;
 
@@ -13,7 +22,6 @@ template <ElemType elem_type>
 class ExodusTest : public MeshPerElemTest<elem_type>
 {
 public:
-
   void test_read_gold()
   {
     LOG_UNIT_TEST;
@@ -64,26 +72,27 @@ public:
   }
 };
 
-#define EXODUSTEST                              \
-  CPPUNIT_TEST( test_read_gold );               \
-  CPPUNIT_TEST( test_write );
+#define EXODUSTEST              \
+  CPPUNIT_TEST(test_read_gold); \
+  CPPUNIT_TEST(test_write);
 
-#define INSTANTIATE_EXODUSTEST(elemtype)                        \
-  class ExodusTest_##elemtype : public ExodusTest<elemtype> {   \
-  public:                                                       \
-  ExodusTest_##elemtype() :                                     \
-    ExodusTest<elemtype>() {                                    \
-    if (unitlog->summarized_logs_enabled())                     \
-      this->libmesh_suite_name = "ExodusTest";                  \
-    else                                                        \
-      this->libmesh_suite_name = "ExodusTest_" #elemtype;       \
-  }                                                             \
-  CPPUNIT_TEST_SUITE( ExodusTest_##elemtype );                  \
-  EXODUSTEST;                                                   \
-  CPPUNIT_TEST_SUITE_END();                                     \
-  };                                                            \
-                                                                \
-  CPPUNIT_TEST_SUITE_REGISTRATION( ExodusTest_##elemtype )
+#define INSTANTIATE_EXODUSTEST(elemtype)                    \
+  class ExodusTest_##elemtype : public ExodusTest<elemtype> \
+  {                                                         \
+  public:                                                   \
+    ExodusTest_##elemtype() : ExodusTest<elemtype>()        \
+    {                                                       \
+      if (unitlog->summarized_logs_enabled())               \
+        this->libmesh_suite_name = "ExodusTest";            \
+      else                                                  \
+        this->libmesh_suite_name = "ExodusTest_" #elemtype; \
+    }                                                       \
+    CPPUNIT_TEST_SUITE(ExodusTest_##elemtype);              \
+    EXODUSTEST;                                             \
+    CPPUNIT_TEST_SUITE_END();                               \
+  };                                                        \
+                                                            \
+  CPPUNIT_TEST_SUITE_REGISTRATION(ExodusTest_##elemtype)
 
 INSTANTIATE_EXODUSTEST(EDGE2);
 INSTANTIATE_EXODUSTEST(EDGE3);
@@ -104,6 +113,126 @@ INSTANTIATE_EXODUSTEST(QUADSHELL9);
 #endif // LIBMESH_DIM > 1
 
 #if LIBMESH_DIM > 2
+class ExodusC0PolyhedronTest : public CppUnit::TestCase
+{
+public:
+  LIBMESH_CPPUNIT_TEST_SUITE(ExodusC0PolyhedronTest);
+
+  CPPUNIT_TEST(test_write_cube_header);
+  CPPUNIT_TEST(test_write_hexagonal_prism_header);
+
+  CPPUNIT_TEST_SUITE_END();
+
+  ExodusHeaderInfo write_and_read_header(Mesh &mesh,
+                                         const std::string &filename)
+  {
+    {
+      ExodusII_IO exii(mesh);
+      exii.write(filename);
+    }
+
+    TestCommWorld->barrier();
+
+    Mesh header_mesh(*TestCommWorld);
+    ExodusII_IO exii(header_mesh);
+    return exii.read_header(filename);
+  }
+
+  void build_c0polyhedron(Mesh &mesh,
+                          const std::vector<Point> &points,
+                          const std::vector<std::vector<unsigned int>> &nodes_on_side)
+  {
+    for (auto p : index_range(points))
+      mesh.add_point(points[p], /*id=*/p);
+
+    std::vector<std::shared_ptr<Polygon>> sides(nodes_on_side.size());
+    for (auto s : index_range(nodes_on_side))
+      {
+        const auto &nodes_on_s = nodes_on_side[s];
+        sides[s] = std::make_shared<C0Polygon>(nodes_on_s.size());
+        for (auto i : index_range(nodes_on_s))
+          sides[s]->set_node(i, mesh.node_ptr(nodes_on_s[i]));
+      }
+
+    std::unique_ptr<Node> mid_elem_node;
+    std::unique_ptr<Elem> polyhedron =
+        std::make_unique<C0Polyhedron>(sides, mid_elem_node);
+    if (mid_elem_node)
+      mesh.add_node(std::move(mid_elem_node));
+
+    polyhedron->set_id() = 0;
+    Elem *elem = mesh.add_elem(std::move(polyhedron));
+    elem->subdomain_id() = 1;
+    mesh.cache_elem_data();
+    mesh.prepare_for_use();
+  }
+
+  void test_write_cube_header()
+  {
+    LOG_UNIT_TEST;
+
+    Mesh mesh(*TestCommWorld);
+    MeshTools::Generation::build_cube(mesh, 2, 2, 2,
+                                      -1., 1.,
+                                      -1., 1.,
+                                      -1., 1.,
+                                      C0POLYHEDRON);
+    mesh.get_boundary_info().clear();
+
+    for (auto &elem : mesh.element_ptr_range())
+      elem->subdomain_id() = 1;
+    mesh.cache_elem_data();
+
+    ExodusHeaderInfo header_info =
+        this->write_and_read_header(mesh, "write_exodus_C0POLYHEDRON.e");
+
+    CPPUNIT_ASSERT_EQUAL(header_info.num_dim, 3);
+    CPPUNIT_ASSERT_EQUAL(header_info.num_elem, 8);
+    CPPUNIT_ASSERT_EQUAL(header_info.num_elem_blk, 1);
+    CPPUNIT_ASSERT_EQUAL(header_info.num_face, 48);
+    CPPUNIT_ASSERT_EQUAL(header_info.num_face_blk, 1);
+    CPPUNIT_ASSERT_EQUAL(header_info.num_node_sets, 0);
+    CPPUNIT_ASSERT_EQUAL(header_info.num_side_sets, 0);
+  }
+
+  void test_write_hexagonal_prism_header()
+  {
+    LOG_UNIT_TEST;
+
+    Mesh mesh(*TestCommWorld);
+    const std::vector<Point> points =
+      { { 0, -2, 0}, {-1, -1, 0}, {-1, 1, 0},
+        { 0,  2, 0}, { 1,  1, 0}, { 1, -1, 0},
+        { 0, -2, 1}, {-1, -1, 1}, {-1, 1, 1},
+        { 0,  2, 1}, { 1,  1, 1}, { 1, -1, 1} };
+
+    const std::vector<std::vector<unsigned int>> nodes_on_side =
+      { {0, 1, 2, 3, 4, 5},
+        {0, 1,  7,  6},
+        {1, 2,  8,  7},
+        {2, 3,  9,  8},
+        {3, 4, 10,  9},
+        {4, 5, 11, 10},
+        {5, 0,  6, 11},
+        {6, 7,  8,  9, 10, 11} };
+
+    this->build_c0polyhedron(mesh, points, nodes_on_side);
+
+    ExodusHeaderInfo header_info =
+        this->write_and_read_header(mesh, "write_exodus_C0POLYHEDRON_HEXPRISM.e");
+
+    CPPUNIT_ASSERT_EQUAL(header_info.num_dim, 3);
+    CPPUNIT_ASSERT_EQUAL(header_info.num_elem, 1);
+    CPPUNIT_ASSERT_EQUAL(header_info.num_elem_blk, 1);
+    CPPUNIT_ASSERT_EQUAL(header_info.num_face, 8);
+    CPPUNIT_ASSERT_EQUAL(header_info.num_face_blk, 1);
+    CPPUNIT_ASSERT_EQUAL(header_info.num_node_sets, 0);
+    CPPUNIT_ASSERT_EQUAL(header_info.num_side_sets, 0);
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(ExodusC0PolyhedronTest);
+
 INSTANTIATE_EXODUSTEST(TET4);
 INSTANTIATE_EXODUSTEST(TET10);
 INSTANTIATE_EXODUSTEST(TET14);

--- a/tests/mesh/exodus_test.C
+++ b/tests/mesh/exodus_test.C
@@ -9,7 +9,6 @@
 #include "libmesh/int_range.h"
 #include "libmesh/mesh_communication.h"
 #include "libmesh/mesh_generation.h"
-#include "libmesh/mesh_serializer.h"
 #include "libmesh/node.h"
 
 #include <memory>
@@ -157,13 +156,18 @@ public:
       exii_input.read("write_exodus_C0POLYGON.e");
 
     MeshCommunication().broadcast(input_mesh);
-    MeshSerializer input_serializer(input_mesh);
     input_mesh.prepare_for_use();
 
     CPPUNIT_ASSERT_EQUAL(cast_int<dof_id_type>(1), input_mesh.n_elem());
 
-    const Elem *elem = input_mesh.elem_ptr(0);
-    CPPUNIT_ASSERT(elem);
+    const Elem *elem = input_mesh.query_elem_ptr(0);
+    bool found_elem = elem;
+    input_mesh.comm().max(found_elem);
+    CPPUNIT_ASSERT(found_elem);
+
+    if (!elem)
+      return;
+
     CPPUNIT_ASSERT_EQUAL(C0POLYGON, elem->type());
     CPPUNIT_ASSERT_EQUAL(5u, elem->n_nodes());
 
@@ -318,17 +322,22 @@ public:
     this->build_c0polyhedron(mesh, points, nodes_on_side);
 
     std::vector<std::vector<dof_id_type>> expected_nodes_on_side;
-    {
-      MeshSerializer output_serializer(mesh);
-      const Elem & output_elem = mesh.elem_ref(0);
-      expected_nodes_on_side.reserve(output_elem.n_sides());
-      for (auto s : output_elem.side_index_range())
-        {
-          expected_nodes_on_side.emplace_back();
-          for (const auto n : output_elem.nodes_on_side(s))
-            expected_nodes_on_side.back().push_back(output_elem.node_id(n));
-        }
-    }
+    const Elem *output_elem = mesh.query_elem_ptr(0);
+    const bool have_output_elem = output_elem;
+    bool found_output_elem = have_output_elem;
+    mesh.comm().max(found_output_elem);
+    CPPUNIT_ASSERT(found_output_elem);
+
+    if (output_elem)
+      {
+        expected_nodes_on_side.reserve(output_elem->n_sides());
+        for (auto s : output_elem->side_index_range())
+          {
+            expected_nodes_on_side.emplace_back();
+            for (const auto n : output_elem->nodes_on_side(s))
+              expected_nodes_on_side.back().push_back(output_elem->node_id(n));
+          }
+      }
 
     {
       ExodusII_IO exii(mesh);
@@ -341,13 +350,23 @@ public:
       exii_input.read("write_exodus_C0POLYHEDRON_HEXPRISM_READ.e");
 
     MeshCommunication().broadcast(input_mesh);
-    MeshSerializer input_serializer(input_mesh);
     input_mesh.prepare_for_use();
 
     CPPUNIT_ASSERT_EQUAL(cast_int<dof_id_type>(1), input_mesh.n_elem());
 
-    const Elem *elem = input_mesh.elem_ptr(0);
-    CPPUNIT_ASSERT(elem);
+    const Elem *elem = input_mesh.query_elem_ptr(0);
+    bool found_elem = elem;
+    input_mesh.comm().max(found_elem);
+    CPPUNIT_ASSERT(found_elem);
+
+    const bool can_compare = have_output_elem && elem;
+    bool found_comparable_elem = can_compare;
+    input_mesh.comm().max(found_comparable_elem);
+    CPPUNIT_ASSERT(found_comparable_elem);
+
+    if (!can_compare)
+      return;
+
     CPPUNIT_ASSERT_EQUAL(C0POLYHEDRON, elem->type());
     CPPUNIT_ASSERT_EQUAL(12u, elem->n_vertices());
     CPPUNIT_ASSERT_EQUAL(8u, elem->n_sides());

--- a/tests/mesh/exodus_test.C
+++ b/tests/mesh/exodus_test.C
@@ -157,6 +157,7 @@ public:
       exii_input.read("write_exodus_C0POLYGON.e");
 
     MeshCommunication().broadcast(input_mesh);
+    MeshSerializer input_serializer(input_mesh);
     input_mesh.prepare_for_use();
 
     CPPUNIT_ASSERT_EQUAL(cast_int<dof_id_type>(1), input_mesh.n_elem());
@@ -317,14 +318,17 @@ public:
     this->build_c0polyhedron(mesh, points, nodes_on_side);
 
     std::vector<std::vector<dof_id_type>> expected_nodes_on_side;
-    const Elem & output_elem = mesh.elem_ref(0);
-    expected_nodes_on_side.reserve(output_elem.n_sides());
-    for (auto s : output_elem.side_index_range())
-      {
-        expected_nodes_on_side.emplace_back();
-        for (const auto n : output_elem.nodes_on_side(s))
-          expected_nodes_on_side.back().push_back(output_elem.node_id(n));
-      }
+    {
+      MeshSerializer output_serializer(mesh);
+      const Elem & output_elem = mesh.elem_ref(0);
+      expected_nodes_on_side.reserve(output_elem.n_sides());
+      for (auto s : output_elem.side_index_range())
+        {
+          expected_nodes_on_side.emplace_back();
+          for (const auto n : output_elem.nodes_on_side(s))
+            expected_nodes_on_side.back().push_back(output_elem.node_id(n));
+        }
+    }
 
     {
       ExodusII_IO exii(mesh);
@@ -337,6 +341,7 @@ public:
       exii_input.read("write_exodus_C0POLYHEDRON_HEXPRISM_READ.e");
 
     MeshCommunication().broadcast(input_mesh);
+    MeshSerializer input_serializer(input_mesh);
     input_mesh.prepare_for_use();
 
     CPPUNIT_ASSERT_EQUAL(cast_int<dof_id_type>(1), input_mesh.n_elem());

--- a/tests/mesh/mesh_generation_test.C
+++ b/tests/mesh/mesh_generation_test.C
@@ -51,6 +51,7 @@ public:
   CPPUNIT_TEST( buildCubeHex8 );
   CPPUNIT_TEST( buildCubeHex20 );
   CPPUNIT_TEST( buildCubeHex27 );
+  CPPUNIT_TEST( buildCubeC0Polyhedron );
   CPPUNIT_TEST( buildCubePrism6 );
   CPPUNIT_TEST( buildCubePrism15 );
   CPPUNIT_TEST( buildCubePrism18 );
@@ -152,6 +153,23 @@ public:
     CPPUNIT_ASSERT(bbox.min()(1) <= Real(-4.0));
     CPPUNIT_ASSERT(bbox.max()(1) >= Real(5.0));
 
+    if (type == C0POLYGON)
+      {
+        BoundingBox nodal_bbox = MeshTools::create_nodal_bounding_box(mesh);
+        LIBMESH_ASSERT_FP_EQUAL(nodal_bbox.min()(0),
+                                Real(-2.0),
+                                TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_FP_EQUAL(nodal_bbox.max()(0),
+                                Real(3.0),
+                                TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_FP_EQUAL(nodal_bbox.min()(1),
+                                Real(-4.0),
+                                TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_FP_EQUAL(nodal_bbox.max()(1),
+                                Real(5.0),
+                                TOLERANCE*TOLERANCE);
+      }
+
     // Do serial assertions *after* all parallel assertions, so we
     // stay in sync after failure on only some processor(s)
     if (type != C0POLYGON)
@@ -162,81 +180,92 @@ public:
   void testBuildCube(UnstructuredMesh & mesh, unsigned int n, ElemType type)
   {
     MeshTools::Generation::build_cube (mesh, n, n, n, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, type);
-    switch (Elem::type_to_n_sides_map[type])
+    if (type == C0POLYHEDRON)
       {
-      case 4: // tets
-        CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), cast_int<dof_id_type>(n*n*n*24));
-        break;
-      case 5: // prisms, pyramids
-        if (type == PRISM6 || type == PRISM15 || type == PRISM18 ||
-            type == PRISM20 || type == PRISM21)
-          CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), cast_int<dof_id_type>(n*n*n*2));
-        else
-          CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), cast_int<dof_id_type>(n*n*n*6));
-        break;
-      case 6: // hexes
+        const dof_id_type grid_nodes = cast_int<dof_id_type>((n+1)*(n+1)*(n+1));
+
         CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), cast_int<dof_id_type>(n*n*n));
-        break;
-      default:
-        libmesh_error();
+        CPPUNIT_ASSERT(mesh.n_nodes() >= grid_nodes);
+        CPPUNIT_ASSERT(mesh.n_nodes() <= grid_nodes + cast_int<dof_id_type>(n*n*n));
       }
-
-
-    switch (Elem::type_to_n_nodes_map[type])
+    else
       {
-      case 4: // First-order tets
-        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
-                             cast_int<dof_id_type>((n+1)*(n+1)*(n+1) + n*n*n + 3*(n+1)*n*n));
-        break;
-      case 6: // First-order prisms and hexes use the same nodes
-      case 8:
-        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
-                             cast_int<dof_id_type>((n+1)*(n+1)*(n+1)));
-        break;
-      case 10: // Second-order tets
-        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
-                             cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) + 14*n*n*n + 4*3*(n+1)*n*n));
-        break;
-      case 18:
-      case 27: // Second-order prisms and hexes use the same nodes
-        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
-                             cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1)));
-        break;
-      case 20:
-        if (type == HEX20)
-          CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
-                               cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) - n*n*n - 3*(n+1)*n*n));
-        if (type == PRISM20)
-          CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
-                               cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) + 2*(n+1)*n*n));
-        break;
-      case 21: // Prisms based on full Tri7 cross sections
-        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
-                             cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) + 2*(2*n+1)*n*n));
-        break;
-      case 15: // weird partial order prism
-        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
-                             cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) - n*n*n - 2*(n+1)*n*n));
-        break;
-      case 5: // pyramids
-        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
-                             cast_int<dof_id_type>((n+1)*(n+1)*(n+1) + n*n*n));
-        break;
-      case 13:
-        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
-                             cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) + 8*n*n*n - 3*(n+1)*n*n));
-        break;
-      case 14: // pyramids, tets
-        if (type == PYRAMID14)
-          CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
-                               cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) + 8*n*n*n));
-        else // TET14
-        CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
-                             cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) + 14*n*n*n + 4*3*(n+1)*n*n +
-                                                   36*n*n*n + 4*3*(n+1)*n*n));
-        break;
-      default:
-        libmesh_error();
+        switch (Elem::type_to_n_sides_map[type])
+          {
+          case 4: // tets
+            CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), cast_int<dof_id_type>(n*n*n*24));
+            break;
+          case 5: // prisms, pyramids
+            if (type == PRISM6 || type == PRISM15 || type == PRISM18 ||
+                type == PRISM20 || type == PRISM21)
+              CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), cast_int<dof_id_type>(n*n*n*2));
+            else
+              CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), cast_int<dof_id_type>(n*n*n*6));
+            break;
+          case 6: // hexes
+            CPPUNIT_ASSERT_EQUAL(mesh.n_elem(), cast_int<dof_id_type>(n*n*n));
+            break;
+          default:
+            libmesh_error();
+          }
+
+
+        switch (Elem::type_to_n_nodes_map[type])
+          {
+          case 4: // First-order tets
+            CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                                 cast_int<dof_id_type>((n+1)*(n+1)*(n+1) + n*n*n + 3*(n+1)*n*n));
+            break;
+          case 6: // First-order prisms and hexes use the same nodes
+          case 8:
+            CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                                 cast_int<dof_id_type>((n+1)*(n+1)*(n+1)));
+            break;
+          case 10: // Second-order tets
+            CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                                 cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) + 14*n*n*n + 4*3*(n+1)*n*n));
+            break;
+          case 18:
+          case 27: // Second-order prisms and hexes use the same nodes
+            CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                                 cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1)));
+            break;
+          case 20:
+            if (type == HEX20)
+              CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                                   cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) - n*n*n - 3*(n+1)*n*n));
+            if (type == PRISM20)
+              CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                                   cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) + 2*(n+1)*n*n));
+            break;
+          case 21: // Prisms based on full Tri7 cross sections
+            CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                                 cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) + 2*(2*n+1)*n*n));
+            break;
+          case 15: // weird partial order prism
+            CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                                 cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) - n*n*n - 2*(n+1)*n*n));
+            break;
+          case 5: // pyramids
+            CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                                 cast_int<dof_id_type>((n+1)*(n+1)*(n+1) + n*n*n));
+            break;
+          case 13:
+            CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                                 cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) + 8*n*n*n - 3*(n+1)*n*n));
+            break;
+          case 14: // pyramids, tets
+            if (type == PYRAMID14)
+              CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                                   cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) + 8*n*n*n));
+            else // TET14
+            CPPUNIT_ASSERT_EQUAL(mesh.n_nodes(),
+                                 cast_int<dof_id_type>((2*n+1)*(2*n+1)*(2*n+1) + 14*n*n*n + 4*3*(n+1)*n*n +
+                                                       36*n*n*n + 4*3*(n+1)*n*n));
+            break;
+          default:
+            libmesh_error();
+          }
       }
 
     // Our bounding boxes can be loose on higher order elements, but
@@ -248,6 +277,44 @@ public:
     CPPUNIT_ASSERT(bbox.max()(1) >= Real(5.0));
     CPPUNIT_ASSERT(bbox.min()(2) <= Real(-6.0));
     CPPUNIT_ASSERT(bbox.max()(2) >= Real(7.0));
+
+    if (type == C0POLYHEDRON)
+      {
+        BoundingBox nodal_bbox = MeshTools::create_nodal_bounding_box(mesh);
+        const Real expected_volume = Real(5) * Real(9) * Real(13);
+
+        LIBMESH_ASSERT_FP_EQUAL(nodal_bbox.min()(0),
+                                Real(-2.0),
+                                TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_FP_EQUAL(nodal_bbox.max()(0),
+                                Real(3.0),
+                                TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_FP_EQUAL(nodal_bbox.min()(1),
+                                Real(-4.0),
+                                TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_FP_EQUAL(nodal_bbox.max()(1),
+                                Real(5.0),
+                                TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_FP_EQUAL(nodal_bbox.min()(2),
+                                Real(-6.0),
+                                TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_FP_EQUAL(nodal_bbox.max()(2),
+                                Real(7.0),
+                                TOLERANCE*TOLERANCE);
+        LIBMESH_ASSERT_FP_EQUAL(MeshTools::volume(mesh),
+                                expected_volume,
+                                TOLERANCE*TOLERANCE);
+
+        for (auto & elem : mesh.element_ptr_range())
+          {
+            CPPUNIT_ASSERT_EQUAL(elem->type(), C0POLYHEDRON);
+            CPPUNIT_ASSERT_EQUAL(elem->n_sides(), 6u);
+            CPPUNIT_ASSERT(elem->n_sub_elem() > 0);
+            CPPUNIT_ASSERT(elem->volume() > 0);
+          }
+
+        return;
+      }
 
     // We don't yet try to do affine map optimizations on pyramids
     if (type == PYRAMID5 ||
@@ -314,6 +381,8 @@ public:
   void buildCubeHex8 ()      { LOG_UNIT_TEST; tester(&MeshGenerationTest::testBuildCube, 2, HEX8); }
   void buildCubeHex20 ()     { LOG_UNIT_TEST; tester(&MeshGenerationTest::testBuildCube, 2, HEX20); }
   void buildCubeHex27 ()     { LOG_UNIT_TEST; tester(&MeshGenerationTest::testBuildCube, 2, HEX27); }
+  void buildCubeC0Polyhedron ()
+  { LOG_UNIT_TEST; tester(&MeshGenerationTest::testBuildCube, 2, C0POLYHEDRON); }
   void buildCubePrism6 ()    { LOG_UNIT_TEST; tester(&MeshGenerationTest::testBuildCube, 2, PRISM6); }
   void buildCubePrism15 ()   { LOG_UNIT_TEST; tester(&MeshGenerationTest::testBuildCube, 2, PRISM15); }
   void buildCubePrism18 ()   { LOG_UNIT_TEST; tester(&MeshGenerationTest::testBuildCube, 2, PRISM18); }


### PR DESCRIPTION
## Summary

This adds ExodusII output support for libMesh’s arbitrary polygon and polyhedron elements:

- writes `C0POLYGON` elements as Exodus `NSIDED` blocks
- writes `C0POLYHEDRON` elements as Exodus `NFACED` blocks
- emits the associated face block, face-node connectivity, face counts, element-face connectivity, and element face counts needed for `NFACED` output

## Notes

- If using ParaView, the default IOSS Reader does not support polygonal/polyhedral input. Please use the Legacy Exodus Reader.
- Fixed an error with build_cube() where corner nodes were scaled twice 