### PR TITLE
find_neighbors() check_non_remote=false option

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -986,10 +986,17 @@ public:
    *
    * If \p assert_valid is left as true, then in dbg mode extensive
    * consistency checking is performed before returning.
+   *
+   * If \p check_non_remote is set to false, then only sides which
+   * currently have remote neighbors are checked for possible local
+   * neighbors.  This is intended to handle a corner case where
+   * ancestor neighbors are redistributed to a processor only by other
+   * processors who do not see that neighbor link.
    */
   virtual void find_neighbors (const bool reset_remote_elements = false,
                                const bool reset_current_list    = true,
-                               const bool assert_valid          = true) = 0;
+                               const bool assert_valid          = true,
+                               const bool check_non_remote      = true) = 0;
 
   /**
    * Removes any orphaned nodes, nodes not connected to any elements.

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -988,10 +988,10 @@ public:
    * consistency checking is performed before returning.
    *
    * If \p check_non_remote is set to false, then only sides which
-   * currently have remote neighbors are checked for possible local
-   * neighbors.  This is intended to handle a corner case where
-   * ancestor neighbors are redistributed to a processor only by other
-   * processors who do not see that neighbor link.
+   * currently have remote neighbor_ptr links are checked for possible
+   * semilocal side-neighbors.  This is intended to handle a corner case
+   * where ancestor neighbors are redistributed to a processor only by
+   * other processors who do not see that neighbor link.
    */
   virtual void find_neighbors (const bool reset_remote_elements = false,
                                const bool reset_current_list    = true,

--- a/include/mesh/unstructured_mesh.h
+++ b/include/mesh/unstructured_mesh.h
@@ -295,7 +295,8 @@ public:
    */
   virtual void find_neighbors (const bool reset_remote_elements = false,
                                const bool reset_current_list    = true,
-                               const bool assert_valid          = true) override;
+                               const bool assert_valid          = true,
+                               const bool check_non_remote      = true) override;
 
 #ifdef LIBMESH_ENABLE_AMR
   /**

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -1055,9 +1055,13 @@ void DistributedMesh::redistribute ()
 
       this->update_parallel_id_counts();
 
-      // We ought to still have valid neighbor links; we communicate
-      // them for newly-redistributed elements
-      // this->find_neighbors();
+      // We communicate valid neighbor links for newly-redistributed
+      // elements, but we may still have remote_elem links that should
+      // be corrected but whose correction wasn't communicated.
+      this->find_neighbors(/*reset_remote_elements*/ false,
+                           /*reset_current_list*/ false /*non-default*/,
+                           /*assert_valid*/ false,
+                           /*check_non_remote*/ false /*non-default!*/);
 
       // Is this necessary?  If we are called from prepare_for_use(), this will be called
       // anyway... but users can always call partition directly, in which case we do need

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -956,7 +956,8 @@ UnstructuredMesh::~UnstructuredMesh ()
 
 void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                                        const bool reset_current_list,
-                                       const bool assert_valid)
+                                       const bool assert_valid,
+                                       const bool check_non_remote)
 {
   // We might actually want to run this on an empty mesh
   // (e.g. the boundary mesh for a nonexistent bcid!)
@@ -1003,7 +1004,10 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
             // If we haven't yet found a neighbor on this side, try.
             // Even if we think our neighbor is remote, that
             // information may be out of date.
-            if (element->neighbor_ptr(ms) == nullptr ||
+            //
+            // If we're only checking remote neighbors, after a
+            // redistribution, then we'll skip the non-remote ones
+            if ((element->neighbor_ptr(ms) == nullptr && check_non_remote) ||
                 element->neighbor_ptr(ms) == remote_elem)
               {
                 // Get the key for the side of this element.  Use the


### PR DESCRIPTION
This fixes a few corner cases where a ghosted element should see another ghosted element but, depending on how repartitioning was done, might only see a remote_elem link.  The fix shouldn't affect simulation codes that only work via local-ghost interactions, but I need it to be able to allow for more hardcore preparation assertions.

Stripped out of #4411 both because it really is an independent fix and because it's the most likely culprit for the distributed-mesh-dbg-mode failures that I see in CI there but can't replicate.