### PR TITLE
Add missing header

### DIFF
--- a/tests/fe/fe_hdiv_grad_test.C
+++ b/tests/fe/fe_hdiv_grad_test.C
@@ -6,6 +6,7 @@
 #include "libmesh/mesh_generation.h"
 #include "libmesh/node.h"
 #include "libmesh/quadrature_gauss.h"
+#include "libmesh/tensor_value.h"
 
 // unit test includes
 #include "test_comm.h"


### PR DESCRIPTION
This fixes --disable-second builds (which presumably lose an indirect inclusion) for me