### PR TITLE
Add dependencies of constrained ghost DOFs to send list

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -270,9 +270,16 @@ public:
   void set_constrained_sparsity_construction(bool use_constraints);
 
   /**
-   * Sets need_full_sparsity_pattern to true regardless of the requirements by matrices
+   * Sets _need_full_sparsity_pattern to true regardless of the
+   * requirements by matrices
    */
   void full_sparsity_pattern_needed();
+
+  /**
+   * Sets _need_ghost_constraints to true regardless of the requirements
+   * by static condensation
+   */
+  void ghost_constraints_needed();
 
   /**
    * Returns true iff the current policy when constructing sparsity
@@ -2066,7 +2073,7 @@ private:
    * which are dependencies for constraint equations on the current
    * processor.
    */
-  void add_constraints_to_send_list();
+  void add_constraints_to_send_list(const MeshBase & mesh);
 
   /**
    * Adds any spline constraints from the Mesh to our DoF constraints.
@@ -2242,7 +2249,13 @@ private:
    * Default false; set to true if any attached matrix requires a full
    * sparsity pattern.
    */
-  bool need_full_sparsity_pattern;
+  bool _need_full_sparsity_pattern;
+
+  /**
+   * Default false; set to true if the dependencies of constrained ghost
+   * DOFs supported by local elements should also be ghosted
+   */
+  bool _need_ghost_constraints;
 
   /**
    * The sparsity pattern of the global matrix.  If
@@ -2553,7 +2566,13 @@ void DofMap::set_constrained_sparsity_construction(bool use_constraints)
 inline
 void DofMap::full_sparsity_pattern_needed()
 {
-  need_full_sparsity_pattern = true;
+  _need_full_sparsity_pattern = true;
+}
+
+inline
+void DofMap::ghost_constraints_needed()
+{
+  _need_ghost_constraints = true;
 }
 
 inline

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -101,7 +101,7 @@ DofMap::build_sparsity (const MeshBase & mesh,
      this->_dof_coupling,
      this->_coupling_functors,
      implicit_neighbor_dofs,
-     need_full_sparsity_pattern,
+     _need_full_sparsity_pattern,
      calculate_constrained,
      sc);
 
@@ -157,7 +157,8 @@ DofMap::DofMap(const unsigned int number,
   _extra_send_list_context(nullptr),
   _default_coupling(std::make_unique<DefaultCoupling>()),
   _default_evaluating(std::make_unique<DefaultCoupling>()),
-  need_full_sparsity_pattern(false),
+  _need_full_sparsity_pattern(false),
+  _need_ghost_constraints(false),
   _n_SCALAR_dofs(0)
 #ifdef LIBMESH_ENABLE_AMR
   , _first_old_scalar_df()
@@ -250,7 +251,7 @@ void DofMap::attach_matrix (SparseMatrix<Number> & matrix)
   this->update_sparsity_pattern(matrix);
 
   if (matrix.need_full_sparsity_pattern())
-    need_full_sparsity_pattern = true;
+    _need_full_sparsity_pattern = true;
 }
 
 
@@ -281,7 +282,7 @@ void DofMap::update_sparsity_pattern(SparseMatrix<Number> & matrix) const
         {
           // We'd better have already computed the full sparsity
           // pattern if we need it here
-          libmesh_assert(need_full_sparsity_pattern);
+          libmesh_assert(_need_full_sparsity_pattern);
 
           matrix.update_sparsity_pattern (_sp->get_sparsity_pattern());
         }
@@ -924,7 +925,8 @@ void DofMap::clear()
   _first_scalar_df.clear();
   this->clear_send_list();
   this->clear_sparsity();
-  need_full_sparsity_pattern = false;
+  _need_full_sparsity_pattern = false;
+  _need_ghost_constraints = false;
 
 #ifdef LIBMESH_ENABLE_AMR
 
@@ -1967,12 +1969,12 @@ void DofMap::compute_sparsity(const MeshBase & mesh)
   for (const auto & mat : _matrices)
     {
       mat->attach_sparsity_pattern (*_sp);
-      if (need_full_sparsity_pattern)
+      if (_need_full_sparsity_pattern)
         mat->update_sparsity_pattern (_sp->get_sparsity_pattern());
     }
   // If we don't need the full sparsity pattern anymore, free the
   // parts of it we don't need.
-  if (!need_full_sparsity_pattern)
+  if (!_need_full_sparsity_pattern)
     _sp->clear_full_sparsity();
 }
 

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -4495,7 +4495,7 @@ void DofMap::process_constraints (MeshBase & mesh)
 
   // Now that we have our root constraint dependencies sorted out, add
   // them to the send_list
-  this->add_constraints_to_send_list();
+  this->add_constraints_to_send_list(mesh);
 }
 
 
@@ -5308,7 +5308,7 @@ void DofMap::gather_constraints (MeshBase & /*mesh*/,
     }
 }
 
