### PR TITLE
Cleanup output system for writing truly constant monomial data

### DIFF
--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -36,6 +36,7 @@
 
 // C++ includes
 #include <cstddef>
+#include <functional>
 #include <map>
 #include <set>
 #include <string>
@@ -281,6 +282,24 @@ public:
                              const std::set<std::string> * system_names=nullptr) const;
 
   /**
+   * \returns Whether \p type can be represented as elemental data.
+   *
+   * Elemental data variables are CONSTANT MONOMIALs and CONSTANT
+   * MONOMIAL_VECs, regardless of their p_refinement flag.
+   */
+  static bool is_elemental_data_fe_type (const FEType & type);
+
+  /**
+   * Filter \p var_names to names of variables that can be represented as
+   * elemental data. If \p var_names is empty, all eligible variable names are
+   * returned. Vector-valued variables are decomposed into component names.
+   * If \p system_names!=nullptr, only include names from the specified systems.
+   */
+  void build_elemental_data_variable_names
+    (std::vector<std::string> & var_names,
+     const std::set<std::string> * system_names=nullptr) const;
+
+  /**
    * Fill the input vector \p soln with the solution values for the
    * system named \p name.
    *
@@ -364,6 +383,14 @@ public:
   find_variable_numbers (std::vector<std::string> & names,
                          const FEType * type=nullptr,
                          const std::vector<FEType> * types=nullptr) const;
+
+  /**
+   * Finds system and variable numbers for variables that can be represented
+   * as elemental data. See find_variable_numbers() for name filtering,
+   * component decomposition, and sorting details.
+   */
+  std::vector<std::pair<unsigned int, unsigned int>>
+  find_elemental_data_variable_numbers (std::vector<std::string> & names) const;
 
   /**
    * Builds a parallel vector of CONSTANT MONOMIAL and/or components of
@@ -609,6 +636,14 @@ protected:
   bool _enable_default_ghosting;
 
 private:
+  /**
+   * Implementation detail for find_variable_numbers() variants.
+   */
+  std::vector<std::pair<unsigned int, unsigned int>>
+  find_variable_numbers_by_predicate
+    (std::vector<std::string> & names,
+     const std::function<bool(const FEType &)> & type_filter) const;
+
   /**
    * This function is used in the implementation of add_system,
    * it loops over the nodes and elements of the Mesh, adding the

--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -313,7 +313,7 @@ public:
 
   /**
    * Fill the input vector \p soln with solution values.  The
-   * entries will be in variable-major format (corresponding to
+   * entries will be in node-major format (corresponding to
    * the names from \p build_variable_names()).
    *
    * If systems_names!=nullptr, only include data from the
@@ -415,8 +415,8 @@ public:
 
   /**
    * Fill the input vector \p soln with solution values.  The
-   * entries will be in variable-major format (corresponding to
-   * the names from \p build_variable_names()).
+   * entries will be in geometry-major format: element, then local
+   * node/vertex, then variable.
 
    * If systems_names!=nullptr, only include data from the
    * specified systems.

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1170,8 +1170,9 @@ void ExodusII_IO::copy_elemental_solution(System & system,
   //
   // NOTE: Currently, this reader is capable of reading only individual components of MONOMIAL_VEC
   //       types, and each must be written out to its own CONSTANT MONOMIAL variable
-  libmesh_error_msg_if((system.variable_type(var_num) != FEType(CONSTANT, MONOMIAL))
-                       && (system.variable_type(var_num) != FEType(CONSTANT, MONOMIAL_VEC)),
+  const auto & var_type = system.variable_type(var_num);
+  libmesh_error_msg_if(var_type.order != CONSTANT ||
+                       (var_type.family != MONOMIAL && var_type.family != MONOMIAL_VEC),
                        "Error! Trying to copy elemental solution into a variable that is not of CONSTANT MONOMIAL nor CONSTANT MONOMIAL_VEC type.");
 
   const MeshBase & mesh = MeshInput<MeshBase>::mesh();
@@ -1395,25 +1396,10 @@ void ExodusII_IO::write_element_data (const EquationSystems & es)
   // To be (possibly) filled with a filtered list of variable names to output.
   std::vector<std::string> names;
 
-  // If _output_variables is populated, only output the monomials which are
-  // also in the _output_variables vector.
+  // If _output_variables is populated, build_elemental_solution_vector() will filter this list to
+  // the monomial variables that can be written as elemental data.
   if (_output_variables.size() > 0)
-    {
-      // Create a list of CONSTANT MONOMIAL variable names
-      std::vector<std::string> monomials;
-      FEType type(CONSTANT, MONOMIAL);
-      es.build_variable_names(monomials, &type);
-
-      // Now concatenate a list of CONSTANT MONOMIAL_VEC variable names
-      type = FEType(CONSTANT, MONOMIAL_VEC);
-      es.build_variable_names(monomials, &type);
-
-      // Filter that list against the _output_variables list.  Note: if names is still empty after
-      // all this filtering, all the monomial variables will be gathered
-      for (const auto & var : monomials)
-        if (std::find(_output_variables.begin(), _output_variables.end(), var) != _output_variables.end())
-          names.push_back(var);
-    }
+    names.assign(_output_variables.begin(), _output_variables.end());
 
   // If we pass in a list of names to "build_elemental_solution_vector()"
   // it'll filter the variables coming back.
@@ -1487,22 +1473,13 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
   std::vector<std::string> var_names;
   es.build_variable_names (var_names, /*fetype=*/nullptr, system_names);
 
