### PR TITLE
Guard SCALAR projection test when AMR is disabled

### DIFF
--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -830,6 +830,7 @@ public:
 #endif
   }
 
+#ifdef LIBMESH_ENABLE_AMR
   void testProjectScalarCoarsening()
   {
     Mesh mesh(*TestCommWorld);
@@ -887,6 +888,7 @@ public:
                                  Number(7.25),
                                  TOLERANCE);
   }
+#endif
 
   void test2DProjectVectorFE(const ElemType elem_type)
   {


### PR DESCRIPTION
Follow-up to #4503.

Guards testProjectScalarCoarsening() with LIBMESH_ENABLE_AMR so no-AMR builds compile successfully.

AMR build: test passes
No-AMR build: test is excluded