### PR TITLE
Add an API for potentially synchronous subdomain name setting

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1695,6 +1695,17 @@ public:
   const std::string & subdomain_name(subdomain_id_type id) const;
 
   /**
+   * Sets the \p name for the provided \p id
+   * @param id The subdomain id to set the name for
+   * @param name The subdomain name
+   * @param synchronous Whether this method is being called across all mesh ranks. If this is true,
+   * then we don't have to register this collective container as being out of sync
+   */
+  void set_subdomain_name(subdomain_id_type id,
+                          const std::string & name,
+                          bool synchronous = false);
+
+  /**
    * \returns The id of the named subdomain if it exists,
    * \p Elem::invalid_subdomain_id otherwise.
    */

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -1894,7 +1894,16 @@ const std::string & MeshBase::subdomain_name(subdomain_id_type id) const
     return iter->second;
 }
 
-
+void MeshBase::set_subdomain_name(const subdomain_id_type id,
+                                  const std::string & name,
+                                  const bool synchronous)
+{
+  if (synchronous)
+    parallel_object_only();
+  else
+    this->unset_has_synched_subdomain_name_map();
+  _block_id_to_name[id] =  name;
+}
 
 
 subdomain_id_type MeshBase::get_id_by_name(std::string_view name) const

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -1900,8 +1900,6 @@ void MeshBase::set_subdomain_name(const subdomain_id_type id,
 {
   if (synchronous)
     parallel_object_only();
-  else
-    this->unset_has_synched_subdomain_name_map();
   _block_id_to_name[id] =  name;
 }
 


### PR DESCRIPTION
This can be used to potentially avoid parallel communication down-the-road to fix the subdomain id to name sync flag