-  // Get a subset of all variable names that are CONSTANT,
-  // MONOMIALs. We treat those slightly differently since they can
+  // Get a subset of all variable names that can be written directly
+  // as elemental data. We treat those slightly differently since they
   // truly only have a single value per Elem.
-  //
-  // Should the same apply here for CONSTANT MONOMIAL_VECs? [CW]
-  // That is, get rid of 'const' on 'fe_type' and rerun:
-  //    fe_type = FEType(CONSTANT, MONOMIAL_VEC);
-  //    es.build_variable_names(monomial_var_names, &fe_type);
-  // Then, es.find_variable_numbers() can be used without a type
-  // (since we know for sure they're monomials) like:
-  //    var_nums = es.find_variable_numbers(monomial_var_names)
-  // for which the DOF indices for 'var_nums' have to be resolved
-  // manually like in build_elemental_solution_vector()
   std::vector<std::string> monomial_var_names;
-  const FEType fe_type(CONSTANT, MONOMIAL);
-  es.build_variable_names(monomial_var_names, &fe_type);
+  if (!_output_variables.empty())
+    monomial_var_names.assign(_output_variables.begin(), _output_variables.end());
+  es.build_elemental_data_variable_names(monomial_var_names, system_names);
 
   // Remove all names from var_names that are not in _output_variables.
   // Note: This approach avoids errors when the user provides invalid
@@ -1519,17 +1496,6 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
                               _output_variables.end(),
                               name);}),
          var_names.end());
-
-      // Also filter the monomial variable names.
-      monomial_var_names.erase
-        (std::remove_if
-         (monomial_var_names.begin(),
-          monomial_var_names.end(),
-          [this](const std::string & name)
-          {return !std::count(_output_variables.begin(),
-                              _output_variables.end(),
-                              name);}),
-         monomial_var_names.end());
     }
 
   // Build a solution vector, limiting the results to the variables in

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -72,40 +72,62 @@ namespace
   }
 
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS
+  enum class SolutionOrdering
+  {
+    variable_major,
+    geometry_major
+  };
+
+  std::size_t ordered_solution_index (const std::size_t var,
+                                      const std::size_t geometry_index,
+                                      const std::size_t num_vars,
+                                      const std::size_t num_geometric_entries,
+                                      const SolutionOrdering ordering)
+  {
+    if (ordering == SolutionOrdering::variable_major)
+      return var * num_geometric_entries + geometry_index;
+    else
+      return geometry_index * num_vars + var;
+  }
+
   std::vector<Real>
   complex_soln_components (const std::vector<Number> & soln,
-                           const unsigned int num_vars,
-                           const bool write_complex_abs)
+                           const std::size_t num_vars,
+                           const bool write_complex_abs,
+                           const SolutionOrdering source_ordering,
+                           const SolutionOrdering destination_ordering)
   {
-    unsigned int num_values = soln.size();
-    unsigned int num_elems = num_values / num_vars;
+    const std::size_t num_values = soln.size();
+    libmesh_assert_greater(num_vars, 0);
+    libmesh_assert_equal_to(num_values % num_vars, 0);
+    const std::size_t num_geometric_entries = num_values / num_vars;
 
     // This will contain the real and imaginary parts and the magnitude
     // of the values in soln
-    int nco = write_complex_abs ? 3 : 2;
+    const std::size_t nco = write_complex_abs ? 3 : 2;
+    const std::size_t num_complex_vars = nco * num_vars;
     std::vector<Real> complex_soln(nco * num_values);
 
-    for (unsigned i=0; i<num_vars; ++i)
-      {
-        for (unsigned int j=0; j<num_elems; ++j)
-          {
-            Number value = soln[i*num_vars + j];
-            complex_soln[nco*i*num_elems + j] = value.real();
-          }
-        for (unsigned int j=0; j<num_elems; ++j)
-          {
-            Number value = soln[i*num_vars + j];
-            complex_soln[nco*i*num_elems + num_elems + j] = value.imag();
-          }
-        if (write_complex_abs)
-          {
-            for (unsigned int j=0; j<num_elems; ++j)
-              {
-                Number value = soln[i*num_vars + j];
-                complex_soln[3*i*num_elems + 2*num_elems + j] = std::abs(value);
-              }
-          }
-      }
+    for (const auto var : make_range(num_vars))
+      for (const auto geometry_index : make_range(num_geometric_entries))
+        {
+          const Number value =
+            soln[ordered_solution_index
+                 (var, geometry_index, num_vars, num_geometric_entries, source_ordering)];
+
+          const std::size_t complex_var = nco * var;
+          complex_soln[ordered_solution_index
+                       (complex_var, geometry_index, num_complex_vars,
+                        num_geometric_entries, destination_ordering)] = value.real();
+          complex_soln[ordered_solution_index
+                       (complex_var + 1, geometry_index, num_complex_vars,
+                        num_geometric_entries, destination_ordering)] = value.imag();
+
+          if (write_complex_abs)
+            complex_soln[ordered_solution_index
+                         (complex_var + 2, geometry_index, num_complex_vars,
+                          num_geometric_entries, destination_ordering)] = std::abs(value);
+        }
 
     return complex_soln;
   }
