### PR TITLE
Adapt neighbor finding logic to polys

### DIFF
--- a/src/geom/cell_polyhedron.C
+++ b/src/geom/cell_polyhedron.C
@@ -23,6 +23,7 @@
 #include "libmesh/hashword.h"
 
 // C++ includes
+#include <algorithm>
 #include <array>
 #include <unordered_map>
 #include <unordered_set>
@@ -271,6 +272,16 @@ dof_id_type Polyhedron::low_order_key (const unsigned int s) const
   std::vector<dof_id_type> vertex_ids(nv);
   for (unsigned int v : make_range(nv))
     vertex_ids[v] = face.node_id(v);
+
+  // Sort the vertex ids before hashing so the key is independent of the
+  // order in which the face's vertices are stored, just like
+  // Elem::compute_key() does for every other element type.  This is
+  // essential for find_neighbors(): two polyhedra sharing a face
+  // generally wind that face in opposite orders (each orienting it
+  // outward from its own cell), so without sorting the two sides would
+  // hash to different keys, never get compared, and never be linked as
+  // neighbors.
+  std::sort(vertex_ids.begin(), vertex_ids.end());
 
   return Utility::hashword(vertex_ids);
 }

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -973,9 +973,9 @@ bool sides_are_the_same_face(const Elem & a, const Elem & b)
   if (a == b)
     return true;
 
-  const bool a_poly = dynamic_cast<const Polygon *>(&a);
-  const bool b_poly = dynamic_cast<const Polygon *>(&b);
-  if (a_poly == b_poly)
+  // The check above would have triggered already if they were both
+  // not polygons. If either is a polygon, we need to check the nodes
+  if (!a.runtime_topology() && !b.runtime_topology())
     return false;
 
   const unsigned int nv = a.n_vertices();

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -25,6 +25,7 @@
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/elem.h"
 #include "libmesh/elem_range.h"
+#include "libmesh/face_polygon.h"
 #include "libmesh/mesh_tools.h" // For n_levels
 #include "libmesh/parallel.h"
 #include "libmesh/remote_elem.h"
@@ -952,6 +953,47 @@ UnstructuredMesh::~UnstructuredMesh ()
 
 
 
+namespace {
+/**
+ * \returns \p true if element sides \p a and \p b are the same face,
+ * for the purpose of linking them as neighbors in find_neighbors().
+ *
+ * This is normally just Elem::operator==, which compares (sorted) node
+ * ids.  But operator== first requires the two sides to have the same
+ * element type, so it never matches a Polyhedron's polygonal side
+ * against the TRI3/QUAD4 side of an adjacent standard element (tet,
+ * hex, ...) even when they are geometrically the same face.  At such a
+ * mixed interface -- exactly one side is a polygon -- we fall back to
+ * comparing the vertex node ids, which is what low_order_key() already
+ * keys on.  Purely standard/standard and polygon/polygon pairs are left
+ * entirely to operator==.
+ */
+bool sides_are_the_same_face(const Elem & a, const Elem & b)
+{
+  if (a == b)
+    return true;
+
+  const bool a_poly = dynamic_cast<const Polygon *>(&a);
+  const bool b_poly = dynamic_cast<const Polygon *>(&b);
+  if (a_poly == b_poly)
+    return false;
+
+  const unsigned int nv = a.n_vertices();
+  if (nv != b.n_vertices())
+    return false;
+
+  std::vector<dof_id_type> a_ids(nv), b_ids(nv);
+  for (unsigned int v = 0; v != nv; ++v)
+    {
+      a_ids[v] = a.node_id(v);
+      b_ids[v] = b.node_id(v);
+    }
+  std::sort(a_ids.begin(), a_ids.end());
+  std::sort(b_ids.begin(), b_ids.end());
+  return a_ids == b_ids;
+}
+}
+
 
 
 void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
@@ -1040,7 +1082,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                         // for matching level() to avoid setting our
                         // neighbor pointer to any of our neighbor's
                         // descendants.
