### PR TITLE
all_tri() pyramid support, refactoring, better unit testing

### DIFF
--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -953,31 +953,12 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
               //
               // Split on 0-2 diagonal
               if (split_first_diagonal(elem, 0,2, 1,3))
-                {
-                  subelem[0]->set_node(0, elem->node_ptr(0));
-                  subelem[0]->set_node(1, elem->node_ptr(1));
-                  subelem[0]->set_node(2, elem->node_ptr(2));
-                  subelem[0]->set_node(3, elem->node_ptr(4));
-
-                  subelem[1]->set_node(0, elem->node_ptr(0));
-                  subelem[1]->set_node(1, elem->node_ptr(2));
-                  subelem[1]->set_node(2, elem->node_ptr(3));
-                  subelem[1]->set_node(3, elem->node_ptr(4));
-                }
+                set_nodes({{0,1,2,4},{0,2,3,4}});
               // Split on 1-3 diagonal
               else
                 {
                   libmesh_assert (split_first_diagonal(elem, 1,3, 0,2));
-
-                  subelem[0]->set_node(0, elem->node_ptr(0));
-                  subelem[0]->set_node(1, elem->node_ptr(1));
-                  subelem[0]->set_node(2, elem->node_ptr(3));
-                  subelem[0]->set_node(3, elem->node_ptr(4));
-
-                  subelem[1]->set_node(0, elem->node_ptr(1));
-                  subelem[1]->set_node(1, elem->node_ptr(2));
-                  subelem[1]->set_node(2, elem->node_ptr(3));
-                  subelem[1]->set_node(3, elem->node_ptr(4));
+                  set_nodes({{0,1,3,4},{1,2,3,4}});
                 }
 
               break;

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -533,11 +533,13 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
 
         auto set_nodes = [&elem, &subelem]
           (const std::initializer_list<std::initializer_list<int>> & node_ids) {
-          for (int i=0; auto row : node_ids)
+          int i=0;
+          for (auto row : node_ids)
             {
+              int j=0;
               Elem * sub = subelem[i++].get();
               libmesh_assert(sub);
-              for (int j=0; auto node_id : row)
+              for (auto node_id : row)
                 sub->set_node(j++, elem->node_ptr(node_id));
             }
         };

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1397,8 +1397,9 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
           case INFPRISM6:
           case INFPRISM12:
             continue;
-            // If we're left with an unimplemented hex we're probably
-            // out of luck.  TODO: implement hexes
+            // If we're left with an unimplemented element we're
+            // probably out of luck.  TODO: implement hex20, hex27,
+            // pyramid15,...
           default:
             {
               libMesh::err << "Error, encountered unimplemented element "

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1401,13 +1401,10 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
             // probably out of luck.  TODO: implement hex20, hex27,
             // pyramid15,...
           default:
-            {
-              libMesh::err << "Error, encountered unimplemented element "
-                           << Utility::enum_to_string<ElemType>(etype)
-                           << " in MeshTools::Modification::all_tri()..."
-                           << std::endl;
-              libmesh_not_implemented();
-            }
+            libmesh_not_implemented_msg
+              ("Error, encountered unimplemented element "
+               << Utility::enum_to_string<ElemType>(etype)
+               << " in MeshTools::Modification::all_tri()...");
           } // end switch (etype)
 
         // Be sure the correct data is set for all subelems.

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1279,6 +1279,48 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
               break;
             }
 