@@ -1432,7 +1454,9 @@ void ExodusII_IO::write_element_data (const EquationSystems & es)
   exio_helper->initialize_element_variables(complex_names, complex_vars_active_subdomains);
 
   const std::vector<Real> complex_soln =
-    complex_soln_components(soln, names.size(), _write_complex_abs);
+    complex_soln_components(soln, names.size(), _write_complex_abs,
+                            SolutionOrdering::variable_major,
+                            SolutionOrdering::variable_major);
 
   exio_helper->write_element_values(mesh, complex_soln, _timestep, complex_vars_active_subdomains);
 
@@ -1985,7 +2009,9 @@ void ExodusII_IO::write_global_data (const std::vector<Number> & soln,
   exio_helper->initialize_global_variables(complex_names);
 
   const std::vector<Real> complex_soln =
-    complex_soln_components(soln, names.size(), _write_complex_abs);
+    complex_soln_components(soln, names.size(), _write_complex_abs,
+                            SolutionOrdering::variable_major,
+                            SolutionOrdering::variable_major);
 
   exio_helper->write_global_values(complex_soln, _timestep);
 

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -1471,30 +1471,16 @@ void Nemesis_IO::write_element_data (const EquationSystems & es)
   // To be (possibly) filled with a filtered list of variable names to output.
   std::vector<std::string> names;
 
-  // All of which should be low order monomials for now
-  const std::vector<FEType> type = {FEType(CONSTANT, MONOMIAL), FEType(CONSTANT, MONOMIAL_VEC)};
-
-  // If _output_variables is populated, only output the monomials which are
-  // also in the _output_variables vector.
+  // If _output_variables is populated, find_elemental_data_variable_numbers()
+  // will filter this list to the monomial variables that can be written as
+  // elemental data.
   if (_output_variables.size())
-    {
-      std::vector<std::string> monomials;
-
-      // Create a list of monomial variable names
-      es.build_variable_names(monomials, &type[0]); /*scalars*/
-      es.build_variable_names(monomials, &type[1]); /*vectors*/
-
-      // Filter that list against the _output_variables list.  Note: if names is still empty after
-      // all this filtering, all the monomial variables will be gathered
-      for (const auto & var : monomials)
-        if (std::find(_output_variables.begin(), _output_variables.end(), var) != _output_variables.end())
-          names.push_back(var);
-    }
+    names.assign(_output_variables.begin(), _output_variables.end());
 
   // The 'names' vector will here be updated with the variable's names
   // that are actually eligible to write
   std::vector<std::pair<unsigned int, unsigned int>> var_nums =
-    es.find_variable_numbers (names, /*type=*/nullptr, &type);
+    es.find_elemental_data_variable_numbers(names);
 
   // find_variable_numbers() can return a nullptr, in which case there are no constant monomial
   // variables to write, and we can just return.
@@ -1756,7 +1742,8 @@ void Nemesis_IO::copy_elemental_solution(System & system,
   parallel_object_only();
 
   const unsigned int var_num = system.variable_number(system_var_name);
-  libmesh_error_msg_if(system.variable_type(var_num) != FEType(CONSTANT, MONOMIAL),
+  const auto & var_type = system.variable_type(var_num);
+  libmesh_error_msg_if(var_type.order != CONSTANT || var_type.family != MONOMIAL,
                        "Error! Trying to copy elemental solution into a variable that is not of CONSTANT MONOMIAL type.");
 
   const MeshBase & mesh = MeshInput<MeshBase>::mesh();

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -2649,11 +2649,13 @@ Nemesis_IO_Helper::write_element_values(const MeshBase & mesh,
       const System & system = es.get_system(sys_num);
 
       // We need to check if the constant monomial is a scalar or a vector and set the number of
-      // components as the mesh spatial dimension for the latter as per es.find_variable_numbers().
+      // components for the latter as per es.find_variable_numbers().
       // Even for the case where a variable is not active on any subdomain belonging to the
       // processor, we still need to know this number to update 'var_ctr'.
+      const auto & var_type = system.variable_type(var);
       const unsigned int n_comps =
-        (system.variable_type(var) == FEType(CONSTANT, MONOMIAL_VEC)) ? mesh.spatial_dimension() : 1;
+        (FEInterface::field_type(var_type) == TYPE_VECTOR) ?
+        FEInterface::n_vec_dim(mesh, var_type) : 1;
 
       // Get list of active subdomains for variable v
       const auto & active_subdomains = vars_active_subdomains[v];

--- a/src/numerics/petsc_preconditioner.C
+++ b/src/numerics/petsc_preconditioner.C
@@ -189,9 +189,15 @@ void PetscPreconditioner<T>::set_petsc_aux_data(PC & pc, System & sys, const uns
                            "variables");
       // If not a 1st order Nédélec or a 2d 1st order Raviart-Thomas system, we
       // error out as we do not support anything else at the moment
-      libmesh_error_msg_if(sys.variable(v).type() != FEType(1, NEDELEC_ONE) &&
-                          (sys.variable(v).type() != FEType(1, RAVIART_THOMAS) ||
-                           sys.get_mesh().mesh_dimension() != 2),
+      const FEType & var_type = sys.variable(v).type();
+      const bool first_order_nedelec =
+        var_type.order == FIRST && var_type.family == NEDELEC_ONE;
+      const bool first_order_raviart_thomas =
+        var_type.order == FIRST && var_type.family == RAVIART_THOMAS;
+
+      libmesh_error_msg_if(!first_order_nedelec &&
+                           (!first_order_raviart_thomas ||
+                            sys.get_mesh().mesh_dimension() != 2),
                            "Error applying hypre AMS to a system "
                            "whose variable is not 1st order Nedelec or 1st "
                            "order Raviart-Thomas on a 2d mesh");
@@ -205,7 +211,11 @@ void PetscPreconditioner<T>::set_petsc_aux_data(PC & pc, System & sys, const uns
                            "variables");
       // If not a 3d 1st order Raviart-Thomas system, we error out as we do not
       // support anything else at the moment
-      libmesh_error_msg_if(sys.variable(v).type() != FEType(1, RAVIART_THOMAS) ||
+      const FEType & var_type = sys.variable(v).type();
+      const bool first_order_raviart_thomas =
+        var_type.order == FIRST && var_type.family == RAVIART_THOMAS;
+
+      libmesh_error_msg_if(!first_order_raviart_thomas ||
                            sys.get_mesh().mesh_dimension() != 3,
                            "Error applying hypre ADS to a system "
                            "whose variable is not 1st "

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -579,6 +579,64 @@ void EquationSystems::build_variable_names (std::vector<std::string> & var_names
   var_names.resize(var_num);
 }
 
+bool EquationSystems::is_elemental_data_fe_type (const FEType & type)
+{
+  return type.order == CONSTANT &&
+         (type.family == MONOMIAL || type.family == MONOMIAL_VEC);
+}
+
+
+
+void EquationSystems::build_elemental_data_variable_names
+  (std::vector<std::string> & var_names,
+   const std::set<std::string> * system_names) const
+{
+  const std::vector<std::string> name_filter = var_names;
+  const bool is_names_empty = name_filter.empty();
+  var_names.clear();
+
+  const std::vector<std::string> component_suffix = {"_x", "_y", "_z"};
+  const unsigned int dim = _mesh.spatial_dimension();
+  libmesh_error_msg_if(dim > 3, "Invalid dim in build_elemental_data_variable_names");
+
+  for (const auto & [sys_name, sys_ptr] : _systems)
+    {
+      const bool use_current_system = (system_names == nullptr) || system_names->count(sys_name);
+      if (!use_current_system || sys_ptr->hide_output())
+        continue;
+
+      for (auto var : make_range(sys_ptr->n_vars()))
+        {
+          const FEType & var_type = sys_ptr->variable_type(var);
+          if (!EquationSystems::is_elemental_data_fe_type(var_type))
+            continue;
+
+          if (FEInterface::field_type(var_type) == TYPE_VECTOR)
+            {
+              for (auto comp : make_range(dim))
+                {
+                  const std::string name =
+                    sys_ptr->variable_name(var) + component_suffix[comp];
+
+                  if (is_names_empty ||
+                      std::find(name_filter.begin(), name_filter.end(), name) != name_filter.end())
+                    var_names.push_back(name);
+                }
+            }
+          else
+            {
+              const std::string & name = sys_ptr->variable_name(var);
+
+              if (is_names_empty ||
+                  std::find(name_filter.begin(), name_filter.end(), name) != name_filter.end())
+                var_names.push_back(name);
+            }
+        }
+    }
+
+  std::sort(var_names.begin(), var_names.end());
+}
+
 
 
 void EquationSystems::build_solution_vector (std::vector<Number> &,
@@ -1048,11 +1106,6 @@ std::vector<std::pair<unsigned int, unsigned int>>
 EquationSystems::find_variable_numbers
   (std::vector<std::string> & names, const FEType * type, const std::vector<FEType> * types) const
 {
-  // This function must be run on all processors at once
-  parallel_object_only();
-
-  libmesh_assert (this->n_systems());
-
   // Resolve class of type input and assert that at least one of them is null
   libmesh_assert_msg(!type || !types,
                      "Input 'type', 'types', or neither in find_variable_numbers, but not both.");
@@ -1062,6 +1115,36 @@ EquationSystems::find_variable_numbers
     type_filter.push_back(*type);
   else if (types)
     type_filter = *types;
+
+  return this->find_variable_numbers_by_predicate
+    (names,
+     [&type_filter](const FEType & var_type)
+     {
+       return type_filter.empty() ||
+              std::find(type_filter.begin(), type_filter.end(), var_type) != type_filter.end();
+     });
+}
+
+
+
+std::vector<std::pair<unsigned int, unsigned int>>
+EquationSystems::find_elemental_data_variable_numbers (std::vector<std::string> & names) const
+{
+  return this->find_variable_numbers_by_predicate
+    (names, EquationSystems::is_elemental_data_fe_type);
+}
+
+
+
+std::vector<std::pair<unsigned int, unsigned int>>
+EquationSystems::find_variable_numbers_by_predicate
+  (std::vector<std::string> & names,
+   const std::function<bool(const FEType &)> & type_filter) const
+{
+  // This function must be run on all processors at once
+  parallel_object_only();
+
+  libmesh_assert (this->n_systems());
 
   // Store a copy of the valid variable names, if any. The names vector will be repopulated with any
   // valid names (or all if 'is_names_empty') in the system that passes through the type filter. If
@@ -1091,8 +1174,7 @@ EquationSystems::find_variable_numbers
         {
           // apply the type filter
           var_type = system.variable_type(var);
-          if (type_filter.size() &&
-              std::find(type_filter.begin(), type_filter.end(), var_type) == type_filter.end())
+          if (!type_filter(var_type))
             continue;
 
           // apply the name filter (note that all variables pass if it is empty)
@@ -1156,9 +1238,8 @@ EquationSystems::build_parallel_elemental_solution_vector (std::vector<std::stri
   // Filter any names that aren't elemental variables and get the system indices for those that are.
   // Note that it's probably fine if the names vector is empty since we'll still at least filter
   // out all non-monomials. If there are no monomials, then nothing is output here.
-  std::vector<FEType> type = {FEType(CONSTANT, MONOMIAL), FEType(CONSTANT, MONOMIAL_VEC)};
   std::vector<std::pair<unsigned int, unsigned int>> var_nums =
-    this->find_variable_numbers(names, /*type=*/nullptr, &type);
+    this->find_elemental_data_variable_numbers(names);
 
   const std::size_t nv = names.size(); /*total number of vars including vector components*/
   const dof_id_type ne = _mesh.n_elem();
@@ -1221,11 +1302,13 @@ EquationSystems::build_parallel_elemental_solution_vector (std::vector<std::stri
       const DofMap & dof_map = system.get_dof_map();
 
       // We need to check if the constant monomial is a scalar or a vector and set the number of
-      // components as the mesh spatial dimension for the latter as per es.find_variable_numbers().
+      // components for the latter as per es.find_variable_numbers().
       // Even for the case where a variable is not active on any subdomain belonging to the
       // processor, we still need to know this number to update 'var_ctr'.
+      const auto & var_type = system.variable_type(var);
       const unsigned int n_comps =
-        (system.variable_type(var) == type[1]) ? _mesh.spatial_dimension() : 1;
+        (FEInterface::field_type(var_type) == TYPE_VECTOR) ?
+        FEInterface::n_vec_dim(_mesh, var_type) : 1;
 
       // Loop over all elements in the mesh and index all components of the variable if it's active
       Threads::parallel_for
@@ -1280,6 +1363,47 @@ EquationSystems::build_discontinuous_solution_vector
 
   libmesh_assert (this->n_systems());
 
+  const std::vector<std::string> component_suffix = {"_x", "_y", "_z"};
+  const auto requested_components =
+    [this, var_names, &component_suffix](const System & system,
+                                         const unsigned int var)
+    {
+      std::vector<unsigned int> components;
+
+      const std::string & var_name = system.variable_name(var);
+      const FEType & fe_type = system.variable_type(var);
+      const unsigned int n_vec_dim = FEInterface::n_vec_dim(_mesh, fe_type);
+
+      if (FEInterface::field_type(fe_type) == TYPE_VECTOR)
+        {
+          libmesh_error_msg_if(n_vec_dim > component_suffix.size(),
+                               "Invalid dim in build_discontinuous_solution_vector");
+
+          const bool use_all_components =
+            (var_names == nullptr) ||
+            std::count(var_names->begin(), var_names->end(), var_name);
+
+          if (n_vec_dim <= 1)
+            {
+              if (use_all_components)
+                components.push_back(0);
+            }
+          else
+            for (auto comp : make_range(n_vec_dim))
+              {
+                const std::string component_name = var_name + component_suffix[comp];
+                if (use_all_components ||
+                    std::count(var_names->begin(), var_names->end(), component_name))
+                  components.push_back(comp);
+              }
+        }
+      else if (var_names == nullptr ||
+               std::count(var_names->begin(), var_names->end(), var_name))
+        components.push_back(0);
+
+      return components;
+    };
+
   // Get the number of variables (nv) by counting the number of variables
   // in each system listed in system_names
   unsigned int nv = 0;
@@ -1296,18 +1420,7 @@ EquationSystems::build_discontinuous_solution_vector
       // Loop over all variables in this System and check whether we
       // are supposed to use each one.
       for (auto var_id : make_range(sys_ptr->n_vars()))
-        {
-          bool use_current_var = (var_names == nullptr);
-          if (!use_current_var)
-            use_current_var = std::count(var_names->begin(),
-                                         var_names->end(),
-                                         sys_ptr->variable_name(var_id));
-
-          // Only increment the total number of vars if we are
-          // supposed to use this one.
-          if (use_current_var)
-            nv++;
-        }
+        nv += cast_int<unsigned int>(requested_components(*sys_ptr, var_id).size());
     }
 
   // get the total "weight" - the number of nodal values to write for
@@ -1381,22 +1494,20 @@ EquationSystems::build_discontinuous_solution_vector
           // the nodal_soln and store it to the "soln" vector. We
           // store zeros for subdomain-restricted variables on
           // elements where they are not active.
-          for (unsigned int var=0; var<nv_sys; var++)
+          for (auto var : make_range(nv_sys))
             {
-              bool use_current_var = (var_names == nullptr);
-              if (!use_current_var)
-                use_current_var = std::count(var_names->begin(),
-                                             var_names->end(),
-                                             system->variable_name(var));
+              const std::vector<unsigned int> components_to_write =
+                requested_components(*system, var);
 
               // If we aren't supposed to write this var, go to the
               // next loop iteration.
-              if (!use_current_var)
+              if (components_to_write.empty())
                 continue;
 
               const FEType & fe_type = system->variable_type(var);
               const Variable & var_description = system->variable(var);
               const bool add_p_level = fe_type.p_refinement;
+              const unsigned int n_vec_dim = FEInterface::n_vec_dim(_mesh, fe_type);
 
               unsigned int nn=0;
 
@@ -1420,23 +1531,25 @@ EquationSystems::build_discontinuous_solution_vector
                                                soln_coeffs,
                                                nodal_soln,
                                                add_p_level,
-                                               FEInterface::n_vec_dim(_mesh, fe_type));
+                                               n_vec_dim);
 
                       // infinite elements should be skipped...
                       if (!elem->infinite())
                         {
-                          libmesh_assert_equal_to (nodal_soln.size(), elem->n_nodes());
+                          libmesh_assert_equal_to (nodal_soln.size(), elem->n_nodes()*n_vec_dim);
 
                           const unsigned int n_vals =
                             vertices_only ? elem->n_vertices() : elem->n_nodes();
 
-                          for (unsigned int n=0; n<n_vals; n++)
+                          for (auto n : make_range(n_vals))
                             {
                               // Compute index into global solution vector.
                               std::size_t index =
                                 nv * (nn++) + (n_vars_written_current_system + var_offset);
 
-                              soln[index] += nodal_soln[n];
+                              for (auto component_index : index_range(components_to_write))
+                                soln[index + component_index] +=
+                                  nodal_soln[n_vec_dim*n + components_to_write[component_index]];
                             }
                         }
                     }
@@ -1485,11 +1598,11 @@ EquationSystems::build_discontinuous_solution_vector
                                 FEInterface::side_nodal_soln
                                   (fe_type, elem, s, soln_coeffs,
                                    nodal_soln, add_p_level,
-                                   FEInterface::n_vec_dim(_mesh, fe_type));
+                                   n_vec_dim);
 
                                 libmesh_assert_equal_to
                                     (nodal_soln.size(),
-                                     side_nodes.size());
+                                     side_nodes.size()*n_vec_dim);
 
                                 // If we don't have a continuous FE
                                 // then we want to average between
@@ -1519,7 +1632,7 @@ EquationSystems::build_discontinuous_solution_vector
                                     FEInterface::side_nodal_soln
                                       (fe_type, neigh, s_neigh,
                                        neigh_coeffs, neigh_soln, add_p_level,
-                                       FEInterface::n_vec_dim(_mesh, fe_type));
+                                       n_vec_dim);
 
                                     const std::vector<unsigned int> neigh_nodes =
                                       neigh->nodes_on_side(s_neigh);
@@ -1527,10 +1640,13 @@ EquationSystems::build_discontinuous_solution_vector
                                       for (auto neigh_n : index_range(neigh_nodes))
                                         if (neigh->node_ptr(neigh_nodes[neigh_n])
                                             == elem->node_ptr(side_nodes[n]))
-                                          {
-                                            nodal_soln[n] += neigh_soln[neigh_n];
-                                            nodal_soln[n] /= 2;
-                                          }
+                                          for (auto comp : make_range(n_vec_dim))
+                                            {
+                                              const auto nodal_index = n_vec_dim*n + comp;
+                                              nodal_soln[nodal_index] +=
+                                                neigh_soln[n_vec_dim*neigh_n + comp];
+                                              nodal_soln[nodal_index] /= 2;
+                                            }
                                   }
 
                                 for (auto n : index_range(side_nodes))
@@ -1543,7 +1659,9 @@ EquationSystems::build_discontinuous_solution_vector
                                     std::size_t index =
                                       nv * (nn++) + (n_vars_written_current_system + var_offset);
 
-                                    soln[index] += nodal_soln[n];
+                                    for (auto component_index : index_range(components_to_write))
+                                      soln[index + component_index] +=
+                                        nodal_soln[n_vec_dim*n + components_to_write[component_index]];
                                   }
                               }
                           }
@@ -1572,7 +1690,7 @@ EquationSystems::build_discontinuous_solution_vector
                 }
               // If we made it here, we actually wrote a variable, so increment
               // the number of variables actually written for the current system.
-              n_vars_written_current_system++;
+              n_vars_written_current_system += cast_int<unsigned int>(components_to_write.size());
 
             } // end loop over vars
         } // end if proc 0

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -722,6 +722,7 @@ public:
       EquationSystems es(mesh);
       System &sys = es.add_system<System> ("SimpleSystem");
       sys.add_variable("e", CONSTANT, MONOMIAL);
