### PR TITLE
libMesh::isfinite() subroutines

### DIFF
--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -212,6 +212,15 @@ template <typename T>
 inline bool libmesh_isinf(std::complex<T> a)
 { return (std::isinf(std::real(a)) || std::isinf(std::imag(a))); }
 
+// std::isfinite() doesn't support complex, but we really want an
+// isfinite to support Number, at least in our own namespace
+template <typename T>
+inline bool isfinite(std::complex<T> a)
+{
+  using std::isfinite;
+  return (isfinite(std::real(a)) && isfinite(std::imag(a)));
+}
+
 // Define the value type for unknowns in simulations.
 // This is either Real or Complex, depending on how
 // the library was configures

--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -1222,6 +1222,7 @@ template <typename T>
 bool isfinite (const DenseMatrix<T> & var)
 {
   using std::isfinite;
+  using libMesh::isfinite; // for T==complex
   const auto m = var.m(), n = var.n();
   for (auto i : make_range(m))
     for (auto j : make_range(n))

--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -1218,6 +1218,17 @@ T DenseMatrix<T>::transpose (const unsigned int i,
 // }
 
 
+template <typename T>
+bool isfinite (const DenseMatrix<T> & var)
+{
+  using std::isfinite;
+  const auto m = var.m(), n = var.n();
+  for (auto i : make_range(m))
+    for (auto j : make_range(n))
+      if (!isfinite(var(i,j)))
+        return false;
+  return true;
+}
 
 
 } // namespace libMesh

--- a/include/numerics/dense_submatrix.h
+++ b/include/numerics/dense_submatrix.h
@@ -229,6 +229,19 @@ T & DenseSubMatrix<T>::operator () (const unsigned int i,
 }
 
 
+template <typename T>
+bool isfinite (const DenseSubMatrix<T> & var)
+{
+  using std::isfinite;
+  const auto m = var.m(), n = var.n();
+  for (auto i : make_range(m))
+    for (auto j : make_range(n))
+      if (!isfinite(var(i,j)))
+        return false;
+  return true;
+}
+
+
 } // namespace libMesh
 
 

