### PR TITLE
Fix broadcast() bug

### DIFF
--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1284,7 +1284,9 @@ void MeshCommunication::broadcast (MeshBase & mesh) const
   mesh.clear_point_locator();
 
   libmesh_assert (mesh.comm().verify(mesh.n_elem()));
+  libmesh_assert (mesh.comm().verify(mesh.max_elem_id()));
   libmesh_assert (mesh.comm().verify(mesh.n_nodes()));
+  libmesh_assert (mesh.comm().verify(mesh.max_node_id()));
 
 #ifdef DEBUG
   MeshTools::libmesh_assert_valid_procids<Elem>(mesh);

--- a/src/mesh/mesh_netgen_interface.C
+++ b/src/mesh/mesh_netgen_interface.C
@@ -182,16 +182,6 @@ void NetGenMeshInterface::triangulate ()
       if (_elem_type == TET4)
         return;
 
-      // NetGen (and volume_to_surface_mesh) can leave gaps in rank 0's
-      // element and node id spaces, while broadcast() compacts them on the
-      // other ranks.  Renumber here -- on every rank, in lockstep -- so all
-      // ranks agree on n_elem()/max_elem_id() before the collective order
-      // increase runs its cross-rank consistency checks.  Note that
-      // renumber_nodes_and_elements() itself performs a collective reduction
-      // for the unique-id counter, so it must be called on all ranks together,
-      // never on rank 0 alone (that would deadlock the others in broadcast()).
-      this->_mesh.renumber_nodes_and_elements();
-
       // find_neighbors() is needed before all_second_order() can place
       // shared edge midpoints correctly.
       this->_mesh.find_neighbors();

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -662,6 +662,15 @@ void ReplicatedMesh::update_parallel_id_counts()
   _next_unique_id = this->parallel_max_unique_id();
 #endif
 
+  // Implicitly get max_elem_id/max_node_id by trimming the vectors
+  auto trim_vec = [](auto & dof_vec) {
+    auto last_non_null = std::find_if(dof_vec.rbegin(), dof_vec.rend(), [](DofObject * d) { return (d != nullptr); });
+    dof_vec.resize(last_non_null.base()-dof_vec.begin());
+  };
+
+  trim_vec(this->_nodes);
+  trim_vec(this->_elements);
+
   this->_preparation.has_synched_id_counts = true;
 }
 


### PR DESCRIPTION
And fix the underlying ReplicatedMesh::update_parallel_id_counts() that triggered it, and remove the workaround from #4506 for it.

This fixes #4512 for me.