### PR TITLE
Add a side hierarchic nodal soln implementation

### DIFF
--- a/src/fe/fe_side_hierarchic.C
+++ b/src/fe/fe_side_hierarchic.C
@@ -23,6 +23,7 @@
 #include "libmesh/fe.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/fe_macro.h"
+#include "libmesh/int_range.h"
 
 namespace libMesh
 {
@@ -34,20 +35,47 @@ namespace libMesh
 namespace {
 
 void side_hierarchic_nodal_soln(const Elem * elem,
-                                const Order /* order */,
-                                const std::vector<Number> & /* elem_soln */,
+                                const Order order,
+                                const std::vector<Number> & elem_soln,
                                 std::vector<Number> & nodal_soln,
-                                const bool /*add_p_level*/)
+                                const bool add_p_level)
 {
   const unsigned int n_nodes = elem->n_nodes();
 
-  std::fill(nodal_soln.begin(), nodal_soln.end(), 0);
-  nodal_soln.resize(n_nodes, 0);
+  nodal_soln.assign(n_nodes, 0);
 
   // We request nodal solutions when plotting, for consistency with
-  // other elements; plotting 0 on non-sides makes sense in that
-  // context.
+  // other elements. Side solutions do not have unique values at element
+  // nodes shared by multiple sides, so average the side values there.
   // libmesh_warning("Nodal solution requested for a side element; this makes no sense.");
+  std::vector<unsigned int> nodal_soln_count(n_nodes, 0);
+  const FEType fe_type{order, SIDE_HIERARCHIC};
+  std::vector<Number> nodal_soln_on_side;
+
+  for (const auto side : elem->side_index_range())
+    {
+      const std::vector<unsigned int> side_nodes =
+        elem->nodes_on_side(side);
+
+      FEInterface::side_nodal_soln(fe_type,
+                                   elem,
+                                   side,
+                                   elem_soln,
+                                   nodal_soln_on_side,
+                                   add_p_level);
+      libmesh_assert_equal_to(nodal_soln_on_side.size(), side_nodes.size());
+
+      for (const auto i : index_range(side_nodes))
+        {
+          const auto n = side_nodes[i];
+          nodal_soln[n] += nodal_soln_on_side[i];
+          ++nodal_soln_count[n];
+        }
+    }
+
+  for (const auto n : index_range(nodal_soln))
+    if (nodal_soln_count[n])
+      nodal_soln[n] /= nodal_soln_count[n];
 } // side_hierarchic_nodal_soln()
 
 

--- a/tests/fe/fe_side_test.C
+++ b/tests/fe/fe_side_test.C
@@ -536,6 +536,72 @@ public:
 };
 
 
+class SideHierarchicNodalSolnTest : public CppUnit::TestCase
+{
+public:
+  LIBMESH_CPPUNIT_TEST_SUITE( SideHierarchicNodalSolnTest );
+  CPPUNIT_TEST( testConstantQuad9 );
+  CPPUNIT_TEST_SUITE_END();
+
+  void testConstantQuad9()
+  {
+    LOG_UNIT_TEST;
+
+#if LIBMESH_DIM > 1
+    Mesh mesh(*TestCommWorld);
+    MeshTools::Generation::build_square(mesh, 1, 1, 0., 1., 0., 1., QUAD9);
+
+    auto range = mesh.active_local_element_ptr_range();
+    if (range.begin() == range.end())
+      return;
+
+    const Elem * elem = *range.begin();
+    CPPUNIT_ASSERT_EQUAL(static_cast<int>(QUAD9),
+                         static_cast<int>(elem->type()));
+
+    const FEType fe_type(CONSTANT, SIDE_HIERARCHIC);
+    const std::vector<Number> elem_soln = {1, 3, 5, 7};
+
+    std::vector<Number> nodal_soln;
+    FEInterface::nodal_soln(/*dim=*/2,
+                            fe_type,
+                            elem,
+                            elem_soln,
+                            nodal_soln,
+                            /*add_p_level=*/false);
+
+    CPPUNIT_ASSERT_EQUAL(std::size_t(9), nodal_soln.size());
+
+    std::vector<Number> expected(nodal_soln.size(), 0);
+    std::vector<unsigned int> expected_count(nodal_soln.size(), 0);
+    for (const auto side : elem->side_index_range())
+      for (const auto n : elem->nodes_on_side(side))
+        {
+          expected[n] += elem_soln[side];
+          ++expected_count[n];
+        }
+
+    unsigned int n_nodes_without_side_value = 0;
+    for (const auto n : index_range(expected))
+      {
+        if (expected_count[n])
+          expected[n] /= expected_count[n];
+        else
+          ++n_nodes_without_side_value;
+
+        LIBMESH_ASSERT_NUMBERS_EQUAL(expected[n],
+                                     nodal_soln[n],
+                                     TOLERANCE * TOLERANCE);
+      }
+
+    CPPUNIT_ASSERT_EQUAL(1u, n_nodes_without_side_value);
+#endif
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( SideHierarchicNodalSolnTest );
+
+
 #define INSTANTIATE_FESIDETEST(order, family, elemtype)                 \
   class FESideTest_##order##_##family##_##elemtype : public FESideTest<order, family, elemtype> { \
   public:                                                               \


### PR DESCRIPTION
Given the previous comment here (which I've temporarily kept), I anticipate some debate on this, although I think the implementation is defensible given what we already do for projecting discontinuous solutions onto nodes for other output cases