--- a/include/numerics/dense_submatrix.h
+++ b/include/numerics/dense_submatrix.h
@@ -233,6 +233,7 @@ template <typename T>
 bool isfinite (const DenseSubMatrix<T> & var)
 {
   using std::isfinite;
+  using libMesh::isfinite; // for T==complex
   const auto m = var.m(), n = var.n();
   for (auto i : make_range(m))
     for (auto j : make_range(n))

--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -726,6 +726,7 @@ template <typename T>
 bool isfinite (const DenseVector<T> & var)
 {
   using std::isfinite;
+  using libMesh::isfinite; // for T==complex
   for (auto i : make_range(var.size()))
     if (!isfinite(var(i)))
       return false;

--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -721,6 +721,20 @@ void DenseVector<T>::get_principal_subvector (unsigned int sub_n,
     dest(i) = _val[i];
 }
 
+
+template <typename T>
+bool isfinite (const DenseVector<T> & var)
+{
+  using std::isfinite;
+  for (auto i : make_range(var.size()))
+    if (!isfinite(var(i)))
+      return false;
+  return true;
+}
+
+
+
+
 } // namespace libMesh
 
 #ifdef LIBMESH_HAVE_METAPHYSICL

--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -1440,6 +1440,7 @@ template <typename T>
 bool isfinite (const TypeTensor<T> & var)
 {
   using std::isfinite;
+  using libMesh::isfinite; // for T==complex
   for (unsigned int i=0; i<LIBMESH_DIM; i++)
     for (unsigned int j=0; j<LIBMESH_DIM; j++)
       if (!isfinite(var(i,j)))

--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -1435,6 +1435,19 @@ void TypeTensor<T>::print(std::ostream & os) const
 #endif
 }
 
+
+template <typename T>
+bool isfinite (const TypeTensor<T> & var)
+{
+  using std::isfinite;
+  for (unsigned int i=0; i<LIBMESH_DIM; i++)
+    for (unsigned int j=0; j<LIBMESH_DIM; j++)
+      if (!isfinite(var(i,j)))
+        return false;
+  return true;
+}
+
+
 template <typename T, typename T2>
 inline
 TypeTensor<typename CompareTypes<T, T2>::supertype>

--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -1191,6 +1191,7 @@ template <typename T>
 bool isfinite (const TypeVector<T> & var)
 {
   using std::isfinite;
+  using libMesh::isfinite; // for T==complex
   for (unsigned int i=0; i<LIBMESH_DIM; i++)
     if (!isfinite(var(i)))
       return false;

--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -1186,6 +1186,18 @@ void TypeVector<T>::print(std::ostream & os) const
 #endif
 }
 
+
+template <typename T>
+bool isfinite (const TypeVector<T> & var)
+{
+  using std::isfinite;
+  for (unsigned int i=0; i<LIBMESH_DIM; i++)
+    if (!isfinite(var(i)))
+      return false;
+  return true;
+}
+
+
 template <typename T>
 struct CompareTypes<TypeVector<T>, TypeVector<T>>
 {

--- a/tests/libmesh_cppunit.h
+++ b/tests/libmesh_cppunit.h
@@ -19,12 +19,15 @@
          CPPUNIT_ASSERT_DOUBLES_EQUAL(expected,actual,tolerance)
 #endif
 
-#ifdef LIBMESH_USE_COMPLEX_NUMBERS
-# define LIBMESH_ASSERT_NUMBERS_EQUAL(expected,actual,tolerance) \
+# define LIBMESH_ASSERT_COMPLEX_EQUAL(expected,actual,tolerance) \
   do { \
     LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_real(expected),libMesh::libmesh_real(actual),tolerance); \
     LIBMESH_ASSERT_FP_EQUAL(libMesh::libmesh_imag(expected),libMesh::libmesh_imag(actual),tolerance); \
   } while (0)
+
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+# define LIBMESH_ASSERT_NUMBERS_EQUAL(expected,actual,tolerance) \
+         LIBMESH_ASSERT_COMPLEX_EQUAL(expected,actual,tolerance)
 #else
 # define LIBMESH_ASSERT_NUMBERS_EQUAL(expected,actual,tolerance) \
          LIBMESH_ASSERT_FP_EQUAL(expected,actual,tolerance)

--- a/tests/numerics/dense_matrix_test.C
+++ b/tests/numerics/dense_matrix_test.C
@@ -1,5 +1,6 @@
 // libmesh includes
 #include <libmesh/dense_matrix.h>
+#include <libmesh/dense_submatrix.h>
 #include <libmesh/dense_vector.h>
 
 #ifdef LIBMESH_HAVE_PETSC
@@ -8,6 +9,7 @@
 
 #include "libmesh_cppunit.h"
 
+#include <limits>
 
 using namespace libMesh;
 
@@ -20,6 +22,7 @@ public:
 
   LIBMESH_CPPUNIT_TEST_SUITE(DenseMatrixTest);
 
+  CPPUNIT_TEST(testIsFinite);
   CPPUNIT_TEST(testOuterProduct);
   CPPUNIT_TEST(testSVD);
   CPPUNIT_TEST(testEVDreal);
@@ -31,6 +34,33 @@ public:
 
 
 private:
+
+  void testIsFinite()
+  {
+    LOG_UNIT_TEST;
+
+    DenseMatrix<Real> a(2, 2, {1, 2,
+                               3, 4});
+    CPPUNIT_ASSERT(isfinite(a));
+
+    DenseVector<Real> diag = a.diagonal();
+    CPPUNIT_ASSERT(isfinite(diag));
+
+    DenseSubMatrix suba1(a,0,0,1,1);
+    CPPUNIT_ASSERT(isfinite(suba1));
+
+    DenseSubMatrix suba2(a,1,1,1,1);
+    CPPUNIT_ASSERT(isfinite(suba2));
+
+    a(0, 0) = std::numeric_limits<Real>::infinity();
+    CPPUNIT_ASSERT(!isfinite(a));
+    CPPUNIT_ASSERT(!isfinite(suba1));
+    CPPUNIT_ASSERT(isfinite(suba2));
+
+    CPPUNIT_ASSERT(isfinite(diag));
+    diag = a.diagonal();
+    CPPUNIT_ASSERT(!isfinite(diag));
+  }
 
   void testOuterProduct()
   {

--- a/tests/numerics/type_tensor_test.C
+++ b/tests/numerics/type_tensor_test.C
@@ -23,6 +23,7 @@ public:
   CPPUNIT_TEST(testRotation);
 #endif
   CPPUNIT_TEST(testRowCol);
+  CPPUNIT_TEST(testIsFinite);
   CPPUNIT_TEST(testIsZero);
   CPPUNIT_TEST(testIsHPD);
 #ifdef LIBMESH_HAVE_METAPHYSICL
@@ -89,6 +90,21 @@ private:
     LIBMESH_ASSERT_FP_EQUAL(20, product(2, 0), tol);
     LIBMESH_ASSERT_FP_EQUAL(24, product(2, 1), tol);
     LIBMESH_ASSERT_FP_EQUAL(28, product(2, 2), tol);
+  }
+
+  void testIsFinite()
+  {
+    LOG_UNIT_TEST;
+
+    {
+      TensorValue<double> tensor;
+      CPPUNIT_ASSERT(isfinite(tensor));
+    }
+    {
+      TensorValue<double> tensor(0,1,0,2,3);
+      tensor(0,0) = std::numeric_limits<double>::infinity();
+      CPPUNIT_ASSERT(!isfinite(tensor));
+    }
   }
 
   void testIsZero()

--- a/tests/numerics/type_vector_test.h
+++ b/tests/numerics/type_vector_test.h
@@ -337,8 +337,10 @@ public:
 #endif
       CPPUNIT_ASSERT(isfinite(avector));
 
+      // numeric_limits isn't specialized for complex, but float
+      // infinity promotes seamlessly to complex<double> etc.
       avector(0) =
-        std::numeric_limits<typename DerivedClass::value_type>::infinity();
+        std::numeric_limits<float>::infinity();
       CPPUNIT_ASSERT(!isfinite(avector));
     }
   }