+      sys.add_variable("e_no_p", FEType(CONSTANT, MONOMIAL).set_p_refinement(false));
 
       MeshTools::Generation::build_square (mesh,
                                            3, 3,
@@ -754,6 +755,7 @@ public:
       EquationSystems es(mesh);
       System &sys = es.add_system<System> ("SimpleSystem");
       sys.add_variable("teste", CONSTANT, MONOMIAL);
+      sys.add_variable("teste_no_p", FEType(CONSTANT, MONOMIAL).set_p_refinement(false));
 
       if (mesh.processor_id() == 0 || meshinput.is_parallel_format())
         meshinput.read(filename);
@@ -769,8 +771,10 @@ public:
       // part.
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS
       meshinput.copy_elemental_solution(sys, "teste", "r_e");
+      meshinput.copy_elemental_solution(sys, "teste_no_p", "r_e_no_p");
 #else
       meshinput.copy_elemental_solution(sys, "teste", "e");
+      meshinput.copy_elemental_solution(sys, "teste_no_p", "e_no_p");
 #endif
 
       // Exodus only handles double precision
@@ -782,6 +786,8 @@ public:
             Point p(x,y);
             LIBMESH_ASSERT_NUMBERS_EQUAL
               (sys.point_value(0,p), 6*x+60*y, exotol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (sys.point_value(1,p), 6*x+60*y, exotol);
           }
     }
   }