+          case PYRAMID5:
+            {
+              // Pyramids all split into two tetrahedra
+              subelem[0] = Elem::build(TET4);
+              subelem[1] = Elem::build(TET4);
+
+              // Choose how to split the quad face in a way that will
+              // be consistent from possibly-different-type elements
+              // splitting from the other side
+              //
+              // Split on 0-2 diagonal
+              if (split_first_diagonal(elem, 0,2, 1,3))
+                {
+                  subelem[0]->set_node(0, elem->node_ptr(0));
+                  subelem[0]->set_node(1, elem->node_ptr(1));
+                  subelem[0]->set_node(2, elem->node_ptr(2));
+                  subelem[0]->set_node(3, elem->node_ptr(4));
+
+                  subelem[1]->set_node(0, elem->node_ptr(0));
+                  subelem[1]->set_node(1, elem->node_ptr(2));
+                  subelem[1]->set_node(2, elem->node_ptr(3));
+                  subelem[1]->set_node(3, elem->node_ptr(4));
+                }
+              // Split on 1-3 diagonal
+              else
+                {
+                  libmesh_assert (split_first_diagonal(elem, 1,3, 0,2));
+
+                  subelem[0]->set_node(0, elem->node_ptr(0));
+                  subelem[0]->set_node(1, elem->node_ptr(1));
+                  subelem[0]->set_node(2, elem->node_ptr(3));
+                  subelem[0]->set_node(3, elem->node_ptr(4));
+
+                  subelem[1]->set_node(0, elem->node_ptr(1));
+                  subelem[1]->set_node(1, elem->node_ptr(2));
+                  subelem[1]->set_node(2, elem->node_ptr(3));
+                  subelem[1]->set_node(3, elem->node_ptr(4));
+                }
+
+              break;
+            }
+
           case C0POLYGON:
             {
               // Split a C0Polygon into the triangles defined by its

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -527,9 +527,20 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
         if (elem->parent())
           libmesh_not_implemented_msg("Cannot convert a refined element into simplices\n");
 
-        // The new elements we will split the quad into. Reserving for the maximum
-        // number of sub-elements created for each element
+        // The new elements we will split the original into. Reserving
+        // for the maximum number of sub-elements created for each element
         std::vector<std::unique_ptr<Elem>> subelem(max_subelems);
+
+        auto set_nodes = [&elem, &subelem]
+          (const std::initializer_list<std::initializer_list<int>> & node_ids) {
+          for (int i=0; auto row : node_ids)
+            {
+              Elem * sub = subelem[i++].get();
+              libmesh_assert(sub);
+              for (int j=0; auto node_id : row)
+                sub->set_node(j++, elem->node_ptr(node_id));
+            }
+        };
 
         switch (etype)
           {
@@ -541,27 +552,9 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
               // Check for possible edge swap
               if ((elem->point(0) - elem->point(2)).norm() <
                   (elem->point(1) - elem->point(3)).norm())
-                {
-                  subelem[0]->set_node(0, elem->node_ptr(0));
-                  subelem[0]->set_node(1, elem->node_ptr(1));
-                  subelem[0]->set_node(2, elem->node_ptr(2));
-
-                  subelem[1]->set_node(0, elem->node_ptr(0));
-                  subelem[1]->set_node(1, elem->node_ptr(2));
-                  subelem[1]->set_node(2, elem->node_ptr(3));
-                }
-
+                set_nodes({{0,1,2},{0,2,3}});
               else
-                {
-                  subelem[0]->set_node(0, elem->node_ptr(0));
-                  subelem[0]->set_node(1, elem->node_ptr(1));
-                  subelem[0]->set_node(2, elem->node_ptr(3));
-
-                  subelem[1]->set_node(0, elem->node_ptr(1));
-                  subelem[1]->set_node(1, elem->node_ptr(2));
-                  subelem[1]->set_node(2, elem->node_ptr(3));
-                }
-
+                set_nodes({{0,1,3},{1,2,3}});
 
               break;
             }
@@ -586,36 +579,14 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
               if ((elem->point(0) - elem->point(2)).norm() <
                   (elem->point(1) - elem->point(3)).norm())
                 {
-                  subelem[0]->set_node(0, elem->node_ptr(0));
-                  subelem[0]->set_node(1, elem->node_ptr(1));
-                  subelem[0]->set_node(2, elem->node_ptr(2));
-                  subelem[0]->set_node(3, elem->node_ptr(4));
-                  subelem[0]->set_node(4, elem->node_ptr(5));
+                  set_nodes({{0,1,2,4,5},{0,2,3,3,6,7}});
                   subelem[0]->set_node(5, new_node);
-
-                  subelem[1]->set_node(0, elem->node_ptr(0));
-                  subelem[1]->set_node(1, elem->node_ptr(2));
-                  subelem[1]->set_node(2, elem->node_ptr(3));
                   subelem[1]->set_node(3, new_node);
-                  subelem[1]->set_node(4, elem->node_ptr(6));
-                  subelem[1]->set_node(5, elem->node_ptr(7));
-
                 }
-
               else
                 {
-                  subelem[0]->set_node(0, elem->node_ptr(3));
-                  subelem[0]->set_node(1, elem->node_ptr(0));
-                  subelem[0]->set_node(2, elem->node_ptr(1));
-                  subelem[0]->set_node(3, elem->node_ptr(7));
-                  subelem[0]->set_node(4, elem->node_ptr(4));
+                  set_nodes({{3,0,1,7,4},{1,2,3,5,6}});
                   subelem[0]->set_node(5, new_node);
-
-                  subelem[1]->set_node(0, elem->node_ptr(1));
-                  subelem[1]->set_node(1, elem->node_ptr(2));
-                  subelem[1]->set_node(2, elem->node_ptr(3));
-                  subelem[1]->set_node(3, elem->node_ptr(5));
-                  subelem[1]->set_node(4, elem->node_ptr(6));
                   subelem[1]->set_node(5, new_node);
                 }
 
@@ -630,38 +601,9 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
               // Check for possible edge swap
               if ((elem->point(0) - elem->point(2)).norm() <
                   (elem->point(1) - elem->point(3)).norm())
-                {
-                  subelem[0]->set_node(0, elem->node_ptr(0));
-                  subelem[0]->set_node(1, elem->node_ptr(1));
-                  subelem[0]->set_node(2, elem->node_ptr(2));
-                  subelem[0]->set_node(3, elem->node_ptr(4));
-                  subelem[0]->set_node(4, elem->node_ptr(5));
-                  subelem[0]->set_node(5, elem->node_ptr(8));
-
-                  subelem[1]->set_node(0, elem->node_ptr(0));
-                  subelem[1]->set_node(1, elem->node_ptr(2));
-                  subelem[1]->set_node(2, elem->node_ptr(3));
-                  subelem[1]->set_node(3, elem->node_ptr(8));
-                  subelem[1]->set_node(4, elem->node_ptr(6));
-                  subelem[1]->set_node(5, elem->node_ptr(7));
-                }
-
+                set_nodes({{0,1,2,4,5,8},{0,2,3,8,6,7}});
               else
-                {
-                  subelem[0]->set_node(0, elem->node_ptr(0));
-                  subelem[0]->set_node(1, elem->node_ptr(1));
-                  subelem[0]->set_node(2, elem->node_ptr(3));
-                  subelem[0]->set_node(3, elem->node_ptr(4));
-                  subelem[0]->set_node(4, elem->node_ptr(8));
-                  subelem[0]->set_node(5, elem->node_ptr(7));
-
-                  subelem[1]->set_node(0, elem->node_ptr(1));
-                  subelem[1]->set_node(1, elem->node_ptr(2));
-                  subelem[1]->set_node(2, elem->node_ptr(3));
-                  subelem[1]->set_node(3, elem->node_ptr(5));
-                  subelem[1]->set_node(4, elem->node_ptr(6));
-                  subelem[1]->set_node(5, elem->node_ptr(8));
-                }
+                set_nodes({{0,1,3,4,8,7},{1,2,3,5,6,8}});
 
               break;
             }