--- a/tests/numerics/type_vector_test.h
+++ b/tests/numerics/type_vector_test.h
@@ -180,12 +180,12 @@ public:
 
     DerivedClass avector = 0;
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , avector(i) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 0.0 , avector(i) , TOLERANCE*TOLERANCE );
 
     DerivedClass bvector = 2.0;
-    LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , bvector(0) , TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_COMPLEX_EQUAL( 2.0 , bvector(0) , TOLERANCE*TOLERANCE );
     for (int i = 1; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , bvector(i) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 0.0 , bvector(i) , TOLERANCE*TOLERANCE );
   }
 
   void testScalarMult()
@@ -194,9 +194,9 @@ public:
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
     {
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 5.0 , ((*m_1_1_1)*5.0)(i) , TOLERANCE*TOLERANCE );
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 5.0 , outer_product(*m_1_1_1,5.0)(i) , TOLERANCE*TOLERANCE );
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 5.0 , outer_product(5.0,*m_1_1_1)(i) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 5.0 , ((*m_1_1_1)*5.0)(i) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 5.0 , outer_product(*m_1_1_1,5.0)(i) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 5.0 , outer_product(5.0,*m_1_1_1)(i) , TOLERANCE*TOLERANCE );
     }
   }
 
@@ -205,7 +205,7 @@ public:
     LOG_UNIT_TEST;
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 1/Real(5) , ((*m_1_1_1)/5.0)(i) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 1/Real(5) , ((*m_1_1_1)/5.0)(i) , TOLERANCE*TOLERANCE );
   }
 
   void testScalarMultAssign()
@@ -216,7 +216,7 @@ public:
     avector*=5.0;
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 5.0 , avector(i) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 5.0 , avector(i) , TOLERANCE*TOLERANCE );
   }
 
   void testScalarDivAssign()
@@ -227,18 +227,18 @@ public:
     avector/=5.0;
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 1/Real(5) , avector(i) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 1/Real(5) , avector(i) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorAdd()
   {
     LOG_UNIT_TEST;
 
-    LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , ((*m_1_1_1)+(*m_n1_1_n1))(0) , TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_COMPLEX_EQUAL( 0.0 , ((*m_1_1_1)+(*m_n1_1_n1))(0) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 1)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , ((*m_1_1_1)+(*m_n1_1_n1))(1) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 2.0 , ((*m_1_1_1)+(*m_n1_1_n1))(1) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 2)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , ((*m_1_1_1)+(*m_n1_1_n1))(2) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 0.0 , ((*m_1_1_1)+(*m_n1_1_n1))(2) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorAddScaled()
@@ -249,18 +249,18 @@ public:
     avector.add_scaled((*m_1_1_1),0.5);
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 1.5 , avector(i) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 1.5 , avector(i) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorSub()
   {
     LOG_UNIT_TEST;
 
-    LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , ((*m_1_1_1)-(*m_n1_1_n1))(0) , TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_COMPLEX_EQUAL( 2.0 , ((*m_1_1_1)-(*m_n1_1_n1))(0) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 1)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , ((*m_1_1_1)-(*m_n1_1_n1))(1) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 0.0 , ((*m_1_1_1)-(*m_n1_1_n1))(1) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 2)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , ((*m_1_1_1)-(*m_n1_1_n1))(2) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 2.0 , ((*m_1_1_1)-(*m_n1_1_n1))(2) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorMult()
@@ -268,9 +268,9 @@ public:
     LOG_UNIT_TEST;
 
     if (LIBMESH_DIM == 2)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , (*m_1_1_1)*(*m_n1_1_n1) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 0.0 , (*m_1_1_1)*(*m_n1_1_n1) , TOLERANCE*TOLERANCE );
     else
