### PR TITLE
Polygonal/Polyhedral support for CheckpointIO

### DIFF
--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -168,6 +168,14 @@ public:
   bool version_at_least_1_5() const;
 
   /**
+   * \returns \p true if the current file has an XDR/XDA version that
+   * matches or exceeds 1.6
+   *
+   * As of this version we encode runtime element topology.
+   */
+  bool version_at_least_1_6() const;
+
+  /**
    * Get/Set the processor id or processor ids to use.
    *
    * The default processor_id to use is the processor_id() of the

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -18,9 +18,12 @@
 // Local includes
 #include "libmesh/checkpoint_io.h"
 #include "libmesh/boundary_info.h"
+#include "libmesh/cell_c0polyhedron.h"
 #include "libmesh/distributed_mesh.h"
 #include "libmesh/elem.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/enum_xdr_mode.h"
+#include "libmesh/face_c0polygon.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/mesh_communication.h"
@@ -167,7 +170,7 @@ CheckpointIO::CheckpointIO (MeshBase & mesh, const bool binary_in) :
   ParallelObject      (mesh),
   _binary             (binary_in),
   _parallel           (false),
-  _version            ("checkpoint-1.5"),
+  _version            ("checkpoint-1.6"),
   _my_processor_ids   (1, processor_id()),
   _my_n_processors    (mesh.is_replicated() ? 1 : n_processors())
 {
@@ -179,7 +182,7 @@ CheckpointIO::CheckpointIO (const MeshBase & mesh, const bool binary_in) :
   ParallelObject      (mesh),
   _binary             (binary_in),
   _parallel           (false),
-  _version            ("checkpoint-1.5"),
+  _version            ("checkpoint-1.6"),
   _my_processor_ids   (1, processor_id()),
   _my_n_processors    (mesh.is_replicated() ? 1 : n_processors())
 {
@@ -278,7 +281,15 @@ void CheckpointIO::cleanup(const std::string & input_name, processor_id_type n_p
 
 bool CheckpointIO::version_at_least_1_5() const
 {
-  return (this->version().find("1.5") != std::string::npos);
+  return
+    (this->version().find("1.5") != std::string::npos) ||
+    (this->version().find("1.6") != std::string::npos);
+}
+
+
+bool CheckpointIO::version_at_least_1_6() const
+{
+  return (this->version().find("1.6") != std::string::npos);
 }
 
 
@@ -594,6 +605,7 @@ void CheckpointIO::write_connectivity (Xdr & io,
   libmesh_assert (io.writing());
 
   const bool write_extra_integers = this->version_at_least_1_5();
+  const bool write_runtime_topology = this->version_at_least_1_6();
   const unsigned int n_extra_integers =
     write_extra_integers ? MeshOutput<MeshBase>::mesh().n_elem_integers() : 0;
 
@@ -601,6 +613,7 @@ void CheckpointIO::write_connectivity (Xdr & io,
   // id type pid subdomain_id parent_id extra_integer_0 ...
   std::vector<largest_id_type> elem_data(6 + n_extra_integers);
   std::vector<largest_id_type> conn_data;
+  std::vector<largest_id_type> runtime_topology;
 
   largest_id_type n_elems_here = elements.size();
 
@@ -656,6 +669,37 @@ void CheckpointIO::write_connectivity (Xdr & io,
       uint16_t pflag = elem->p_refinement_flag();
       io.data(pflag, "# pflag");
 #endif
+
+      if (elem->runtime_topology())
+        {
+          libmesh_error_msg_if
+            (!write_runtime_topology,
+             "Checkpoint format 1.6 or newer is required to write " <<
+             Utility::enum_to_string(elem->type()) << " elements.");
+
+          libmesh_error_msg_if
+            (elem->type() != C0POLYGON && elem->type() != C0POLYHEDRON,
+             "Unsupported runtime topology for " <<
+             Utility::enum_to_string(elem->type()) << " elements.");
+
+          runtime_topology.clear();
+          runtime_topology.push_back(n_nodes);
+
+          if (elem->type() == C0POLYHEDRON)
+            {
+              runtime_topology.push_back(elem->n_sides());
+              for (auto s : elem->side_index_range())
+                {
+                  const auto side_nodes = elem->nodes_on_side(s);
+                  runtime_topology.push_back(side_nodes.size());
+                  for (const auto n : side_nodes)
+                    runtime_topology.push_back(n);
+                }
+            }
+
+          io.data(runtime_topology, "# runtime topology");
+        }
+
       io.data_stream(conn_data.data(),
                      cast_int<unsigned int>(conn_data.size()),
                      cast_int<unsigned int>(conn_data.size()));
@@ -910,6 +954,7 @@ file_id_type CheckpointIO::read_header (const std::string & name)
   uint16_t input_parallel;
   file_id_type input_n_procs;
 
+  std::string input_version;
   std::vector<std::string> node_integer_names, elem_integer_names;
 
   // We'll write a header file from processor 0 and broadcast.
@@ -917,8 +962,7 @@ file_id_type CheckpointIO::read_header (const std::string & name)
     {
       Xdr io (name, this->binary() ? DECODE : READ);
 
-      // read the version, but don't care about it
-      std::string input_version;
+      // read the version
       io.data(input_version);
 
       // read the data type, don't care about it this time
@@ -955,6 +999,9 @@ file_id_type CheckpointIO::read_header (const std::string & name)
     }
 
   // broadcast data from processor 0, set values everywhere
+  this->comm().broadcast(input_version);
+  this->version() = input_version;
+
   this->comm().broadcast(mesh_dimension);
   mesh.set_mesh_dimension(cast_int<unsigned char>(mesh_dimension));
 
@@ -1139,6 +1186,7 @@ void CheckpointIO::read_connectivity (Xdr & io)
   MeshBase & mesh = MeshInput<MeshBase>::mesh();
 
   const bool read_extra_integers = this->version_at_least_1_5();
+  const bool read_runtime_topology = this->version_at_least_1_6();
 
   const unsigned int n_extra_integers =
     read_extra_integers ? mesh.n_elem_integers() : 0;
@@ -1147,7 +1195,7 @@ void CheckpointIO::read_connectivity (Xdr & io)
   io.data(n_elems_here);
 
   // Keep track of the highest dimensional element we've added to the mesh
-  unsigned int highest_elem_dim = 1;
+  unsigned int highest_elem_dim = mesh.mesh_dimension();
 
   // RHS: Originally we used invalid_processor_id as a "no parent" tag
   // number, because I'm an idiot.  Let's try to support broken files
@@ -1176,8 +1224,79 @@ void CheckpointIO::read_connectivity (Xdr & io)
       io.data(pflag, "# pflag");
 #endif
 
+      const ElemType elem_type =
+        static_cast<ElemType>(elem_data[1]);
+      const bool is_c0polygon = (elem_type == C0POLYGON);
+      const bool is_c0polyhedron = (elem_type == C0POLYHEDRON);
+
       unsigned int n_nodes = Elem::type_to_n_nodes_map[elem_data[1]];
-      if (n_nodes == invalid_uint)
+      std::vector<std::vector<unsigned int>> nodes_on_sides;
+
+      if (is_c0polygon || is_c0polyhedron)
+        {
+          libmesh_error_msg_if
+            (!read_runtime_topology,
+             "Checkpoint format 1.6 or newer is required to read " <<
+             Utility::enum_to_string(elem_type) << " elements.");
+
+          std::vector<file_id_type> runtime_topology;
+          io.data(runtime_topology, "# runtime topology");
+          libmesh_error_msg_if(runtime_topology.empty(),
+                               "Invalid empty runtime element topology.");
+
+          n_nodes = cast_int<unsigned int>(runtime_topology[0]);
+
+          if (is_c0polygon)
+            {
+              libmesh_error_msg_if
+                (runtime_topology.size() != 1 || n_nodes < 3,
+                 "Invalid C0POLYGON checkpoint topology.");
+            }
+          else
+            {
+              libmesh_error_msg_if(runtime_topology.size() < 2,
+                                   "Invalid C0POLYHEDRON checkpoint topology.");
+
+              std::size_t topology_index = 1;
+              const unsigned int n_sides =
+                cast_int<unsigned int>(runtime_topology[topology_index++]);
+              libmesh_error_msg_if(n_sides < 4,
+                                   "Invalid C0POLYHEDRON checkpoint topology.");
+              nodes_on_sides.resize(n_sides);
+
+              for (auto s : index_range(nodes_on_sides))
+                {
+                  libmesh_error_msg_if
+                    (topology_index == runtime_topology.size(),
+                     "Incomplete C0POLYHEDRON checkpoint topology.");
+
+                  const unsigned int n_side_nodes =
+                    cast_int<unsigned int>(runtime_topology[topology_index++]);
+                  libmesh_error_msg_if
+                    (n_side_nodes < 3 ||
+                     n_side_nodes > runtime_topology.size() - topology_index,
+                     "Invalid C0POLYHEDRON side checkpoint topology.");
+
+                  auto & side_nodes = nodes_on_sides[s];
+                  side_nodes.resize(n_side_nodes);
+                  for (auto n : index_range(side_nodes))
+                    {
+                      const unsigned int local_node =
+                        cast_int<unsigned int>(runtime_topology[topology_index++]);
+                      libmesh_error_msg_if
+                        (local_node >= n_nodes,
+                         "C0POLYHEDRON side checkpoint topology references "
+                         "an invalid local node.");
+                      side_nodes[n] = local_node;
+                    }
+                }
+
+              libmesh_error_msg_if
+                (topology_index != runtime_topology.size(),
+                 "Extra data in C0POLYHEDRON checkpoint topology.");
+            }
+        }
+      else if (n_nodes == invalid_uint)
         libmesh_not_implemented_msg("Support for Polygons/Polyhedra not yet implemented");
 
       // Snag the node ids this element was connected to
@@ -1188,8 +1307,6 @@ void CheckpointIO::read_connectivity (Xdr & io)
 
       const dof_id_type id                 =
         cast_int<dof_id_type>      (elem_data[0]);
-      const ElemType elem_type             =
-        static_cast<ElemType>      (elem_data[1]);
       const processor_id_type proc_id      =
         cast_int<processor_id_type>
         (elem_data[2] % mesh.n_processors());
@@ -1254,11 +1371,59 @@ void CheckpointIO::read_connectivity (Xdr & io)
             libmesh_assert_equal_to
               (old_elem->node_id(n),
                cast_int<dof_id_type>(conn_data[n]));
+
+          if (is_c0polyhedron)
+            {
+              libmesh_assert_equal_to(old_elem->n_sides(),
+                                      nodes_on_sides.size());
+#ifndef NDEBUG
+              for (auto s : index_range(nodes_on_sides))
+                libmesh_assert(old_elem->nodes_on_side(s) ==
+                               nodes_on_sides[s]);
+#endif
+            }
         }
       else
         {
           // Create the element
-          auto elem = Elem::build(elem_type, parent);
+          std::unique_ptr<Elem> elem;
+          std::unique_ptr<Node> generated_mid_elem_node;
+
+          if (is_c0polygon)
+            elem = std::make_unique<C0Polygon>(n_nodes, parent);
+          else if (is_c0polyhedron)
+            {
+              std::vector<std::shared_ptr<Polygon>> sides(nodes_on_sides.size());
+              for (auto s : index_range(nodes_on_sides))
+                {
+                  const auto & side_node_indices = nodes_on_sides[s];
+                  auto side =
+                    std::make_shared<C0Polygon>
+                      (cast_int<unsigned int>(side_node_indices.size()));
+                  for (auto n : index_range(side_node_indices))
+                    side->set_node
+                      (n, mesh.node_ptr(cast_int<dof_id_type>
+                       (conn_data[side_node_indices[n]])));
+                  sides[s] = std::move(side);
+                }
+
+              elem = std::make_unique<C0Polyhedron>
+                (sides, generated_mid_elem_node, parent);
+
+              libmesh_error_msg_if
+                (elem->n_nodes() != conn_data.size(),
+                 "C0POLYHEDRON checkpoint topology is incompatible with "
+                 "this libMesh configuration.");
+
+              for (auto n : make_range(elem->n_vertices()))
+                libmesh_error_msg_if
+                  (elem->node_id(n) !=
+                   cast_int<dof_id_type>(conn_data[n]),
+                   "C0POLYHEDRON checkpoint topology has inconsistent "
+                   "local node ordering.");
+            }
+          else
+            elem = Elem::build(elem_type, parent);
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
           elem->set_unique_id(unique_id);

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -677,24 +677,15 @@ void CheckpointIO::write_connectivity (Xdr & io,
              "Checkpoint format 1.6 or newer is required to write " <<
              Utility::enum_to_string(elem->type()) << " elements.");
 
-          libmesh_error_msg_if
-            (elem->type() != C0POLYGON && elem->type() != C0POLYHEDRON,
-             "Unsupported runtime topology for " <<
-             Utility::enum_to_string(elem->type()) << " elements.");
-
           runtime_topology.clear();
           runtime_topology.push_back(n_nodes);
-
-          if (elem->type() == C0POLYHEDRON)
+          runtime_topology.push_back(elem->n_sides());
+          for (auto s : elem->side_index_range())
             {
-              runtime_topology.push_back(elem->n_sides());
-              for (auto s : elem->side_index_range())
-                {
-                  const auto side_nodes = elem->nodes_on_side(s);
-                  runtime_topology.push_back(side_nodes.size());
-                  for (const auto n : side_nodes)
-                    runtime_topology.push_back(n);
-                }
+              const auto side_nodes = elem->nodes_on_side(s);
+              runtime_topology.push_back(side_nodes.size());
+              for (const auto n : side_nodes)
+                runtime_topology.push_back(n);
             }
 
           io.data(runtime_topology, "# runtime topology");
@@ -1230,9 +1221,11 @@ void CheckpointIO::read_connectivity (Xdr & io)
       const bool is_c0polyhedron = (elem_type == C0POLYHEDRON);
 
       unsigned int n_nodes = Elem::type_to_n_nodes_map[elem_data[1]];
+      // Runtime-topology types have no fixed node count in this map.
+      const bool has_runtime_topology = (n_nodes == invalid_uint);
       std::vector<std::vector<unsigned int>> nodes_on_sides;
 
-      if (is_c0polygon || is_c0polyhedron)
+      if (has_runtime_topology)
         {
           libmesh_error_msg_if
             (!read_runtime_topology,
@@ -1241,63 +1234,66 @@ void CheckpointIO::read_connectivity (Xdr & io)
 
           std::vector<file_id_type> runtime_topology;
           io.data(runtime_topology, "# runtime topology");
-          libmesh_error_msg_if(runtime_topology.empty(),
-                               "Invalid empty runtime element topology.");
+          libmesh_error_msg_if(runtime_topology.size() < 2,
+                               "Invalid runtime element topology.");
 
-          n_nodes = cast_int<unsigned int>(runtime_topology[0]);
+          std::size_t topology_index = 0;
+          n_nodes =
+            cast_int<unsigned int>(runtime_topology[topology_index++]);
+          const unsigned int n_sides =
+            cast_int<unsigned int>(runtime_topology[topology_index++]);
+          nodes_on_sides.resize(n_sides);
+
+          for (auto s : index_range(nodes_on_sides))
+            {
+              libmesh_error_msg_if
+                (topology_index == runtime_topology.size(),
+                 "Incomplete runtime element checkpoint topology.");
+
+              const unsigned int n_side_nodes =
+                cast_int<unsigned int>(runtime_topology[topology_index++]);
+              libmesh_error_msg_if
+                (n_side_nodes > runtime_topology.size() - topology_index,
+                 "Invalid runtime element side checkpoint topology.");
+
+              auto & side_nodes = nodes_on_sides[s];
+              side_nodes.resize(n_side_nodes);
+              for (auto n : index_range(side_nodes))
+                {
+                  const unsigned int local_node =
+                    cast_int<unsigned int>(runtime_topology[topology_index++]);
+                  libmesh_error_msg_if
+                    (local_node >= n_nodes,
+                     "Runtime element side checkpoint topology references "
+                     "an invalid local node.");
+                  side_nodes[n] = local_node;
+                }
+            }
+
+          libmesh_error_msg_if
+            (topology_index != runtime_topology.size(),
+             "Extra data in runtime element checkpoint topology.");
 
           if (is_c0polygon)
             {
               libmesh_error_msg_if
-                (runtime_topology.size() != 1 || n_nodes < 3,
+                (n_nodes < 3 || n_sides != n_nodes,
                  "Invalid C0POLYGON checkpoint topology.");
+              for (const auto & side_nodes : nodes_on_sides)
+                libmesh_error_msg_if
+                  (side_nodes.size() != 2,
+                   "Invalid C0POLYGON side checkpoint topology.");
             }
-          else
+          else if (is_c0polyhedron)
             {
-              libmesh_error_msg_if(runtime_topology.size() < 2,
-                                   "Invalid C0POLYHEDRON checkpoint topology.");
-
-              std::size_t topology_index = 1;
-              const unsigned int n_sides =
-                cast_int<unsigned int>(runtime_topology[topology_index++]);
               libmesh_error_msg_if(n_sides < 4,
                                    "Invalid C0POLYHEDRON checkpoint topology.");
-              nodes_on_sides.resize(n_sides);
-
-              for (auto s : index_range(nodes_on_sides))
-                {
-                  libmesh_error_msg_if
-                    (topology_index == runtime_topology.size(),
-                     "Incomplete C0POLYHEDRON checkpoint topology.");
-
-                  const unsigned int n_side_nodes =
-                    cast_int<unsigned int>(runtime_topology[topology_index++]);
-                  libmesh_error_msg_if
-                    (n_side_nodes < 3 ||
-                     n_side_nodes > runtime_topology.size() - topology_index,
-                     "Invalid C0POLYHEDRON side checkpoint topology.");
-
-                  auto & side_nodes = nodes_on_sides[s];
-                  side_nodes.resize(n_side_nodes);
-                  for (auto n : index_range(side_nodes))
-                    {
-                      const unsigned int local_node =
-                        cast_int<unsigned int>(runtime_topology[topology_index++]);
-                      libmesh_error_msg_if
-                        (local_node >= n_nodes,
-                         "C0POLYHEDRON side checkpoint topology references "
-                         "an invalid local node.");
-                      side_nodes[n] = local_node;
-                    }
-                }
-
-              libmesh_error_msg_if
-                (topology_index != runtime_topology.size(),
-                 "Extra data in C0POLYHEDRON checkpoint topology.");
+              for (const auto & side_nodes : nodes_on_sides)
+                libmesh_error_msg_if
+                  (side_nodes.size() < 3,
+                   "Invalid C0POLYHEDRON side checkpoint topology.");
             }
         }
-      else if (n_nodes == invalid_uint)
-        libmesh_not_implemented_msg("Support for Polygons/Polyhedra not yet implemented");
 
       // Snag the node ids this element was connected to
       std::vector<file_id_type> conn_data(n_nodes);
@@ -1372,7 +1368,7 @@ void CheckpointIO::read_connectivity (Xdr & io)
               (old_elem->node_id(n),
                cast_int<dof_id_type>(conn_data[n]));
 
-          if (is_c0polyhedron)
+          if (has_runtime_topology)
             {
               libmesh_assert_equal_to(old_elem->n_sides(),
                                       nodes_on_sides.size());
@@ -1424,6 +1420,23 @@ void CheckpointIO::read_connectivity (Xdr & io)
             }
           else
             elem = Elem::build(elem_type, parent);
+
+          if (has_runtime_topology)
+            {
+              libmesh_error_msg_if
+                (!elem->runtime_topology() ||
+                 elem->n_nodes() != conn_data.size() ||
+                 elem->n_sides() != nodes_on_sides.size(),
+                 Utility::enum_to_string(elem_type) <<
+                 " checkpoint topology is incompatible with this "
+                 "libMesh configuration.");
+
+              for (auto s : index_range(nodes_on_sides))
+                libmesh_error_msg_if
+                  (elem->nodes_on_side(s) != nodes_on_sides[s],
+                   Utility::enum_to_string(elem_type) <<
+                   " checkpoint topology has inconsistent side ordering.");
+            }
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
           elem->set_unique_id(unique_id);

--- a/tests/mesh/checkpoint.C
+++ b/tests/mesh/checkpoint.C
@@ -3,6 +3,7 @@
 #include "libmesh/distributed_mesh.h"
 #include "libmesh/face_c0polygon.h"
 #include "libmesh/int_range.h"
+#include "libmesh/mesh.h"
 #include "libmesh/mesh_generation.h"
 #include "libmesh/node.h"
 #include "libmesh/parallel.h"
@@ -152,7 +153,7 @@ public:
       {{0., 0.}, {1., 0.}, {1.5, 0.5}, {1., 1.}, {0., 1.}};
 
     {
-      ReplicatedMesh mesh(comm_self, 2);
+      Mesh mesh(comm_self, 2);
       mesh.allow_renumbering(false);
 
       auto polygon =
@@ -169,7 +170,7 @@ public:
     }
 
     {
-      ReplicatedMesh mesh(comm_self);
+      Mesh mesh(comm_self);
       CheckpointIO checkpoint(mesh, binary);
       checkpoint.read(filename);
 
@@ -177,23 +178,30 @@ public:
       CPPUNIT_ASSERT_EQUAL(dof_id_type(5), mesh.n_nodes());
       CPPUNIT_ASSERT_EQUAL(2u, static_cast<unsigned int>(mesh.mesh_dimension()));
 
-      const Elem & elem = mesh.elem_ref(0);
-      CPPUNIT_ASSERT_EQUAL(C0POLYGON, elem.type());
-      CPPUNIT_ASSERT_EQUAL(5u, elem.n_nodes());
-      CPPUNIT_ASSERT_EQUAL(5u, elem.n_vertices());
-      CPPUNIT_ASSERT_EQUAL(5u, elem.n_sides());
-      CPPUNIT_ASSERT_EQUAL(5u, elem.n_edges());
+      const Elem * elem = mesh.query_elem_ptr(0);
+      bool found_elem = elem;
+      mesh.comm().max(found_elem);
+      CPPUNIT_ASSERT(found_elem);
 
-      for (auto n : index_range(points))
+      if (elem)
         {
-          CPPUNIT_ASSERT_EQUAL(cast_int<dof_id_type>(n), elem.node_id(n));
-          CPPUNIT_ASSERT_EQUAL(points[n], elem.point(n));
+          CPPUNIT_ASSERT_EQUAL(C0POLYGON, elem->type());
+          CPPUNIT_ASSERT_EQUAL(5u, elem->n_nodes());
+          CPPUNIT_ASSERT_EQUAL(5u, elem->n_vertices());
+          CPPUNIT_ASSERT_EQUAL(5u, elem->n_sides());
+          CPPUNIT_ASSERT_EQUAL(5u, elem->n_edges());
 
-          const auto side_nodes = elem.nodes_on_side(n);
-          CPPUNIT_ASSERT_EQUAL(std::size_t(2), side_nodes.size());
-          CPPUNIT_ASSERT_EQUAL(cast_int<unsigned int>(n), side_nodes[0]);
-          CPPUNIT_ASSERT_EQUAL
-            (cast_int<unsigned int>((n + 1) % points.size()), side_nodes[1]);
+          for (auto n : index_range(points))
+            {
+              CPPUNIT_ASSERT_EQUAL(cast_int<dof_id_type>(n), elem->node_id(n));
+              CPPUNIT_ASSERT_EQUAL(points[n], elem->point(n));
+
+              const auto side_nodes = elem->nodes_on_side(n);
+              CPPUNIT_ASSERT_EQUAL(std::size_t(2), side_nodes.size());
+              CPPUNIT_ASSERT_EQUAL(cast_int<unsigned int>(n), side_nodes[0]);
+              CPPUNIT_ASSERT_EQUAL
+                (cast_int<unsigned int>((n + 1) % points.size()), side_nodes[1]);
+            }
         }
     }
 
@@ -229,7 +237,7 @@ public:
        {6, 7, 8, 9, 10, 11}};
 
     {
-      ReplicatedMesh mesh(comm_self, 3);
+      Mesh mesh(comm_self, 3);
       mesh.allow_renumbering(false);
       for (auto n : index_range(points))
         mesh.add_point(points[n], n);
@@ -250,6 +258,10 @@ public:
       auto polyhedron =
         std::make_unique<C0Polyhedron>(sides, mid_elem_node);
       CPPUNIT_ASSERT(mid_elem_node);
+
+      // Explicit id so DistributedMesh matches ReplicatedMesh
+      mid_elem_node->set_id(points.size());
+
       mesh.add_node(std::move(mid_elem_node));
       polyhedron->set_id() = 0;
       mesh.add_elem(std::move(polyhedron));
@@ -260,7 +272,7 @@ public:
     }
 
     {
-      ReplicatedMesh mesh(comm_self);
+      Mesh mesh(comm_self);
       CheckpointIO checkpoint(mesh, binary);
       checkpoint.read(filename);
 
@@ -268,23 +280,30 @@ public:
       CPPUNIT_ASSERT_EQUAL(dof_id_type(13), mesh.n_nodes());
       CPPUNIT_ASSERT_EQUAL(3u, static_cast<unsigned int>(mesh.mesh_dimension()));
 
-      const Elem & elem = mesh.elem_ref(0);
-      CPPUNIT_ASSERT_EQUAL(C0POLYHEDRON, elem.type());
-      CPPUNIT_ASSERT_EQUAL(12u, elem.n_vertices());
-      CPPUNIT_ASSERT_EQUAL(13u, elem.n_nodes());
-      CPPUNIT_ASSERT_EQUAL(8u, elem.n_sides());
-      CPPUNIT_ASSERT_EQUAL(18u, elem.n_edges());
-      CPPUNIT_ASSERT_EQUAL(dof_id_type(12),
-                           elem.node_id(elem.n_vertices()));
+      const Elem * elem = mesh.query_elem_ptr(0);
+      bool found_elem = elem;
+      mesh.comm().max(found_elem);
+      CPPUNIT_ASSERT(found_elem);
 
-      for (auto s : index_range(nodes_on_sides))
+      if (elem)
         {
-          const auto side_nodes = elem.nodes_on_side(s);
-          CPPUNIT_ASSERT_EQUAL(nodes_on_sides[s].size(), side_nodes.size());
-          for (auto n : index_range(side_nodes))
-            CPPUNIT_ASSERT_EQUAL
-              (cast_int<dof_id_type>(nodes_on_sides[s][n]),
-               elem.node_id(side_nodes[n]));
+          CPPUNIT_ASSERT_EQUAL(C0POLYHEDRON, elem->type());
+          CPPUNIT_ASSERT_EQUAL(12u, elem->n_vertices());
+          CPPUNIT_ASSERT_EQUAL(13u, elem->n_nodes());
+          CPPUNIT_ASSERT_EQUAL(8u, elem->n_sides());
+          CPPUNIT_ASSERT_EQUAL(18u, elem->n_edges());
+          CPPUNIT_ASSERT_EQUAL(dof_id_type(12),
+                               elem->node_id(elem->n_vertices()));
+
+          for (auto s : index_range(nodes_on_sides))
+            {
+              const auto side_nodes = elem->nodes_on_side(s);
+              CPPUNIT_ASSERT_EQUAL(nodes_on_sides[s].size(), side_nodes.size());
+              for (auto n : index_range(side_nodes))
+                CPPUNIT_ASSERT_EQUAL
+                  (cast_int<dof_id_type>(nodes_on_sides[s][n]),
+                   elem->node_id(side_nodes[n]));
+            }
         }
     }
 

--- a/tests/mesh/checkpoint.C
+++ b/tests/mesh/checkpoint.C
@@ -1,9 +1,13 @@
-#include "libmesh/distributed_mesh.h"
-#include "libmesh/replicated_mesh.h"
+#include "libmesh/cell_c0polyhedron.h"
 #include "libmesh/checkpoint_io.h"
+#include "libmesh/distributed_mesh.h"
+#include "libmesh/face_c0polygon.h"
+#include "libmesh/int_range.h"
 #include "libmesh/mesh_generation.h"
+#include "libmesh/node.h"
 #include "libmesh/parallel.h"
 #include "libmesh/partitioner.h"
+#include "libmesh/replicated_mesh.h"
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"
@@ -27,6 +31,12 @@ public:
   CPPUNIT_TEST( testBinaryRepRepSplitter );
   CPPUNIT_TEST( testAsciiDistDistSplitter );
   CPPUNIT_TEST( testBinaryDistDistSplitter );
+  CPPUNIT_TEST( testAsciiC0Polygon );
+  CPPUNIT_TEST( testBinaryC0Polygon );
+#if LIBMESH_DIM > 2
+  CPPUNIT_TEST( testAsciiC0Polyhedron );
+  CPPUNIT_TEST( testBinaryC0Polyhedron );
+#endif
 #endif
 
   CPPUNIT_TEST_SUITE_END();
@@ -127,6 +137,162 @@ public:
 #endif // LIBMESH_HAVE_XDR
   }
 
+  void testC0PolygonCheckpoint(bool binary)
+  {
+#ifdef LIBMESH_HAVE_XDR
+    // Parallel element packing does not yet support runtime topology,
+    // so exercise serial CheckpointIO independently on rank 0.
+    if (TestCommWorld->rank() != 0)
+      return;
+
+    Parallel::Communicator comm_self;
+    const std::string filename =
+      std::string("checkpoint_c0polygon.cp") + (binary ? "r" : "a");
+    const std::vector<Point> points =
+      {{0., 0.}, {1., 0.}, {1.5, 0.5}, {1., 1.}, {0., 1.}};
+
+    {
+      ReplicatedMesh mesh(comm_self, 2);
+      mesh.allow_renumbering(false);
+
+      auto polygon =
+        std::make_unique<C0Polygon>(cast_int<unsigned int>(points.size()));
+      polygon->set_id() = 0;
+      for (auto n : index_range(points))
+        polygon->set_node(n, mesh.add_point(points[n], n));
+
+      mesh.add_elem(std::move(polygon));
+      mesh.prepare_for_use();
+
+      CheckpointIO checkpoint(mesh, binary);
+      checkpoint.write(filename);
+    }
+
+    {
+      ReplicatedMesh mesh(comm_self);
+      CheckpointIO checkpoint(mesh, binary);
+      checkpoint.read(filename);
+
+      CPPUNIT_ASSERT_EQUAL(dof_id_type(1), mesh.n_elem());
+      CPPUNIT_ASSERT_EQUAL(dof_id_type(5), mesh.n_nodes());
+      CPPUNIT_ASSERT_EQUAL(2u, static_cast<unsigned int>(mesh.mesh_dimension()));
+
+      const Elem & elem = mesh.elem_ref(0);
+      CPPUNIT_ASSERT_EQUAL(C0POLYGON, elem.type());
+      CPPUNIT_ASSERT_EQUAL(5u, elem.n_nodes());
+      CPPUNIT_ASSERT_EQUAL(5u, elem.n_vertices());
+      CPPUNIT_ASSERT_EQUAL(5u, elem.n_sides());
+      CPPUNIT_ASSERT_EQUAL(5u, elem.n_edges());
+
+      for (auto n : index_range(points))
+        {
+          CPPUNIT_ASSERT_EQUAL(cast_int<dof_id_type>(n), elem.node_id(n));
+          CPPUNIT_ASSERT_EQUAL(points[n], elem.point(n));
+
+          const auto side_nodes = elem.nodes_on_side(n);
+          CPPUNIT_ASSERT_EQUAL(std::size_t(2), side_nodes.size());
+          CPPUNIT_ASSERT_EQUAL(cast_int<unsigned int>(n), side_nodes[0]);
+          CPPUNIT_ASSERT_EQUAL
+            (cast_int<unsigned int>((n + 1) % points.size()), side_nodes[1]);
+        }
+    }
+
+    CheckpointIO::cleanup(filename, 1);
+#endif // LIBMESH_HAVE_XDR
+  }
+
+#if LIBMESH_DIM > 2
+  void testC0PolyhedronCheckpoint(bool binary)
+  {
+#ifdef LIBMESH_HAVE_XDR
+    // Parallel element packing does not yet support runtime topology,
+    // so exercise serial CheckpointIO independently on rank 0.
+    if (TestCommWorld->rank() != 0)
+      return;
+
+    Parallel::Communicator comm_self;
+    const std::string filename =
+      std::string("checkpoint_c0polyhedron.cp") + (binary ? "r" : "a");
+    const std::vector<Point> points =
+      {{0., -2., 0.}, {-1., -1., 0.}, {-1., 1., 0.},
+       {0., 2., 0.}, {1., 1., 0.}, {1., -1., 0.},
+       {0., -2., 1.}, {-1., -1., 1.}, {-1., 1., 1.},
+       {0., 2., 1.}, {1., 1., 1.}, {1., -1., 1.}};
+    const std::vector<std::vector<unsigned int>> nodes_on_sides =
+      {{0, 1, 2, 3, 4, 5},
+       {0, 1, 7, 6},
+       {1, 2, 8, 7},
+       {2, 3, 9, 8},
+       {3, 4, 10, 9},
+       {4, 5, 11, 10},
+       {5, 0, 6, 11},
+       {6, 7, 8, 9, 10, 11}};
+
+    {
+      ReplicatedMesh mesh(comm_self, 3);
+      mesh.allow_renumbering(false);
+      for (auto n : index_range(points))
+        mesh.add_point(points[n], n);
+
+      std::vector<std::shared_ptr<Polygon>> sides(nodes_on_sides.size());
+      for (auto s : index_range(nodes_on_sides))
+        {
+          const auto & side_nodes = nodes_on_sides[s];
+          auto side =
+            std::make_shared<C0Polygon>
+              (cast_int<unsigned int>(side_nodes.size()));
+          for (auto n : index_range(side_nodes))
+            side->set_node(n, mesh.node_ptr(side_nodes[n]));
+          sides[s] = std::move(side);
+        }
+
+      std::unique_ptr<Node> mid_elem_node;
+      auto polyhedron =
+        std::make_unique<C0Polyhedron>(sides, mid_elem_node);
+      CPPUNIT_ASSERT(mid_elem_node);
+      mesh.add_node(std::move(mid_elem_node));
+      polyhedron->set_id() = 0;
+      mesh.add_elem(std::move(polyhedron));
+      mesh.prepare_for_use();
+
+      CheckpointIO checkpoint(mesh, binary);
+      checkpoint.write(filename);
+    }
+
+    {
+      ReplicatedMesh mesh(comm_self);
+      CheckpointIO checkpoint(mesh, binary);
+      checkpoint.read(filename);
+
+      CPPUNIT_ASSERT_EQUAL(dof_id_type(1), mesh.n_elem());
+      CPPUNIT_ASSERT_EQUAL(dof_id_type(13), mesh.n_nodes());
+      CPPUNIT_ASSERT_EQUAL(3u, static_cast<unsigned int>(mesh.mesh_dimension()));
+
+      const Elem & elem = mesh.elem_ref(0);
+      CPPUNIT_ASSERT_EQUAL(C0POLYHEDRON, elem.type());
+      CPPUNIT_ASSERT_EQUAL(12u, elem.n_vertices());
+      CPPUNIT_ASSERT_EQUAL(13u, elem.n_nodes());
+      CPPUNIT_ASSERT_EQUAL(8u, elem.n_sides());
+      CPPUNIT_ASSERT_EQUAL(18u, elem.n_edges());
+      CPPUNIT_ASSERT_EQUAL(dof_id_type(12),
+                           elem.node_id(elem.n_vertices()));
+
+      for (auto s : index_range(nodes_on_sides))
+        {
+          const auto side_nodes = elem.nodes_on_side(s);
+          CPPUNIT_ASSERT_EQUAL(nodes_on_sides[s].size(), side_nodes.size());
+          for (auto n : index_range(side_nodes))
+            CPPUNIT_ASSERT_EQUAL
+              (cast_int<dof_id_type>(nodes_on_sides[s][n]),
+               elem.node_id(side_nodes[n]));
+        }
+    }
+
+    CheckpointIO::cleanup(filename, 1);
+#endif // LIBMESH_HAVE_XDR
+  }
+#endif
+
   void testAsciiDistRepSplitter()
   {
     LOG_UNIT_TEST;
@@ -182,6 +348,36 @@ public:
 
     testSplitter<DistributedMesh, DistributedMesh>(true, true);
   }
+
+  void testAsciiC0Polygon()
+  {
+    LOG_UNIT_TEST;
+
+    testC0PolygonCheckpoint(false);
+  }
+
+  void testBinaryC0Polygon()
+  {
+    LOG_UNIT_TEST;
+
+    testC0PolygonCheckpoint(true);
+  }
+
+#if LIBMESH_DIM > 2
+  void testAsciiC0Polyhedron()
+  {
+    LOG_UNIT_TEST;
+
+    testC0PolyhedronCheckpoint(false);
+  }
+
+  void testBinaryC0Polyhedron()
+  {
+    LOG_UNIT_TEST;
+
+    testC0PolyhedronCheckpoint(true);
+  }
+#endif
 
   void testAsciiDistDistSplitterCache()
   {


### PR DESCRIPTION
Adds support for Checkpoint I/O for polygonal and polyhedral elements. Writes runtime node counts for C0polygon and node counts, faces, and node indices for c0polyhedron. 

Includes some tests. 