@@ -878,6 +884,8 @@ public:
       EquationSystems es(mesh);
       System & sys = es.add_system<System> ("SimpleSystem");
       auto e_var = sys.add_variable("e", CONSTANT, MONOMIAL_VEC);
+      auto e_no_p_var = sys.add_variable("e_no_p",
+                                         FEType(CONSTANT, MONOMIAL_VEC).set_p_refinement(false));
 
       MeshTools::Generation::build_square (mesh,
                                            3, 3,
@@ -905,6 +913,10 @@ public:
           elem->dof_number(sys.number(), e_var, 0), six_x_plus_sixty_y(p, params, "", ""));
         sys.current_local_solution->set(
           elem->dof_number(sys.number(), e_var, 1), sin_x_plus_cos_y(p, params, "", ""));
+        sys.current_local_solution->set(
+          elem->dof_number(sys.number(), e_no_p_var, 0), six_x_plus_sixty_y(p, params, "", ""));
+        sys.current_local_solution->set(
+          elem->dof_number(sys.number(), e_no_p_var, 1), sin_x_plus_cos_y(p, params, "", ""));
       }
 
       // After setting values, we need to assemble
@@ -937,8 +949,10 @@ public:
       // We have to read the CONSTANT MONOMIAL_VEC var "e" into separate CONSTANT MONOMIAL vars
       // "e_x" and "e_y" because 'copy_elemental_solution()' currently doesn't support vectors.
       // Again, this isn't a test for reading/copying an elemental vector solution, only writing.
