### PR TITLE
Deprecate bad setter

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1697,11 +1697,20 @@ public:
    */
   virtual void libmesh_assert_valid_parallel_ids() const {}
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
   /**
-   * \returns A writable reference for getting/setting an optional
-   * name for a subdomain.
+   * \deprecated
+   * \returns A writable reference for setting an optional name for a
+   * subdomain.  This method is deprecated; use set_subdomain_name()
+   * instead.
    */
   std::string & subdomain_name(subdomain_id_type id);
+#endif // LIBMESH_ENABLE_DEPRECATED
+
+  /**
+   * \returns A reference for getting an optional name for a
+   * subdomain.
+   */
   const std::string & subdomain_name(subdomain_id_type id) const;
 
   /**

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -1038,7 +1038,7 @@ void AbaqusIO::assign_subdomain_ids()
             // name to the elset name provided by the user in the
             // Abaqus file.
             std::string computed_name = it->first + "_" + Utility::enum_to_string(elem.type());
-            the_mesh.subdomain_name(computed_id) = computed_name;
+            the_mesh.set_subdomain_name(computed_id, computed_name);
           }
       }
   }

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -471,7 +471,7 @@ void ExodusII_IO::read (const std::string & fname)
       // populate the map of names
       std::string subdomain_name = exio_helper->get_block_name(i);
       if (!subdomain_name.empty())
-        mesh.subdomain_name(subdomain_id) = subdomain_name;
+        mesh.set_subdomain_name(subdomain_id, subdomain_name);
 
       // Set any relevant node/edge maps for this element
       const std::string type_str (exio_helper->get_elem_type());

--- a/src/mesh/gmsh_io.C
+++ b/src/mesh/gmsh_io.C
@@ -279,7 +279,7 @@ void GmshIO::read_mesh(std::istream & in)
                       // The user has explicitly told us that this
                       // block is a subdomain, so set that association
                       // in the Mesh.
-                      mesh.subdomain_name(restrict_int<subdomain_id_type>(phys_id)) = phys_name;
+                      mesh.set_subdomain_name(restrict_int<subdomain_id_type>(phys_id), phys_name);
                     }
                 }
             }
@@ -795,7 +795,7 @@ void GmshIO::read_mesh(std::istream & in)
               // If the physical's dimension matches the largest
               // dimension we've seen, it's a subdomain name.
               if (phys_dim == max_elem_dimension_seen)
-                mesh.subdomain_name(restrict_int<subdomain_id_type>(phys_id)) = phys_name;
+                mesh.set_subdomain_name(restrict_int<subdomain_id_type>(phys_id), phys_name);
 
               // If it's zero-dimensional then it's a nodeset
               else if (phys_dim == 0)

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -1883,7 +1883,7 @@ bool MeshBase::get_count_lower_dim_elems_in_point_locator() const
 }
 
 
-
+#ifdef LIBMESH_ENABLE_DEPRECATED
 std::string & MeshBase::subdomain_name(subdomain_id_type id)
 {
   // Use set_subdomain_name() instead
@@ -1896,6 +1896,8 @@ std::string & MeshBase::subdomain_name(subdomain_id_type id)
 
   return _block_id_to_name[id];
 }
+#endif // LIBMESH_ENABLE_DEPRECATED
+
 
 const std::string & MeshBase::subdomain_name(subdomain_id_type id) const
 {

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -1886,7 +1886,14 @@ bool MeshBase::get_count_lower_dim_elems_in_point_locator() const
 
 std::string & MeshBase::subdomain_name(subdomain_id_type id)
 {
-  this->unset_has_synched_subdomain_name_map();
+  // Use set_subdomain_name() instead
+  libmesh_deprecated();
+
+  // We'd like to do this so our preparation isn't invalidated by a
+  // write, but for all we know the user is just reading from a
+  // non-const mesh!
+  // this->unset_has_synched_subdomain_name_map();
+
   return _block_id_to_name[id];
 }
 

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -924,7 +924,7 @@ void Nemesis_IO::read (const std::string & base_filename)
 
   for (const auto & [id, name] : nemhelper->id_to_block_names)
     if (name != "")
-      mesh.subdomain_name(id) = name;
+      mesh.set_subdomain_name(id, name);
 
   if (_verbose)
     {

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -2546,12 +2546,12 @@ UnstructuredMesh::stitching_helper (const MeshBase * other_mesh,
                                             "Subdomain id overflow");
 
                       id_remapping[sid] = next_free_id++;
-                      this->subdomain_name(next_free_id) = sname;
+                      this->set_subdomain_name(next_free_id, sname);
                     }
                   // If we don't have this subdomain id, well, we're
                   // about to, so we should have its name too.
                   else
-                    this->subdomain_name(sid) = sname;
+                    this->set_subdomain_name(sid, sname);
                 }
             }
         }

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -548,8 +548,8 @@ void UNVIO::groups_in (std::istream & in_file)
           (cast_int<boundary_id_type>(group_number)) = group_name;
 
       if (is_subdomain_group)
-        mesh.subdomain_name
-          (cast_int<subdomain_id_type>(group_number)) = group_name;
+        mesh.set_subdomain_name
+          (cast_int<subdomain_id_type>(group_number), group_name);
 
     } // end while (true)
 

--- a/tests/geom/elem_test.h
+++ b/tests/geom/elem_test.h
@@ -292,7 +292,7 @@ public:
       std::ostringstream sbdname;
       sbdname <<
         "a_very_long_subdomain_name_for_the_subdomain_with_number_" << sbdid;
-      this->_mesh->subdomain_name(sbdid) = sbdname.str();
+      this->_mesh->set_subdomain_name(sbdid, sbdname.str());
     }
 
     // Make sure our mesh's cache knows about them all for later

--- a/tests/mesh/mesh_stitch.C
+++ b/tests/mesh/mesh_stitch.C
@@ -396,8 +396,8 @@ public:
       elem->subdomain_id() = 456;
 
     // Resolve them to the same name
-    mesh0.subdomain_name(123) = "OneTwoThree";
-    mesh1.subdomain_name(456) = "OneTwoThree"; // silly autogen
+    mesh0.set_subdomain_name(123, "OneTwoThree");
+    mesh1.set_subdomain_name(456, "OneTwoThree"); // silly autogen
 
     mesh0.stitch_meshes(mesh1, 2, 10, TOLERANCE, true, false, false,
                         false, false, /* remap_subdomain_ids = */ true);
@@ -433,7 +433,7 @@ public:
       elem->subdomain_id() = 123;
 
     // Create a conflict when only one is named
-    mesh1.subdomain_name(123) = "OneTwoThree";
+    mesh1.set_subdomain_name(123, "OneTwoThree");
 
 #ifdef LIBMESH_ENABLE_EXCEPTIONS
     bool threw_error = false;


### PR DESCRIPTION
We got a little overzealous with the unset call in the old "pseudo-setter" in #4485.  Every read-only access on a non-const object ends up resolving to the "setter" overload instead of the const "getter" overload, and thereby calls the setter code unnecessarily.

But, we can get the same benefits as long as we restrict that call and our up-to-date users to a "real" setter.

In hindsight we should just never have accepted "setter" methods that return references rather than taking values; they're not much better encapsulated than `public:` member variables.  They look nicer but they never seem to be robust or flexible enough in these cases where we actually *need* a setter.