### PR TITLE
Guard use of max_new_nodes_per_elem

### DIFF
--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -119,8 +119,10 @@ void transfer_elem(Elem & lo_elem,
   const unsigned int hon_end   = hi_elem->n_nodes();
 
   libmesh_assert_less (hon_begin, hon_end);
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
   libmesh_assert_less_equal
     (hon_end-hon_begin, max_new_nodes_per_elem);
+#endif
 
   for (unsigned int hon=hon_begin; hon<hon_end; hon++)
     {


### PR DESCRIPTION
In the parameter list `max_new_nodes_per_elem` is wrapped by our unique id ifdef guards, so we must do the same for use of the variable in the function body