-void DofMap::add_constraints_to_send_list()
+void DofMap::add_constraints_to_send_list (const MeshBase & mesh)
 {
   // This function must be run on all processors at once
   parallel_object_only();
@@ -5344,7 +5344,7 @@ void DofMap::add_constraints_to_send_list()
 
   // If we only need constraint DoFs constraining DoFs which are
   // algebraically local, we're done.
-  if (!this->has_static_condensation())
+  if (!this->has_static_condensation() && !_need_ghost_constraints)
     return;
 
   // If we use StaticCondensation, though, we may need constraint DoFs
@@ -5352,10 +5352,16 @@ void DofMap::add_constraints_to_send_list()
   // node) but which are supported on local elements.  Let's get those
   // too if we have to.
   //
+  // Kokkos-MOOSE also requires that, because it cannot use VecSetValues
+  // and MatSetValues which can dynamically cache remote entries. Instead,
+  // it allocates ghost entries in advance based on libMesh send_list and
+  // accumulates to those, and does the assembly at once. When ghost DOFs
+  // are constrained, it has to add residual/Jacobian contributions to the
+  // dependencies of ghost DOFs locally as well.
+  //
   // We'll potentially be hitting the same constrained DoFs from
   // multiple directions.
-  std::unordered_set<dof_id_type> extra_dependencies;
-  for (auto & elem : this->get_static_condensation().mesh().active_local_element_ptr_range())
+  for (auto & elem : mesh.active_local_element_ptr_range())
     {
       std::vector<dof_id_type> di;
       this->dof_indices (elem, di);

--- a/tests/base/dof_map_test.C
+++ b/tests/base/dof_map_test.C
@@ -3,6 +3,8 @@
 #include <libmesh/mesh_generation.h>
 #include <libmesh/elem.h>
 #include <libmesh/dof_map.h>
+#include <libmesh/partitioner.h>
+#include <libmesh/replicated_mesh.h>
 
 #include <timpi/parallel_implementation.h>
 
@@ -44,6 +46,58 @@ public:
     }
   }
 };
+
+class GhostDofConstraint : public System::Constraint
+{
+private:
+
+  System & _sys;
+
+public:
+
+  GhostDofConstraint(System & sys) : Constraint(), _sys(sys) {}
+
+  void constrain() override
+  {
+    const unsigned int sys_num = _sys.number();
+
+    // Constrain the interface DOF on node 3 by the distant DOF on node 0.
+    // On the processor owning element 3, both DOFs are nonlocal, but only
+    // node 3 is directly needed by the local element.
+    const dof_id_type constrained_dof =
+      _sys.get_mesh().node_ref(3).dof_number(sys_num, 0, 0);
+    const dof_id_type dependency_dof =
+      _sys.get_mesh().node_ref(0).dof_number(sys_num, 0, 0);
+
+    // This represents constrained_dof = dependency_dof.
+    DofConstraintRow constraint_row;
+    constraint_row[dependency_dof] = 1.;
+    _sys.get_dof_map().add_constraint_row(constrained_dof, constraint_row);
+  }
+};
+
+class GhostDofConstraintPartitioner : public Partitioner
+{
+public:
+
+  std::unique_ptr<Partitioner> clone() const override
+  {
+    return std::make_unique<GhostDofConstraintPartitioner>(*this);
+  }
+
+protected:
+
+  void _do_partition(MeshBase & mesh, const unsigned int n) override
+  {
+    // Keep the first three elements on processor 0 and move the final
+    // element to another processor, creating a processor interface at node 3.
+    for (auto & elem : mesh.active_element_ptr_range())
+      elem->processor_id() = 0;
+
+    if (n > 1)
+      mesh.elem_ref(3).processor_id() = n - 1;
+  }
+};
 #endif
 
 
@@ -66,6 +120,10 @@ public:
 
 #if defined(LIBMESH_ENABLE_CONSTRAINTS) && defined(LIBMESH_ENABLE_EXCEPTIONS) && LIBMESH_DIM > 1
   CPPUNIT_TEST( testConstraintLoopDetection );
+#endif
+
+#if defined(LIBMESH_ENABLE_CONSTRAINTS)
+  CPPUNIT_TEST( testGhostConstraintSendList );
 #endif
 
   CPPUNIT_TEST( testArrayDofIndices );
@@ -189,6 +247,92 @@ public:
     dof_map.set_error_on_constraint_loop(true);
 
     CPPUNIT_ASSERT_THROW_MESSAGE("Constraint loop not detected", es.init(), libMesh::LogicError);