-      LIBMESH_ASSERT_NUMBERS_EQUAL( -1.0 , (*m_1_1_1)*(*m_n1_1_n1) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( -1.0 , (*m_1_1_1)*(*m_n1_1_n1) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorAddAssign()
@@ -281,7 +281,7 @@ public:
     avector+=(*m_1_1_1);
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , avector(i) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 2.0 , avector(i) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorSubAssign()
@@ -291,11 +291,11 @@ public:
     DerivedClass avector {*basem_1_1_1};
     avector-=(*m_n1_1_n1);
 
-    LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , avector(0) , TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_COMPLEX_EQUAL( 2.0 , avector(0) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 1)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , avector(1) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 0.0 , avector(1) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 2)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , avector(2) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 2.0 , avector(2) , TOLERANCE*TOLERANCE );
   }
 
   void testValueBase()
@@ -377,7 +377,7 @@ public:
     LOG_UNIT_TEST;
 
     const DerivedClass xvec(1.3);
-    LIBMESH_ASSERT_NUMBERS_EQUAL( solid_angle(xvec, xvec, xvec), 0, TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_COMPLEX_EQUAL( solid_angle(xvec, xvec, xvec), 0, TOLERANCE*TOLERANCE );
 
 #if LIBMESH_DIM > 1
     // This is ambiguous with --enable-complex builds?  We really need
@@ -392,18 +392,18 @@ public:
     xypdiag(0) = 0.8; xypdiag(1) = -.8;
 
     // Yeah, nothing subtends a non-zero solid angle in 2D either.
-    LIBMESH_ASSERT_NUMBERS_EQUAL( solid_angle(xvec, xvec, yvec), 0, TOLERANCE*TOLERANCE );
-    LIBMESH_ASSERT_NUMBERS_EQUAL( solid_angle(xvec, yvec, xydiag), 0, TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_COMPLEX_EQUAL( solid_angle(xvec, xvec, yvec), 0, TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_COMPLEX_EQUAL( solid_angle(xvec, yvec, xydiag), 0, TOLERANCE*TOLERANCE );
 #endif
 
 #if LIBMESH_DIM > 2
     const DerivedClass zvec(0.,0.,1.1),
                        xzdiag(0.,.7,.7);
-    LIBMESH_ASSERT_NUMBERS_EQUAL(solid_angle(xydiag, yvec, zvec),
+    LIBMESH_ASSERT_COMPLEX_EQUAL(solid_angle(xydiag, yvec, zvec),
                                 libMesh::pi/4, TOLERANCE*TOLERANCE);
-    LIBMESH_ASSERT_NUMBERS_EQUAL(solid_angle(xvec, yvec, xzdiag),
+    LIBMESH_ASSERT_COMPLEX_EQUAL(solid_angle(xvec, yvec, xzdiag),
                                 libMesh::pi/4, TOLERANCE*TOLERANCE);
-    LIBMESH_ASSERT_NUMBERS_EQUAL(solid_angle(xypdiag, xydiag, zvec),
+    LIBMESH_ASSERT_COMPLEX_EQUAL(solid_angle(xypdiag, xydiag, zvec),
                                 libMesh::pi/2, TOLERANCE*TOLERANCE);
 
     // Icosahedron coordinates are a nice analytic test
@@ -411,7 +411,7 @@ public:
     const DerivedClass icosa1(1., golden, 0.),
                        icosa2(-1., golden, 0.),
                        icosa3(0., 1., golden);
-    LIBMESH_ASSERT_NUMBERS_EQUAL(solid_angle(icosa1, icosa2, icosa3),
+    LIBMESH_ASSERT_COMPLEX_EQUAL(solid_angle(icosa1, icosa2, icosa3),
                                 libMesh::pi/5, TOLERANCE*TOLERANCE);
 #endif
   }
@@ -424,20 +424,20 @@ public:
     DerivedClass twoone(2); twoone(1) = 1;
 
     auto cc1 = circumcenter(origin, e_x, twoone);
-    LIBMESH_ASSERT_NUMBERS_EQUAL(cc1(0), 0.5, TOLERANCE*TOLERANCE);
-    LIBMESH_ASSERT_NUMBERS_EQUAL(cc1(1), 1.5, TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_COMPLEX_EQUAL(cc1(0), 0.5, TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_COMPLEX_EQUAL(cc1(1), 1.5, TOLERANCE*TOLERANCE);
 
 #if LIBMESH_DIM > 2
-    LIBMESH_ASSERT_NUMBERS_EQUAL(cc1(2), 0, TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_COMPLEX_EQUAL(cc1(2), 0, TOLERANCE*TOLERANCE);
     const DerivedClass twozeroone(2,0,1);
     auto cc2 = circumcenter(origin, e_x, twozeroone);
-    LIBMESH_ASSERT_NUMBERS_EQUAL(cc2(0), 0.5, TOLERANCE*TOLERANCE);
-    LIBMESH_ASSERT_NUMBERS_EQUAL(cc2(1), 0, TOLERANCE*TOLERANCE);
-    LIBMESH_ASSERT_NUMBERS_EQUAL(cc2(2), 1.5, TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_COMPLEX_EQUAL(cc2(0), 0.5, TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_COMPLEX_EQUAL(cc2(1), 0, TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_COMPLEX_EQUAL(cc2(2), 1.5, TOLERANCE*TOLERANCE);
     auto cc3 = circumcenter(e_x, twoone, twozeroone);
-    LIBMESH_ASSERT_NUMBERS_EQUAL(cc3(0), Real(5)/3, TOLERANCE*TOLERANCE);
-    LIBMESH_ASSERT_NUMBERS_EQUAL(cc3(1), Real(1)/3, TOLERANCE*TOLERANCE);
-    LIBMESH_ASSERT_NUMBERS_EQUAL(cc3(2), Real(1)/3, TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_COMPLEX_EQUAL(cc3(0), Real(5)/3, TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_COMPLEX_EQUAL(cc3(1), Real(1)/3, TOLERANCE*TOLERANCE);
+    LIBMESH_ASSERT_COMPLEX_EQUAL(cc3(2), Real(1)/3, TOLERANCE*TOLERANCE);
 #endif
   }
 
@@ -488,7 +488,7 @@ public:
     LOG_UNIT_TEST;
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 5.0 , ((*basem_1_1_1)*5.0)(i) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 5.0 , ((*basem_1_1_1)*5.0)(i) , TOLERANCE*TOLERANCE );
   }
 
   void testScalarDivBase()
@@ -496,7 +496,7 @@ public:
     LOG_UNIT_TEST;
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 1/Real(5) , ((*basem_1_1_1)/5.0)(i) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 1/Real(5) , ((*basem_1_1_1)/5.0)(i) , TOLERANCE*TOLERANCE );
   }
 
   void testScalarMultAssignBase()
@@ -507,7 +507,7 @@ public:
     avector*=5.0;
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 5.0 , avector(i) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 5.0 , avector(i) , TOLERANCE*TOLERANCE );
   }
 
   void testScalarDivAssignBase()
@@ -518,18 +518,18 @@ public:
     avector/=5.0;
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 1/Real(5) , avector(i) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 1/Real(5) , avector(i) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorAddBase()
   {
     LOG_UNIT_TEST;
 
-    LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , ((*basem_1_1_1)+(*basem_n1_1_n1))(0) , TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_COMPLEX_EQUAL( 0.0 , ((*basem_1_1_1)+(*basem_n1_1_n1))(0) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 1)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , ((*basem_1_1_1)+(*basem_n1_1_n1))(1) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 2.0 , ((*basem_1_1_1)+(*basem_n1_1_n1))(1) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 2)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , ((*basem_1_1_1)+(*basem_n1_1_n1))(2) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 0.0 , ((*basem_1_1_1)+(*basem_n1_1_n1))(2) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorAddScaledBase()
@@ -540,18 +540,18 @@ public:
     avector.add_scaled((*basem_1_1_1),0.5);
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 1.5 , avector(i) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 1.5 , avector(i) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorSubBase()
   {
     LOG_UNIT_TEST;
 
-    LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , ((*basem_1_1_1)-(*basem_n1_1_n1))(0) , TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_COMPLEX_EQUAL( 2.0 , ((*basem_1_1_1)-(*basem_n1_1_n1))(0) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 1)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , ((*basem_1_1_1)-(*basem_n1_1_n1))(1) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 0.0 , ((*basem_1_1_1)-(*basem_n1_1_n1))(1) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 2)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , ((*basem_1_1_1)-(*basem_n1_1_n1))(2) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 2.0 , ((*basem_1_1_1)-(*basem_n1_1_n1))(2) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorMultBase()
@@ -559,9 +559,9 @@ public:
     LOG_UNIT_TEST;
 
     if (LIBMESH_DIM == 2)
-      LIBMESH_ASSERT_NUMBERS_EQUAL(  0.0 , (*basem_1_1_1)*(*basem_n1_1_n1) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL(  0.0 , (*basem_1_1_1)*(*basem_n1_1_n1) , TOLERANCE*TOLERANCE );
     else
-      LIBMESH_ASSERT_NUMBERS_EQUAL( -1.0 , (*basem_1_1_1)*(*basem_n1_1_n1) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( -1.0 , (*basem_1_1_1)*(*basem_n1_1_n1) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorAddAssignBase()
@@ -572,7 +572,7 @@ public:
     avector+=(*basem_1_1_1);
 
     for (int i = 0; i != LIBMESH_DIM; ++i)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , avector(i) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 2.0 , avector(i) , TOLERANCE*TOLERANCE );
   }
 
   void testVectorSubAssignBase()
@@ -582,11 +582,11 @@ public:
     TypeVector<T> avector(*m_1_1_1);
     avector-=(*basem_n1_1_n1);
 
-    LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , avector(0) , TOLERANCE*TOLERANCE );
+    LIBMESH_ASSERT_COMPLEX_EQUAL( 2.0 , avector(0) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 1)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 0.0 , avector(1) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 0.0 , avector(1) , TOLERANCE*TOLERANCE );
     if (LIBMESH_DIM > 2)
-      LIBMESH_ASSERT_NUMBERS_EQUAL( 2.0 , avector(2) , TOLERANCE*TOLERANCE );
+      LIBMESH_ASSERT_COMPLEX_EQUAL( 2.0 , avector(2) , TOLERANCE*TOLERANCE );
   }
 
   void testReplaceAlgebraicType()

--- a/tests/numerics/type_vector_test.h
+++ b/tests/numerics/type_vector_test.h
@@ -30,6 +30,7 @@
   CPPUNIT_TEST( testVectorAddAssign );          \
   CPPUNIT_TEST( testVectorSubAssign );          \
                                                 \
+  CPPUNIT_TEST( testIsFinite );                 \
   CPPUNIT_TEST( testIsZero );                   \
   CPPUNIT_TEST( testSolidAngle );               \
   CPPUNIT_TEST( testCircumcenter );             \
@@ -321,6 +322,27 @@ public:
     for (int i = 0; i != LIBMESH_DIM; ++i)
       CPPUNIT_ASSERT_EQUAL( T(0), avector(i));
   }
+
+  void testIsFinite()
+  {
+    LOG_UNIT_TEST;
+
+    {
+#if LIBMESH_DIM > 2
+      DerivedClass avector(0,0,0);
+#elif LIBMESH_DIM > 1
+      DerivedClass avector(0,0);
+#else
+      DerivedClass avector(0);
+#endif
+      CPPUNIT_ASSERT(isfinite(avector));
+
+      avector(0) =
+        std::numeric_limits<typename DerivedClass::value_type>::infinity();
+      CPPUNIT_ASSERT(!isfinite(avector));
+    }
+  }
+
 
   void testIsZero()
   {

--- a/tests/numerics/vector_value_test.C
+++ b/tests/numerics/vector_value_test.C
@@ -49,7 +49,7 @@ public:
     this->libmesh_suite_name = "ComplexVectorValueTest";
   }
 
-  LIBMESH_CPPUNIT_TEST_SUITE( NumberVectorValueTest );
+  CPPUNIT_TEST_SUITE( ComplexVectorValueTest );
 
   VECTORVALUETEST
 


### PR DESCRIPTION
From https://github.com/idaholab/moose/pull/33439#discussion_r3693684525:

> in the longer term maybe should be a class method on `TypeVector`. What do you think @roystgnr ?

I think it should be a global method so future generic code can use the same `isfinite(foo)` and get `std::isfinite` via a `using` or `libMesh::isfinite` via ADL, but otherwise I agree.

@lindsayad - we should probably be adding `isfinite` to MetaPhysicL too, and `isnan` here, don't you think?  More urgently the former?  I think long ago I got into the habit of using `isnan` in cases which in hindsight should have been `isnan` 20% of the time and `isfinite` 80% of the time, simply because I formed that habit pre-C++11.