@@ -873,40 +815,11 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                     {
                       // Split on 1-5 diagonal
                       if (split_first_diagonal(elem, 1,5, 2,4))
-                        {
-                          subelem[0]->set_node(0, elem->node_ptr(0));
-                          subelem[0]->set_node(1, elem->node_ptr(4));
-                          subelem[0]->set_node(2, elem->node_ptr(5));
-                          subelem[0]->set_node(3, elem->node_ptr(3));
-
-                          subelem[1]->set_node(0, elem->node_ptr(0));
-                          subelem[1]->set_node(1, elem->node_ptr(4));
-                          subelem[1]->set_node(2, elem->node_ptr(1));
-                          subelem[1]->set_node(3, elem->node_ptr(5));
-
-                          subelem[2]->set_node(0, elem->node_ptr(0));
-                          subelem[2]->set_node(1, elem->node_ptr(1));
-                          subelem[2]->set_node(2, elem->node_ptr(2));
-                          subelem[2]->set_node(3, elem->node_ptr(5));
-                        }
+                        set_nodes({{0,4,5,3},{0,4,1,5},{0,1,2,5}});
                       else // Split on 2-4 diagonal
                         {
                           libmesh_assert (split_first_diagonal(elem, 2,4, 1,5));
-
-                          subelem[0]->set_node(0, elem->node_ptr(0));
-                          subelem[0]->set_node(1, elem->node_ptr(4));
-                          subelem[0]->set_node(2, elem->node_ptr(5));
-                          subelem[0]->set_node(3, elem->node_ptr(3));
-
-                          subelem[1]->set_node(0, elem->node_ptr(0));
-                          subelem[1]->set_node(1, elem->node_ptr(4));
-                          subelem[1]->set_node(2, elem->node_ptr(2));
-                          subelem[1]->set_node(3, elem->node_ptr(5));
-
-                          subelem[2]->set_node(0, elem->node_ptr(0));
-                          subelem[2]->set_node(1, elem->node_ptr(1));
-                          subelem[2]->set_node(2, elem->node_ptr(2));
-                          subelem[2]->set_node(3, elem->node_ptr(4));
+                          set_nodes({{0,4,5,3},{0,4,2,5},{0,1,2,4}});
                         }
                     }
                   else // Split on 2-3 diagonal
@@ -916,20 +829,7 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                       // 0-4 and 2-3 split implies 2-4 split
                       libmesh_assert (split_first_diagonal(elem, 2,4, 1,5));
 
-                      subelem[0]->set_node(0, elem->node_ptr(0));
-                      subelem[0]->set_node(1, elem->node_ptr(4));
-                      subelem[0]->set_node(2, elem->node_ptr(2));
-                      subelem[0]->set_node(3, elem->node_ptr(3));
-
-                      subelem[1]->set_node(0, elem->node_ptr(3));
-                      subelem[1]->set_node(1, elem->node_ptr(4));
-                      subelem[1]->set_node(2, elem->node_ptr(2));
-                      subelem[1]->set_node(3, elem->node_ptr(5));
-
-                      subelem[2]->set_node(0, elem->node_ptr(0));
-                      subelem[2]->set_node(1, elem->node_ptr(1));
-                      subelem[2]->set_node(2, elem->node_ptr(2));
-                      subelem[2]->set_node(3, elem->node_ptr(4));
+                      set_nodes({{0,4,2,3},{3,4,2,5},{0,1,2,4}});
                     }
                 }
               else // Split on 1-3 diagonal
@@ -942,20 +842,7 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                       // 1-3 and 0-5 split implies 1-5 split
                       libmesh_assert (split_first_diagonal(elem, 1,5, 2,4));
 
-                      subelem[0]->set_node(0, elem->node_ptr(1));
-                      subelem[0]->set_node(1, elem->node_ptr(3));
-                      subelem[0]->set_node(2, elem->node_ptr(4));
-                      subelem[0]->set_node(3, elem->node_ptr(5));
-
-                      subelem[1]->set_node(0, elem->node_ptr(1));
-                      subelem[1]->set_node(1, elem->node_ptr(0));
-                      subelem[1]->set_node(2, elem->node_ptr(3));
-                      subelem[1]->set_node(3, elem->node_ptr(5));
-
-                      subelem[2]->set_node(0, elem->node_ptr(0));
-                      subelem[2]->set_node(1, elem->node_ptr(1));
-                      subelem[2]->set_node(2, elem->node_ptr(2));
-                      subelem[2]->set_node(3, elem->node_ptr(5));
+                      set_nodes({{1,3,4,5},{1,0,3,5},{0,1,2,5}});
                     }
                   else // Split on 2-3 diagonal
                     {
@@ -963,40 +850,11 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
 
                       // Split on 1-5 diagonal
                       if (split_first_diagonal(elem, 1,5, 2,4))
-                        {
-                          subelem[0]->set_node(0, elem->node_ptr(0));
-                          subelem[0]->set_node(1, elem->node_ptr(1));
-                          subelem[0]->set_node(2, elem->node_ptr(2));
-                          subelem[0]->set_node(3, elem->node_ptr(3));
-
-                          subelem[1]->set_node(0, elem->node_ptr(3));
-                          subelem[1]->set_node(1, elem->node_ptr(1));
-                          subelem[1]->set_node(2, elem->node_ptr(2));
-                          subelem[1]->set_node(3, elem->node_ptr(5));
-
-                          subelem[2]->set_node(0, elem->node_ptr(1));
-                          subelem[2]->set_node(1, elem->node_ptr(3));
-                          subelem[2]->set_node(2, elem->node_ptr(4));
-                          subelem[2]->set_node(3, elem->node_ptr(5));
-                        }
+                        set_nodes({{0,1,2,3},{3,1,2,5},{1,3,4,5}});
                       else // Split on 2-4 diagonal
                         {
                           libmesh_assert (split_first_diagonal(elem, 2,4, 1,5));
-
-                          subelem[0]->set_node(0, elem->node_ptr(0));
-                          subelem[0]->set_node(1, elem->node_ptr(1));
-                          subelem[0]->set_node(2, elem->node_ptr(2));
-                          subelem[0]->set_node(3, elem->node_ptr(3));
-
-                          subelem[1]->set_node(0, elem->node_ptr(2));
-                          subelem[1]->set_node(1, elem->node_ptr(3));
-                          subelem[1]->set_node(2, elem->node_ptr(4));
-                          subelem[1]->set_node(3, elem->node_ptr(5));
-
-                          subelem[2]->set_node(0, elem->node_ptr(3));
-                          subelem[2]->set_node(1, elem->node_ptr(1));
-                          subelem[2]->set_node(2, elem->node_ptr(2));
-                          subelem[2]->set_node(3, elem->node_ptr(4));
+                          set_nodes({{0,1,2,3},{2,3,4,5},{3,1,2,4}});
                         }
                     }
                 }