+  }
+#endif
+
+#if defined(LIBMESH_ENABLE_CONSTRAINTS)
+  void testGhostConstraintSendList()
+  {
+    LOG_UNIT_TEST;
+
+    if (TestCommWorld->size() == 1)
+      return;
+
+    ReplicatedMesh mesh(*TestCommWorld);
+    mesh.partitioner() = std::make_unique<GhostDofConstraintPartitioner>();
+
+    // Build this four-element line:
+    //
+    //   node:  0 ----- 1 ----- 2 ----- 3 ----- 4
+    //   elem:     0       1       2       3
+    //   owner:    0       0       0     remote
+    //
+    // Node 3 remains owned by processor 0, so its DOF is ghosted on the
+    // processor owning element 3. Node 0 is too distant to be ghosted by
+    // the ordinary element-neighbor send-list construction.
+    MeshTools::Generation::build_line(mesh, 4, 0., 4., EDGE2);
+    const processor_id_type ghost_dof_processor = mesh.elem_ref(3).processor_id();
+    mesh.node_ref(3).processor_id() = 0;
+
+    EquationSystems es(mesh);
+    // The default route should not ghost dependencies of constrained ghost DOFs.
+    System & default_sys = es.add_system<System>("DefaultSystem");
+    default_sys.add_variable("u", FIRST);
+    // The enabled route should add those dependencies to the send list.
+    System & ghost_sys = es.add_system<System>("GhostSystem");
+    ghost_sys.add_variable("u", FIRST);
+
+    GhostDofConstraint default_constraint(default_sys);
+    default_sys.attach_constraint_object(default_constraint);
+    GhostDofConstraint ghost_constraint(ghost_sys);
+    ghost_sys.attach_constraint_object(ghost_constraint);
+
+    // Enable the new behavior only for GhostSystem so DefaultSystem provides
+    // a control route using the original send-list behavior.
+    DofMap & ghost_dof_map = ghost_sys.get_dof_map();
+    ghost_dof_map.ghost_constraints_needed();
+    es.init();
+
+    // Only the processor owning element 3 has the constrained DOF as a ghost
+    // supported by one of its local elements.
+    if (mesh.processor_id() == ghost_dof_processor)
+      {
+        const Elem & local_elem = mesh.elem_ref(3);
+        CPPUNIT_ASSERT_EQUAL(mesh.processor_id(), local_elem.processor_id());
+
+        auto verify_send_list = [&local_elem](System & sys, const bool dependency_is_ghosted)
+        {
+          DofMap & dof_map = sys.get_dof_map();
+          const dof_id_type ghost_constrained_dof =
+            sys.get_mesh().node_ref(3).dof_number(sys.number(), 0, 0);
+          const dof_id_type dependency_dof =
+            sys.get_mesh().node_ref(0).dof_number(sys.number(), 0, 0);
+
+          CPPUNIT_ASSERT(!dof_map.local_index(ghost_constrained_dof));
+          CPPUNIT_ASSERT(!dof_map.local_index(dependency_dof));
+
+          // Verify that the nonlocal constrained DOF is supported by this
+          // processor's local element, making it a constrained ghost DOF.
+          std::vector<dof_id_type> local_dofs;
+          dof_map.dof_indices(&local_elem, local_dofs);
+          CPPUNIT_ASSERT(std::find(local_dofs.begin(), local_dofs.end(), ghost_constrained_dof) !=
+                         local_dofs.end());
+
+          const auto & send_list = dof_map.get_send_list();
+          // The constrained DOF is always ghosted because the local element
+          // uses it; its distant dependency is ghosted only when requested.
+          CPPUNIT_ASSERT(std::binary_search(send_list.begin(), send_list.end(),
+                                            ghost_constrained_dof));
+          // This assertion is false for the control route and true for the
+          // route with ghost constraint dependency expansion enabled.
+          CPPUNIT_ASSERT_EQUAL(dependency_is_ghosted,
+                               std::binary_search(send_list.begin(), send_list.end(),
+                                                  dependency_dof));
+        };
+
+        verify_send_list(default_sys, false);
+        verify_send_list(ghost_sys, true);
+      }
   }
 #endif
 


### PR DESCRIPTION
In Kokkos-MOOSE, we cannot use `VecSetValues` and `MatSetValues` which can dynamically cache remote entries. Instead, we allocate ghost entries in advance based on libMesh `send_list` and accumulate to those, and do the assembly at once. When constraints exist, we might have to add residual/Jacobian contributions to the dependencies of ghost DOFs. So additional ghosting is required.