### PR TITLE
Fix polyhedron edge adjacency for sparce side-edge lookups

### DIFF
--- a/src/geom/cell_polyhedron.C
+++ b/src/geom/cell_polyhedron.C
@@ -444,65 +444,29 @@ Polyhedron::edges_adjacent_to_node(const unsigned int n) const
   // overridden this.
   libmesh_assert_less(n, this->n_vertices());
 
-  const unsigned int ne = this->n_edges();
-  libmesh_assert_equal_to(ne, _edge_lookup.size());
+  libmesh_assert_equal_to(this->n_edges(), _edge_lookup.size());
 
   std::vector<unsigned int> adjacent_edges;
 
-  unsigned int next_edge = 0;
-
-  // Look for any adjacent edges on each side.  Make use of the fact
-  // that we number our edges in order as we encounter them from each
-  // side.
-  for (auto t : index_range(_sidelinks_data))
+  for (const auto edge : index_range(_edge_lookup))
     {
-      const Polygon & face = *std::get<0>(_sidelinks_data[t]);
+      const auto [side, side_edge] = _edge_lookup[edge];
+      const Polygon & face = *std::get<0>(_sidelinks_data[side]);
       const std::vector<unsigned int> & node_map =
-        std::get<2>(_sidelinks_data[t]);
-
-      while (_edge_lookup[next_edge].first < t)
-        {
-          ++next_edge;
-          if (next_edge == ne)
-            return adjacent_edges;
-        }
-
-      // If we haven't seen the next edge on this or an earlier side
-      // then we might as well go on to the next.
-      if (_edge_lookup[next_edge].first > t)
-        continue;
+        std::get<2>(_sidelinks_data[side]);
 
       const unsigned int fnv = face.n_vertices();
       libmesh_assert_equal_to(fnv, face.n_edges());
       libmesh_assert_equal_to(fnv, face.n_sides());
       libmesh_assert_less_equal(fnv, node_map.size());
+      libmesh_assert_less(side_edge, fnv);
 
-      // Polygon faces have one edge per vertex
-      for (auto v : make_range(fnv))
-        {
-          libmesh_assert_equal_to (_edge_lookup[next_edge].first, t);
-
-          if (_edge_lookup[next_edge].second > v)
-            continue;
-
-          while (_edge_lookup[next_edge].first == t &&
-                 _edge_lookup[next_edge].second < v)
-            {
-              ++next_edge;
-              if (next_edge == ne)
-                return adjacent_edges;
-            }
-
-          if (_edge_lookup[next_edge].first > t)
-            break;
-
-          const unsigned int vn = node_map[v];
-          const unsigned int vnp = node_map[(v+1)%fnv];
-          libmesh_assert_less(vn, this->n_vertices());
-          libmesh_assert_less(vnp, this->n_vertices());
-          if (vn == n || vnp == n)
-            adjacent_edges.push_back(next_edge);
-        }
+      const unsigned int vn = node_map[side_edge];
+      const unsigned int vnp = node_map[(side_edge + 1) % fnv];
+      libmesh_assert_less(vn, this->n_vertices());
+      libmesh_assert_less(vnp, this->n_vertices());
+      if (vn == n || vnp == n)
+        adjacent_edges.push_back(edge);
     }
 
   return adjacent_edges;

--- a/tests/geom/elem_test.h
+++ b/tests/geom/elem_test.h
@@ -231,16 +231,17 @@ public:
         // The initial "natural" way to orient our sides is commented
         // out here; permutations that fix diagonals for us are used
         // instead.
+        // Listing both z sides first also tests nonconsecutive local
+        // side edges in the polyhedron edge lookup.
         const std::vector<std::vector<unsigned int>> nodes_on_side =
           { {0, 1, 2, 3},   // min z
+            {5, 6, 7, 4},   // max z
             {0, 1, 5, 4},   // min y
         //     {1, 2, 6, 5},   // max x - bad
             {2, 6, 5, 1},   // max x
             {2, 3, 7, 6},   // max y
         //     {3, 0, 4, 7},   // min x - bad
-            {0, 4, 7, 3},   // min x
-        //     {4, 5, 6, 7} }; // max z - bad
-            {5, 6, 7, 4} }; // max z
+            {0, 4, 7, 3} }; // min x
 #endif
 
         // Build all the sides.


### PR DESCRIPTION
## Reason

`Polyhedron::_edge_lookup` stores each physical polyhedron edge once, indexed from the side and edge where it is first encountered.

Because shared edges are omitted from later sides, stored indices for a side are not necessarily consecutive. For example, a side may contribute local edges 1 and 3 while edge 2 was already encountered on another side.

`Polyhedron::edges_adjacent_to_node()` previously advanced through this lookup while iterating every local side edge. When the current side edge had no corresponding `_edge_lookup` entry, advancing the lookup cursor could move it to a later edge. The code did not recheck the local edge index after advancing, so it could test the nodes of one edge while returning the ID of another.

This was occurred during C0POLYHEDRON element-quality test like so:

    Assertion `second_edge_node_0 == n' failed.
    second_edge_node_0 = 6
    n = 0

## Changes

- Iterate over unique entries in `_edge_lookup`.
- Use each entry's side and local side-edge index to determine its endpoint nodes.
- Reorder the C0POLYHEDRON cube fixture so a side contributes nonconsecutive local edges.