@@ -1022,82 +880,16 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                     {
                       // Split on 1-5 diagonal
                       if (split_first_diagonal(elem, 1,5, 2,4))
-                        {
-                          subelem[0]->set_node(0, elem->node_ptr(0));
-                          subelem[0]->set_node(1, elem->node_ptr(4));
-                          subelem[0]->set_node(2, elem->node_ptr(5));
-                          subelem[0]->set_node(3, elem->node_ptr(3));
-
-                          subelem[0]->set_node(4, elem->node_ptr(15));
-                          subelem[0]->set_node(5, elem->node_ptr(13));
-                          subelem[0]->set_node(6, elem->node_ptr(17));
-                          subelem[0]->set_node(7, elem->node_ptr(9));
-                          subelem[0]->set_node(8, elem->node_ptr(12));
-                          subelem[0]->set_node(9, elem->node_ptr(14));
-
-                          subelem[1]->set_node(0, elem->node_ptr(0));
-                          subelem[1]->set_node(1, elem->node_ptr(4));
-                          subelem[1]->set_node(2, elem->node_ptr(1));
-                          subelem[1]->set_node(3, elem->node_ptr(5));
-
-                          subelem[1]->set_node(4, elem->node_ptr(15));
-                          subelem[1]->set_node(5, elem->node_ptr(10));
-                          subelem[1]->set_node(6, elem->node_ptr(6));
-                          subelem[1]->set_node(7, elem->node_ptr(17));
-                          subelem[1]->set_node(8, elem->node_ptr(13));
-                          subelem[1]->set_node(9, elem->node_ptr(16));
-
-                          subelem[2]->set_node(0, elem->node_ptr(0));
-                          subelem[2]->set_node(1, elem->node_ptr(1));
-                          subelem[2]->set_node(2, elem->node_ptr(2));
-                          subelem[2]->set_node(3, elem->node_ptr(5));
-
-                          subelem[2]->set_node(4, elem->node_ptr(6));
-                          subelem[2]->set_node(5, elem->node_ptr(7));
-                          subelem[2]->set_node(6, elem->node_ptr(8));
-                          subelem[2]->set_node(7, elem->node_ptr(17));
-                          subelem[2]->set_node(8, elem->node_ptr(16));
-                          subelem[2]->set_node(9, elem->node_ptr(11));
-                        }
+                        set_nodes({{0,4,5,3,15,13,17,9,12,14},
+                                   {0,4,1,5,15,10,6,17,13,16},
+                                   {0,1,2,5,6,7,8,17,16,11}});
                       else // Split on 2-4 diagonal
                         {
                           libmesh_assert (split_first_diagonal(elem, 2,4, 1,5));
 
-                          subelem[0]->set_node(0, elem->node_ptr(0));
-                          subelem[0]->set_node(1, elem->node_ptr(4));
-                          subelem[0]->set_node(2, elem->node_ptr(5));
-                          subelem[0]->set_node(3, elem->node_ptr(3));
-
-                          subelem[0]->set_node(4, elem->node_ptr(15));
-                          subelem[0]->set_node(5, elem->node_ptr(13));
-                          subelem[0]->set_node(6, elem->node_ptr(17));
-                          subelem[0]->set_node(7, elem->node_ptr(9));
-                          subelem[0]->set_node(8, elem->node_ptr(12));
-                          subelem[0]->set_node(9, elem->node_ptr(14));
-
-                          subelem[1]->set_node(0, elem->node_ptr(0));
-                          subelem[1]->set_node(1, elem->node_ptr(4));
-                          subelem[1]->set_node(2, elem->node_ptr(2));
-                          subelem[1]->set_node(3, elem->node_ptr(5));
-
-                          subelem[1]->set_node(4, elem->node_ptr(15));
-                          subelem[1]->set_node(5, elem->node_ptr(16));
-                          subelem[1]->set_node(6, elem->node_ptr(8));
-                          subelem[1]->set_node(7, elem->node_ptr(17));
-                          subelem[1]->set_node(8, elem->node_ptr(13));
-                          subelem[1]->set_node(9, elem->node_ptr(11));
-
-                          subelem[2]->set_node(0, elem->node_ptr(0));
-                          subelem[2]->set_node(1, elem->node_ptr(1));
-                          subelem[2]->set_node(2, elem->node_ptr(2));
-                          subelem[2]->set_node(3, elem->node_ptr(4));
-
-                          subelem[2]->set_node(4, elem->node_ptr(6));
-                          subelem[2]->set_node(5, elem->node_ptr(7));
-                          subelem[2]->set_node(6, elem->node_ptr(8));
-                          subelem[2]->set_node(7, elem->node_ptr(15));
-                          subelem[2]->set_node(8, elem->node_ptr(10));
-                          subelem[2]->set_node(9, elem->node_ptr(16));
+                          set_nodes({{0,4,5,3,15,13,17,9,12,14},
+                                     {0,4,2,5,15,16,8,17,13,11},
+                                     {0,1,2,4,6,7,8,15,10,16}});
                         }
                     }
                   else // Split on 2-3 diagonal
@@ -1107,41 +899,9 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                       // 0-4 and 2-3 split implies 2-4 split
                       libmesh_assert (split_first_diagonal(elem, 2,4, 1,5));
 
