### PR TITLE
Work around nvc++ 26.5 bugs

### DIFF
--- a/tests/fe/fe_rational_map.C
+++ b/tests/fe/fe_rational_map.C
@@ -73,9 +73,12 @@ public:
 
     for (auto node : _mesh->node_ptr_range())
       {
+        // Workaround for nvc++ bug
+        Node & n = *node;
+
         Real & x = (*node)(0);
         Real & y = (*node)(1);
-        node->set_extra_datum<Real>(weight_index, 1);
+        n.set_extra_datum<Real>(weight_index, 1);
         if (y > .6)
           {
             y = .5 + x;
@@ -85,7 +88,7 @@ public:
           {
             y = .5 + x;
             x = y - .5;
-            node->set_extra_datum<Real>(weight_index, sqrt(Real(2))/2);
+            n.set_extra_datum<Real>(weight_index, sqrt(Real(2))/2);
           }
       }
 

--- a/tests/fe/fe_test.h
+++ b/tests/fe/fe_test.h
@@ -503,6 +503,9 @@ public:
       {
         for (auto elem : _mesh->active_element_ptr_range())
           {
+            // Workaround for nvc++ bug
+            Elem & e = *elem;
+
             const unsigned int nv = elem->n_vertices();
             const unsigned int nn = elem->n_nodes();
             // We want interiors in lower dimensional elements treated
@@ -515,15 +518,15 @@ public:
             const unsigned int nvef = std::min(nve + n_faces, nn);
 
             for (unsigned int i = 0; i != nv; ++i)
-              elem->node_ref(i).set_extra_datum<Real>(weight_index, 1.);
+              e.node_ref(i).set_extra_datum<Real>(weight_index, 1.);
             for (unsigned int i = nv; i != nve; ++i)
-              elem->node_ref(i).set_extra_datum<Real>(weight_index, rational_w);
+              e.node_ref(i).set_extra_datum<Real>(weight_index, rational_w);
             const Real w2 = rational_w * rational_w;
             for (unsigned int i = nve; i != nvef; ++i)
-              elem->node_ref(i).set_extra_datum<Real>(weight_index, w2);
+              e.node_ref(i).set_extra_datum<Real>(weight_index, w2);
             const Real w3 = rational_w * w2;
             for (unsigned int i = nvef; i != nn; ++i)
-              elem->node_ref(i).set_extra_datum<Real>(weight_index, w3);
+              e.node_ref(i).set_extra_datum<Real>(weight_index, w3);
           }
       }
 


### PR DESCRIPTION
I'm reporting the compilation errors that prompted these upstream, but in the meantime the changes here (a couple intermediate references) seem like a reasonable workaround to me, for the first nvc++ release (literally in forever? at least since I started testing in 2022; see pull #3409) that passes all our unit tests at all optimization levels without problems.

Marking this as "Draft" until I'm done playing with example apps, MOOSE, etc. and I'm confident we don't need more libMesh-level changes.