### PR TITLE
Skip SCALAR variables during AMR projection

### DIFF
--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -385,10 +385,12 @@ void System::project_vector (const NumericVector<Number> & old_v,
           std::iota(vars.begin(), vars.end(), 0);
         }
 
-      std::vector<unsigned int> regular_vars, vector_vars;
+      std::vector<unsigned int> regular_vars, vector_vars, scalar_vars;
       for (auto var : vars)
       {
-        if (FEInterface::field_type(this->variable_type(var)) == TYPE_SCALAR)
+        if (this->variable(var).type().family == SCALAR)
+          scalar_vars.push_back(var);
+        else if (FEInterface::field_type(this->variable_type(var)) == TYPE_SCALAR)
           regular_vars.push_back(var);
         else
           vector_vars.push_back(var);
@@ -433,16 +435,15 @@ void System::project_vector (const NumericVector<Number> & old_v,
       if (this->processor_id() == (this->n_processors()-1))
         {
           const DofMap & dof_map = this->get_dof_map();
-          for (auto var : vars)
-            if (this->variable(var).type().family == SCALAR)
-              {
-                // We can just map SCALAR dofs directly across
-                std::vector<dof_id_type> new_SCALAR_indices, old_SCALAR_indices;
-                dof_map.SCALAR_dof_indices (new_SCALAR_indices, var, false);
-                dof_map.SCALAR_dof_indices (old_SCALAR_indices, var, true);
-                for (auto i : index_range(new_SCALAR_indices))
-                  new_vector.set(new_SCALAR_indices[i], old_vector(old_SCALAR_indices[i]));
-              }
+          for (auto var : scalar_vars)
+            {
+              // We can just map SCALAR dofs directly across
+              std::vector<dof_id_type> new_SCALAR_indices, old_SCALAR_indices;
+              dof_map.SCALAR_dof_indices (new_SCALAR_indices, var, false);
+              dof_map.SCALAR_dof_indices (old_SCALAR_indices, var, true);
+              for (auto i : index_range(new_SCALAR_indices))
+                new_vector.set(new_SCALAR_indices[i], old_vector(old_SCALAR_indices[i]));
+            }
         }
     }
 

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -488,6 +488,8 @@ public:
 #endif
 
 #ifdef LIBMESH_ENABLE_AMR
+  CPPUNIT_TEST( testProjectScalarCoarsening );
+
 #ifdef LIBMESH_HAVE_METAPHYSICL
 #ifdef LIBMESH_HAVE_PETSC
   CPPUNIT_TEST( testProjectMatrixEdge2 );
@@ -826,6 +828,64 @@ public:
                       u_subdomains, v_subdomains, w_subdomains,
                       es.parameters);
 #endif
+  }
+
+  void testProjectScalarCoarsening()
+  {
+    Mesh mesh(*TestCommWorld);
+
+    MeshTools::Generation::build_square(mesh,
+                                        2, 2,
+                                        0., 1.,
+                                        0., 1.,
+                                        QUAD4);
+
+    // Initialize the EquationSystems on a refined mesh so that the
+    // subsequent reinit performs a fine-to-coarse projection.
+    MeshRefinement mesh_refinement(mesh);
+    for (auto & elem : mesh.active_element_ptr_range())
+      elem->set_refinement_flag(Elem::REFINE);
+    mesh_refinement.refine_elements();
+    mesh.prepare_for_use();
+
+    EquationSystems es(mesh);
+    ExplicitSystem & sys =
+      es.add_system<ExplicitSystem>("SimpleSystem");
+
+    sys.add_variable("u", CONSTANT, MONOMIAL);
+    const unsigned int scalar_var =
+      sys.add_variable("scalar", FIRST, SCALAR);
+
+    es.init();
+
+    std::vector<dof_id_type> scalar_dofs;
+    sys.get_dof_map().SCALAR_dof_indices(scalar_dofs, scalar_var);
+    CPPUNIT_ASSERT_EQUAL(std::size_t(1), scalar_dofs.size());
+
+    NumericVector<Number> & solution = *sys.solution;
+    const dof_id_type scalar_dof = scalar_dofs[0];
+    if (scalar_dof >= solution.first_local_index() &&
+        scalar_dof < solution.last_local_index())
+      solution.set(scalar_dof, 7.25);
+    solution.close();
+
+    for (auto & elem : mesh.active_element_ptr_range())
+      elem->set_refinement_flag(Elem::COARSEN);
+
+    es.reinit();
+
+    scalar_dofs.clear();
+    sys.get_dof_map().SCALAR_dof_indices(scalar_dofs, scalar_var);
+    CPPUNIT_ASSERT_EQUAL(std::size_t(1), scalar_dofs.size());
+
+    std::unique_ptr<NumericVector<Number>> localized_solution =
+      NumericVector<Number>::build(es.comm());
+    localized_solution->init(sys.n_dofs(), false, SERIAL);
+    sys.solution->localize(*localized_solution);
+
+    LIBMESH_ASSERT_NUMBERS_EQUAL((*localized_solution)(scalar_dofs[0]),
+                                 Number(7.25),
+                                 TOLERANCE);
   }
 
   void test2DProjectVectorFE(const ElemType elem_type)


### PR DESCRIPTION
# Skip SCALAR variables during AMR projection

## Summary

Exclude global `SCALAR` variables from spatial AMR projection and copy their degrees of freedom directly between the old and new solution vectors.

## Problem

`System::project_vector()` classified variables using `FEInterface::field_type()`. Both spatial scalar-valued variables and global `SCALAR` variables have `TYPE_SCALAR`, so global `SCALAR` variables were incorrectly passed to `GenericProjector`.

During fine-to-coarse projection with element-interior degrees of freedom, this caused `GenericProjector::ProjectInteriors` to call `FE<2, SCALAR>::reinit()`, which failed because global `SCALAR` variables do not have a spatial finite-element representation.

## Change

Separate variables with the `SCALAR` FE family before classifying the remaining spatial variables.

The global `SCALAR` variables are then handled only by the existing direct degree-of-freedom mapping logic.

## Testing

Added a CppUnit regression that:

* creates a refined two-dimensional mesh;
* combines a `CONSTANT MONOMIAL` spatial variable with a global `SCALAR` variable;
* performs a fine-to-coarse `EquationSystems::reinit()`;
* verifies that the global scalar value is preserved.

The test fails without this change in `FE<2, SCALAR>::reinit()` and passes with the fix.

Also ran the complete `SystemsTest` and `EquationSystemsTest` selection: 47 tests passed.

## Related report

Addresses idaholab/moose#33366 also discussed in idaholab/moose#33008

## Future possible work

Other projection paths contain similar interactions between spatial projection and explicit handling of global SCALAR variables. While working on this I also came accros issue but did not reproduce the same failure there - this is becuase I'm not sure how to reproduce them as for this PR I actually had a MOOSE input file. Thus, this PR is only to System::project_vector() issue. Other projection paths may warrant separate follow-up review e.g., project_matrix.
