### PR TITLE
Use node_ptr_range() when scaling

### DIFF
--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -1777,11 +1777,11 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
           }
         else // !gauss_lobatto_grid
           {
-            for (unsigned int p=0; p<mesh.n_nodes(); p++)
+            for (Node * node : mesh.node_ptr_range())
               {
-                mesh.node_ref(p)(0) = (mesh.node_ref(p)(0))*(xmax-xmin) + xmin;
-                mesh.node_ref(p)(1) = (mesh.node_ref(p)(1))*(ymax-ymin) + ymin;
-                mesh.node_ref(p)(2) = (mesh.node_ref(p)(2))*(zmax-zmin) + zmin;
+                (*node)(0) = ((*node)(0))*(xmax-xmin) + xmin;
+                (*node)(1) = ((*node)(1))*(ymax-ymin) + ymin;
+                (*node)(2) = ((*node)(2))*(zmax-zmin) + zmin;
               }
           }
 


### PR DESCRIPTION
I'm guessing the reason it's just a new C0Poly test that's triggering this is because that gave us some node numbering gaps, but I still have no idea why it's only segfaulting for us in a --disable-exceptions build, I'm just thankful that I was able to replicate that.

The worst thing Undefined Behavior can do is "what you expect, but not all the time".

This fixes a unit test segfault in my --disable-exceptions build that seems to match the one in CI; hopefully it'll be enough for our stopped-up devel->master CI too.