### PR TITLE
Mesh-preparation-related test fixes

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex15/miscellaneous_ex15.C
+++ b/examples/miscellaneous/miscellaneous_ex15/miscellaneous_ex15.C
@@ -221,6 +221,10 @@ int main (int argc, char** argv)
          sync_obj);
     }
 
+  // We'll need to update caches of subdomain ids too, to keep the
+  // mesh prepared.
+  mesh.cache_elem_data();
+
   // Now we set the sources of the field: prism-shaped objects that are
   // determined here by containing certain points:
   auto p_pt_lctr = mesh.sub_point_locator();

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -64,6 +64,9 @@ VariationalMeshSmoother::VariationalMeshSmoother(
 void VariationalMeshSmoother::setup()
 {
   // Check for multiple dimensions
+  if (!_mesh.preparation().has_cached_elem_data)
+    _mesh.cache_elem_data();
+
   if (_mesh.elem_dimensions().size() > 1)
     libmesh_not_implemented_msg("Meshes containing elements of differing dimension are not yet supported.");
 

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -888,14 +888,18 @@ public:
       MeshType mesh(*TestCommWorld);
 
       EquationSystems es(mesh);
+
+      // We need a mesh.spatial_dimension() *before* adding a
+      // vector-valued variable, so add_variable() can figure out how
+      // many components it needs.
+      MeshTools::Generation::build_square (mesh,
+                                           3, 3,
+                                           0., 1., 0., 1.);
+
       System & sys = es.add_system<System> ("SimpleSystem");
       auto e_var = sys.add_variable("e", CONSTANT, MONOMIAL_VEC);
       auto e_no_p_var = sys.add_variable("e_no_p",
                                          FEType(CONSTANT, MONOMIAL_VEC).set_p_refinement(false));
-
-      MeshTools::Generation::build_square (mesh,
-                                           3, 3,
-                                           0., 1., 0., 1.);
 
       es.init();
 

--- a/tests/mesh/mesh_smoother_test.C
+++ b/tests/mesh/mesh_smoother_test.C
@@ -592,11 +592,14 @@ public:
 
             mesh.comm().sum(distorted_subdomain_volumes[sub_id]);
           }
-
-        // We've just invalidated the get_mesh_subdomains() cache by
-        // adding a new one; fix it.
-        mesh.cache_elem_data();
       }
+
+    // We may have just invalidated the get_mesh_subdomains() cache by
+    // adding a new one, and libMesh marked our spatial_dimension()
+    // cache as invalidated in redistribute().  Just rebuild our
+    // caches before we start asking for anything like
+    // elem_default_orders().
+    mesh.cache_elem_data();
 
     // Get the mesh order
     const auto & elem_orders = mesh.elem_default_orders();


### PR DESCRIPTION
More fixes (3 in tests, one a robustness improvement that fixes downstream tests) independent of the rest of #4411.  We can merge the fixes first and save the stricter internal testing that makes the fixes necessary for later.