-      sys.add_variable("teste_x", CONSTANT, MONOMIAL);
-      sys.add_variable("teste_y", CONSTANT, MONOMIAL);
+      sys.add_variable("teste_x", FEType(CONSTANT, MONOMIAL).set_p_refinement(false));
+      sys.add_variable("teste_y", FEType(CONSTANT, MONOMIAL).set_p_refinement(false));
+      sys.add_variable("teste_no_p_x", FEType(CONSTANT, MONOMIAL).set_p_refinement(false));
+      sys.add_variable("teste_no_p_y", FEType(CONSTANT, MONOMIAL).set_p_refinement(false));
 
       if (mesh.processor_id() == 0 || meshinput.is_parallel_format())
         meshinput.read(filename);
@@ -951,6 +965,8 @@ public:
       // Read the solution e_x and e_y into variable teste_x and teste_y, respectively.
       meshinput.copy_elemental_solution(sys, "teste_x", "e_x");
       meshinput.copy_elemental_solution(sys, "teste_y", "e_y");
+      meshinput.copy_elemental_solution(sys, "teste_no_p_x", "e_no_p_x");
+      meshinput.copy_elemental_solution(sys, "teste_no_p_y", "e_no_p_y");
 
       // Exodus only handles double precision
       Real exotol = std::max(TOLERANCE*TOLERANCE, Real(1e-12));