-                      subelem[0]->set_node(0, elem->node_ptr(0));
-                      subelem[0]->set_node(1, elem->node_ptr(4));
-                      subelem[0]->set_node(2, elem->node_ptr(2));
-                      subelem[0]->set_node(3, elem->node_ptr(3));
-
-                      subelem[0]->set_node(4, elem->node_ptr(15));
-                      subelem[0]->set_node(5, elem->node_ptr(16));
-                      subelem[0]->set_node(6, elem->node_ptr(8));
-                      subelem[0]->set_node(7, elem->node_ptr(9));
-                      subelem[0]->set_node(8, elem->node_ptr(12));
-                      subelem[0]->set_node(9, elem->node_ptr(17));
-
-                      subelem[1]->set_node(0, elem->node_ptr(3));
-                      subelem[1]->set_node(1, elem->node_ptr(4));
-                      subelem[1]->set_node(2, elem->node_ptr(2));
-                      subelem[1]->set_node(3, elem->node_ptr(5));
-
-                      subelem[1]->set_node(4, elem->node_ptr(12));
-                      subelem[1]->set_node(5, elem->node_ptr(16));
-                      subelem[1]->set_node(6, elem->node_ptr(17));
-                      subelem[1]->set_node(7, elem->node_ptr(14));
-                      subelem[1]->set_node(8, elem->node_ptr(13));
-                      subelem[1]->set_node(9, elem->node_ptr(11));
-
-                      subelem[2]->set_node(0, elem->node_ptr(0));
-                      subelem[2]->set_node(1, elem->node_ptr(1));
-                      subelem[2]->set_node(2, elem->node_ptr(2));
-                      subelem[2]->set_node(3, elem->node_ptr(4));
-
-                      subelem[2]->set_node(4, elem->node_ptr(6));
-                      subelem[2]->set_node(5, elem->node_ptr(7));
-                      subelem[2]->set_node(6, elem->node_ptr(8));
-                      subelem[2]->set_node(7, elem->node_ptr(15));
-                      subelem[2]->set_node(8, elem->node_ptr(10));
-                      subelem[2]->set_node(9, elem->node_ptr(16));
+                      set_nodes({{0,4,2,3,15,16,8,9,12,17},
+                                 {3,4,2,5,12,16,17,14,13,11},
+                                 {0,1,2,4,6,7,8,15,10,16}});
                     }
                 }
               else // Split on 1-3 diagonal
@@ -1154,41 +914,9 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                       // 1-3 and 0-5 split implies 1-5 split
                       libmesh_assert (split_first_diagonal(elem, 1,5, 2,4));
 
-                      subelem[0]->set_node(0, elem->node_ptr(1));
-                      subelem[0]->set_node(1, elem->node_ptr(3));
-                      subelem[0]->set_node(2, elem->node_ptr(4));
-                      subelem[0]->set_node(3, elem->node_ptr(5));
-
-                      subelem[0]->set_node(4, elem->node_ptr(15));
-                      subelem[0]->set_node(5, elem->node_ptr(12));
-                      subelem[0]->set_node(6, elem->node_ptr(10));
-                      subelem[0]->set_node(7, elem->node_ptr(16));
-                      subelem[0]->set_node(8, elem->node_ptr(14));
-                      subelem[0]->set_node(9, elem->node_ptr(13));
-
-                      subelem[1]->set_node(0, elem->node_ptr(1));
-                      subelem[1]->set_node(1, elem->node_ptr(0));
-                      subelem[1]->set_node(2, elem->node_ptr(3));
-                      subelem[1]->set_node(3, elem->node_ptr(5));
-
-                      subelem[1]->set_node(4, elem->node_ptr(6));
-                      subelem[1]->set_node(5, elem->node_ptr(9));
-                      subelem[1]->set_node(6, elem->node_ptr(15));
-                      subelem[1]->set_node(7, elem->node_ptr(16));
-                      subelem[1]->set_node(8, elem->node_ptr(17));
-                      subelem[1]->set_node(9, elem->node_ptr(14));
-
-                      subelem[2]->set_node(0, elem->node_ptr(0));
-                      subelem[2]->set_node(1, elem->node_ptr(1));
-                      subelem[2]->set_node(2, elem->node_ptr(2));
-                      subelem[2]->set_node(3, elem->node_ptr(5));
-
-                      subelem[2]->set_node(4, elem->node_ptr(6));
-                      subelem[2]->set_node(5, elem->node_ptr(7));
-                      subelem[2]->set_node(6, elem->node_ptr(8));
-                      subelem[2]->set_node(7, elem->node_ptr(17));
-                      subelem[2]->set_node(8, elem->node_ptr(16));
-                      subelem[2]->set_node(9, elem->node_ptr(11));
+                      set_nodes({{1,3,4,5,15,12,10,16,14,13},
+                                 {1,0,3,5,6,9,15,16,17,14},
+                                 {0,1,2,5,6,7,8,17,16,11}});
                     }
                   else // Split on 2-3 diagonal
                     {
@@ -1196,82 +924,16 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
 
                       // Split on 1-5 diagonal
                       if (split_first_diagonal(elem, 1,5, 2,4))
-                        {
-                          subelem[0]->set_node(0, elem->node_ptr(0));
-                          subelem[0]->set_node(1, elem->node_ptr(1));
-                          subelem[0]->set_node(2, elem->node_ptr(2));
-                          subelem[0]->set_node(3, elem->node_ptr(3));
-
-                          subelem[0]->set_node(4, elem->node_ptr(6));
-                          subelem[0]->set_node(5, elem->node_ptr(7));
-                          subelem[0]->set_node(6, elem->node_ptr(8));
-                          subelem[0]->set_node(7, elem->node_ptr(9));
-                          subelem[0]->set_node(8, elem->node_ptr(15));
-                          subelem[0]->set_node(9, elem->node_ptr(17));
-
-                          subelem[1]->set_node(0, elem->node_ptr(3));
-                          subelem[1]->set_node(1, elem->node_ptr(1));
-                          subelem[1]->set_node(2, elem->node_ptr(2));
-                          subelem[1]->set_node(3, elem->node_ptr(5));
-
-                          subelem[1]->set_node(4, elem->node_ptr(15));
-                          subelem[1]->set_node(5, elem->node_ptr(7));
-                          subelem[1]->set_node(6, elem->node_ptr(17));
-                          subelem[1]->set_node(7, elem->node_ptr(14));
-                          subelem[1]->set_node(8, elem->node_ptr(16));
-                          subelem[1]->set_node(9, elem->node_ptr(11));
-
-                          subelem[2]->set_node(0, elem->node_ptr(1));
-                          subelem[2]->set_node(1, elem->node_ptr(3));
-                          subelem[2]->set_node(2, elem->node_ptr(4));
-                          subelem[2]->set_node(3, elem->node_ptr(5));
-
-                          subelem[2]->set_node(4, elem->node_ptr(15));
-                          subelem[2]->set_node(5, elem->node_ptr(12));
-                          subelem[2]->set_node(6, elem->node_ptr(10));
-                          subelem[2]->set_node(7, elem->node_ptr(16));
-                          subelem[2]->set_node(8, elem->node_ptr(14));
-                          subelem[2]->set_node(9, elem->node_ptr(13));
-                        }
+                        set_nodes({{0,1,2,3,6,7,8,9,15,17},
+                                   {3,1,2,5,15,7,17,14,16,11},
+                                   {1,3,4,5,15,12,10,16,14,13}});
                       else // Split on 2-4 diagonal
                         {
                           libmesh_assert (split_first_diagonal(elem, 2,4, 1,5));
 
-                          subelem[0]->set_node(0, elem->node_ptr(0));
-                          subelem[0]->set_node(1, elem->node_ptr(1));
-                          subelem[0]->set_node(2, elem->node_ptr(2));
-                          subelem[0]->set_node(3, elem->node_ptr(3));
-
-                          subelem[0]->set_node(4, elem->node_ptr(6));
-                          subelem[0]->set_node(5, elem->node_ptr(7));
-                          subelem[0]->set_node(6, elem->node_ptr(8));
-                          subelem[0]->set_node(7, elem->node_ptr(9));
-                          subelem[0]->set_node(8, elem->node_ptr(15));
-                          subelem[0]->set_node(9, elem->node_ptr(17));
-
-                          subelem[1]->set_node(0, elem->node_ptr(2));
-                          subelem[1]->set_node(1, elem->node_ptr(3));
-                          subelem[1]->set_node(2, elem->node_ptr(4));
-                          subelem[1]->set_node(3, elem->node_ptr(5));
-
-                          subelem[1]->set_node(4, elem->node_ptr(17));
-                          subelem[1]->set_node(5, elem->node_ptr(12));
-                          subelem[1]->set_node(6, elem->node_ptr(16));
-                          subelem[1]->set_node(7, elem->node_ptr(11));
-                          subelem[1]->set_node(8, elem->node_ptr(14));
-                          subelem[1]->set_node(9, elem->node_ptr(13));
-
-                          subelem[2]->set_node(0, elem->node_ptr(3));
-                          subelem[2]->set_node(1, elem->node_ptr(1));
-                          subelem[2]->set_node(2, elem->node_ptr(2));
-                          subelem[2]->set_node(3, elem->node_ptr(4));
-
-                          subelem[2]->set_node(4, elem->node_ptr(15));
-                          subelem[2]->set_node(5, elem->node_ptr(7));
-                          subelem[2]->set_node(6, elem->node_ptr(17));
-                          subelem[2]->set_node(7, elem->node_ptr(12));
-                          subelem[2]->set_node(8, elem->node_ptr(10));
-                          subelem[2]->set_node(9, elem->node_ptr(16));
+                          set_nodes({{0,1,2,3,6,7,8,9,15,17},
+                                     {2,3,4,5,17,12,16,11,14,13},
+                                     {3,1,2,4,15,7,17,12,10,16}});
                         }
                     }
                 }

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -964,6 +964,31 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
               break;
             }
 