-                        if ((*my_side == *their_side) &&
+                        if (sides_are_the_same_face(*my_side, *their_side) &&
                             (element->level() == neighbor->level()))
                           {
                             // So share a side.  Is this a mixed pair

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -955,7 +955,7 @@ UnstructuredMesh::~UnstructuredMesh ()
 
 namespace {
 /**
- * \returns \p true if element sides \p a and \p b are the same face,
+ * \returns \p true if element sides \p a and \p b are the same elem,
  * for the purpose of linking them as neighbors in find_neighbors().
  *
  * This is normally just Elem::operator==, which compares (sorted) node
@@ -968,13 +968,13 @@ namespace {
  * keys on.  Purely standard/standard and polygon/polygon pairs are left
  * entirely to operator==.
  */
-bool sides_are_the_same_face(const Elem & a, const Elem & b)
+bool sides_are_the_same_elem(const Elem & a, const Elem & b)
 {
   if (a == b)
     return true;
 
-  // The check above would have triggered already if they were both
-  // not polygons. If either is a polygon, we need to check the nodes
+  // The check above would have been sufficient if they were both
+  // polygons or both not. If just one is a polygon, we need to check the nodes
   if (!a.runtime_topology() && !b.runtime_topology())
     return false;
 
@@ -1082,7 +1082,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                         // for matching level() to avoid setting our
                         // neighbor pointer to any of our neighbor's
                         // descendants.
-                        if (sides_are_the_same_face(*my_side, *their_side) &&
+                        if (sides_are_the_same_elem(*my_side, *their_side) &&
                             (element->level() == neighbor->level()))
                           {
                             // So share a side.  Is this a mixed pair

--- a/tests/mesh/mesh_generation_test.C
+++ b/tests/mesh/mesh_generation_test.C
@@ -1,12 +1,20 @@
 #include <libmesh/libmesh.h>
 #include <libmesh/distributed_mesh.h>
 #include <libmesh/elem.h>
+#include <libmesh/cell_c0polyhedron.h>
+#include <libmesh/face_c0polygon.h>
+#include <libmesh/face_polygon.h>
 #include <libmesh/mesh_generation.h>
 #include <libmesh/mesh_tools.h>
 #include <libmesh/replicated_mesh.h>
 
+#include <timpi/parallel_implementation.h> // Communicator::sum definition
+
 #include "test_comm.h"
 #include "libmesh_cppunit.h"
+
+#include <memory>
+#include <vector>
 
 
 using namespace libMesh;
@@ -52,6 +60,7 @@ public:
   CPPUNIT_TEST( buildCubeHex20 );
   CPPUNIT_TEST( buildCubeHex27 );
   CPPUNIT_TEST( buildCubeC0Polyhedron );
+  CPPUNIT_TEST( polyhedronTetNeighbor );
   CPPUNIT_TEST( buildCubePrism6 );
   CPPUNIT_TEST( buildCubePrism15 );
   CPPUNIT_TEST( buildCubePrism18 );
@@ -322,7 +331,7 @@ public:
         // boundary face with no neighbor.  For an n x n x n cube there
         // are 3*(n-1)*n*n interior faces, each shared by two elements,
         // so 2*3*(n-1)*n*n sides should carry a neighbor link.
-        dof_id_type n_neighbor_links = 0;
+        int n_neighbor_links = 0;
         for (auto & elem : mesh.active_local_element_ptr_range())
           for (auto s : elem->side_index_range())
             {
@@ -342,7 +351,7 @@ public:
         mesh.comm().sum(n_neighbor_links);
 
         CPPUNIT_ASSERT_EQUAL(n_neighbor_links,
-                             cast_int<dof_id_type>(2 * 3 * (n-1) * n * n));
+                             static_cast<int>(2 * 3 * (n-1) * n * n));
 
         return;
       }
@@ -414,6 +423,70 @@ public:
   void buildCubeHex27 ()     { LOG_UNIT_TEST; tester(&MeshGenerationTest::testBuildCube, 2, HEX27); }
   void buildCubeC0Polyhedron ()
   { LOG_UNIT_TEST; tester(&MeshGenerationTest::testBuildCube, 2, C0POLYHEDRON); }
+
+  // Verify that find_neighbors() links a C0Polyhedron to an adjacent
+  // standard element (here a TET4) across their shared triangular face.
+  // The polyhedron's side is a C0POLYGON while the tet's side is a TRI3,
+  // so Elem::operator== alone (which requires matching element types)
+  // would not match them; find_neighbors() falls back to a vertex-id
+  // comparison at such a mixed interface.
+  void polyhedronTetNeighbor ()
+  {
+    LOG_UNIT_TEST;
+
+    ReplicatedMesh mesh(*TestCommWorld, /*dim=*/3);
+
+    // Five nodes: {0,1,2,3} form a tet-shaped polyhedron, and the TET4
+    // is {1,2,3,4} on the far side of the shared face {1,2,3}.
+    mesh.add_point(Point(0,0,0), 0);
+    mesh.add_point(Point(1,0,0), 1);
+    mesh.add_point(Point(0,1,0), 2);
+    mesh.add_point(Point(0,0,1), 3);
+    mesh.add_point(Point(1,1,1), 4);
+
+    auto tri = [&mesh](dof_id_type a, dof_id_type b, dof_id_type c)
+    {
+      auto p = std::make_shared<C0Polygon>(3);
+      p->set_node(0, mesh.node_ptr(a));
+      p->set_node(1, mesh.node_ptr(b));
+      p->set_node(2, mesh.node_ptr(c));
+      return std::shared_ptr<Polygon>(std::move(p));
+    };
+
+    std::vector<std::shared_ptr<Polygon>> faces =
+      { tri(0,1,2), tri(0,1,3), tri(1,2,3), tri(0,2,3) };
+
+    std::unique_ptr<Node> mid_elem_node;
+    std::unique_ptr<Elem> poly =
+      std::make_unique<C0Polyhedron>(faces, mid_elem_node);
+    if (mid_elem_node)
+      mesh.add_node(std::move(mid_elem_node));
+    poly->set_id() = 0;
+    Elem * polye = mesh.add_elem(std::move(poly));
+
+    std::unique_ptr<Elem> tet = Elem::build(TET4);
+    tet->set_id() = 1;
+    tet->set_node(0, mesh.node_ptr(1));
+    tet->set_node(1, mesh.node_ptr(2));
+    tet->set_node(2, mesh.node_ptr(3));
+    tet->set_node(3, mesh.node_ptr(4));
+    Elem * tete = mesh.add_elem(std::move(tet));
+
+    mesh.prepare_for_use();
+
+    // Exactly one side of each element should be linked, to the other.
+    unsigned int poly_links = 0, tet_links = 0;
+    for (auto s : polye->side_index_range())
+      if (const Elem * n = polye->neighbor_ptr(s))
+        { ++poly_links; CPPUNIT_ASSERT(n == tete); }
+    for (auto s : tete->side_index_range())
+      if (const Elem * n = tete->neighbor_ptr(s))
+        { ++tet_links; CPPUNIT_ASSERT(n == polye); }
+
+    CPPUNIT_ASSERT_EQUAL(1u, poly_links);
+    CPPUNIT_ASSERT_EQUAL(1u, tet_links);
+  }
+
   void buildCubePrism6 ()    { LOG_UNIT_TEST; tester(&MeshGenerationTest::testBuildCube, 2, PRISM6); }
   void buildCubePrism15 ()   { LOG_UNIT_TEST; tester(&MeshGenerationTest::testBuildCube, 2, PRISM15); }
   void buildCubePrism18 ()   { LOG_UNIT_TEST; tester(&MeshGenerationTest::testBuildCube, 2, PRISM18); }

--- a/tests/mesh/mesh_generation_test.C
+++ b/tests/mesh/mesh_generation_test.C
@@ -435,57 +435,93 @@ public:
   {
     LOG_UNIT_TEST;
 
-    Mesh mesh(*TestCommWorld, /*dim=*/3);
+    // Exercise both a replicated and a (genuinely) distributed mesh; on
+    // a DistributedMesh with more ranks than elements this used to be
+    // built in a way that dereferenced elements deleted by
+    // delete_remote_elements(), so we must not hold element pointers
+    // across prepare_for_use() and must reduce counts across ranks.
+    for (int is_replicated = 0; is_replicated != 2; ++is_replicated)
+      {
+        std::unique_ptr<UnstructuredMesh> mesh_ptr = new_mesh(is_replicated);
+        UnstructuredMesh & mesh = *mesh_ptr;
 
-    // Five nodes: {0,1,2,3} form a tet-shaped polyhedron, and the TET4
-    // is {1,2,3,4} on the far side of the shared face {1,2,3}.
-    mesh.add_point(Point(0,0,0), 0);
-    mesh.add_point(Point(1,0,0), 1);
-    mesh.add_point(Point(0,1,0), 2);
-    mesh.add_point(Point(0,0,1), 3);
-    mesh.add_point(Point(1,1,1), 4);
+        // Five nodes: {0,1,2,3} form a tet-shaped polyhedron, and the
+        // TET4 is {1,2,3,4} on the far side of the shared face {1,2,3}.
+        mesh.add_point(Point(0,0,0), 0);
+        mesh.add_point(Point(1,0,0), 1);
+        mesh.add_point(Point(0,1,0), 2);
+        mesh.add_point(Point(0,0,1), 3);
+        mesh.add_point(Point(1,1,1), 4);
 
-    auto tri = [&mesh](dof_id_type a, dof_id_type b, dof_id_type c)
-    {
-      auto p = std::make_shared<C0Polygon>(3);
-      p->set_node(0, mesh.node_ptr(a));
-      p->set_node(1, mesh.node_ptr(b));
-      p->set_node(2, mesh.node_ptr(c));
-      return std::shared_ptr<Polygon>(std::move(p));
-    };
+        auto tri = [&mesh](dof_id_type a, dof_id_type b, dof_id_type c)
+        {
+          auto p = std::make_shared<C0Polygon>(3);
+          p->set_node(0, mesh.node_ptr(a));
+          p->set_node(1, mesh.node_ptr(b));
+          p->set_node(2, mesh.node_ptr(c));
+          return std::shared_ptr<Polygon>(std::move(p));
+        };
 
-    std::vector<std::shared_ptr<Polygon>> faces =
-      { tri(0,1,2), tri(0,1,3), tri(1,2,3), tri(0,2,3) };
+        std::vector<std::shared_ptr<Polygon>> faces =
+          { tri(0,1,2), tri(0,1,3), tri(1,2,3), tri(0,2,3) };
 
-    std::unique_ptr<Node> mid_elem_node;
-    std::unique_ptr<Elem> poly =
-      std::make_unique<C0Polyhedron>(faces, mid_elem_node);
-    if (mid_elem_node)
-      mesh.add_node(std::move(mid_elem_node));
-    poly->set_id() = 0;
-    Elem * polye = mesh.add_elem(std::move(poly));
+        std::unique_ptr<Node> mid_elem_node;
+        std::unique_ptr<Elem> poly =
+          std::make_unique<C0Polyhedron>(faces, mid_elem_node);
+        if (mid_elem_node)
+          mesh.add_node(std::move(mid_elem_node));
+        poly->set_id() = 0;
+        mesh.add_elem(std::move(poly));
 
-    std::unique_ptr<Elem> tet = Elem::build(TET4);
-    tet->set_id() = 1;
-    tet->set_node(0, mesh.node_ptr(1));
-    tet->set_node(1, mesh.node_ptr(2));
-    tet->set_node(2, mesh.node_ptr(3));
-    tet->set_node(3, mesh.node_ptr(4));
-    Elem * tete = mesh.add_elem(std::move(tet));
+        std::unique_ptr<Elem> tet = Elem::build(TET4);
+        tet->set_id() = 1;
+        tet->set_node(0, mesh.node_ptr(1));
+        tet->set_node(1, mesh.node_ptr(2));
+        tet->set_node(2, mesh.node_ptr(3));
+        tet->set_node(3, mesh.node_ptr(4));
+        mesh.add_elem(std::move(tet));
 
-    mesh.prepare_for_use();
+        mesh.prepare_for_use();
 
-    // Exactly one side of each element should be linked, to the other.
-    unsigned int poly_links = 0, tet_links = 0;
-    for (auto s : polye->side_index_range())
-      if (const Elem * n = polye->neighbor_ptr(s))
-        { ++poly_links; CPPUNIT_ASSERT(n == tete); }
-    for (auto s : tete->side_index_range())
-      if (const Elem * n = tete->neighbor_ptr(s))
-        { ++tet_links; CPPUNIT_ASSERT(n == polye); }
+        // find_neighbors() must link the polyhedron's C0POLYGON face to
+        // the tet's TRI3 face.  Count the interface from each owned
+        // element's side and reduce, so the check is valid however the
+        // two elements are partitioned.
+        int poly_to_tet = 0, tet_to_poly = 0;
+        for (const Elem * elem : mesh.active_local_element_ptr_range())
+          for (auto s : elem->side_index_range())
+            {
+              const Elem * neigh = elem->neighbor_ptr(s);
+              if (!neigh)
+                continue;
 
-    CPPUNIT_ASSERT_EQUAL(1u, poly_links);
-    CPPUNIT_ASSERT_EQUAL(1u, tet_links);
+              if (elem->type() == C0POLYHEDRON)
+                {
+                  ++poly_to_tet;
+                  if (!neigh->is_remote())
+                    {
+                      CPPUNIT_ASSERT_EQUAL(neigh->type(), TET4);
+                      CPPUNIT_ASSERT(neigh->neighbor_ptr
+                                     (neigh->which_neighbor_am_i(elem)) == elem);
+                    }
+                }
+              else if (elem->type() == TET4)
+                {
+                  ++tet_to_poly;
+                  if (!neigh->is_remote())
+                    {
+                      CPPUNIT_ASSERT_EQUAL(neigh->type(), C0POLYHEDRON);
+                      CPPUNIT_ASSERT(neigh->neighbor_ptr
+                                     (neigh->which_neighbor_am_i(elem)) == elem);
+                    }
+                }
+            }
+        mesh.comm().sum(poly_to_tet);
+        mesh.comm().sum(tet_to_poly);
+
+        CPPUNIT_ASSERT_EQUAL(1, poly_to_tet);
+        CPPUNIT_ASSERT_EQUAL(1, tet_to_poly);
+      }
   }
 
   void buildCubePrism6 ()    { LOG_UNIT_TEST; tester(&MeshGenerationTest::testBuildCube, 2, PRISM6); }

--- a/tests/mesh/mesh_generation_test.C
+++ b/tests/mesh/mesh_generation_test.C
@@ -313,6 +313,37 @@ public:
             CPPUNIT_ASSERT(elem->volume() > 0);
           }
 
+        // Verify that find_neighbors() actually linked the polyhedra to
+        // one another.  This is a regression test for a bug where
+        // Polyhedron::low_order_key() hashed a face's nodes in their
+        // stored (winding) order rather than sorted; since two adjacent
+        // cells wind their shared face in opposite orders, the keys
+        // never matched and every interior face was left looking like a
+        // boundary face with no neighbor.  For an n x n x n cube there
+        // are 3*(n-1)*n*n interior faces, each shared by two elements,
+        // so 2*3*(n-1)*n*n sides should carry a neighbor link.
+        dof_id_type n_neighbor_links = 0;
+        for (auto & elem : mesh.active_local_element_ptr_range())
+          for (auto s : elem->side_index_range())
+            {
+              const Elem * neigh = elem->neighbor_ptr(s);
+              if (!neigh)
+                continue;
+              ++n_neighbor_links;
+
+              // Links to a non-remote neighbor must be reciprocal.
+              if (!neigh->is_remote())
+                {
+                  const unsigned int ns = neigh->which_neighbor_am_i(elem);
+                  CPPUNIT_ASSERT(ns < neigh->n_sides());
+                  CPPUNIT_ASSERT(neigh->neighbor_ptr(ns) == elem);
+                }
+            }
+        mesh.comm().sum(n_neighbor_links);
+
+        CPPUNIT_ASSERT_EQUAL(n_neighbor_links,
+                             cast_int<dof_id_type>(2 * 3 * (n-1) * n * n));
+
         return;
       }
 

--- a/tests/mesh/mesh_generation_test.C
+++ b/tests/mesh/mesh_generation_test.C
@@ -4,6 +4,7 @@
 #include <libmesh/cell_c0polyhedron.h>
 #include <libmesh/face_c0polygon.h>
 #include <libmesh/face_polygon.h>
+#include <libmesh/mesh.h>
 #include <libmesh/mesh_generation.h>
 #include <libmesh/mesh_tools.h>
 #include <libmesh/replicated_mesh.h>
@@ -434,7 +435,7 @@ public:
   {
     LOG_UNIT_TEST;
 
-    ReplicatedMesh mesh(*TestCommWorld, /*dim=*/3);
+    Mesh mesh(*TestCommWorld, /*dim=*/3);
 
     // Five nodes: {0,1,2,3} form a tet-shaped polyhedron, and the TET4
     // is {1,2,3,4} on the far side of the shared face {1,2,3}.


### PR DESCRIPTION
Two issues:
- poly sides might have been created differently and they wont be ordered the same way
- a polygon side does not say true when == with a tri side of a tet for example