@@ -963,6 +979,10 @@ public:
               (sys.point_value(0,p), 6*x+60*y, exotol);
             LIBMESH_ASSERT_NUMBERS_EQUAL
               (sys.point_value(1,p), sin(x)+cos(y), exotol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (sys.point_value(2,p), 6*x+60*y, exotol);
+            LIBMESH_ASSERT_NUMBERS_EQUAL
+              (sys.point_value(3,p), sin(x)+cos(y), exotol);
           }
     }
   }
@@ -986,6 +1006,9 @@ public:
   {
     LOG_UNIT_TEST;
 
+    const Real scalar_value = 42.;
+    const std::vector<Real> vector_values = {10., 20., 30.};
+
     // first scope: write file
     {
       Mesh mesh(*TestCommWorld);
@@ -993,6 +1016,10 @@ public:
       EquationSystems es(mesh);
       System & sys = es.add_system<System> ("SimpleSystem");
       sys.add_variable("u", FIRST, L2_LAGRANGE);
+      const auto c_var =
+        sys.add_variable("c", FEType(CONSTANT, MONOMIAL).set_p_refinement(false));
+      const auto vec_var =
+        sys.add_variable("vec", FEType(CONSTANT, MONOMIAL_VEC).set_p_refinement(false));
 
       MeshTools::Generation::build_cube
         (mesh, 2, 2, 2, 0., 1., 0., 1., 0., 1., HEX8);
@@ -1007,6 +1034,13 @@ public:
           dof_map.dof_indices(elem, dof_indices, /*var_id=*/0);
           for (unsigned int i=0; i<dof_indices.size(); ++i)
             sys.solution->set(dof_indices[i], i);
+
+          sys.solution->set(elem->dof_number(sys.number(), c_var, 0), scalar_value);
+          for (auto comp : index_range(vector_values))
+            sys.solution->set(elem->dof_number(sys.number(),
+                                               vec_var,
+                                               cast_int<unsigned int>(comp)),
+                              vector_values[comp]);
         }
       sys.solution->close();
 
@@ -1030,8 +1064,14 @@ public:
         {"u_elem_corner_0",
          "u_elem_corner_1",
          "u_elem_corner_2",
-         "u_elem_corner_3"};
-      std::vector<Real> expected_values = {0., 1., 2., 3.};
+         "u_elem_corner_3",
+         "c",
+         "vec_x",
+         "vec_y",
+         "vec_z"};
+      std::vector<Real> expected_values =
+        {0., 1., 2., 3.,
+         scalar_value, vector_values[0], vector_values[1], vector_values[2]};
 
       // copy_elemental_solution currently requires ReplicatedMesh
       ReplicatedMesh mesh(*TestCommWorld);
@@ -1040,7 +1080,7 @@ public:
       EquationSystems es(mesh);
       System & sys = es.add_system<System> ("SimpleSystem");
       for (auto i : index_range(file_var_names))
-        sys.add_variable(file_var_names[i], CONSTANT, MONOMIAL);
+        sys.add_variable(file_var_names[i], FEType(CONSTANT, MONOMIAL).set_p_refinement(false));
 
       ExodusII_IO exii(mesh);
 


### PR DESCRIPTION
There's a decent amount of `operator==` comparisons with `FEType`, and this would lead to rejection of the new `p_refinement == false` option for `CONSTANT MONOMIAL` finite element types when determining elemental data for output. This changeset consolidates some code into `EquationSystems` for use in both exodus and nemesis. We also consolidate our definition of elemental data to always include scalar field and vector field monomials. Consistent with previous library behavior we treat `CONSTANT MONOMIAL` with `p_refinement == true` as elemental data even though it's possible that if the mesh has been p-refined this conceptually may not be the case.