+          case PYRAMID14:
+            {
+              // Pyramids all split into two tetrahedra
+              subelem[0] = Elem::build(TET10);
+              subelem[1] = Elem::build(TET10);
+
+              // Choose how to split the quad face in a way that will
+              // be consistent from possibly-different-type elements
+              // splitting from the other side
+              //
+              // Split on 0-2 diagonal
+              if (split_first_diagonal(elem, 0,2, 1,3))
+                set_nodes({{0,1,2,4,5,6,13,9,10,11},
+                           {0,2,3,4,13,7,8,9,11,12}});
+              // Split on 1-3 diagonal
+              else
+                {
+                  libmesh_assert (split_first_diagonal(elem, 1,3, 0,2));
+                  set_nodes({{0,1,3,4,5,13,8,9,10,12},
+                             {1,2,3,4,6,7,13,10,11,12}});
+                }
+
+              break;
+            }
+
           case C0POLYGON:
             {
               // Split a C0Polygon into the triangles defined by its
@@ -1042,7 +1067,7 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
             continue;
             // If we're left with an unimplemented element we're
             // probably out of luck.  TODO: implement hex20, hex27,
-            // pyramid15,...
+            // pyramid13,...
           default:
             libmesh_not_implemented_msg
               ("Error, encountered unimplemented element "

--- a/tests/mesh/all_tri.C
+++ b/tests/mesh/all_tri.C
@@ -45,6 +45,7 @@ public:
   CPPUNIT_TEST( testAllTriPrism18 );
   CPPUNIT_TEST( testAllTriPrism20 );
   CPPUNIT_TEST( testAllTriPrism21 );
+  CPPUNIT_TEST( testAllTriPyramid5 );
   CPPUNIT_TEST( testAllTriC0PolyhedronCube );
   CPPUNIT_TEST( testAllTriC0PolyhedronHexagonalPrism );
 #endif
@@ -123,6 +124,9 @@ public:
   void testAllTriPrism18() { LOG_UNIT_TEST; test_helper_3D(PRISM18, /*nelem=*/6, /*nbcs=*/12); }
   void testAllTriPrism20() { LOG_UNIT_TEST; test_helper_3D(PRISM20, /*nelem=*/6, /*nbcs=*/12); }
   void testAllTriPrism21() { LOG_UNIT_TEST; test_helper_3D(PRISM21, /*nelem=*/6, /*nbcs=*/12); }
+
+  // 6 PYRAMIDs split into 12 TETs with 2 boundary faces per side
+  void testAllTriPyramid5() { LOG_UNIT_TEST; test_helper_3D(PYRAMID5, /*nelem=*/12, /*nbcs=*/12); }
 
   // Build a C0Polygon paving (triangles, quads, hexagons) via
   // build_square and split it into a pure TRI3 mesh.

--- a/tests/mesh/all_tri.C
+++ b/tests/mesh/all_tri.C
@@ -46,6 +46,7 @@ public:
   CPPUNIT_TEST( testAllTriPrism20 );
   CPPUNIT_TEST( testAllTriPrism21 );
   CPPUNIT_TEST( testAllTriPyramid5 );
+  CPPUNIT_TEST( testAllTriPyramid14 );
   CPPUNIT_TEST( testAllTriC0PolyhedronCube );
   CPPUNIT_TEST( testAllTriC0PolyhedronHexagonalPrism );
 #endif
@@ -127,6 +128,7 @@ public:
 
   // 6 PYRAMIDs split into 12 TETs with 2 boundary faces per side
   void testAllTriPyramid5() { LOG_UNIT_TEST; test_helper_3D(PYRAMID5, /*nelem=*/12, /*nbcs=*/12); }
+  void testAllTriPyramid14() { LOG_UNIT_TEST; test_helper_3D(PYRAMID14, /*nelem=*/12, /*nbcs=*/12); }
 
   // Build a C0Polygon paving (triangles, quads, hexagons) via
   // build_square and split it into a pure TRI3 mesh.

--- a/tests/mesh/all_tri.C
+++ b/tests/mesh/all_tri.C
@@ -55,9 +55,32 @@ public:
 
 protected:
   // Helper function called by the test implementations, saves a few lines of code.
-  void test_elements(const MeshBase & mesh)
+  void test_helper(ElemType elem_type,
+                   dof_id_type n_elem_expected,
+                   std::size_t n_boundary_conds_expected)
   {
+    ReplicatedMesh mesh(*TestCommWorld);
+
+    // Build a 2x1 2D or 1x1x1 3D mesh, ask to split it into simplices
+    const unsigned int dim = Elem::type_to_dim_map[elem_type];
+    MeshTools::Generation::build_cube(mesh,
+                                      /*nx=*/dim < 3 ? 2 : 1,
+                                      /*ny=*/1,
+                                      /*nz=*/dim < 3 ? 0 : 1,
+                                      /*xmin=*/0., /*xmax=*/1.,
+                                      /*ymin=*/0., /*ymax=*/1.,
+                                      /*zmin=*/0., /*zmax=*/1.,
+                                      elem_type);
+
+    MeshTools::Modification::all_tri(mesh);
+
+    // Make sure that the expected number of elements is found.
+    CPPUNIT_ASSERT_EQUAL(n_elem_expected, mesh.n_elem());
+
     const BoundaryInfo & boundary_info = mesh.get_boundary_info();
+
+    // Make sure the expected number of BCs is found.
+    CPPUNIT_ASSERT_EQUAL(n_boundary_conds_expected, boundary_info.n_boundary_conds());
 
     // In these tests we expect all our elements to have the proper
     // orientation, and we set up the inputs such that our outputs
@@ -76,84 +99,32 @@ protected:
     LIBMESH_ASSERT_NUMBERS_EQUAL(1, MeshTools::volume(mesh), TOLERANCE);
   }
 
-  void test_helper_2D(ElemType elem_type,
-                      dof_id_type n_elem_expected,
-                      std::size_t n_boundary_conds_expected)
-  {
-    ReplicatedMesh mesh(*TestCommWorld, /*dim=*/2);
-
-    // Build a 2x1 TRI3 mesh and ask to split it into triangles.
-    // Should be a no-op
-    MeshTools::Generation::build_square(mesh,
-                                        /*nx=*/2, /*ny=*/1,
-                                        /*xmin=*/0., /*xmax=*/1.,
-                                        /*ymin=*/0., /*ymax=*/1.,
-                                        elem_type);
-
-    MeshTools::Modification::all_tri(mesh);
-
-    // Make sure that the expected number of elements is found.
-    CPPUNIT_ASSERT_EQUAL(n_elem_expected, mesh.n_elem());
-
-    // Make sure the expected number of BCs is found.
-    CPPUNIT_ASSERT_EQUAL(n_boundary_conds_expected, mesh.get_boundary_info().n_boundary_conds());
-
-    test_elements(mesh);
-  }
-
-  // Helper function called by the test implementations in 3D, saves a few lines of code.
-  void test_helper_3D(ElemType elem_type,
-                      dof_id_type n_elem_expected,
-                      std::size_t n_boundary_conds_expected)
-  {
-    ReplicatedMesh mesh(*TestCommWorld, /*dim=*/3);
-
-    // Build a 2x1 TRI3 mesh and ask to split it into triangles.
-    // Should be a no-op
-    MeshTools::Generation::build_cube(mesh,
-                                      /*nx=*/1, /*ny=*/1, /*nz=*/1,
-                                      /*xmin=*/0., /*xmax=*/1.,
-                                      /*ymin=*/0., /*ymax=*/1.,
-                                      /*zmin=*/0., /*zmax=*/1.,
-                                      elem_type);
-
-    MeshTools::Modification::all_tri(mesh);
-
-    // Make sure that the expected number of elements is found.
-    CPPUNIT_ASSERT_EQUAL(n_elem_expected, mesh.n_elem());
-
-    // Make sure the expected number of BCs is found.
-    CPPUNIT_ASSERT_EQUAL(n_boundary_conds_expected, mesh.get_boundary_info().n_boundary_conds());
-
-    test_elements(mesh);
-  }
-
 public:
   void setUp() {}
 
   void tearDown() {}
 
   // 4 TRIs no-op
-  void testAllTriTri() { LOG_UNIT_TEST; test_helper_2D(TRI3, /*nelem=*/4, /*nbcs=*/6); }
+  void testAllTriTri() { LOG_UNIT_TEST; test_helper(TRI3, /*nelem=*/4, /*nbcs=*/6); }
 
   // 2 quads split into 4 TRIs.
-  void testAllTriQuad() { LOG_UNIT_TEST; test_helper_2D(QUAD4, /*nelem=*/4, /*nbcs=*/6); }
+  void testAllTriQuad() { LOG_UNIT_TEST; test_helper(QUAD4, /*nelem=*/4, /*nbcs=*/6); }
 
   // 2 QUAD8s split into 4 TRIs.
-  void testAllTriQuad8() { LOG_UNIT_TEST; test_helper_2D(QUAD8, /*nelem=*/4, /*nbcs=*/6); }
+  void testAllTriQuad8() { LOG_UNIT_TEST; test_helper(QUAD8, /*nelem=*/4, /*nbcs=*/6); }
 
   // 2 QUAD9s split into 4 TRIs.
-  void testAllTriQuad9() { LOG_UNIT_TEST; test_helper_2D(QUAD9, /*nelem=*/4, /*nbcs=*/6); }
+  void testAllTriQuad9() { LOG_UNIT_TEST; test_helper(QUAD9, /*nelem=*/4, /*nbcs=*/6); }
 
   // 2 PRISMs split into 6 TETs with 2 boundary faces per side.
-  void testAllTriPrism6() { LOG_UNIT_TEST; test_helper_3D(PRISM6, /*nelem=*/6, /*nbcs=*/12); }
-  void testAllTriPrism18() { LOG_UNIT_TEST; test_helper_3D(PRISM18, /*nelem=*/6, /*nbcs=*/12); }
-  void testAllTriPrism20() { LOG_UNIT_TEST; test_helper_3D(PRISM20, /*nelem=*/6, /*nbcs=*/12); }
-  void testAllTriPrism21() { LOG_UNIT_TEST; test_helper_3D(PRISM21, /*nelem=*/6, /*nbcs=*/12); }
+  void testAllTriPrism6() { LOG_UNIT_TEST; test_helper(PRISM6, /*nelem=*/6, /*nbcs=*/12); }
+  void testAllTriPrism18() { LOG_UNIT_TEST; test_helper(PRISM18, /*nelem=*/6, /*nbcs=*/12); }
+  void testAllTriPrism20() { LOG_UNIT_TEST; test_helper(PRISM20, /*nelem=*/6, /*nbcs=*/12); }
+  void testAllTriPrism21() { LOG_UNIT_TEST; test_helper(PRISM21, /*nelem=*/6, /*nbcs=*/12); }
 
   // 6 PYRAMIDs split into 12 TETs with 2 boundary faces per side
-  void testAllTriPyramid5() { LOG_UNIT_TEST; test_helper_3D(PYRAMID5, /*nelem=*/12, /*nbcs=*/12); }
-  void testAllTriPyramid14() { LOG_UNIT_TEST; test_helper_3D(PYRAMID14, /*nelem=*/12, /*nbcs=*/12); }
+  void testAllTriPyramid5() { LOG_UNIT_TEST; test_helper(PYRAMID5, /*nelem=*/12, /*nbcs=*/12); }
+  void testAllTriPyramid14() { LOG_UNIT_TEST; test_helper(PYRAMID14, /*nelem=*/12, /*nbcs=*/12); }
 
   // Build a C0Polygon paving (triangles, quads, hexagons) via
   // build_square and split it into a pure TRI3 mesh.

--- a/tests/mesh/all_tri.C
+++ b/tests/mesh/all_tri.C
@@ -55,6 +55,27 @@ public:
 
 protected:
   // Helper function called by the test implementations, saves a few lines of code.
+  void test_elements(const MeshBase & mesh)
+  {
+    const BoundaryInfo & boundary_info = mesh.get_boundary_info();
+
+    // In these tests we expect all our elements to have the proper
+    // orientation, and we set up the inputs such that our outputs
+    // should be non-curved and should have no boundary sides that
+    // aren't on the previous external boundaries
+    for (const Elem * elem : mesh.element_ptr_range())
+      {
+        CPPUNIT_ASSERT(!elem->is_flipped());
+        CPPUNIT_ASSERT(elem->has_affine_map());
+        for (auto s : elem->side_index_range())
+          if (!elem->neighbor_ptr(s))
+            CPPUNIT_ASSERT_EQUAL(boundary_info.n_boundary_ids(elem, s), 1u);
+      }
+
+    // We set up inputs with measure 1
+    LIBMESH_ASSERT_NUMBERS_EQUAL(1, MeshTools::volume(mesh), TOLERANCE);
+  }
+
   void test_helper_2D(ElemType elem_type,
                       dof_id_type n_elem_expected,
                       std::size_t n_boundary_conds_expected)
@@ -76,6 +97,8 @@ protected:
 
     // Make sure the expected number of BCs is found.
     CPPUNIT_ASSERT_EQUAL(n_boundary_conds_expected, mesh.get_boundary_info().n_boundary_conds());
+
+    test_elements(mesh);
   }
 
   // Helper function called by the test implementations in 3D, saves a few lines of code.
@@ -101,6 +124,8 @@ protected:
 
     // Make sure the expected number of BCs is found.
     CPPUNIT_ASSERT_EQUAL(n_boundary_conds_expected, mesh.get_boundary_info().n_boundary_conds());
+
+    test_elements(mesh);
   }
 
 public:


### PR DESCRIPTION
I was just going to throw a `case PYRAMID5:` in there as a quick fix for @GiudGiud's particular case, but then I noticed some atavisms, and a refactoring opportunity, and that made adding `PYRAMID14` support less annoying, and after that I got worried about the refactoring and noticed a bunch of additional assertions we could add to the unit tests, and then I noticed that the tests themselves could use a bit of refactoring...

Now this essentially fixes #4495 entirely - the remaining unsupported `PYRAMID13` case is analogous to the other serendipity `PRISM15` and `HEX20` cases that I don't intend to support until someone specifically requests them.