### PR TITLE
Work around weird g++ bug

### DIFF
--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -642,10 +642,7 @@ std::size_t System::read_serialized_blocked_dof_objects (const dof_id_type n_obj
   std::vector<unsigned int> vars_to_read (_written_var_indices);
 
   if (var_to_read != libMesh::invalid_uint)
-    {
-      vars_to_read.clear();
-      vars_to_read.push_back(var_to_read);
-    }
+    vars_to_read.assign({var_to_read});
 
   const unsigned int
     sys_num    = this->number(),


### PR DESCRIPTION
The former code was triggering a -Wfree-nonheap-object for me with g++ 15.2.0, but only with exceptions disabled, only in devel mode, and only with -std=c++20; c++17 and c++23 were both fine with it.

Too weird for me to distill, and the replacement code is better anyway.

This probably has nothing to do with our --disable-exceptions test failures, I just hit it while investigating those.